### PR TITLE
style: fix docs typography sizing and rhythm

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -40,8 +40,8 @@
     color: var(--text);
     position: relative;
     font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-    font-size: 15px;
-    line-height: 1.7;
+    font-size: 1rem;
+    line-height: 1.65;
     min-height: 100vh;
   }
 
@@ -100,11 +100,11 @@
   }
   .topnav-sep {
     color: var(--border2);
-    font-size: 18px;
+    font-size: 1.125rem;
     font-weight: 200;
   }
   .topnav-page {
-    font-size: 14px;
+    font-size: 0.8125rem;
     color: var(--muted);
     font-family: 'SF Mono', 'Fira Mono', monospace;
   }
@@ -181,7 +181,7 @@
     border-radius: 6px;
     color: var(--muted);
     text-decoration: none;
-    font-size: 13.5px;
+    font-size: 0.8125rem;
     transition: color 0.15s, background 0.15s;
     line-height: 1.4;
   }
@@ -189,7 +189,7 @@
   .nav-link.active { color: var(--accent); background: rgba(56,189,248,0.08); }
   .nav-link.sub {
     padding-left: 20px;
-    font-size: 13px;
+    font-size: 0.8125rem;
   }
 
   /* ── MAIN CONTENT ── */
@@ -203,7 +203,7 @@
     -webkit-backdrop-filter: blur(32px);
   }
   .main-inner {
-    max-width: 860px;
+    max-width: 70ch;
     margin: 0 auto;
   }
 
@@ -224,17 +224,17 @@
   }
 
   h1 {
-    font-size: 38px;
+    font-size: 2.375rem;
     font-weight: 600;
     font-style: italic;
     letter-spacing: -0.02em;
-    line-height: 1.1;
+    line-height: 1.15;
     font-family: 'Cormorant Garamond', Georgia, serif;
     margin-bottom: 16px;
   }
 
   h2 {
-    font-size: 24px;
+    font-size: 1.5rem;
     font-weight: 700;
     letter-spacing: -0.01em;
     margin-bottom: 14px;
@@ -243,7 +243,7 @@
   }
 
   h3 {
-    font-size: 16px;
+    font-size: 1.125rem;
     font-weight: 700;
     margin-bottom: 10px;
     margin-top: 28px;
@@ -255,7 +255,6 @@
   p {
     color: var(--text);
     margin-bottom: 14px;
-    opacity: 0.9;
   }
 
   a { color: var(--accent); text-decoration: none; }
@@ -264,9 +263,9 @@
   strong { color: var(--text); font-weight: 600; }
 
   .lead {
-    font-size: 17px;
+    font-size: 1.125rem;
     color: var(--muted);
-    line-height: 1.65;
+    line-height: 1.6;
     margin-bottom: 32px;
   }
 
@@ -301,7 +300,7 @@
     background: none;
     border: none;
     padding: 0;
-    font-size: 13.5px;
+    font-size: 0.8125rem;
     color: var(--text);
     line-height: 1.65;
   }
@@ -461,7 +460,7 @@
   }
   .cmd-ref-body {
     padding: 16px 20px;
-    font-size: 13.5px;
+    font-size: 0.8125rem;
     line-height: 1.6;
     color: var(--text);
     opacity: 0.85;
@@ -509,10 +508,10 @@
     .topnav-sep, .topnav-page, .copy-page-btn { display: none; }
     .topnav-right { gap: 12px; }
     .main { padding: 24px 16px 60px; }
-    h1 { font-size: 28px; }
-    h2 { font-size: 20px; }
-    pre { font-size: 12px; white-space: pre-wrap; word-break: break-all; }
-    .cmd-ref-header code { font-size: 12px; word-break: break-all; }
+    h1 { font-size: 1.75rem; }
+    h2 { font-size: 1.25rem; }
+    pre { font-size: 0.75rem; white-space: pre-wrap; word-break: break-all; }
+    .cmd-ref-header code { font-size: 0.75rem; word-break: break-all; }
   }
 </style>
 </head>


### PR DESCRIPTION
## Summary
- Body text to 1rem (was 15px, below readability floor)
- All font sizes converted from px to rem for accessibility
- Consolidated muddy 13/13.5px size pair → 0.8125rem
- Bumped h3 and lead text so they're distinguishable from body by scale, not just color
- Content max-width to 70ch for proper line measure
- Removed `opacity: 0.9` on paragraphs (use color directly on dark backgrounds)

## Test plan
- [ ] Open docs/index.html locally and verify text hierarchy reads clearly
- [ ] Check mobile breakpoint (~600px) for responsive sizing
- [ ] Verify browser zoom to 200% doesn't break layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)