### PR TITLE
refactor: split prependSystemContext / prependContext in OpenClaw plugin

### DIFF
--- a/mycelium-cli/src/mycelium/adapters/openclaw/extensions/mycelium/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/extensions/mycelium/index.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { join } from "node:path";
 
 /**
@@ -91,8 +92,8 @@ const AGENT_ID = process.env.MYCELIUM_AGENT_ID ?? "";
 
 // Custom memory file — read fresh on every before_agent_start invocation
 const MEMORY_FILE = join(
-  process.env.HOME ?? process.env.USERPROFILE ?? "/home/ubuntu",
-  ".openclaw/workspace/memory/custom-context.md"
+  homedir(),
+  ".openclaw/workspace/memory/mycelium-context.md"
 );
 
 // ── Per-session tracking ───────────────────────────────────────────────────


### PR DESCRIPTION

## Context                                                                                                                                                                                                                                 
The before_agent_start hook in the Mycelium OpenClaw plugin previously put everything (static instructions + dynamic coordination messages) into prependSystemContext (system prompt space, cached by the LLM provider). This change correctly splits content into:                                                                                                                                                                                                          

- prependSystemContext — static instructions + handle (cacheable, cheap after turn 1)                                                                                                                                                   
- prependContext — coordination ticks/consensus + custom memory file (fresh per-turn, user message space)    

## Summary

- Split `before_agent_start` hook to use **both** `prependSystemContext` (cached) and `prependContext` (per-turn) instead of putting everything in system context
- Static instructions + handle → `prependSystemContext` (cached by LLM provider after turn 1)
- Dynamic coordination ticks/consensus + custom memory file (`~/.openclaw/workspace/memory/custom-context.md`) → `prependContext` (fresh per-turn)
- Fixed doc comments to accurately reflect the dual-context approach