### PR TITLE
Add auto-generated CLI reference documentation system

### DIFF
--- a/mycelium-cli/src/mycelium/commands/docs.py
+++ b/mycelium-cli/src/mycelium/commands/docs.py
@@ -179,6 +179,10 @@ def docs_main(
         _do_search(docs_root, topic)
         return
 
+    if section == "generate":
+        _do_generate(topic)
+        return
+
     if not section:
         doc_path = docs_root / "index.md"
         if doc_path.exists():
@@ -239,6 +243,17 @@ def _print_section_list(docs_root: Path, section: str) -> None:
         typer.echo(f"  {cmd:<40} {title}")
 
 
+def _do_generate(output: str | None = None) -> None:
+    from mycelium.generate_cli_docs import generate_all
+
+    out_dir = Path(output) if output else None
+    written = generate_all(output_dir=out_dir)
+
+    typer.secho(f"Generated {len(written)} documentation files:", bold=True)
+    for p in written:
+        typer.echo(f"  {p}")
+
+
 def _do_search(docs_root: Path, query: str) -> None:
     results = _search_docs(docs_root, query)
     if not results:
@@ -270,3 +285,17 @@ def search(query: str = typer.Argument(..., help="Search query")) -> None:
     """Search documentation for a term."""
     docs_root = _get_docs_root()
     _do_search(docs_root, query)
+
+
+@app.command()
+def generate(
+    output: str | None = typer.Option(
+        None, "--output", "-o", help="Output directory (default: bundled docs)"
+    ),
+) -> None:
+    """Auto-generate CLI reference docs from command definitions.
+
+    Introspects the Typer command tree and writes markdown files
+    into the bundled docs/commands/ directory (or a custom path).
+    """
+    _do_generate(output)

--- a/mycelium-cli/src/mycelium/docs/cli-reference.md
+++ b/mycelium-cli/src/mycelium/docs/cli-reference.md
@@ -1,0 +1,130 @@
+# CLI Reference
+
+Auto-generated from CLI source. Run `mycelium docs generate` to regenerate.
+
+## Global Options
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--version`, `-V` | option |  |  | Print version information |
+| `--verbose`, `-v` | option |  | `False` | Enable verbose/debug output |
+| `--quiet`, `-q` | option |  | `False` | Suppress non-essential output |
+| `--json` | option |  | `False` | Output in JSON format |
+
+## Top-Level Commands
+
+### `mycelium catchup`
+
+Get briefed on a room's current state — latest synthesis + recent activity.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--room`, `-r` | option |  |  | Room name |
+
+### `mycelium down`
+
+Stop Mycelium services.
+
+Examples:
+    mycelium down             # stop containers, keep volumes
+    mycelium down --volumes   # stop and delete all data
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--volumes`, `-v` | option |  | `False` | Also remove volumes (destructive) |
+
+### `mycelium init`
+
+Initialize Mycelium configuration.
+
+Creates ~/.mycelium/config.toml with default settings.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--api-url` | option |  |  | Backend API URL (default: http://localhost:8000) |
+| `--force`, `-f` | option |  | `False` | Overwrite existing configuration |
+
+### `mycelium install`
+
+Install an Mycelium instance.
+
+Checks system requirements, prompts for configuration, then brings up
+all services via docker compose.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--ascii` | option |  | `False` | Use ASCII rendering |
+| `--blocks` | option |  | `False` | Use unicode block rendering |
+| `--color` | option |  | `cyan` | Color theme (cyan|amber|magenta|green|white) |
+| `--yes`, `-y` | option |  | `False` | Skip confirmations |
+| `--non-interactive`, `-n` | option |  | `False` | Skip prompts and animation (use --llm-model etc.) |
+| `--llm-model` | option |  | `` | LLM model in litellm format (non-interactive) |
+| `--llm-base-url` | option |  | `` | LLM base URL (non-interactive) |
+| `--llm-api-key` | option |  | `` | LLM API key (non-interactive) |
+| `--ioc` | option |  | `False` | Enable IoC CFN stack (non-interactive) |
+
+### `mycelium logs`
+
+View service logs via docker compose.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `service` | argument |  |  | Service name (e.g. mycelium-backend, ioc-cfn-mgmt-plane-svc) |
+| `--follow`, `-f` | option |  | `False` | Follow log output |
+| `--tail` | option |  |  | Number of lines to show from the end |
+
+### `mycelium status`
+
+Show service health.
+
+Checks if Mycelium backend is running and accessible.
+
+### `mycelium synthesize`
+
+Trigger CognitiveEngine synthesis for an async/hybrid room.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `room_name` | argument |  |  | Room to synthesize (default: active room) |
+| `--room`, `-r` | option |  |  | Room name (alternative to positional arg) |
+
+### `mycelium up`
+
+Start Mycelium services.
+
+Runs docker compose up -d using the bundled compose file and
+~/.mycelium/.env for configuration.
+
+Examples:
+    mycelium up          # start all services
+    mycelium up --build  # rebuild images first
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--build` | option |  | `False` | Rebuild images before starting |
+
+### `mycelium watch`
+
+Stream live messages from a room.
+
+Auto-resolves the active room — no argument needed.
+Renders coordination events, agent joins, ticks, and consensus.
+
+Examples:
+    mycelium room watch
+    mycelium room watch my-room
+    mycelium room watch --timeout 120
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `room_name` | argument |  |  | Room to watch (default: active room) |
+| `--timeout`, `-t` | option |  | `0` | Timeout in seconds (0=no timeout) |
+
+## Command Groups
+
+- [`mycelium adapter`](commands/adapter.md) — Connect agent frameworks (OpenClaw, Claude Code) to Mycelium. Install hooks, skills, and plugins.
+- [`mycelium config`](commands/config.md) — View and update Mycelium settings. Global config lives at ~/.mycelium/config.toml.
+- [`mycelium docs`](commands/docs.md) — Browse and search built-in documentation for Mycelium concepts, protocols, and API reference.
+- [`mycelium memory`](commands/memory.md) — Read and write persistent memories scoped to rooms. Memories persist across sessions and support semantic vector search.
+- [`mycelium message`](commands/message.md) — Respond to CognitiveEngine during sync negotiation. Propose offers, accept/reject, or send raw JSON.
+- [`mycelium room`](commands/room.md) — Shared namespaces for agent coordination. Rooms can be sync (real-time negotiation), async (persistent memory), or hybrid.

--- a/mycelium-cli/src/mycelium/docs/commands/adapter.md
+++ b/mycelium-cli/src/mycelium/docs/commands/adapter.md
@@ -1,0 +1,45 @@
+# mycelium adapter
+
+Connect agent frameworks (OpenClaw, Claude Code) to Mycelium. Install hooks, skills, and plugins.
+
+## Commands
+
+### `mycelium adapter add`
+
+Register and install an agent framework adapter, then optionally wire it into your environment.
+
+Examples:
+    mycelium adapter add openclaw
+    mycelium adapter add openclaw --reinstall
+    mycelium adapter add openclaw --step=local-gateway
+    mycelium adapter add openclaw --step=docker-env
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `adapter_type` | argument | Yes |  | Adapter type: openclaw, cursor, claude-code |
+| `--dry-run` | option |  | `False` | Show what would be installed without doing it |
+| `--step` | option |  |  | Run a follow-up setup step: local-gateway, docker-env |
+| `--reinstall` | option |  | `False` | Reinstall assets even if adapter is already registered |
+| `--scaffold-only` | option |  |  | Copy adapter assets to a directory without running install commands (for Docker/experiment setups) |
+| `--force`, `-f` | option |  | `False` | Overwrite existing assets when using --scaffold-only |
+
+### `mycelium adapter ls`
+
+List registered adapters.
+
+### `mycelium adapter remove`
+
+Unregister and uninstall an adapter.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `adapter_type` | argument | Yes |  | Adapter type to remove |
+| `--force`, `-f` | option |  | `False` | Skip confirmation |
+
+### `mycelium adapter status`
+
+Check adapter health.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `adapter_type` | argument |  |  | Adapter type to check (all if omitted) |

--- a/mycelium-cli/src/mycelium/docs/commands/config.md
+++ b/mycelium-cli/src/mycelium/docs/commands/config.md
@@ -1,0 +1,31 @@
+# mycelium config
+
+View and update Mycelium settings. Global config lives at ~/.mycelium/config.toml.
+
+## Commands
+
+### `mycelium config get`
+
+Get a configuration value.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `key` | argument | Yes |  | Config key (e.g., server.api_url) |
+
+### `mycelium config set`
+
+Set a configuration value or switch environment.
+
+Examples:
+    mycelium config set server.api_url http://myhost:8000
+    mycelium config set --env local
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `key` | argument |  |  | Config key (e.g., server.api_url) |
+| `value` | argument |  |  | Config value |
+| `--env`, `-e` | option |  |  | Apply environment preset (local) |
+
+### `mycelium config show`
+
+Show current configuration.

--- a/mycelium-cli/src/mycelium/docs/commands/docs.md
+++ b/mycelium-cli/src/mycelium/docs/commands/docs.md
@@ -1,0 +1,28 @@
+# mycelium docs
+
+Browse and search built-in documentation for Mycelium concepts, protocols, and API reference.
+
+## Commands
+
+### `mycelium docs generate`
+
+Auto-generate CLI reference docs from command definitions.
+
+Introspects the Typer command tree and writes markdown files
+into the bundled docs/commands/ directory (or a custom path).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--output`, `-o` | option |  |  | Output directory (default: bundled docs) |
+
+### `mycelium docs ls`
+
+List all available documentation.
+
+### `mycelium docs search`
+
+Search documentation for a term.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | argument | Yes |  | Search query |

--- a/mycelium-cli/src/mycelium/docs/commands/memory.md
+++ b/mycelium-cli/src/mycelium/docs/commands/memory.md
@@ -1,0 +1,79 @@
+# mycelium memory
+
+Read and write persistent memories scoped to rooms. Memories persist across sessions and support semantic vector search.
+
+## Commands
+
+### `mycelium memory catchup`
+
+Get briefed on a room's current state — latest synthesis + recent activity.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--room`, `-r` | option |  |  | Room name |
+
+### `mycelium memory get`
+
+Read a memory by key.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `key` | argument | Yes |  | Memory key |
+| `--room`, `-r` | option |  |  | Room name |
+
+### `mycelium memory ls`
+
+List memories in a room, optionally filtered by namespace prefix.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `namespace` | argument |  |  | Key prefix to filter by (e.g. 'position/' or 'decisions/') |
+| `--room`, `-r` | option |  |  | Room name |
+| `--prefix`, `-p` | option |  |  | Key prefix filter (same as positional arg) |
+| `--limit`, `-n` | option |  | `20` | Max results |
+
+### `mycelium memory rm`
+
+Delete a memory.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `key` | argument | Yes |  | Memory key to delete |
+| `--room`, `-r` | option |  |  | Room name |
+| `--force`, `-f` | option |  | `False` | Skip confirmation |
+
+### `mycelium memory search`
+
+Semantic search over memories.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | argument | Yes |  | Natural language search query |
+| `--room`, `-r` | option |  |  | Room name |
+| `--limit`, `-n` | option |  | `5` | Max results |
+
+### `mycelium memory set`
+
+Write a memory to a room's persistent namespace.
+
+Fails if the key already exists unless --update is passed.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `key` | argument | Yes |  | Memory key (e.g. 'project/status') |
+| `value` | argument | Yes |  | Memory value (string or JSON) |
+| `--room`, `-r` | option |  |  | Room name (defaults to active room) |
+| `--handle`, `-h` | option |  | `cli-user` | Agent handle |
+| `--no-embed` | option |  | `False` | Skip vector embedding |
+| `--tags`, `-t` | option |  |  | Comma-separated tags |
+| `--update`, `-u` | option |  | `False` | Allow overwriting an existing memory |
+
+### `mycelium memory subscribe`
+
+Subscribe to memory change notifications.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `pattern` | argument | Yes |  | Key glob pattern (e.g. 'project/*') |
+| `--room`, `-r` | option |  |  | Room name |
+| `--handle`, `-h` | option |  | `cli-user` | Subscriber agent handle |

--- a/mycelium-cli/src/mycelium/docs/commands/message.md
+++ b/mycelium-cli/src/mycelium/docs/commands/message.md
@@ -1,0 +1,51 @@
+# mycelium message
+
+Respond to CognitiveEngine during sync negotiation. Propose offers, accept/reject, or send raw JSON.
+
+## Commands
+
+### `mycelium message propose`
+
+Submit an offer for the current negotiate/propose tick.
+
+Pass issue assignments as KEY=VALUE pairs.  The CLI wraps them in the
+correct wire format so you never have to write JSON by hand.
+
+Examples:
+    mycelium message propose budget=medium timeline=standard scope=standard quality=standard
+    mycelium message propose budget=high scope=full --room my-room --handle julia-agent
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `assignments` | argument | Yes |  | Issue assignments as KEY=VALUE pairs, e.g. budget=medium timeline=standard |
+| `--room`, `-r` | option |  |  | Room to respond in (overrides MYCELIUM_ROOM_ID) |
+| `--handle`, `-H` | option |  |  | Your agent handle (overrides identity config) |
+
+### `mycelium message query`
+
+Post a raw JSON response (advanced use — prefer 'propose' or 'respond' for negotiate ticks).
+
+Examples:
+    mycelium message query '{"offer": {"budget": "high", "scope": "extended"}}'
+    mycelium message query '{"action": "accept"}' --room my-experiment
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `text` | argument | Yes |  | Raw JSON payload to post as your coordination response |
+| `--room`, `-r` | option |  |  | Room to respond in (overrides MYCELIUM_ROOM_ID) |
+| `--handle`, `-H` | option |  |  | Your agent handle (overrides identity config) |
+
+### `mycelium message respond`
+
+Accept, reject, or end the negotiation for the current respond tick.
+
+Examples:
+    mycelium message respond accept
+    mycelium message respond reject --room my-room
+    mycelium message respond end    --handle julia-agent
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `action` | argument | Yes |  | Your response: accept | reject | end |
+| `--room`, `-r` | option |  |  | Room to respond in (overrides MYCELIUM_ROOM_ID) |
+| `--handle`, `-H` | option |  |  | Your agent handle (overrides identity config) |

--- a/mycelium-cli/src/mycelium/docs/commands/room.md
+++ b/mycelium-cli/src/mycelium/docs/commands/room.md
@@ -1,0 +1,137 @@
+# mycelium room
+
+Shared namespaces for agent coordination. Rooms can be sync (real-time negotiation), async (persistent memory), or hybrid.
+
+## Commands
+
+### `mycelium room await`
+
+Block until CognitiveEngine addresses you, then print the tick and exit.
+
+Designed for Claude Code agents: call this in a loop to participate in
+sync negotiation without a persistent SSE plugin.
+
+Flow:
+    1. mycelium room join --handle my-agent -m "my position"
+    2. mycelium room await --handle my-agent        # blocks
+       → prints tick JSON when CE addresses you
+    3. mycelium message propose budget=high          # respond
+    4. mycelium room await --handle my-agent        # wait for next tick
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--handle`, `-H` | option | Yes |  | Your agent handle (listens for ticks addressed to you) |
+| `--room`, `-r` | option |  |  | Room (overrides active room) |
+| `--timeout`, `-t` | option |  | `120` | Timeout in seconds (default 120) |
+
+### `mycelium room create`
+
+Create a new room.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | argument |  |  | Room name |
+| `--public`, `--private` | option |  | `True` |  |
+| `--mode`, `-m` | option |  | `sync` | Room mode: sync, async, or hybrid |
+| `--trigger` | option |  |  | Trigger config (e.g. 'threshold:5' or 'explicit') |
+| `--persistent` | option |  | `False` | Room persists after coordination completes |
+
+### `mycelium room delegate`
+
+Delegate a task to an agent in a room.
+
+Posts a 'delegate' type message to the room.
+
+Examples:
+    mycelium room delegate my-room --to cfn-agent --task "Scan CVE-2024-1234"
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `session_id` | argument | Yes |  | Room session/name |
+| `--to` | option | Yes |  | Target agent handle |
+| `--task`, `-t` | option | Yes |  | Task description to delegate |
+
+### `mycelium room delete`
+
+Delete a room.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `room_name` | argument | Yes |  | Room name to delete |
+| `--force`, `-f` | option |  | `False` |  |
+
+### `mycelium room join`
+
+Join the coordination backchannel for the current room.
+
+Room is resolved from --room, MYCELIUM_ROOM_ID env var, or 'mycelium room set'.
+Returns immediately after joining — CognitiveEngine will address you in this room
+when the session starts and when it is your turn to respond.
+
+Examples:
+    mycelium room join --handle julia-agent -m "My human wants to visit Hawaii"
+    mycelium room join --handle local-agent -m "..." --room my-experiment
+    mycelium room join --handle local-agent -f requirements.txt
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--message`, `-m` | option |  |  | Your requirements/intent for this coordination session |
+| `--file`, `-f` | option |  |  | Read requirements from a file |
+| `--room`, `-r` | option |  |  | Room to join (overrides MYCELIUM_ROOM_ID) |
+| `--handle`, `-H` | option | Yes |  | Agent handle (your identity in this coordination session) |
+
+### `mycelium room ls`
+
+List available rooms.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `--limit`, `-l` | option |  | `20` |  |
+| `--name`, `-n` | option |  |  |  |
+
+### `mycelium room respond`
+
+Post a message to a room (triggers NOTIFY).
+
+Examples:
+    mycelium room respond my-room --agent alpha#a1b2 --response "Task complete"
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `session_id` | argument | Yes |  | Room session/name |
+| `--agent`, `-a` | option | Yes |  | Agent handle sending the response |
+| `--response`, `-r` | option | Yes |  | Response message text |
+
+### `mycelium room set`
+
+Set active room for this project.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `room_name` | argument | Yes |  | Room name to set as active |
+
+### `mycelium room synthesize`
+
+Trigger CognitiveEngine synthesis for an async/hybrid room.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `room_name` | argument |  |  | Room to synthesize (default: active room) |
+| `--room`, `-r` | option |  |  | Room name (alternative to positional arg) |
+
+### `mycelium room watch`
+
+Stream live messages from a room.
+
+Auto-resolves the active room — no argument needed.
+Renders coordination events, agent joins, ticks, and consensus.
+
+Examples:
+    mycelium room watch
+    mycelium room watch my-room
+    mycelium room watch --timeout 120
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `room_name` | argument |  |  | Room to watch (default: active room) |
+| `--timeout`, `-t` | option |  | `0` | Timeout in seconds (0=no timeout) |

--- a/mycelium-cli/src/mycelium/docs/index.md
+++ b/mycelium-cli/src/mycelium/docs/index.md
@@ -1,0 +1,25 @@
+# Mycelium Documentation
+
+Multi-agent coordination + persistent memory.
+
+## Sections
+
+- **commands** — CLI reference (auto-generated from source)
+
+## Quick Start
+
+```bash
+mycelium docs commands cli-reference   # full CLI reference
+mycelium docs commands memory          # memory command group
+mycelium docs commands room            # room command group
+mycelium docs search "negotiate"       # search all docs
+```
+
+## Regenerating CLI Reference
+
+```bash
+mycelium docs generate
+```
+
+This introspects the Typer command tree and writes markdown into the
+bundled `docs/commands/` directory.

--- a/mycelium-cli/src/mycelium/generate_cli_docs.py
+++ b/mycelium-cli/src/mycelium/generate_cli_docs.py
@@ -1,0 +1,221 @@
+"""
+Auto-generate CLI reference documentation by introspecting the Typer/Click command tree.
+
+Usage:
+    from mycelium.generate_cli_docs import generate_all
+    generate_all()            # writes markdown into mycelium/docs/commands/
+    generate_all(output_dir)  # writes to a custom directory
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+
+def _docs_dir() -> Path:
+    """Default output directory — bundled docs/commands/ inside the package."""
+    return Path(__file__).parent / "docs" / "commands"
+
+
+# ── Click introspection helpers ──────────────────────────────────────────────
+
+
+def _format_param(param: click.Parameter) -> str:
+    """Format a single Click parameter as a markdown table row."""
+    names = ", ".join(f"`{n}`" for n in param.opts) if param.opts else f"`{param.name}`"
+    if param.secondary_opts:
+        names += ", " + ", ".join(f"`{s}`" for s in param.secondary_opts)
+
+    required = "Yes" if param.required else ""
+    default = ""
+    if param.default is not None and param.default != () and not param.required:
+        default = f"`{param.default}`"
+
+    help_text = ""
+    if isinstance(param, click.Option) and param.help:
+        help_text = param.help
+    elif isinstance(param, click.Argument):
+        # Typer stores argument help in the type's metavar or in custom attrs
+        help_text = getattr(param, "help", "") or ""
+        if not help_text and hasattr(param.type, "name"):
+            help_text = ""
+
+    kind = "argument" if isinstance(param, click.Argument) else "option"
+
+    return f"| {names} | {kind} | {required} | {default} | {help_text} |"
+
+
+def _extract_command_doc(cmd: click.Command, prefix: str = "") -> str:
+    """Generate markdown documentation for a single command."""
+    full_name = f"{prefix} {cmd.name}".strip() if cmd.name else prefix
+    lines: list[str] = []
+
+    # Heading
+    lines.append(f"### `{full_name}`")
+    lines.append("")
+
+    # Help text (first paragraph = short, rest = long description)
+    help_text = (cmd.help or "").strip()
+    if help_text:
+        # Strip Rich markup tags for docs
+        import re
+
+        clean = re.sub(r"\[/?[^\]]+\]", "", help_text)
+        lines.append(clean)
+        lines.append("")
+
+    # Parameters table
+    params = [p for p in cmd.params if p.name not in ("ctx", "help")]
+    if params:
+        lines.append("| Parameter | Type | Required | Default | Description |")
+        lines.append("|-----------|------|----------|---------|-------------|")
+        for param in params:
+            lines.append(_format_param(param))
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _walk_group(group: click.Group, prefix: str = "mycelium") -> list[tuple[str, str]]:
+    """Recursively walk a Click group and collect (section_key, markdown) pairs."""
+    results: list[tuple[str, str]] = []
+
+    for name in sorted(group.commands):
+        cmd = group.commands[name]
+        full_prefix = f"{prefix} {name}"
+
+        if isinstance(cmd, click.Group):
+            # It's a subgroup — generate a page for the whole group
+            section_md = _generate_group_page(cmd, full_prefix)
+            results.append((name, section_md))
+        else:
+            # Top-level command — collected into the "top-level" bucket
+            doc = _extract_command_doc(cmd, prefix)
+            results.append(("_top", doc))
+
+    return results
+
+
+def _generate_group_page(group: click.Group, prefix: str) -> str:
+    """Generate a full markdown page for a command group."""
+    group_name = prefix.split()[-1]
+    lines: list[str] = []
+
+    lines.append(f"# mycelium {group_name}")
+    lines.append("")
+
+    # Group help
+    help_text = (group.help or "").strip()
+    if help_text:
+        import re
+
+        clean = re.sub(r"\[/?[^\]]+\]", "", help_text)
+        lines.append(clean)
+        lines.append("")
+
+    lines.append("## Commands")
+    lines.append("")
+
+    for name in sorted(group.commands):
+        cmd = group.commands[name]
+        if name == group_name:
+            continue  # skip self-referencing callback
+        lines.append(_extract_command_doc(cmd, prefix))
+
+    return "\n".join(lines)
+
+
+def _generate_top_level_page(app_group: click.Group, top_level_docs: list[str]) -> str:
+    """Generate the top-level commands reference page."""
+    lines: list[str] = []
+
+    lines.append("# CLI Reference")
+    lines.append("")
+    lines.append("Auto-generated from CLI source. Run `mycelium docs generate` to regenerate.")
+    lines.append("")
+
+    # Global options
+    callback = app_group
+    if hasattr(callback, "params"):
+        global_params = [
+            p for p in callback.params if p.name not in ("help",) and isinstance(p, click.Option)
+        ]
+        if global_params:
+            lines.append("## Global Options")
+            lines.append("")
+            lines.append("| Parameter | Type | Required | Default | Description |")
+            lines.append("|-----------|------|----------|---------|-------------|")
+            for param in global_params:
+                lines.append(_format_param(param))
+            lines.append("")
+
+    # Top-level commands
+    lines.append("## Top-Level Commands")
+    lines.append("")
+    for doc in top_level_docs:
+        lines.append(doc)
+
+    # Command groups index
+    groups = [
+        name
+        for name in sorted(app_group.commands)
+        if isinstance(app_group.commands[name], click.Group)
+    ]
+    if groups:
+        lines.append("## Command Groups")
+        lines.append("")
+        for g in groups:
+            group_cmd = app_group.commands[g]
+            short_help = (group_cmd.help or "").split("\n")[0].strip()
+            import re
+
+            short_help = re.sub(r"\[/?[^\]]+\]", "", short_help)
+            lines.append(f"- [`mycelium {g}`](commands/{g}.md) — {short_help}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def generate_all(output_dir: Path | None = None) -> list[Path]:
+    """
+    Introspect the Typer app and write CLI reference docs.
+
+    Returns a list of generated file paths.
+    """
+    from mycelium.cli import app as typer_app
+
+    # Convert Typer app → Click group
+    click_app: click.Group = typer.main.get_group(typer_app)  # type: ignore[attr-defined]
+
+    out = output_dir or _docs_dir()
+    out.mkdir(parents=True, exist_ok=True)
+
+    entries = _walk_group(click_app)
+
+    top_level_docs: list[str] = []
+    written: list[Path] = []
+
+    for key, markdown in entries:
+        if key == "_top":
+            top_level_docs.append(markdown)
+        else:
+            dest = out / f"{key}.md"
+            dest.write_text(markdown)
+            written.append(dest)
+
+    # Write the index page
+    index = _generate_top_level_page(click_app, top_level_docs)
+    index_path = out.parent / "cli-reference.md"
+    index_path.write_text(index)
+    written.append(index_path)
+
+    return written
+
+
+# Need typer imported for get_group
+import typer  # noqa: E402


### PR DESCRIPTION
## Summary
Adds an automated CLI reference documentation generation system that introspects the Typer/Click command tree and generates markdown documentation files. This enables keeping CLI docs in sync with the actual command definitions without manual maintenance.

## Key Changes

- **New `generate_cli_docs.py` module**: Implements introspection of Click command groups to extract command metadata (parameters, help text, defaults) and generate formatted markdown documentation
  - `_format_param()`: Formats individual parameters as markdown table rows
  - `_extract_command_doc()`: Generates markdown for a single command with parameters table
  - `_walk_group()`: Recursively traverses command groups to collect documentation
  - `_generate_group_page()`: Creates full markdown pages for command groups
  - `_generate_top_level_page()`: Generates the main CLI reference index with global options and command group index
  - `generate_all()`: Public API that introspects the Typer app and writes all documentation files

- **New `docs generate` command**: Added to `mycelium/commands/docs.py` to expose the documentation generation functionality via CLI
  - Supports optional `--output` flag to write to custom directory
  - Defaults to bundled `docs/commands/` directory

- **Generated documentation files**:
  - `docs/cli-reference.md`: Main CLI reference index with global options and command group links
  - `docs/commands/adapter.md`: Adapter command group documentation
  - `docs/commands/config.md`: Config command group documentation
  - `docs/commands/docs.md`: Docs command group documentation
  - `docs/commands/memory.md`: Memory command group documentation
  - `docs/commands/message.md`: Message command group documentation
  - `docs/commands/room.md`: Room command group documentation
  - `docs/index.md`: Documentation index with quick start guide

## Implementation Details

- Uses Click's introspection API to extract command metadata without executing commands
- Strips Rich markup tags from help text for clean markdown output
- Generates parameter tables with name, type (argument/option), required status, default value, and description
- Organizes documentation hierarchically: global options → top-level commands → command groups
- Returns list of generated file paths for confirmation/logging

https://claude.ai/code/session_015J7M2WDAACHmsXm5NmtmXY