### PR TITLE
feat: decorator-based CLI reference docs generator

### DIFF
--- a/.claude/skills/generate-cli-docs/SKILL.md
+++ b/.claude/skills/generate-cli-docs/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: generate-cli-docs
+description: Regenerate the HTML CLI reference from @doc_ref decorators
+user_invocable: true
+---
+
+Regenerate the CLI Reference section of the HTML docs site from `@doc_ref` decorators in the CLI codebase.
+
+Steps:
+1. Run: `cd mycelium-cli && uv run python ../docs/generate_cli_reference.py`
+2. Report what was generated
+
+If a CLI command was added or modified and doesn't have a `@doc_ref` decorator, add one:
+
+```python
+from mycelium.doc_ref import doc_ref
+
+@doc_ref(
+    usage="mycelium <group> <command> <args>",
+    desc="One-line description. May contain <code>html</code>.",
+    group="room",  # room, memory, message, or "other" for top-level
+)
+@app.command()
+def my_command(...): ...
+```
+
+Then re-run the generator.

--- a/.claude/skills/precommit/SKILL.md
+++ b/.claude/skills/precommit/SKILL.md
@@ -26,6 +26,8 @@ Run all quality checks on the mycelium codebase. Report issues without auto-fixi
    cd fastapi-backend && python -m pytest tests/ -x -q
    ```
 
-4. **Report** — Summarize all issues found. Do NOT auto-fix anything. Just report what needs attention.
+4. **CLI docs check** — If any CLI command files were changed (`mycelium-cli/src/mycelium/commands/`), remind the user to run `/generate-cli-docs` to regenerate the HTML CLI reference. Check if any new commands are missing `@doc_ref` decorators.
+
+5. **Report** — Summarize all issues found. Do NOT auto-fix anything. Just report what needs attention.
 
 If everything passes, say so clearly.

--- a/docs/generate_cli_reference.py
+++ b/docs/generate_cli_reference.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Generate the CLI Reference HTML section for docs/index.html.
+
+Reads @doc_ref decorators from the CLI codebase and replaces the
+CLI Reference section in index.html with the generated HTML.
+
+Run from repo root:
+    cd mycelium-cli && uv run python ../docs/generate_cli_reference.py
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from collections import defaultdict
+from pathlib import Path
+
+# Group display config — controls section headings and sidebar labels.
+# Order here = order in the docs page.
+GROUP_CONFIG: list[tuple[str, str, str]] = [
+    # (group_key, heading_text, sidebar_label)
+    ("room", "room", "room"),
+    ("memory", "memory", "memory"),
+    ("message", "message", "message"),
+    ("other", "synthesize / catchup / watch", "synthesize / catchup / watch"),
+]
+
+
+def _generate_html() -> tuple[str, str]:
+    """Generate CLI Reference HTML section and sidebar nav.
+
+    Returns (section_html, sidebar_html).
+    """
+    # Import triggers all @doc_ref decorators to register
+    from mycelium.doc_ref import get_registry
+
+    # Force-import all command modules so decorators run
+    import mycelium.commands.memory  # noqa: F401
+    import mycelium.commands.message  # noqa: F401
+    import mycelium.commands.room  # noqa: F401
+
+    entries = get_registry()
+
+    # Group entries by group key, preserving registration order
+    groups: dict[str, list] = defaultdict(list)
+    for entry in entries:
+        groups[entry.group].append(entry)
+
+    # Build section HTML
+    section_lines = ['      <h2>CLI Reference</h2>']
+
+    sidebar_links = []
+
+    for group_key, heading, sidebar_label in GROUP_CONFIG:
+        if group_key not in groups:
+            continue
+
+        anchor = f"cli-{group_key}"
+        section_lines.append("")
+        section_lines.append(f'      <h3 id="{anchor}">{html.escape(heading)}</h3>')
+
+        sidebar_links.append(
+            f'      <a href="#{anchor}" class="nav-link sub">{html.escape(sidebar_label)}</a>'
+        )
+
+        for entry in groups[group_key]:
+            escaped_usage = html.escape(entry.usage)
+            section_lines.append("")
+            section_lines.append('      <div class="cmd-ref">')
+            section_lines.append('        <div class="cmd-ref-header">')
+            section_lines.append(f"          <code>{escaped_usage}</code>")
+            section_lines.append("        </div>")
+            # desc may contain intentional HTML (<code> tags), don't escape it
+            section_lines.append(f'        <div class="cmd-ref-body">{entry.desc}</div>')
+            section_lines.append("      </div>")
+
+    section_html = "\n".join(section_lines)
+
+    sidebar_html = "\n".join(
+        [
+            '    <div class="nav-section">',
+            '      <div class="nav-section-label">CLI Reference</div>',
+            *sidebar_links,
+            "    </div>",
+        ]
+    )
+
+    return section_html, sidebar_html
+
+
+def _replace_between_markers(content: str, marker: str, replacement: str) -> str:
+    """Replace content between <!-- marker --> and <!-- /marker --> comments."""
+    pattern = re.compile(
+        rf"(<!-- {re.escape(marker)} -->).*?(<!-- /{re.escape(marker)} -->)",
+        re.DOTALL,
+    )
+    match = pattern.search(content)
+    if not match:
+        msg = f"Could not find <!-- {marker} --> markers in index.html"
+        raise RuntimeError(msg)
+    return content[: match.start(1)] + match.group(1) + "\n" + replacement + "\n" + match.group(2) + content[match.end(2) :]
+
+
+def _update_index_html(section_html: str, sidebar_html: str) -> None:
+    """Replace the CLI Reference section and sidebar nav in docs/index.html."""
+    index_path = Path(__file__).parent / "index.html"
+    content = index_path.read_text()
+
+    content = _replace_between_markers(content, "codegen:cli-reference", section_html)
+    content = _replace_between_markers(content, "codegen:cli-sidebar", sidebar_html)
+
+    index_path.write_text(content)
+
+
+def main() -> None:
+    section_html, sidebar_html = _generate_html()
+    _update_index_html(section_html, sidebar_html)
+
+    # Count commands
+    from mycelium.doc_ref import get_registry
+
+    entries = get_registry()
+    groups = defaultdict(list)
+    for e in entries:
+        groups[e.group].append(e)
+
+    print(f"Updated docs/index.html with {len(entries)} commands:")
+    for group_key, heading, _ in GROUP_CONFIG:
+        if group_key in groups:
+            print(f"  {heading}: {len(groups[group_key])} commands")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/index.html
+++ b/docs/index.html
@@ -541,6 +541,7 @@
       <a href="#cognitive-engine" class="nav-link">CognitiveEngine</a>
       <a href="#knowledge-graph" class="nav-link">Knowledge Graph</a>
     </div>
+    <!-- codegen:cli-sidebar -->
     <div class="nav-section">
       <div class="nav-section-label">CLI Reference</div>
       <a href="#cli-room" class="nav-link sub">room</a>
@@ -548,6 +549,7 @@
       <a href="#cli-message" class="nav-link sub">message</a>
       <a href="#cli-other" class="nav-link sub">synthesize / catchup / watch</a>
     </div>
+<!-- /codegen:cli-sidebar -->
     <div class="nav-section">
       <div class="nav-section-label">Architecture</div>
       <a href="#stack" class="nav-link">Stack</a>
@@ -882,9 +884,17 @@ mycelium install</code></pre>
 
     <!-- CLI REFERENCE -->
     <section class="doc-section" id="cli-reference">
+      <!-- codegen:cli-reference -->
       <h2>CLI Reference</h2>
 
       <h3 id="cli-room">room</h3>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code>mycelium room ls</code>
+        </div>
+        <div class="cmd-ref-body">List all rooms with mode, state, and member count.</div>
+      </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
@@ -897,28 +907,21 @@ mycelium install</code></pre>
         <div class="cmd-ref-header">
           <code>mycelium room set &lt;name&gt;</code>
         </div>
-        <div class="cmd-ref-body">Set the active room for the current session. Subsequent <code>memory</code> and <code>message</code> commands use this room by default.</div>
+        <div class="cmd-ref-body">Set the active room. Subsequent <code>memory</code> and <code>message</code> commands use this room by default.</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code>mycelium room join --handle &lt;handle&gt; -m &lt;position&gt; [-c &lt;room&gt;]</code>
+          <code>mycelium room join --handle &lt;handle&gt; -m &lt;position&gt; [-r &lt;room&gt;]</code>
         </div>
         <div class="cmd-ref-body">Join a sync room with an initial position. Starts the 60s join window if you're the first.</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code>mycelium room await --handle &lt;handle&gt; [-c &lt;room&gt;]</code>
+          <code>mycelium room await --handle &lt;handle&gt; [-r &lt;room&gt;]</code>
         </div>
-        <div class="cmd-ref-body">Block and wait for a negotiation tick. Returns when CE has an action for your agent. Call this repeatedly between propose/respond actions until you receive <code>type: consensus</code>.</div>
-      </div>
-
-      <div class="cmd-ref">
-        <div class="cmd-ref-header">
-          <code>mycelium room ls</code>
-        </div>
-        <div class="cmd-ref-body">List all rooms.</div>
+        <div class="cmd-ref-body">Block and wait for a negotiation tick. Returns when CE has an action for your agent.</div>
       </div>
 
       <h3 id="cli-memory">memory</h3>
@@ -927,7 +930,7 @@ mycelium install</code></pre>
         <div class="cmd-ref-header">
           <code>mycelium memory set &lt;key&gt; &lt;value&gt; [--handle &lt;handle&gt;] [--update]</code>
         </div>
-        <div class="cmd-ref-body">Write a memory. Fails on duplicate key unless <code>--update</code> is passed.</div>
+        <div class="cmd-ref-body">Write a memory. Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Fails on duplicate unless <code>--update</code> is passed.</div>
       </div>
 
       <div class="cmd-ref">
@@ -955,26 +958,19 @@ mycelium install</code></pre>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code>mycelium message propose budget=&lt;v&gt; timeline=&lt;v&gt; scope=&lt;v&gt; quality=&lt;v&gt; -c &lt;room&gt; -H &lt;handle&gt;</code>
+          <code>mycelium message propose budget=&lt;v&gt; timeline=&lt;v&gt; scope=&lt;v&gt; quality=&lt;v&gt; -r &lt;room&gt; -H &lt;handle&gt;</code>
         </div>
         <div class="cmd-ref-body">Make a negotiation proposal with issue values. Only valid after <code>room await</code> returns <code>action: propose</code>.</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code>mycelium message respond &lt;accept|reject&gt; -c &lt;room&gt; -H &lt;handle&gt;</code>
+          <code>mycelium message respond &lt;accept|reject&gt; -r &lt;room&gt; -H &lt;handle&gt;</code>
         </div>
         <div class="cmd-ref-body">Accept or reject the current proposal. Only valid after <code>room await</code> returns <code>action: respond</code>.</div>
       </div>
 
       <h3 id="cli-other">synthesize / catchup / watch</h3>
-
-      <div class="cmd-ref">
-        <div class="cmd-ref-header">
-          <code>mycelium synthesize</code>
-        </div>
-        <div class="cmd-ref-body">Trigger CE to synthesize all memories in the active room into a structured summary.</div>
-      </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
@@ -985,10 +981,18 @@ mycelium install</code></pre>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
+          <code>mycelium synthesize</code>
+        </div>
+        <div class="cmd-ref-body">Trigger CE to synthesize all memories in the active room into a structured summary.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
           <code>mycelium watch [room]</code>
         </div>
         <div class="cmd-ref-body">Stream live room activity via SSE. Messages appear in real time as other agents write.</div>
       </div>
+<!-- /codegen:cli-reference -->
     </section>
 
     <hr class="divider">

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -16,6 +16,7 @@ from rich.console import Console
 from rich.table import Table
 
 from mycelium.config import MyceliumConfig
+from mycelium.doc_ref import doc_ref
 from mycelium.sstp import MEMORY_CATEGORIES, MemoryLogEntry
 
 app = typer.Typer(
@@ -47,6 +48,11 @@ def _get_active_room(room: str | None) -> str:
     raise typer.Exit(1)
 
 
+@doc_ref(
+    usage="mycelium memory set <key> <value> [--handle <handle>] [--update]",
+    desc="Write a memory. Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Fails on duplicate unless <code>--update</code> is passed.",
+    group="memory",
+)
 @app.command(name="set")
 def memory_set(
     key: str = typer.Argument(..., help="Memory key (e.g. 'status/deploy', 'project/config')"),
@@ -158,6 +164,11 @@ def memory_set(
             console.print(f"[green]Memory set:[/green] {room_name}/{key}")
 
 
+@doc_ref(
+    usage="mycelium memory get <key>",
+    desc="Read a memory by exact key.",
+    group="memory",
+)
 @app.command(name="get")
 def memory_get(
     key: str = typer.Argument(..., help="Memory key"),
@@ -187,6 +198,11 @@ def memory_get(
             console.print(str(value))
 
 
+@doc_ref(
+    usage="mycelium memory ls [prefix/]",
+    desc="List memories. Optional prefix filters by namespace.",
+    group="memory",
+)
 @app.command(name="ls")
 def memory_ls(
     namespace: str | None = typer.Argument(
@@ -231,6 +247,11 @@ def memory_ls(
             console.print()
 
 
+@doc_ref(
+    usage="mycelium memory search <query>",
+    desc="Semantic search — finds memories by meaning using cosine similarity on local embeddings.",
+    group="memory",
+)
 @app.command(name="search")
 def memory_search(
     query: str = typer.Argument(..., help="Natural language search query"),
@@ -309,6 +330,11 @@ def memory_subscribe(
             console.print(f"[green]Subscribed:[/green] {pattern} (id: {sub_id}...)")
 
 
+@doc_ref(
+    usage="mycelium catchup",
+    desc="Get a full briefing on everything in the room — ideal for a new agent joining an active project.",
+    group="other",
+)
 @app.command(name="catchup")
 def memory_catchup(
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),

--- a/mycelium-cli/src/mycelium/commands/message.py
+++ b/mycelium-cli/src/mycelium/commands/message.py
@@ -17,6 +17,7 @@ import typer
 from pydantic import ValidationError
 
 from mycelium.config import MyceliumConfig
+from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
 from mycelium.sstp import ProposeReply, RespondReply
 
@@ -65,6 +66,11 @@ def _post(ctx: typer.Context, room: str | None, handle: str | None, content: str
 # ── propose ───────────────────────────────────────────────────────────────────
 
 
+@doc_ref(
+    usage="mycelium message propose budget=<v> timeline=<v> scope=<v> quality=<v> -r <room> -H <handle>",
+    desc="Make a negotiation proposal with issue values. Only valid after <code>room await</code> returns <code>action: propose</code>.",
+    group="message",
+)
 @app.command("propose")
 def propose(
     ctx: typer.Context,
@@ -124,6 +130,11 @@ def propose(
 VALID_ACTIONS = {"accept", "reject", "end"}
 
 
+@doc_ref(
+    usage="mycelium message respond <accept|reject> -r <room> -H <handle>",
+    desc="Accept or reject the current proposal. Only valid after <code>room await</code> returns <code>action: respond</code>.",
+    group="message",
+)
 @app.command("respond")
 def respond(
     ctx: typer.Context,

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import typer
 
 from mycelium.config import MyceliumConfig
+from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
 from mycelium.exceptions import ConfigNotFoundError, MyceliumError
 
@@ -81,6 +82,11 @@ def room_main(ctx: typer.Context) -> None:
         print_error(e, verbose=verbose)
 
 
+@doc_ref(
+    usage="mycelium room ls",
+    desc="List all rooms with mode, state, and member count.",
+    group="room",
+)
 @app.command("ls")
 def list_rooms(
     ctx: typer.Context,
@@ -137,6 +143,11 @@ def list_rooms(
         print_error(e, verbose=verbose)
 
 
+@doc_ref(
+    usage="mycelium room create <name> --mode <async|sync|hybrid> [--trigger threshold:N]",
+    desc="Create a new coordination room. Mode is required.",
+    group="room",
+)
 @app.command()
 def create(
     ctx: typer.Context,
@@ -208,6 +219,11 @@ def create(
         print_error(e, verbose=verbose)
 
 
+@doc_ref(
+    usage="mycelium synthesize",
+    desc="Trigger CE to synthesize all memories in the active room into a structured summary.",
+    group="other",
+)
 @app.command()
 def synthesize(
     ctx: typer.Context,
@@ -255,6 +271,11 @@ def synthesize(
         print_error(e, verbose=verbose)
 
 
+@doc_ref(
+    usage="mycelium room set <name>",
+    desc="Set the active room. Subsequent <code>memory</code> and <code>message</code> commands use this room by default.",
+    group="room",
+)
 @app.command()
 def set(
     ctx: typer.Context,
@@ -486,6 +507,11 @@ def _render_coordination_event(msg: dict, current_identity: str) -> tuple[str | 
     return None, False
 
 
+@doc_ref(
+    usage="mycelium room join --handle <handle> -m <position> [-r <room>]",
+    desc="Join a sync room with an initial position. Starts the 60s join window if you're the first.",
+    group="room",
+)
 @app.command()
 def join(
     ctx: typer.Context,
@@ -703,6 +729,11 @@ def _watch_room(config: MyceliumConfig, room_name: str, timeout: int) -> None:
                     console.print(rendered, highlight=False)
 
 
+@doc_ref(
+    usage="mycelium room await --handle <handle> [-r <room>]",
+    desc="Block and wait for a negotiation tick. Returns when CE has an action for your agent.",
+    group="room",
+)
 @app.command(name="await")
 def await_tick(
     ctx: typer.Context,
@@ -813,6 +844,11 @@ def await_tick(
         print_error(e, verbose=verbose)
 
 
+@doc_ref(
+    usage="mycelium watch [room]",
+    desc="Stream live room activity via SSE. Messages appear in real time as other agents write.",
+    group="other",
+)
 @app.command()
 def watch(
     ctx: typer.Context,

--- a/mycelium-cli/src/mycelium/doc_ref.py
+++ b/mycelium-cli/src/mycelium/doc_ref.py
@@ -1,0 +1,56 @@
+"""
+Decorator for registering CLI commands in the HTML docs reference.
+
+Usage:
+    from mycelium.doc_ref import doc_ref
+
+    @doc_ref(
+        usage="mycelium room create <name> --mode <async|sync|hybrid> [--trigger threshold:N]",
+        desc="Create a new coordination room. Mode is required.",
+        group="room",
+    )
+    @app.command()
+    def create(...): ...
+
+Then run `docs/generate_cli_reference.py` to update the HTML docs site.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# Global registry — collected at import time, read by the generator.
+_registry: list[DocEntry] = []
+
+
+@dataclass
+class DocEntry:
+    usage: str
+    desc: str
+    group: str
+
+
+def doc_ref(
+    usage: str,
+    desc: str,
+    group: str = "other",
+) -> Callable:
+    """Register a CLI command for the HTML docs reference.
+
+    Args:
+        usage: The full command signature shown in docs.
+        desc: One-line description for the docs page. May contain HTML.
+        group: Command group name (e.g. "room", "memory"). Use "other" for top-level.
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        _registry.append(DocEntry(usage=usage, desc=desc, group=group))
+        return fn
+
+    return decorator
+
+
+def get_registry() -> list[DocEntry]:
+    """Return all registered doc entries, in definition order."""
+    return list(_registry)


### PR DESCRIPTION
## Summary

- Adds `@doc_ref` decorator for explicitly registering CLI commands in the HTML docs site
- Generator script (`docs/generate_cli_reference.py`) reads the decorator registry and replaces content between `<!-- codegen:cli-reference -->` markers in `index.html`
- Commands appear in definition order within each group — no manual ordering needed
- Descriptions are curated per-command, not auto-extracted from `--help` text

## What's included

- `doc_ref.py` — decorator + global registry
- `generate_cli_reference.py` — marker-based HTML generation
- `@doc_ref` decorators on 14 commands (room, memory, message, top-level)
- `/generate-cli-docs` skill for easy regeneration
- `/precommit` updated to flag when CLI docs may need regeneration

Supersedes #10 (which generated markdown docs inside the CLI package instead of updating the HTML docs site).

## Test plan

- [ ] Run `/generate-cli-docs` and verify output
- [ ] Check docs page renders correctly on mobile and desktop
- [ ] Add a new `@doc_ref` decorator, re-run, verify it appears