### PR TITLE
refactor: CLI pattern audit — rename commands, standardize flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Embeddings: fastembed (BAAI/bge-small-en-v1.5, local, 384 dimensions).
 - **Rooms are namespaces** — memories are scoped to rooms. A room IS its namespace.
 - **Three room modes** — sync (NegMAS negotiation), async (persistent memory), hybrid (both).
 - **The CLI skill is a protocol** — join → wait → respond → consensus. This is the value add, don't change it to an augmentation layer.
-- **Upserts require --update** — `memory set` fails on duplicate keys unless `--update` is passed.
+- **memory set always upserts** — `memory set` overwrites existing keys automatically (version increments).
 - **No Ensue references in code** — we took inspiration from their API design but the implementation is independent.
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ mycelium install
 
 # Create a room and start sharing context
 mycelium room create my-project --mode async
-mycelium room set my-project
+mycelium room use my-project
 mycelium memory set "context/goal" "Build a REST API for the new service"
 mycelium memory set "decision/db" "PostgreSQL with pgvector for embeddings"
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -21,16 +21,16 @@ mycelium --help
 
 ```bash
 mycelium room create design-review --mode async --trigger threshold:5
-mycelium room set design-review
+mycelium room use design-review
 ```
 
 ### Agent 1: Julia shares architecture decisions
 
 ```bash
 # Category keys (work/, decisions/, context/, status/) get auto-validated
-mycelium memory set decisions/database "Consolidated to single AgensGraph instance — SQL + graph + vector in one DB" -h julia-agent
-mycelium memory set decisions/llm-provider "litellm — 100+ providers, one interface" -h julia-agent
-mycelium memory set decisions/api-style "REST for now, generated OpenAPI client for type safety" -h julia-agent
+mycelium memory set decisions/database "Consolidated to single AgensGraph instance — SQL + graph + vector in one DB" -H julia-agent
+mycelium memory set decisions/llm-provider "litellm — 100+ providers, one interface" -H julia-agent
+mycelium memory set decisions/api-style "REST for now, generated OpenAPI client for type safety" -H julia-agent
 ```
 
 ### Agent 2: Selina shares research
@@ -44,15 +44,15 @@ mycelium memory set "research/fastembed" "BAAI/bge-small-en-v1.5 runs locally, 3
 ### Agent 3: Kappa reports what didn't work
 
 ```bash
-mycelium memory set decisions/no-sqlite-tests "SQLite can't handle pgvector or JSONB — need real Postgres for integration tests" -h kappa-agent
-mycelium memory set decisions/no-qdrant "Considered Qdrant but AgensGraph+pgvector eliminates the need" -h kappa-agent
+mycelium memory set decisions/no-sqlite-tests "SQLite can't handle pgvector or JSONB — need real Postgres for integration tests" -H kappa-agent
+mycelium memory set decisions/no-qdrant "Considered Qdrant but AgensGraph+pgvector eliminates the need" -H kappa-agent
 ```
 
 ### Agent 4: Prometheus shares status
 
 ```bash
-mycelium memory set status/cfn-integration "Working on CFN integration — mapping mycelium agents to CFN objects" -h prometheus-agent
-mycelium memory set context/blocker "Need ioc-cfn-mgmt-plane-svc running to test agent registration flow" -h prometheus-agent
+mycelium memory set status/cfn-integration "Working on CFN integration — mapping mycelium agents to CFN objects" -H prometheus-agent
+mycelium memory set context/blocker "Need ioc-cfn-mgmt-plane-svc running to test agent registration flow" -H prometheus-agent
 ```
 
 ### Browse & Search

--- a/docs/index.html
+++ b/docs/index.html
@@ -658,7 +658,7 @@ mycelium install</code></pre>
 <span class="cmd">mycelium room create</span> my-project <span class="flag">--mode</span> async
 
 <span class="comment"># Set it as your active room</span>
-<span class="cmd">mycelium room set</span> my-project
+<span class="cmd">mycelium room use</span> my-project
 
 <span class="comment"># Share context</span>
 <span class="cmd">mycelium memory set</span> <span class="str">"decisions/db"</span> <span class="str">"PostgreSQL with pgvector"</span>
@@ -776,8 +776,8 @@ mycelium install</code></pre>
 
       <div class="callout callout-note">
         <div class="callout-bar"></div>
-        <div class="callout-body"><strong>Upserts require --update.</strong> Calling <code>memory set</code> on an existing key
-        fails unless you pass <code>--update</code>. This prevents silent overwrites of shared context.</div>
+        <div class="callout-body"><strong>Always upserts.</strong> Calling <code>memory set</code> on an existing key
+        overwrites it. The version number increments automatically so you can track changes.</div>
       </div>
 
       <h3>Semantic Search</h3>
@@ -905,9 +905,9 @@ mycelium install</code></pre>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code>mycelium room set &lt;name&gt;</code>
+          <code>mycelium room use &lt;name&gt;</code>
         </div>
-        <div class="cmd-ref-body">Set the active room. Subsequent <code>memory</code> and <code>message</code> commands use this room by default.</div>
+        <div class="cmd-ref-body">Switch active room. Subsequent <code>memory</code> and <code>message</code> commands use this room by default.</div>
       </div>
 
       <div class="cmd-ref">
@@ -928,9 +928,9 @@ mycelium install</code></pre>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code>mycelium memory set &lt;key&gt; &lt;value&gt; [--handle &lt;handle&gt;] [--update]</code>
+          <code>mycelium memory set &lt;key&gt; &lt;value&gt; [--handle &lt;handle&gt;]</code>
         </div>
-        <div class="cmd-ref-body">Write a memory. Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Fails on duplicate unless <code>--update</code> is passed.</div>
+        <div class="cmd-ref-body">Write a memory (upsert). Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Always upserts — the backend handles versioning.</div>
       </div>
 
       <div class="cmd-ref">

--- a/mycelium-cli/src/mycelium/adapters/claude-code/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/skills/mycelium/SKILL.md
@@ -39,7 +39,7 @@ mycelium memory rm <key>
 mycelium memory subscribe "decision/*" --handle claude-agent
 ```
 
-All memory commands use the active room. Set it with `mycelium room set <name>` or pass `--room <name>`.
+All memory commands use the active room. Set it with `mycelium room use <name>` or pass `--room <name>`.
 
 ## Room Operations
 
@@ -50,7 +50,7 @@ mycelium room create sprint-plan --mode sync                     # real-time neg
 mycelium room create design-review --mode hybrid --trigger threshold:5  # both
 
 # Set active room
-mycelium room set my-project
+mycelium room use my-project
 
 # List rooms
 mycelium room ls
@@ -128,7 +128,7 @@ The catchup shows: latest CognitiveEngine synthesis (current state, what worked,
 
 ```bash
 # 1. Set your project room
-mycelium room set my-project
+mycelium room use my-project
 
 # 2. Catch up on what others have done
 mycelium memory catchup

--- a/mycelium-cli/src/mycelium/adapters/openclaw/extensions/mycelium/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/extensions/mycelium/skills/mycelium/SKILL.md
@@ -79,7 +79,7 @@ mycelium room watch <room-name>
 
 ### Post a direct message
 ```
-mycelium room respond <room-name> --agent <your-handle> --response "<text>"
+mycelium room post <room-name> --agent <your-handle> --response "<text>"
 ```
 
 ### Delegate a subtask

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -49,8 +49,8 @@ def _get_active_room(room: str | None) -> str:
 
 
 @doc_ref(
-    usage="mycelium memory set <key> <value> [--handle <handle>] [--update]",
-    desc="Write a memory. Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Fails on duplicate unless <code>--update</code> is passed.",
+    usage="mycelium memory set <key> <value> [--handle <handle>]",
+    desc="Write a memory (upsert). Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Always upserts — the backend handles versioning.",
     group="memory",
 )
 @app.command(name="set")
@@ -60,19 +60,16 @@ def memory_set(
     room: str | None = typer.Option(
         None, "--room", "-r", help="Room name (defaults to active room)"
     ),
-    handle: str = typer.Option("cli-user", "--handle", "-h", help="Agent handle"),
+    handle: str = typer.Option("cli-user", "--handle", "-H", help="Agent handle"),
     no_embed: bool = typer.Option(False, "--no-embed", help="Skip vector embedding"),
     tags: str | None = typer.Option(None, "--tags", "-t", help="Comma-separated tags"),
-    update: bool = typer.Option(
-        False, "--update", "-u", help="Allow overwriting an existing memory"
-    ),
 ) -> None:
-    """Write a memory to a room's persistent namespace.
+    """Write a memory to a room's persistent namespace (upsert).
 
     Keys with a known category prefix (work/, decisions/, context/, status/) are
     validated for slug format. Other keys pass through freely.
 
-    Fails if the key already exists unless --update is passed.
+    Always upserts — the backend handles versioning.
 
     Examples:
         mycelium memory set status/deploy ACTIVE
@@ -82,9 +79,6 @@ def memory_set(
     """
     from mycelium_backend_client.api.memory import (
         create_memories_rooms_room_name_memory_post as create_api,
-    )
-    from mycelium_backend_client.api.memory import (
-        get_memory_rooms_room_name_memory_key_get as get_api,
     )
     from mycelium_backend_client.models import MemoryBatchCreate, MemoryCreate
 
@@ -108,23 +102,6 @@ def memory_set(
                 else:
                     console.print(f"[red]Error:[/red] {exc}")
                 raise typer.Exit(1) from exc
-
-    # Check for existing key unless --update is set
-    if not update:
-        try:
-            from mycelium_backend_client.errors import UnexpectedStatus
-
-            with _get_client() as client:
-                existing = get_api.sync(room_name=room_name, key=key, client=client)
-                if existing is not None:
-                    console.print(
-                        f"[red]Error:[/red] {room_name}/{key} already exists (v{existing.version}). "
-                        f"Use [bold]--update[/bold] to overwrite."
-                    )
-                    raise typer.Exit(1)
-        except UnexpectedStatus as e:
-            if e.status_code != 404:
-                raise
 
     tag_list = [t.strip() for t in tags.split(",")] if tags else None
 
@@ -312,7 +289,7 @@ def memory_rm(
 def memory_subscribe(
     pattern: str = typer.Argument(..., help="Key glob pattern (e.g. 'project/*')"),
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
-    handle: str = typer.Option("cli-user", "--handle", "-h", help="Subscriber agent handle"),
+    handle: str = typer.Option("cli-user", "--handle", "-H", help="Subscriber agent handle"),
 ) -> None:
     """Subscribe to memory change notifications."""
     from mycelium_backend_client.api.memory import (

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -5,11 +5,11 @@ Commands:
 - (default): Show current active room
 - ls: List rooms
 - create: Create a new room
-- set: Set active room context
+- use: Switch active room context
 - delete: Delete a room
 - join: Join coordination backchannel (blocks until first coordination tick)
 - watch: Stream messages from a room via SSE
-- respond: Post a message to a room
+- post: Post a message to a room
 - delegate: Delegate a task to an agent in a room
 """
 
@@ -56,7 +56,7 @@ def room_main(ctx: typer.Context) -> None:
                 typer.echo(json_module.dumps({"active_room": None}))
             else:
                 typer.secho("No active room set.", fg=typer.colors.YELLOW)
-                typer.echo("Set a room with: mycelium room set <name>")
+                typer.echo("Set a room with: mycelium room use <name>")
             raise typer.Exit(1)
 
         from mycelium_backend_client.api.rooms import list_rooms_rooms_get as list_api
@@ -136,7 +136,7 @@ def list_rooms(
                     typer.echo(f"    {room['name']}  (created {created_at})")
 
             typer.echo("")
-            typer.echo("Use 'mycelium room set <name>' to set the active room")
+            typer.echo("Use 'mycelium room use <name>' to set the active room")
 
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False
@@ -212,7 +212,7 @@ def create(
             typer.echo(f"  ID:      {room_data.get('id')}")
             typer.echo(f"  Created: {str(room_data.get('created_at', ''))[:10]}")
             typer.echo("")
-            typer.echo(f"  Run 'mycelium room set {name}' to make it your active room")
+            typer.echo(f"  Run 'mycelium room use {name}' to make it your active room")
 
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False
@@ -272,16 +272,16 @@ def synthesize(
 
 
 @doc_ref(
-    usage="mycelium room set <name>",
-    desc="Set the active room. Subsequent <code>memory</code> and <code>message</code> commands use this room by default.",
+    usage="mycelium room use <name>",
+    desc="Switch active room. Subsequent <code>memory</code> and <code>message</code> commands use this room by default.",
     group="room",
 )
-@app.command()
-def set(
+@app.command("use")
+def use(
     ctx: typer.Context,
     room_name: str = typer.Argument(..., help="Room name to set as active"),
 ) -> None:
-    """Set active room for this project."""
+    """Switch active room for this project."""
     try:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
         json_output = ctx.obj.get("json", False) if ctx.obj else False
@@ -356,7 +356,7 @@ def _resolve_room(config: MyceliumConfig, channel: str | None = None) -> str:
     Priority:
       1. --room flag (explicit override, used as-is)
       2. MYCELIUM_ROOM_ID env var (used as-is)
-      3. config.rooms.active (set via 'mycelium room set')
+      3. config.rooms.active (set via 'mycelium room use')
       4. Error
     """
     if channel:
@@ -370,7 +370,7 @@ def _resolve_room(config: MyceliumConfig, channel: str | None = None) -> str:
         "No room context found",
         suggestion=(
             "Pass --room <room>, set MYCELIUM_ROOM_ID in your environment, "
-            "or run: mycelium room set <name>"
+            "or run: mycelium room use <name>"
         ),
     )
 
@@ -529,7 +529,7 @@ def join(
     """
     Join the coordination backchannel for the current room.
 
-    Room is resolved from --room, MYCELIUM_ROOM_ID env var, or 'mycelium room set'.
+    Room is resolved from --room, MYCELIUM_ROOM_ID env var, or 'mycelium room use'.
     Returns immediately after joining — CognitiveEngine will address you in this room
     when the session starts and when it is your turn to respond.
 
@@ -878,8 +878,8 @@ def watch(
         print_error(e, verbose=verbose)
 
 
-@app.command()
-def respond(
+@app.command("post")
+def post(
     ctx: typer.Context,
     session_id: str = typer.Argument(..., help="Room session/name"),
     agent: str = typer.Option(..., "--agent", "-a", help="Agent handle sending the response"),
@@ -889,7 +889,7 @@ def respond(
     Post a message to a room (triggers NOTIFY).
 
     Examples:
-        mycelium room respond my-room --agent alpha#a1b2 --response "Task complete"
+        mycelium room post my-room --agent alpha#a1b2 --response "Task complete"
     """
     try:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841

--- a/mycelium-cli/src/mycelium/docs/concepts/rooms.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/rooms.md
@@ -24,7 +24,7 @@ mycelium room create sprint --mode hybrid --persistent # hybrid
 Set an active room to avoid passing `--room` on every command:
 
 ```bash
-mycelium room set lab
+mycelium room use lab
 mycelium memory status    # uses 'lab' automatically
 ```
 

--- a/mycelium-cli/src/mycelium/docs/guides/structured-memory.md
+++ b/mycelium-cli/src/mycelium/docs/guides/structured-memory.md
@@ -30,7 +30,7 @@ category prefix, it checks the slug format and auto-timestamps the content.
 
 ```bash
 mycelium room create project-x --mode async --persistent
-mycelium room set project-x
+mycelium room use project-x
 ```
 
 ### 2. Write structured memories as you work
@@ -93,8 +93,8 @@ Latest Synthesis
 ### 5. Update status as things change
 
 ```bash
-# --update/-u flag allows overwriting
-mycelium memory set status/deploy "ACTIVE — deployed to vps.example.com" -u
+# memory set always upserts — just set the new value
+mycelium memory set status/deploy "ACTIVE — deployed to vps.example.com"
 ```
 
 ## Type Safety

--- a/mycelium-cli/src/mycelium/docs/index.md
+++ b/mycelium-cli/src/mycelium/docs/index.md
@@ -13,7 +13,7 @@ Built-in reference for the Mycelium multi-agent coordination CLI.
 mycelium init              # Set up local config
 mycelium up                # Start the backend
 mycelium room create lab   # Create a room
-mycelium room set lab      # Make it your active room
+mycelium room use lab      # Make it your active room
 mycelium memory set work/setup "Initialized the project"
 mycelium memory status     # See what's active
 mycelium catchup           # Get briefed on a room

--- a/mycelium-cli/src/mycelium/utils/room.py
+++ b/mycelium-cli/src/mycelium/utils/room.py
@@ -19,7 +19,7 @@ def ensure_room_set(
         if room_override.strip() == "":
             raise MyceliumError(
                 "Empty room name not allowed",
-                suggestion="Run 'mycelium room set <room-name>' to set your active room",
+                suggestion="Run 'mycelium room use <room-name>' to set your active room",
             )
         target_room = room_override
     elif active_room:
@@ -27,7 +27,7 @@ def ensure_room_set(
     else:
         raise MyceliumError(
             "No room set",
-            suggestion="Run 'mycelium room set <room-name>' first",
+            suggestion="Run 'mycelium room use <room-name>' first",
         )
 
     if target_room != active_room:

--- a/scratchpad/cli-pattern-audit.md
+++ b/scratchpad/cli-pattern-audit.md
@@ -1,5 +1,16 @@
 # CLI Pattern Audit
 
+## Status: Implemented
+
+The following changes from this audit have been implemented:
+
+- `room respond` renamed to `room post` (avoids collision with `message respond`)
+- `room set` renamed to `room use` (avoids overloaded verb confusion with `config set`)
+- `memory set` no longer requires `--update` flag (always upserts)
+- `--handle/-h` standardized to `--handle/-H` everywhere (avoids collision with `--help`)
+
+---
+
 *What agents will assume, what breaks those assumptions, and what to fix.*
 
 The test: an agent that has never read our docs tries to use the CLI based on


### PR DESCRIPTION
## Summary

- `room set` → `room use` — fixes overloaded verb ("set" implies key-value write)
- `room respond` → `room post` — fixes collision with SSTP `message respond` 
- `memory set` always upserts — drops `--update` guard, backend handles versioning
- `--handle/-H` standardized everywhere (memory commands used `-h` which collides with `--help`)

## Files touched

- CLI command definitions (room.py, memory.py)
- All documentation (index.html, demo-script.md, README, CLAUDE.md)
- Adapter skills (claude-code, openclaw)
- Internal docs (concepts, guides, index)
- Regenerated CLI reference HTML via codegen markers

## Test plan

- [ ] `mycelium room use <name>` works (was `room set`)
- [ ] `mycelium room post` works (was `room respond`)
- [ ] `mycelium memory set key value` upserts without `--update`
- [ ] `mycelium memory set key value -H agent` works (was `-h`)
- [ ] Backend tests pass
- [ ] No stale references to old command names in docs