### PR TITLE
feat: /decompose skill — extract session into structured room memory

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -551,6 +551,11 @@
     </div>
 <!-- /codegen:cli-sidebar -->
     <div class="nav-section">
+      <div class="nav-section-label">Skills</div>
+      <a href="#skill-decompose" class="nav-link sub">decompose</a>
+      <a href="#skill-mycelium" class="nav-link sub">mycelium</a>
+    </div>
+    <div class="nav-section">
       <div class="nav-section-label">Architecture</div>
       <a href="#stack" class="nav-link">Stack</a>
       <a href="#adapters" class="nav-link">Adapters</a>
@@ -993,6 +998,62 @@ mycelium install</code></pre>
         <div class="cmd-ref-body">Stream live room activity via SSE. Messages appear in real time as other agents write.</div>
       </div>
 <!-- /codegen:cli-reference -->
+    </section>
+
+    <hr class="divider">
+
+    <!-- SKILLS -->
+    <section class="doc-section" id="skills">
+      <h2>Skills</h2>
+      <p>
+        Skills are protocol-level instructions that any agent can run — no code, just a well-defined
+        prompt with a schema for what to extract and where to put it. They ship with the adapters
+        (Claude Code, OpenClaw) and work with any agent that has CLI access.
+      </p>
+
+      <h3 id="skill-decompose">/decompose</h3>
+      <p>
+        Fungi decompose organic matter into reusable nutrients. This skill does the same
+        with conversation — extracting decisions, work artifacts, context, and procedures
+        from your session and persisting them into room memory.
+      </p>
+      <pre><code><span class="cmd">/decompose</span> [room-name]</code></pre>
+      <p>
+        The agent walks through its current session and identifies findings that fit
+        the structured memory categories:
+      </p>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>Category</th><th>What to extract</th><th>Example key</th></tr></thead>
+          <tbody>
+            <tr><td><code>decisions/</code></td><td>Choices made, alternatives rejected, and why</td><td><code>decisions/no-sqlite</code></td></tr>
+            <tr><td><code>work/</code></td><td>Concrete artifacts — code written, features built</td><td><code>work/cli-reference-generator</code></td></tr>
+            <tr><td><code>status/</code></td><td>Current state of things — what's passing, what's blocked</td><td><code>status/ci</code></td></tr>
+            <tr><td><code>context/</code></td><td>Constraints, preferences, goals for future agents</td><td><code>context/typography</code></td></tr>
+            <tr><td><code>procedures/</code></td><td>Reusable step-by-step instructions</td><td><code>procedures/ship-pr</code></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        Each finding becomes a <code>mycelium memory set</code> call. The skill is idempotent —
+        <code>memory set</code> upserts, so re-running is safe.
+      </p>
+
+      <h3 id="skill-mycelium">/mycelium</h3>
+      <p>
+        The core coordination skill. Join rooms, share memory, search shared knowledge,
+        and participate in negotiation sessions. This is the primary interface between
+        an agent and the Mycelium network.
+      </p>
+      <pre><code><span class="comment"># Join a room and contribute</span>
+<span class="cmd">mycelium room use</span> design-review
+<span class="cmd">mycelium memory set</span> decisions/api-style <span class="str">"REST for now, generated OpenAPI client"</span>
+
+<span class="comment"># Search what other agents know</span>
+<span class="cmd">mycelium memory search</span> <span class="str">"database decisions"</span>
+
+<span class="comment"># Get briefed on everything in the room</span>
+<span class="cmd">mycelium catchup</span></code></pre>
     </section>
 
     <hr class="divider">

--- a/mycelium-cli/src/mycelium/adapters/claude-code/skills/decompose/SKILL.md
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/skills/decompose/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: decompose
+description: Extract structured memories from your current session into a Mycelium room
+user_invocable: true
+---
+
+# /decompose
+
+Decompose your current session into structured Mycelium memories.
+
+Fungi decompose organic matter into reusable nutrients. This skill does the same with conversation — extracting decisions, work artifacts, context, and procedures from your session and persisting them into the room's collective memory.
+
+## How to run
+
+```
+/decompose [room-name]
+```
+
+If no room is given, use the active room (`mycelium room use`).
+
+## Extraction schema
+
+Walk through your current session and identify anything that fits these categories. For each finding, run `mycelium memory set <key> "<value>" -H <your-handle>`.
+
+### `decisions/` — Choices made and why
+
+What was decided, what alternatives were considered, what was rejected.
+
+- Key format: `decisions/<slug>` (e.g. `decisions/no-redis`, `decisions/use-agens-graph`)
+- Value should include the choice AND the reasoning
+- Include negative decisions — what you tried and abandoned, and why
+
+Examples:
+```bash
+mycelium memory set decisions/no-sqlite "SQLite can't handle pgvector — need real Postgres for integration tests"
+mycelium memory set decisions/upsert-by-default "Dropped --update flag, memory set always upserts. Backend has version tracking for conflict detection."
+```
+
+### `work/` — What was built or changed
+
+Concrete artifacts: code written, files changed, features implemented.
+
+- Key format: `work/<slug>` (e.g. `work/cli-reference-generator`, `work/auth-middleware`)
+- Value should describe what was done, not just name the file
+
+Examples:
+```bash
+mycelium memory set work/doc-ref-decorator "Added @doc_ref decorator system for registering CLI commands in HTML docs. Generator reads registry and replaces content between codegen markers."
+mycelium memory set work/mobile-layout-fix "Fixed negotiation flow steps — switched from flex to positioned counters so inline code elements wrap correctly on mobile."
+```
+
+### `status/` — Where things stand
+
+Current state of work in progress, blockers, what's passing/failing.
+
+- Key format: `status/<slug>` (e.g. `status/deploy`, `status/ci`)
+- Value should be the current state, not history
+
+Examples:
+```bash
+mycelium memory set status/ci "All checks passing — backend tests (67 passed, 12 skipped), CLI lint clean"
+mycelium memory set status/blocker "Need ioc-cfn-mgmt-plane-svc running to test agent registration flow"
+```
+
+### `context/` — Background and constraints
+
+User preferences, project constraints, goals, environment facts that future agents need.
+
+- Key format: `context/<slug>` (e.g. `context/user-goal`, `context/deploy-target`)
+- Value should explain WHY this matters, not just state it
+
+Examples:
+```bash
+mycelium memory set context/typography "Keep Cormorant Garamond + IBM Plex Sans pairing. Only change sizing/rhythm."
+mycelium memory set context/protocol-is-value "The CLI skill being a protocol (join-wait-respond-consensus) is by design. Don't change it to an augmentation layer."
+```
+
+### `procedures/` — Reusable how-to steps
+
+Steps you figured out that another agent could follow to repeat a task.
+
+- Key format: `procedures/<slug>` (e.g. `procedures/regenerate-cli-docs`, `procedures/deploy`)
+- Value should be step-by-step, concrete enough to follow without context
+
+Examples:
+```bash
+mycelium memory set procedures/regenerate-cli-docs "1. Add @doc_ref decorator to command. 2. cd mycelium-cli && uv run python ../docs/generate_cli_reference.py. 3. Verify with /last-screenshot or browser."
+mycelium memory set procedures/ship-pr "1. /precommit. 2. git add specific files. 3. git commit with conventional prefix. 4. git push -u origin branch. 5. gh pr create. 6. gh pr checks --watch. 7. gh pr merge --admin."
+```
+
+## Guidelines
+
+- **Be selective** — not everything in a session is worth persisting. Extract what a future agent would need to avoid rediscovering.
+- **Be specific** — "fixed the bug" is useless. "Fixed mobile layout — flex on li turned inline code into flex items, switched to positioned counters" is useful.
+- **Include negative results** — what you tried and abandoned is as valuable as what worked.
+- **Idempotent** — `memory set` upserts, so re-running is safe.
+- **Report what you wrote** — after extracting, list the keys you set so the user can review.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/extensions/mycelium/skills/decompose/SKILL.md
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/extensions/mycelium/skills/decompose/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: decompose
+description: Extract structured memories from your current session into a Mycelium room
+user_invocable: true
+---
+
+# /decompose
+
+Decompose your current session into structured Mycelium memories.
+
+Fungi decompose organic matter into reusable nutrients. This skill does the same with conversation — extracting decisions, work artifacts, context, and procedures from your session and persisting them into the room's collective memory.
+
+## How to run
+
+```
+/decompose [room-name]
+```
+
+If no room is given, use the active room (`mycelium room use`).
+
+## Extraction schema
+
+Walk through your current session and identify anything that fits these categories. For each finding, run `mycelium memory set <key> "<value>" -H <your-handle>`.
+
+### `decisions/` — Choices made and why
+
+What was decided, what alternatives were considered, what was rejected.
+
+- Key format: `decisions/<slug>` (e.g. `decisions/no-redis`, `decisions/use-agens-graph`)
+- Value should include the choice AND the reasoning
+- Include negative decisions — what you tried and abandoned, and why
+
+Examples:
+```bash
+mycelium memory set decisions/no-sqlite "SQLite can't handle pgvector — need real Postgres for integration tests"
+mycelium memory set decisions/upsert-by-default "Dropped --update flag, memory set always upserts. Backend has version tracking for conflict detection."
+```
+
+### `work/` — What was built or changed
+
+Concrete artifacts: code written, files changed, features implemented.
+
+- Key format: `work/<slug>` (e.g. `work/cli-reference-generator`, `work/auth-middleware`)
+- Value should describe what was done, not just name the file
+
+Examples:
+```bash
+mycelium memory set work/doc-ref-decorator "Added @doc_ref decorator system for registering CLI commands in HTML docs. Generator reads registry and replaces content between codegen markers."
+mycelium memory set work/mobile-layout-fix "Fixed negotiation flow steps — switched from flex to positioned counters so inline code elements wrap correctly on mobile."
+```
+
+### `status/` — Where things stand
+
+Current state of work in progress, blockers, what's passing/failing.
+
+- Key format: `status/<slug>` (e.g. `status/deploy`, `status/ci`)
+- Value should be the current state, not history
+
+Examples:
+```bash
+mycelium memory set status/ci "All checks passing — backend tests (67 passed, 12 skipped), CLI lint clean"
+mycelium memory set status/blocker "Need ioc-cfn-mgmt-plane-svc running to test agent registration flow"
+```
+
+### `context/` — Background and constraints
+
+User preferences, project constraints, goals, environment facts that future agents need.
+
+- Key format: `context/<slug>` (e.g. `context/user-goal`, `context/deploy-target`)
+- Value should explain WHY this matters, not just state it
+
+Examples:
+```bash
+mycelium memory set context/typography "Keep Cormorant Garamond + IBM Plex Sans pairing. Only change sizing/rhythm."
+mycelium memory set context/protocol-is-value "The CLI skill being a protocol (join-wait-respond-consensus) is by design. Don't change it to an augmentation layer."
+```
+
+### `procedures/` — Reusable how-to steps
+
+Steps you figured out that another agent could follow to repeat a task.
+
+- Key format: `procedures/<slug>` (e.g. `procedures/regenerate-cli-docs`, `procedures/deploy`)
+- Value should be step-by-step, concrete enough to follow without context
+
+Examples:
+```bash
+mycelium memory set procedures/regenerate-cli-docs "1. Add @doc_ref decorator to command. 2. cd mycelium-cli && uv run python ../docs/generate_cli_reference.py. 3. Verify with /last-screenshot or browser."
+mycelium memory set procedures/ship-pr "1. /precommit. 2. git add specific files. 3. git commit with conventional prefix. 4. git push -u origin branch. 5. gh pr create. 6. gh pr checks --watch. 7. gh pr merge --admin."
+```
+
+## Guidelines
+
+- **Be selective** — not everything in a session is worth persisting. Extract what a future agent would need to avoid rediscovering.
+- **Be specific** — "fixed the bug" is useless. "Fixed mobile layout — flex on li turned inline code into flex items, switched to positioned counters" is useful.
+- **Include negative results** — what you tried and abandoned is as valuable as what worked.
+- **Idempotent** — `memory set` upserts, so re-running is safe.
+- **Report what you wrote** — after extracting, list the keys you set so the user can review.


### PR DESCRIPTION
## Summary

- `/decompose [room]` skill for both Claude Code and OpenClaw adapters
- Agent-neutral markdown prompt — no code, just a well-defined schema
- Instructs any agent to walk its session, extract findings into structured memory categories (decisions/, work/, status/, context/, procedures/), and persist via `mycelium memory set`
- Skills section added to HTML docs page

Closes #14

## Test plan

- [ ] Run `/decompose` in a Claude Code session with an active room
- [ ] Verify memories are written with correct category prefixes
- [ ] Check docs page Skills section renders correctly