### PR TITLE
chore: add SPDX-License-Identifier headers to all source files

### DIFF
--- a/docs/generate_cli_reference.py
+++ b/docs/generate_cli_reference.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Generate the CLI Reference HTML section for docs/index.html.
 

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Generate docs/index.html from markdown source files + CLI @doc_ref decorators.
 

--- a/fastapi-backend/alembic_migrations/__init__.py
+++ b/fastapi-backend/alembic_migrations/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/fastapi-backend/alembic_migrations/env.py
+++ b/fastapi-backend/alembic_migrations/env.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 import asyncio
 import os
 from logging.config import fileConfig

--- a/fastapi-backend/alembic_migrations/versions/0001_initial.py
+++ b/fastapi-backend/alembic_migrations/versions/0001_initial.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Initial schema — users, rooms, messages, sessions, presences.
 
 Revision ID: 0001

--- a/fastapi-backend/alembic_migrations/versions/0002_coordination.py
+++ b/fastapi-backend/alembic_migrations/versions/0002_coordination.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Add coordination fields to rooms and sessions.
 
 Revision ID: 0002

--- a/fastapi-backend/alembic_migrations/versions/0003_drop_presences_and_user_tables.py
+++ b/fastapi-backend/alembic_migrations/versions/0003_drop_presences_and_user_tables.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Drop presences and user tables.
 
 Revision ID: 0003

--- a/fastapi-backend/alembic_migrations/versions/0004_add_audit_events.py
+++ b/fastapi-backend/alembic_migrations/versions/0004_add_audit_events.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Add audit_events table.
 
 Revision ID: 0004

--- a/fastapi-backend/alembic_migrations/versions/0005_add_workspace_mas_agents.py
+++ b/fastapi-backend/alembic_migrations/versions/0005_add_workspace_mas_agents.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Add workspaces, mas, agents tables.
 
 Revision ID: 0005

--- a/fastapi-backend/alembic_migrations/versions/0006_add_memory_and_room_modes.py
+++ b/fastapi-backend/alembic_migrations/versions/0006_add_memory_and_room_modes.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Add persistent memory system and room mode extensions.
 
 Enables pgvector extension, creates memories and memory_subscriptions tables,

--- a/fastapi-backend/alembic_migrations/versions/0007_add_notebook_scope_and_namespace_fields.py
+++ b/fastapi-backend/alembic_migrations/versions/0007_add_notebook_scope_and_namespace_fields.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Add notebook scope to memories and namespace fields to rooms.
 
 Adds scope/owner_handle columns to memories for notebook (agent-private)

--- a/fastapi-backend/alembic_migrations/versions/0008_add_file_path_to_memories.py
+++ b/fastapi-backend/alembic_migrations/versions/0008_add_file_path_to_memories.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Add file_path column to memories for filesystem-native storage.
 
 Revision ID: 0008

--- a/fastapi-backend/app/__init__.py
+++ b/fastapi-backend/app/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/fastapi-backend/app/agents/__init__.py
+++ b/fastapi-backend/app/agents/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 # Cognitive agents: semantic_negotiation and evidence_gathering

--- a/fastapi-backend/app/agents/evidence_gathering/__init__.py
+++ b/fastapi-backend/app/agents/evidence_gathering/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/fastapi-backend/app/agents/evidence_gathering/embeddings.py
+++ b/fastapi-backend/app/agents/evidence_gathering/embeddings.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Embedding manager (ported from ioc-cfn-cognitive-agents).
 
 Rewired: config path resolves relative to this file.

--- a/fastapi-backend/app/agents/evidence_gathering/evidence.py
+++ b/fastapi-backend/app/agents/evidence_gathering/evidence.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Evidence gathering pipeline (ported from ioc-cfn-cognitive-agents).
 
 Rewired: uses local schemas; no external dependencies/config references.

--- a/fastapi-backend/app/agents/evidence_gathering/llm_clients.py
+++ b/fastapi-backend/app/agents/evidence_gathering/llm_clients.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """LLM clients for evidence gathering (ported from ioc-cfn-cognitive-agents).
 
 Rewired: uses Azure OpenAI when AZURE_OPENAI_* env vars are set; graceful

--- a/fastapi-backend/app/agents/evidence_gathering/multi_entities.py
+++ b/fastapi-backend/app/agents/evidence_gathering/multi_entities.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Multi-entity evidence engine (ported from ioc-cfn-cognitive-agents).
 
 Rewired: imports use local package paths.

--- a/fastapi-backend/app/agents/evidence_gathering/schemas.py
+++ b/fastapi-backend/app/agents/evidence_gathering/schemas.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Evidence gathering request/response schemas (ported from ioc-cfn-cognitive-agents)."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/evidence_gathering/single_entity.py
+++ b/fastapi-backend/app/agents/evidence_gathering/single_entity.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Single-entity evidence engine (ported from ioc-cfn-cognitive-agents).
 
 Rewired: all imports use local package paths (no ..api.schemas, no ..config).

--- a/fastapi-backend/app/agents/evidence_gathering/utiles.py
+++ b/fastapi-backend/app/agents/evidence_gathering/utiles.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Path utilities, GraphSession, and MMR selection (ported from ioc-cfn-cognitive-agents)."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/llm_provider.py
+++ b/fastapi-backend/app/agents/llm_provider.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 LLM provider for semantic negotiation agents.
 

--- a/fastapi-backend/app/agents/protocol/__init__.py
+++ b/fastapi-backend/app/agents/protocol/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/fastapi-backend/app/agents/protocol/sstp/__init__.py
+++ b/fastapi-backend/app/agents/protocol/sstp/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 sstp — Pydantic v2 models for the Semantic State Transfer Protocol (SSTP)
 ================================================================================

--- a/fastapi-backend/app/agents/protocol/sstp/__main__.py
+++ b/fastapi-backend/app/agents/protocol/sstp/__main__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Dump SSTP JSON Schema(s) or example messages to stdout.
 

--- a/fastapi-backend/app/agents/protocol/sstp/_base.py
+++ b/fastapi-backend/app/agents/protocol/sstp/_base.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 sstp/_base.py — Shared literals, sub-models, and envelope base for SSTP.
 

--- a/fastapi-backend/app/agents/protocol/sstp/commit.py
+++ b/fastapi-backend/app/agents/protocol/sstp/commit.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """sstp/commit.py — SSTPCommitMessage kind."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/protocol/sstp/delegation.py
+++ b/fastapi-backend/app/agents/protocol/sstp/delegation.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """sstp/delegation.py — DelegationMessage kind."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/protocol/sstp/evidence_bundle.py
+++ b/fastapi-backend/app/agents/protocol/sstp/evidence_bundle.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """sstp/evidence_bundle.py — EvidenceBundleMessage kind."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/protocol/sstp/intent.py
+++ b/fastapi-backend/app/agents/protocol/sstp/intent.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """sstp/intent.py — IntentMessage kind."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/protocol/sstp/knowledge.py
+++ b/fastapi-backend/app/agents/protocol/sstp/knowledge.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """sstp/knowledge.py — KnowledgeMessage kind."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/protocol/sstp/memory_delta.py
+++ b/fastapi-backend/app/agents/protocol/sstp/memory_delta.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """sstp/memory_delta.py — MemoryDeltaMessage kind."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/protocol/sstp/negmas_sao.py
+++ b/fastapi-backend/app/agents/protocol/sstp/negmas_sao.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 negmas_sao.py — Local Pydantic v2 mirror of NegMAS SAO types
 =============================================================

--- a/fastapi-backend/app/agents/protocol/sstp/negotiate.py
+++ b/fastapi-backend/app/agents/protocol/sstp/negotiate.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """sstp/negotiate.py — SSTPNegotiateMessage kind with NegMAS SAO semantic context."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/protocol/sstp/query.py
+++ b/fastapi-backend/app/agents/protocol/sstp/query.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """sstp/query.py — QueryMessage kind."""
 
 from __future__ import annotations

--- a/fastapi-backend/app/agents/semantic_negotiation/__init__.py
+++ b/fastapi-backend/app/agents/semantic_negotiation/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Semantic negotiation agent package."""
 
 from .semantic_negotiation import (

--- a/fastapi-backend/app/agents/semantic_negotiation/intent_discovery.py
+++ b/fastapi-backend/app/agents/semantic_negotiation/intent_discovery.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Intent discovery — component 1 of the semantic negotiation pipeline.
 
 Ported from ioc-cfn-cognitive-agents/semantic-negotiation-agent/app/agent/intent_discovery.py.

--- a/fastapi-backend/app/agents/semantic_negotiation/negotiation_model.py
+++ b/fastapi-backend/app/agents/semantic_negotiation/negotiation_model.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Negotiation model — component 3 of the semantic negotiation pipeline.
 
 Takes issues (from component 1) and options per issue (from component 2) and

--- a/fastapi-backend/app/agents/semantic_negotiation/options_generation.py
+++ b/fastapi-backend/app/agents/semantic_negotiation/options_generation.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Options generation — component 2 of the semantic negotiation pipeline.
 
 Ported from ioc-cfn-cognitive-agents/semantic-negotiation-agent/app/agent/options_generation.py.

--- a/fastapi-backend/app/agents/semantic_negotiation/room_negotiator.py
+++ b/fastapi-backend/app/agents/semantic_negotiation/room_negotiator.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """RoomNegotiator — NegMAS SAO negotiator that routes decisions through Mycelium rooms.
 
 Routes decisions through room messages rather than HTTP callbacks.

--- a/fastapi-backend/app/agents/semantic_negotiation/semantic_negotiation.py
+++ b/fastapi-backend/app/agents/semantic_negotiation/semantic_negotiation.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Semantic negotiation pipeline — top-level orchestrator.
 
 Wires together the three components in order:

--- a/fastapi-backend/app/bus.py
+++ b/fastapi-backend/app/bus.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Async Postgres LISTEN/NOTIFY bus.
 

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 from pathlib import Path
 
 from pydantic import field_validator

--- a/fastapi-backend/app/database.py
+++ b/fastapi-backend/app/database.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 from collections.abc import AsyncGenerator
 from urllib.parse import urlparse
 

--- a/fastapi-backend/app/knowledge/__init__.py
+++ b/fastapi-backend/app/knowledge/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/fastapi-backend/app/knowledge/adapter.py
+++ b/fastapi-backend/app/knowledge/adapter.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Convert knowledge graph API schemas to/from Node/Edge models."""
 
 import json

--- a/fastapi-backend/app/knowledge/edge.py
+++ b/fastapi-backend/app/knowledge/edge.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 import json
 import re
 from dataclasses import dataclass, field

--- a/fastapi-backend/app/knowledge/graph_db.py
+++ b/fastapi-backend/app/knowledge/graph_db.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Sync AgensGraph database access.
 

--- a/fastapi-backend/app/knowledge/ingestion.py
+++ b/fastapi-backend/app/knowledge/ingestion.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Two-stage LLM extraction service for OpenClaw turns.
 

--- a/fastapi-backend/app/knowledge/node.py
+++ b/fastapi-backend/app/knowledge/node.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 import json
 import logging
 from dataclasses import dataclass, field

--- a/fastapi-backend/app/knowledge/prompts.py
+++ b/fastapi-backend/app/knowledge/prompts.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Format-specific system prompts for concept and relationship extraction.
 

--- a/fastapi-backend/app/knowledge/schemas.py
+++ b/fastapi-backend/app/knowledge/schemas.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Knowledge graph API schemas — ported from ioc-knowledge-memory-svc."""
 
 from enum import Enum

--- a/fastapi-backend/app/knowledge/service.py
+++ b/fastapi-backend/app/knowledge/service.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Knowledge graph service — business logic layer."""
 
 import logging

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Mycelium FastAPI backend.
 

--- a/fastapi-backend/app/models.py
+++ b/fastapi-backend/app/models.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Mycelium data models.
 

--- a/fastapi-backend/app/routes/__init__.py
+++ b/fastapi-backend/app/routes/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/fastapi-backend/app/routes/agents.py
+++ b/fastapi-backend/app/routes/agents.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Agent CRUD — POST/GET/PATCH/DELETE /api/workspaces/{wid}/mas/{mid}/agents."""
 
 import logging

--- a/fastapi-backend/app/routes/audit.py
+++ b/fastapi-backend/app/routes/audit.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Audit event endpoints (internal API).
 

--- a/fastapi-backend/app/routes/cfn_proxy.py
+++ b/fastapi-backend/app/routes/cfn_proxy.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 CFN proxy endpoints.
 

--- a/fastapi-backend/app/routes/cognition_engine.py
+++ b/fastapi-backend/app/routes/cognition_engine.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Cognition Engine adapter endpoints.
 

--- a/fastapi-backend/app/routes/knowledge.py
+++ b/fastapi-backend/app/routes/knowledge.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Knowledge graph endpoints.
 

--- a/fastapi-backend/app/routes/mas.py
+++ b/fastapi-backend/app/routes/mas.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """MAS CRUD — POST/GET/DELETE /api/workspaces/{workspace_id}/mas."""
 
 import logging

--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Memory API — persistent namespaced key-value store with semantic vector search.
 

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Messages API — POST only.
 

--- a/fastapi-backend/app/routes/notebook.py
+++ b/fastapi-backend/app/routes/notebook.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Notebook API — agent-private memory scoped by handle.
 

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Room CRUD endpoints."""
 
 import logging

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Sessions API — tracks agent presence in rooms.
 

--- a/fastapi-backend/app/routes/stream.py
+++ b/fastapi-backend/app/routes/stream.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 SSE stream endpoint — GET /rooms/{room}/messages/stream
 

--- a/fastapi-backend/app/routes/workspaces.py
+++ b/fastapi-backend/app/routes/workspaces.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Workspace CRUD — POST/GET/DELETE /api/workspaces."""
 
 import logging

--- a/fastapi-backend/app/services/__init__.py
+++ b/fastapi-backend/app/services/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/fastapi-backend/app/services/async_coordination.py
+++ b/fastapi-backend/app/services/async_coordination.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Async CognitiveEngine — synthesis for namespace rooms.
 

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Multi-agent coordination service.
 

--- a/fastapi-backend/app/services/embedding.py
+++ b/fastapi-backend/app/services/embedding.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Local embedding service using sentence-transformers.
 

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Memory storage — markdown files with YAML frontmatter.
 

--- a/fastapi-backend/app/services/indexer.py
+++ b/fastapi-backend/app/services/indexer.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Filesystem → pgvector indexer.
 

--- a/fastapi-backend/app/services/reindex.py
+++ b/fastapi-backend/app/services/reindex.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Auto-reindex: startup scan + file watcher.
 

--- a/fastapi-backend/scripts/test_negotiation_llm.py
+++ b/fastapi-backend/scripts/test_negotiation_llm.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Test script for intent_discovery + options_generation using the configured LiteLLM.
 

--- a/fastapi-backend/tests/__init__.py
+++ b/fastapi-backend/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/fastapi-backend/tests/conftest.py
+++ b/fastapi-backend/tests/conftest.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Shared test fixtures.
 

--- a/fastapi-backend/tests/test_audit.py
+++ b/fastapi-backend/tests/test_audit.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Tests for /api/internal/audit-events endpoints."""
 
 import pytest

--- a/fastapi-backend/tests/test_cfn_proxy.py
+++ b/fastapi-backend/tests/test_cfn_proxy.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Tests for CFN proxy endpoints."""
 
 import httpx

--- a/fastapi-backend/tests/test_filesystem.py
+++ b/fastapi-backend/tests/test_filesystem.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Tests for the filesystem-native memory service."""
 
 import tempfile

--- a/fastapi-backend/tests/test_ingestion.py
+++ b/fastapi-backend/tests/test_ingestion.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Tests for Phase 8 additions:
 - MEMORY_OPERATION audit type (schema change)

--- a/fastapi-backend/tests/test_integration.py
+++ b/fastapi-backend/tests/test_integration.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Integration tests — require a running Postgres/AgensGraph with pgvector.
 

--- a/fastapi-backend/tests/test_memory.py
+++ b/fastapi-backend/tests/test_memory.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Tests for the persistent memory API.
 

--- a/fastapi-backend/tests/test_notebook.py
+++ b/fastapi-backend/tests/test_notebook.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Tests for notebook (agent-private) memory."""
 
 import pytest

--- a/fastapi-backend/tests/test_registry.py
+++ b/fastapi-backend/tests/test_registry.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Tests for workspace / MAS / agent CRUD endpoints."""
 
 import pytest

--- a/fastapi-backend/tests/test_session_spawn.py
+++ b/fastapi-backend/tests/test_session_spawn.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Tests for session spawning within namespace rooms."""
 
 import pytest

--- a/fastapi-backend/tests/test_structured_memory.py
+++ b/fastapi-backend/tests/test_structured_memory.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Tests for structured memory conventions and synthesis grouping.
 

--- a/mycelium-cli/src/mycelium/__init__.py
+++ b/mycelium-cli/src/mycelium/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Mycelium CLI — IoC/CFN coordination layer."""
 
 from importlib.metadata import PackageNotFoundError, version

--- a/mycelium-cli/src/mycelium/__main__.py
+++ b/mycelium-cli/src/mycelium/__main__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Allow running mycelium as a module: python -m mycelium"""
 
 from mycelium.cli import app

--- a/mycelium-cli/src/mycelium/adapters/__init__.py
+++ b/mycelium-cli/src/mycelium/adapters/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/mycelium-cli/src/mycelium/adapters/claude-code/__init__.py
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/mycelium-cli/src/mycelium/adapters/openclaw/__init__.py
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/mycelium-cli/src/mycelium/adapters/openclaw/extensions/mycelium/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/extensions/mycelium/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { homedir } from "node:os";

--- a/mycelium-cli/src/mycelium/animations/__init__.py
+++ b/mycelium-cli/src/mycelium/animations/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Animation modules for Mycelium CLI."""
 
 from mycelium.animations.spores import (

--- a/mycelium-cli/src/mycelium/animations/spores.py
+++ b/mycelium-cli/src/mycelium/animations/spores.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Twinkling spore starfield animation for the Mycelium CLI.
 Call run_animation_with_output() or run_animation_live() to play.

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Mycelium CLI — Multi-agent coordination + persistent memory.
 """

--- a/mycelium-cli/src/mycelium/commands/__init__.py
+++ b/mycelium-cli/src/mycelium/commands/__init__.py
@@ -1,1 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Mycelium CLI command modules."""

--- a/mycelium-cli/src/mycelium/commands/adapter.py
+++ b/mycelium-cli/src/mycelium/commands/adapter.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Adapter commands — connect agent frameworks to Mycelium.
 

--- a/mycelium-cli/src/mycelium/commands/config.py
+++ b/mycelium-cli/src/mycelium/commands/config.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Config commands for Mycelium CLI."""
 
 import json as json_module

--- a/mycelium-cli/src/mycelium/commands/docs.py
+++ b/mycelium-cli/src/mycelium/commands/docs.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Documentation commands for Mycelium CLI.
 

--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Install command for Mycelium CLI.
 

--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Instance management commands for Mycelium CLI.
 

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Memory commands — persistent namespaced memory operations.
 

--- a/mycelium-cli/src/mycelium/commands/message.py
+++ b/mycelium-cli/src/mycelium/commands/message.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Message coordination commands for Mycelium CLI.
 

--- a/mycelium-cli/src/mycelium/commands/notebook.py
+++ b/mycelium-cli/src/mycelium/commands/notebook.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Notebook commands — agent-private persistent memory.
 

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Session commands — breakout negotiation within rooms.
 

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Configuration management for Mycelium CLI.
 

--- a/mycelium-cli/src/mycelium/doc_ref.py
+++ b/mycelium-cli/src/mycelium/doc_ref.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Decorator for registering CLI commands in the HTML docs reference.
 

--- a/mycelium-cli/src/mycelium/docker/__init__.py
+++ b/mycelium-cli/src/mycelium/docker/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+

--- a/mycelium-cli/src/mycelium/error_handler.py
+++ b/mycelium-cli/src/mycelium/error_handler.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Error handler for formatting exceptions into user-friendly CLI messages."""
 
 import httpx

--- a/mycelium-cli/src/mycelium/exceptions.py
+++ b/mycelium-cli/src/mycelium/exceptions.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Custom exceptions for Mycelium CLI."""
 
 

--- a/mycelium-cli/src/mycelium/filesystem.py
+++ b/mycelium-cli/src/mycelium/filesystem.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Memory file operations for the CLI.
 

--- a/mycelium-cli/src/mycelium/http_client.py
+++ b/mycelium-cli/src/mycelium/http_client.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 HTTP client for Mycelium API.
 

--- a/mycelium-cli/src/mycelium/identity.py
+++ b/mycelium-cli/src/mycelium/identity.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Identity management for Mycelium CLI.
 

--- a/mycelium-cli/src/mycelium/sstp.py
+++ b/mycelium-cli/src/mycelium/sstp.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """
 Lightweight SSTP (Semantic State Transfer Protocol) models for the CLI.
 

--- a/mycelium-cli/src/mycelium/utils/__init__.py
+++ b/mycelium-cli/src/mycelium/utils/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Utility modules for Mycelium CLI."""
 
 from mycelium.utils.room import ensure_room_set

--- a/mycelium-cli/src/mycelium/utils/room.py
+++ b/mycelium-cli/src/mycelium/utils/room.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
 """Room utilities for Mycelium CLI."""
 
 from mycelium.config import MyceliumConfig

--- a/mycelium-frontend/next.config.ts
+++ b/mycelium-frontend/next.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 import type { NextConfig } from "next";
 const nextConfig: NextConfig = {};
 export default nextConfig;

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 import type { Metadata } from "next";
 import "./globals.css";
 

--- a/mycelium-frontend/src/app/page.tsx
+++ b/mycelium-frontend/src/app/page.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 "use client";
 
 import { useEffect, useState } from "react";

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 "use client";
 
 import { useParams, useRouter } from "next/navigation";

--- a/mycelium-frontend/src/components/create-room-dialog.tsx
+++ b/mycelium-frontend/src/components/create-room-dialog.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 "use client";
 
 import { useState } from "react";

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 "use client";
 
 import { useEffect, useRef, useState } from "react";

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 "use client";
 
 import { useEffect, useState, useCallback } from "react";

--- a/mycelium-frontend/src/components/room-card.tsx
+++ b/mycelium-frontend/src/components/room-card.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 "use client";
 
 import Link from "next/link";

--- a/mycelium-frontend/src/components/sessions-panel.tsx
+++ b/mycelium-frontend/src/components/sessions-panel.tsx
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 "use client";
 
 import { useEffect, useState } from "react";

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8888";
 
 export async function fetchRooms() {

--- a/mycelium-frontend/src/lib/utils.ts
+++ b/mycelium-frontend/src/lib/utils.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) { return twMerge(clsx(inputs)); }

--- a/mycelium-frontend/tailwind.config.ts
+++ b/mycelium-frontend/tailwind.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
 import type { Config } from "tailwindcss";
 
 const config: Config = {


### PR DESCRIPTION
## Summary

Add a two-line SPDX header to all `.py`, `.ts`, and `.tsx` source files:

\`\`\`
# SPDX-License-Identifier: Apache-2.0
# Copyright 2026 Julia Valenti
\`\`\`

Covers `fastapi-backend/`, `mycelium-cli/src/`, `mycelium-frontend/src/`, and `docs/` scripts. Excludes generated code (`mycelium-client/`, `node_modules/`, `.venv/`, `.next/`).

## Test plan

- [ ] Spot-check a few files across each subproject for correct header placement