### PR TITLE
fix: CFN database provisioning fails silently on install

### DIFF
--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -316,6 +316,22 @@ def _get_compose_path() -> Path:
     dest = Path.home() / ".mycelium" / "docker" / "compose.yml"
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_bytes(compose_ref.read_bytes())
+
+    # Also copy bundled initdb/ scripts so the Postgres initdb hook creates
+    # cfn_mgmt and cfn_cp on first DB init (compose mounts ./initdb as initdb.d).
+    try:
+        initdb_dest = dest.parent / "initdb"
+        initdb_dest.mkdir(exist_ok=True)
+        initdb_pkg = importlib.resources.files("mycelium.docker.initdb")
+        for item in importlib.resources.contents("mycelium.docker.initdb"):
+            if item.startswith("_"):
+                continue
+            script_path = initdb_dest / item
+            script_path.write_bytes((initdb_pkg / item).read_bytes())
+            script_path.chmod(0o755)
+    except Exception:
+        pass  # non-fatal: _ensure_cfn_databases() handles it at install time
+
     return dest
 
 
@@ -445,10 +461,16 @@ def _ensure_cfn_databases(db_container: str = "mycelium-db") -> None:
     """
     for db in ("cfn_mgmt", "cfn_cp"):
         sql = f"SELECT 'CREATE DATABASE {db}' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '{db}')\\gexec"
-        subprocess.run(
+        result = subprocess.run(
             ["docker", "exec", db_container, "psql", "-U", "postgres", "-c", sql],
             capture_output=True,
         )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to create database '{db}':\n{result.stderr.decode().strip()}\n"
+                "Tip: if Docker requires sudo on this system, add your user to the "
+                "docker group:  sudo usermod -aG docker $USER  (then re-login)."
+            )
 
 
 def _wait_for_db_container(
@@ -737,7 +759,9 @@ def install(
                 if not _compose_up_services(compose_path, env_path, services=["mycelium-db"]):
                     typer.secho("\n  ✗ docker compose up failed (db)", fg=typer.colors.RED)
                     raise typer.Exit(1) from None
-                _wait_for_db_container(compose_path, env_path)
+                if not _wait_for_db_container(compose_path, env_path):
+                    typer.secho("\n  ✗ Timed out waiting for mycelium-db to become healthy", fg=typer.colors.RED)
+                    raise typer.Exit(1) from None
                 _ensure_cfn_databases()
                 typer.echo("  ✓ CFN databases provisioned")
 
@@ -970,7 +994,9 @@ def install(
             if not _compose_up_services(compose_path, env_path, services=["mycelium-db"]):
                 typer.secho("\n  ✗ docker compose up failed (db)", fg=typer.colors.RED)
                 raise typer.Exit(1) from None
-            _wait_for_db_container(compose_path, env_path)
+            if not _wait_for_db_container(compose_path, env_path):
+                typer.secho("\n  ✗ Timed out waiting for mycelium-db to become healthy", fg=typer.colors.RED)
+                raise typer.Exit(1) from None
             _ensure_cfn_databases()
             typer.echo("  ✓ CFN databases provisioned")
 


### PR DESCRIPTION
## Summary

Three bugs in `mycelium install` caused `cfn_mgmt` and `cfn_cp` databases to never be created when installing with the IoC/CFN stack, leaving `ioc-cfn-mgmt-plane-svc` and `ioc-cognition-fabric-node-svc` stuck in a crash loop with `database does not exist` errors.

- **Bug 1** — `_ensure_cfn_databases()` used `capture_output=True` with no `returncode` check, silently swallowing `docker exec` failures. On systems where Docker requires `sudo` (user not in the `docker` group), the command failed silently and `✓ CFN databases provisioned` was printed despite nothing being created.

- **Bug 2** — `_wait_for_db_container()` return value was ignored at both call sites (interactive and non-interactive paths). If the DB wasn't ready yet, `_ensure_cfn_databases()` ran immediately and psql failed — again silently.

- **Bug 3** — `_get_compose_path()` extracted only `compose.yml` to `~/.mycelium/docker/` but never copied the bundled `initdb/create-cfn-cp-db.sh` alongside it. Since `compose.yml` mounts `./initdb` as `/docker-entrypoint-initdb.d`, the initdb directory was always empty and the Postgres hook never fired. This left `_ensure_cfn_databases()` as the only protection — which was broken by bugs 1 and 2.

## Test plan

- [ ] Fresh install with `--ioc` on a system where docker requires sudo — verify install fails with a clear error message pointing to `usermod -aG docker`
- [ ] Fresh install with `--ioc` on a system where docker works without sudo — verify `cfn_mgmt` and `cfn_cp` databases are created and all 4 containers reach healthy state
- [ ] Verify `~/.mycelium/docker/initdb/create-cfn-cp-db.sh` is present after install
- [ ] Re-install over an existing volume — verify idempotency (no duplicate database errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)