### PR TITLE
fix: replace curl with python3 in cognition-fabric-node health check

### DIFF
--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -146,7 +146,7 @@ services:
       LLM_BASE_URL: ${LLM_BASE_URL:-}
       HEARTBEAT_INTERVAL_SECONDS: ${HEARTBEAT_INTERVAL_SECONDS:-29}
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:9002/api/internal/diagnostics/health || exit 1"]
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:9002/api/internal/diagnostics/health')\" || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 6


### PR DESCRIPTION
## Summary

- The `ioc-cognition-fabric-node-svc` image does not include `curl`, so the Docker health check fails immediately on every container start/restart
- Replaces the `curl` health check with an equivalent `python3 urllib` one-liner, which is already available in the image (the service runs under Python/uvicorn)

## Test plan

- [ ] Start the CFN stack (`mycelium start --cfn`)
- [ ] Confirm `ioc-cognition-fabric-node-svc` reaches `(healthy)` status without manually installing curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)