### PR TITLE
fix: bootstrap hook falls back to config.toml for MYCELIUM_API_URL

### DIFF
--- a/mycelium-cli/src/mycelium/adapters/openclaw/hooks/mycelium-bootstrap/handler.js
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/hooks/mycelium-bootstrap/handler.js
@@ -4,13 +4,16 @@
  * Mycelium hook for OpenClaw.
  * Extracts the channel/conversation ID from event context and injects it as
  * MYCELIUM_ROOM_ID so all agents in the same Matrix channel share a coordination room.
- * Also forwards MYCELIUM_API_URL from gateway env into the agent session env.
+ * Also forwards MYCELIUM_API_URL from gateway env (or ~/.mycelium/config.toml)
+ * into the agent session env.
  *
  * Instructions are injected via the mycelium-cfn plugin (prependSystemContext),
  * not here.
  *
  * Installed by: mycelium adapter add openclaw
  */
+
+import { readMyceliumServerFromToml } from "../../extensions/mycelium/read-mycelium-config.js";
 
 export default async function HookHandler(event) {
   if (event.type !== "agent" || event.action !== "bootstrap") return;
@@ -31,8 +34,9 @@ export default async function HookHandler(event) {
     ctx.env.MYCELIUM_ROOM_ID = channelId;
   }
 
-  if (process.env.MYCELIUM_API_URL) {
+  const apiUrl = process.env.MYCELIUM_API_URL || readMyceliumServerFromToml().api_url;
+  if (apiUrl) {
     ctx.env = ctx.env ?? {};
-    ctx.env.MYCELIUM_API_URL = process.env.MYCELIUM_API_URL;
+    ctx.env.MYCELIUM_API_URL = apiUrl;
   }
 }


### PR DESCRIPTION
## Summary

- The `mycelium-bootstrap` hook only forwarded `MYCELIUM_API_URL` into agent sessions when the env var was already set on the gateway process. Unlike the plugin (`mycelium-env.ts`) and the knowledge-extract hook (`knowledge-env.js`), it had no fallback to `~/.mycelium/config.toml`.
- After a fresh reinstall via `mycelium adapter add openclaw`, if the gateway wasn't started with `MYCELIUM_API_URL` exported, agents silently received no URL and couldn't reach the backend.
- This adds a TOML fallback using `readMyceliumServerFromToml()` (the same helper and import path the knowledge-extract hook already uses), matching the env-then-TOML precedence used everywhere else in the adapter.

## Test plan

- [ ] Run `mycelium adapter add openclaw --reinstall` on a host where `MYCELIUM_API_URL` is **not** exported in the shell
- [ ] Verify `~/.mycelium/config.toml` has `[server]` with `api_url` set
- [ ] Start the OpenClaw gateway and spawn an agent
- [ ] Confirm the agent session has `MYCELIUM_API_URL` in its environment (visible in agent logs or via the mycelium skill)
- [ ] Verify that when `MYCELIUM_API_URL` **is** exported, the env var still takes precedence over the TOML value


Made with [Cursor](https://cursor.com)