### PR TITLE
Fix LLM_BASE_URL handling to prevent stale empty values

### DIFF
--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -46,6 +46,15 @@ class Settings(BaseSettings):
     # during a negotiation round before falling back to the safe default.
     COORDINATION_TICK_TIMEOUT_SECONDS: int = 30
 
+    @field_validator("LLM_BASE_URL", mode="before")
+    @classmethod
+    def _coerce_base_url(cls, v: object) -> object:
+        """Treat empty string as unset — litellm and the OpenAI SDK both pass
+        "" through to httpx which rejects it as UnsupportedProtocol."""
+        if isinstance(v, str) and v.strip() == "":
+            return None
+        return v
+
     @field_validator("COORDINATION_TICK_TIMEOUT_SECONDS", mode="before")
     @classmethod
     def _coerce_tick_timeout(cls, v: object) -> object:

--- a/fastapi-backend/app/services/async_coordination.py
+++ b/fastapi-backend/app/services/async_coordination.py
@@ -294,7 +294,7 @@ async def _llm_synthesize(room_name: str, context: str, memory_count: int) -> st
         if settings.LLM_API_KEY:
             kwargs["api_key"] = settings.LLM_API_KEY
         if settings.LLM_BASE_URL:
-            kwargs["api_base"] = settings.LLM_BASE_URL
+            kwargs["base_url"] = settings.LLM_BASE_URL
 
         response = litellm.completion(**kwargs)
         return response.choices[0].message.content

--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -213,8 +213,12 @@ def _write_env_file(env_path: Path, llm_config: dict[str, str]) -> None:
     import importlib.resources
 
     # On re-install, preserve existing .env and only update/append changed keys.
+    # Remove LLM_BASE_URL when the new config doesn't include it — avoids
+    # leaving a stale empty value that breaks litellm (see #97).
     if env_path.exists():
         _patch_env_vars(env_path, llm_config)
+        if "LLM_BASE_URL" not in llm_config:
+            _remove_env_var(env_path, "LLM_BASE_URL")
         return
 
     defaults_ref = importlib.resources.files("mycelium.docker") / "env.defaults"
@@ -279,6 +283,23 @@ def _patch_env_vars(env_path: Path, updates: dict[str, str]) -> None:
     # Append any keys not yet present
     for key, value in remaining.items():
         new_lines.append(f"{key}={value}")
+    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+
+def _remove_env_var(env_path: Path, key: str) -> None:
+    """Remove a key from an existing .env file (no-op if absent)."""
+    if not env_path.exists():
+        return
+    lines = env_path.read_text(encoding="utf-8").splitlines()
+    new_lines = [
+        ln
+        for ln in lines
+        if not (
+            "=" in ln
+            and not ln.lstrip().startswith("#")
+            and ln.split("=")[0].strip() == key
+        )
+    ]
     env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary

Fixes issue #97 where stale or empty `LLM_BASE_URL` values in the `.env` file cause litellm and the OpenAI SDK to fail. The changes ensure that empty base URLs are treated as unset and are properly removed during reinstalls.

## Changes

- **mycelium-cli**: Added `_remove_env_var()` function to remove environment variables from `.env` files. During reinstall, `LLM_BASE_URL` is now explicitly removed if the new config doesn't include it, preventing stale values from persisting.

- **fastapi-backend config**: Added a field validator for `LLM_BASE_URL` that treats empty strings as `None`, since both litellm and the OpenAI SDK reject empty strings as invalid protocols.

- **fastapi-backend async_coordination**: Fixed the litellm API call to use the correct parameter name `base_url` instead of the deprecated `api_base`.

## Testing

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Format check passes (`uv run ruff format --check .`)

## Related Issues

Closes #97

https://claude.ai/code/session_01ChFnYe43vsFpnFJdX865zn