### PR TITLE
fix(config): parse JSON values in config set to avoid TOML type corruption

### DIFF
--- a/mycelium-cli/src/mycelium/commands/config.py
+++ b/mycelium-cli/src/mycelium/commands/config.py
@@ -112,11 +112,18 @@ def set_config(
         config = MyceliumConfig.load()
         parts = key.split(".")
 
+        # Try to coerce JSON arrays/bools/numbers so list fields round-trip correctly
+        parsed_value: object = value
+        try:
+            parsed_value = json_module.loads(value)
+        except (json_module.JSONDecodeError, ValueError):
+            pass
+
         if len(parts) == 2:
             section = getattr(config, parts[0])
-            setattr(section, parts[1], value)
+            setattr(section, parts[1], parsed_value)
         elif len(parts) == 1:
-            setattr(config, parts[0], value)
+            setattr(config, parts[0], parsed_value)
         else:
             raise ValueError(f"Unsupported key format: {key}")
 


### PR DESCRIPTION
## Summary

- `mycelium config set` was calling `setattr` with the raw string value, so list fields like `knowledge_ingest.events` were written as TOML string literals instead of arrays
- This broke `mycelium doctor` with "Cannot parse config.toml" and caused the `events` field to degrade silently in the JS hook (substring matching instead of array membership)
- Fix: attempt `json.loads` on the value before setting — arrays, bools, and numbers now round-trip correctly; plain strings fall through unchanged

## Test plan
- [ ] `mycelium config set knowledge_ingest.events '["message:sent", "agent:bootstrap"]'` writes a TOML array, not a string literal
- [ ] `mycelium doctor` passes after setting a list value
- [ ] Plain string values (e.g. `mycelium config set server.api_url http://localhost:8000`) still work