### PR TITLE
feat: backend-resolved CFN IDs for leaf nodes + channel room auto-create

### DIFF
--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -80,6 +80,9 @@ class Settings(BaseSettings):
     # Workspace ID in the CFN mgmt plane (set by mycelium install)
     WORKSPACE_ID: str = ""
 
+    # Default MAS ID — fallback when ingest requests omit mas_id and room_name
+    MAS_ID: str = ""
+
     # Knowledge ingest control surface — see KnowledgeIngestConfig in the CLI
     # for the authoritative descriptions. Defaults here match CLI defaults.
     MYCELIUM_INGEST_ENABLED: bool = True

--- a/fastapi-backend/app/routes/cfn_proxy.py
+++ b/fastapi-backend/app/routes/cfn_proxy.py
@@ -33,7 +33,6 @@ from pydantic import BaseModel, Field
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
 from app.database import get_async_session
 from app.models import Agent, AuditEvent
 from app.services.cfn_graph_read import CfnGraphUnavailable, list_concepts
@@ -44,6 +43,7 @@ from app.services.cfn_knowledge import (
     get_graph_paths,
     query_shared_memories,
 )
+from app.services.cfn_resolve import resolve_mas_id, resolve_workspace_id
 
 logger = logging.getLogger(__name__)
 
@@ -164,29 +164,14 @@ async def memory_operations(
 # ── CFN shared-memories read surface ────────────────────────────────────────
 
 
-def _resolve_workspace(workspace_id: str | None) -> str:
-    """Fall back to settings.WORKSPACE_ID when the client omits workspace_id."""
-    resolved = workspace_id or settings.WORKSPACE_ID
-    if not resolved:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "workspace_id not provided and settings.WORKSPACE_ID is unset. "
-                "Set a default via `mycelium config set runtime.workspace_id <id>` "
-                "or pass workspace_id explicitly."
-            ),
-        )
-    return resolved
-
-
 def _raise_from_cfn_error(exc: CfnKnowledgeError) -> None:
     code = exc.status_code or 502
     raise HTTPException(status_code=code, detail=str(exc))
 
 
 class QueryRequest(BaseModel):
-    mas_id: str
     intent: str
+    mas_id: str | None = None
     workspace_id: str | None = None
     agent_id: str | None = None
     search_strategy: str = "semantic_graph_traversal"
@@ -194,18 +179,22 @@ class QueryRequest(BaseModel):
 
 
 @cfn_read_router.post("/query")
-async def cfn_query(data: QueryRequest) -> dict[str, Any]:
+async def cfn_query(
+    data: QueryRequest,
+    db: Annotated[AsyncSession, Depends(get_async_session)],
+) -> dict[str, Any]:
     """Semantic-graph query against CFN's shared memory.
 
     CFN returns a natural-language answer from its evidence agent
     (``{"response_id": str, "message": str}``), not a structured record
     list. The ``mycelium cfn query`` CLI renders the message directly.
     """
-    workspace_id = _resolve_workspace(data.workspace_id)
+    workspace_id = resolve_workspace_id(data.workspace_id)
+    mas_id = await resolve_mas_id(data.mas_id, None, db)
     try:
         return await query_shared_memories(
             workspace_id=workspace_id,
-            mas_id=data.mas_id,
+            mas_id=mas_id,
             intent=data.intent,
             agent_id=data.agent_id,
             search_strategy=data.search_strategy,
@@ -217,19 +206,23 @@ async def cfn_query(data: QueryRequest) -> dict[str, Any]:
 
 
 class ConceptsByIdsRequest(BaseModel):
-    mas_id: str
     ids: list[str] = Field(..., min_length=1)
+    mas_id: str | None = None
     workspace_id: str | None = None
 
 
 @cfn_read_router.post("/concepts")
-async def cfn_concepts_by_ids(data: ConceptsByIdsRequest) -> dict[str, Any]:
+async def cfn_concepts_by_ids(
+    data: ConceptsByIdsRequest,
+    db: Annotated[AsyncSession, Depends(get_async_session)],
+) -> dict[str, Any]:
     """Fetch CFN concept records by explicit IDs."""
-    workspace_id = _resolve_workspace(data.workspace_id)
+    workspace_id = resolve_workspace_id(data.workspace_id)
+    mas_id = await resolve_mas_id(data.mas_id, None, db)
     try:
         return await get_concepts_by_ids(
             workspace_id=workspace_id,
-            mas_id=data.mas_id,
+            mas_id=mas_id,
             ids=data.ids,
         )
     except CfnKnowledgeError as exc:
@@ -240,15 +233,17 @@ async def cfn_concepts_by_ids(data: ConceptsByIdsRequest) -> dict[str, Any]:
 @cfn_read_router.get("/concepts/{concept_id}/neighbors")
 async def cfn_concept_neighbors(
     concept_id: str,
-    mas_id: str,
+    db: Annotated[AsyncSession, Depends(get_async_session)],
+    mas_id: str | None = None,
     workspace_id: str | None = None,
 ) -> dict[str, Any]:
     """Fetch a concept's graph neighbors from CFN."""
-    resolved_workspace = _resolve_workspace(workspace_id)
+    resolved_workspace = resolve_workspace_id(workspace_id)
+    resolved_mas = await resolve_mas_id(mas_id, None, db)
     try:
         return await get_concept_neighbors(
             workspace_id=resolved_workspace,
-            mas_id=mas_id,
+            mas_id=resolved_mas,
             concept_id=concept_id,
         )
     except CfnKnowledgeError as exc:
@@ -257,9 +252,9 @@ async def cfn_concept_neighbors(
 
 
 class GraphPathsRequest(BaseModel):
-    mas_id: str
     source_id: str
     target_id: str
+    mas_id: str | None = None
     workspace_id: str | None = None
     max_depth: int | None = None
     relations: list[str] | None = None
@@ -267,13 +262,17 @@ class GraphPathsRequest(BaseModel):
 
 
 @cfn_read_router.post("/paths")
-async def cfn_graph_paths(data: GraphPathsRequest) -> dict[str, Any]:
+async def cfn_graph_paths(
+    data: GraphPathsRequest,
+    db: Annotated[AsyncSession, Depends(get_async_session)],
+) -> dict[str, Any]:
     """Fetch paths between two CFN concepts by ID."""
-    workspace_id = _resolve_workspace(data.workspace_id)
+    workspace_id = resolve_workspace_id(data.workspace_id)
+    mas_id = await resolve_mas_id(data.mas_id, None, db)
     try:
         return await get_graph_paths(
             workspace_id=workspace_id,
-            mas_id=data.mas_id,
+            mas_id=mas_id,
             source_id=data.source_id,
             target_id=data.target_id,
             max_depth=data.max_depth,
@@ -286,7 +285,11 @@ async def cfn_graph_paths(data: GraphPathsRequest) -> dict[str, Any]:
 
 
 @cfn_read_router.get("/list")
-def cfn_list(mas_id: str, limit: int = 50) -> dict[str, Any]:
+async def cfn_list(
+    db: Annotated[AsyncSession, Depends(get_async_session)],
+    mas_id: str | None = None,
+    limit: int = 50,
+) -> dict[str, Any]:
     """Enumerate nodes in CFN's AgensGraph for a given MAS.
 
     **Not a CFN API**. Goes around CFN's HTTP surface and queries the
@@ -294,10 +297,11 @@ def cfn_list(mas_id: str, limit: int = 50) -> dict[str, Any]:
     endpoint. Coupled to CFN's graph-naming convention
     (``graph_<mas_id_with_hyphens_underscored>``).
     """
+    resolved_mas = await resolve_mas_id(mas_id, None, db)
     if limit < 1 or limit > 500:
         raise HTTPException(status_code=422, detail="limit must be 1..500")
     try:
-        nodes = list_concepts(mas_id=mas_id, limit=limit)
+        nodes = list_concepts(mas_id=resolved_mas, limit=limit)
     except CfnGraphUnavailable as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
-    return {"mas_id": mas_id, "limit": limit, "count": len(nodes), "nodes": nodes}
+    return {"mas_id": resolved_mas, "limit": limit, "count": len(nodes), "nodes": nodes}

--- a/fastapi-backend/app/routes/cfn_proxy.py
+++ b/fastapi-backend/app/routes/cfn_proxy.py
@@ -20,6 +20,7 @@ Two concerns live here:
    in ``app/services/cfn_knowledge.py``.
 """
 
+import asyncio
 import json
 import logging
 import uuid as uuid_mod
@@ -301,7 +302,7 @@ async def cfn_list(
     if limit < 1 or limit > 500:
         raise HTTPException(status_code=422, detail="limit must be 1..500")
     try:
-        nodes = list_concepts(mas_id=resolved_mas, limit=limit)
+        nodes = await asyncio.to_thread(list_concepts, mas_id=resolved_mas, limit=limit)
     except CfnGraphUnavailable as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     return {"mas_id": resolved_mas, "limit": limit, "count": len(nodes), "nodes": nodes}

--- a/fastapi-backend/app/routes/knowledge.py
+++ b/fastapi-backend/app/routes/knowledge.py
@@ -31,6 +31,7 @@ from app.services.cfn_knowledge import (
     create_or_update_shared_memories,
     estimate_cfn_knowledge_input_tokens,
 )
+from app.services.cfn_resolve import resolve_mas_id, resolve_workspace_id
 from app.services.ingest_dedupe import get_cache
 from app.services.ingest_log_buffer import IngestEvent, IngestState, get_buffer
 
@@ -43,10 +44,11 @@ router = APIRouter(tags=["knowledge"])
 
 
 class KnowledgeIngestRequest(BaseModel):
-    workspace_id: str
-    mas_id: str
-    agent_id: str | None = None
     records: list[dict]
+    agent_id: str | None = None
+    room_name: str | None = None
+    workspace_id: str | None = None
+    mas_id: str | None = None
 
 
 class KnowledgeIngestResponse(BaseModel):
@@ -61,6 +63,8 @@ class KnowledgeIngestResponse(BaseModel):
 
 def _log_ingest_event(
     *,
+    workspace_id: str,
+    mas_id: str,
     data: KnowledgeIngestRequest,
     request_id: str,
     est_tokens: int,
@@ -74,8 +78,8 @@ def _log_ingest_event(
     get_buffer().append(
         IngestEvent(
             timestamp=datetime.now(UTC),
-            workspace_id=data.workspace_id,
-            mas_id=data.mas_id,
+            workspace_id=workspace_id,
+            mas_id=mas_id,
             agent_id=data.agent_id,
             request_id=request_id,
             record_count=len(data.records),
@@ -136,9 +140,15 @@ async def knowledge_ingest(
     payload_bytes = len(json.dumps(data.records))
     started = time.perf_counter()
 
+    # ── Resolve CFN routing IDs ───────────────────────────────────────────────
+    workspace_id = resolve_workspace_id(data.workspace_id)
+    mas_id = await resolve_mas_id(data.mas_id, data.room_name, db)
+
     # ── Gate 1: master kill switch ────────────────────────────────────────────
     if not settings.MYCELIUM_INGEST_ENABLED:
         _log_ingest_event(
+            workspace_id=workspace_id,
+            mas_id=mas_id,
             data=data,
             request_id=request_id,
             est_tokens=est_tokens,
@@ -147,7 +157,7 @@ async def knowledge_ingest(
             state="disabled",
             reason="MYCELIUM_INGEST_ENABLED=false",
         )
-        _write_audit_event(db, data.mas_id)
+        _write_audit_event(db, mas_id)
         try:
             await db.commit()
         except SQLAlchemyError as exc:
@@ -164,6 +174,8 @@ async def knowledge_ingest(
     if max_tokens > 0 and est_tokens > max_tokens:
         reason = f"payload exceeded {max_tokens} estimated input tokens (actual: {est_tokens})"
         _log_ingest_event(
+            workspace_id=workspace_id,
+            mas_id=mas_id,
             data=data,
             request_id=request_id,
             est_tokens=est_tokens,
@@ -174,7 +186,7 @@ async def knowledge_ingest(
         )
         logger.warning(
             "ingest refused | mas=%s agent=%s request_id=%s reason=%s",
-            data.mas_id,
+            mas_id,
             data.agent_id,
             request_id,
             reason,
@@ -191,6 +203,8 @@ async def knowledge_ingest(
     cached = cache.lookup(content_hash) if content_hash else None
     if cached is not None:
         _log_ingest_event(
+            workspace_id=workspace_id,
+            mas_id=mas_id,
             data=data,
             request_id=request_id,
             est_tokens=est_tokens,
@@ -200,8 +214,7 @@ async def knowledge_ingest(
             reason=f"hash match within {ttl}s TTL",
             cfn_message=cached.message,
         )
-        # Durable audit — deduped still represents a "we accepted this" event.
-        _write_audit_event(db, data.mas_id)
+        _write_audit_event(db, mas_id)
         try:
             await db.commit()
         except SQLAlchemyError as exc:
@@ -216,14 +229,16 @@ async def knowledge_ingest(
     # ── Forward to CFN ────────────────────────────────────────────────────────
     try:
         cfn_resp = await create_or_update_shared_memories(
-            workspace_id=data.workspace_id,
-            mas_id=data.mas_id,
+            workspace_id=workspace_id,
+            mas_id=mas_id,
             records=data.records,
             agent_id=data.agent_id,
             request_id=request_id,
         )
     except CfnKnowledgeError as exc:
         _log_ingest_event(
+            workspace_id=workspace_id,
+            mas_id=mas_id,
             data=data,
             request_id=request_id,
             est_tokens=est_tokens,
@@ -249,6 +264,8 @@ async def knowledge_ingest(
         )
 
     _log_ingest_event(
+        workspace_id=workspace_id,
+        mas_id=mas_id,
         data=data,
         request_id=request_id,
         est_tokens=est_tokens,
@@ -259,7 +276,7 @@ async def knowledge_ingest(
         cfn_message=cfn_message,
     )
 
-    _write_audit_event(db, data.mas_id)
+    _write_audit_event(db, mas_id)
     try:
         await db.commit()
     except SQLAlchemyError as exc:

--- a/fastapi-backend/app/services/cfn_resolve.py
+++ b/fastapi-backend/app/services/cfn_resolve.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""
+Resolve CFN identifiers (workspace_id, mas_id) from client input, room
+context, or backend settings.
+
+Used by the knowledge ingest and CFN proxy routes to make these IDs
+optional on the client side — the backend can fill them in from its own
+config and database.
+"""
+
+import logging
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models import Room
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_workspace_id(client_value: str | None) -> str:
+    """Return client_value if set, else settings.WORKSPACE_ID, else 400."""
+    resolved = client_value or settings.WORKSPACE_ID
+    if not resolved:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "workspace_id not provided and WORKSPACE_ID is unset. "
+                "Run `mycelium install` or set WORKSPACE_ID in your .env."
+            ),
+        )
+    return resolved
+
+
+async def resolve_mas_id(
+    client_value: str | None,
+    room_name: str | None,
+    db: AsyncSession,
+) -> str:
+    """Resolve mas_id via: client value > room DB lookup > settings > 400.
+
+    When room_name is provided, looks up the Room row and reads its mas_id.
+    If the room is a session sub-room (has parent_namespace), walks up to
+    the parent namespace which owns the MAS.
+    """
+    if client_value:
+        return client_value
+
+    if room_name:
+        result = await db.execute(select(Room).where(Room.name == room_name))
+        room = result.scalar_one_or_none()
+        if room is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"room_name '{room_name}' not found — cannot resolve mas_id.",
+            )
+        if room.mas_id:
+            return room.mas_id
+        # Session sub-rooms inherit mas_id from their parent namespace
+        if room.parent_namespace:
+            parent_result = await db.execute(select(Room).where(Room.name == room.parent_namespace))
+            parent = parent_result.scalar_one_or_none()
+            if parent and parent.mas_id:
+                return parent.mas_id
+        logger.warning("room '%s' exists but has no mas_id (and no parent with one)", room_name)
+
+    if settings.MAS_ID:
+        return settings.MAS_ID
+
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            "mas_id not provided, no room_name supplied, and MAS_ID is unset. "
+            "Run `mycelium install` or set MAS_ID in your .env, or pass room_name "
+            "so the backend can resolve the room's mas_id."
+        ),
+    )

--- a/fastapi-backend/app/services/cfn_resolve.py
+++ b/fastapi-backend/app/services/cfn_resolve.py
@@ -67,6 +67,16 @@ async def resolve_mas_id(
             if parent and parent.mas_id:
                 return parent.mas_id
         logger.warning("room '%s' exists but has no mas_id (and no parent with one)", room_name)
+        if not settings.MAS_ID:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Room '{room_name}' exists but has no mas_id configured "
+                    f"(and no parent namespace with one). Either create the room "
+                    f"via `mycelium room create` (which provisions a MAS), or set "
+                    f"MAS_ID in your backend .env as a fallback."
+                ),
+            )
 
     if settings.MAS_ID:
         return settings.MAS_ID
@@ -74,8 +84,9 @@ async def resolve_mas_id(
     raise HTTPException(
         status_code=400,
         detail=(
-            "mas_id not provided, no room_name supplied, and MAS_ID is unset. "
-            "Run `mycelium install` or set MAS_ID in your .env, or pass room_name "
-            "so the backend can resolve the room's mas_id."
+            "Cannot resolve mas_id: none provided, no room_name supplied, "
+            "and MAS_ID is unset. Run `mycelium install` or set MAS_ID in "
+            "your .env, or pass room_name so the backend can look up the "
+            "room's mas_id."
         ),
     )

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -391,55 +391,68 @@ async def _cfn_decide_round(room_name: str) -> None:
         await _finish_cfn(room_name, plan=f"CFN decide failed — {exc}", assignments={}, broken=True)
         return
 
-    result = _normalize_cfn_decide_response(result)
+    try:
+        if not isinstance(result, dict):
+            logger.error("CFN decide returned non-dict for %s: %s", room_name, type(result))
+            await _finish_cfn(
+                room_name, plan="CFN decide returned invalid response", assignments={}, broken=True
+            )
+            return
 
-    # CFN returns a nested envelope: status lives in result["payload"]["status"]
-    # and the agreement in result["semantic_context"]["final_agreement"].
-    # Fall back to top-level keys for backward compatibility.
-    payload = result.get("payload", {})
-    status = payload.get("status", result.get("status", ""))
+        result = _normalize_cfn_decide_response(result)
 
-    if status in ("agreed",):
-        final_result = result.get("final_result", {})
-        # final_result is an SSTPCommitMessage dict.
-        # Agreement is in semantic_context.final_agreement (list of {issue_id, chosen_option}).
-        if isinstance(final_result, dict):
-            sc = final_result.get("semantic_context") or {}
-            raw_agreement = sc.get("final_agreement") or []
-            # Fallback: some versions embed it in payload.trace.final_agreement
-            if not raw_agreement:
-                trace = (final_result.get("payload") or {}).get("trace") or {}
-                raw_agreement = trace.get("final_agreement") or []
+        # CFN returns a nested envelope: status lives in result["payload"]["status"]
+        # and the agreement in result["semantic_context"]["final_agreement"].
+        # Fall back to top-level keys for backward compatibility.
+        payload = result.get("payload", {})
+        status = payload.get("status", result.get("status", ""))
+
+        if status in ("agreed",):
+            final_result = result.get("final_result", {})
+            # final_result is an SSTPCommitMessage dict.
+            # Agreement is in semantic_context.final_agreement (list of {issue_id, chosen_option}).
+            if isinstance(final_result, dict):
+                sc = final_result.get("semantic_context") or {}
+                raw_agreement = sc.get("final_agreement") or []
+                # Fallback: some versions embed it in payload.trace.final_agreement
+                if not raw_agreement:
+                    trace = (final_result.get("payload") or {}).get("trace") or {}
+                    raw_agreement = trace.get("final_agreement") or []
+            else:
+                raw_agreement = []
+            if isinstance(raw_agreement, list):
+                agreement = {
+                    item["issue_id"]: item.get("chosen_option", "")
+                    for item in raw_agreement
+                    if isinstance(item, dict) and "issue_id" in item
+                }
+            else:
+                agreement = {}
+            plan = "; ".join(f"{k}={v}" for k, v in agreement.items()) if agreement else "agreed"
+            await _finish_cfn(room_name, plan=plan, assignments=agreement, broken=False)
+
+        elif status == "ongoing":
+            messages = result.get("messages", [])
+            addressed = await _fan_out_cfn_messages(
+                room_name,
+                messages,
+                all_agents=state.agents,
+            )
+            async with state.lock:
+                state.pending_replies = {h: None for h in addressed}
+                state.deciding = False
+            _reset_round_timeout(room_name, state)
+
         else:
-            raw_agreement = []
-        if isinstance(raw_agreement, list):
-            agreement = {
-                item["issue_id"]: item.get("chosen_option", "")
-                for item in raw_agreement
-                if isinstance(item, dict) and "issue_id" in item
-            }
-        else:
-            agreement = {}
-        plan = "; ".join(f"{k}={v}" for k, v in agreement.items()) if agreement else "agreed"
-        await _finish_cfn(room_name, plan=plan, assignments=agreement, broken=False)
-
-    elif status == "ongoing":
-        messages = result.get("messages", [])
-        addressed = await _fan_out_cfn_messages(
-            room_name,
-            messages,
-            all_agents=state.agents,
-        )
-        async with state.lock:
-            state.pending_replies = {h: None for h in addressed}
-            state.deciding = False
-        _reset_round_timeout(room_name, state)
-
-    else:
-        # Unknown / failed status
-        logger.warning("CFN decide returned status=%s for %s", status, room_name)
+            # Unknown / failed status
+            logger.warning("CFN decide returned status=%s for %s", status, room_name)
+            await _finish_cfn(
+                room_name, plan=f"Negotiation ended: {status}", assignments={}, broken=True
+            )
+    except Exception as exc:
+        logger.exception("Unhandled error processing CFN decide response for %s", room_name)
         await _finish_cfn(
-            room_name, plan=f"Negotiation ended: {status}", assignments={}, broken=True
+            room_name, plan=f"CFN response processing failed — {exc}", assignments={}, broken=True
         )
 
 

--- a/fastapi-backend/tests/test_cfn_read_surface.py
+++ b/fastapi-backend/tests/test_cfn_read_surface.py
@@ -16,6 +16,7 @@ pytestmark = pytest.mark.asyncio
 @pytest.fixture(autouse=True)
 def _set_default_workspace(monkeypatch):
     monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "ws-default")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "mas-default")
 
 
 # ── /api/cfn/knowledge/query ───────────────────────────────────────────────────
@@ -58,6 +59,37 @@ async def test_query_uses_explicit_workspace_over_default(
         },
     )
     assert mock.await_args.kwargs["workspace_id"] == "ws-override"
+
+
+async def test_query_resolves_mas_id_from_settings_when_omitted(
+    client: AsyncClient,
+    monkeypatch,
+):
+    """Leaf nodes can omit mas_id; backend resolves from settings.MAS_ID."""
+    mock = AsyncMock(return_value={"response_id": "r", "message": "ok"})
+    monkeypatch.setattr("app.routes.cfn_proxy.query_shared_memories", mock)
+
+    resp = await client.post(
+        "/api/cfn/knowledge/query",
+        json={"intent": "anything"},
+    )
+    assert resp.status_code == 200
+    call = mock.await_args.kwargs
+    assert call["workspace_id"] == "ws-default"
+    assert call["mas_id"] == "mas-default"
+
+
+async def test_query_400_when_no_mas_id_and_no_default(
+    client: AsyncClient,
+    monkeypatch,
+):
+    monkeypatch.setattr("app.config.settings.MAS_ID", "")
+    resp = await client.post(
+        "/api/cfn/knowledge/query",
+        json={"intent": "anything"},
+    )
+    assert resp.status_code == 400
+    assert "mas_id" in resp.json()["detail"].lower()
 
 
 async def test_query_400_when_no_workspace_and_no_default(

--- a/fastapi-backend/tests/test_cfn_resolve.py
+++ b/fastapi-backend/tests/test_cfn_resolve.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""
+Tests for CFN identifier resolution (workspace_id, mas_id).
+
+The resolve helpers allow clients to omit workspace_id/mas_id and have the
+backend resolve them from room context or settings fallbacks.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import Room
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── resolve_workspace_id ──────────────────────────────────────────────────────
+
+
+async def test_resolve_workspace_id_from_client_value(client: AsyncClient, monkeypatch):
+    """Client-provided workspace_id takes priority over settings."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "settings-mas")
+    monkeypatch.setattr("app.config.settings.MYCELIUM_INGEST_ENABLED", False)
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "workspace_id": "client-ws",
+            "mas_id": "client-mas",
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 200
+    # Ingest is disabled but we still verify resolution happened (no 400)
+
+
+async def test_resolve_workspace_id_from_settings(client: AsyncClient, monkeypatch):
+    """Falls back to settings.WORKSPACE_ID when client omits it."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "settings-mas")
+    monkeypatch.setattr("app.config.settings.MYCELIUM_INGEST_ENABLED", False)
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "mas_id": "client-mas",
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 200
+
+
+async def test_resolve_workspace_id_400_when_unset(client: AsyncClient, monkeypatch):
+    """Returns 400 when workspace_id is neither provided nor configured."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "settings-mas")
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "mas_id": "client-mas",
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 400
+    assert "workspace_id" in resp.json()["detail"].lower()
+
+
+# ── resolve_mas_id ────────────────────────────────────────────────────────────
+
+
+async def test_resolve_mas_id_from_client_value(client: AsyncClient, monkeypatch):
+    """Client-provided mas_id takes priority over room lookup and settings."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "settings-mas")
+    monkeypatch.setattr("app.config.settings.MYCELIUM_INGEST_ENABLED", False)
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "workspace_id": "client-ws",
+            "mas_id": "client-mas",
+            "room_name": "some-room",  # should be ignored when mas_id is provided
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 200
+
+
+async def test_resolve_mas_id_from_room_lookup(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    """Resolves mas_id from room DB record when room_name is provided."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "settings-mas")
+    monkeypatch.setattr("app.config.settings.MYCELIUM_INGEST_ENABLED", False)
+
+    room = Room(name="test-room", mas_id="room-mas-id", workspace_id="room-ws-id")
+    db_session.add(room)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "room_name": "test-room",
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 200
+
+
+async def test_resolve_mas_id_from_parent_namespace(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    """Session sub-rooms inherit mas_id from parent namespace."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "")  # no fallback
+    monkeypatch.setattr("app.config.settings.MYCELIUM_INGEST_ENABLED", False)
+
+    parent = Room(
+        name="parent-ns",
+        mas_id="parent-mas-id",
+        workspace_id="parent-ws-id",
+        is_namespace=True,
+    )
+    db_session.add(parent)
+    await db_session.flush()
+
+    child = Room(
+        name="parent-ns:session:abc",
+        mas_id=None,  # session doesn't have its own mas_id
+        workspace_id="parent-ws-id",
+        parent_namespace="parent-ns",
+    )
+    db_session.add(child)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "room_name": "parent-ns:session:abc",
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 200
+
+
+async def test_resolve_mas_id_room_exists_no_mas_id_falls_back_to_settings(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    """Room exists but has no mas_id; falls back to settings.MAS_ID."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "settings-mas")
+    monkeypatch.setattr("app.config.settings.MYCELIUM_INGEST_ENABLED", False)
+
+    room = Room(name="orphan-room", mas_id=None, workspace_id="ws")
+    db_session.add(room)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "room_name": "orphan-room",
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 200
+
+
+async def test_resolve_mas_id_room_not_found_400(client: AsyncClient, monkeypatch):
+    """Returns 400 when room_name is provided but room doesn't exist."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "settings-mas")
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "room_name": "nonexistent-room",
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 400
+    assert "not found" in resp.json()["detail"].lower()
+
+
+async def test_resolve_mas_id_room_exists_no_mas_id_no_settings_400(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch
+):
+    """Room exists but has no mas_id and settings.MAS_ID is unset; returns 400."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "")
+
+    room = Room(name="orphan-room", mas_id=None, workspace_id="ws")
+    db_session.add(room)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "room_name": "orphan-room",
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 400
+    assert "no mas_id" in resp.json()["detail"].lower()
+
+
+async def test_resolve_mas_id_from_settings_fallback(client: AsyncClient, monkeypatch):
+    """Falls back to settings.MAS_ID when no room_name and no client mas_id."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "settings-mas")
+    monkeypatch.setattr("app.config.settings.MYCELIUM_INGEST_ENABLED", False)
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 200
+
+
+async def test_resolve_mas_id_400_when_nothing_available(client: AsyncClient, monkeypatch):
+    """Returns 400 when mas_id cannot be resolved from any source."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    monkeypatch.setattr("app.config.settings.MAS_ID", "")
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "records": [{"response": "test"}],
+        },
+    )
+    assert resp.status_code == 400
+    assert "cannot resolve mas_id" in resp.json()["detail"].lower()
+
+
+# ── Direct tests of resolve helpers ───────────────────────────────────────────
+
+
+async def test_resolve_helpers_direct(db_session: AsyncSession, monkeypatch):
+    """Direct unit tests for the resolve helper functions."""
+    from app.services.cfn_resolve import resolve_mas_id, resolve_workspace_id
+
+    # resolve_workspace_id: client value wins
+    assert resolve_workspace_id("client-ws") == "client-ws"
+
+    # resolve_workspace_id: settings fallback
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+    assert resolve_workspace_id(None) == "settings-ws"
+    assert resolve_workspace_id("") == "settings-ws"
+
+    # resolve_mas_id: client value wins
+    mas = await resolve_mas_id("client-mas", None, db_session)
+    assert mas == "client-mas"
+
+    # resolve_mas_id: settings fallback when no room
+    monkeypatch.setattr("app.config.settings.MAS_ID", "settings-mas")
+    mas = await resolve_mas_id(None, None, db_session)
+    assert mas == "settings-mas"

--- a/fastapi-backend/tests/test_knowledge_ingest.py
+++ b/fastapi-backend/tests/test_knowledge_ingest.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models import Room
 from app.services.cfn_knowledge import CfnKnowledgeError
 from app.services.ingest_dedupe import get_cache
 from app.services.ingest_log_buffer import get_buffer
@@ -186,3 +188,35 @@ async def test_ingest_cfn_http_status_error_preserves_code(
 
     resp = await client.post("/api/knowledge/ingest", json=INGEST_BODY)
     assert resp.status_code == 503
+
+
+# ── Leaf-node ingest (room_name only, no workspace_id/mas_id) ─────────────────
+
+
+async def test_ingest_leaf_node_resolves_ids_from_room(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    mock_cfn,
+    monkeypatch,
+):
+    """Leaf nodes send only room_name; backend resolves workspace_id and mas_id."""
+    monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
+
+    room = Room(name="leaf-room", mas_id="room-mas", workspace_id="room-ws")
+    db_session.add(room)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/knowledge/ingest",
+        json={
+            "room_name": "leaf-room",
+            "agent_id": "leaf-agent",
+            "records": [{"response": "hello from leaf"}],
+        },
+    )
+    assert resp.status_code == 200
+    assert mock_cfn.await_count == 1
+
+    call_kwargs = mock_cfn.await_args.kwargs
+    assert call_kwargs["workspace_id"] == "settings-ws"
+    assert call_kwargs["mas_id"] == "room-mas"

--- a/mycelium-cli/src/mycelium/adapters/claude-code/hooks/mycelium-knowledge-extract.py
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/hooks/mycelium-knowledge-extract.py
@@ -23,10 +23,13 @@ Keeping each fire bounded (~1 turn, a few KB) is the whole point.
      every adapter (also honored by openclaw).
   2. ``[adapters.claude-code] knowledge_extract = true`` — per-adapter
      switch so Claude Code can be on while openclaw is off (or vice versa).
-  3. Both ``[server] workspace_id`` and ``[server] mas_id`` are set.
+
+``workspace_id``, ``mas_id``, and ``room_name`` are sent when available
+but are no longer required — the backend resolves them from its own config
+and room database when omitted (see issue #139).
 
 CFN ingest costs real tokens per record, so we don't turn this on for
-people automatically. All three gates default to off/unset.
+people automatically. Both gates default to off/unset.
 
 Hook input (stdin JSON, from Claude Code):
   {
@@ -148,12 +151,14 @@ def _env_bool(name: str, default: bool) -> bool:
 def _resolve_target(config: dict[str, Any]) -> dict[str, Any]:
     server = config.get("server", {}) or {}
     identity = config.get("identity", {}) or {}
+    rooms = config.get("rooms", {}) or {}
     return {
         "api_url": os.environ.get("MYCELIUM_API_URL")
         or server.get("api_url")
         or "http://localhost:8000",
         "workspace_id": os.environ.get("MYCELIUM_WORKSPACE_ID") or server.get("workspace_id"),
         "mas_id": os.environ.get("MYCELIUM_MAS_ID") or server.get("mas_id"),
+        "room_name": os.environ.get("MYCELIUM_ACTIVE_ROOM") or rooms.get("active"),
         "agent_handle": os.environ.get("MYCELIUM_AGENT_HANDLE")
         or identity.get("name")
         or "claude-code",
@@ -460,17 +465,23 @@ def _build_payload(
 
 def _post_ingest(
     api_url: str,
-    workspace_id: str,
-    mas_id: str,
     agent_handle: str,
     payload: dict[str, Any],
+    *,
+    workspace_id: str | None = None,
+    mas_id: str | None = None,
+    room_name: str | None = None,
 ) -> bool:
-    body = {
-        "workspace_id": workspace_id,
-        "mas_id": mas_id,
+    body: dict[str, Any] = {
         "agent_id": agent_handle,
         "records": [payload],
     }
+    if room_name:
+        body["room_name"] = room_name
+    if workspace_id:
+        body["workspace_id"] = workspace_id
+    if mas_id:
+        body["mas_id"] = mas_id
     url = api_url.rstrip("/") + "/api/knowledge/ingest"
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(
@@ -541,9 +552,6 @@ def main() -> int:
         return 0
 
     target = _resolve_target(config)
-    if not target["workspace_id"] or not target["mas_id"]:
-        # No CFN binding configured — nothing to ingest. Silent.
-        return 0
 
     if not transcript_path:
         return 0
@@ -573,10 +581,11 @@ def main() -> int:
 
     ok = _post_ingest(
         api_url=target["api_url"],
-        workspace_id=target["workspace_id"],
-        mas_id=target["mas_id"],
         agent_handle=target["agent_handle"],
         payload=payload,
+        workspace_id=target.get("workspace_id"),
+        mas_id=target.get("mas_id"),
+        room_name=target.get("room_name"),
     )
     if not ok:
         _append_log({"event": "ingest_failed", "payload": payload})

--- a/mycelium-cli/src/mycelium/adapters/claude-code/hooks/mycelium-knowledge-extract.py
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/hooks/mycelium-knowledge-extract.py
@@ -24,9 +24,8 @@ Keeping each fire bounded (~1 turn, a few KB) is the whole point.
   2. ``[adapters.claude-code] knowledge_extract = true`` — per-adapter
      switch so Claude Code can be on while openclaw is off (or vice versa).
 
-``workspace_id``, ``mas_id``, and ``room_name`` are sent when available
-but are no longer required — the backend resolves them from its own config
-and room database when omitted (see issue #139).
+Leaf nodes only send ``room_name`` — the backend resolves ``workspace_id``
+and ``mas_id`` from the room's DB record or its own settings (see #139).
 
 CFN ingest costs real tokens per record, so we don't turn this on for
 people automatically. Both gates default to off/unset.
@@ -41,9 +40,10 @@ Hook input (stdin JSON, from Claude Code):
 
 Config (``~/.mycelium/config.toml``):
   [server]
-  api_url      = "http://localhost:8000"
-  workspace_id = "<uuid>"
-  mas_id       = "<uuid>"
+  api_url = "http://localhost:8000"
+
+  [rooms]
+  active = "my-room"   # optional — routes ingest to per-room MAS
 
   [knowledge_ingest]
   enabled                = false     # global — must be explicitly true
@@ -55,8 +55,7 @@ Config (``~/.mycelium/config.toml``):
 
 Env overrides (ephemeral; take precedence over config):
   MYCELIUM_API_URL
-  MYCELIUM_WORKSPACE_ID
-  MYCELIUM_MAS_ID
+  MYCELIUM_ACTIVE_ROOM
   MYCELIUM_AGENT_HANDLE
   MYCELIUM_INGEST_ENABLED
   MYCELIUM_INGEST_MAX_TOOL_CONTENT_BYTES
@@ -149,6 +148,11 @@ def _env_bool(name: str, default: bool) -> bool:
 
 
 def _resolve_target(config: dict[str, Any]) -> dict[str, Any]:
+    """Resolve target API and identity for ingest.
+
+    Leaf nodes only send room_name — the backend resolves workspace_id and
+    mas_id from the room's DB record or its own settings (#139).
+    """
     server = config.get("server", {}) or {}
     identity = config.get("identity", {}) or {}
     rooms = config.get("rooms", {}) or {}
@@ -156,8 +160,6 @@ def _resolve_target(config: dict[str, Any]) -> dict[str, Any]:
         "api_url": os.environ.get("MYCELIUM_API_URL")
         or server.get("api_url")
         or "http://localhost:8000",
-        "workspace_id": os.environ.get("MYCELIUM_WORKSPACE_ID") or server.get("workspace_id"),
-        "mas_id": os.environ.get("MYCELIUM_MAS_ID") or server.get("mas_id"),
         "room_name": os.environ.get("MYCELIUM_ACTIVE_ROOM") or rooms.get("active"),
         "agent_handle": os.environ.get("MYCELIUM_AGENT_HANDLE")
         or identity.get("name")
@@ -468,20 +470,19 @@ def _post_ingest(
     agent_handle: str,
     payload: dict[str, Any],
     *,
-    workspace_id: str | None = None,
-    mas_id: str | None = None,
     room_name: str | None = None,
 ) -> bool:
+    """POST knowledge to the backend ingest endpoint.
+
+    Leaf nodes only send room_name — the backend resolves workspace_id and
+    mas_id from the room's DB record or its own settings (#139).
+    """
     body: dict[str, Any] = {
         "agent_id": agent_handle,
         "records": [payload],
     }
     if room_name:
         body["room_name"] = room_name
-    if workspace_id:
-        body["workspace_id"] = workspace_id
-    if mas_id:
-        body["mas_id"] = mas_id
     url = api_url.rstrip("/") + "/api/knowledge/ingest"
     data = json.dumps(body).encode("utf-8")
     req = urllib.request.Request(
@@ -583,8 +584,6 @@ def main() -> int:
         api_url=target["api_url"],
         agent_handle=target["agent_handle"],
         payload=payload,
-        workspace_id=target.get("workspace_id"),
-        mas_id=target.get("mas_id"),
         room_name=target.get("room_name"),
     )
     if not ok:

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -40,6 +40,35 @@ export function installChannel(
     if (_abort) return;
     _abort = new AbortController();
 
+    // Ensure the configured room exists before subscribing to SSE.
+    try {
+      const checkRes = await fetch(
+        `${cfg.backendUrl}/rooms/${encodeURIComponent(cfg.room)}`,
+      );
+      if (checkRes.status === 404) {
+        const createRes = await fetch(`${cfg.backendUrl}/rooms`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: cfg.room,
+            mode: "coordination",
+            description: `Channel room created by mycelium-room plugin`,
+          }),
+        });
+        if (createRes.ok) {
+          log.info(`[${CHANNEL_ID}] created room "${cfg.room}"`);
+        } else {
+          log.warn(
+            `[${CHANNEL_ID}] failed to create room "${cfg.room}": ${createRes.status}`,
+          );
+        }
+      }
+    } catch (err: any) {
+      log.warn(
+        `[${CHANNEL_ID}] room ensure check failed: ${err?.message ?? err}`,
+      );
+    }
+
     startRoomSSE(runtime, cfg, _abort, handleMessage, log);
 
     // Poll for session sub-rooms and subscribe to their SSE streams.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/knowledge/ingest.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/knowledge/ingest.ts
@@ -20,8 +20,6 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import {
   type ChannelConfig,
   getAgentId,
-  getMasId,
-  getWorkspaceId,
   resolveHandle,
 } from "../config.js";
 import { apiPost } from "../http.js";
@@ -63,19 +61,19 @@ export function installKnowledgeIngest(
       // (which getAgentId reads) belongs to the gateway, not the agent.
       // Falling back to getAgentId() keeps direct `openclaw agent --agent`
       // invocations attributed. See issue #144.
+      //
+      // Leaf nodes only send room_name — the backend resolves workspace_id
+      // and mas_id from the room's DB record or its own settings (#139).
       const ingestAgentId = agentId?.trim() || getAgentId() || undefined;
-      const ws = getWorkspaceId();
-      const ms = getMasId();
-      const ingestBody: Record<string, unknown> = {
-        room_name: channelCfg?.room || undefined,
-        agent_id: ingestAgentId,
-        records: [{ response: event.content }],
-      };
-      if (ws) ingestBody.workspace_id = ws;
-      if (ms) ingestBody.mas_id = ms;
-      apiPost("/api/knowledge/ingest", ingestBody, log).catch((err) =>
-        log.warn(`[mycelium] ingest failed: ${err}`),
-      );
+      apiPost(
+        "/api/knowledge/ingest",
+        {
+          room_name: channelCfg?.room || undefined,
+          agent_id: ingestAgentId,
+          records: [{ response: event.content }],
+        },
+        log,
+      ).catch((err) => log.warn(`[mycelium] ingest failed: ${err}`));
     },
   );
 }

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/knowledge/ingest.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/knowledge/ingest.ts
@@ -58,26 +58,24 @@ export function installKnowledgeIngest(
         );
       }
 
+      // Prefer the per-turn agentId from the OpenClaw context — it's
+      // present for channel-dispatched turns, where the process env
+      // (which getAgentId reads) belongs to the gateway, not the agent.
+      // Falling back to getAgentId() keeps direct `openclaw agent --agent`
+      // invocations attributed. See issue #144.
+      const ingestAgentId = agentId?.trim() || getAgentId() || undefined;
       const ws = getWorkspaceId();
       const ms = getMasId();
-      if (ws && ms) {
-        // Prefer the per-turn agentId from the OpenClaw context — it's
-        // present for channel-dispatched turns, where the process env
-        // (which getAgentId reads) belongs to the gateway, not the agent.
-        // Falling back to getAgentId() keeps direct `openclaw agent --agent`
-        // invocations attributed. See issue #144.
-        const ingestAgentId = agentId?.trim() || getAgentId() || undefined;
-        apiPost(
-          "/api/knowledge/ingest",
-          {
-            workspace_id: ws,
-            mas_id: ms,
-            agent_id: ingestAgentId,
-            records: [{ response: event.content }],
-          },
-          log,
-        ).catch((err) => log.warn(`[mycelium] ingest failed: ${err}`));
-      }
+      const ingestBody: Record<string, unknown> = {
+        room_name: channelCfg?.room || undefined,
+        agent_id: ingestAgentId,
+        records: [{ response: event.content }],
+      };
+      if (ws) ingestBody.workspace_id = ws;
+      if (ms) ingestBody.mas_id = ms;
+      apiPost("/api/knowledge/ingest", ingestBody, log).catch((err) =>
+        log.warn(`[mycelium] ingest failed: ${err}`),
+      );
     },
   );
 }

--- a/mycelium-cli/src/mycelium/commands/cfn.py
+++ b/mycelium-cli/src/mycelium/commands/cfn.py
@@ -334,6 +334,11 @@ def _default_workspace() -> str | None:
     return cfg.server.workspace_id or cfg.runtime.workspace_id or None
 
 
+def _default_mas() -> str | None:
+    cfg = MyceliumConfig.load()
+    return cfg.server.mas_id or None
+
+
 def _cfn_request(method: str, path: str, **kwargs) -> dict:
     """Hit a mycelium-backend route, exit(1) with a clear error on failure."""
     try:
@@ -355,7 +360,7 @@ def _cfn_request(method: str, path: str, **kwargs) -> dict:
 
 
 @doc_ref(
-    usage="mycelium cfn query <intent> --mas <mas-id> [--workspace <ws>]",
+    usage="mycelium cfn query <intent> [--mas <mas-id>] [--workspace <ws>]",
     desc=(
         "Ask CFN's evidence agent a natural-language question about the "
         "shared knowledge graph. Returns a synthesized answer, not a record list."
@@ -365,7 +370,7 @@ def _cfn_request(method: str, path: str, **kwargs) -> dict:
 @app.command(name="query")
 def cfn_query(
     intent: str = typer.Argument(..., help="Natural-language question to ask CFN"),
-    mas_id: str = typer.Option(..., "--mas", "-m", help="Multi-agentic system ID"),
+    mas_id: str | None = typer.Option(None, "--mas", "-m", help="MAS ID (defaults to config)"),
     workspace: str | None = typer.Option(
         None,
         "--workspace",
@@ -387,7 +392,10 @@ def cfn_query(
     "graph missing"). This command renders that as a "no evidence" message,
     not a hard error.
     """
-    body: dict = {"mas_id": mas_id, "intent": intent}
+    resolved_mas = mas_id or _default_mas()
+    body: dict = {"intent": intent}
+    if resolved_mas:
+        body["mas_id"] = resolved_mas
     if workspace or _default_workspace():
         body["workspace_id"] = workspace or _default_workspace()
     if agent_id:
@@ -449,14 +457,14 @@ def cfn_query(
 
 
 @doc_ref(
-    usage="mycelium cfn concepts <id>[,<id>,...] --mas <mas-id>",
+    usage="mycelium cfn concepts <id>[,<id>,...] [--mas <mas-id>]",
     desc="Fetch specific CFN concept records by ID.",
     group="cfn",
 )
 @app.command(name="concepts")
 def cfn_concepts(
     ids: str = typer.Argument(..., help="Comma-separated concept IDs"),
-    mas_id: str = typer.Option(..., "--mas", "-m", help="Multi-agentic system ID"),
+    mas_id: str | None = typer.Option(None, "--mas", "-m", help="MAS ID (defaults to config)"),
     workspace: str | None = typer.Option(
         None,
         "--workspace",
@@ -471,7 +479,10 @@ def cfn_concepts(
         console.print("[red]no concept IDs provided[/red]")
         raise typer.Exit(2)
 
-    body: dict = {"mas_id": mas_id, "ids": id_list}
+    resolved_mas = mas_id or _default_mas()
+    body: dict = {"ids": id_list}
+    if resolved_mas:
+        body["mas_id"] = resolved_mas
     if workspace or _default_workspace():
         body["workspace_id"] = workspace or _default_workspace()
 
@@ -497,14 +508,14 @@ def cfn_concepts(
 
 
 @doc_ref(
-    usage="mycelium cfn neighbors <concept-id> --mas <mas-id>",
+    usage="mycelium cfn neighbors <concept-id> [--mas <mas-id>]",
     desc="Show CFN graph neighbors for a concept.",
     group="cfn",
 )
 @app.command(name="neighbors")
 def cfn_neighbors(
     concept_id: str = typer.Argument(..., help="Concept ID to look up neighbors for"),
-    mas_id: str = typer.Option(..., "--mas", "-m", help="Multi-agentic system ID"),
+    mas_id: str | None = typer.Option(None, "--mas", "-m", help="MAS ID (defaults to config)"),
     workspace: str | None = typer.Option(
         None,
         "--workspace",
@@ -514,7 +525,10 @@ def cfn_neighbors(
     json_output: bool = typer.Option(False, "--json", help="Print raw JSON response"),
 ) -> None:
     """Show CFN graph neighbors for a concept."""
-    params: dict = {"mas_id": mas_id}
+    resolved_mas = mas_id or _default_mas()
+    params: dict = {}
+    if resolved_mas:
+        params["mas_id"] = resolved_mas
     if workspace or _default_workspace():
         params["workspace_id"] = workspace or _default_workspace()
 
@@ -544,7 +558,7 @@ def cfn_neighbors(
 
 
 @doc_ref(
-    usage="mycelium cfn ls --mas <mas-id> [--limit N] [--json]",
+    usage="mycelium cfn ls [--mas <mas-id>] [--limit N] [--json]",
     desc=(
         "Enumerate nodes in CFN's knowledge graph by reading AgensGraph "
         "directly. NOT a CFN-supported API — couples to CFN's internal "
@@ -554,7 +568,7 @@ def cfn_neighbors(
 )
 @app.command(name="ls")
 def cfn_ls(
-    mas_id: str = typer.Option(..., "--mas", "-m", help="Multi-agentic system ID"),
+    mas_id: str | None = typer.Option(None, "--mas", "-m", help="MAS ID (defaults to config)"),
     limit: int = typer.Option(
         50,
         "--limit",
@@ -571,10 +585,14 @@ def cfn_ls(
     does not expose an enumeration endpoint. Returns empty or 404 if the
     graph doesn't exist (nothing has been ingested yet for that MAS).
     """
+    resolved_mas = mas_id or _default_mas()
+    params: dict = {"limit": limit}
+    if resolved_mas:
+        params["mas_id"] = resolved_mas
     data = _cfn_request(
         "GET",
         "/api/cfn/knowledge/list",
-        params={"mas_id": mas_id, "limit": limit},
+        params=params,
     )
 
     if json_output:
@@ -604,7 +622,7 @@ def cfn_ls(
 
 
 @doc_ref(
-    usage="mycelium cfn paths <source-id> <target-id> --mas <mas-id> [--max-depth N] [--limit N]",
+    usage="mycelium cfn paths <source-id> <target-id> [--mas <mas-id>] [--max-depth N] [--limit N]",
     desc="Show CFN graph paths between two concepts.",
     group="cfn",
 )
@@ -612,7 +630,7 @@ def cfn_ls(
 def cfn_paths(
     source_id: str = typer.Argument(..., help="Source concept ID"),
     target_id: str = typer.Argument(..., help="Target concept ID"),
-    mas_id: str = typer.Option(..., "--mas", "-m", help="Multi-agentic system ID"),
+    mas_id: str | None = typer.Option(None, "--mas", "-m", help="MAS ID (defaults to config)"),
     workspace: str | None = typer.Option(
         None,
         "--workspace",
@@ -634,7 +652,10 @@ def cfn_paths(
     json_output: bool = typer.Option(False, "--json", help="Print raw JSON response"),
 ) -> None:
     """Show CFN graph paths between two concepts."""
-    body: dict = {"mas_id": mas_id, "source_id": source_id, "target_id": target_id}
+    resolved_mas = mas_id or _default_mas()
+    body: dict = {"source_id": source_id, "target_id": target_id}
+    if resolved_mas:
+        body["mas_id"] = resolved_mas
     if workspace or _default_workspace():
         body["workspace_id"] = workspace or _default_workspace()
     if max_depth is not None:

--- a/mycelium-cli/src/mycelium/commands/cfn.py
+++ b/mycelium-cli/src/mycelium/commands/cfn.py
@@ -602,11 +602,12 @@ def cfn_ls(
     nodes = data.get("nodes", []) or []
     count = data.get("count", len(nodes))
 
+    display_mas = resolved_mas or data.get("mas_id", "?")
     if not nodes:
-        console.print(f"[dim]no nodes in graph for mas={mas_id}[/dim]")
+        console.print(f"[dim]no nodes in graph for mas={display_mas}[/dim]")
         return
 
-    console.print(f"[bold]{count} node(s) in graph for mas={mas_id}[/bold]")
+    console.print(f"[bold]{count} node(s) in graph for mas={display_mas}[/bold]")
     for n in nodes:
         label = n.get("label") or "node"
         nid = n.get("id") or ""

--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -1052,9 +1052,11 @@ def install(
                     typer.secho(f"  ⚠  Could not provision backend: {exc}", fg=typer.colors.YELLOW)
                     workspace_id, mas_id = "", ""
 
-            # Persist WORKSPACE_ID into .env and restart backend so it picks it up
+            # Persist WORKSPACE_ID and MAS_ID into .env and restart backend so it picks them up
             if workspace_id:
                 ws_patch: dict[str, str] = {"WORKSPACE_ID": workspace_id}
+                if mas_id:
+                    ws_patch["MAS_ID"] = mas_id
                 if ioc:
                     ws_patch["CFN_MGMT_URL"] = "http://ioc-cfn-mgmt-plane-svc:9000"
                     ws_patch["COGNITION_FABRIC_NODE_URL"] = (
@@ -1330,9 +1332,11 @@ def install(
                 workspace_id, mas_id = "", ""
 
         # ── Phase 6: Migrate DB + write config ────────────────────────────
-        # Persist WORKSPACE_ID into .env and restart backend so it picks it up
+        # Persist WORKSPACE_ID and MAS_ID into .env and restart backend so it picks them up
         if workspace_id:
             ws_patch: dict[str, str] = {"WORKSPACE_ID": workspace_id}
+            if mas_id:
+                ws_patch["MAS_ID"] = mas_id
             if ioc_enabled:
                 ws_patch["CFN_MGMT_URL"] = "http://ioc-cfn-mgmt-plane-svc:9000"
                 ws_patch["COGNITION_FABRIC_NODE_URL"] = "http://ioc-cognition-fabric-node-svc:9002"


### PR DESCRIPTION
## Summary

- **Leaf nodes no longer need `workspace_id` or `mas_id`** — they send only `room_name` and the backend resolves both from the room's DB record or its own settings. This eliminates configuration burden on leaf devices (oclw3, oclw5) and fixes mis-routing where every room's knowledge was ingested under the global default `mas_id`. Closes #139.
- **Channel plugin auto-creates its room** — the `mycelium-room` channel plugin now ensures the configured room exists on `gateway_start`, instead of silently retrying SSE on 404. Discovered during cross-channel memory isolation testing for #108.
- **Client-side cleanup** — removes `workspace_id`/`mas_id` from the OpenClaw ingest plugin and Claude Code knowledge-extract hook, keeping the ingest payload minimal (`room_name` + `agent_id` + `records`).
- **Hardening** — guards `_cfn_decide_round` against crashes, runs blocking `list_concepts` in a threadpool, and improves error messages when a room exists but has no `mas_id`.

## Commits

| Commit | What |
|--------|------|
| `75515c4` | `feat(ingest): resolve workspace_id and mas_id on the backend` — core backend resolution logic with `cfn_resolve` service |
| `642bfd5` | `fix(cfn-proxy): run blocking list_concepts in threadpool` |
| `1f4d5fa` | `fix(coordination): guard _cfn_decide_round result processing against crashes` |
| `895f0bb` | `fix(cfn-resolve): accurate error when room exists but has no mas_id` |
| `3831204` | `fix(cfn-cli): display resolved MAS ID in cfn ls output, not raw param` |
| `9ee6331` | `feat(ingest): leaf nodes send only room_name, backend resolves IDs` — client-side cleanup + tests |
| `421e0d6` | `fix(channel): auto-create room on gateway_start if it doesn't exist` |

## Test plan

- [x] `test_cfn_resolve.py` — 264-line test suite for the new `cfn_resolve` service (room lookup, settings fallback, error cases)
- [x] `test_cfn_read_surface.py` — new tests for `mas_id` resolution from settings and 400 when missing
- [x] `test_knowledge_ingest.py` — new test for leaf-node ingest resolving IDs from room DB record
- [x] E2E on oclw4: `test_48_distributed_backend_resolved_cfn_ids` — verifies leaf nodes can ingest without `workspace_id`/`mas_id`
- [x] E2E on oclw4: `test_60_cross_channel_memory_isolation` — 12/12 checks passed, proves room-scoped memory isolation and context bridging (see #108 comment)

Made with [Cursor](https://cursor.com)