### PR TITLE
fix(rooms): cascade DELETE /rooms to children + tear down CFN state

### DIFF
--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -7,13 +7,14 @@ import logging
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database import get_async_session
-from app.models import Room
+from app.models import Room, Session
 from app.schemas import RoomCreate, RoomRead
+from app.services import coordination
 from app.services.filesystem import ensure_room_structure, get_room_dir, remove_room_dir
 
 logger = logging.getLogger(__name__)
@@ -270,7 +271,25 @@ async def delete_room(
     room_name: str,
     session: AsyncSession = Depends(get_async_session),
 ):
-    """Delete a room by name."""
+    """Delete a room and cascade to its child session rooms.
+
+    Cleanup order is important to avoid stale state firing against
+    already-deleted rows:
+
+      1. Enumerate child session rooms (``parent_namespace == room_name``).
+      2. Tear down all in-memory CFN coordination state for the namespace
+         and its children (cancels pending join timers and active round
+         timeouts, posts ``coordination_consensus broken=True`` to any
+         SSE subscribers).
+      3. Delete child ``Session`` rows, then child ``Room`` rows.
+      4. Mark any active child rooms as ``coordination_state="failed"``
+         (defensive — if step 3 didn't catch them due to a race, the
+         state still reflects reality).
+      5. Delete the parent ``Room`` row.
+      6. Remove the filesystem directory.
+      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
+         error doesn't block the local cleanup).
+    """
     if room_name in RESERVED_ROOMS:
         raise HTTPException(status_code=400, detail=f"'{room_name}' is a reserved system room")
 
@@ -279,12 +298,54 @@ async def delete_room(
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
 
-    # Delete MAS from CFN mgmt plane (non-fatal)
-    await _sync_delete_mas(room)
+    # 1. Enumerate child session rooms.
+    child_result = await session.execute(
+        select(Room.name).where(Room.parent_namespace == room_name)
+    )
+    child_room_names = [r for r in child_result.scalars().all()]
 
+    # 2. Tear down in-memory coordination state for namespace + all children.
+    # Do this BEFORE the DB deletes so any in-flight `_run_tick` that resolves
+    # against the DB sees the row gone and bails, rather than firing ticks
+    # against a half-deleted state.
+    try:
+        await coordination.teardown_for_namespace(room_name, child_room_names)
+    except Exception as exc:
+        # Teardown is best-effort cleanup; log but don't block the delete.
+        logger.warning(
+            "coordination.teardown_for_namespace failed for %s: %s", room_name, exc
+        )
+
+    # 3. Delete child Session rows for every child room (and the parent, in
+    #    case anyone joined it directly), then the child Room rows.
+    if child_room_names:
+        await session.execute(
+            delete(Session).where(Session.room_name.in_(child_room_names))
+        )
+    await session.execute(delete(Session).where(Session.room_name == room_name))
+
+    # 4. Defensive: mark any still-existing child rooms as failed before delete
+    #    so any concurrent reader sees a consistent state.
+    if child_room_names:
+        await session.execute(
+            update(Room)
+            .where(Room.name.in_(child_room_names))
+            .values(coordination_state="failed")
+        )
+        await session.execute(delete(Room).where(Room.name.in_(child_room_names)))
+
+    # 5. Delete the parent room row.
     await session.delete(room)
     await session.commit()
 
-    # Remove filesystem directory
+    # 6. Remove filesystem directory for the parent (children share the parent
+    #    namespace's filesystem layout — no separate per-session directory).
     remove_room_dir(room_name)
-    logger.info("Removed room directory for: %s", room_name)
+    logger.info(
+        "Removed room %s and %d child session room(s)",
+        room_name,
+        len(child_room_names),
+    )
+
+    # 7. Delete MAS from CFN mgmt plane (non-fatal, last).
+    await _sync_delete_mas(room)

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -312,25 +312,19 @@ async def delete_room(
         await coordination.teardown_for_namespace(room_name, child_room_names)
     except Exception as exc:
         # Teardown is best-effort cleanup; log but don't block the delete.
-        logger.warning(
-            "coordination.teardown_for_namespace failed for %s: %s", room_name, exc
-        )
+        logger.warning("coordination.teardown_for_namespace failed for %s: %s", room_name, exc)
 
     # 3. Delete child Session rows for every child room (and the parent, in
     #    case anyone joined it directly), then the child Room rows.
     if child_room_names:
-        await session.execute(
-            delete(Session).where(Session.room_name.in_(child_room_names))
-        )
+        await session.execute(delete(Session).where(Session.room_name.in_(child_room_names)))
     await session.execute(delete(Session).where(Session.room_name == room_name))
 
     # 4. Defensive: mark any still-existing child rooms as failed before delete
     #    so any concurrent reader sees a consistent state.
     if child_room_names:
         await session.execute(
-            update(Room)
-            .where(Room.name.in_(child_room_names))
-            .values(coordination_state="failed")
+            update(Room).where(Room.name.in_(child_room_names)).values(coordination_state="failed")
         )
         await session.execute(delete(Room).where(Room.name.in_(child_room_names)))
 

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -172,7 +172,7 @@ async def join_room(
         if claimed is not None:
             from app.services import coordination
 
-            asyncio.ensure_future(coordination.start_join_timer(target_room.name, deadline))
+            coordination.schedule_join_timer(target_room.name, deadline)
             logger.info(
                 "Coordination join timer started for session %s (deadline=%s)",
                 target_room.name,

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -61,6 +61,11 @@ class _CfnRoundState:
 # {room_name: _CfnRoundState}
 _cfn_state: dict[str, _CfnRoundState] = {}
 
+# {room_name: asyncio.Task}
+# Tracks in-flight `start_join_timer` tasks so room deletion can cancel them
+# before the join window fires `_run_tick` for an already-deleted room.
+_join_timer_tasks: dict[str, asyncio.Task] = {}
+
 
 def _utcnow() -> datetime:
     return datetime.now(UTC)
@@ -115,6 +120,26 @@ async def start_join_timer(room_name: str, deadline: datetime) -> None:
     if sleep_secs > 0:
         await asyncio.sleep(sleep_secs)
     await _run_tick(room_name, tick=0)
+
+
+def schedule_join_timer(room_name: str, deadline: datetime) -> asyncio.Task:
+    """Schedule ``start_join_timer`` and register the task for later cancellation.
+
+    Callers should prefer this over a bare ``asyncio.ensure_future(start_join_timer(...))``
+    so :func:`teardown_for_namespace` can cancel a still-pending join window
+    when the room is deleted.
+    """
+    task = asyncio.ensure_future(start_join_timer(room_name, deadline))
+    _join_timer_tasks[room_name] = task
+
+    def _clear(t: asyncio.Task, _name: str = room_name) -> None:
+        # Remove only if this exact task is still the registered one — guards
+        # against a re-scheduled timer for the same room replacing us.
+        if _join_timer_tasks.get(_name) is t:
+            _join_timer_tasks.pop(_name, None)
+
+    task.add_done_callback(_clear)
+    return task
 
 
 async def _run_tick(room_name: str, tick: int) -> None:
@@ -453,6 +478,78 @@ async def _cfn_decide_round(room_name: str) -> None:
         logger.exception("Unhandled error processing CFN decide response for %s", room_name)
         await _finish_cfn(
             room_name, plan=f"CFN response processing failed — {exc}", assignments={}, broken=True
+        )
+
+
+async def teardown_for_namespace(
+    namespace_name: str, child_room_names: list[str]
+) -> None:
+    """Tear down all in-memory CFN state for a namespace and its child sessions.
+
+    Called from ``DELETE /rooms/{room_name}`` to prevent cross-test (and
+    cross-deletion) interference: without this, a deleted room's
+    ``_cfn_state`` entry keeps its ``round_timeout_task`` alive and continues
+    posting ``coordination_tick`` messages to the (recreated) room, and a
+    pending ``start_join_timer`` will fire ``_run_tick`` against a now-empty
+    DB which produces a stream of confused log entries.
+
+    For every active room (the namespace itself plus every child session
+    room provided), this:
+
+      1. Cancels the pending ``start_join_timer`` task, if any.
+      2. Cancels the active CFN ``round_timeout_task`` and pops the
+         ``_cfn_state`` entry.
+      3. Posts a ``coordination_consensus`` message with ``broken=True`` so
+         any SSE subscribers (agents waiting on a tick) are notified the
+         negotiation has been aborted.
+
+    The caller is responsible for the actual DB row deletes.
+    """
+    affected = [namespace_name, *child_room_names]
+    for room_name in affected:
+        # 1. Cancel any pending join timer.
+        join_task = _join_timer_tasks.pop(room_name, None)
+        if join_task is not None and not join_task.done():
+            join_task.cancel()
+
+        # 2. Cancel any active CFN round and drop the in-memory state.
+        state = _cfn_state.pop(room_name, None)
+        had_active_cfn = False
+        if state is not None:
+            had_active_cfn = True
+            if state.round_timeout_task and not state.round_timeout_task.done():
+                state.round_timeout_task.cancel()
+
+        # 3. Notify any SSE subscribers that the negotiation was aborted.
+        # We only send this for rooms that had active CFN state — there is no
+        # point waking subscribers on rooms that never started negotiating.
+        if had_active_cfn:
+            try:
+                await _post_message(
+                    room_name,
+                    message_type="coordination_consensus",
+                    content=json.dumps(
+                        {
+                            "plan": "Coordination aborted — room deleted",
+                            "assignments": {},
+                            "broken": True,
+                        }
+                    ),
+                )
+            except Exception as exc:
+                # Posting to a room that's mid-delete can race with the row
+                # being removed; that's fine, just log and continue.
+                logger.warning(
+                    "teardown_for_namespace: failed to post abort notice for %s: %s",
+                    room_name,
+                    exc,
+                )
+
+    if affected:
+        logger.info(
+            "Coordination teardown complete for namespace %s (cleared %d rooms)",
+            namespace_name,
+            len(affected),
         )
 
 

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -481,9 +481,7 @@ async def _cfn_decide_round(room_name: str) -> None:
         )
 
 
-async def teardown_for_namespace(
-    namespace_name: str, child_room_names: list[str]
-) -> None:
+async def teardown_for_namespace(namespace_name: str, child_room_names: list[str]) -> None:
     """Tear down all in-memory CFN state for a namespace and its child sessions.
 
     Called from ``DELETE /rooms/{room_name}`` to prevent cross-test (and

--- a/fastapi-backend/tests/test_coordination.py
+++ b/fastapi-backend/tests/test_coordination.py
@@ -460,6 +460,7 @@ async def test_teardown_cancels_pending_join_timer():
 @pytest.mark.asyncio
 async def test_teardown_cancels_round_timeout_and_pops_state():
     """Active CFN round state must be removed and its watchdog cancelled."""
+
     # Build a never-ending round_timeout_task to simulate an in-flight round.
     async def never() -> None:
         await asyncio.sleep(3600)

--- a/fastapi-backend/tests/test_coordination.py
+++ b/fastapi-backend/tests/test_coordination.py
@@ -427,3 +427,111 @@ async def test_timeout_status_posts_broken_consensus():
     assert consensus["broken"] is True
 
     _cfn_state.clear()
+
+
+# ── teardown_for_namespace ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_teardown_cancels_pending_join_timer():
+    """A pending start_join_timer task should be cancelled, not allowed to run."""
+    from datetime import timedelta
+
+    fired = asyncio.Event()
+
+    async def slow_run_tick(_room: str, tick: int) -> None:  # noqa: ARG001
+        fired.set()
+
+    with patch.object(coord, "_run_tick", new=AsyncMock(side_effect=slow_run_tick)):
+        deadline = coord._utcnow() + timedelta(seconds=10)
+        task = coord.schedule_join_timer("ns-a", deadline)
+        assert "ns-a" in coord._join_timer_tasks
+
+        # Tear down before the timer fires.
+        await coord.teardown_for_namespace("ns-a", [])
+
+        # Task should be cancelled and removed from registry.
+        await asyncio.sleep(0.05)
+        assert task.cancelled() or task.done()
+        assert "ns-a" not in coord._join_timer_tasks
+        assert not fired.is_set()
+
+
+@pytest.mark.asyncio
+async def test_teardown_cancels_round_timeout_and_pops_state():
+    """Active CFN round state must be removed and its watchdog cancelled."""
+    # Build a never-ending round_timeout_task to simulate an in-flight round.
+    async def never() -> None:
+        await asyncio.sleep(3600)
+
+    timeout_task = asyncio.ensure_future(never())
+    state = _CfnRoundState(
+        session_id="sess",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["alice", "bob"],
+        pending_replies={"alice": None, "bob": None},
+    )
+    state.round_timeout_task = timeout_task
+    _cfn_state["ns-b:session:1"] = state
+
+    with patch.object(coord, "_post_message", new=AsyncMock()) as post:
+        await coord.teardown_for_namespace("ns-b", ["ns-b:session:1"])
+
+    assert "ns-b:session:1" not in _cfn_state
+    await asyncio.sleep(0)
+    assert timeout_task.cancelled()
+
+    # An abort consensus message should have been posted to the child room
+    # (the only room that had active CFN state).
+    assert post.call_count == 1
+    call = post.call_args_list[0]
+    assert call.args[0] == "ns-b:session:1"
+    assert call.kwargs["message_type"] == "coordination_consensus"
+    body = json.loads(call.kwargs["content"])
+    assert body["broken"] is True
+    assert body["assignments"] == {}
+
+
+@pytest.mark.asyncio
+async def test_teardown_skips_post_for_rooms_without_cfn_state():
+    """Rooms that never started negotiating should NOT receive an abort consensus."""
+    # No state for this namespace at all.
+    with patch.object(coord, "_post_message", new=AsyncMock()) as post:
+        await coord.teardown_for_namespace("ns-c", ["ns-c:session:x"])
+
+    assert post.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_teardown_handles_post_message_exceptions_gracefully():
+    """A broken _post_message call must not propagate; teardown still completes."""
+    state = _CfnRoundState(
+        session_id="sess",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["alice"],
+        pending_replies={"alice": None},
+    )
+    _cfn_state["ns-d"] = state
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("simulated post failure")
+
+    with patch.object(coord, "_post_message", new=AsyncMock(side_effect=boom)):
+        # Must not raise.
+        await coord.teardown_for_namespace("ns-d", [])
+
+    assert "ns-d" not in _cfn_state
+
+
+@pytest.mark.asyncio
+async def test_schedule_join_timer_clears_registry_on_completion():
+    """When the timer task completes naturally, the registry slot is cleared."""
+    with patch.object(coord, "_run_tick", new=AsyncMock()):
+        deadline = coord._utcnow()  # already passed → run_tick fires immediately
+        task = coord.schedule_join_timer("ns-e", deadline)
+        await task
+        # Allow the done-callback to run.
+        await asyncio.sleep(0)
+        assert "ns-e" not in coord._join_timer_tasks

--- a/fastapi-backend/tests/test_coordination.py
+++ b/fastapi-backend/tests/test_coordination.py
@@ -439,7 +439,7 @@ async def test_teardown_cancels_pending_join_timer():
 
     fired = asyncio.Event()
 
-    async def slow_run_tick(_room: str, tick: int) -> None:  # noqa: ARG001
+    async def slow_run_tick(_room: str, tick: int) -> None:
         fired.set()
 
     with patch.object(coord, "_run_tick", new=AsyncMock(side_effect=slow_run_tick)):


### PR DESCRIPTION
## Summary

Deleting a room only removed the parent `Room` row, leaving behind:

- **In-memory CFN coordination state** (`_cfn_state[room]`) with a live `round_timeout_task` that kept firing `coordination_tick` messages against the (recreated) room — the **root cause of cross-test coordination interference** observed in distributed E2E runs.
- **Pending `start_join_timer` tasks** scheduled by \`routes/sessions.py\` that would later wake and call \`_run_tick\` against an empty DB.
- **Child \`:session:<id>\` Room rows** linked via \`parent_namespace\`, plus their \`Session\` participant rows.
- **SSE subscribers (agents)** waiting on a tick with no signal that the negotiation had been aborted.

## Changes

- \`coordination.teardown_for_namespace(namespace, child_rooms)\` — cancels pending join timers, cancels active round watchdogs, pops \`_cfn_state\` entries, and posts \`coordination_consensus broken=True\` to any room that had active CFN state.
- \`coordination.schedule_join_timer(...)\` — registers the join-timer task in a new \`_join_timer_tasks\` dict so teardown can cancel it. \`routes/sessions.py\` now uses this instead of a bare \`asyncio.ensure_future(start_join_timer(...))\`.
- \`routes/rooms.py::delete_room\` — enumerates children, calls the teardown helper, deletes child \`Session\` + \`Room\` rows, marks any surviving children as failed, then deletes the parent. MAS delete moved last so a CFN error doesn't block local cleanup.
- 5 new unit tests cover join-timer cancellation, round-timeout + state pop, no-op when no CFN state was active, exception swallowing, and registry clearing on natural completion.

## Why now

Without this, \`test_4*\` cross-test interference is the dominant failure mode and every other coordination change is impossible to verify. Smoke-tested on \`test_41\`: the consensus-stall failure mode no longer reproduces; the only remaining flakiness is content-quality assertions unrelated to CFN lifecycle.

## Test plan

- [ ] \`cd fastapi-backend && uv run ruff check .\` — passes (1 stale \`noqa\` removed in fixup commit)
- [ ] \`cd fastapi-backend && uv run pytest tests/test_coordination.py\` — 15 passed
- [ ] \`cd fastapi-backend && uv run pytest\` — full suite passes
- [ ] Manual: smoke \`test_41\` twice back-to-back, verify no leftover \`_cfn_state\` entries and no phantom ticks against deleted rooms

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)