### PR TITLE
fix(coordination): adaptive CFN round timeout

### DIFF
--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -42,9 +42,21 @@ class Settings(BaseSettings):
     # How long to wait for additional agents to join after the first agent joins
     # a session before CognitiveEngine fires tick-0 (starts negotiation).
     COORDINATION_JOIN_WINDOW_SECONDS: int = 30
-    # Per-round timeout: how long CognitiveEngine waits for an agent to reply
-    # during a negotiation round before falling back to the safe default.
-    COORDINATION_TICK_TIMEOUT_SECONDS: int = 30
+    # Per-agent base budget for the per-round watchdog. The initial deadline
+    # for a round is BASE * N + STARTUP. Set high enough to cover a typical
+    # LLM agent's read-tick → narrate → run-CLI cycle (15-60s).
+    COORDINATION_TICK_TIMEOUT_SECONDS: int = 45
+    # Constant added on top of BASE * N for the initial round deadline. Covers
+    # gateway routing, model cold start, and the first network leg.
+    COORDINATION_ROUND_STARTUP_SECONDS: int = 30
+    # When a new (real, non-synthesised) reply arrives mid-round, extend the
+    # watchdog by EXTENSION * remaining_handles, but never less than FLOOR.
+    # Bounded above by COORDINATION_ROUND_MAX_SECONDS.
+    COORDINATION_ROUND_EXTENSION_PER_REMAINING_SECONDS: int = 30
+    COORDINATION_ROUND_EXTENSION_FLOOR_SECONDS: int = 20
+    # Hard cap on total wall time per round, regardless of activity. Prevents
+    # one wedged agent from blocking the negotiation indefinitely.
+    COORDINATION_ROUND_MAX_SECONDS: int = 300
 
     @field_validator("LLM_BASE_URL", mode="before")
     @classmethod
@@ -59,7 +71,27 @@ class Settings(BaseSettings):
     @classmethod
     def _coerce_tick_timeout(cls, v: object) -> object:
         if v == "" or v is None:
-            return 30
+            return 45
+        return v
+
+    _ROUND_TIMER_DEFAULTS = {
+        "COORDINATION_ROUND_STARTUP_SECONDS": 30,
+        "COORDINATION_ROUND_EXTENSION_PER_REMAINING_SECONDS": 30,
+        "COORDINATION_ROUND_EXTENSION_FLOOR_SECONDS": 20,
+        "COORDINATION_ROUND_MAX_SECONDS": 300,
+    }
+
+    @field_validator(
+        "COORDINATION_ROUND_STARTUP_SECONDS",
+        "COORDINATION_ROUND_EXTENSION_PER_REMAINING_SECONDS",
+        "COORDINATION_ROUND_EXTENSION_FLOOR_SECONDS",
+        "COORDINATION_ROUND_MAX_SECONDS",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_round_timer_int(cls, v: object, info) -> object:  # type: ignore[no-untyped-def]
+        if v == "" or v is None:
+            return cls._ROUND_TIMER_DEFAULTS[info.field_name]
         return v
 
     # Filesystem-native memory storage

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -100,8 +100,11 @@ async def send_message(
         content_preview = msg.content[:120].replace("\n", "\\n")
         logger.info(
             "CFN_TRACE msg_in room=%s sender=%s type=%s recipient=%s content=%r",
-            room_name, msg.sender_handle, msg.message_type,
-            msg.recipient_handle, content_preview,
+            room_name,
+            msg.sender_handle,
+            msg.message_type,
+            msg.recipient_handle,
+            content_preview,
         )
         asyncio.ensure_future(
             coordination.on_agent_response(room_name, msg.sender_handle, msg.content)

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -97,6 +97,12 @@ async def send_message(
     if room.coordination_state == "negotiating":
         from app.services import coordination
 
+        content_preview = msg.content[:120].replace("\n", "\\n")
+        logger.info(
+            "CFN_TRACE msg_in room=%s sender=%s type=%s recipient=%s content=%r",
+            room_name, msg.sender_handle, msg.message_type,
+            msg.recipient_handle, content_preview,
+        )
         asyncio.ensure_future(
             coordination.on_agent_response(room_name, msg.sender_handle, msg.content)
         )

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -387,7 +387,10 @@ async def _fan_out_cfn_messages(
         if is_broadcast and all_agents:
             logger.info(
                 "CFN_TRACE fanout_broadcast room=%s round=%s next_proposer=%s agents=%s",
-                room_name, payload.get("round"), next_proposer_id, all_agents,
+                room_name,
+                payload.get("round"),
+                next_proposer_id,
+                all_agents,
             )
             # Fan out one tick per agent; mark who is authorised to counter_offer.
             for handle in all_agents:
@@ -498,7 +501,9 @@ async def _cfn_decide_round(room_name: str) -> None:
 
         logger.info(
             "CFN_TRACE decide_result room=%s status=%s round=%s",
-            room_name, status, payload.get("round"),
+            room_name,
+            status,
+            payload.get("round"),
         )
 
         if status in ("agreed",):
@@ -593,7 +598,9 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
         if handle not in cfn.pending_replies:
             logger.info(
                 "CFN_TRACE reply_unexpected room=%s handle=%s (not in pending=%s)",
-                room_name, handle, list(cfn.pending_replies.keys()),
+                room_name,
+                handle,
+                list(cfn.pending_replies.keys()),
             )
         if handle in cfn.pending_replies:
             # Only a previously-empty slot counts as a "new" reply for extension
@@ -604,8 +611,12 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
             received = sum(1 for v in cfn.pending_replies.values() if v is not None)
             logger.info(
                 "CFN_TRACE reply_collected room=%s handle=%s action=%s received=%d/%d new=%s",
-                room_name, handle, reply_data.get("action"),
-                received, len(cfn.pending_replies), is_new_reply,
+                room_name,
+                handle,
+                reply_data.get("action"),
+                received,
+                len(cfn.pending_replies),
+                is_new_reply,
             )
             all_received = all(v is not None for v in cfn.pending_replies.values())
             if all_received:

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -40,10 +40,20 @@ logger = logging.getLogger(__name__)
 # ── CFN mode state ─────────────────────────────────────────────────────────────
 
 
-# How long to wait for agent replies before calling /decide with whatever we have.
-# The IOC's BatchCallbackRunner uses a 30s per-round timeout; we fire slightly earlier
-# so the backend stays in sync with the IOC's internal loop.
-_CFN_ROUND_TIMEOUT_SECS = 25
+# Adaptive per-round watchdog (see _round_watchdog / _extend_round_timeout).
+#
+# History: this used to be a single fixed 25s asyncio.sleep that fired
+# unconditionally after every round opened, regardless of whether real replies
+# were still landing. With slow LLM agents (15-60s typical turn) that timer
+# always pre-empted the natural "all replies received" path, leaving N-1
+# pending_replies as None — which _cfn_decide_round then synthesised as
+# "reject" before shipping to CFN. CFN's consensus rule (all N must accept)
+# then never fired for 3+-agent LLM rooms; see issue #162.
+#
+# The watchdog now opens with a generous initial deadline scaled by N, then
+# *extends* every time a new real reply arrives — fast rounds still finish
+# fast, slow rounds finish when all real replies are in, and only a hard cap
+# (COORDINATION_ROUND_MAX_SECONDS) bounds total wall time.
 
 
 @dataclass
@@ -56,6 +66,10 @@ class _CfnRoundState:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     round_timeout_task: asyncio.Task | None = field(default=None)
     deciding: bool = field(default=False)  # guard against double-decide
+    # Wall-clock when the current round opened (set by _reset_round_timeout).
+    # Used by _extend_round_timeout to enforce COORDINATION_ROUND_MAX_SECONDS
+    # across multiple extension cycles.
+    round_started_monotonic: float = field(default=0.0)
 
 
 # {room_name: _CfnRoundState}
@@ -250,25 +264,91 @@ async def _run_cfn_negotiation(
     _reset_round_timeout(room_name, state)
 
 
+def _initial_round_budget_seconds(n_agents: int) -> float:
+    """Return the initial wall-clock budget for a round opened with N agents."""
+    base = max(1, settings.COORDINATION_TICK_TIMEOUT_SECONDS)
+    startup = max(0, settings.COORDINATION_ROUND_STARTUP_SECONDS)
+    cap = max(base, settings.COORDINATION_ROUND_MAX_SECONDS)
+    return min(float(cap), float(startup + base * max(1, n_agents)))
+
+
+def _extension_seconds(remaining: int) -> float:
+    """Return the extension applied each time a new real reply lands mid-round."""
+    per = max(0, settings.COORDINATION_ROUND_EXTENSION_PER_REMAINING_SECONDS)
+    floor = max(1, settings.COORDINATION_ROUND_EXTENSION_FLOOR_SECONDS)
+    return float(max(floor, per * max(1, remaining)))
+
+
 def _reset_round_timeout(room_name: str, state: "_CfnRoundState") -> None:
-    """Cancel any existing round timeout and start a new one."""
+    """Cancel any existing round timeout and open a fresh adaptive watchdog.
+
+    Called on round-open (after _fan_out_cfn_messages) and after _cfn_decide_round
+    transitions to "ongoing" with a new set of pending_replies.
+    """
     if state.round_timeout_task and not state.round_timeout_task.done():
         state.round_timeout_task.cancel()
-    state.round_timeout_task = asyncio.ensure_future(_round_timeout(room_name))
+    n = len(state.pending_replies) or len(state.agents) or 1
+    state.round_started_monotonic = asyncio.get_event_loop().time()
+    delay = _initial_round_budget_seconds(n)
+    state.round_timeout_task = asyncio.ensure_future(_round_watchdog(room_name, delay))
 
 
-async def _round_timeout(room_name: str) -> None:
-    """Fire /decide with whatever replies exist after _CFN_ROUND_TIMEOUT_SECS.
+def _extend_round_timeout(room_name: str, state: "_CfnRoundState") -> None:
+    """Restart the watchdog with a shorter extension after a new real reply.
 
-    The IOC's BatchCallbackRunner uses a 30s per-round timeout and auto-advances
-    when it fires.  We call /decide slightly earlier so the backend stays in sync
-    with the IOC's internal loop rather than waiting forever for all replies.
+    Fast rounds (all replies in quickly) never see this — on_agent_response cancels
+    the watchdog directly when the last reply lands and triggers _cfn_decide_round.
+    Slow rounds get extra time per outstanding handle, capped by
+    COORDINATION_ROUND_MAX_SECONDS measured from round-open.
     """
-    await asyncio.sleep(_CFN_ROUND_TIMEOUT_SECS)
+    if state.round_timeout_task and state.round_timeout_task.done():
+        # Watchdog already fired — nothing to extend; _cfn_decide_round is in flight.
+        return
+    remaining = sum(1 for v in state.pending_replies.values() if v is None)
+    if remaining <= 0:
+        return
+    elapsed = asyncio.get_event_loop().time() - state.round_started_monotonic
+    cap = max(1, settings.COORDINATION_ROUND_MAX_SECONDS)
+    budget_left = cap - elapsed
+    if budget_left <= 0:
+        # Hard cap already exceeded; let the existing watchdog fire on schedule.
+        return
+    extension = min(_extension_seconds(remaining), budget_left)
+    if state.round_timeout_task and not state.round_timeout_task.done():
+        state.round_timeout_task.cancel()
+    state.round_timeout_task = asyncio.ensure_future(_round_watchdog(room_name, extension))
+
+
+async def _round_watchdog(room_name: str, delay: float) -> None:
+    """Sleep `delay` seconds, then fire /decide with whatever replies exist.
+
+    On firing, log the synthesised handles explicitly so operators can see *why*
+    a consensus failure happened (per the bug report's "defensive instrumentation"
+    recommendation in issue #162).
+    """
+    try:
+        await asyncio.sleep(delay)
+    except asyncio.CancelledError:
+        return
     state = _cfn_state.get(room_name)
     if not state:
         return
-    logger.debug("CFN round timeout fired for %s — calling decide with partial replies", room_name)
+    synthesised = [h for h, v in state.pending_replies.items() if v is None]
+    if synthesised:
+        logger.warning(
+            "CFN round watchdog fired for %s after %.1fs — synthesising reject for %d/%d handles: %s",
+            room_name,
+            delay,
+            len(synthesised),
+            len(state.pending_replies),
+            synthesised,
+        )
+    else:
+        logger.debug(
+            "CFN round watchdog fired for %s after %.1fs — all replies present, calling decide",
+            room_name,
+            delay,
+        )
     await _cfn_decide_round(room_name)
 
 
@@ -305,6 +385,10 @@ async def _fan_out_cfn_messages(
         next_proposer_id = payload.get("next_proposer_id")
 
         if is_broadcast and all_agents:
+            logger.info(
+                "CFN_TRACE fanout_broadcast room=%s round=%s next_proposer=%s agents=%s",
+                room_name, payload.get("round"), next_proposer_id, all_agents,
+            )
             # Fan out one tick per agent; mark who is authorised to counter_offer.
             for handle in all_agents:
                 await _post_message(
@@ -379,6 +463,11 @@ async def _cfn_decide_round(room_name: str) -> None:
         else:
             agent_replies.append(reply_data)
 
+    logger.info(
+        "CFN_TRACE decide_call room=%s replies=%s",
+        room_name,
+        [(r.get("agent_id"), r.get("action")) for r in agent_replies],
+    )
     try:
         result = await decide_negotiation(
             session_id=state.session_id,
@@ -406,6 +495,11 @@ async def _cfn_decide_round(room_name: str) -> None:
         # Fall back to top-level keys for backward compatibility.
         payload = result.get("payload", {})
         status = payload.get("status", result.get("status", ""))
+
+        logger.info(
+            "CFN_TRACE decide_result room=%s status=%s round=%s",
+            room_name, status, payload.get("round"),
+        )
 
         if status in ("agreed",):
             final_result = result.get("final_result", {})
@@ -494,20 +588,32 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
         return
 
     should_decide = False
+    is_new_reply = False
     async with cfn.lock:
+        if handle not in cfn.pending_replies:
+            logger.info(
+                "CFN_TRACE reply_unexpected room=%s handle=%s (not in pending=%s)",
+                room_name, handle, list(cfn.pending_replies.keys()),
+            )
         if handle in cfn.pending_replies:
+            # Only a previously-empty slot counts as a "new" reply for extension
+            # purposes; agents that resubmit shouldn't keep stretching the round.
+            is_new_reply = cfn.pending_replies[handle] is None
             reply_data = _parse_agent_reply(handle, content)
             cfn.pending_replies[handle] = reply_data
-            logger.debug(
-                "CFN room %s: collected reply from %s (%d/%d)",
-                room_name,
-                handle,
-                sum(1 for v in cfn.pending_replies.values() if v is not None),
-                len(cfn.pending_replies),
+            received = sum(1 for v in cfn.pending_replies.values() if v is not None)
+            logger.info(
+                "CFN_TRACE reply_collected room=%s handle=%s action=%s received=%d/%d new=%s",
+                room_name, handle, reply_data.get("action"),
+                received, len(cfn.pending_replies), is_new_reply,
             )
             all_received = all(v is not None for v in cfn.pending_replies.values())
             if all_received:
                 should_decide = True
+            elif is_new_reply:
+                # Real reply landed but more outstanding — extend the watchdog
+                # under the lock so we don't race a parallel reply.
+                _extend_round_timeout(room_name, cfn)
     if should_decide:
         # All replies in — cancel the timeout so it doesn't double-fire
         if cfn.round_timeout_task and not cfn.round_timeout_task.done():

--- a/fastapi-backend/tests/test_coordination.py
+++ b/fastapi-backend/tests/test_coordination.py
@@ -427,3 +427,199 @@ async def test_timeout_status_posts_broken_consensus():
     assert consensus["broken"] is True
 
     _cfn_state.clear()
+
+
+# ── Tests: adaptive round watchdog (issue #162) ───────────────────────────────
+
+
+def test_initial_round_budget_scales_with_n():
+    """Initial budget = STARTUP + BASE * N, capped at MAX_ROUND_SECONDS."""
+    from app.config import settings
+    from app.services.coordination import _initial_round_budget_seconds
+
+    base = settings.COORDINATION_TICK_TIMEOUT_SECONDS
+    startup = settings.COORDINATION_ROUND_STARTUP_SECONDS
+    cap = settings.COORDINATION_ROUND_MAX_SECONDS
+
+    # 1 agent → at least startup + base, well under the cap
+    assert _initial_round_budget_seconds(1) == min(cap, startup + base)
+    # 3 agents → scales linearly
+    assert _initial_round_budget_seconds(3) == min(cap, startup + 3 * base)
+    # Pathologically large N is clamped at the cap
+    assert _initial_round_budget_seconds(10_000) == cap
+    # Defensive: 0 / negative N treated as 1
+    assert _initial_round_budget_seconds(0) == _initial_round_budget_seconds(1)
+
+
+def test_extension_seconds_floor_and_scaling():
+    """Extension = max(FLOOR, PER_REMAINING * remaining); never below FLOOR."""
+    from app.config import settings
+    from app.services.coordination import _extension_seconds
+
+    per = settings.COORDINATION_ROUND_EXTENSION_PER_REMAINING_SECONDS
+    floor = settings.COORDINATION_ROUND_EXTENSION_FLOOR_SECONDS
+
+    assert _extension_seconds(1) == max(floor, per * 1)
+    assert _extension_seconds(5) == max(floor, per * 5)
+    # Defensive: 0 remaining still returns at least the floor
+    assert _extension_seconds(0) >= floor
+
+
+@pytest.mark.asyncio
+async def test_extend_round_timeout_restarts_with_shorter_window():
+    """A new real reply mid-round should restart the watchdog at extension delay,
+    not the full initial budget — proves we stop firing the 25s default."""
+    from app.services.coordination import _extend_round_timeout, _reset_round_timeout
+
+    _cfn_state.clear()
+    state = _CfnRoundState(
+        session_id="room-ext",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["alice", "bob", "carol"],
+        pending_replies={"alice": None, "bob": None, "carol": None},
+    )
+    _cfn_state["room-ext"] = state
+
+    # Open the round normally — schedules a long initial watchdog.
+    _reset_round_timeout("room-ext", state)
+    initial_task = state.round_timeout_task
+    assert initial_task is not None and not initial_task.done()
+
+    # Simulate alice replying.
+    state.pending_replies["alice"] = {"agent_id": "alice", "action": "accept"}
+    _extend_round_timeout("room-ext", state)
+
+    # Yield once so the cancellation requested by _extend_round_timeout has a
+    # chance to settle (cancel() puts the task in CANCELLING, the next loop
+    # iteration completes the transition to CANCELLED).
+    try:
+        await initial_task
+    except asyncio.CancelledError:
+        pass
+
+    assert initial_task.cancelled() or initial_task.done()
+    assert state.round_timeout_task is not initial_task
+    assert state.round_timeout_task is not None and not state.round_timeout_task.done()
+
+    # Cleanup: cancel the new task to avoid leaking a sleep into the test loop.
+    state.round_timeout_task.cancel()
+    try:
+        await state.round_timeout_task
+    except asyncio.CancelledError:
+        pass
+    _cfn_state.clear()
+
+
+@pytest.mark.asyncio
+async def test_extend_round_timeout_respects_hard_cap():
+    """If we've already burned more than COORDINATION_ROUND_MAX_SECONDS,
+    extension is a no-op (the original watchdog is left to fire)."""
+    from app.config import settings
+    from app.services.coordination import _extend_round_timeout, _reset_round_timeout
+
+    _cfn_state.clear()
+    state = _CfnRoundState(
+        session_id="room-cap",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["a", "b"],
+        pending_replies={"a": None, "b": None},
+    )
+    _cfn_state["room-cap"] = state
+
+    _reset_round_timeout("room-cap", state)
+    original_task = state.round_timeout_task
+
+    # Pretend the round opened well in the past so budget_left <= 0.
+    state.round_started_monotonic -= settings.COORDINATION_ROUND_MAX_SECONDS + 5
+
+    state.pending_replies["a"] = {"agent_id": "a", "action": "accept"}
+    _extend_round_timeout("room-cap", state)
+
+    # No new task scheduled; original watchdog still in place.
+    assert state.round_timeout_task is original_task
+
+    # Cleanup
+    if original_task is not None and not original_task.done():
+        original_task.cancel()
+        try:
+            await original_task
+        except asyncio.CancelledError:
+            pass
+    _cfn_state.clear()
+
+
+@pytest.mark.asyncio
+async def test_on_agent_response_extends_watchdog_when_partial():
+    """A real reply that doesn't complete the round triggers _extend_round_timeout."""
+    _cfn_state.clear()
+    state = _CfnRoundState(
+        session_id="room-on",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["alice", "bob", "carol"],
+        pending_replies={"alice": None, "bob": None, "carol": None},
+    )
+    _cfn_state["room-on"] = state
+
+    with patch.object(coord, "_extend_round_timeout") as mock_extend:
+        await on_agent_response("room-on", "alice", json.dumps({"action": "accept"}))
+
+    mock_extend.assert_called_once_with("room-on", state)
+    assert state.pending_replies["alice"]["action"] == "accept"
+    _cfn_state.clear()
+
+
+@pytest.mark.asyncio
+async def test_on_agent_response_does_not_extend_when_all_in():
+    """The last reply triggers decide, NOT extend — no double-scheduling."""
+    _cfn_state.clear()
+    state = _CfnRoundState(
+        session_id="room-last",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["alice", "bob"],
+        pending_replies={
+            "alice": {"agent_id": "alice", "action": "accept"},
+            "bob": None,
+        },
+    )
+    _cfn_state["room-last"] = state
+
+    with (
+        patch.object(coord, "_extend_round_timeout") as mock_extend,
+        patch.object(coord, "_cfn_decide_round", AsyncMock()) as mock_decide,
+    ):
+        await on_agent_response("room-last", "bob", json.dumps({"action": "accept"}))
+        # Let the asyncio.ensure_future(_cfn_decide_round) settle.
+        await asyncio.sleep(0)
+
+    mock_extend.assert_not_called()
+    mock_decide.assert_called_once_with("room-last")
+    _cfn_state.clear()
+
+
+@pytest.mark.asyncio
+async def test_on_agent_response_does_not_extend_on_resubmit():
+    """If an agent re-sends an already-collected reply, don't keep extending —
+    only first-time real replies should restart the watchdog."""
+    _cfn_state.clear()
+    state = _CfnRoundState(
+        session_id="room-resub",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["alice", "bob", "carol"],
+        pending_replies={
+            "alice": {"agent_id": "alice", "action": "accept"},  # already replied
+            "bob": None,
+            "carol": None,
+        },
+    )
+    _cfn_state["room-resub"] = state
+
+    with patch.object(coord, "_extend_round_timeout") as mock_extend:
+        await on_agent_response("room-resub", "alice", json.dumps({"action": "accept"}))
+
+    mock_extend.assert_not_called()
+    _cfn_state.clear()


### PR DESCRIPTION
## Summary

Replace the previous fixed-duration round timeout (\`_CFN_ROUND_TIMEOUT_SECS = 25\`) with an adaptive budget that grows with the number of agents and is extended each time a partial response set arrives, up to a configurable hard cap. This eliminates spurious round-failure events under realistic agent latency while still bounding total negotiation time.

## Changes

**New tunables** (\`app/config.py\`):

| Setting | Default | Purpose |
|---|---|---|
| \`COORDINATION_TICK_TIMEOUT_SECONDS\` | 45 | Per-tick base budget |
| \`COORDINATION_ROUND_STARTUP_SECONDS\` | 30 | Initial round window |
| \`COORDINATION_ROUND_EXTENSION_PER_REMAINING_SECONDS\` | 30 | Extension per still-pending agent |
| \`COORDINATION_ROUND_EXTENSION_FLOOR_SECONDS\` | 20 | Minimum extension on partial reply |
| \`COORDINATION_ROUND_MAX_SECONDS\` | 300 | Hard cap |

**Implementation** (\`app/services/coordination.py\`):

- \`_initial_round_budget_seconds\` / \`_extension_seconds\` compute the budget
- \`_extend_round_timeout\` cancels and restarts the watchdog with a shorter remaining window when a partial set of responses arrives
- \`_round_watchdog\` finalizes the round if the cap is hit
- \`on_agent_response\` extends only on **first** responses (not resubmits) and **not** when the full quorum is already in

Plus structured \`CFN_TRACE\` logging in \`routes/messages.py\` and unit tests covering scaling, extension, hard cap, and resubmit behavior.

## Why now

The fixed 25s timeout was firing spuriously during normal multi-agent negotiations (3+ agents with even modest LLM latency would routinely hit the limit before all replies arrived). Becomes more important after the upcoming Phase 3 redesign change that prepends evidence to negotiations — round payloads will grow, increasing per-tick latency.

## Test plan

- [ ] \`cd fastapi-backend && uv run ruff check .\` — passes
- [ ] \`cd fastapi-backend && uv run pytest tests/test_coordination.py\` — passes
- [ ] Manual: \`test_4*\` runs no longer show premature round-failure events
- [ ] Verify hard cap fires correctly when an agent never responds

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)