### PR TITLE
feat(plugin): dynamic Mycelium room binding for OpenClaw agents

### DIFF
--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/bindings.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/bindings.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+/**
+ * Per-agent room bindings.
+ *
+ * Background: the channel plugin originally subscribed to a single fixed
+ * `cfg.room` (e.g. "mycelium_room") for SSE push and tick dispatch. That worked
+ * for the case the plugin was designed for — long-lived shared rooms — but
+ * broke for dynamic per-test rooms ("dist-e2e-<uuid>"). When an agent was
+ * mentioned in a Matrix message that asked them to join a dynamic Mycelium
+ * room, the plugin had no mechanism to learn about that room, so the
+ * coordination push path was silent and agents fell back to polling via
+ * `mycelium session await` (which deadlocks under OpenClaw's exec/yield model
+ * and is explicitly banned by the plugin's own SKILL.md).
+ *
+ * This module is the per-agent room registry. The session module's
+ * `message_received` handler extracts a room name from the inbound prompt
+ * text and calls `bindAgentToRoom(agentId, room)`. The channel module's
+ * session-sub-room poll consults `getAllBoundRooms()` to know which parent
+ * rooms to watch for `:session:` sub-rooms.
+ *
+ * Bindings are additive: once an agent is bound to a room we keep watching
+ * it until gateway stop, so cross-test stragglers can still wake up. Memory
+ * footprint is bounded by the number of distinct test rooms a gateway sees
+ * in its lifetime.
+ */
+
+const _agentRooms = new Map<string, Set<string>>();
+
+/**
+ * Register that `agentId` is participating in `room`. Idempotent. Returns
+ * true if this is a new binding (caller may want to log or kick a poll),
+ * false if the binding already existed.
+ */
+export function bindAgentToRoom(agentId: string, room: string): boolean {
+  if (!agentId || !room) return false;
+  let rooms = _agentRooms.get(agentId);
+  if (!rooms) {
+    rooms = new Set<string>();
+    _agentRooms.set(agentId, rooms);
+  }
+  if (rooms.has(room)) return false;
+  rooms.add(room);
+  return true;
+}
+
+/**
+ * Most-recently-bound room for the given agent (if any). Used by
+ * before_agent_start to know which room's latest tick to pull into the
+ * agent's prompt context. Falls back to undefined if no binding has been
+ * recorded — caller is expected to fall back to channelCfg.room.
+ */
+export function getMostRecentRoomForAgent(agentId: string): string | undefined {
+  const rooms = _agentRooms.get(agentId);
+  if (!rooms || rooms.size === 0) return undefined;
+  // Set iteration is insertion-ordered — last() = newest binding.
+  let last: string | undefined;
+  for (const r of rooms) last = r;
+  return last;
+}
+
+/** All rooms across all agents — used by the channel poll to widen its watch set. */
+export function getAllBoundRooms(): Set<string> {
+  const all = new Set<string>();
+  for (const rooms of _agentRooms.values()) {
+    for (const r of rooms) all.add(r);
+  }
+  return all;
+}
+
+/** Rooms a specific agent is currently bound to (defensive copy). */
+export function getRoomsForAgent(agentId: string): Set<string> {
+  return new Set(_agentRooms.get(agentId) ?? []);
+}
+
+/** Reset all bindings — called from gateway_stop. Tests may call this too. */
+export function clearAllBindings(): void {
+  _agentRooms.clear();
+}

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -18,6 +18,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
 import { CHANNEL_ID, type ChannelConfig } from "../config.js";
+import { clearAllBindings, getAllBoundRooms } from "./bindings.js";
 import { dispatchToAgent } from "./dispatch.js";
 import { _ownMessageIds } from "./post-to-room.js";
 import { routeMessage, type RouteAction } from "./route.js";
@@ -73,18 +74,67 @@ export function installChannel(
 
     // Poll for session sub-rooms and subscribe to their SSE streams.
     // Coordination ticks live in session sub-rooms, not the parent room.
+    //
+    // We watch sub-rooms of `cfg.room` (the static channel default) AND any
+    // room an agent has been bound to via the `message_received` hook
+    // (channel/bindings.ts). The bindings registry gets populated when an
+    // inbound channel message references `--room <name>` — typically the
+    // dynamic per-test rooms (`dist-e2e-<uuid>`). Without this widening, the
+    // push path was deaf to anything except cfg.room and agents fell back to
+    // polling via `mycelium session await` (which deadlocks under exec/yield;
+    // see plugin SKILL.md).
+    //
+    // We also subscribe to the parent room's own SSE on first sighting, so
+    // broadcast messages and `coordination_join` messages from dynamic rooms
+    // reach the router. Each call to startRoomSSE / startSessionSSE is
+    // idempotent per (URL), so duplicates are fine.
+    const _watchedParentRooms = new Set<string>([cfg.room]);
     const pollInterval = setInterval(async () => {
       try {
+        const parentRooms = new Set<string>([cfg.room, ...getAllBoundRooms()]);
+        // Open SSE on any new parent room we haven't watched yet so broadcasts
+        // and coordination_join messages flow through the router.
+        for (const parent of parentRooms) {
+          if (!_watchedParentRooms.has(parent) && _abort) {
+            _watchedParentRooms.add(parent);
+            log.info(`[${CHANNEL_ID}] subscribing to bound parent room: ${parent}`);
+            startRoomSSE(
+              runtime,
+              { ...cfg, room: parent },
+              _abort,
+              handleMessage,
+              log,
+            );
+          }
+        }
+
         const res = await fetch(`${cfg.backendUrl}/rooms`);
         if (!res.ok) return;
         const rooms: any[] = await res.json();
         for (const room of rooms) {
+          const name: string | undefined = room.name;
+          if (!name) continue;
+          // Match against every parent room we know about, not just cfg.room.
+          let matchedParent: string | null = null;
+          for (const parent of parentRooms) {
+            if (name.startsWith(parent + ":session:")) {
+              matchedParent = parent;
+              break;
+            }
+          }
+          if (!matchedParent) continue;
           if (
-            room.name?.startsWith(cfg.room + ":session:") &&
-            (room.coordination_state === "waiting" ||
-              room.coordination_state === "negotiating")
+            room.coordination_state === "waiting" ||
+            room.coordination_state === "negotiating"
           ) {
-            startSessionSSE(runtime, cfg, room.name, _abort!, handleMessage, log);
+            startSessionSSE(
+              runtime,
+              { ...cfg, room: matchedParent },
+              name,
+              _abort!,
+              handleMessage,
+              log,
+            );
           }
         }
       } catch {
@@ -99,6 +149,7 @@ export function installChannel(
     _abort?.abort();
     _abort = null;
     clearSubscribedSessions();
+    clearAllBindings();
     log.info(`[${CHANNEL_ID}] gateway stopping — SSE closed`);
   });
 }

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/session/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/session/index.ts
@@ -20,9 +20,35 @@
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
+import {
+  bindAgentToRoom,
+  getMostRecentRoomForAgent,
+} from "../channel/bindings.js";
 import { type ChannelConfig, getApiUrl, readMemoryFileContent, resolveHandle } from "../config.js";
 import { apiGet, apiPost, fetchBackendHealth } from "../http.js";
 import { MYCELIUM_INSTRUCTIONS } from "../instructions.js";
+
+/**
+ * Extract a Mycelium room name from inbound prompt text.
+ *
+ * Recognises (in priority order):
+ *   1. `--room <name>`  or  `--room=<name>`     — the canonical CLI flag
+ *      that test prompts and the SKILL examples both use. Captures the
+ *      same character set as Mycelium room names: alphanumeric + `_-:`.
+ *   2. `Mycelium room: <name>` / `Room: <name>` — narrative form, useful
+ *      for human-authored Matrix prompts.
+ *
+ * Returns null when no room mention is found, so callers can leave any
+ * existing binding (or fallback to channelCfg.room) intact.
+ */
+export function extractMyceliumRoomFromText(text: string): string | null {
+  if (!text) return null;
+  const flag = text.match(/--room[=\s]+([A-Za-z0-9_:-]+)/);
+  if (flag) return flag[1];
+  const labeled = text.match(/(?:^|[\n\s—–-])\s*(?:Mycelium\s+)?Room:\s*([A-Za-z0-9_:-]+)/i);
+  if (labeled) return labeled[1];
+  return null;
+}
 
 type Logger = { info: (s: string) => void; warn: (s: string) => void };
 
@@ -126,10 +152,46 @@ export function installSession(
     },
   );
 
+  // ── Inbound message hook ────────────────────────────────────────────────
+  //
+  // Fires for every message a channel plugin (e.g. matrix) routes to one of
+  // our agents, *before* before_agent_start. We use it solely to learn which
+  // Mycelium room the agent was just told to join — by extracting `--room
+  // <name>` from the message body — and record that as a per-agent binding.
+  // The channel module's session-sub-room poll consults the same registry to
+  // decide which `:session:` sub-rooms to subscribe to, so the push-based
+  // tick path now works for any room mentioned in the inbound prompt, not
+  // just the static channelCfg.room.
+  //
+  // We deliberately don't mutate prompt content here — message rewriting is
+  // the channel plugin's job. We're just sniffing for a room name.
+  api.on(
+    "message_received",
+    async (
+      event: { from: string; content: string; metadata?: Record<string, unknown> },
+      ctx: { channelId: string; accountId?: string; conversationId?: string },
+    ) => {
+      const agentId = ctx?.accountId;
+      if (!agentId) return;
+      const room = extractMyceliumRoomFromText(event?.content ?? "");
+      if (!room) return;
+      const fresh = bindAgentToRoom(agentId, room);
+      if (fresh) {
+        log.info(
+          `[mycelium] bound agent ${agentId} -> room "${room}" (from ${ctx.channelId}/${ctx.conversationId ?? "?"})`,
+        );
+        // Reflect the binding into _sessions so before_agent_start picks it
+        // up immediately for tick-context injection.
+        const entry = _sessions.get(agentId);
+        if (entry) entry.room = room;
+      }
+    },
+  );
+
   api.on(
     "before_agent_start",
     async (
-      _event: any,
+      event: { prompt?: string },
       ctx: any,
     ): Promise<
       { prependSystemContext?: string; prependContext?: string } | undefined
@@ -144,19 +206,41 @@ export function installSession(
         `[mycelium] before_agent_start handle:${handle} sessionKey:${sessionKey ?? "none"} isCliSession:${isCliSession}`,
       );
 
+      // Belt-and-braces: also try to extract a room from the prompt text we
+      // were given. message_received covers the normal Matrix path, but some
+      // agent activations (e.g. CLI-driven sessions, replays) bypass it and
+      // come straight here.
+      if (agentId && event?.prompt) {
+        const promptRoom = extractMyceliumRoomFromText(event.prompt);
+        if (promptRoom && bindAgentToRoom(agentId, promptRoom)) {
+          log.info(
+            `[mycelium] bound agent ${agentId} -> room "${promptRoom}" (from before_agent_start prompt)`,
+          );
+        }
+      }
+
       let existing = _sessions.get(agentId ?? "default");
+      // Prefer a binding learned from inbound messages over the static default.
+      const boundRoom = agentId ? getMostRecentRoomForAgent(agentId) : undefined;
+      const effectiveRoom = boundRoom ?? existing?.room ?? channelCfg?.room;
+
       if (!existing && sessionKey) {
         existing = {
           sessionKey,
           sessionId: isCliSession ? undefined : sessionId,
           handle,
-          room: channelCfg?.room,
+          room: effectiveRoom,
         };
         _sessions.set(agentId ?? "default", existing);
       } else if (existing) {
         if (sessionKey) existing.sessionKey = sessionKey;
         if (sessionId && !existing.sessionId && !isCliSession) {
           existing.sessionId = sessionId;
+        }
+        // Promote a freshly-discovered binding into the live entry so
+        // session_end's "agent offline" announce hits the right room.
+        if (boundRoom && existing.room !== boundRoom) {
+          existing.room = boundRoom;
         }
       }
 
@@ -167,20 +251,68 @@ export function installSession(
 
       const contextParts: string[] = [];
 
-      const room = existing?.room;
+      const room = effectiveRoom;
       if (room) {
-        const data = (await apiGet(`/rooms/${room}/messages?limit=30`, log)) as any;
-        const coord = data?.messages?.find(
-          (m: any) =>
-            m.message_type === "coordination_consensus" ||
-            m.message_type === "coordination_tick",
-        );
-        if (coord) {
-          const label =
-            coord.message_type === "coordination_consensus"
-              ? "[Mycelium — consensus]"
-              : "[Mycelium — coordination tick]";
-          contextParts.push(`${label}\nRoom: ${room}\n\n${coord.content}`);
+        // Look first in any active session sub-room of this parent — that's
+        // where coordination ticks actually live. Fall back to the parent
+        // room itself for legacy / non-coordination contexts.
+        const candidateRooms: string[] = [];
+        try {
+          const allRooms = (await apiGet(`/rooms`, log)) as any[];
+          if (Array.isArray(allRooms)) {
+            const subs = allRooms
+              .filter(
+                (r) =>
+                  typeof r?.name === "string" &&
+                  r.name.startsWith(`${room}:session:`) &&
+                  (r.coordination_state === "negotiating" ||
+                    r.coordination_state === "waiting" ||
+                    r.coordination_state === "complete"),
+              )
+              .sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+            for (const s of subs) candidateRooms.push(s.name);
+          }
+        } catch {
+          /* fall through to parent-room scan */
+        }
+        candidateRooms.push(room);
+
+        for (const candidate of candidateRooms) {
+          const data = (await apiGet(
+            `/rooms/${candidate}/messages?limit=30`,
+            log,
+          )) as any;
+          // Prefer ticks addressed to *this* agent's handle, then any
+          // consensus, then any tick. (Ticks are per-participant.)
+          const messages: any[] = data?.messages ?? [];
+          const myTick = messages.find((m: any) => {
+            if (m.message_type !== "coordination_tick") return false;
+            try {
+              const parsed =
+                typeof m.content === "string" ? JSON.parse(m.content) : m.content;
+              const pid = parsed?.payload?.participant_id ?? parsed?.participant_id;
+              return pid === handle;
+            } catch {
+              return false;
+            }
+          });
+          const consensus = messages.find(
+            (m: any) => m.message_type === "coordination_consensus",
+          );
+          const anyTick = messages.find(
+            (m: any) => m.message_type === "coordination_tick",
+          );
+          const coord = myTick ?? consensus ?? anyTick;
+          if (coord) {
+            const label =
+              coord.message_type === "coordination_consensus"
+                ? "[Mycelium — consensus]"
+                : "[Mycelium — coordination tick]";
+            contextParts.push(
+              `${label}\nRoom: ${candidate}\n\n${coord.content}`,
+            );
+            break;
+          }
         }
       }
 

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/bindings.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/bindings.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+import { describe, expect, it, beforeEach } from "vitest";
+
+import {
+  bindAgentToRoom,
+  clearAllBindings,
+  getAllBoundRooms,
+  getMostRecentRoomForAgent,
+  getRoomsForAgent,
+} from "../src/channel/bindings.js";
+
+describe("channel/bindings", () => {
+  beforeEach(() => clearAllBindings());
+
+  it("registers a fresh binding and returns true", () => {
+    expect(bindAgentToRoom("alpha", "room-1")).toBe(true);
+    expect(getRoomsForAgent("alpha").has("room-1")).toBe(true);
+  });
+
+  it("is idempotent for repeated bindings", () => {
+    expect(bindAgentToRoom("alpha", "room-1")).toBe(true);
+    expect(bindAgentToRoom("alpha", "room-1")).toBe(false);
+  });
+
+  it("supports multiple rooms per agent and returns most recent", () => {
+    bindAgentToRoom("alpha", "room-1");
+    bindAgentToRoom("alpha", "room-2");
+    bindAgentToRoom("alpha", "room-3");
+    expect(getMostRecentRoomForAgent("alpha")).toBe("room-3");
+    expect(getRoomsForAgent("alpha").size).toBe(3);
+  });
+
+  it("returns undefined for unknown agent", () => {
+    expect(getMostRecentRoomForAgent("ghost")).toBeUndefined();
+    expect(getRoomsForAgent("ghost").size).toBe(0);
+  });
+
+  it("aggregates bound rooms across all agents", () => {
+    bindAgentToRoom("alpha", "room-1");
+    bindAgentToRoom("alpha", "room-2");
+    bindAgentToRoom("beta", "room-2");
+    bindAgentToRoom("beta", "room-3");
+    const all = getAllBoundRooms();
+    expect(all.size).toBe(3);
+    expect(all.has("room-1")).toBe(true);
+    expect(all.has("room-2")).toBe(true);
+    expect(all.has("room-3")).toBe(true);
+  });
+
+  it("rejects empty agentId or room", () => {
+    expect(bindAgentToRoom("", "room-1")).toBe(false);
+    expect(bindAgentToRoom("alpha", "")).toBe(false);
+  });
+
+  it("clearAllBindings empties the registry", () => {
+    bindAgentToRoom("alpha", "room-1");
+    bindAgentToRoom("beta", "room-2");
+    clearAllBindings();
+    expect(getAllBoundRooms().size).toBe(0);
+    expect(getMostRecentRoomForAgent("alpha")).toBeUndefined();
+  });
+});

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/extract-room.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/extract-room.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+import { describe, expect, it } from "vitest";
+
+import { extractMyceliumRoomFromText } from "../src/session/index.js";
+
+describe("extractMyceliumRoomFromText", () => {
+  it("extracts --room <name> from CLI-style instructions", () => {
+    const text =
+      "Run: mycelium session join --handle alpha --room dist-e2e-abc123 -m 'hi'";
+    expect(extractMyceliumRoomFromText(text)).toBe("dist-e2e-abc123");
+  });
+
+  it("extracts --room=<name> form", () => {
+    expect(extractMyceliumRoomFromText("--room=mycelium_room")).toBe(
+      "mycelium_room",
+    );
+  });
+
+  it("extracts narrative 'Room: <name>' form", () => {
+    const text = "Please coordinate.\nRoom: dist-e2e-xyz\nDeadline: 30s";
+    expect(extractMyceliumRoomFromText(text)).toBe("dist-e2e-xyz");
+  });
+
+  it("extracts 'Mycelium Room: <name>' form", () => {
+    const text = "Heads up — Mycelium Room: shared-roadmap";
+    expect(extractMyceliumRoomFromText(text)).toBe("shared-roadmap");
+  });
+
+  it("preserves colons (session sub-room names)", () => {
+    expect(
+      extractMyceliumRoomFromText("--room dist-e2e-abc:session:42"),
+    ).toBe("dist-e2e-abc:session:42");
+  });
+
+  it("returns null when no room mention present", () => {
+    expect(extractMyceliumRoomFromText("hello world")).toBeNull();
+    expect(extractMyceliumRoomFromText("")).toBeNull();
+  });
+
+  it("--room flag takes priority over narrative form", () => {
+    const text = "Room: legacy-room\nmycelium session join --room new-room";
+    expect(extractMyceliumRoomFromText(text)).toBe("new-room");
+  });
+
+  it("rejects characters outside the allowed set", () => {
+    // Stops at the first disallowed char (space, slash, etc.)
+    expect(extractMyceliumRoomFromText("--room foo/bar")).toBe("foo");
+  });
+});


### PR DESCRIPTION
## Summary

When an agent receives a channel message referencing \`--room <name>\`, the mycelium plugin now records that room in a per-agent bindings registry and subscribes its SSE listener to both the parent room and its session sub-rooms. Previously the channel only watched the static \`cfg.room\` default, so coordination ticks for dynamic rooms (e.g. \`dist-e2e-<uuid>\` test rooms) were never delivered and agents had to fall back to \`mycelium session await\` — which deadlocks the gateway thread (see plugin SKILL.md).

## Changes

- \`src/channel/bindings.ts\` — new per-agent room registry (80 lines)
- \`src/session/index.ts\` — extract room from \`--room <name>\` in incoming text via \`message_received\`; prefer dynamically bound rooms in \`before_agent_start\`
- \`src/channel/index.ts\` — poll loop now subscribes to all bound parent rooms and their session sub-rooms; clear bindings on \`gateway_stop\`
- \`test/bindings.test.ts\`, \`test/extract-room.test.ts\` — unit tests

## Caveat — tactical, may be revisited

This change supports the current namespace + session-subroom model used by distributed E2E tests. A pending memory-architecture redesign (team-MAS lookup) may eventually let us collapse the subroom model, in which case some of this binding logic could be removed. Documenting here so reviewers know it's not eternal load-bearing infrastructure.

## Test plan

- [ ] \`pnpm test\` in plugin dir — 113 tests pass (15 new in this PR)
- [ ] Manual: \`test_4*\` distributed E2E suite — agents now receive ticks on dynamic rooms without falling back to \`session await\`
- [ ] Manual: verify \`gateway_stop\` clears all bindings (no leaked SSE subscriptions across gateway restarts)

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)