### PR TITLE
chore(ci): add ruff format check to mycelium-cli lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
         working-directory: mycelium-cli
         run: uv run ruff check src/
 
+      - name: Format check
+        working-directory: mycelium-cli
+        run: uv run ruff format --check src/
+
   test-openclaw-plugin:
     name: OpenClaw plugin tests
     runs-on: ubuntu-latest

--- a/mycelium-cli/package.json
+++ b/mycelium-cli/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build":    "uv sync --frozen",
     "dev":      "echo \"CLI has no dev server\"",
-    "lint":     "uv run ruff check .",
-    "lint:fix": "uv run ruff check . --fix",
+    "lint":     "uv run ruff check src/ && uv run ruff format --check src/",
+    "lint:fix": "uv run ruff check src/ --fix && uv run ruff format src/",
     "test":     "uv run pytest",
     "clean":    "rm -rf __pycache__ .pytest_cache"
   }

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -48,6 +48,7 @@ def _is_local_backend(api_url: str) -> bool:
     host = (urlparse(api_url).hostname or "").lower()
     return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
 
+
 # ── Individual checks ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Make the `mycelium-cli` lint surface symmetric with `fastapi-backend` so format drift can't accumulate silently. While verifying the change, found that `doctor.py` had already drifted — included the format fix here.

## Background

A previous batch of PRs (#164, #165) failed CI on `ruff format --check` even though `ruff check` passed locally. Root cause: the two folders had asymmetric lint scripts.

| Folder | `pnpm run lint` ran | Format check? |
|---|---|---|
| `fastapi-backend` | `ruff check . && ruff format --check .` | ✅ |
| `mycelium-cli` | `ruff check .` only | ❌ |

CI mirrored the same asymmetry, so format drift in `mycelium-cli` was invisible to both local devs and CI.

## Changes

- **`mycelium-cli/package.json`** — extend `lint` and `lint:fix` scripts to include format check / format, mirroring `fastapi-backend`.
- **`.github/workflows/ci.yml`** — add a "Format check" step to the `lint-cli` job that runs `uv run ruff format --check src/`.
- **`mycelium-cli/src/mycelium/commands/doctor.py`** — apply `ruff format` to satisfy the new check (one-line whitespace diff that had drifted on `main`).

## Test plan

- [x] `cd mycelium-cli && pnpm run lint` — passes locally
- [ ] CI `CLI lint` job now includes a `Format check` step that passes
- [ ] Confirm no other folders have the same asymmetry (only these two have lint scripts)

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)