### PR TITLE
chore(copyright): update copyright holder to Cisco Systems

### DIFF
--- a/docs/generate_cli_reference.py
+++ b/docs/generate_cli_reference.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Generate the CLI Reference HTML section for docs/index.html.

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Generate docs/index.html from markdown source files + CLI @doc_ref decorators.

--- a/fastapi-backend/alembic_migrations/__init__.py
+++ b/fastapi-backend/alembic_migrations/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/fastapi-backend/alembic_migrations/env.py
+++ b/fastapi-backend/alembic_migrations/env.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 import asyncio
 import os

--- a/fastapi-backend/alembic_migrations/versions/0001_initial.py
+++ b/fastapi-backend/alembic_migrations/versions/0001_initial.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Initial schema — users, rooms, messages, sessions, presences.
 

--- a/fastapi-backend/alembic_migrations/versions/0002_coordination.py
+++ b/fastapi-backend/alembic_migrations/versions/0002_coordination.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Add coordination fields to rooms and sessions.
 

--- a/fastapi-backend/alembic_migrations/versions/0003_drop_presences_and_user_tables.py
+++ b/fastapi-backend/alembic_migrations/versions/0003_drop_presences_and_user_tables.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Drop presences and user tables.
 

--- a/fastapi-backend/alembic_migrations/versions/0004_add_audit_events.py
+++ b/fastapi-backend/alembic_migrations/versions/0004_add_audit_events.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Add audit_events table.
 

--- a/fastapi-backend/alembic_migrations/versions/0005_add_workspace_mas_agents.py
+++ b/fastapi-backend/alembic_migrations/versions/0005_add_workspace_mas_agents.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Add workspaces, mas, agents tables.
 

--- a/fastapi-backend/alembic_migrations/versions/0006_add_memory_and_room_modes.py
+++ b/fastapi-backend/alembic_migrations/versions/0006_add_memory_and_room_modes.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Add persistent memory system and room mode extensions.
 

--- a/fastapi-backend/alembic_migrations/versions/0007_add_notebook_scope_and_namespace_fields.py
+++ b/fastapi-backend/alembic_migrations/versions/0007_add_notebook_scope_and_namespace_fields.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Add notebook scope to memories and namespace fields to rooms.
 

--- a/fastapi-backend/alembic_migrations/versions/0008_add_file_path_to_memories.py
+++ b/fastapi-backend/alembic_migrations/versions/0008_add_file_path_to_memories.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Add file_path column to memories for filesystem-native storage.
 

--- a/fastapi-backend/alembic_migrations/versions/0009_room_mas_id.py
+++ b/fastapi-backend/alembic_migrations/versions/0009_room_mas_id.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Add mas_id and workspace_id to rooms for CFN MAS sync.
 

--- a/fastapi-backend/app/__init__.py
+++ b/fastapi-backend/app/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/fastapi-backend/app/agents/__init__.py
+++ b/fastapi-backend/app/agents/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 # Cognitive agents: semantic_negotiation and evidence_gathering

--- a/fastapi-backend/app/agents/evidence_gathering/__init__.py
+++ b/fastapi-backend/app/agents/evidence_gathering/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/fastapi-backend/app/agents/evidence_gathering/embeddings.py
+++ b/fastapi-backend/app/agents/evidence_gathering/embeddings.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Embedding manager (ported from ioc-cfn-cognitive-agents).
 

--- a/fastapi-backend/app/agents/evidence_gathering/evidence.py
+++ b/fastapi-backend/app/agents/evidence_gathering/evidence.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Evidence gathering pipeline (ported from ioc-cfn-cognitive-agents).
 

--- a/fastapi-backend/app/agents/evidence_gathering/llm_clients.py
+++ b/fastapi-backend/app/agents/evidence_gathering/llm_clients.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """LLM clients for evidence gathering (ported from ioc-cfn-cognitive-agents).
 

--- a/fastapi-backend/app/agents/evidence_gathering/multi_entities.py
+++ b/fastapi-backend/app/agents/evidence_gathering/multi_entities.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Multi-entity evidence engine (ported from ioc-cfn-cognitive-agents).
 

--- a/fastapi-backend/app/agents/evidence_gathering/schemas.py
+++ b/fastapi-backend/app/agents/evidence_gathering/schemas.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Evidence gathering request/response schemas (ported from ioc-cfn-cognitive-agents)."""
 

--- a/fastapi-backend/app/agents/evidence_gathering/single_entity.py
+++ b/fastapi-backend/app/agents/evidence_gathering/single_entity.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Single-entity evidence engine (ported from ioc-cfn-cognitive-agents).
 

--- a/fastapi-backend/app/agents/evidence_gathering/utiles.py
+++ b/fastapi-backend/app/agents/evidence_gathering/utiles.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Path utilities, GraphSession, and MMR selection (ported from ioc-cfn-cognitive-agents)."""
 

--- a/fastapi-backend/app/agents/llm_provider.py
+++ b/fastapi-backend/app/agents/llm_provider.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 LLM provider for semantic negotiation agents.

--- a/fastapi-backend/app/agents/protocol/__init__.py
+++ b/fastapi-backend/app/agents/protocol/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/fastapi-backend/app/agents/protocol/sstp/__init__.py
+++ b/fastapi-backend/app/agents/protocol/sstp/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 sstp — Pydantic v2 models for the Semantic State Transfer Protocol (SSTP)

--- a/fastapi-backend/app/agents/protocol/sstp/__main__.py
+++ b/fastapi-backend/app/agents/protocol/sstp/__main__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Dump SSTP JSON Schema(s) or example messages to stdout.

--- a/fastapi-backend/app/agents/protocol/sstp/_base.py
+++ b/fastapi-backend/app/agents/protocol/sstp/_base.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 sstp/_base.py — Shared literals, sub-models, and envelope base for SSTP.

--- a/fastapi-backend/app/agents/protocol/sstp/commit.py
+++ b/fastapi-backend/app/agents/protocol/sstp/commit.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """sstp/commit.py — SSTPCommitMessage kind."""
 

--- a/fastapi-backend/app/agents/protocol/sstp/delegation.py
+++ b/fastapi-backend/app/agents/protocol/sstp/delegation.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """sstp/delegation.py — DelegationMessage kind."""
 

--- a/fastapi-backend/app/agents/protocol/sstp/evidence_bundle.py
+++ b/fastapi-backend/app/agents/protocol/sstp/evidence_bundle.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """sstp/evidence_bundle.py — EvidenceBundleMessage kind."""
 

--- a/fastapi-backend/app/agents/protocol/sstp/intent.py
+++ b/fastapi-backend/app/agents/protocol/sstp/intent.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """sstp/intent.py — IntentMessage kind."""
 

--- a/fastapi-backend/app/agents/protocol/sstp/knowledge.py
+++ b/fastapi-backend/app/agents/protocol/sstp/knowledge.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """sstp/knowledge.py — KnowledgeMessage kind."""
 

--- a/fastapi-backend/app/agents/protocol/sstp/memory_delta.py
+++ b/fastapi-backend/app/agents/protocol/sstp/memory_delta.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """sstp/memory_delta.py — MemoryDeltaMessage kind."""
 

--- a/fastapi-backend/app/agents/protocol/sstp/query.py
+++ b/fastapi-backend/app/agents/protocol/sstp/query.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """sstp/query.py — QueryMessage kind."""
 

--- a/fastapi-backend/app/bus.py
+++ b/fastapi-backend/app/bus.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Async Postgres LISTEN/NOTIFY bus.

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 from pathlib import Path
 

--- a/fastapi-backend/app/database.py
+++ b/fastapi-backend/app/database.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 from collections.abc import AsyncGenerator
 from urllib.parse import urlparse

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Mycelium FastAPI backend.

--- a/fastapi-backend/app/models.py
+++ b/fastapi-backend/app/models.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Mycelium data models.

--- a/fastapi-backend/app/routes/__init__.py
+++ b/fastapi-backend/app/routes/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/fastapi-backend/app/routes/audit.py
+++ b/fastapi-backend/app/routes/audit.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Audit event endpoints (internal API).

--- a/fastapi-backend/app/routes/cfn_proxy.py
+++ b/fastapi-backend/app/routes/cfn_proxy.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 CFN proxy endpoints.

--- a/fastapi-backend/app/routes/knowledge.py
+++ b/fastapi-backend/app/routes/knowledge.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Knowledge graph endpoints.

--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Memory API — persistent namespaced key-value store with semantic vector search.

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Messages API — POST only.

--- a/fastapi-backend/app/routes/notebook.py
+++ b/fastapi-backend/app/routes/notebook.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Notebook API — agent-private memory scoped by handle.

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Room CRUD endpoints."""
 

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Sessions API — tracks agent presence in rooms.

--- a/fastapi-backend/app/routes/stream.py
+++ b/fastapi-backend/app/routes/stream.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 SSE stream endpoint — GET /rooms/{room}/messages/stream

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Minimal schemas for Mycelium's core models.

--- a/fastapi-backend/app/services/__init__.py
+++ b/fastapi-backend/app/services/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/fastapi-backend/app/services/async_coordination.py
+++ b/fastapi-backend/app/services/async_coordination.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Async CognitiveEngine — synthesis for namespace rooms.

--- a/fastapi-backend/app/services/cfn_graph_read.py
+++ b/fastapi-backend/app/services/cfn_graph_read.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Direct AgensGraph read for CFN's knowledge graphs.
 

--- a/fastapi-backend/app/services/cfn_knowledge.py
+++ b/fastapi-backend/app/services/cfn_knowledge.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Async httpx client for CFN's shared-memories knowledge API.
 

--- a/fastapi-backend/app/services/cfn_negotiation.py
+++ b/fastapi-backend/app/services/cfn_negotiation.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Async httpx client for the CFN cognitive agents semantic negotiation API.

--- a/fastapi-backend/app/services/cfn_resolve.py
+++ b/fastapi-backend/app/services/cfn_resolve.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Resolve CFN identifiers (workspace_id, mas_id) from client input, room

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Multi-agent coordination service.

--- a/fastapi-backend/app/services/embedding.py
+++ b/fastapi-backend/app/services/embedding.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Local embedding service using fastembed (ONNX-based).

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Memory storage — markdown files with YAML frontmatter.

--- a/fastapi-backend/app/services/indexer.py
+++ b/fastapi-backend/app/services/indexer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Filesystem → pgvector indexer.

--- a/fastapi-backend/app/services/ingest_dedupe.py
+++ b/fastapi-backend/app/services/ingest_dedupe.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Content-hash TTL dedupe cache for CFN shared-memories forwards.
 

--- a/fastapi-backend/app/services/ingest_log_buffer.py
+++ b/fastapi-backend/app/services/ingest_log_buffer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """In-memory ring buffer of CFN shared-memories ingest attempts.
 

--- a/fastapi-backend/app/services/llm_health.py
+++ b/fastapi-backend/app/services/llm_health.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 """
 LLM health checking: key format validation, masked key hints, and
 zero-cost provider probes using read-only model-list endpoints.

--- a/fastapi-backend/app/services/reindex.py
+++ b/fastapi-backend/app/services/reindex.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Auto-reindex: startup scan + file watcher.

--- a/fastapi-backend/scripts/test_negotiation_llm.py
+++ b/fastapi-backend/scripts/test_negotiation_llm.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Test script for intent_discovery + options_generation using the configured LiteLLM.

--- a/fastapi-backend/tests/__init__.py
+++ b/fastapi-backend/tests/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/fastapi-backend/tests/conftest.py
+++ b/fastapi-backend/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Shared test fixtures.

--- a/fastapi-backend/tests/test_audit.py
+++ b/fastapi-backend/tests/test_audit.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Tests for /api/internal/audit-events endpoints."""
 

--- a/fastapi-backend/tests/test_cfn_proxy.py
+++ b/fastapi-backend/tests/test_cfn_proxy.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Tests for the per-agent memory-operations CFN proxy.
 

--- a/fastapi-backend/tests/test_cfn_read_surface.py
+++ b/fastapi-backend/tests/test_cfn_read_surface.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Tests for /api/cfn/knowledge/* — the CFN shared-memories read proxy."""
 

--- a/fastapi-backend/tests/test_cfn_resolve.py
+++ b/fastapi-backend/tests/test_cfn_resolve.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Tests for CFN identifier resolution (workspace_id, mas_id).

--- a/fastapi-backend/tests/test_coordination.py
+++ b/fastapi-backend/tests/test_coordination.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Unit tests for app.services.coordination.

--- a/fastapi-backend/tests/test_filesystem.py
+++ b/fastapi-backend/tests/test_filesystem.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Tests for the filesystem-native memory service."""
 

--- a/fastapi-backend/tests/test_ingest_dedupe.py
+++ b/fastapi-backend/tests/test_ingest_dedupe.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Tests for the content-hash TTL dedupe cache."""
 

--- a/fastapi-backend/tests/test_ingest_log_buffer.py
+++ b/fastapi-backend/tests/test_ingest_log_buffer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Tests for the in-memory CFN ingest log buffer and its GET endpoints."""
 

--- a/fastapi-backend/tests/test_integration.py
+++ b/fastapi-backend/tests/test_integration.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Integration tests — require a running Postgres/AgensGraph with pgvector.

--- a/fastapi-backend/tests/test_knowledge_ingest.py
+++ b/fastapi-backend/tests/test_knowledge_ingest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Tests for /api/knowledge/ingest gates: disabled, refused, deduped, ok, error."""
 

--- a/fastapi-backend/tests/test_llm_health.py
+++ b/fastapi-backend/tests/test_llm_health.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 """
 Tests for health checking: LLM key validation, database connectivity,
 embedding model status, version info, and the /health endpoint.

--- a/fastapi-backend/tests/test_memory.py
+++ b/fastapi-backend/tests/test_memory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Tests for the persistent memory API.

--- a/fastapi-backend/tests/test_notebook.py
+++ b/fastapi-backend/tests/test_notebook.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Tests for notebook (agent-private) memory."""
 

--- a/fastapi-backend/tests/test_session_spawn.py
+++ b/fastapi-backend/tests/test_session_spawn.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Tests for session spawning within namespace rooms."""
 

--- a/fastapi-backend/tests/test_structured_memory.py
+++ b/fastapi-backend/tests/test_structured_memory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Tests for structured memory conventions and synthesis grouping.

--- a/mycelium-cli/src/mycelium/__init__.py
+++ b/mycelium-cli/src/mycelium/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Mycelium CLI — IoC/CFN coordination layer."""
 

--- a/mycelium-cli/src/mycelium/__main__.py
+++ b/mycelium-cli/src/mycelium/__main__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Allow running mycelium as a module: python -m mycelium"""
 

--- a/mycelium-cli/src/mycelium/adapters/__init__.py
+++ b/mycelium-cli/src/mycelium/adapters/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/mycelium-cli/src/mycelium/adapters/claude-code/__init__.py
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/mycelium-cli/src/mycelium/adapters/claude-code/hooks/mycelium-knowledge-extract.py
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/hooks/mycelium-knowledge-extract.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 mycelium-knowledge-extract (Claude Code)

--- a/mycelium-cli/src/mycelium/adapters/openclaw/__init__.py
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * mycelium — OpenClaw plugin entry point.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/dispatch.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/dispatch.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * In-process agent dispatch via runtime.channel.reply.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Channel concern entry point.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/mentions.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/mentions.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Return the subset of `agents` that are @-mentioned in `content`.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/post-to-room.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/post-to-room.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Outbound POST to a Mycelium room with echo-loop prevention.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/room-sse.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/room-sse.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Room SSE subscription — the single inbound surface for the channel plugin.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/route.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Pure routing logic for channel messages.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/session-sse.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/session-sse.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Session sub-room SSE subscription.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/config.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/config.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Environment + filesystem-backed config only. No HTTP (see http.ts).

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/http.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/http.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * HTTP helpers for talking to the Mycelium backend.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/instructions.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/instructions.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * System-prompt text injected into every agent turn via before_agent_start.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/knowledge/ingest.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/knowledge/ingest.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Forward agent output to the Mycelium knowledge graph.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/register.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/register.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Unified plugin register function.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/session-key.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/session-key.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Mirrors OpenClaw's buildAgentPeerSessionKey format for group peers.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/session/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/session/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Session lifecycle + per-turn context injection.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/config.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/config.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 import { describe, expect, it } from "vitest";
 import { readChannelConfig } from "../src/config.js";

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/knowledge-extract-handler.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/knowledge-extract-handler.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Tests for the mycelium-knowledge-extract hook's pure helpers.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/knowledge-extract-integration.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/knowledge-extract-integration.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * End-to-end wiring test for the mycelium-knowledge-extract HookHandler.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/knowledge-ingest.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/knowledge-ingest.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Tests for the in-process knowledge ingest plugin shim (src/knowledge/ingest.ts).

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/mentions.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/mentions.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 import { describe, expect, it } from "vitest";
 import { resolveMentions } from "../src/channel/mentions.js";

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/route.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/route.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 /**
  * Tests for routeMessage — the pure routing logic that decides what to do

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/session-key.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/session-key.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 import { describe, expect, it } from "vitest";
 import { buildSessionKey } from "../src/session-key.js";

--- a/mycelium-cli/src/mycelium/animations/__init__.py
+++ b/mycelium-cli/src/mycelium/animations/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Animation modules for Mycelium CLI."""
 

--- a/mycelium-cli/src/mycelium/animations/spores.py
+++ b/mycelium-cli/src/mycelium/animations/spores.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Twinkling spore starfield animation for the Mycelium CLI.

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Mycelium CLI — Multi-agent coordination + persistent memory.

--- a/mycelium-cli/src/mycelium/commands/__init__.py
+++ b/mycelium-cli/src/mycelium/commands/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Mycelium CLI command modules."""

--- a/mycelium-cli/src/mycelium/commands/adapter.py
+++ b/mycelium-cli/src/mycelium/commands/adapter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Adapter commands — connect agent frameworks to Mycelium.

--- a/mycelium-cli/src/mycelium/commands/cfn.py
+++ b/mycelium-cli/src/mycelium/commands/cfn.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 CFN observability commands — see what mycelium-backend is forwarding to

--- a/mycelium-cli/src/mycelium/commands/config.py
+++ b/mycelium-cli/src/mycelium/commands/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Config commands for Mycelium CLI."""
 

--- a/mycelium-cli/src/mycelium/commands/docs.py
+++ b/mycelium-cli/src/mycelium/commands/docs.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Documentation commands for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Doctor command — diagnose and fix common Mycelium configuration issues.

--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Install command for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Instance management commands for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Memory commands — persistent namespaced memory operations.

--- a/mycelium-cli/src/mycelium/commands/negotiate.py
+++ b/mycelium-cli/src/mycelium/commands/negotiate.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Structured negotiation commands for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/notebook.py
+++ b/mycelium-cli/src/mycelium/commands/notebook.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Notebook commands — agent-private persistent memory.

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Room management commands for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Session commands — breakout negotiation within rooms.

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Configuration management for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/doc_ref.py
+++ b/mycelium-cli/src/mycelium/doc_ref.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Decorator for registering CLI commands in the HTML docs reference.

--- a/mycelium-cli/src/mycelium/docker/__init__.py
+++ b/mycelium-cli/src/mycelium/docker/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 

--- a/mycelium-cli/src/mycelium/docker_utils.py
+++ b/mycelium-cli/src/mycelium/docker_utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Generate .env files from config.toml — makes .env a derived artifact.

--- a/mycelium-cli/src/mycelium/error_handler.py
+++ b/mycelium-cli/src/mycelium/error_handler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Error handler for formatting exceptions into user-friendly CLI messages."""
 

--- a/mycelium-cli/src/mycelium/exceptions.py
+++ b/mycelium-cli/src/mycelium/exceptions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Custom exceptions for Mycelium CLI."""
 

--- a/mycelium-cli/src/mycelium/filesystem.py
+++ b/mycelium-cli/src/mycelium/filesystem.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Memory file operations for the CLI.

--- a/mycelium-cli/src/mycelium/http_client.py
+++ b/mycelium-cli/src/mycelium/http_client.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 HTTP client for Mycelium API.

--- a/mycelium-cli/src/mycelium/identity.py
+++ b/mycelium-cli/src/mycelium/identity.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Identity management for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/sstp.py
+++ b/mycelium-cli/src/mycelium/sstp.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Lightweight SSTP (Semantic State Transfer Protocol) models for the CLI.

--- a/mycelium-cli/src/mycelium/ui_status.py
+++ b/mycelium-cli/src/mycelium/ui_status.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Shared presentation helpers for ``mycelium status`` and ``mycelium doctor``.

--- a/mycelium-cli/src/mycelium/utils/__init__.py
+++ b/mycelium-cli/src/mycelium/utils/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Utility modules for Mycelium CLI."""
 

--- a/mycelium-cli/src/mycelium/utils/room.py
+++ b/mycelium-cli/src/mycelium/utils/room.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """Room utilities for Mycelium CLI."""
 

--- a/mycelium-cli/tests/test_openclaw_scanner_guard.py
+++ b/mycelium-cli/tests/test_openclaw_scanner_guard.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 """
 Static guard against OpenClaw's plugin security scanner.

--- a/mycelium-frontend/next.config.ts
+++ b/mycelium-frontend/next.config.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 import type { NextConfig } from "next";
 const nextConfig: NextConfig = {};

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 import type { Metadata } from "next";
 import "./globals.css";

--- a/mycelium-frontend/src/app/page.tsx
+++ b/mycelium-frontend/src/app/page.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 "use client";
 

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 "use client";
 

--- a/mycelium-frontend/src/components/create-room-dialog.tsx
+++ b/mycelium-frontend/src/components/create-room-dialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 "use client";
 

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 "use client";
 

--- a/mycelium-frontend/src/components/knowledge-panel.tsx
+++ b/mycelium-frontend/src/components/knowledge-panel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 "use client";
 

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 "use client";
 

--- a/mycelium-frontend/src/components/room-card.tsx
+++ b/mycelium-frontend/src/components/room-card.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 "use client";
 

--- a/mycelium-frontend/src/components/sessions-view.tsx
+++ b/mycelium-frontend/src/components/sessions-view.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 "use client";
 

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8001";
 

--- a/mycelium-frontend/src/lib/utils.ts
+++ b/mycelium-frontend/src/lib/utils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Cisco Systems, Inc. and its affiliates
 
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";


### PR DESCRIPTION
## Summary

- Replaces `Copyright 2026 Julia Valenti` with `Copyright 2026 Cisco Systems, Inc. and its affiliates` across all 153 authored source files (Python, TypeScript, TSX)
- Adds the missing copyright header to `fastapi-backend/app/services/llm_health.py` and `fastapi-backend/tests/test_llm_health.py`
- SPDX-License-Identifier line (`Apache-2.0`) is unchanged

## Test plan

- [ ] Spot-check a few files to confirm header format is correct
- [ ] No functional code changes — CI should pass as-is