### PR TITLE
chore: rename topology "leaf" → "spoke" (hard cutover)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ No external message broker, no separate vector DB, no Redis. One database.
 
 **Rooms are git-friendly** — commit `.mycelium/rooms/` to share context across machines. Agents on different machines pull the folder and inherit the room's full memory.
 
+**Hub-and-spoke deployments** — one machine runs the backend (the **hub**); other machines run only the CLI + agents (**spokes**) and connect to the hub over HTTPS/SSE. `mycelium doctor` auto-detects which role a node is playing based on `server.api_url`; pass `--mode hub` or `--mode spoke` to override. See [`docs/architecture.md`](mycelium-cli/src/mycelium/docs/architecture.md#topology) for details.
+
 Room folders use standard namespaces:
 
 ```

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ No external message broker, no separate vector DB, no Redis. One database.
 
 **Rooms are git-friendly** — commit `.mycelium/rooms/` to share context across machines. Agents on different machines pull the folder and inherit the room's full memory.
 
-**Hub-and-spoke deployments** — one machine runs the backend (the **hub**); other machines run only the CLI + agents (**spokes**) and connect to the hub over HTTPS/SSE. `mycelium doctor` auto-detects which role a node is playing based on `server.api_url`; pass `--mode hub` or `--mode spoke` to override. See [`docs/architecture.md`](mycelium-cli/src/mycelium/docs/architecture.md#topology) for details.
+**Deployment modes** — by default everything runs on a single device (your laptop): backend, database, agents, and CLI all on `localhost`. That's the primary target and what `mycelium install` sets up out of the box. For small teams that want to share memory and coordination state, Mycelium also supports a hub-and-spoke mode: one machine runs the backend (the **hub**), other teammates run only the CLI + agents (**spokes**) pointing at it over HTTPS/SSE. `mycelium doctor` auto-detects which mode you're in based on `server.api_url`; pass `--mode hub` or `--mode spoke` to override. See [`docs/architecture.md`](mycelium-cli/src/mycelium/docs/architecture.md#deployment-modes) for details.
 
 Room folders use standard namespaces:
 

--- a/fastapi-backend/tests/test_cfn_read_surface.py
+++ b/fastapi-backend/tests/test_cfn_read_surface.py
@@ -65,7 +65,7 @@ async def test_query_resolves_mas_id_from_settings_when_omitted(
     client: AsyncClient,
     monkeypatch,
 ):
-    """Leaf nodes can omit mas_id; backend resolves from settings.MAS_ID."""
+    """Spoke nodes can omit mas_id; backend resolves from settings.MAS_ID."""
     mock = AsyncMock(return_value={"response_id": "r", "message": "ok"})
     monkeypatch.setattr("app.routes.cfn_proxy.query_shared_memories", mock)
 

--- a/fastapi-backend/tests/test_knowledge_ingest.py
+++ b/fastapi-backend/tests/test_knowledge_ingest.py
@@ -190,28 +190,28 @@ async def test_ingest_cfn_http_status_error_preserves_code(
     assert resp.status_code == 503
 
 
-# ── Leaf-node ingest (room_name only, no workspace_id/mas_id) ─────────────────
+# ── Spoke-node ingest (room_name only, no workspace_id/mas_id) ────────────────
 
 
-async def test_ingest_leaf_node_resolves_ids_from_room(
+async def test_ingest_spoke_node_resolves_ids_from_room(
     client: AsyncClient,
     db_session: AsyncSession,
     mock_cfn,
     monkeypatch,
 ):
-    """Leaf nodes send only room_name; backend resolves workspace_id and mas_id."""
+    """Spoke nodes send only room_name; backend resolves workspace_id and mas_id."""
     monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
 
-    room = Room(name="leaf-room", mas_id="room-mas", workspace_id="room-ws")
+    room = Room(name="spoke-room", mas_id="room-mas", workspace_id="room-ws")
     db_session.add(room)
     await db_session.commit()
 
     resp = await client.post(
         "/api/knowledge/ingest",
         json={
-            "room_name": "leaf-room",
-            "agent_id": "leaf-agent",
-            "records": [{"response": "hello from leaf"}],
+            "room_name": "spoke-room",
+            "agent_id": "spoke-agent",
+            "records": [{"response": "hello from spoke"}],
         },
     )
     assert resp.status_code == 200

--- a/mycelium-cli/src/mycelium/adapters/claude-code/hooks/mycelium-knowledge-extract.py
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/hooks/mycelium-knowledge-extract.py
@@ -24,7 +24,7 @@ Keeping each fire bounded (~1 turn, a few KB) is the whole point.
   2. ``[adapters.claude-code] knowledge_extract = true`` — per-adapter
      switch so Claude Code can be on while openclaw is off (or vice versa).
 
-Leaf nodes only send ``room_name`` — the backend resolves ``workspace_id``
+Spoke nodes only send ``room_name`` — the backend resolves ``workspace_id``
 and ``mas_id`` from the room's DB record or its own settings (see #139).
 
 CFN ingest costs real tokens per record, so we don't turn this on for
@@ -150,7 +150,7 @@ def _env_bool(name: str, default: bool) -> bool:
 def _resolve_target(config: dict[str, Any]) -> dict[str, Any]:
     """Resolve target API and identity for ingest.
 
-    Leaf nodes only send room_name — the backend resolves workspace_id and
+    Spoke nodes only send room_name — the backend resolves workspace_id and
     mas_id from the room's DB record or its own settings (#139).
     """
     server = config.get("server", {}) or {}
@@ -474,7 +474,7 @@ def _post_ingest(
 ) -> bool:
     """POST knowledge to the backend ingest endpoint.
 
-    Leaf nodes only send room_name — the backend resolves workspace_id and
+    Spoke nodes only send room_name — the backend resolves workspace_id and
     mas_id from the room's DB record or its own settings (#139).
     """
     body: dict[str, Any] = {

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/knowledge/ingest.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/knowledge/ingest.ts
@@ -62,7 +62,7 @@ export function installKnowledgeIngest(
       // Falling back to getAgentId() keeps direct `openclaw agent --agent`
       // invocations attributed. See issue #144.
       //
-      // Leaf nodes only send room_name — the backend resolves workspace_id
+      // Spoke nodes only send room_name — the backend resolves workspace_id
       // and mas_id from the room's DB record or its own settings (#139).
       const ingestAgentId = agentId?.trim() || getAgentId() || undefined;
       apiPost(

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -15,12 +15,14 @@ Checks:
   8. Room MAS IDs present (CFN-enabled installs)
   9. OpenClaw adapter health (plugin, channel config, agent sandbox)
 
-In a hub-and-spoke topology, spoke nodes connect to a remote backend and
-don't run local Docker containers.  When ``server.api_url`` points at a
-non-local host the doctor auto-detects **spoke mode** and skips checks
-that only apply to the hub (Docker containers, runtime config drift,
-.env port vs Docker port, localhost CFN mgmt plane).  An explicit
-``--mode hub|spoke`` flag overrides the auto-detection.
+Single-device installs (the default) run the backend locally and exercise
+all checks. In the optional hub-and-spoke deployment mode, spoke nodes
+connect to a remote backend and don't run local Docker containers. When
+``server.api_url`` points at a non-local host the doctor auto-detects
+**spoke mode** and skips checks that only apply when the backend is
+local (Docker containers, runtime config drift, .env port vs Docker
+port, localhost CFN mgmt plane).  An explicit ``--mode hub|spoke`` flag
+overrides the auto-detection.
 """
 
 import subprocess
@@ -1029,11 +1031,12 @@ def doctor(
     Checks config files, LLM setup, Docker containers, backend connectivity,
     workspace ID sync, and config consistency. Offers to fix issues it finds.
 
-    In a hub-and-spoke topology, spoke nodes talk to a remote backend and
-    don't run Docker containers locally. When --mode is 'auto' (the default),
-    doctor detects spoke mode from server.api_url — if it points to a
-    non-local host the Docker, runtime-drift, and port-drift checks are
-    skipped automatically.
+    Single-device installs (the default) run the backend locally and
+    exercise all checks. In the optional hub-and-spoke deployment mode
+    spoke nodes talk to a remote backend and don't run Docker containers
+    locally. When --mode is 'auto' (the default), doctor detects spoke
+    mode from server.api_url — if it points to a non-local host the
+    Docker, runtime-drift, and port-drift checks are skipped automatically.
 
     \b
     Examples:

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -15,12 +15,12 @@ Checks:
   8. Room MAS IDs present (CFN-enabled installs)
   9. OpenClaw adapter health (plugin, channel config, agent sandbox)
 
-In a hub-and-spoke topology, leaf nodes connect to a remote backend and
+In a hub-and-spoke topology, spoke nodes connect to a remote backend and
 don't run local Docker containers.  When ``server.api_url`` points at a
-non-local host the doctor auto-detects **leaf mode** and skips checks
+non-local host the doctor auto-detects **spoke mode** and skips checks
 that only apply to the hub (Docker containers, runtime config drift,
 .env port vs Docker port, localhost CFN mgmt plane).  An explicit
-``--mode hub|leaf`` flag overrides the auto-detection.
+``--mode hub|spoke`` flag overrides the auto-detection.
 """
 
 import subprocess
@@ -332,7 +332,7 @@ def _check_backend_reachable(*, local_backend: bool = True) -> CheckResult:
 def _check_workspace_id(*, local_backend: bool = True) -> CheckResult:
     """Check workspace_id consistency between .env, config.toml, and CFN mgmt plane.
 
-    When *local_backend* is False (leaf mode) the localhost CFN management
+    When *local_backend* is False (spoke mode) the localhost CFN management
     plane check is skipped — the mgmt plane runs on the hub, not here.
     """
     env_path = Path.home() / ".mycelium" / ".env"
@@ -364,7 +364,7 @@ def _check_workspace_id(*, local_backend: bool = True) -> CheckResult:
             return CheckResult(
                 name="Workspace ID",
                 status="ok",
-                message="Not set (optional for leaf nodes)",
+                message="Not set (optional for spoke nodes)",
             )
         return CheckResult(
             name="Workspace ID",
@@ -374,7 +374,7 @@ def _check_workspace_id(*, local_backend: bool = True) -> CheckResult:
         )
 
     # If CFN is enabled *and* we're on the hub, check against the local
-    # mgmt plane.  Leaf nodes don't run the mgmt plane locally.
+    # mgmt plane.  Spoke nodes don't run the mgmt plane locally.
     cfn_ws = None
     if cfn_enabled and local_backend:
         from mycelium.commands.install import _get_cfn_workspace_id
@@ -491,7 +491,7 @@ def _check_config_file_drift(*, local_backend: bool = True) -> CheckResult:
     The sibling runtime-drift check covers "I edited both files but forgot
     to restart the container" — this one only looks at disk, not runtime.
 
-    When *local_backend* is False (leaf mode) the Docker-port comparison is
+    When *local_backend* is False (spoke mode) the Docker-port comparison is
     skipped because there is no local container to map the port for.
     """
     env_path = Path.home() / ".mycelium" / ".env"
@@ -1010,7 +1010,7 @@ def _check_openclaw_agent_sandbox() -> CheckResult:
 
 
 @doc_ref(
-    usage="mycelium doctor [--fix] [--json] [--mode auto|hub|leaf]",
+    usage="mycelium doctor [--fix] [--json] [--mode auto|hub|spoke]",
     desc="Diagnose and fix common configuration issues (workspace sync, LLM, containers).",
     group="setup",
 )
@@ -1020,7 +1020,7 @@ def doctor(
     mode: str = typer.Option(
         "auto",
         "--mode",
-        help="Check scope: auto (detect from api_url), hub (all checks), or leaf (skip local-only checks)",
+        help="Check scope: auto (detect from api_url), hub (all checks), or spoke (skip local-only checks)",
     ),
 ) -> None:
     """
@@ -1029,17 +1029,17 @@ def doctor(
     Checks config files, LLM setup, Docker containers, backend connectivity,
     workspace ID sync, and config consistency. Offers to fix issues it finds.
 
-    In a hub-and-spoke topology, leaf nodes talk to a remote backend and
+    In a hub-and-spoke topology, spoke nodes talk to a remote backend and
     don't run Docker containers locally. When --mode is 'auto' (the default),
-    doctor detects leaf mode from server.api_url — if it points to a
+    doctor detects spoke mode from server.api_url — if it points to a
     non-local host the Docker, runtime-drift, and port-drift checks are
     skipped automatically.
 
     \b
     Examples:
-        mycelium doctor              # interactive — auto-detects hub vs leaf
+        mycelium doctor              # interactive — auto-detects hub vs spoke
         mycelium doctor --fix        # auto-fix all fixable issues
-        mycelium doctor --mode leaf  # force leaf mode (skip local-only checks)
+        mycelium doctor --mode spoke # force spoke mode (skip local-only checks)
         mycelium doctor --mode hub   # force hub mode (run all checks)
     """
     try:
@@ -1058,18 +1058,18 @@ def doctor(
             local = _is_local_backend(api_url)
         elif mode == "hub":
             local = True
-        elif mode == "leaf":
+        elif mode == "spoke":
             local = False
         else:
-            typer.secho(f"Unknown --mode '{mode}'. Use auto, hub, or leaf.", fg=typer.colors.RED)
+            typer.secho(f"Unknown --mode '{mode}'. Use auto, hub, or spoke.", fg=typer.colors.RED)
             raise typer.Exit(1)
 
-        detected_mode = "hub" if local else "leaf"
+        detected_mode = "hub" if local else "spoke"
 
         # ── Build check list ──────────────────────────────────────────
         # Checks are grouped into sections for display but we collect
         # them once so the JSON output and verdict have a single source
-        # of truth.  Leaf nodes skip checks that only apply when the
+        # of truth.  Spoke nodes skip checks that only apply when the
         # backend runs locally (Docker containers, runtime config drift,
         # .env port vs Docker port).
         config_checks: list[CheckResult] = [

--- a/mycelium-cli/src/mycelium/docs/architecture.md
+++ b/mycelium-cli/src/mycelium/docs/architecture.md
@@ -1,19 +1,43 @@
 # Architecture
 
-## Topology
+## Deployment Modes
 
-Mycelium deployments follow a **hub-and-spoke** model:
+Mycelium supports two deployment modes. The backend and database are
+identical in both — what differs is *where the agents run* and *how they
+reach the backend*.
+
+### 1. Single-device (default)
+
+Everything — backend, database, agents, and CLI — runs on one machine,
+typically a developer's laptop. This is what `mycelium install` sets up
+out of the box. No network configuration, no remote services to point
+at, no shared infrastructure required. Agents talk to `localhost:8000`.
+
+This is the primary deployment target. Use it when one person (or one
+machine) owns the whole agent workflow.
+
+### 2. Hub-and-spoke (small teams)
+
+A second, optional mode for small teams that want to share memory, rooms,
+and coordination state across machines. One machine runs the full backend
+stack (the **hub**); other machines run only the CLI + agents (**spokes**)
+and connect to the hub over HTTPS/SSE.
 
 | Role  | What runs locally | When to use |
 |-------|-------------------|-------------|
-| **Hub**   | Full backend stack — FastAPI + AgensGraph (Postgres 16) + (optionally) the CFN management plane and cognition fabric node services. | Single-machine setups, the team's shared coordination server, or any node that owns the source-of-truth database. |
-| **Spoke** | CLI + agents only. Talks to a remote hub via HTTPS / SSE. No Docker containers, no local database. | Developer laptops, CI runners, edge agents — anywhere that should *participate* in coordination without hosting it. |
+| **Hub**   | Full backend stack — FastAPI + AgensGraph (Postgres 16) + (optionally) the CFN management plane and cognition fabric node services. | The team's shared coordination server. One per team. |
+| **Spoke** | CLI + agents only. Talks to a remote hub via HTTPS / SSE. No Docker containers, no local database. | Each teammate's laptop. Agents on the spoke participate in shared rooms hosted by the hub. |
 
-Detection is automatic: if `server.api_url` in `~/.mycelium/config.toml`
-points to `localhost`/`127.0.0.1`, the node is a **hub**; otherwise it's a
-**spoke**. `mycelium doctor` uses this to skip checks that don't apply
-(Docker containers, runtime config drift, local CFN mgmt plane). Override
-the auto-detection with:
+Use this when a small team wants one place to look at shared memory,
+results, and ongoing coordinations — without each member running their
+own isolated stack.
+
+`mycelium doctor` auto-detects which mode you're in by looking at
+`server.api_url` in `~/.mycelium/config.toml`: if it points to
+`localhost`/`127.0.0.1`, you're a hub; otherwise a spoke. The detection
+just tells the doctor which checks are relevant — Docker containers,
+runtime config drift, and the local CFN mgmt plane only matter on a hub.
+Override the auto-detection with:
 
 ```bash
 mycelium doctor --mode hub     # force hub checks

--- a/mycelium-cli/src/mycelium/docs/architecture.md
+++ b/mycelium-cli/src/mycelium/docs/architecture.md
@@ -1,5 +1,31 @@
 # Architecture
 
+## Topology
+
+Mycelium deployments follow a **hub-and-spoke** model:
+
+| Role  | What runs locally | When to use |
+|-------|-------------------|-------------|
+| **Hub**   | Full backend stack — FastAPI + AgensGraph (Postgres 16) + (optionally) the CFN management plane and cognition fabric node services. | Single-machine setups, the team's shared coordination server, or any node that owns the source-of-truth database. |
+| **Spoke** | CLI + agents only. Talks to a remote hub via HTTPS / SSE. No Docker containers, no local database. | Developer laptops, CI runners, edge agents — anywhere that should *participate* in coordination without hosting it. |
+
+Detection is automatic: if `server.api_url` in `~/.mycelium/config.toml`
+points to `localhost`/`127.0.0.1`, the node is a **hub**; otherwise it's a
+**spoke**. `mycelium doctor` uses this to skip checks that don't apply
+(Docker containers, runtime config drift, local CFN mgmt plane). Override
+the auto-detection with:
+
+```bash
+mycelium doctor --mode hub     # force hub checks
+mycelium doctor --mode spoke   # force spoke checks (skip local-only)
+mycelium doctor --mode auto    # default — detect from api_url
+```
+
+> **Terminology note.** Earlier releases used "leaf" instead of "spoke".
+> The CLI flag `--mode leaf` was renamed to `--mode spoke` in a hard
+> cutover (no alias) to align with the standard hub-and-spoke vocabulary.
+> If you have scripts that pass `--mode leaf`, update them to `--mode spoke`.
+
 ## Stack
 
 Everything runs on a single **AgensGraph** instance — a PostgreSQL 16 fork


### PR DESCRIPTION
## Summary

Standardize deployment topology terminology on the industry-standard **hub-and-spoke** model. Previously the codebase mixed `hub-and-spoke` in some docs/comments with a `--mode leaf` CLI flag and "leaf node" terminology elsewhere — confusing because leaves attach to branches, not hubs.

## Changes

- **CLI breaking change**: `mycelium doctor --mode leaf` → `--mode spoke` (hard cutover, no deprecated alias)
- All internal comments, docstrings, help text, and test names updated:
  - `mycelium-cli/src/mycelium/commands/doctor.py`
  - `mycelium-cli/src/mycelium/adapters/claude-code/hooks/mycelium-knowledge-extract.py`
  - `mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/knowledge/ingest.ts`
  - `fastapi-backend/tests/test_cfn_read_surface.py`
  - `fastapi-backend/tests/test_knowledge_ingest.py` (renamed `test_ingest_leaf_node_resolves_ids_from_room` → `..._spoke_node_...`)
- New **Topology** section in `mycelium-cli/src/mycelium/docs/architecture.md` defining hub vs spoke roles, auto-detection rules, and the `--mode` flag — plus a "Terminology note" callout documenting the rename
- README "Architecture" section gains a one-paragraph hub-and-spoke description with a link to the architecture doc

## Breaking change

Scripts or CI that pass `--mode leaf` to `mycelium doctor` must update to `--mode spoke`. There is no compatibility alias.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pytest tests/test_knowledge_ingest.py tests/test_cfn_read_surface.py` — 23 passed
- [ ] CI lint + format + tests

Made with [Cursor](https://cursor.com)