### PR TITLE
feat(negotiation): validate counter-offer keys, fill partial offers, add negotiate status

### DIFF
--- a/.claude/skills/mycelium/SKILL.md
+++ b/.claude/skills/mycelium/SKILL.md
@@ -1,1 +1,0 @@
-../../../mycelium-cli/src/mycelium/adapters/claude-code/skills/mycelium/SKILL.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,75 @@ Embeddings: sentence-transformers (all-MiniLM-L6-v2, local, 384 dimensions).
 - **Git for sharing** — rooms can be shared via git push/pull.
 - **No Ensue references in code** — we took inspiration from their API design but the implementation is independent.
 
+## Local development
+
+> **This section is for contributors iterating on the backend source.** End users should follow the normal install path: `curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash` then `mycelium install`.
+
+### Starting the stack
+
+The normal `mycelium up` / `mycelium install` flow uses `compose.yml` with `pull_policy: always` — it always pulls released images and is the correct path for end users. For dev, use `compose-dev.yml` instead, which builds `mycelium-backend` from local source and wires `~/.mycelium/.env` into all service containers. **Always run from the repo root.**
+
+```bash
+# Full stack with CFN (required for negotiate/session commands)
+docker compose \
+  -f mycelium-cli/src/mycelium/docker/compose.yml \
+  -f mycelium-cli/src/mycelium/docker/compose-dev.yml \
+  --profile cfn up -d --build
+
+# Memory only (no CFN)
+docker compose \
+  -f mycelium-cli/src/mycelium/docker/compose.yml \
+  -f mycelium-cli/src/mycelium/docker/compose-dev.yml \
+  up -d --build
+```
+
+On subsequent runs, drop `--build` unless you've changed backend code.
+
+### LLM config
+
+All containers get their LLM settings from `~/.mycelium/.env`, which is generated from `config.toml`. Set these once:
+
+```bash
+mycelium config set llm.model "anthropic/bedrock/global.anthropic.claude-sonnet-4-6"
+mycelium config set llm.api_key "<key>"
+mycelium config set llm.base_url "<base-url>"
+mycelium config apply
+```
+
+Then recreate any running CFN containers to pick up the new env:
+```bash
+docker compose -f mycelium-cli/src/mycelium/docker/compose.yml \
+  -f mycelium-cli/src/mycelium/docker/compose-dev.yml \
+  --profile cfn up -d --force-recreate ioc-cognition-fabric-node-svc
+```
+
+**Important:** `mycelium config apply` regenerates `.env` from `config.toml`. If you edit `.env` directly, those changes will be overwritten. Always use `mycelium config set` to persist values.
+
+### MAS ID
+
+`mas_id` in `config.toml` is a CFN Multi-Agent System UUID required for `session join`/`await`/`negotiate`. Each room gets its own MAS ID on creation — use the one for the room you're testing:
+
+```bash
+mycelium room create my-room        # prints MAS ID on creation
+mycelium config set server.mas_id <uuid-from-above>
+```
+
+After a volume wipe, existing MAS IDs are gone. Create a new room and use its ID.
+
+### Running the backend outside Docker (hot-reload)
+
+```bash
+cd fastapi-backend
+DATABASE_URL="postgresql+asyncpg://postgres:password@localhost:5432/mycelium" \
+  uv run uvicorn app.main:app --reload --port 8000
+```
+
+DB container still needs to be running (`docker compose up -d mycelium-db`). Update `config.toml` if you change the backend port:
+```bash
+mycelium config set server.api_url "http://localhost:8000"
+mycelium config apply
+```
+
 ## Conventions
 
 - Use `uv run` for all Python commands, never bare `python` or `pip install`

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -343,3 +343,37 @@ async def delete_room(
 
     # 7. Delete MAS from CFN mgmt plane (non-fatal, last).
     await _sync_delete_mas(room)
+
+
+@router.get("/{room_name}/negotiation")
+async def get_negotiation_status(
+    room_name: str,
+    session: AsyncSession = Depends(get_async_session),
+) -> dict:
+    """Return live negotiation state for an active session room.
+
+    Returns ``{"active": false}`` when no negotiation is in progress.
+    ``pending_replies`` values are ``"received"`` or ``"waiting"``.
+    """
+    from app.services.coordination import _cfn_state
+
+    result = await session.execute(select(Room).where(Room.name == room_name))
+    if not result.scalar_one_or_none():
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    state = _cfn_state.get(room_name)
+    if not state:
+        return {"active": False}
+
+    return {
+        "active": True,
+        "session_id": state.session_id,
+        "round": state.current_round,
+        "issues": state.issues,
+        "issue_options": state.issue_options,
+        "current_offer": state.current_offer,
+        "pending_replies": {
+            h: "received" if v is not None else "waiting"
+            for h, v in state.pending_replies.items()
+        },
+    }

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -373,7 +373,6 @@ async def get_negotiation_status(
         "issue_options": state.issue_options,
         "current_offer": state.current_offer,
         "pending_replies": {
-            h: "received" if v is not None else "waiting"
-            for h, v in state.pending_replies.items()
+            h: "received" if v is not None else "waiting" for h, v in state.pending_replies.items()
         },
     }

--- a/fastapi-backend/app/services/cfn_negotiation.py
+++ b/fastapi-backend/app/services/cfn_negotiation.py
@@ -58,9 +58,18 @@ def _describe_exc(exc: Exception) -> str:
 
 async def _cfn_post(url: str, body: dict[str, Any], endpoint: str) -> dict[str, Any]:
     """POST to CFN and raise ``CfnNegotiationError`` with a descriptive reason on any failure."""
+    import json as _json
+
+    logger.info("CFN %s → %s | body=%s", endpoint, url, _json.dumps(body))
     try:
         async with httpx.AsyncClient(timeout=_CFN_HTTP_TIMEOUT) as client:
             resp = await client.post(url, json=body)
+            logger.info(
+                "CFN %s ← status=%d | body=%s",
+                endpoint,
+                resp.status_code,
+                resp.text[:2000],
+            )
             resp.raise_for_status()
             return resp.json()
     except httpx.HTTPStatusError as exc:

--- a/fastapi-backend/app/services/cfn_negotiation.py
+++ b/fastapi-backend/app/services/cfn_negotiation.py
@@ -58,18 +58,9 @@ def _describe_exc(exc: Exception) -> str:
 
 async def _cfn_post(url: str, body: dict[str, Any], endpoint: str) -> dict[str, Any]:
     """POST to CFN and raise ``CfnNegotiationError`` with a descriptive reason on any failure."""
-    import json as _json
-
-    logger.info("CFN %s → %s | body=%s", endpoint, url, _json.dumps(body))
     try:
         async with httpx.AsyncClient(timeout=_CFN_HTTP_TIMEOUT) as client:
             resp = await client.post(url, json=body)
-            logger.info(
-                "CFN %s ← status=%d | body=%s",
-                endpoint,
-                resp.status_code,
-                resp.text[:2000],
-            )
             resp.raise_for_status()
             return resp.json()
     except httpx.HTTPStatusError as exc:

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -301,8 +301,17 @@ async def _round_timeout(room_name: str) -> None:
     state = _cfn_state.get(room_name)
     if not state:
         return
-    logger.warning("CFN round timeout fired for %s — agents silent for %ds, aborting session", room_name, _CFN_ROUND_TIMEOUT_SECS)
-    await _finish_cfn(room_name, plan="Negotiation timed out — agents did not respond", assignments={}, broken=True)
+    logger.warning(
+        "CFN round timeout fired for %s — agents silent for %ds, aborting session",
+        room_name,
+        _CFN_ROUND_TIMEOUT_SECS,
+    )
+    await _finish_cfn(
+        room_name,
+        plan="Negotiation timed out — agents did not respond",
+        assignments={},
+        broken=True,
+    )
 
 
 async def _fan_out_cfn_messages(
@@ -621,7 +630,11 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
     async with cfn.lock:
         if handle in cfn.pending_replies:
             reply_data = _parse_agent_reply(handle, content, cfn.current_offer, cfn.issue_options)
-            if reply_data.get("action") == "counter_offer" and cfn.next_proposer_id and handle != cfn.next_proposer_id:
+            if (
+                reply_data.get("action") == "counter_offer"
+                and cfn.next_proposer_id
+                and handle != cfn.next_proposer_id
+            ):
                 out_of_turn = True
                 # Leave pending_replies[handle] as None — round waits for a corrected reply.
             elif reply_data.get("action") == "invalid_keys":
@@ -650,14 +663,16 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
         await _post_message(
             room_name,
             message_type="coordination_tick",
-            content=json.dumps({
-                "error": "counter_offer_not_your_turn",
-                "instruction": (
-                    f"It is not your turn to propose. Only '{cfn.next_proposer_id}' may counter-offer "
-                    "this round. Use 'accept' or 'reject' instead."
-                ),
-                "payload": {"participant_id": handle},
-            }),
+            content=json.dumps(
+                {
+                    "error": "counter_offer_not_your_turn",
+                    "instruction": (
+                        f"It is not your turn to propose. Only '{cfn.next_proposer_id}' may counter-offer "
+                        "this round. Use 'accept' or 'reject' instead."
+                    ),
+                    "payload": {"participant_id": handle},
+                }
+            ),
         )
         return
 
@@ -672,15 +687,17 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
         await _post_message(
             room_name,
             message_type="coordination_tick",
-            content=json.dumps({
-                "error": "counter_offer_invalid_keys",
-                "bad_keys": corrective["bad_keys"],
-                "valid_keys": corrective["valid_keys"],
-                "instruction": (
-                    "Re-submit your counter_offer using only the exact keys listed in valid_keys."
-                ),
-                "payload": {"participant_id": handle},
-            }),
+            content=json.dumps(
+                {
+                    "error": "counter_offer_invalid_keys",
+                    "bad_keys": corrective["bad_keys"],
+                    "valid_keys": corrective["valid_keys"],
+                    "instruction": (
+                        "Re-submit your counter_offer using only the exact keys listed in valid_keys."
+                    ),
+                    "payload": {"participant_id": handle},
+                }
+            ),
         )
         return
 

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -56,6 +56,10 @@ class _CfnRoundState:
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     round_timeout_task: asyncio.Task | None = field(default=None)
     deciding: bool = field(default=False)  # guard against double-decide
+    current_round: int = 0
+    current_offer: dict | None = None
+    issues: list[str] | None = None
+    issue_options: dict[str, list[str]] | None = None
 
 
 # {room_name: _CfnRoundState}
@@ -375,6 +379,22 @@ async def _fan_out_cfn_messages(
                 ),
             )
             addressed.append(participant_id)
+
+    # Update round state so validation and the status endpoint can read it.
+    state = _cfn_state.get(room_name)
+    if state and messages:
+        last_payload = messages[-1].get("payload", messages[-1])
+        if issues:
+            state.issues = issues
+        if issue_options:
+            state.issue_options = issue_options
+        round_num = last_payload.get("round")
+        if round_num is not None:
+            state.current_round = round_num
+        current_offer = last_payload.get("current_offer")
+        if current_offer is not None:
+            state.current_offer = current_offer
+
     return addressed
 
 
@@ -589,20 +609,49 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
         return
 
     should_decide = False
+    corrective: dict | None = None
     async with cfn.lock:
         if handle in cfn.pending_replies:
-            reply_data = _parse_agent_reply(handle, content)
-            cfn.pending_replies[handle] = reply_data
-            logger.debug(
-                "CFN room %s: collected reply from %s (%d/%d)",
-                room_name,
-                handle,
-                sum(1 for v in cfn.pending_replies.values() if v is not None),
-                len(cfn.pending_replies),
-            )
-            all_received = all(v is not None for v in cfn.pending_replies.values())
-            if all_received:
-                should_decide = True
+            reply_data = _parse_agent_reply(handle, content, cfn.current_offer, cfn.issue_options)
+            if reply_data.get("action") == "invalid_keys":
+                corrective = reply_data
+                # Leave pending_replies[handle] as None — round waits for a corrected reply.
+            else:
+                cfn.pending_replies[handle] = reply_data
+                logger.debug(
+                    "CFN room %s: collected reply from %s (%d/%d)",
+                    room_name,
+                    handle,
+                    sum(1 for v in cfn.pending_replies.values() if v is not None),
+                    len(cfn.pending_replies),
+                )
+                all_received = all(v is not None for v in cfn.pending_replies.values())
+                if all_received:
+                    should_decide = True
+
+    if corrective:
+        logger.warning(
+            "CFN room %s: agent %s counter_offer rejected — bad keys %s (valid: %s)",
+            room_name,
+            handle,
+            corrective["bad_keys"],
+            corrective["valid_keys"],
+        )
+        await _post_message(
+            room_name,
+            message_type="coordination_tick",
+            content=json.dumps({
+                "error": "counter_offer_invalid_keys",
+                "bad_keys": corrective["bad_keys"],
+                "valid_keys": corrective["valid_keys"],
+                "instruction": (
+                    "Re-submit your counter_offer using only the exact keys listed in valid_keys."
+                ),
+                "payload": {"participant_id": handle},
+            }),
+        )
+        return
+
     if should_decide:
         # All replies in — cancel the timeout so it doesn't double-fire
         if cfn.round_timeout_task and not cfn.round_timeout_task.done():
@@ -610,13 +659,56 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
         asyncio.ensure_future(_cfn_decide_round(room_name))
 
 
-def _parse_agent_reply(handle: str, content: str) -> dict:
+def _validate_and_fill_offer(handle: str, result: dict, current_offer: dict | None) -> dict:
+    """Validate counter_offer keys and silently fill partial offers from the anchor.
+
+    Returns the (possibly mutated) result dict, or an ``invalid_keys`` sentinel if
+    the offer contains keys not present in ``current_offer``.
+    """
+    if not current_offer or not result.get("offer"):
+        return result
+
+    offer = result["offer"]
+    bad_keys = set(offer) - set(current_offer)
+    if bad_keys:
+        return {
+            "agent_id": handle,
+            "participant_id": handle,
+            "action": "invalid_keys",
+            "bad_keys": sorted(bad_keys),
+            "valid_keys": sorted(current_offer),
+        }
+
+    # Partial offer: fill missing keys from the anchor so CFN sees a complete offer.
+    if set(offer) < set(current_offer):
+        logger.debug(
+            "Agent %s submitted partial offer (%d/%d keys); filling from anchor",
+            handle,
+            len(offer),
+            len(current_offer),
+        )
+        result["offer"] = {**current_offer, **offer}
+
+    return result
+
+
+def _parse_agent_reply(
+    handle: str,
+    content: str,
+    current_offer: dict | None = None,
+    issue_options: dict | None = None,
+) -> dict:
     """Try to parse agent reply content as a CFN AgentReply dict.
 
     Expected formats (in order of preference):
       1. JSON with "action" key: {"action": "accept"|"reject"|"counter_offer", "offer": {...}}
       2. JSON with "offer" key only: treated as counter_offer
       3. Plain text: treat as "reject"
+
+    When ``current_offer`` is provided, counter_offer replies are validated:
+    - Keys not present in ``current_offer`` → returns ``invalid_keys`` sentinel so
+      ``on_agent_response`` can post a corrective tick without advancing the round.
+    - Valid but partial offers → silently filled from ``current_offer`` (agent values win).
 
     Always returns a dict with at least {"agent_id": handle, "participant_id": handle, "action": ...}.
 
@@ -628,24 +720,27 @@ def _parse_agent_reply(handle: str, content: str) -> dict:
         parsed = json.loads(content)
         if isinstance(parsed, dict):
             if "offer" in parsed and "action" not in parsed:
-                return {
+                result: dict = {
                     "agent_id": handle,
                     "participant_id": handle,
                     "action": "counter_offer",
                     "offer": parsed["offer"],
                 }
+                return _validate_and_fill_offer(handle, result, current_offer)
 
             if "action" in parsed:
                 action = parsed["action"]
                 if action not in ("accept", "reject", "counter_offer"):
                     action = "reject"
-                result: dict = {
+                result = {
                     "agent_id": handle,
                     "participant_id": handle,
                     "action": action,
                 }
                 if parsed.get("offer"):
                     result["offer"] = parsed["offer"]
+                if action == "counter_offer":
+                    return _validate_and_fill_offer(handle, result, current_offer)
                 return result
     except (json.JSONDecodeError, TypeError):
         pass

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -40,10 +40,11 @@ logger = logging.getLogger(__name__)
 # ── CFN mode state ─────────────────────────────────────────────────────────────
 
 
-# How long to wait for agent replies before calling /decide with whatever we have.
-# The IOC's BatchCallbackRunner uses a 30s per-round timeout; we fire slightly earlier
-# so the backend stays in sync with the IOC's internal loop.
-_CFN_ROUND_TIMEOUT_SECS = 25
+# How long to wait for agent replies before aborting the session.
+# We wait indefinitely for replies within a round; this only fires when agents
+# go completely silent (disconnected / crashed).  Using /decide with partial
+# rejects caused a double-decide race that silently dropped valid counter-offers.
+_CFN_ROUND_TIMEOUT_SECS = 300
 
 
 @dataclass
@@ -60,6 +61,7 @@ class _CfnRoundState:
     current_offer: dict | None = None
     issues: list[str] | None = None
     issue_options: dict[str, list[str]] | None = None
+    next_proposer_id: str | None = None
 
 
 # {room_name: _CfnRoundState}
@@ -287,18 +289,20 @@ def _reset_round_timeout(room_name: str, state: "_CfnRoundState") -> None:
 
 
 async def _round_timeout(room_name: str) -> None:
-    """Fire /decide with whatever replies exist after _CFN_ROUND_TIMEOUT_SECS.
+    """Abort the session if agents go silent for _CFN_ROUND_TIMEOUT_SECS.
 
-    The IOC's BatchCallbackRunner uses a 30s per-round timeout and auto-advances
-    when it fires.  We call /decide slightly earlier so the backend stays in sync
-    with the IOC's internal loop rather than waiting forever for all replies.
+    We wait for all agents to reply within a round.  Calling /decide with
+    partial reject placeholders caused a double-decide race: the timeout fired,
+    reset pending_replies, and then the real replies landed in the new round's
+    slot — triggering a second /decide on an already-consumed SAO step, which
+    CFN silently dropped.  Instead, a long silence means the session is dead.
     """
     await asyncio.sleep(_CFN_ROUND_TIMEOUT_SECS)
     state = _cfn_state.get(room_name)
     if not state:
         return
-    logger.debug("CFN round timeout fired for %s — calling decide with partial replies", room_name)
-    await _cfn_decide_round(room_name)
+    logger.warning("CFN round timeout fired for %s — agents silent for %ds, aborting session", room_name, _CFN_ROUND_TIMEOUT_SECS)
+    await _finish_cfn(room_name, plan="Negotiation timed out — agents did not respond", assignments={}, broken=True)
 
 
 async def _fan_out_cfn_messages(
@@ -394,6 +398,9 @@ async def _fan_out_cfn_messages(
         current_offer = last_payload.get("current_offer")
         if current_offer is not None:
             state.current_offer = current_offer
+        next_proposer_id = last_payload.get("next_proposer_id")
+        if next_proposer_id is not None:
+            state.next_proposer_id = next_proposer_id
 
     return addressed
 
@@ -610,10 +617,14 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
 
     should_decide = False
     corrective: dict | None = None
+    out_of_turn: bool = False
     async with cfn.lock:
         if handle in cfn.pending_replies:
             reply_data = _parse_agent_reply(handle, content, cfn.current_offer, cfn.issue_options)
-            if reply_data.get("action") == "invalid_keys":
+            if reply_data.get("action") == "counter_offer" and cfn.next_proposer_id and handle != cfn.next_proposer_id:
+                out_of_turn = True
+                # Leave pending_replies[handle] as None — round waits for a corrected reply.
+            elif reply_data.get("action") == "invalid_keys":
                 corrective = reply_data
                 # Leave pending_replies[handle] as None — round waits for a corrected reply.
             else:
@@ -628,6 +639,27 @@ async def on_agent_response(room_name: str, handle: str, content: str) -> None:
                 all_received = all(v is not None for v in cfn.pending_replies.values())
                 if all_received:
                     should_decide = True
+
+    if out_of_turn:
+        logger.warning(
+            "CFN room %s: agent %s submitted counter_offer but next_proposer_id=%s — rejecting",
+            room_name,
+            handle,
+            cfn.next_proposer_id,
+        )
+        await _post_message(
+            room_name,
+            message_type="coordination_tick",
+            content=json.dumps({
+                "error": "counter_offer_not_your_turn",
+                "instruction": (
+                    f"It is not your turn to propose. Only '{cfn.next_proposer_id}' may counter-offer "
+                    "this round. Use 'accept' or 'reject' instead."
+                ),
+                "payload": {"participant_id": handle},
+            }),
+        )
+        return
 
     if corrective:
         logger.warning(

--- a/fastapi-backend/tests/test_coordination.py
+++ b/fastapi-backend/tests/test_coordination.py
@@ -22,6 +22,8 @@ from app.services.coordination import (
     _cfn_state,
     _CfnRoundState,
     _fan_out_cfn_messages,
+    _parse_agent_reply,
+    _validate_and_fill_offer,
     on_agent_response,
 )
 
@@ -536,3 +538,172 @@ async def test_schedule_join_timer_clears_registry_on_completion():
         # Allow the done-callback to run.
         await asyncio.sleep(0)
         assert "ns-e" not in coord._join_timer_tasks
+
+
+# ── Tests: _validate_and_fill_offer / _parse_agent_reply ─────────────────────
+
+
+def test_validate_and_fill_offer_bad_key_returns_invalid_keys():
+    """Keys not in current_offer return the invalid_keys sentinel."""
+    current_offer = {"price": "mid", "timeline": "12mo"}
+    result = {"agent_id": "alice", "participant_id": "alice", "action": "counter_offer",
+              "offer": {"price": "high", "scope": "full"}}
+    out = _validate_and_fill_offer("alice", result, current_offer)
+    assert out["action"] == "invalid_keys"
+    assert out["bad_keys"] == ["scope"]
+    assert set(out["valid_keys"]) == {"price", "timeline"}
+
+
+def test_validate_and_fill_offer_case_sensitive():
+    """Key matching is case-sensitive — wrong casing produces invalid_keys."""
+    current_offer = {"Demo is non-negotiable": "yes"}
+    result = {"agent_id": "alice", "participant_id": "alice", "action": "counter_offer",
+              "offer": {"demo is non-negotiable": "yes"}}
+    out = _validate_and_fill_offer("alice", result, current_offer)
+    assert out["action"] == "invalid_keys"
+    assert out["bad_keys"] == ["demo is non-negotiable"]
+
+
+def test_validate_and_fill_offer_partial_fill():
+    """Valid but partial offer gets silently filled from anchor; agent values win."""
+    current_offer = {"price": "mid", "timeline": "12mo", "scope": "standard"}
+    result = {"agent_id": "alice", "participant_id": "alice", "action": "counter_offer",
+              "offer": {"price": "high"}}
+    out = _validate_and_fill_offer("alice", result, current_offer)
+    assert out["action"] == "counter_offer"
+    assert out["offer"] == {"price": "high", "timeline": "12mo", "scope": "standard"}
+
+
+def test_validate_and_fill_offer_no_current_offer_passthrough():
+    """When current_offer is None, the offer is returned unchanged."""
+    result = {"agent_id": "alice", "participant_id": "alice", "action": "counter_offer",
+              "offer": {"anything": "goes"}}
+    out = _validate_and_fill_offer("alice", result, None)
+    assert out["action"] == "counter_offer"
+    assert out["offer"] == {"anything": "goes"}
+
+
+def test_parse_agent_reply_counter_offer_invalid_key():
+    """_parse_agent_reply returns invalid_keys when offer has unrecognised keys."""
+    content = json.dumps({"action": "counter_offer", "offer": {"bad_key": "val"}})
+    out = _parse_agent_reply("alice", content, current_offer={"price": "mid"})
+    assert out["action"] == "invalid_keys"
+    assert "bad_key" in out["bad_keys"]
+
+
+def test_parse_agent_reply_offer_only_format_validates():
+    """offer-only JSON also goes through validation."""
+    content = json.dumps({"offer": {"wrong": "x"}})
+    out = _parse_agent_reply("bob", content, current_offer={"price": "mid"})
+    assert out["action"] == "invalid_keys"
+
+
+# ── Tests: on_agent_response — invalid keys ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_agent_response_invalid_key_posts_corrective_tick():
+    """Bad counter-offer key: corrective tick posted, pending_replies stays None."""
+    _cfn_state.clear()
+
+    state = _CfnRoundState(
+        session_id="room-v",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["alice", "bob"],
+        pending_replies={"alice": None, "bob": None},
+        current_offer={"price": "mid", "timeline": "12mo"},
+        issue_options={"price": ["low", "mid", "high"], "timeline": ["6mo", "12mo"]},
+    )
+    _cfn_state["room-v"] = state
+
+    posted = []
+
+    async def fake_post(room_name, message_type, content):
+        posted.append((message_type, json.loads(content)))
+
+    with patch.object(coord, "_post_message", side_effect=fake_post):
+        await on_agent_response(
+            "room-v", "alice", json.dumps({"action": "counter_offer", "offer": {"typo_key": "x"}})
+        )
+
+    # Pending reply must still be None — round is not advanced
+    assert _cfn_state["room-v"].pending_replies["alice"] is None
+
+    # Exactly one corrective tick posted
+    assert len(posted) == 1
+    msg_type, content = posted[0]
+    assert msg_type == "coordination_tick"
+    assert content["error"] == "counter_offer_invalid_keys"
+    assert "typo_key" in content["bad_keys"]
+    assert content["payload"]["participant_id"] == "alice"
+
+    _cfn_state.clear()
+
+
+@pytest.mark.asyncio
+async def test_on_agent_response_partial_offer_stored_as_merged():
+    """Partial counter-offer is filled from anchor and stored in pending_replies."""
+    _cfn_state.clear()
+
+    state = _CfnRoundState(
+        session_id="room-p",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["alice"],
+        pending_replies={"alice": None},
+        current_offer={"price": "mid", "timeline": "12mo"},
+        issue_options={"price": ["low", "mid", "high"], "timeline": ["6mo", "12mo"]},
+    )
+    _cfn_state["room-p"] = state
+
+    decide_called = []
+
+    async def fake_decide(room_name):
+        decide_called.append(room_name)
+
+    with patch.object(coord, "_cfn_decide_round", side_effect=fake_decide):
+        await on_agent_response(
+            "room-p", "alice", json.dumps({"action": "counter_offer", "offer": {"price": "high"}})
+        )
+        await asyncio.sleep(0)
+
+    stored = _cfn_state["room-p"].pending_replies["alice"]
+    assert stored is not None
+    assert stored["offer"]["price"] == "high"
+    assert stored["offer"]["timeline"] == "12mo"  # filled from anchor
+    assert decide_called == ["room-p"]
+
+    _cfn_state.clear()
+
+
+# ── Tests: fan_out updates _cfn_state ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fan_out_populates_cfn_state_fields():
+    """After fan-out, _cfn_state reflects current_offer, issues, issue_options, round."""
+    _cfn_state.clear()
+
+    state = _CfnRoundState(
+        session_id="room-fo",
+        workspace_id="ws",
+        mas_id="mas",
+        agents=["alice"],
+        pending_replies={"alice": None},
+    )
+    _cfn_state["room-fo"] = state
+
+    async def fake_post(room_name, message_type, content):
+        pass
+
+    msg = _make_broadcast_msg(round_num=2, next_proposer="alice")
+    with patch.object(coord, "_post_message", side_effect=fake_post):
+        await _fan_out_cfn_messages("room-fo", [msg], all_agents=["alice"])
+
+    assert state.current_round == 2
+    assert state.current_offer == {"price": "mid", "timeline": "12mo"}
+    assert state.issues == ["price", "timeline"]
+    assert state.issue_options == {"price": ["low", "mid", "high"], "timeline": ["6mo", "12mo"]}
+
+    _cfn_state.clear()

--- a/fastapi-backend/tests/test_coordination.py
+++ b/fastapi-backend/tests/test_coordination.py
@@ -81,8 +81,9 @@ def _patch_db():
     msg = MagicMock()
     msg.id = 1
     msg.created_at = MagicMock(isoformat=MagicMock(return_value="2026-01-01T00:00:00"))
-    mock_session.add.side_effect = lambda m: setattr(m, "id", 1) or setattr(
-        m, "created_at", MagicMock(isoformat=lambda: "2026-01-01T00:00:00")
+    mock_session.add.side_effect = lambda m: (
+        setattr(m, "id", 1)
+        or setattr(m, "created_at", MagicMock(isoformat=lambda: "2026-01-01T00:00:00"))
     )
 
     return patch("app.services.coordination.async_session_maker", return_value=mock_session)
@@ -546,8 +547,12 @@ async def test_schedule_join_timer_clears_registry_on_completion():
 def test_validate_and_fill_offer_bad_key_returns_invalid_keys():
     """Keys not in current_offer return the invalid_keys sentinel."""
     current_offer = {"price": "mid", "timeline": "12mo"}
-    result = {"agent_id": "alice", "participant_id": "alice", "action": "counter_offer",
-              "offer": {"price": "high", "scope": "full"}}
+    result = {
+        "agent_id": "alice",
+        "participant_id": "alice",
+        "action": "counter_offer",
+        "offer": {"price": "high", "scope": "full"},
+    }
     out = _validate_and_fill_offer("alice", result, current_offer)
     assert out["action"] == "invalid_keys"
     assert out["bad_keys"] == ["scope"]
@@ -557,8 +562,12 @@ def test_validate_and_fill_offer_bad_key_returns_invalid_keys():
 def test_validate_and_fill_offer_case_sensitive():
     """Key matching is case-sensitive — wrong casing produces invalid_keys."""
     current_offer = {"Demo is non-negotiable": "yes"}
-    result = {"agent_id": "alice", "participant_id": "alice", "action": "counter_offer",
-              "offer": {"demo is non-negotiable": "yes"}}
+    result = {
+        "agent_id": "alice",
+        "participant_id": "alice",
+        "action": "counter_offer",
+        "offer": {"demo is non-negotiable": "yes"},
+    }
     out = _validate_and_fill_offer("alice", result, current_offer)
     assert out["action"] == "invalid_keys"
     assert out["bad_keys"] == ["demo is non-negotiable"]
@@ -567,8 +576,12 @@ def test_validate_and_fill_offer_case_sensitive():
 def test_validate_and_fill_offer_partial_fill():
     """Valid but partial offer gets silently filled from anchor; agent values win."""
     current_offer = {"price": "mid", "timeline": "12mo", "scope": "standard"}
-    result = {"agent_id": "alice", "participant_id": "alice", "action": "counter_offer",
-              "offer": {"price": "high"}}
+    result = {
+        "agent_id": "alice",
+        "participant_id": "alice",
+        "action": "counter_offer",
+        "offer": {"price": "high"},
+    }
     out = _validate_and_fill_offer("alice", result, current_offer)
     assert out["action"] == "counter_offer"
     assert out["offer"] == {"price": "high", "timeline": "12mo", "scope": "standard"}
@@ -576,8 +589,12 @@ def test_validate_and_fill_offer_partial_fill():
 
 def test_validate_and_fill_offer_no_current_offer_passthrough():
     """When current_offer is None, the offer is returned unchanged."""
-    result = {"agent_id": "alice", "participant_id": "alice", "action": "counter_offer",
-              "offer": {"anything": "goes"}}
+    result = {
+        "agent_id": "alice",
+        "participant_id": "alice",
+        "action": "counter_offer",
+        "offer": {"anything": "goes"},
+    }
     out = _validate_and_fill_offer("alice", result, None)
     assert out["action"] == "counter_offer"
     assert out["offer"] == {"anything": "goes"}

--- a/mycelium-cli/src/mycelium/adapters/claude-code/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/skills/mycelium/SKILL.md
@@ -114,26 +114,25 @@ mycelium session await --handle claude-agent
 
 **Room discipline**: speak only when CognitiveEngine addresses you. Default to silence between turns.
 
-### Counter-offer validity (silent failure modes)
+### Counter-offer validity
 
-CognitiveEngine silently drops counter-offers that don't match the tick's issue
-schema. Before running `negotiate propose`:
+Mycelium validates counter-offers before they reach CFN. Two things to know:
 
 1. **Use exactly the issue keys from the tick's `issue_options`.** Do not invent
-   new fields (e.g. `api_style`, `migration_plan`) — if a key isn't in
-   `issue_options`, the whole counter is discarded and the anchor offer
-   re-serves next round.
-2. **Include every issue in the tick**, not just the ones you care about.
-   Partial counters are treated as invalid.
+   new fields (e.g. `api_style`, `migration_plan`) — key matching is
+   case-sensitive. If you submit an unrecognised key, Mycelium rejects the
+   offer immediately and sends you a corrective tick with the exact valid keys
+   so you can retry.
+2. **Partial offers are accepted.** You only need to include the issues you want
+   to change. Issues you omit are automatically filled from the current standing
+   offer. There is no need to copy every key.
 3. **Pick each value from that issue's option list.** Free-text values outside
-   the listed options are dropped the same way.
+   the listed options are not validated by Mycelium but may be rejected by CFN.
 4. **Only counter when `can_counter_offer: true`.** A counter from the wrong
    agent gets silently downgraded to a reject.
 
-The symptom when any of these fail is the same: next round's `current_offer`
-is identical to the previous round. If you see two ticks in a row with no
-offer movement after you submitted a counter, one of the four rules above
-was violated.
+To see the current round, canonical issue list, and per-agent reply status at
+any time: `mycelium negotiate status`
 
 ### Narrate your choices
 

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/skills/mycelium/SKILL.md
@@ -167,13 +167,13 @@ mycelium negotiate respond reject --room <room-name> --handle <your-handle>
 
 > **Key rule**: `can_counter_offer: true` means it's your turn to propose. Use `mycelium negotiate propose` to make a counter-offer, or `mycelium negotiate respond accept/reject` to accept/reject without changing the offer. When `can_counter_offer: false`, only accept or reject.
 
-> **Counter-offer validity (silent failure modes)**: CognitiveEngine silently drops counter-offers that don't match the tick's issue schema. Before running `negotiate propose`:
-> 1. **Use exactly the issue keys from the tick's `issue_options`.** Do not invent new fields (e.g. `api_style`, `migration_plan`) — if a key isn't in `issue_options`, the whole counter is discarded and the anchor offer re-serves next round.
-> 2. **Include every issue in the tick**, not just the ones you care about. Partial counters are treated as invalid.
-> 3. **Pick each value from that issue's option list.** Free-text values outside the listed options are dropped the same way.
+> **Counter-offer validity**: Mycelium validates counter-offers before they reach CFN. Two things to know:
+> 1. **Use exactly the issue keys from the tick's `issue_options`.** Do not invent new fields (e.g. `api_style`, `migration_plan`) — key matching is case-sensitive. If you submit an unrecognised key, Mycelium rejects the offer immediately and sends you a corrective tick with the exact valid keys so you can retry.
+> 2. **Partial offers are accepted.** You only need to include the issues you want to change. Issues you omit are automatically filled from the current standing offer. There is no need to copy every key.
+> 3. **Pick each value from that issue's option list.** Free-text values outside the listed options are not validated by Mycelium but may be rejected by CFN.
 > 4. **Only counter when `can_counter_offer: true`.** A counter from the wrong agent gets silently downgraded to a reject.
 >
-> The symptom when any of these fail is the same: next round's `current_offer` is identical to the previous round. If you see two ticks in a row with no offer movement after you submitted a counter, one of the four rules above was violated.
+> To see the current round, canonical issue list, and per-agent reply status at any time: `mycelium negotiate status`
 
 > **Narrate your choices**: When you accept, reject, or propose, explain your reasoning in the chat so the human can follow along. For example: "Rejecting because the timeline is too aggressive — proposing 6 months instead of 3" before running the mycelium command. This makes the negotiation legible to observers.
 

--- a/mycelium-cli/src/mycelium/commands/negotiate.py
+++ b/mycelium-cli/src/mycelium/commands/negotiate.py
@@ -22,6 +22,7 @@ before posting, so the CLI is statically forced to adhere to the protocol.
 
 import json as json_module
 
+import httpx
 import typer
 from pydantic import ValidationError
 
@@ -249,6 +250,82 @@ def query(
     """
     try:
         _post(ctx, room, handle, text)
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+
+
+# ── status ────────────────────────────────────────────────────────────────────
+
+
+@doc_ref(
+    usage="mycelium negotiate status [-r <room>]",
+    desc="Show the current negotiation state: round, issues, current offer, and per-agent reply status.",
+    group="negotiate",
+)
+@app.command("status")
+def status(
+    ctx: typer.Context,
+    room: str | None = typer.Option(
+        None, "--room", "-r", help="Room to check (overrides MYCELIUM_ROOM_ID)"
+    ),
+) -> None:
+    """
+    Show live negotiation state for the active session in a room.
+
+    Displays the current round, canonical issue list, standing offer, and which
+    agents have submitted replies this round.
+
+    Examples:
+        mycelium negotiate status
+        mycelium negotiate status --room sprint-plan
+    """
+    from mycelium.commands.room import _resolve_room
+
+    json_output = ctx.obj.get("json", False) if ctx.obj else False
+
+    try:
+        config = MyceliumConfig.load()
+        room_name = _resolve_room(config, room)
+        room_name = _resolve_active_session_room(config, room_name)
+
+        resp = httpx.get(
+            f"{config.server.api_url}/rooms/{room_name}/negotiation",
+            timeout=5,
+        )
+        if resp.status_code == 404:
+            typer.echo("  Room not found.", err=True)
+            raise typer.Exit(1)
+        resp.raise_for_status()
+        data = resp.json()
+
+        if json_output:
+            typer.echo(json_module.dumps(data, indent=2))
+            return
+
+        if not data.get("active"):
+            typer.echo("  No active negotiation.")
+            return
+
+        typer.echo(f"  Round {data['round']}  —  {room_name}")
+        typer.echo("")
+        issues = data.get("issues") or []
+        issue_options = data.get("issue_options") or {}
+        current_offer = data.get("current_offer") or {}
+        for issue in issues:
+            opts = ", ".join(issue_options.get(issue, []))
+            current = current_offer.get(issue, "—")
+            typer.echo(f"  {issue}")
+            typer.echo(f"    current: {current}")
+            if opts:
+                typer.echo(f"    options: {opts}")
+        typer.echo("")
+        for agent_handle, reply_status in (data.get("pending_replies") or {}).items():
+            icon = "+" if reply_status == "received" else "."
+            typer.echo(f"  [{icon}] {agent_handle}")
+
+    except (typer.Exit, typer.Abort):
+        raise
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False
         print_error(e, verbose=verbose)

--- a/mycelium-cli/src/mycelium/commands/negotiate.py
+++ b/mycelium-cli/src/mycelium/commands/negotiate.py
@@ -169,9 +169,13 @@ def propose(
                 if current_offer:
                     bad_keys = sorted(set(offer) - set(current_offer))
                     if bad_keys:
-                        typer.echo("  Error: counter-offer contains unrecognised issue keys:", err=True)
+                        typer.echo(
+                            "  Error: counter-offer contains unrecognised issue keys:", err=True
+                        )
                         for bk in bad_keys:
-                            matches = difflib.get_close_matches(bk, current_offer.keys(), n=1, cutoff=0.6)
+                            matches = difflib.get_close_matches(
+                                bk, current_offer.keys(), n=1, cutoff=0.6
+                            )
                             suggestion = matches[0] if matches else None
                             hint = f'  →  did you mean "{suggestion}"?' if suggestion else ""
                             typer.echo(f'    "{bk}"{hint}', err=True)

--- a/mycelium-cli/src/mycelium/commands/negotiate.py
+++ b/mycelium-cli/src/mycelium/commands/negotiate.py
@@ -20,6 +20,7 @@ payloads are validated against SSTP wire-format models (mycelium.sstp)
 before posting, so the CLI is statically forced to adhere to the protocol.
 """
 
+import difflib
 import json as json_module
 
 import httpx
@@ -170,10 +171,8 @@ def propose(
                     if bad_keys:
                         typer.echo("  Error: counter-offer contains unrecognised issue keys:", err=True)
                         for bk in bad_keys:
-                            # fuzzy suggestion: case-insensitive match
-                            suggestion = next(
-                                (v for v in current_offer if v.lower() == bk.lower()), None
-                            )
+                            matches = difflib.get_close_matches(bk, current_offer.keys(), n=1, cutoff=0.6)
+                            suggestion = matches[0] if matches else None
                             hint = f'  →  did you mean "{suggestion}"?' if suggestion else ""
                             typer.echo(f'    "{bk}"{hint}', err=True)
                         typer.echo("", err=True)

--- a/mycelium-cli/src/mycelium/commands/negotiate.py
+++ b/mycelium-cli/src/mycelium/commands/negotiate.py
@@ -138,6 +138,8 @@ def propose(
         mycelium negotiate propose budget=medium timeline=standard scope=standard quality=standard
         mycelium negotiate propose budget=high scope=full --room my-room --handle julia-agent
     """
+    from mycelium.commands.room import _resolve_room
+
     try:
         offer: dict[str, str] = {}
         for pair in assignments:
@@ -150,6 +152,39 @@ def propose(
         if not offer:
             typer.echo("  Error: at least one KEY=VALUE assignment is required.", err=True)
             raise typer.Exit(1)
+
+        # Validate keys against live negotiation state before posting.
+        config = MyceliumConfig.load()
+        room_name = _resolve_room(config, room)
+        session_room = _resolve_active_session_room(config, room_name)
+        try:
+            resp = httpx.get(
+                f"{config.server.api_url}/rooms/{session_room}/negotiation",
+                timeout=5,
+            )
+            if resp.status_code == 200:
+                neg = resp.json()
+                current_offer = neg.get("current_offer") or {}
+                if current_offer:
+                    bad_keys = sorted(set(offer) - set(current_offer))
+                    if bad_keys:
+                        typer.echo("  Error: counter-offer contains unrecognised issue keys:", err=True)
+                        for bk in bad_keys:
+                            # fuzzy suggestion: case-insensitive match
+                            suggestion = next(
+                                (v for v in current_offer if v.lower() == bk.lower()), None
+                            )
+                            hint = f'  →  did you mean "{suggestion}"?' if suggestion else ""
+                            typer.echo(f'    "{bk}"{hint}', err=True)
+                        typer.echo("", err=True)
+                        typer.echo("  Valid keys for this session:", err=True)
+                        for vk in sorted(current_offer):
+                            typer.echo(f'    "{vk}"', err=True)
+                        raise typer.Exit(1)
+        except (httpx.RequestError, typer.Exit):
+            raise
+        except Exception:
+            pass  # validation is best-effort; backend enforces authoritatively
 
         try:
             reply = ProposeReply(offer=offer)

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -319,11 +319,15 @@ def await_tick(
                     if "error" in data:
                         participant = (data.get("payload") or {}).get("participant_id")
                         if participant == handle or participant is None:
-                            typer.echo(json_module.dumps({
-                                "type": "error",
-                                "error": data["error"],
-                                "instruction": data.get("instruction"),
-                            }))
+                            typer.echo(
+                                json_module.dumps(
+                                    {
+                                        "type": "error",
+                                        "error": data["error"],
+                                        "instruction": data.get("instruction"),
+                                    }
+                                )
+                            )
                             return
                         continue
                     if "payload" in data and isinstance(data["payload"], dict):

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -254,6 +254,16 @@ def await_tick(
                                     data = json_module.loads(msg.get("content", "{}"))
                                 except json_module.JSONDecodeError:
                                     continue
+                                if "error" in data:
+                                    participant = (data.get("payload") or {}).get("participant_id")
+                                    if participant == handle or participant is None:
+                                        missed_tick = {
+                                            "type": "error",
+                                            "error": data["error"],
+                                            "instruction": data.get("instruction"),
+                                            "replayed": True,
+                                        }
+                                    continue
                                 if "payload" in data and isinstance(data["payload"], dict):
                                     data = data["payload"]
                                 participant = data.get("participant_id")
@@ -266,6 +276,7 @@ def await_tick(
                                         "issue_options": data.get("issue_options", {}),
                                         "current_offer": data.get("current_offer"),
                                         "proposer_id": data.get("proposer_id"),
+                                        "can_counter_offer": data.get("can_counter_offer", False),
                                         "history": data.get("history"),
                                         "replayed": True,
                                     }
@@ -303,6 +314,18 @@ def await_tick(
                         data = json_module.loads(msg.get("content", "{}"))
                     except json_module.JSONDecodeError:
                         data = {}
+                    # Error ticks (e.g. out-of-turn counter-offer) have an "error" key
+                    # and no round/action. Surface them directly and return.
+                    if "error" in data:
+                        participant = (data.get("payload") or {}).get("participant_id")
+                        if participant == handle or participant is None:
+                            typer.echo(json_module.dumps({
+                                "type": "error",
+                                "error": data["error"],
+                                "instruction": data.get("instruction"),
+                            }))
+                            return
+                        continue
                     if "payload" in data and isinstance(data["payload"], dict):
                         data = data["payload"]
                     participant = data.get("participant_id")
@@ -317,6 +340,7 @@ def await_tick(
                                     "issue_options": data.get("issue_options", {}),
                                     "current_offer": data.get("current_offer"),
                                     "proposer_id": data.get("proposer_id"),
+                                    "can_counter_offer": data.get("can_counter_offer", False),
                                     "history": data.get("history"),
                                 }
                             )

--- a/mycelium-cli/src/mycelium/docker/compose-dev.yml
+++ b/mycelium-cli/src/mycelium/docker/compose-dev.yml
@@ -1,0 +1,36 @@
+# Dev override: build mycelium-backend from local source instead of pulling.
+#
+# Run from the repo root:
+#   docker compose -f mycelium-cli/src/mycelium/docker/compose.yml \
+#                  -f mycelium-cli/src/mycelium/docker/compose-dev.yml \
+#                  --profile cfn up -d --build
+#
+# Build context paths are relative to this file's location (docker/).
+# env_file paths are also relative to this file's location.
+services:
+  mycelium-db:
+    pull_policy: always   # keep pulling the pre-built agensgraph image
+    build: !reset {}      # suppress the build context so --build doesn't fail
+
+  # Override env_file for all services to point at ~/.mycelium/.env so that
+  # LLM_MODEL, WORKSPACE_ID etc. are available when running compose manually
+  # from the repo root (compose.yml's ../.env path resolves incorrectly then).
+  mycelium-backend:
+    build:
+      context: ../../../../fastapi-backend
+      dockerfile: Dockerfile
+    pull_policy: never
+    image: mycelium-backend:dev
+    env_file:
+      - path: ~/.mycelium/.env
+        required: false
+
+  ioc-cfn-mgmt-plane-svc:
+    env_file:
+      - path: ~/.mycelium/.env
+        required: false
+
+  ioc-cognition-fabric-node-svc:
+    env_file:
+      - path: ~/.mycelium/.env
+        required: false

--- a/mycelium-cli/src/mycelium/docker/compose-dev.yml
+++ b/mycelium-cli/src/mycelium/docker/compose-dev.yml
@@ -24,6 +24,9 @@ services:
     env_file:
       - path: ~/.mycelium/.env
         required: false
+    environment:
+      CFN_MGMT_URL: http://ioc-cfn-mgmt-plane-svc:9000
+      COGNITION_FABRIC_NODE_URL: http://ioc-cognition-fabric-node-svc:9002
 
   ioc-cfn-mgmt-plane-svc:
     env_file:

--- a/mycelium-cli/src/mycelium/docker_utils.py
+++ b/mycelium-cli/src/mycelium/docker_utils.py
@@ -54,7 +54,7 @@ def generate_env_file(config: MyceliumConfig) -> str:
         "# ── IoC CFN ──────────────────────────────────────────────────────────────",
         f"CFN_MGMT_URL={config.runtime.cfn_mgmt_url or ''}",
         f"COGNITION_FABRIC_NODE_URL={config.runtime.cognition_fabric_node_url or ''}",
-        f"WORKSPACE_ID={config.runtime.workspace_id or ''}",
+        f"WORKSPACE_ID={config.server.workspace_id or config.runtime.workspace_id or ''}",
         f"CFN_DB={config.runtime.cfn_db}",
         f"ADMIN_USER_PASSWORD={config.runtime.admin_user_password}",
         f"CFN_DEV_MODE={'true' if config.runtime.cfn_dev_mode else 'false'}",


### PR DESCRIPTION
Closes #172

## Summary

- **Key validation**: counter-offers with unrecognised keys are rejected before reaching CFN. The offending agent receives a corrective `coordination_tick` with `error: counter_offer_invalid_keys`, the bad keys, and the exact valid key list — round waits for a corrected reply rather than silently dropping the offer.
- **Partial offer fill**: valid but incomplete offers are silently merged with the current standing offer (agent values win on keys they specify). Agents no longer need to copy every key to submit a counter.
- **State tracking**: `_CfnRoundState` now carries `current_offer`, `issues`, `issue_options`, `current_round`, and `next_proposer_id`, populated during fan-out so validation context is always available.
- **`GET /rooms/{room_name}/negotiation`**: new endpoint returning live negotiation snapshot — round number, issues, options, current offer, per-agent reply status (`"received"` / `"waiting"`).
- **`mycelium negotiate status`**: new CLI command that resolves to the active session sub-room and renders the snapshot in human-readable or JSON format.
- **SKILL.md** (openclaw + claude-code): updated counter-offer guidance to document partial-offer fill, corrective tick behavior, and `negotiate status`.
- **Fix double-decide race**: the 25s round timeout was firing `/decide` with reject placeholders before agents replied. Real replies landed seconds later into the freshly-reset `pending_replies`, triggering a second `/decide` on an already-consumed NegMAS SAO step — CFN returned 200 but dropped the offer (`new_offers: []`, `n_acceptances: 0`). Fixed by changing the timeout to 300s and aborting the session cleanly on silence instead of submitting partial rejects.
- **`can_counter_offer` surfaced**: `session await` now includes `can_counter_offer: true/false` in tick output so agents know their eligibility without querying state separately.
- **Out-of-turn guard**: `on_agent_response` now checks the incoming action against `next_proposer_id`. Counter-offers from ineligible agents are rejected immediately with a `coordination_tick` error before reaching CFN.
- **Error tick rendering**: `session await` renders error ticks as `{"type": "error", ...}` instead of a garbled null tick.

## Test plan

- [ ] `uv run pytest tests/test_coordination.py -x -q` — all tests pass
- [ ] `mycelium negotiate status` against an active negotiation session shows round, issues, current offer, and agent reply state
- [ ] Submitting a counter-offer with a wrong key produces a corrective tick and the round does not advance
- [ ] Submitting a partial offer (only some keys) propagates correctly to CFN with missing keys filled from the anchor
- [ ] `session await` output includes `can_counter_offer` field
- [ ] Submitting a counter-offer when `can_counter_offer: false` returns `{"type": "error", "error": "counter_offer_not_your_turn", ...}`
- [ ] `current_offer` advances in the next tick after a valid counter-offer + accept (no double-decide)