### PR TITLE
fix(db): replace NullPool with bounded connection pool

### DIFF
--- a/fastapi-backend/app/database.py
+++ b/fastapi-backend/app/database.py
@@ -4,7 +4,6 @@
 from collections.abc import AsyncGenerator
 from urllib.parse import urlparse
 
-from sqlalchemy import NullPool
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from .config import settings
@@ -18,8 +17,13 @@ async_db_connection_url = (
     f"{parsed_db_url.path}"
 )
 
-# Disable connection pooling for serverless-friendly operation
-engine = create_async_engine(async_db_connection_url, poolclass=NullPool)
+engine = create_async_engine(
+    async_db_connection_url,
+    pool_size=5,
+    max_overflow=10,
+    pool_timeout=30,
+    pool_recycle=1800,
+)
 
 
 async_session_maker = async_sessionmaker(engine, expire_on_commit=settings.EXPIRE_ON_COMMIT)

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -592,17 +592,26 @@ async def _finish_cfn(room_name: str, plan: str, assignments: dict, broken: bool
     state = _cfn_state.pop(room_name, None)
     if state and state.round_timeout_task and not state.round_timeout_task.done():
         state.round_timeout_task.cancel()
-    await _post_message(
-        room_name,
-        message_type="coordination_consensus",
-        content=json.dumps(
-            {
-                "plan": plan,
-                "assignments": assignments,
-                "broken": broken,
-            }
-        ),
-    )
+    try:
+        await _post_message(
+            room_name,
+            message_type="coordination_consensus",
+            content=json.dumps(
+                {
+                    "plan": plan,
+                    "assignments": assignments,
+                    "broken": broken,
+                }
+            ),
+        )
+    except Exception as exc:
+        # FK violation means the room was deleted before consensus could be written.
+        # Log clearly so it's visible in traces rather than silently dropped.
+        logger.error(
+            "_finish_cfn: failed to write coordination_consensus for %s: %s",
+            room_name,
+            exc,
+        )
     async with async_session_maker() as db:
         await db.execute(
             update(Room)

--- a/fastapi-backend/tests/test_integration.py
+++ b/fastapi-backend/tests/test_integration.py
@@ -37,6 +37,8 @@ async def integration_client():
     """Client wired to real database — creates and drops tables per test."""
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+    import app.database as _db_module
+    import app.services.coordination as _coord_module
     from app.database import get_async_session
     from app.main import app
     from app.models import Base
@@ -49,6 +51,13 @@ async def integration_client():
 
     session_maker = async_sessionmaker(engine, expire_on_commit=False)
 
+    # Override both the HTTP-layer DI session and the module-level session_maker
+    # used directly by coordination.py background tasks, so all DB ops share
+    # one engine and avoid concurrent-operation errors on pooled connections.
+    _orig_session_maker = _db_module.async_session_maker
+    _db_module.async_session_maker = session_maker
+    _coord_module.async_session_maker = session_maker
+
     async def _override_db():
         async with session_maker() as session:
             yield session
@@ -57,6 +66,9 @@ async def integration_client():
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         yield ac
     app.dependency_overrides.clear()
+
+    _db_module.async_session_maker = _orig_session_maker
+    _coord_module.async_session_maker = _orig_session_maker
 
     # Clean up tables after test
     async with engine.begin() as conn:


### PR DESCRIPTION
## Summary

- Swaps `NullPool` for `AsyncAdaptedQueuePool` (`pool_size=5, max_overflow=10`) in `database.py` — fixes root cause of `out of shared memory` errors during CFN negotiation rounds
- `NullPool` opened a new DB connection per operation; concurrent `_post_message` calls and graph upserts during negotiation stacked connections simultaneously, exhausting AgensGraph's `max_locks_per_transaction=64`
- Wraps `_finish_cfn`'s consensus write in try/except so `ForeignKeyViolationError` surfaces in logs instead of being silently dropped

## Test plan

- [ ] Run before-and-after skill through a full negotiation round — confirm `coordination_consensus` message appears
- [ ] Check backend logs for no `out of shared memory` errors during CFN knowledge POSTs
- [ ] Confirm 189 unit tests still pass (`uv run pytest tests/ -x -q`)