### PR TITLE
fix(knowledge-extract): defer workspace_id/mas_id resolution to hub backend

### DIFF
--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/hooks/mycelium-knowledge-extract/handler.js
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/hooks/mycelium-knowledge-extract/handler.js
@@ -321,19 +321,30 @@ function buildPayload(sessionMeta, turns, entries, maxToolContentBytes) {
  * turns where ``event.context.agentId`` is absent. Without this fallback,
  * every ingest from a mycelium-room turn lands under agent ``(none)`` in
  * ``mycelium cfn stats`` (issue #144).
+ *
+ * ``workspace_id`` / ``mas_id`` are sent only when the local config supplies
+ * them. Spoke nodes (no backend installed) typically have neither; the hub
+ * backend resolves both from its own ``settings.WORKSPACE_ID`` /
+ * ``settings.MAS_ID`` (or per-room DB lookup) — sending empty strings would
+ * shadow that fallback and 400 the request. Mirrors the in-process plugin
+ * behaviour added in issue #139.
  */
 export function buildIngestBody(target, resolvedAgentId, payload) {
-  return {
-    workspace_id: target.workspaceId,
-    mas_id: target.masId,
+  const body = {
     agent_id: resolvedAgentId ?? target.agentId ?? null,
     records: [payload],
   };
+  if (target.workspaceId) body.workspace_id = target.workspaceId;
+  if (target.masId) body.mas_id = target.masId;
+  return body;
 }
 
 async function ingestToMycelium(payload, resolvedAgentId) {
   const target = getIngestTarget();
-  if (!target.apiUrl || !target.workspaceId || !target.masId) return false;
+  // Only api_url is mandatory at the spoke. workspace_id / mas_id are
+  // resolved server-side when the spoke can't supply them — see
+  // resolve_workspace_id / resolve_mas_id in the backend (issue #139).
+  if (!target.apiUrl) return false;
 
   return postKnowledgeIngest(
     target.apiUrl,
@@ -432,9 +443,24 @@ export default async function HookHandler(event) {
 
   ingestToMycelium(payload, agentId)
     .then((ok) => {
-      if (!ok) appendLog(LOG_FILE, payload);
+      if (!ok) {
+        // Loud fallback: a silent local-only archive is how issue #139
+        // hid hundreds of MB of un-ingested conversation data on spoke
+        // nodes. If we can't reach the backend, say so on stderr — the
+        // openclaw gateway captures it into its own logs.
+        process.stderr.write(
+          `[mycelium-knowledge-extract] backend POST failed or skipped — ` +
+            `archiving locally to ${LOG_FILE}. ` +
+            `Check ~/.mycelium/config.toml [server].api_url is reachable.\n`,
+        );
+        appendLog(LOG_FILE, payload);
+      }
     })
     .catch((err) => {
+      process.stderr.write(
+        `[mycelium-knowledge-extract] backend POST raised: ` +
+          `${err?.message ?? String(err)} — archiving locally to ${LOG_FILE}.\n`,
+      );
       appendLog(LOG_FILE, {
         error: err?.message ?? String(err),
         payload,

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/knowledge-extract-handler.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/knowledge-extract-handler.test.ts
@@ -84,11 +84,41 @@ describe("buildIngestBody — agent_id precedence", () => {
     expect(body.agent_id).toBe("fallback");
   });
 
-  it("wraps payload in records array and echoes workspace/mas ids", () => {
+  it("wraps payload in records array and echoes workspace/mas ids when present", () => {
     const body = buildIngestBody(baseTarget, "a", payload);
     expect(body.workspace_id).toBe("ws-1");
     expect(body.mas_id).toBe("mas-1");
     expect(body.records).toEqual([payload]);
+  });
+
+  it("omits workspace_id / mas_id when the spoke target has neither (issue #139)", () => {
+    // Pure spokes (clients with no local backend) typically have no
+    // [server].workspace_id / mas_id configured. The backend's
+    // resolve_workspace_id / resolve_mas_id chain falls back to its
+    // own settings — but only if the keys are absent from the body.
+    // Sending empty strings would shadow the fallback and 400 the
+    // request, which is exactly how the silent-archive bug in #139
+    // hid all spoke-side ingest.
+    const target = { ...baseTarget, workspaceId: null, masId: null };
+    const body = buildIngestBody(target, "a", payload);
+    expect(body).not.toHaveProperty("workspace_id");
+    expect(body).not.toHaveProperty("mas_id");
+    expect(body.agent_id).toBe("a");
+    expect(body.records).toEqual([payload]);
+  });
+
+  it("omits workspace_id / mas_id when target has empty strings", () => {
+    const target = { ...baseTarget, workspaceId: "", masId: "" };
+    const body = buildIngestBody(target, "a", payload);
+    expect(body).not.toHaveProperty("workspace_id");
+    expect(body).not.toHaveProperty("mas_id");
+  });
+
+  it("includes one id when only one is present (mixed config)", () => {
+    const target = { ...baseTarget, workspaceId: "ws-only", masId: null };
+    const body = buildIngestBody(target, "a", payload);
+    expect(body.workspace_id).toBe("ws-only");
+    expect(body).not.toHaveProperty("mas_id");
   });
 });
 

--- a/mycelium-cli/src/mycelium/commands/adapter.py
+++ b/mycelium-cli/src/mycelium/commands/adapter.py
@@ -18,6 +18,8 @@ import shutil
 import subprocess
 import tempfile
 import time
+import urllib.error
+import urllib.request
 from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlparse
@@ -400,6 +402,27 @@ def add(
             return
 
         if adapter_type == "openclaw":
+            # Probe the configured hub so a misconfigured spoke fails loudly
+            # at install time rather than silently archiving conversation
+            # turns to ~/.openclaw/mycelium-knowledge-extract.log forever
+            # (issue #139). Best-effort: warn-only so air-gapped or
+            # not-yet-running setups still install.
+            api_url = config.server.api_url
+            ok, reason = _probe_hub_reachable(api_url)
+            if ok:
+                if verbose:
+                    typer.echo(f"  hub probe: {api_url}/health → {reason}")
+            else:
+                typer.secho(
+                    f"  warning: cannot reach Mycelium backend at "
+                    f"{api_url}/health ({reason})",
+                    fg=typer.colors.YELLOW,
+                )
+                typer.echo(
+                    "  The knowledge-extract hook will archive locally "
+                    "until the backend is reachable. Verify "
+                    "[server].api_url in ~/.mycelium/config.toml."
+                )
             _install_openclaw(
                 verbose=verbose,
                 profile=openclaw_profile,
@@ -1371,6 +1394,37 @@ def _allow_plugin_remove(
             Path(cfg_path).write_text(_json.dumps(cfg, indent=2))
     except Exception:
         pass
+
+
+def _probe_hub_reachable(api_url: str, timeout: float = 3.0) -> tuple[bool, str]:
+    """Best-effort probe of the configured Mycelium backend.
+
+    Issue #139: spoke-only nodes silently archived hundreds of MB of
+    conversation data because the out-of-process knowledge-extract hook
+    couldn't reach the configured api_url and there was no install-time
+    signal that anything was wrong. A 3-second probe at adapter add
+    catches the obvious typo / wrong-port / firewall cases without
+    blocking air-gapped installs (we only warn).
+
+    Returns (ok, message). ``ok`` is False on any non-2xx response,
+    timeout, DNS error, or connection refusal. ``message`` is a short
+    human-readable reason suitable for stderr.
+    """
+    if not api_url:
+        return False, "no api_url configured"
+    health_url = api_url.rstrip("/") + "/health"
+    try:
+        req = urllib.request.Request(health_url, method="GET")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            if 200 <= resp.status < 300:
+                return True, f"reachable ({resp.status})"
+            return False, f"unexpected HTTP {resp.status}"
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code}"
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        # URLError wraps refused connections, DNS failures, timeouts.
+        reason = getattr(exc, "reason", exc)
+        return False, f"{type(exc).__name__}: {reason}"
 
 
 def _docker_api_url(config: "MyceliumConfig") -> str:

--- a/mycelium-cli/src/mycelium/commands/adapter.py
+++ b/mycelium-cli/src/mycelium/commands/adapter.py
@@ -414,8 +414,7 @@ def add(
                     typer.echo(f"  hub probe: {api_url}/health → {reason}")
             else:
                 typer.secho(
-                    f"  warning: cannot reach Mycelium backend at "
-                    f"{api_url}/health ({reason})",
+                    f"  warning: cannot reach Mycelium backend at {api_url}/health ({reason})",
                     fg=typer.colors.YELLOW,
                 )
                 typer.echo(


### PR DESCRIPTION
## Summary

Pure spoke nodes (clients with no local Mycelium backend) were silently
losing **all** out-of-process knowledge ingest to local log files. The
out-of-process `mycelium-knowledge-extract` hook gated every backend
POST on a locally-configured `workspace_id` **and** `mas_id`, but spokes
typically have neither — so every conversation turn was archived to
`~/.openclaw/mycelium-knowledge-extract.log` and never reached the hub
(observed: `oclw3` accumulated 134 MB, `oclw5` 9.4 MB, both never
ingested into CFN).

The in-process plugin already does the right thing here (issue #139): it
sends just `room_name` and lets the backend's `resolve_workspace_id` /
`resolve_mas_id` chain fall back to its own settings. This PR aligns the
out-of-process hook with that contract and adds two guard rails so the
same class of bug can't go unnoticed again.

### Changes

**1. Hook (`handler.js`) — drop the routing gate**
- `ingestToMycelium` only requires `api_url`. `workspace_id` / `mas_id`
  are no longer mandatory.
- `buildIngestBody` omits `workspace_id` / `mas_id` when the local target
  has no value, so the backend's fallback chain isn't shadowed by empty
  strings (which would 400 the request).

**2. Hook (`handler.js`) — loud local-archive fallback**
- Any failed POST writes a short reason to stderr (captured by the
  openclaw gateway logs) before appending to the local log file. Silent
  archiving is exactly how #139 went undetected on `oclw3` / `oclw5`.

**3. Adapter add (`adapter.py`) — install-time hub probe**
- `mycelium adapter add openclaw` probes `${api_url}/health` with a
  3-second timeout. Warn-only — air-gapped and not-yet-running setups
  still install — but the obvious typo / wrong-port / firewall cases now
  fail loudly at install rather than weeks later when someone notices
  missing CFN ingest.

### Out of scope

- Backfill of the existing `~/.openclaw/mycelium-knowledge-extract.log`
  archives on `oclw3` / `oclw5`. That's separate operational cleanup
  (replay or accept loss); discussed but deliberately not bundled here.

## Test plan

- [x] Vitest: 7 files / 101 tests pass (`mycelium-knowledge-extract`
      hook tests include 3 new cases for the null / empty-string /
      mixed-id `buildIngestBody` shapes).
- [x] Ruff + ast.parse on the modified `adapter.py`.
- [ ] Manual: re-run `mycelium adapter add openclaw` on a fresh spoke
      pointing at a reachable hub; confirm probe prints OK and ingest
      lands at the hub via `mycelium cfn stats`.
- [ ] Manual: re-run on a spoke pointing at an unreachable URL;
      confirm the install warns (warn-only, exits 0) and that a
      subsequent agent turn writes the new stderr warning to the
      gateway log before archiving.

Made with [Cursor](https://cursor.com)