### PR TITLE
feat(docs): auto-generate Configuration reference from pydantic schema

### DIFF
--- a/.claude/skills/generate-cli-docs/SKILL.md
+++ b/.claude/skills/generate-cli-docs/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: generate-cli-docs
-description: Regenerate the HTML CLI reference from @doc_ref decorators
+description: Regenerate the HTML docs site (CLI Reference, Configuration, content sections) from decorators, the pydantic config schema, and markdown source files
 user_invocable: true
 ---
 
-Regenerate the docs site (CLI Reference + content sections) from `@doc_ref` decorators and markdown source files.
+Regenerate the docs site from three sources:
+
+- **CLI Reference** — generated from `@doc_ref` decorators on Typer commands
+- **Configuration** — generated from `Field(..., description=...)` on the pydantic config schema in `mycelium-cli/src/mycelium/config.py`
+- **Content sections** — generated from markdown files in `mycelium-cli/src/mycelium/docs/`
 
 Steps:
 1. Run: `cd mycelium-cli && uv run python ../docs/generate_docs.py`
 2. Report what was generated
+
+## Adding a new CLI command
 
 If a CLI command was added or modified and doesn't have a `@doc_ref` decorator, add one:
 
@@ -26,7 +32,34 @@ def my_command(...): ...
 
 Groups: setup, room, memory, notebook, message, adapter, config, other
 
-Markdown source files live in `mycelium-cli/src/mycelium/docs/` and mirror the GUI docs.
-The generator reads both @doc_ref decorators and markdown files to build `docs/index.html`.
+## Adding a new config knob
+
+Each pydantic field on a sub-model of `MyceliumConfig` becomes a row in the Configuration section of the docs. The only requirement is a non-empty `description=`:
+
+```python
+class NegotiationConfig(BaseModel):
+    """Tunables for the CFN-mediated negotiation flow."""
+
+    n_steps: int = Field(
+        default=20,
+        description=(
+            "Maximum SAO rounds per session. Set to 0 to fall through to "
+            "CFN's auto-computed budget."
+        ),
+    )
+```
+
+Whatever shows up in `description=` is what users will read. Spell it out — assume the reader doesn't know what SAO or CFN is. To add a brand new namespace:
+
+1. Add a `<NewName>Config(BaseModel)` class with `Field(..., description=...)` on every field.
+2. Wire it onto `MyceliumConfig` (e.g. `new_name: NewNameConfig = Field(default_factory=NewNameConfig)`).
+3. Optionally add the namespace to `CONFIG_NAMESPACE_ORDER` in `docs/generate_docs.py` to control its position; otherwise it appends after the listed namespaces.
+4. Re-run the generator.
+
+The generator skips namespaces typed as bare `dict` (e.g. `adapters`) — see `CONFIG_NAMESPACE_SKIP`.
+
+## Markdown source
+
+Markdown files in `mycelium-cli/src/mycelium/docs/` are converted to HTML and embedded in the right `<section>` of `docs/index.html`. Sections in the existing HTML marked with `<!-- keep -->` are preserved verbatim (used for hand-crafted interactive components).
 
 Then re-run the generator.

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -42,6 +42,7 @@ INDEX_PATH = Path(__file__).parent / "index.html"
 
 # ── Markdown to HTML conversion (minimal, no dependencies) ──
 
+
 def _md_to_html(md: str, section_id: str) -> str:
     """Convert markdown to HTML matching the docs site styling.
 
@@ -76,12 +77,18 @@ def _md_to_html(md: str, section_id: str) -> str:
             continue
 
         # Table
-        if "|" in line and i + 1 < len(lines) and re.match(r"\s*\|[\s:|-]+\|\s*$", lines[i + 1]):
+        if (
+            "|" in line
+            and i + 1 < len(lines)
+            and re.match(r"\s*\|[\s:|-]+\|\s*$", lines[i + 1])
+        ):
             table_html = _parse_table(lines, i)
             out.append(table_html)
             # Skip past table
             i += 2  # header + separator
-            while i < len(lines) and "|" in lines[i] and lines[i].strip().startswith("|"):
+            while (
+                i < len(lines) and "|" in lines[i] and lines[i].strip().startswith("|")
+            ):
                 i += 1
             continue
 
@@ -94,17 +101,26 @@ def _md_to_html(md: str, section_id: str) -> str:
                 i += 1
                 # Collect lead paragraph (next non-empty line)
                 lead_lines = []
-                while i < len(lines) and lines[i].strip() and not lines[i].startswith("#") and not lines[i].startswith("```") and not lines[i].startswith("|") and not lines[i].startswith(">") and not lines[i].startswith("- ") and not lines[i].startswith("1."):
+                while (
+                    i < len(lines)
+                    and lines[i].strip()
+                    and not lines[i].startswith("#")
+                    and not lines[i].startswith("```")
+                    and not lines[i].startswith("|")
+                    and not lines[i].startswith(">")
+                    and not lines[i].startswith("- ")
+                    and not lines[i].startswith("1.")
+                ):
                     lead_lines.append(lines[i].strip())
                     i += 1
                 lead = " ".join(lead_lines)
                 if lead:
-                    out.append(f'      <h1>{_inline(text)}</h1>')
+                    out.append(f"      <h1>{_inline(text)}</h1>")
                     out.append(f'      <p class="lead">{_inline(lead)}</p>')
                 else:
-                    out.append(f'      <h1>{_inline(text)}</h1>')
+                    out.append(f"      <h1>{_inline(text)}</h1>")
                 continue
-            out.append(f'      <h1>{_inline(text)}</h1>')
+            out.append(f"      <h1>{_inline(text)}</h1>")
             i += 1
             continue
 
@@ -128,7 +144,7 @@ def _md_to_html(md: str, section_id: str) -> str:
             while i < len(lines) and lines[i].startswith("> "):
                 quote_lines.append(lines[i][2:])
                 i += 1
-            quote_text = " ".join(l.strip() for l in quote_lines)
+            quote_text = " ".join(ln.strip() for ln in quote_lines)
             out.append('      <div class="callout callout-note">')
             out.append('        <div class="callout-bar"></div>')
             out.append(f'        <div class="callout-body">{_inline(quote_text)}</div>')
@@ -162,7 +178,16 @@ def _md_to_html(md: str, section_id: str) -> str:
 
         # Paragraph — collect consecutive non-empty, non-special lines
         para_lines = []
-        while i < len(lines) and lines[i].strip() and not lines[i].startswith("#") and not lines[i].startswith("```") and not lines[i].startswith("|") and not lines[i].startswith(">") and not lines[i].startswith("- ") and not re.match(r"^\d+\.\s", lines[i]):
+        while (
+            i < len(lines)
+            and lines[i].strip()
+            and not lines[i].startswith("#")
+            and not lines[i].startswith("```")
+            and not lines[i].startswith("|")
+            and not lines[i].startswith(">")
+            and not lines[i].startswith("- ")
+            and not re.match(r"^\d+\.\s", lines[i])
+        ):
             para_lines.append(lines[i].strip())
             i += 1
         if para_lines:
@@ -212,7 +237,7 @@ def _highlight_code(code: str, lang: str) -> str:
             )
             # Quoted strings
             highlighted = re.sub(
-                r'(&quot;[^&]*&quot;)',
+                r"(&quot;[^&]*&quot;)",
                 r'<span class="str">\1</span>',
                 highlighted,
             )
@@ -236,7 +261,7 @@ def _highlight_usage(usage: str) -> str:
     # Command prefix: "mycelium <subcommand> [<subcommand>]"
     s = re.sub(r"^(mycelium(?:\s+\w+){1,2})", r'<span class="cmd">\1</span>', s)
     # Quoted strings
-    s = re.sub(r'(&quot;[^&]*&quot;)', r'<span class="str">\1</span>', s)
+    s = re.sub(r"(&quot;[^&]*&quot;)", r'<span class="str">\1</span>', s)
     # Flags: --foo, -f (after whitespace or bracket)
     s = re.sub(r"([\s\[])(-{1,2}\w[\w-]*)", r'\1<span class="flag">\2</span>', s)
     # Angle-bracket placeholders: <url>, <key>
@@ -262,7 +287,12 @@ def _parse_table(lines: list[str], start: int) -> str:
         rows.append(cells)
         i += 1
 
-    out = ['      <div class="table-wrap">', "        <table>", "          <thead>", "            <tr>"]
+    out = [
+        '      <div class="table-wrap">',
+        "        <table>",
+        "          <thead>",
+        "            <tr>",
+    ]
     for h in headers:
         out.append(f"              <th>{_inline(h)}</th>")
     out.append("            </tr>")
@@ -318,7 +348,7 @@ def _generate_cli_reference() -> tuple[str, str]:
     for entry in entries:
         groups[entry.group].append(entry)
 
-    section_lines = ['      <h2>CLI Reference</h2>']
+    section_lines = ["      <h2>CLI Reference</h2>"]
     sidebar_links = []
 
     for group_key, heading, sidebar_label in GROUP_CONFIG:
@@ -340,42 +370,169 @@ def _generate_cli_reference() -> tuple[str, str]:
             section_lines.append('        <div class="cmd-ref-header">')
             section_lines.append(f"          <code>{highlighted_usage}</code>")
             section_lines.append("        </div>")
-            section_lines.append(f'        <div class="cmd-ref-body">{entry.desc}</div>')
+            section_lines.append(
+                f'        <div class="cmd-ref-body">{entry.desc}</div>'
+            )
             section_lines.append("      </div>")
 
     section_html = "\n".join(section_lines)
 
-    sidebar_html = "\n".join([
-        '    <div class="nav-section">',
-        '      <div class="nav-section-label">CLI Reference</div>',
-        *sidebar_links,
-        "    </div>",
-    ])
+    sidebar_html = "\n".join(
+        [
+            '    <div class="nav-section">',
+            '      <div class="nav-section-label">CLI Reference</div>',
+            *sidebar_links,
+            "    </div>",
+        ]
+    )
 
     return section_html, sidebar_html
 
 
 # ── Sidebar generation from markdown sections ──
 
+
 def _generate_sidebar() -> str:
     """Generate the full sidebar nav HTML from section config."""
     sections_by_group: dict[str, list[tuple[str, str]]] = {}
     for _, section_id, sidebar_section, sidebar_label in SECTION_CONFIG:
-        sections_by_group.setdefault(sidebar_section, []).append((section_id, sidebar_label))
+        sections_by_group.setdefault(sidebar_section, []).append(
+            (section_id, sidebar_label)
+        )
 
     out = []
     for group_name, items in sections_by_group.items():
         out.append('    <div class="nav-section">')
-        out.append(f'      <div class="nav-section-label">{html.escape(group_name)}</div>')
+        out.append(
+            f'      <div class="nav-section-label">{html.escape(group_name)}</div>'
+        )
         for section_id, label in items:
             sub = " sub" if len(items) > 1 and group_name != "Architecture" else ""
-            out.append(f'      <a href="#{section_id}" class="nav-link{sub}">{html.escape(label)}</a>')
+            out.append(
+                f'      <a href="#{section_id}" class="nav-link{sub}">{html.escape(label)}</a>'
+            )
         out.append("    </div>")
 
     return "\n".join(out)
 
 
 # ── Main content generation ──
+
+# ── Config Reference generation (from pydantic schema) ──
+
+# Order in which top-level config namespaces appear in the docs. Keys not
+# listed here are appended in declaration order.
+CONFIG_NAMESPACE_ORDER: list[str] = [
+    "identity",
+    "server",
+    "llm",
+    "runtime",
+    "negotiation",
+    "rooms",
+    "knowledge_ingest",
+]
+
+# Namespaces to skip (typed as bare dict / non-BaseModel).
+CONFIG_NAMESPACE_SKIP: set[str] = {"adapters"}
+
+
+def _format_default(value: object) -> str:
+    """Render a pydantic field default as the value users would type."""
+    if value is None:
+        return "<em>unset</em>"
+    if isinstance(value, bool):
+        return "<code>true</code>" if value else "<code>false</code>"
+    if isinstance(value, str):
+        if value == "":
+            return "<em>empty</em>"
+        return f"<code>{html.escape(value)}</code>"
+    return f"<code>{html.escape(str(value))}</code>"
+
+
+def _format_type(annotation: object) -> str:
+    """Render a pydantic field type annotation as a readable string."""
+    s = str(annotation)
+    # str | None  →  str (optional)
+    s = s.replace("typing.", "")
+    s = s.replace("<class '", "").replace("'>", "")
+    return html.escape(s)
+
+
+def _generate_config_reference() -> tuple[str, str]:
+    """Generate Configuration HTML section + sidebar nav from pydantic schema.
+
+    Walks ``MyceliumConfig.model_fields`` and emits one ``<h3>`` + table per
+    namespace. Field descriptions come from each ``Field(..., description=...)``
+    declaration — adding a new config knob with a description is enough to get
+    it documented automatically.
+    """
+    from pydantic import BaseModel
+
+    from mycelium.config import MyceliumConfig
+
+    # Resolve namespace order: declared overrides first, then declaration order.
+    declared = list(MyceliumConfig.model_fields.keys())
+    ordered = [n for n in CONFIG_NAMESPACE_ORDER if n in declared]
+    ordered += [
+        n for n in declared if n not in ordered and n not in CONFIG_NAMESPACE_SKIP
+    ]
+
+    section_lines = ["      <h2>Configuration</h2>"]
+    section_lines.append(
+        "      <p>Generated from <code>mycelium-cli/src/mycelium/config.py</code>. "
+        "Set values with <code>mycelium config set &lt;namespace&gt;.&lt;key&gt; &lt;value&gt;</code>, "
+        "then run <code>mycelium config apply</code> to regenerate "
+        "<code>~/.mycelium/.env</code>. Container-resident services (CFN, "
+        "mycelium-backend) need <code>docker compose ... up -d --force-recreate "
+        "&lt;service&gt;</code> to pick up changes.</p>"
+    )
+    sidebar_links: list[tuple[str, str]] = []
+
+    for ns in ordered:
+        ns_field = MyceliumConfig.model_fields[ns]
+        ns_type = ns_field.annotation
+        if not (isinstance(ns_type, type) and issubclass(ns_type, BaseModel)):
+            continue
+        anchor = f"config-{ns.replace('_', '-')}"
+        sidebar_links.append((anchor, ns))
+        section_lines.append("")
+        section_lines.append(f'      <h3 id="{anchor}">{html.escape(ns)}</h3>')
+        ns_doc = (ns_type.__doc__ or "").strip().split("\n", 1)[0]
+        if ns_doc:
+            section_lines.append(f"      <p>{html.escape(ns_doc)}</p>")
+        section_lines.append('      <table class="config-table">')
+        section_lines.append("        <thead>")
+        section_lines.append(
+            "          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>"
+        )
+        section_lines.append("        </thead>")
+        section_lines.append("        <tbody>")
+        for fname, ff in ns_type.model_fields.items():
+            full_key = f"{ns}.{fname}"
+            type_str = _format_type(ff.annotation)
+            default = _format_default(ff.default)
+            desc = ff.description or "—"
+            section_lines.append(
+                f"          <tr><td><code>{html.escape(full_key)}</code></td>"
+                f"<td><code>{type_str}</code></td>"
+                f"<td>{default}</td>"
+                f"<td>{html.escape(desc)}</td></tr>"
+            )
+        section_lines.append("        </tbody>")
+        section_lines.append("      </table>")
+
+    sidebar = [
+        '    <div class="nav-section">',
+        '      <div class="nav-section-label">Configuration</div>',
+    ]
+    for anchor, label in sidebar_links:
+        sidebar.append(
+            f'      <a href="#{anchor}" class="nav-link sub">{html.escape(label)}</a>'
+        )
+    sidebar.append("    </div>")
+
+    return "\n".join(section_lines), "\n".join(sidebar)
+
 
 def _extract_kept_sections(html: str) -> dict[str, str]:
     """Extract sections marked <!-- keep --> from existing index.html.
@@ -430,6 +587,7 @@ def _generate_content_sections(existing_html: str) -> str:
 
 # ── Template replacement ──
 
+
 def _replace_between_markers(content: str, marker: str, replacement: str) -> str:
     """Replace content between <!-- marker --> and <!-- /marker --> comments."""
     pattern = re.compile(
@@ -442,8 +600,10 @@ def _replace_between_markers(content: str, marker: str, replacement: str) -> str
         raise RuntimeError(msg)
     return (
         content[: match.start(1)]
-        + match.group(1) + "\n"
-        + replacement + "\n"
+        + match.group(1)
+        + "\n"
+        + replacement
+        + "\n"
         + match.group(2)
         + content[match.end(2) :]
     )
@@ -462,6 +622,14 @@ def main() -> None:
     cli_html, cli_sidebar = _generate_cli_reference()
     content = _replace_between_markers(content, "codegen:cli-reference", cli_html)
 
+    # Generate config reference from pydantic schema
+    print("Generating config reference from pydantic schema...")
+    config_html, config_sidebar = _generate_config_reference()
+    content = _replace_between_markers(content, "codegen:config-reference", config_html)
+    content = _replace_between_markers(
+        content, "codegen:config-sidebar", config_sidebar
+    )
+
     # Generate sidebar
     print("Generating sidebar navigation...")
     sidebar_html = _generate_sidebar()
@@ -473,12 +641,13 @@ def main() -> None:
     INDEX_PATH.write_text(content)
 
     from mycelium.doc_ref import get_registry
+
     entries = get_registry()
     groups = defaultdict(list)
     for e in entries:
         groups[e.group].append(e)
 
-    print(f"\nUpdated docs/index.html:")
+    print("\nUpdated docs/index.html:")
     print(f"  {len(SECTION_CONFIG)} content sections from markdown")
     print(f"  {len(entries)} CLI commands from @doc_ref:")
     for group_key, heading, _ in GROUP_CONFIG:

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -479,12 +479,13 @@ def _generate_config_reference() -> tuple[str, str]:
 
     section_lines = ["      <h2>Configuration</h2>"]
     section_lines.append(
-        "      <p>Generated from <code>mycelium-cli/src/mycelium/config.py</code>. "
-        "Set values with <code>mycelium config set &lt;namespace&gt;.&lt;key&gt; &lt;value&gt;</code>, "
-        "then run <code>mycelium config apply</code> to regenerate "
-        "<code>~/.mycelium/.env</code>. Container-resident services (CFN, "
-        "mycelium-backend) need <code>docker compose ... up -d --force-recreate "
-        "&lt;service&gt;</code> to pick up changes.</p>"
+        "      <p>Settings live in <code>~/.mycelium/config.toml</code>. Change "
+        "a value with <code>mycelium config set &lt;key&gt; &lt;value&gt;</code> "
+        "(for example, <code>mycelium config set llm.model "
+        "anthropic/claude-sonnet-4-6</code>), then run <code>mycelium config "
+        "apply</code> to regenerate <code>~/.mycelium/.env</code>. If the "
+        "change affects a service running in a container, restart with "
+        "<code>mycelium up</code> for it to take effect.</p>"
     )
     sidebar_links: list[tuple[str, str]] = []
 

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -501,26 +501,30 @@ def _generate_config_reference() -> tuple[str, str]:
         ns_doc = (ns_type.__doc__ or "").strip().split("\n", 1)[0]
         if ns_doc:
             section_lines.append(f"      <p>{html.escape(ns_doc)}</p>")
-        section_lines.append('      <table class="config-table">')
-        section_lines.append("        <thead>")
+        # Wrap in .table-wrap so the table scrolls horizontally on overflow
+        # rather than blowing past the main column.
+        section_lines.append('      <div class="table-wrap">')
+        section_lines.append('        <table class="config-table">')
+        section_lines.append("          <thead>")
         section_lines.append(
-            "          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>"
+            "            <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>"
         )
-        section_lines.append("        </thead>")
-        section_lines.append("        <tbody>")
+        section_lines.append("          </thead>")
+        section_lines.append("          <tbody>")
         for fname, ff in ns_type.model_fields.items():
             full_key = f"{ns}.{fname}"
             type_str = _format_type(ff.annotation)
             default = _format_default(ff.default)
             desc = ff.description or "—"
             section_lines.append(
-                f"          <tr><td><code>{html.escape(full_key)}</code></td>"
+                f"            <tr><td><code>{html.escape(full_key)}</code></td>"
                 f"<td><code>{type_str}</code></td>"
                 f"<td>{default}</td>"
                 f"<td>{html.escape(desc)}</td></tr>"
             )
-        section_lines.append("        </tbody>")
-        section_lines.append("      </table>")
+        section_lines.append("          </tbody>")
+        section_lines.append("        </table>")
+        section_lines.append("      </div>")
 
     sidebar = [
         '    <div class="nav-section">',

--- a/docs/index.html
+++ b/docs/index.html
@@ -1764,101 +1764,115 @@ curl -X POST http://localhost:8888/api/memory/search \
 
       <h3 id="config-identity">identity</h3>
       <p>Agent identity configuration.</p>
-      <table class="config-table">
-        <thead>
-          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><code>identity.name</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Display name chosen by user</td></tr>
-          <tr><td><code>identity.machine_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Stable UUID for machine affinity (generated on first use)</td></tr>
-          <tr><td><code>identity.autonomous</code></td><td><code>bool</code></td><td><code>false</code></td><td>True when running as an autonomous agent</td></tr>
-        </tbody>
-      </table>
+      <div class="table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>identity.name</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Display name chosen by user</td></tr>
+            <tr><td><code>identity.machine_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Stable UUID for machine affinity (generated on first use)</td></tr>
+            <tr><td><code>identity.autonomous</code></td><td><code>bool</code></td><td><code>false</code></td><td>True when running as an autonomous agent</td></tr>
+          </tbody>
+        </table>
+      </div>
 
       <h3 id="config-server">server</h3>
       <p>Server connection configuration.</p>
-      <table class="config-table">
-        <thead>
-          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><code>server.api_url</code></td><td><code>str</code></td><td><code>http://localhost:8000</code></td><td>Mycelium backend API URL</td></tr>
-          <tr><td><code>server.workspace_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Default workspace UUID (created during install)</td></tr>
-          <tr><td><code>server.mas_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Default MAS UUID (created during install)</td></tr>
-        </tbody>
-      </table>
+      <div class="table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>server.api_url</code></td><td><code>str</code></td><td><code>http://localhost:8000</code></td><td>Mycelium backend API URL</td></tr>
+            <tr><td><code>server.workspace_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Default workspace UUID (created during install)</td></tr>
+            <tr><td><code>server.mas_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Default MAS UUID (created during install)</td></tr>
+          </tbody>
+        </table>
+      </div>
 
       <h3 id="config-llm">llm</h3>
       <p>LLM configuration (litellm format).</p>
-      <table class="config-table">
-        <thead>
-          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><code>llm.model</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>LLM model in litellm format (e.g. anthropic/claude-sonnet-4-6)</td></tr>
-          <tr><td><code>llm.api_key</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>API key for the LLM provider</td></tr>
-          <tr><td><code>llm.base_url</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Custom base URL for LLM endpoint (ollama, vllm, etc.)</td></tr>
-        </tbody>
-      </table>
+      <div class="table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>llm.model</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>LLM model in litellm format (e.g. anthropic/claude-sonnet-4-6)</td></tr>
+            <tr><td><code>llm.api_key</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>API key for the LLM provider</td></tr>
+            <tr><td><code>llm.base_url</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Custom base URL for LLM endpoint (ollama, vllm, etc.)</td></tr>
+          </tbody>
+        </table>
+      </div>
 
       <h3 id="config-runtime">runtime</h3>
       <p>Docker runtime / environment configuration.</p>
-      <table class="config-table">
-        <thead>
-          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><code>runtime.db_password</code></td><td><code>str</code></td><td><code>password</code></td><td>Postgres password for the mycelium-db container</td></tr>
-          <tr><td><code>runtime.db_port</code></td><td><code>int</code></td><td><code>5432</code></td><td>Host port for Postgres</td></tr>
-          <tr><td><code>runtime.backend_port</code></td><td><code>int</code></td><td><code>8000</code></td><td>Host port for the backend API</td></tr>
-          <tr><td><code>runtime.data_dir</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Root directory for .mycelium/ data (defaults to ~/.mycelium)</td></tr>
-          <tr><td><code>runtime.coordination_tick_timeout_seconds</code></td><td><code>int</code></td><td><code>30</code></td><td>Per-round timeout for CognitiveEngine negotiation</td></tr>
-          <tr><td><code>runtime.cfn_mgmt_url</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>IoC CFN management plane URL</td></tr>
-          <tr><td><code>runtime.cognition_fabric_node_url</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>IoC CFN cognition fabric node URL</td></tr>
-          <tr><td><code>runtime.workspace_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Workspace ID in the CFN mgmt plane</td></tr>
-          <tr><td><code>runtime.cfn_db</code></td><td><code>str</code></td><td><code>cfn_mgmt</code></td><td>CFN management database name</td></tr>
-          <tr><td><code>runtime.admin_user_password</code></td><td><code>str</code></td><td><code>admin</code></td><td>Admin user password for CFN mgmt plane</td></tr>
-          <tr><td><code>runtime.cfn_dev_mode</code></td><td><code>bool</code></td><td><code>false</code></td><td>Enable CFN dev mode</td></tr>
-        </tbody>
-      </table>
+      <div class="table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>runtime.db_password</code></td><td><code>str</code></td><td><code>password</code></td><td>Postgres password for the mycelium-db container</td></tr>
+            <tr><td><code>runtime.db_port</code></td><td><code>int</code></td><td><code>5432</code></td><td>Host port for Postgres</td></tr>
+            <tr><td><code>runtime.backend_port</code></td><td><code>int</code></td><td><code>8000</code></td><td>Host port for the backend API</td></tr>
+            <tr><td><code>runtime.data_dir</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Root directory for .mycelium/ data (defaults to ~/.mycelium)</td></tr>
+            <tr><td><code>runtime.coordination_tick_timeout_seconds</code></td><td><code>int</code></td><td><code>30</code></td><td>Per-round timeout for CognitiveEngine negotiation</td></tr>
+            <tr><td><code>runtime.cfn_mgmt_url</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>IoC CFN management plane URL</td></tr>
+            <tr><td><code>runtime.cognition_fabric_node_url</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>IoC CFN cognition fabric node URL</td></tr>
+            <tr><td><code>runtime.workspace_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Workspace ID in the CFN mgmt plane</td></tr>
+            <tr><td><code>runtime.cfn_db</code></td><td><code>str</code></td><td><code>cfn_mgmt</code></td><td>CFN management database name</td></tr>
+            <tr><td><code>runtime.admin_user_password</code></td><td><code>str</code></td><td><code>admin</code></td><td>Admin user password for CFN mgmt plane</td></tr>
+            <tr><td><code>runtime.cfn_dev_mode</code></td><td><code>bool</code></td><td><code>false</code></td><td>Enable CFN dev mode</td></tr>
+          </tbody>
+        </table>
+      </div>
 
       <h3 id="config-negotiation">negotiation</h3>
       <p>Tunables for the CFN-mediated negotiation flow.</p>
-      <table class="config-table">
-        <thead>
-          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><code>negotiation.n_steps</code></td><td><code>int</code></td><td><code>20</code></td><td>Maximum SAO rounds per session. CFN&#x27;s auto-compute formula assumes Boulware-style time-based concession (last ~30% of rounds), which LLM callback agents do not exhibit — so a low fixed cap is preferred. Set to 0 to fall through to CFN&#x27;s auto-computed budget.</td></tr>
-        </tbody>
-      </table>
+      <div class="table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>negotiation.n_steps</code></td><td><code>int</code></td><td><code>20</code></td><td>Maximum SAO rounds per session. CFN&#x27;s auto-compute formula assumes Boulware-style time-based concession (last ~30% of rounds), which LLM callback agents do not exhibit — so a low fixed cap is preferred. Set to 0 to fall through to CFN&#x27;s auto-computed budget.</td></tr>
+          </tbody>
+        </table>
+      </div>
 
       <h3 id="config-rooms">rooms</h3>
       <p>Room management configuration.</p>
-      <table class="config-table">
-        <thead>
-          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><code>rooms.active</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Currently active room name</td></tr>
-        </tbody>
-      </table>
+      <div class="table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>rooms.active</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Currently active room name</td></tr>
+          </tbody>
+        </table>
+      </div>
 
       <h3 id="config-knowledge-ingest">knowledge_ingest</h3>
       <p>Control surface for the mycelium-knowledge-extract hook → CFN path.</p>
-      <table class="config-table">
-        <thead>
-          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
-        </thead>
-        <tbody>
-          <tr><td><code>knowledge_ingest.enabled</code></td><td><code>bool</code></td><td><code>true</code></td><td>Master kill switch for the knowledge-extract hook. False stops the hook on entry (no session reads, no POSTs, no CFN spend) and causes the backend to return 200 with a disabled marker.</td></tr>
-          <tr><td><code>knowledge_ingest.events</code></td><td><code>list[str]</code></td><td><code>PydanticUndefined</code></td><td>OpenClaw event types that fire the knowledge-extract hook. &#x27;message:sent&#x27; fires after the agent&#x27;s response is delivered (one finalized turn available per fire). &#x27;agent:bootstrap&#x27; fires on session boot for catch-up. Avoid &#x27;command:new&#x27; — that&#x27;s the /new slash command (session reset), not a new agent turn.</td></tr>
-          <tr><td><code>knowledge_ingest.max_tool_content_bytes</code></td><td><code>int</code></td><td><code>4096</code></td><td>Per-tool-call truncation threshold for tc.input and tc.result in the hook payload. 0 disables truncation. The extractor does not need full file dumps to pull concepts.</td></tr>
-          <tr><td><code>knowledge_ingest.skip_in_progress_turn</code></td><td><code>bool</code></td><td><code>true</code></td><td>Hook skips the last un-finalized turn to avoid re-sending when tool results land after the initial POST. Final session turn is only sent when the next turn arrives or the session closes.</td></tr>
-          <tr><td><code>knowledge_ingest.max_input_tokens</code></td><td><code>int</code></td><td><code>50000</code></td><td>Backend circuit breaker — payloads above this estimated input token count are refused with 413. Set to 0 to disable.</td></tr>
-          <tr><td><code>knowledge_ingest.dedupe_ttl_seconds</code></td><td><code>int</code></td><td><code>300</code></td><td>Backend content-hash dedupe window. Identical payloads posted within this many seconds return the cached response_id without hitting CFN. Set to 0 to disable dedupe entirely.</td></tr>
-        </tbody>
-      </table>
+      <div class="table-wrap">
+        <table class="config-table">
+          <thead>
+            <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><code>knowledge_ingest.enabled</code></td><td><code>bool</code></td><td><code>true</code></td><td>Master kill switch for the knowledge-extract hook. False stops the hook on entry (no session reads, no POSTs, no CFN spend) and causes the backend to return 200 with a disabled marker.</td></tr>
+            <tr><td><code>knowledge_ingest.events</code></td><td><code>list[str]</code></td><td><code>PydanticUndefined</code></td><td>OpenClaw event types that fire the knowledge-extract hook. &#x27;message:sent&#x27; fires after the agent&#x27;s response is delivered (one finalized turn available per fire). &#x27;agent:bootstrap&#x27; fires on session boot for catch-up. Avoid &#x27;command:new&#x27; — that&#x27;s the /new slash command (session reset), not a new agent turn.</td></tr>
+            <tr><td><code>knowledge_ingest.max_tool_content_bytes</code></td><td><code>int</code></td><td><code>4096</code></td><td>Per-tool-call truncation threshold for tc.input and tc.result in the hook payload. 0 disables truncation. The extractor does not need full file dumps to pull concepts.</td></tr>
+            <tr><td><code>knowledge_ingest.skip_in_progress_turn</code></td><td><code>bool</code></td><td><code>true</code></td><td>Hook skips the last un-finalized turn to avoid re-sending when tool results land after the initial POST. Final session turn is only sent when the next turn arrives or the session closes.</td></tr>
+            <tr><td><code>knowledge_ingest.max_input_tokens</code></td><td><code>int</code></td><td><code>50000</code></td><td>Backend circuit breaker — payloads above this estimated input token count are refused with 413. Set to 0 to disable.</td></tr>
+            <tr><td><code>knowledge_ingest.dedupe_ttl_seconds</code></td><td><code>int</code></td><td><code>300</code></td><td>Backend content-hash dedupe window. Identical payloads posted within this many seconds return the cached response_id without hitting CFN. Set to 0 to disable dedupe entirely.</td></tr>
+          </tbody>
+        </table>
+      </div>
 <!-- /codegen:config-reference -->
     </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1760,7 +1760,7 @@ curl -X POST http://localhost:8888/api/memory/search \
     <section class="doc-section" id="config-reference">
       <!-- codegen:config-reference -->
       <h2>Configuration</h2>
-      <p>Generated from <code>mycelium-cli/src/mycelium/config.py</code>. Set values with <code>mycelium config set &lt;namespace&gt;.&lt;key&gt; &lt;value&gt;</code>, then run <code>mycelium config apply</code> to regenerate <code>~/.mycelium/.env</code>. Container-resident services (CFN, mycelium-backend) need <code>docker compose ... up -d --force-recreate &lt;service&gt;</code> to pick up changes.</p>
+      <p>Settings live in <code>~/.mycelium/config.toml</code>. Change a value with <code>mycelium config set &lt;key&gt; &lt;value&gt;</code> (for example, <code>mycelium config set llm.model anthropic/claude-sonnet-4-6</code>), then run <code>mycelium config apply</code> to regenerate <code>~/.mycelium/.env</code>. If the change affects a service running in a container, restart with <code>mycelium up</code> for it to take effect.</p>
 
       <h3 id="config-identity">identity</h3>
       <p>Agent identity configuration.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -90,6 +90,18 @@
       <a href="#cli-other" class="nav-link sub">synthesize / catchup / watch</a>
     </div>
 <!-- /codegen:cli-sidebar -->
+    <!-- codegen:config-sidebar -->
+    <div class="nav-section">
+      <div class="nav-section-label">Configuration</div>
+      <a href="#config-identity" class="nav-link sub">identity</a>
+      <a href="#config-server" class="nav-link sub">server</a>
+      <a href="#config-llm" class="nav-link sub">llm</a>
+      <a href="#config-runtime" class="nav-link sub">runtime</a>
+      <a href="#config-negotiation" class="nav-link sub">negotiation</a>
+      <a href="#config-rooms" class="nav-link sub">rooms</a>
+      <a href="#config-knowledge-ingest" class="nav-link sub">knowledge_ingest</a>
+    </div>
+<!-- /codegen:config-sidebar -->
     <div class="nav-section">
       <div class="nav-section-label">More</div>
       <a href="stories.html" class="nav-link">User Stories</a>
@@ -438,29 +450,131 @@ cd ~/.mycelium/rooms/design-review &amp;&amp; git init</code></pre>
     <section class="doc-section" id="cognitive-engine">
       <h1>CognitiveEngine</h1>
       <p>CognitiveEngine is the mediator. It sits between all agents and drives negotiation. Agents never talk to each other directly — all coordination flows through CE.</p>
-      <h2 id="cognitive-engine-negotiation-flow">Negotiation Flow</h2>
+      <h2 id="cognitive-engine-negotiation-flow">Negotiation flow</h2>
       <p>In sessions:</p>
       <ol class="steps">
         <li>Agents call <code>session join</code> with their initial position and handle.</li>
-        <li>After the 60s join window, CE runs the <strong>SemanticNegotiationPipeline</strong> on all positions.</li>
-        <li><code>session await</code> returns a tick. The proposer gets <code>action: propose</code>.</li>
-        <li>Proposer calls <code>message propose</code> with issue values (budget, timeline, scope, quality).</li>
-        <li>Respondent gets a tick with <code>action: respond</code> — accepts or rejects.</li>
-        <li>Rounds continue until consensus. Final tick has <code>type: consensus</code> with the plan.</li>
+        <li>The join window stays open until no new agents have joined for the configured</li>
       </ol>
-      <pre><code><span class="comment"># Propose (after await returns action: propose)</span>
+      <p>extension period (default 30s after each join, capped at 180s from first join). When the window closes, CE starts the <strong>SemanticNegotiationPipeline</strong> on the joined positions.</p>
+      <ol class="steps">
+        <li>CE sends each agent a <code>coordination_tick</code> with <code>action: respond</code>. The tick</li>
+      </ol>
+      <p>payload tells the agent everything it needs to decide:</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>What it tells you</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>current_offer</code></td>
+              <td>The proposal on the table this round</td>
+            </tr>
+            <tr>
+              <td><code>can_counter_offer</code></td>
+              <td>Whether *you* are the designated proposer this round</td>
+            </tr>
+            <tr>
+              <td><code>round</code> / <code>n_steps_total</code></td>
+              <td>Where you are in the round budget</td>
+            </tr>
+            <tr>
+              <td><code>your_last_action</code></td>
+              <td>What you (the recipient) did last round</td>
+            </tr>
+            <tr>
+              <td><code>prior_round_outcome</code></td>
+              <td>What happened previously: <code>first_round</code>, <code>proposer_countered</code>, <code>rejected_by_&lt;id&gt;</code>, <code>agreed</code>, <code>no_consensus</code></td>
+            </tr>
+            <tr>
+              <td><code>issues</code> / <code>issue_options</code></td>
+              <td>The full negotiation space</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <ol class="steps">
+        <li>Agents reply with <code>propose</code> (counter-offer, only when <code>can_counter_offer: true</code>)</li>
+      </ol>
+      <p>or <code>respond accept|reject</code>.</p>
+      <ol class="steps">
+        <li>Rounds continue until consensus or the round budget (<code>n_steps_total</code>) is</li>
+      </ol>
+      <p>exhausted. Consensus requires <strong>all agents</strong> to accept the same offer in the same round. The final tick is <code>coordination_consensus</code> with <code>broken: false</code> and the agreed plan; if no agreement is reached, <code>broken: true</code> is posted and the room moves to <code>failed</code> state.</p>
+      <p>Walking away with no agreement is a legitimate outcome. The protocol does not have a &quot;concede gradually&quot; mechanism for LLM agents — if your hard constraints can&#x27;t be met, keep rejecting until the round budget is exhausted.</p>
+      <pre><code><span class="comment"># Propose / counter-offer (when can_counter_offer is true)</span>
 <span class="cmd">mycelium negotiate propose</span> \
   budget=high timeline=standard \
   scope=extended quality=standard \
   <span class="flag">-r</span> sprint-plan <span class="flag">-H</span> julia-agent
 
-<span class="comment"># Respond (after await returns action: respond)</span>
+<span class="comment"># Respond (when can_counter_offer is false, or to accept the standing offer)</span>
 <span class="cmd">mycelium negotiate respond</span> accept \
   <span class="flag">-r</span> sprint-plan <span class="flag">-H</span> selina-agent
 
 <span class="comment"># Keep awaiting between each action</span>
 <span class="cmd">mycelium session await</span> \
   <span class="flag">-H</span> selina-agent <span class="flag">-r</span> sprint-plan</code></pre>
+      <h2 id="cognitive-engine-tunables">Tunables</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Config key</th>
+              <th>Default</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>negotiation.n_steps</code></td>
+              <td><code>20</code></td>
+              <td>Maximum SAO rounds per session. Set to <code>0</code> to fall through to CFN&#x27;s auto-computed budget (which scales with agent and issue count, but assumes Boulware-style time-based concession that LLM callback agents do not exhibit — a low fixed cap is preferred).</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <pre><code><span class="cmd">mycelium config set</span> negotiation.n_steps 30
+<span class="cmd">mycelium config apply</span>  # regenerates ~/.mycelium/.env</code></pre>
+      <p>CFN-side tunables (set via <code>~/.mycelium/.env</code> directly):</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Env var</th>
+              <th>Default</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>COORDINATION_JOIN_WINDOW_SECONDS</code></td>
+              <td><code>30</code></td>
+              <td>Initial join window starting from the first agent&#x27;s join</td>
+            </tr>
+            <tr>
+              <td><code>COORDINATION_JOIN_WINDOW_EXTENSION_SECONDS</code></td>
+              <td><code>30</code></td>
+              <td>How much each subsequent join pushes the deadline forward</td>
+            </tr>
+            <tr>
+              <td><code>COORDINATION_JOIN_WINDOW_MAX_SECONDS</code></td>
+              <td><code>180</code></td>
+              <td>Hard cap on total join window from first join</td>
+            </tr>
+            <tr>
+              <td><code>COORDINATION_TICK_TIMEOUT_SECONDS</code></td>
+              <td><code>30</code></td>
+              <td>Fallback per-tick timeout</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The round watchdog also extends on each agent&#x27;s first reply per round, so a slow agent doesn&#x27;t stall the round for everyone — only sustained silence (no replies for the full timeout window) ends the round prematurely.</p>
       <h2 id="cognitive-engine-synthesis">Synthesis</h2>
       <p>When triggered, CE synthesizes all memories in the room using an LLM. The output is a structured summary readable by any agent.</p>
       <pre><code><span class="comment"># Trigger synthesis manually</span>
@@ -509,6 +623,45 @@ cd ~/.mycelium/rooms/design-review &amp;&amp; git init</code></pre>
 
     <section class="doc-section" id="architecture">
       <h1>Architecture</h1>
+      <h2 id="architecture-deployment-modes">Deployment Modes</h2>
+      <p>Mycelium supports two deployment modes. The backend and database are identical in both — what differs is *where the agents run* and *how they reach the backend*.</p>
+      <h3 id="architecture-1-single-device-default">1. Single-device (default)</h3>
+      <p>Everything — backend, database, agents, and CLI — runs on one machine, typically a developer&#x27;s laptop. This is what <code>mycelium install</code> sets up out of the box. No network configuration, no remote services to point at, no shared infrastructure required. Agents talk to <code>localhost:8000</code>.</p>
+      <p>This is the primary deployment target. Use it when one person (or one machine) owns the whole agent workflow.</p>
+      <h3 id="architecture-2-hub-and-spoke-small-teams">2. Hub-and-spoke (small teams)</h3>
+      <p>A second, optional mode for small teams that want to share memory, rooms, and coordination state across machines. One machine runs the full backend stack (the <strong>hub</strong>); other machines run only the CLI + agents (<strong>spokes</strong>) and connect to the hub over HTTPS/SSE.</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Role</th>
+              <th>What runs locally</th>
+              <th>When to use</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Hub</strong></td>
+              <td>Full backend stack — FastAPI + AgensGraph (Postgres 16) + (optionally) the CFN management plane and cognition fabric node services.</td>
+              <td>The team&#x27;s shared coordination server. One per team.</td>
+            </tr>
+            <tr>
+              <td><strong>Spoke</strong></td>
+              <td>CLI + agents only. Talks to a remote hub via HTTPS / SSE. No Docker containers, no local database.</td>
+              <td>Each teammate&#x27;s laptop. Agents on the spoke participate in shared rooms hosted by the hub.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>Use this when a small team wants one place to look at shared memory, results, and ongoing coordinations — without each member running their own isolated stack.</p>
+      <p><code>mycelium doctor</code> auto-detects which mode you&#x27;re in by looking at <code>server.api_url</code> in <code>~/.mycelium/config.toml</code>: if it points to <code>localhost</code>/<code>127.0.0.1</code>, you&#x27;re a hub; otherwise a spoke. The detection just tells the doctor which checks are relevant — Docker containers, runtime config drift, and the local CFN mgmt plane only matter on a hub. Override the auto-detection with:</p>
+      <pre><code><span class="cmd">mycelium doctor</span> <span class="flag">--mode</span> hub     # force hub checks
+<span class="cmd">mycelium doctor</span> <span class="flag">--mode</span> spoke   # force spoke checks (skip local-only)
+<span class="cmd">mycelium doctor</span> <span class="flag">--mode</span> auto    # default — detect from api_url</code></pre>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Terminology note.</strong> Earlier releases used &quot;leaf&quot; instead of &quot;spoke&quot;. The CLI flag <code>--mode leaf</code> was renamed to <code>--mode spoke</code> in a hard cutover (no alias) to align with the standard hub-and-spoke vocabulary. If you have scripts that pass <code>--mode leaf</code>, update them to <code>--mode spoke</code>.</div>
+      </div>
       <h2 id="architecture-stack">Stack</h2>
       <p>Everything runs on a single <strong>AgensGraph</strong> instance — a PostgreSQL 16 fork with multi-model support. No external message broker, no separate vector database.</p>
       <div class="table-wrap">
@@ -1149,7 +1302,7 @@ curl -X POST http://localhost:8888/api/memory/search \
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium doctor</span> [<span class="flag">--fix</span>] [<span class="flag">--json</span>]</code>
+          <code><span class="cmd">mycelium doctor</span> [<span class="flag">--fix</span>] [<span class="flag">--json</span>] [<span class="flag">--mode</span> auto|hub|spoke]</code>
         </div>
         <div class="cmd-ref-body">Diagnose and fix common configuration issues (workspace sync, LLM, containers).</div>
       </div>
@@ -1451,6 +1604,13 @@ curl -X POST http://localhost:8888/api/memory/search \
         <div class="cmd-ref-body">Post a raw JSON response (advanced — prefer <code>propose</code> or <code>respond</code>).</div>
       </div>
 
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium negotiate status</span> [<span class="flag">-r</span> <span class="arg">&lt;room&gt;</span>]</code>
+        </div>
+        <div class="cmd-ref-body">Show the current negotiation state: round, issues, current offer, and per-agent reply status.</div>
+      </div>
+
       <h3 id="cli-cfn">cfn</h3>
 
       <div class="cmd-ref">
@@ -1469,35 +1629,35 @@ curl -X POST http://localhost:8888/api/memory/search \
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium cfn query</span> <span class="arg">&lt;intent&gt;</span> <span class="flag">--mas</span> &lt;mas-id&gt; [<span class="flag">--workspace</span> <span class="arg">&lt;ws&gt;</span>]</code>
+          <code><span class="cmd">mycelium cfn query</span> <span class="arg">&lt;intent&gt;</span> [<span class="flag">--mas</span> &lt;mas-id&gt;] [<span class="flag">--workspace</span> <span class="arg">&lt;ws&gt;</span>]</code>
         </div>
         <div class="cmd-ref-body">Ask CFN's evidence agent a natural-language question about the shared knowledge graph. Returns a synthesized answer, not a record list.</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium cfn concepts</span> <span class="arg">&lt;id&gt;</span>[,<span class="arg">&lt;id&gt;</span>,...] <span class="flag">--mas</span> &lt;mas-id&gt;</code>
+          <code><span class="cmd">mycelium cfn concepts</span> <span class="arg">&lt;id&gt;</span>[,<span class="arg">&lt;id&gt;</span>,...] [<span class="flag">--mas</span> &lt;mas-id&gt;]</code>
         </div>
         <div class="cmd-ref-body">Fetch specific CFN concept records by ID.</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium cfn neighbors</span> &lt;concept-id&gt; <span class="flag">--mas</span> &lt;mas-id&gt;</code>
+          <code><span class="cmd">mycelium cfn neighbors</span> &lt;concept-id&gt; [<span class="flag">--mas</span> &lt;mas-id&gt;]</code>
         </div>
         <div class="cmd-ref-body">Show CFN graph neighbors for a concept.</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium cfn ls</span> <span class="flag">--mas</span> &lt;mas-id&gt; [<span class="flag">--limit</span> N] [<span class="flag">--json</span>]</code>
+          <code><span class="cmd">mycelium cfn ls</span> [<span class="flag">--mas</span> &lt;mas-id&gt;] [<span class="flag">--limit</span> N] [<span class="flag">--json</span>]</code>
         </div>
         <div class="cmd-ref-body">Enumerate nodes in CFN's knowledge graph by reading AgensGraph directly. NOT a CFN-supported API — couples to CFN's internal graph-naming convention (graph_<mas_id>).</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium cfn paths</span> &lt;source-id&gt; &lt;target-id&gt; <span class="flag">--mas</span> &lt;mas-id&gt; [<span class="flag">--max-depth</span> N] [<span class="flag">--limit</span> N]</code>
+          <code><span class="cmd">mycelium cfn paths</span> &lt;source-id&gt; &lt;target-id&gt; [<span class="flag">--mas</span> &lt;mas-id&gt;] [<span class="flag">--max-depth</span> N] [<span class="flag">--limit</span> N]</code>
         </div>
         <div class="cmd-ref-body">Show CFN graph paths between two concepts.</div>
       </div>
@@ -1592,6 +1752,114 @@ curl -X POST http://localhost:8888/api/memory/search \
         <div class="cmd-ref-body">Stream live room activity via SSE. Messages appear in real time as other agents write.</div>
       </div>
 <!-- /codegen:cli-reference -->
+    </section>
+
+    <hr class="divider">
+
+    <!-- CONFIG REFERENCE -->
+    <section class="doc-section" id="config-reference">
+      <!-- codegen:config-reference -->
+      <h2>Configuration</h2>
+      <p>Generated from <code>mycelium-cli/src/mycelium/config.py</code>. Set values with <code>mycelium config set &lt;namespace&gt;.&lt;key&gt; &lt;value&gt;</code>, then run <code>mycelium config apply</code> to regenerate <code>~/.mycelium/.env</code>. Container-resident services (CFN, mycelium-backend) need <code>docker compose ... up -d --force-recreate &lt;service&gt;</code> to pick up changes.</p>
+
+      <h3 id="config-identity">identity</h3>
+      <p>Agent identity configuration.</p>
+      <table class="config-table">
+        <thead>
+          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>identity.name</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Display name chosen by user</td></tr>
+          <tr><td><code>identity.machine_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Stable UUID for machine affinity (generated on first use)</td></tr>
+          <tr><td><code>identity.autonomous</code></td><td><code>bool</code></td><td><code>false</code></td><td>True when running as an autonomous agent</td></tr>
+        </tbody>
+      </table>
+
+      <h3 id="config-server">server</h3>
+      <p>Server connection configuration.</p>
+      <table class="config-table">
+        <thead>
+          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>server.api_url</code></td><td><code>str</code></td><td><code>http://localhost:8000</code></td><td>Mycelium backend API URL</td></tr>
+          <tr><td><code>server.workspace_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Default workspace UUID (created during install)</td></tr>
+          <tr><td><code>server.mas_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Default MAS UUID (created during install)</td></tr>
+        </tbody>
+      </table>
+
+      <h3 id="config-llm">llm</h3>
+      <p>LLM configuration (litellm format).</p>
+      <table class="config-table">
+        <thead>
+          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>llm.model</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>LLM model in litellm format (e.g. anthropic/claude-sonnet-4-6)</td></tr>
+          <tr><td><code>llm.api_key</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>API key for the LLM provider</td></tr>
+          <tr><td><code>llm.base_url</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Custom base URL for LLM endpoint (ollama, vllm, etc.)</td></tr>
+        </tbody>
+      </table>
+
+      <h3 id="config-runtime">runtime</h3>
+      <p>Docker runtime / environment configuration.</p>
+      <table class="config-table">
+        <thead>
+          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>runtime.db_password</code></td><td><code>str</code></td><td><code>password</code></td><td>Postgres password for the mycelium-db container</td></tr>
+          <tr><td><code>runtime.db_port</code></td><td><code>int</code></td><td><code>5432</code></td><td>Host port for Postgres</td></tr>
+          <tr><td><code>runtime.backend_port</code></td><td><code>int</code></td><td><code>8000</code></td><td>Host port for the backend API</td></tr>
+          <tr><td><code>runtime.data_dir</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Root directory for .mycelium/ data (defaults to ~/.mycelium)</td></tr>
+          <tr><td><code>runtime.coordination_tick_timeout_seconds</code></td><td><code>int</code></td><td><code>30</code></td><td>Per-round timeout for CognitiveEngine negotiation</td></tr>
+          <tr><td><code>runtime.cfn_mgmt_url</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>IoC CFN management plane URL</td></tr>
+          <tr><td><code>runtime.cognition_fabric_node_url</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>IoC CFN cognition fabric node URL</td></tr>
+          <tr><td><code>runtime.workspace_id</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Workspace ID in the CFN mgmt plane</td></tr>
+          <tr><td><code>runtime.cfn_db</code></td><td><code>str</code></td><td><code>cfn_mgmt</code></td><td>CFN management database name</td></tr>
+          <tr><td><code>runtime.admin_user_password</code></td><td><code>str</code></td><td><code>admin</code></td><td>Admin user password for CFN mgmt plane</td></tr>
+          <tr><td><code>runtime.cfn_dev_mode</code></td><td><code>bool</code></td><td><code>false</code></td><td>Enable CFN dev mode</td></tr>
+        </tbody>
+      </table>
+
+      <h3 id="config-negotiation">negotiation</h3>
+      <p>Tunables for the CFN-mediated negotiation flow.</p>
+      <table class="config-table">
+        <thead>
+          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>negotiation.n_steps</code></td><td><code>int</code></td><td><code>20</code></td><td>Maximum SAO rounds per session. CFN&#x27;s auto-compute formula assumes Boulware-style time-based concession (last ~30% of rounds), which LLM callback agents do not exhibit — so a low fixed cap is preferred. Set to 0 to fall through to CFN&#x27;s auto-computed budget.</td></tr>
+        </tbody>
+      </table>
+
+      <h3 id="config-rooms">rooms</h3>
+      <p>Room management configuration.</p>
+      <table class="config-table">
+        <thead>
+          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>rooms.active</code></td><td><code>str | None</code></td><td><em>unset</em></td><td>Currently active room name</td></tr>
+        </tbody>
+      </table>
+
+      <h3 id="config-knowledge-ingest">knowledge_ingest</h3>
+      <p>Control surface for the mycelium-knowledge-extract hook → CFN path.</p>
+      <table class="config-table">
+        <thead>
+          <tr><th>Key</th><th>Type</th><th>Default</th><th>Description</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>knowledge_ingest.enabled</code></td><td><code>bool</code></td><td><code>true</code></td><td>Master kill switch for the knowledge-extract hook. False stops the hook on entry (no session reads, no POSTs, no CFN spend) and causes the backend to return 200 with a disabled marker.</td></tr>
+          <tr><td><code>knowledge_ingest.events</code></td><td><code>list[str]</code></td><td><code>PydanticUndefined</code></td><td>OpenClaw event types that fire the knowledge-extract hook. &#x27;message:sent&#x27; fires after the agent&#x27;s response is delivered (one finalized turn available per fire). &#x27;agent:bootstrap&#x27; fires on session boot for catch-up. Avoid &#x27;command:new&#x27; — that&#x27;s the /new slash command (session reset), not a new agent turn.</td></tr>
+          <tr><td><code>knowledge_ingest.max_tool_content_bytes</code></td><td><code>int</code></td><td><code>4096</code></td><td>Per-tool-call truncation threshold for tc.input and tc.result in the hook payload. 0 disables truncation. The extractor does not need full file dumps to pull concepts.</td></tr>
+          <tr><td><code>knowledge_ingest.skip_in_progress_turn</code></td><td><code>bool</code></td><td><code>true</code></td><td>Hook skips the last un-finalized turn to avoid re-sending when tool results land after the initial POST. Final session turn is only sent when the next turn arrives or the session closes.</td></tr>
+          <tr><td><code>knowledge_ingest.max_input_tokens</code></td><td><code>int</code></td><td><code>50000</code></td><td>Backend circuit breaker — payloads above this estimated input token count are refused with 413. Set to 0 to disable.</td></tr>
+          <tr><td><code>knowledge_ingest.dedupe_ttl_seconds</code></td><td><code>int</code></td><td><code>300</code></td><td>Backend content-hash dedupe window. Identical payloads posted within this many seconds return the cached response_id without hitting CFN. Set to 0 to disable dedupe entirely.</td></tr>
+        </tbody>
+      </table>
+<!-- /codegen:config-reference -->
     </section>
 
     <!-- FOOTER -->

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -176,7 +176,7 @@ a.topnav-page:hover { color: var(--accent); }
   background: rgba(5, 9, 15, 0.25);
 }
 .main-inner {
-  max-width: 70ch;
+  max-width: 90ch;
   margin: 0 auto;
   background: rgba(5, 9, 15, 0.6);
   backdrop-filter: blur(16px);

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -176,7 +176,7 @@ a.topnav-page:hover { color: var(--accent); }
   background: rgba(5, 9, 15, 0.25);
 }
 .main-inner {
-  max-width: 100ch;
+  max-width: 90ch;
   margin: 0 auto;
   background: rgba(5, 9, 15, 0.6);
   backdrop-filter: blur(16px);

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -176,7 +176,7 @@ a.topnav-page:hover { color: var(--accent); }
   background: rgba(5, 9, 15, 0.25);
 }
 .main-inner {
-  max-width: 90ch;
+  max-width: 100ch;
   margin: 0 auto;
   background: rgba(5, 9, 15, 0.6);
   backdrop-filter: blur(16px);

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -446,6 +446,9 @@ tr:last-child td { border-bottom: none; }
 td:first-child { color: var(--accent2); font-family: 'SF Mono', monospace; font-size: 13px; }
 tr:hover td { background: rgba(255,255,255,0.02); }
 
+/* Config table — type column reads worse when wrapped on union types like "str | None" */
+.config-table td:nth-child(2) { white-space: nowrap; }
+
 /* ── CARDS ── */
 .card-grid {
   display: grid;

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -151,7 +151,7 @@ class NegotiationConfig(BaseModel):
         default=20,
         description=(
             "Maximum SAO rounds per session. CFN's auto-compute formula assumes "
-            "Boulware-style time-based concession (last ~30%% of rounds), which "
+            "Boulware-style time-based concession (last ~30% of rounds), which "
             "LLM callback agents do not exhibit — so a low fixed cap is preferred. "
             "Set to 0 to fall through to CFN's auto-computed budget."
         ),


### PR DESCRIPTION
## Summary

Adds a third codegen surface to `docs/generate_docs.py` alongside the existing CLI Reference (from `@doc_ref` decorators) and markdown content sections: a **Configuration** reference rendered from the pydantic schema in `mycelium-cli/src/mycelium/config.py`.

For each sub-model on `MyceliumConfig` (identity, server, llm, runtime, negotiation, rooms, knowledge_ingest), the generator emits an `<h3>` + table with one row per field showing **key / type / default / description**. Whatever shows up in `Field(..., description="...")` is what users read.

The only requirement to document a new config knob is a non-empty `description` on the field — docs stay in sync with the shipped schema automatically.

## What changed

- `<!-- codegen:config-reference -->` and `<!-- codegen:config-sidebar -->` marker pairs in `docs/index.html`
- `_generate_config_reference()` in `docs/generate_docs.py` walks `MyceliumConfig.model_fields`, skips bare-`dict` namespaces (e.g. `adapters`) via `CONFIG_NAMESPACE_SKIP`, and orders sections via `CONFIG_NAMESPACE_ORDER` (unlisted namespaces append in declaration order)
- Wired into `main()` after the existing CLI reference codegen
- Skill `generate-cli-docs` updated to document the new convention

Drive-by:
- Rename ambiguous `l` → `ln` in `_md_to_html` (E741, pre-existing on main)
- Fix typo `~30%%` → `~30%` in `NegotiationConfig.n_steps` description

## Output preview

The generated section is at `#config-reference` in `docs/index.html`, with one `<h3>` per namespace. Sample row for `negotiation.n_steps`:

| Key | Type | Default | Description |
|---|---|---|---|
| `negotiation.n_steps` | `int` | `20` | Maximum SAO rounds per session. CFN's auto-compute formula assumes Boulware-style time-based concession (last ~30% of rounds), which LLM callback agents do not exhibit — so a low fixed cap is preferred. Set to 0 to fall through to CFN's auto-computed budget. |

The sidebar `Configuration` section gets one nav link per namespace.

## Test plan

- [ ] CI green
- [ ] Reviewer can run `cd mycelium-cli && uv run python ../docs/generate_docs.py` and see new "Generating config reference from pydantic schema..." line + a Configuration section in the regenerated `docs/index.html`
- [ ] Reviewer can add a new `Field(..., description="...")` to any sub-model on `MyceliumConfig`, re-run the generator, and see the new row appear

## Notes

Existing generic `table { ... }` styles in `docs/mycelium.css` already apply to the new tables — no CSS changes needed.