### PR TITLE
feat(release): support preview builds without affecting stable users

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
-description: Cut a release — commit any staged changes, tag, create GitHub release, and optionally notify Webex. Use when the user says /release or /release --with-webex.
-argument-hint: "[--with-webex]"
+description: Cut a release — commit any staged changes, tag, create GitHub release, and optionally notify Webex. Use when the user says /release, /release --with-webex, or /release --preview.
+argument-hint: "[--with-webex] [--preview]"
 ---
 
 # Release
@@ -10,26 +10,38 @@ Commit latest changes (if any), tag, cut a GitHub release, and optionally notify
 
 ## Arguments
 
-- `--with-webex` — after releasing, post a summary to Webex (default: `Mycelium Release Notes` only; add `--with-webex=eng` to also post to `IoC::Mycelium Eng`)
+- `--with-webex` — after releasing, post a summary to Webex (default: `Mycelium Release Notes` only; add `--with-webex=eng` to also post to `IoC::Mycelium Eng`).
+- `--preview` — cut a prerelease build for testing without affecting stable users. Skips Docker `:latest`, Homebrew, and ClawHub. Webex still gets a short preview ping (eng channel only — not user-facing release notes). Testers opt in via `mycelium upgrade --version <tag>`.
+
+## Why preview releases are safe
+
+The release pipeline's "promote to latest" steps (Docker `:latest` tags, GH "Latest" label, Homebrew formula, ClawHub) are gated on the tag matching a stable pattern. Tags containing `rc`, `alpha`, `beta`, or `preview` are detected as prereleases by the `detect-release-type` job in `.github/workflows/release.yml` and bypass all of those.
+
+`install.sh` and `mycelium upgrade` both follow the GitHub `/releases/latest` redirect, which only resolves to releases NOT marked as prerelease. So stable users never see preview builds. Testers install with an explicit version pin.
 
 ## Steps
 
 1. **Commit staged changes** — Run `git status`. If there are uncommitted changes, run /precommit checks then commit directly to main (admin push, no PR needed). Use a conventional commit message.
 
-2. **Determine next tag** — Run `gh release list --limit 5` to find the current "Latest" release tag. Increment the patch version (e.g. `v1.0.0` → `v1.0.1`).
+   **For `--preview`:** do NOT commit a `pyproject.toml` version bump to main. The release workflow seds the version in-place during the build only — main keeps tracking the next stable version, not the preview.
+
+2. **Determine next tag** —
+   - **Stable (`/release`):** Run `gh release list --limit 5` to find the current "Latest" release tag. Increment the patch version (e.g. `v1.0.0` → `v1.0.1`).
+   - **Preview (`/release --preview`):** Find the latest stable tag (highest non-prerelease in `gh release list`). Target version is `<latest-stable-patch+1>`. Then check existing prereleases for that target: if `vX.Y.Zrc1` exists, cut `vX.Y.Zrc2`, etc. First preview for a target version is always `rc1`. Use PEP 440 format with no separator (`vX.Y.ZrcN`, NOT `vX.Y.Z-rc.N`) so the wheel filename matches what `install.sh` expects.
 
 3. **Tag and push** — Run:
    ```
    git tag <new-tag> && git push origin <new-tag>
    ```
+   The `release.yml` workflow detects whether the tag is a prerelease and gates the rest of the pipeline accordingly.
 
-4. **Create GitHub release** — Run:
-   ```
-   gh release create <new-tag> --title "<new-tag>" --notes "<summary of changes since last tag>"
-   ```
-   Generate the release notes from `git log <prev-tag>..HEAD --oneline`.
+4. **Create GitHub release** — The `release.yml` workflow handles this automatically (via `softprops/action-gh-release`), including setting `prerelease: true` for preview tags. No manual `gh release create` needed.
 
-5. **Webex notification** — If `--with-webex` was passed, invoke `/webex` (no confirmation needed) to post a bullet-point changelog summary with the tag and release URL. Each bullet should include the PR link if one exists (e.g. `- feat: description ([#123](https://github.com/mycelium-io/mycelium/pull/123))`). Follow with upgrade instructions using triple-backtick code blocks so they're copyable:
+   Wait for the workflow to finish (`gh run watch` or `gh run list --workflow=release.yml --limit 1`). If it fails, fix and re-run before posting any notifications.
+
+5. **Webex notification** — Invoke `/webex` (no confirmation needed). Behavior depends on whether this is a stable or preview release.
+
+   **Stable release** — when `--with-webex` is passed, post a bullet-point changelog summary with the tag and release URL. Each bullet should include the PR link if one exists (e.g. `- feat: description ([#123](https://github.com/mycelium-io/mycelium/pull/123))`). Follow with upgrade instructions using triple-backtick code blocks so they're copyable:
    ```
    To upgrade:
    mycelium upgrade && mycelium pull
@@ -41,7 +53,26 @@ Commit latest changes (if any), tag, cut a GitHub release, and optionally notify
    - `Mycelium Release Notes` — always (room ID in `/webex` skill)
    - `IoC::Mycelium Eng` — only if `--with-webex=eng` was passed (room ID in `/webex` skill)
 
-6. **Mycelium patch notes** — Write the same changelog summary to the active Mycelium room:
+   **Preview release (`--preview`)** — post a short eng-only ping to `IoC::Mycelium Eng` (NOT `Mycelium Release Notes` — that channel is user-facing). No changelog. Just the tag, the GH release URL, and the install/upgrade commands testers need:
+   ```
+   Preview build cut: <tag>
+   <release-url>
+
+   Test on a fresh server:
+       MYCELIUM_VERSION=<tag-without-v> curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
+       mycelium pull --version <tag-without-v>
+
+   Or upgrade in place:
+       mycelium upgrade --version <tag-without-v>
+       mycelium pull --version <tag-without-v>
+
+   Roll back:
+       mycelium upgrade --version <previous-stable>
+       mycelium pull --version latest
+   ```
+   `mycelium pull --version <tag>` is the critical second step — it pins both `mycelium-backend` and `mycelium-db` images via `MYCELIUM_IMAGE_TAG` in `~/.mycelium/.env`. Without it, the new CLI runs against stale stable containers. Stable users are unaffected — `install.sh` and `mycelium upgrade` (no `--version`) still resolve to the latest stable, and `mycelium pull` (no `--version`) still pulls `:latest`.
+
+6. **Mycelium patch notes** — Skipped for `--preview` (or scope to a `previews/<tag>` key if the user explicitly asks for it). Otherwise write the same changelog summary to the active Mycelium room:
    ```bash
    mycelium memory set "releases/<tag>" "<same bullet-point summary as Webex>" --handle claude-code-agent
    ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,28 @@ permissions:
   packages: write   # needed to push to GHCR
 
 jobs:
+  # Prerelease tags follow PEP 440: vX.Y.ZrcN, vX.Y.ZbN, vX.Y.ZaN, or
+  # anything with "preview" in it. Prereleases skip every "promote to latest"
+  # step (Docker :latest tag, GH "Latest" label, Homebrew bump, ClawHub).
+  detect-release-type:
+    name: Detect release type
+    runs-on: ubuntu-latest
+    outputs:
+      is_prerelease: ${{ steps.detect.outputs.is_prerelease }}
+    steps:
+      - id: detect
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if [[ "$tag" =~ (rc|alpha|beta|preview)[0-9]* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "→ $tag is a prerelease (skipping :latest promotion)"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "→ $tag is a stable release"
+          fi
+
   publish-images:
+    needs: detect-release-type
     name: Build and push Docker images to GHCR
     runs-on: ubuntu-latest
     steps:
@@ -30,6 +51,38 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Compute image tags
+        id: tags
+        env:
+          IS_PRERELEASE: ${{ needs.detect-release-type.outputs.is_prerelease }}
+          VERSION: ${{ steps.version.outputs.version }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          # Stable releases get :latest + :version. Prereleases get :version only —
+          # otherwise compose.yml's `pull_policy: always` would push the preview
+          # to every existing user on their next `mycelium pull`.
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            {
+              echo "db<<EOF"
+              echo "ghcr.io/$OWNER/mycelium-db:$VERSION"
+              echo "EOF"
+              echo "backend<<EOF"
+              echo "ghcr.io/$OWNER/mycelium-backend:$VERSION"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "db<<EOF"
+              echo "ghcr.io/$OWNER/mycelium-db:latest"
+              echo "ghcr.io/$OWNER/mycelium-db:$VERSION"
+              echo "EOF"
+              echo "backend<<EOF"
+              echo "ghcr.io/$OWNER/mycelium-backend:latest"
+              echo "ghcr.io/$OWNER/mycelium-backend:$VERSION"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push mycelium-db
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
@@ -37,9 +90,7 @@ jobs:
           file: fastapi-backend/docker/Dockerfile.agensgraph
           platforms: linux/amd64
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/mycelium-db:latest
-            ghcr.io/${{ github.repository_owner }}/mycelium-db:${{ steps.version.outputs.version }}
+          tags: ${{ steps.tags.outputs.db }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mycelium-db:cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mycelium-db:cache,mode=max
 
@@ -50,9 +101,7 @@ jobs:
           file: fastapi-backend/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/mycelium-backend:latest
-            ghcr.io/${{ github.repository_owner }}/mycelium-backend:${{ steps.version.outputs.version }}
+          tags: ${{ steps.tags.outputs.backend }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mycelium-backend:cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mycelium-backend:cache,mode=max
 
@@ -117,7 +166,7 @@ jobs:
           path: mycelium-cli/dist/mycelium-${{ matrix.platform }}
 
   build-and-release:
-    needs: [publish-images, build-binaries]
+    needs: [detect-release-type, publish-images, build-binaries]
     name: Build wheel and publish release
     runs-on: ubuntu-latest
 
@@ -166,6 +215,10 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: mycelium ${{ github.ref_name }}
+          # Marking the release as a prerelease keeps it out of the
+          # /releases/latest redirect that install.sh and `mycelium upgrade`
+          # both follow — testers opt in via `mycelium upgrade --version <tag>`.
+          prerelease: ${{ needs.detect-release-type.outputs.is_prerelease == 'true' }}
           body: |
             ## Install
 
@@ -188,7 +241,8 @@ jobs:
           fail_on_unmatched_files: true
 
   update-tap:
-    needs: build-and-release
+    needs: [detect-release-type, build-and-release]
+    if: needs.detect-release-type.outputs.is_prerelease == 'false'
     name: Update homebrew tap
     runs-on: ubuntu-latest
 
@@ -240,7 +294,8 @@ jobs:
           git diff --staged --quiet || git commit -m "chore: bump mycelium to v${{ steps.version.outputs.version }}"
           git push
   publish-clawhub:
-    needs: build-and-release
+    needs: [detect-release-type, build-and-release]
+    if: needs.detect-release-type.outputs.is_prerelease == 'false'
     name: Publish skill to clawhub
     runs-on: ubuntu-latest
 

--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -110,6 +110,32 @@ def _compose_base_cmd(compose_path: Path | None = None, env_path: Path | None = 
     return cmd
 
 
+def _patch_env_image_tag(env_path: Path, tag: str) -> None:
+    """Set MYCELIUM_IMAGE_TAG=<tag> in ~/.mycelium/.env (insert if absent).
+
+    Used by ``mycelium pull --version`` to pin compose's ``${MYCELIUM_IMAGE_TAG:-latest}``
+    substitution across restarts. Pass ``tag="latest"`` to unpin.
+    """
+    if not env_path.exists():
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        env_path.write_text(f"MYCELIUM_IMAGE_TAG={tag}\n", encoding="utf-8")
+        return
+    lines = env_path.read_text(encoding="utf-8").splitlines()
+    found = False
+    new_lines = []
+    for line in lines:
+        if "=" in line and not line.lstrip().startswith("#"):
+            key = line.split("=", 1)[0].strip()
+            if key == "MYCELIUM_IMAGE_TAG":
+                new_lines.append(f"MYCELIUM_IMAGE_TAG={tag}")
+                found = True
+                continue
+        new_lines.append(line)
+    if not found:
+        new_lines.append(f"MYCELIUM_IMAGE_TAG={tag}")
+    env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+
 def _cfn_enabled() -> bool:
     """Return True if CFN_MGMT_URL is set in ~/.mycelium/.env."""
     env_path = _get_env_path()
@@ -925,28 +951,39 @@ def migrate(
 
 
 @doc_ref(
-    usage="mycelium pull [--no-restart]",
-    desc="Pull latest Docker images and restart services.",
+    usage="mycelium pull [--version <tag>] [--no-restart]",
+    desc="Pull Mycelium Docker images and restart services. Pass --version to pin a preview/specific build.",
     group="setup",
 )
 def pull(
     ctx: typer.Context,
+    target_version: str | None = typer.Option(
+        None,
+        "--version",
+        help="Pin mycelium-backend and mycelium-db image tags to a specific version "
+        "(e.g. 0.1.84rc1). Without --version, pulls :latest. Persisted to ~/.mycelium/.env "
+        "as MYCELIUM_IMAGE_TAG so subsequent restarts stay pinned. Pass --version=latest to "
+        "unpin and return to tracking the latest stable.",
+    ),
     no_restart: bool = typer.Option(
         False, "--no-restart", help="Pull images but don't restart services"
     ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmations"),  # noqa: ARG001
 ) -> None:
     """
-    Pull latest Docker images and restart services.
+    Pull Mycelium Docker images and restart services.
 
-    Fetches the newest versions of all Mycelium container images, then
-    restarts the stack so the updated images take effect. Also runs
-    database migrations.
+    By default, pulls the :latest tag of each Mycelium image. Pass
+    --version <tag> to pin to a specific build (typically used with preview
+    releases) — the tag is persisted to ~/.mycelium/.env as
+    MYCELIUM_IMAGE_TAG so the stack stays pinned across restarts.
 
     \b
     Examples:
-        mycelium pull              # pull + restart + migrate
-        mycelium pull --no-restart # pull only, restart later with mycelium up
+        mycelium pull                       # latest stable
+        mycelium pull --version 0.1.84rc1   # pin to preview build
+        mycelium pull --version latest      # unpin (back to latest stable)
+        mycelium pull --no-restart          # pull only, restart later
     """
     try:
         compose_path = _get_compose_path()
@@ -958,6 +995,18 @@ def pull(
 
         env_path = _get_env_path()
         cfn = _cfn_enabled()
+
+        # If the user explicitly pinned a version (or asked to unpin via
+        # --version=latest), persist that to .env *before* compose pull so the
+        # ${MYCELIUM_IMAGE_TAG:-latest} substitution in compose.yml resolves
+        # correctly. Stripping a leading 'v' lets users pass tag names freely.
+        if target_version is not None and env_path is not None:
+            normalized = target_version.lstrip("v") or "latest"
+            _patch_env_image_tag(env_path, normalized)
+            if normalized == "latest":
+                typer.echo("  ✓ Unpinned image tag (back to :latest)")
+            else:
+                typer.echo(f"  ✓ Pinned image tag to {normalized} (in {env_path})")
 
         base = _compose_base_cmd(compose_path, env_path)
         if cfn:

--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -10,7 +10,7 @@ services:
     build:
       context: ../fastapi-backend
       dockerfile: docker/Dockerfile.agensgraph
-    image: ghcr.io/mycelium-io/mycelium-db:latest
+    image: ghcr.io/mycelium-io/mycelium-db:${MYCELIUM_IMAGE_TAG:-latest}
     pull_policy: always
     platform: linux/amd64
     container_name: mycelium-db
@@ -38,7 +38,7 @@ services:
     build:
       context: ../fastapi-backend
       dockerfile: Dockerfile
-    image: ghcr.io/mycelium-io/mycelium-backend:latest
+    image: ghcr.io/mycelium-io/mycelium-backend:${MYCELIUM_IMAGE_TAG:-latest}
     pull_policy: always
     container_name: mycelium-backend
     restart: unless-stopped


### PR DESCRIPTION
Adds a path for cutting release candidates / staging builds against remote test environments without disturbing stable users on \`install.sh\` / \`mycelium upgrade\` / \`mycelium pull\`.

## What was unsafe before

Any \`v*\` tag pushed to \`release.yml\` would:

1. Push \`mycelium-backend:latest\` and \`mycelium-db:latest\` to GHCR — every existing user reaches that on next \`mycelium pull\` (compose.yml has \`pull_policy: always\`).
2. Get the GH "Latest" label, claiming the \`/releases/latest\` redirect that \`install.sh\` and \`mycelium upgrade\` follow.
3. Bump the Homebrew formula.
4. Publish to ClawHub with \`tags: ["latest"]\`.

So there was no way to ship a build for testers to validate without also shipping it to everyone.

## What changes

**Workflow gating** (\`.github/workflows/release.yml\`):
- New \`detect-release-type\` job matches \`rc | alpha | beta | preview\` in the tag.
- \`publish-images\` skips the \`:latest\` Docker tag for prereleases (only the version-pinned tag is pushed).
- GH release marked \`prerelease: true\` so \`/releases/latest\` ignores it.
- \`update-tap\` and \`publish-clawhub\` jobs gated \`if: is_prerelease == 'false'\`.

**Compose tag override** (\`mycelium-cli/src/mycelium/docker/compose.yml\`):
- \`mycelium-backend\` and \`mycelium-db\` now resolve \`\${MYCELIUM_IMAGE_TAG:-latest}\`. Stable defaults unchanged.

**\`mycelium pull --version <tag>\`** (\`mycelium-cli/src/mycelium/commands/instance.py\`):
- Writes \`MYCELIUM_IMAGE_TAG=<tag>\` into \`~/.mycelium/.env\` before compose pull, so the substitution above resolves to the pinned version.
- \`--version latest\` unpins.

**\`/release --preview\` skill** (\`.claude/skills/release/SKILL.md\`):
- Tag scheme \`vX.Y.ZrcN\` (PEP 440, no separator — keeps wheel filename aligned).
- Skips user-facing \`Mycelium Release Notes\` Webex channel; still pings \`IoC::Mycelium Eng\` with the install / upgrade / rollback commands testers need.
- Skips the \`releases/<tag>\` mycelium memory write.

## Tester flow

Fresh remote server:
\`\`\`bash
MYCELIUM_VERSION=0.1.84rc1 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
mycelium pull --version 0.1.84rc1
\`\`\`

Upgrade in place:
\`\`\`bash
mycelium upgrade --version 0.1.84rc1
mycelium pull --version 0.1.84rc1
\`\`\`

Roll back:
\`\`\`bash
mycelium upgrade --version <prev-stable>
mycelium pull --version latest
\`\`\`

## Test plan

- [x] \`yaml.safe_load\` on \`release.yml\` passes
- [x] \`uv run ty check .\` and \`ruff check\` clean for the CLI
- [ ] First real preview cut (\`/release --preview\`) confirms:
  - GH release shows the prerelease badge
  - \`gh release list\` "Latest" still points to the prior stable
  - \`docker pull ghcr.io/mycelium-io/mycelium-backend:latest\` returns the prior stable digest
  - Homebrew tap and ClawHub jobs are skipped in the workflow run