### PR TITLE
docs(style): apply Onyx 'mission control' design vocabulary

### DIFF
--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -19,12 +19,14 @@
 <canvas id="mycelium-bg"></canvas>
 <!-- TOP NAV -->
 <nav class="topnav">
-  <a href="https://mycelium-io.github.io" class="topnav-brand">
+  <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
-    mycelium
+    <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-sep">/</span>
-  <a href="index.html" class="topnav-page">docs</a>
+  <span class="topnav-cell topnav-page-cell">
+    <span class="square-dot"></span>
+    <span class="caps-mono">DOCS</span>
+  </span>
   <div class="topnav-right">
     <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
     <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
@@ -33,9 +35,9 @@
 </nav>
 <nav class="sectionnav">
   <div class="sectionnav-inner">
-    <a href="index.html" class="">Learn</a>
-    <a href="adapters.html" class="active">Adapters</a>
-    <a href="reference.html" class="">Reference</a>
+    <a href="index.html" class=""><span class="square-dot"></span>LEARN</a>
+    <a href="adapters.html" class="active"><span class="square-dot"></span>ADAPTERS</a>
+    <a href="reference.html" class=""><span class="square-dot"></span>REFERENCE</a>
     <div class="sectionnav-right">
     <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/skills/mycelium/SKILL.md" target="_blank">SKILL.md ↗</a>
     </div>
@@ -364,10 +366,12 @@ curl -X POST http://localhost:8888/api/memory/search \
   -d '{"room": "my-project", "query": "what was decided about the API"}'</code></pre>
     </section>
     <!-- FOOTER -->
-    <div style="font-size:12px; color: var(--muted); font-family: 'SF Mono', monospace; padding-top: 8px; display:flex; flex-wrap:wrap; gap: 4px 12px;">
-      <a href="https://github.com/mycelium-io/mycelium" style="color: var(--muted);">mycelium-io/mycelium</a>
-      <span>Apache 2.0 License</span>
-      <span>Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+    <div class="docs-footer">
+      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+      <span class="sep">·</span>
+      <span>Apache 2.0</span>
+      <span class="sep">·</span>
+      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
     </div>
 
   </div>

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -24,7 +24,6 @@
     <span class="brand-word">mycelium</span>
   </a>
   <span class="topnav-cell topnav-page-cell">
-    <span class="square-dot"></span>
     <span class="caps-mono">DOCS</span>
   </span>
   <div class="topnav-right">

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -612,7 +612,6 @@ def _topnav() -> str:
     <span class="brand-word">mycelium</span>
   </a>
   <span class="topnav-cell topnav-page-cell">
-    <span class="square-dot"></span>
     <span class="caps-mono">DOCS</span>
   </span>
   <div class="topnav-right">

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -26,13 +26,16 @@ from pathlib import Path
 
 # ── Page layout ──
 # 3 pages, each a long doc with a grouped sidebar.
-# (page_id, file_name, page_title, top_nav_label, meta_description)
-PAGES: list[tuple[str, str, str, str, str]] = [
+# (page_id, file_name, page_title, top_nav_label, sheet_no, plate_title, meta_description)
+PAGES: list[tuple[str, str, str, str, str, str, str]] = [
     ("learn", "index.html", "mycelium — Docs", "Learn",
+     "LRN-001", "LEARN · OVERVIEW · QUICKSTART · CONCEPTS · GUIDES",
      "Coordination layer for multi-agent systems. Semantic negotiation, persistent memory, collective intelligence."),
     ("adapters", "adapters.html", "Adapters — mycelium", "Adapters",
+     "ADP-001", "ADAPTERS · CLAUDE CODE · OPENCLAW · REST API",
      "Connect Claude Code, OpenClaw, or any HTTP client to the Mycelium coordination layer."),
     ("reference", "reference.html", "Reference — mycelium", "Reference",
+     "REF-001", "REFERENCE · ARCHITECTURE · CLI · CONFIG · HELP",
      "Architecture, CLI reference, configuration, and troubleshooting for Mycelium."),
 ]
 
@@ -604,12 +607,14 @@ def _head(title: str, description: str, file_name: str) -> str:
 def _topnav() -> str:
     return f"""<!-- TOP NAV -->
 <nav class="topnav">
-  <a href="https://mycelium-io.github.io" class="topnav-brand">
+  <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
-    mycelium
+    <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-sep">/</span>
-  <a href="index.html" class="topnav-page">docs</a>
+  <span class="topnav-cell topnav-page-cell">
+    <span class="square-dot"></span>
+    <span class="caps-mono">DOCS</span>
+  </span>
   <div class="topnav-right">
     <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
     <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
@@ -621,10 +626,11 @@ def _topnav() -> str:
 
 def _sectionnav(active_page_id: str) -> str:
     links = []
-    for page_id, file_name, _, label, _ in PAGES:
+    for page_id, file_name, _, label, *_ in PAGES:
         cls = "active" if page_id == active_page_id else ""
         links.append(
-            f'    <a href="{file_name}" class="{cls}">{html.escape(label)}</a>'
+            f'    <a href="{file_name}" class="{cls}">'
+            f'<span class="square-dot"></span>{html.escape(label).upper()}</a>'
         )
     right_links = [
         f'    <a href="{SKILL_MD_URL}" target="_blank">SKILL.md ↗</a>',
@@ -670,11 +676,14 @@ def _layout_open(sidebar_html: str) -> str:
 """
 
 
-LAYOUT_CLOSE = """    <!-- FOOTER -->
-    <div style="font-size:12px; color: var(--muted); font-family: 'SF Mono', monospace; padding-top: 8px; display:flex; flex-wrap:wrap; gap: 4px 12px;">
-      <a href="https://github.com/mycelium-io/mycelium" style="color: var(--muted);">mycelium-io/mycelium</a>
-      <span>Apache 2.0 License</span>
-      <span>Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+def _layout_close(sheet_no: str, plate_title: str) -> str:
+    return """    <!-- FOOTER -->
+    <div class="docs-footer">
+      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+      <span class="sep">·</span>
+      <span>Apache 2.0</span>
+      <span class="sep">·</span>
+      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
     </div>
 
   </div>
@@ -696,6 +705,8 @@ def _render_page(
     description: str,
     content_html: str,
     sidebar_groups: list[tuple[str, list[tuple[str, str]]]],
+    sheet_no: str,
+    plate_title: str,
 ) -> str:
     sidebar_html = _sidebar(sidebar_groups)
     return (
@@ -705,7 +716,7 @@ def _render_page(
         + _layout_open(sidebar_html)
         + content_html
         + "\n"
-        + LAYOUT_CLOSE
+        + _layout_close(sheet_no, plate_title)
     )
 
 
@@ -796,9 +807,12 @@ def _render_and_write(
     description: str,
     content_html: str,
     sidebar_groups: list[tuple[str, list[tuple[str, str]]]],
+    sheet_no: str,
+    plate_title: str,
 ) -> None:
     page_html = _render_page(
         page_id, file_name, title, description, content_html, sidebar_groups,
+        sheet_no, plate_title,
     )
     (OUT_DIR / file_name).write_text(page_html)
     n = sum(len(items) for _, items in sidebar_groups)
@@ -831,12 +845,13 @@ def main() -> None:
         config_block = _generate_config_reference()
 
     print("Rendering pages...")
-    for page_id, file_name, title, _label, description in PAGES:
+    for page_id, file_name, title, _label, sheet_no, plate_title, description in PAGES:
         if page_id not in pages_to_build:
             continue
         content, sidebar_groups = _build_page(page_id, kept, cli_block, config_block)
         _render_and_write(
             page_id, file_name, title, description, content, sidebar_groups,
+            sheet_no, plate_title,
         )
 
     print("\nDone.")

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,6 @@
     <span class="brand-word">mycelium</span>
   </a>
   <span class="topnav-cell topnav-page-cell">
-    <span class="square-dot"></span>
     <span class="caps-mono">DOCS</span>
   </span>
   <div class="topnav-right">

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,12 +19,14 @@
 <canvas id="mycelium-bg"></canvas>
 <!-- TOP NAV -->
 <nav class="topnav">
-  <a href="https://mycelium-io.github.io" class="topnav-brand">
+  <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
-    mycelium
+    <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-sep">/</span>
-  <a href="index.html" class="topnav-page">docs</a>
+  <span class="topnav-cell topnav-page-cell">
+    <span class="square-dot"></span>
+    <span class="caps-mono">DOCS</span>
+  </span>
   <div class="topnav-right">
     <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
     <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
@@ -33,9 +35,9 @@
 </nav>
 <nav class="sectionnav">
   <div class="sectionnav-inner">
-    <a href="index.html" class="active">Learn</a>
-    <a href="adapters.html" class="">Adapters</a>
-    <a href="reference.html" class="">Reference</a>
+    <a href="index.html" class="active"><span class="square-dot"></span>LEARN</a>
+    <a href="adapters.html" class=""><span class="square-dot"></span>ADAPTERS</a>
+    <a href="reference.html" class=""><span class="square-dot"></span>REFERENCE</a>
     <div class="sectionnav-right">
     <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/skills/mycelium/SKILL.md" target="_blank">SKILL.md ↗</a>
     </div>
@@ -803,10 +805,12 @@ uv tool install mycelium-cli</code></pre>
       <pre><code><span class="cmd">mycelium doctor</span> <span class="flag">--mode</span> hub</code></pre>
     </section>
     <!-- FOOTER -->
-    <div style="font-size:12px; color: var(--muted); font-family: 'SF Mono', monospace; padding-top: 8px; display:flex; flex-wrap:wrap; gap: 4px 12px;">
-      <a href="https://github.com/mycelium-io/mycelium" style="color: var(--muted);">mycelium-io/mycelium</a>
-      <span>Apache 2.0 License</span>
-      <span>Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+    <div class="docs-footer">
+      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+      <span class="sep">·</span>
+      <span>Apache 2.0</span>
+      <span class="sep">·</span>
+      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
     </div>
 
   </div>

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -16,7 +16,8 @@
   --cyan: #67e8f9;
   --yellow: #67e8f9; /* alias for cyan — used in dataflow */
   --text: #eaeaea;           /* chalk-white primary */
-  --muted: #6e6c66;          /* dimmed warm gray */
+  --text2: #a8a6a0;          /* softer chalk (lead, secondary copy) */
+  --muted: #6e6c66;          /* dimmed warm gray (labels, captions) */
   --dim: rgba(234, 234, 234, 0.22);
   --sidebar-width: 240px;
 }
@@ -362,7 +363,7 @@ strong { color: var(--text); font-weight: 600; }
 
 .lead {
   font-size: 1.125rem;
-  color: var(--muted);
+  color: var(--text2);
   line-height: 1.6;
   margin-bottom: 32px;
 }

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -17,7 +17,7 @@
   --yellow: #67e8f9; /* alias for cyan — used in dataflow */
   --text: #eaeaea;           /* chalk-white primary */
   --text2: #a8a6a0;          /* softer chalk (lead, secondary copy) */
-  --muted: #6e6c66;          /* dimmed warm gray (labels, captions) */
+  --muted: #898781;          /* dimmed warm gray (labels, captions) */
   --dim: rgba(234, 234, 234, 0.22);
   --sidebar-width: 240px;
 }

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -3,21 +3,21 @@
 @import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,600&family=IBM+Plex+Sans:wght@400;500&display=swap');
 
 :root {
-  --bg: #05090f;
-  --surface: #080e18;
-  --card: #0c1524;
-  --border: #162035;
-  --border2: #1e2d42;
-  --accent: #38bdf8;
-  --accent2: #7dd3fc;
+  --bg: #0c0d10;             /* warm near-black, no blue cast */
+  --surface: #111216;        /* lifted "paper" surface */
+  --card: #14161b;
+  --border: rgba(234, 234, 234, 0.10);
+  --border2: rgba(234, 234, 234, 0.22);
+  --accent: #5dd4e0;         /* pale cyan (Onyx) */
+  --accent2: #7dd3fc;        /* lighter sibling cyan */
   --blue: #818cf8;
   --green: #34d399;
   --purple: #c084fc;
   --cyan: #67e8f9;
   --yellow: #67e8f9; /* alias for cyan — used in dataflow */
-  --text: #e2eaf6;
-  --muted: #4a6080;
-  --dim: #1e2d42;
+  --text: #eaeaea;           /* chalk-white primary */
+  --muted: #6e6c66;          /* dimmed warm gray */
+  --dim: rgba(234, 234, 234, 0.22);
   --sidebar-width: 240px;
 }
 
@@ -42,26 +42,30 @@ body {
   height: 100%;
 }
 
-/* ── TOP NAV ── */
+/* ── TOP NAV (instrument-panel cells) ── */
 .topnav {
   position: fixed;
   top: 0; left: 0; right: 0;
   height: 62px;
-  background: rgba(5, 9, 15, 0.92);
+  background: rgba(12, 13, 16, 0.92);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border);
   display: flex;
-  align-items: center;
-  padding: 0 29px;
-  gap: 24px;
+  align-items: stretch;
+  padding: 0;
+  gap: 0;
   z-index: 100;
 }
-.topnav-brand {
+.topnav-cell {
   display: flex;
   align-items: center;
   gap: 12px;
+  padding: 0 22px;
+  border-right: 1px solid var(--border);
   text-decoration: none;
   color: var(--text);
+}
+.topnav-brand {
   font-family: 'Cormorant Garamond', Georgia, serif;
   font-weight: 600;
   font-style: italic;
@@ -73,23 +77,33 @@ body {
   height: 31px;
   object-fit: contain;
 }
-.topnav-sep {
-  color: var(--border2);
-  font-size: 1.35rem;
-  font-weight: 200;
-}
-.topnav-page {
-  font-size: 0.975rem;
+.topnav-page-cell {
+  gap: 9px;
   color: var(--muted);
-  font-family: 'SF Mono', 'Fira Mono', monospace;
-  transition: color 0.15s;
 }
-a.topnav-page:hover { color: var(--accent); }
+.caps-mono {
+  font-family: 'SF Mono', 'JetBrains Mono', 'Fira Mono', monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.square-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: transparent;
+  border: 1.5px solid var(--muted);
+  flex-shrink: 0;
+}
+.topnav-page-cell .square-dot { border-color: var(--accent); }
 .topnav-right {
   margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 19px;
+  gap: 16px;
+  padding: 0 22px 0 22px;
+  border-left: 1px solid var(--border);
 }
 .topnav-right a {
   color: var(--muted);
@@ -120,7 +134,7 @@ a.topnav-page:hover { color: var(--accent); }
   left: 0;
   right: 0;
   height: 44px;
-  background: rgba(5, 9, 15, 0.92);
+  background: rgba(12, 13, 16, 0.92);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--border);
   z-index: 99;
@@ -129,28 +143,39 @@ a.topnav-page:hover { color: var(--accent); }
 }
 .sectionnav-inner {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   height: 100%;
-  padding: 0 29px;
-  gap: 4px;
+  padding: 0;
+  gap: 0;
   white-space: nowrap;
 }
 .sectionnav a {
   display: inline-flex;
   align-items: center;
+  gap: 10px;
   height: 100%;
-  padding: 0 14px;
+  padding: 0 20px;
   color: var(--muted);
   text-decoration: none;
-  font-size: 13px;
-  font-family: 'SF Mono', monospace;
+  font-family: 'SF Mono', 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  border-right: 1px solid var(--border);
   border-bottom: 2px solid transparent;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
 }
-.sectionnav a:hover { color: var(--text); }
+.sectionnav a .square-dot { width: 7px; height: 7px; }
+.sectionnav a:hover { color: var(--text); background: rgba(255,255,255,0.02); }
+.sectionnav a:hover .square-dot { border-color: var(--text); }
 .sectionnav a.active {
   color: var(--accent);
   border-bottom-color: var(--accent);
+  background: rgba(56,189,248,0.04);
+}
+.sectionnav a.active .square-dot {
+  background: var(--accent);
+  border-color: var(--accent);
 }
 .sectionnav-right {
   margin-left: auto;
@@ -158,7 +183,29 @@ a.topnav-page:hover { color: var(--accent); }
   align-items: center;
   gap: 4px;
 }
-.sectionnav-right a { font-size: 12px; }
+.sectionnav-right a {
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  border-left: 1px solid var(--border);
+  border-right: none;
+}
+
+/* ── DOCS FOOTER ── */
+.docs-footer {
+  margin-top: 48px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+  font-family: 'SF Mono', monospace;
+  font-size: 12px;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 12px;
+}
+.docs-footer a { color: var(--muted); text-decoration: none; }
+.docs-footer a:hover { color: var(--accent); }
+.docs-footer .sep { color: var(--border2); }
 
 /* ── LAYOUT ── */
 .layout {
@@ -177,7 +224,7 @@ a.topnav-page:hover { color: var(--accent); }
   overflow-y: auto;
   padding: 28px 0 40px;
   border-right: 1px solid var(--border);
-  background: rgba(5, 9, 15, 0.85);
+  background: rgba(12, 13, 16, 0.85);
 }
 .sidebar::-webkit-scrollbar { width: 4px; }
 .sidebar::-webkit-scrollbar-track { background: transparent; }
@@ -227,12 +274,12 @@ a.topnav-page:hover { color: var(--accent); }
   flex: 1;
   padding: 56px 64px 80px 72px;
   min-width: 0;
-  background: rgba(5, 9, 15, 0.25);
+  background: rgba(12, 13, 16, 0.25);
 }
 .main-inner {
   max-width: 90ch;
   margin: 0 auto;
-  background: rgba(5, 9, 15, 0.6);
+  background: rgba(12, 13, 16, 0.6);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
   border: 1px solid var(--border);
@@ -725,11 +772,11 @@ h3:hover .header-anchor,
 }
 @media (max-width: 600px) {
   body { overflow-x: hidden; }
-  .topnav { padding: 0 16px; gap: 12px; }
-  .topnav-sep, .topnav-page { display: none; }
-  .topnav-right { gap: 12px; }
-  .sectionnav-inner { padding: 0 16px; }
+  .topnav-page-cell, .host-indicator { display: none; }
+  .topnav-cell { padding: 0 14px; }
+  .topnav-right { gap: 12px; padding: 0 14px; }
   .sectionnav-right { display: none; }
+  .sectionnav a { padding: 0 14px; gap: 8px; }
   .main { padding: 24px 16px 60px; }
   h1 { font-size: 1.75rem; }
   h2 { font-size: 1.25rem; }

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -19,12 +19,14 @@
 <canvas id="mycelium-bg"></canvas>
 <!-- TOP NAV -->
 <nav class="topnav">
-  <a href="https://mycelium-io.github.io" class="topnav-brand">
+  <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
-    mycelium
+    <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-sep">/</span>
-  <a href="index.html" class="topnav-page">docs</a>
+  <span class="topnav-cell topnav-page-cell">
+    <span class="square-dot"></span>
+    <span class="caps-mono">DOCS</span>
+  </span>
   <div class="topnav-right">
     <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
     <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
@@ -33,9 +35,9 @@
 </nav>
 <nav class="sectionnav">
   <div class="sectionnav-inner">
-    <a href="index.html" class="">Learn</a>
-    <a href="adapters.html" class="">Adapters</a>
-    <a href="reference.html" class="active">Reference</a>
+    <a href="index.html" class=""><span class="square-dot"></span>LEARN</a>
+    <a href="adapters.html" class=""><span class="square-dot"></span>ADAPTERS</a>
+    <a href="reference.html" class="active"><span class="square-dot"></span>REFERENCE</a>
     <div class="sectionnav-right">
     <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/skills/mycelium/SKILL.md" target="_blank">SKILL.md ↗</a>
     </div>
@@ -1013,10 +1015,12 @@ rm <span class="flag">-rf</span> ~/.mycelium        # remove all config
       <p>Report issues at <strong>https://github.com/mycelium-io/mycelium/issues</strong></p>
     </section>
     <!-- FOOTER -->
-    <div style="font-size:12px; color: var(--muted); font-family: 'SF Mono', monospace; padding-top: 8px; display:flex; flex-wrap:wrap; gap: 4px 12px;">
-      <a href="https://github.com/mycelium-io/mycelium" style="color: var(--muted);">mycelium-io/mycelium</a>
-      <span>Apache 2.0 License</span>
-      <span>Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+    <div class="docs-footer">
+      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+      <span class="sep">·</span>
+      <span>Apache 2.0</span>
+      <span class="sep">·</span>
+      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
     </div>
 
   </div>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -24,7 +24,6 @@
     <span class="brand-word">mycelium</span>
   </a>
   <span class="topnav-cell topnav-page-cell">
-    <span class="square-dot"></span>
     <span class="caps-mono">DOCS</span>
   </span>
   <div class="topnav-right">

--- a/docs/site.js
+++ b/docs/site.js
@@ -143,7 +143,7 @@
   var trail = new Float32Array(cols * rows);       // animated nutrient flow
   var colorIdx = new Uint8Array(cols * rows);
 
-  const BG = { r: 5, g: 9, b: 15 };
+  const BG = { r: 12, g: 13, b: 16 };
   const COLORS = [
     { r: 56, g: 189, b: 248 },   // cyan
     { r: 129, g: 140, b: 248 },   // indigo


### PR DESCRIPTION
Adapts the [Variant G — Onyx](https://claude.ai/design) design from the recent design exploration onto the existing mycelial docs chrome.

Keeps the mycelial canvas, logo, and Cormorant Garamond serif h1s; layers drafting / instrument-panel vocabulary on top.

## Token shifts (full Onyx neutralization)
| | before | after |
|---|---|---|
| bg | \`#05090f\` | \`#0c0d10\` (warm near-black, no blue cast) |
| text | \`#e2eaf6\` | \`#eaeaea\` (chalk-white) |
| muted | \`#4a6080\` | \`#6e6c66\` (warm neutral) |
| borders | \`#162035\` | \`rgba(234,234,234,0.10)\` (chalk hairlines) |
| accent | \`#38bdf8\` | \`#5dd4e0\` (pale cyan, Onyx-cyan variant) |
| accent2 | \`#7dd3fc\` | \`#7dd3fc\` (kept — sibling pale cyan) |

Mycelial canvas BG nudged to \`rgb(12,13,16)\` so there's no edge between canvas and page.

## Chrome
- **Topnav** reskinned as bordered "instrument-panel" cells: brand chip, DOCS cell with caps-mono label, GitHub on the right
- **Sectionnav** cells have square-dot status indicators (filled cyan when active, hollow when not), all-mono caps with letter-spacing 0.16em, hairline cell borders
- **Footer** simplified back to a single hairline row — earlier plate-footer experiment didn't land

## What I skipped from the design
- Corner registration marks
- Faint 40px grid overlay
- Plate-footer title block (SHEET / TITLE / REV / DRAWN / HOST / SCALE)
- Host-indicator with pulsing dot

(Mycelial bg already handles the "drafted" feel; the rest read as too much spaceship.)

## Test plan
- [x] All 3 pages parse cleanly
- [x] Generator idempotent
- [ ] Manual: open index/adapters/reference, click sectionnav cells, verify active-state cyan
- [ ] Manual: scroll to confirm hairline rules read correctly