### PR TITLE
feat(frontend): redesign + ship the UI via mycelium up --ui

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
               echo "backend<<EOF"
               echo "ghcr.io/$OWNER/mycelium-backend:$VERSION"
               echo "EOF"
+              echo "frontend<<EOF"
+              echo "ghcr.io/$OWNER/mycelium-frontend:$VERSION"
+              echo "EOF"
             } >> "$GITHUB_OUTPUT"
           else
             {
@@ -79,6 +82,10 @@ jobs:
               echo "backend<<EOF"
               echo "ghcr.io/$OWNER/mycelium-backend:latest"
               echo "ghcr.io/$OWNER/mycelium-backend:$VERSION"
+              echo "EOF"
+              echo "frontend<<EOF"
+              echo "ghcr.io/$OWNER/mycelium-frontend:latest"
+              echo "ghcr.io/$OWNER/mycelium-frontend:$VERSION"
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
           fi
@@ -104,6 +111,22 @@ jobs:
           tags: ${{ steps.tags.outputs.backend }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mycelium-backend:cache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mycelium-backend:cache,mode=max
+
+      - name: Build and push mycelium-frontend
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: mycelium-frontend
+          file: mycelium-frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          # NEXT_PUBLIC_API_URL is baked at build time — keep the published
+          # image pointing at the default local-install backend port. Users
+          # with custom setups can rebuild the image with --build-arg API_URL=…
+          build-args: |
+            API_URL=http://localhost:8000
+          tags: ${{ steps.tags.outputs.frontend }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mycelium-frontend:cache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/mycelium-frontend:cache,mode=max
 
   build-binaries:
     needs: publish-images

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ Mycelium — multi-agent coordination + persistent memory, built on the Internet
 fastapi-backend/    FastAPI coordination engine (Python 3.12, asyncpg, SQLAlchemy)
 mycelium-cli/       CLI tool (typer, Rich, typed OpenAPI client)
 mycelium-client/    Generated OpenAPI client (openapi-python-client)
-mycelium-frontend/  Next.js room viewer (TypeScript, Tailwind)
+mycelium-frontend/  Next.js frontend (TypeScript, Tailwind)
 docs/               Presentation deck, demo script
 ```
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -227,6 +227,6 @@ Give this to the second Claude Code instance:
 ### Key URLs during demo
 
 - Frontend: `http://localhost:3000`
-- Room viewer: `http://localhost:3000/room/design-review`
+- Frontend: `http://localhost:3000/room/design-review`
 - Presentation deck: `docs/mycelium-dataflow.html`
 - Backend API docs: `http://localhost:8888/docs`

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -23,6 +23,7 @@ from mycelium.commands import (
     negotiate,
     room,
     session,
+    ui,
 )
 
 app = typer.Typer(
@@ -128,6 +129,7 @@ app.add_typer(memory.app, name="memory")
 app.add_typer(config.app, name="config")
 app.add_typer(adapter.app, name="adapter")
 app.add_typer(docs.app, name="docs")
+app.add_typer(ui.app, name="ui")
 app.add_typer(session.app, name="session")
 app.add_typer(cfn.app, name="cfn")
 

--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -901,6 +901,11 @@ def install(
         0, "--backend-port", help="Host port for backend API (0 = auto-detect, default 8000)"
     ),
     ioc: bool = typer.Option(True, "--ioc/--no-ioc", help="Enable IoC CFN stack (default: on)"),
+    ui: bool = typer.Option(
+        True,
+        "--ui/--no-ui",
+        help="Bring up the frontend (default: on; interactive mode prompts to confirm)",
+    ),
     force: bool = typer.Option(
         False, "--force", help="Force full reinstall even if already installed"
     ),
@@ -981,11 +986,21 @@ def install(
                 )
                 compose_profiles.append("cfn")
 
+            # Non-interactive: trust the --ui/--no-ui flag, never prompt.
+            enable_ui = ui
+            if enable_ui:
+                compose_profiles.append("ui")
+
             # Resolve ports — use explicit flags, or auto-detect conflicts
-            default_ports = {"db": db_port or 5432, "backend": backend_port or 8000}
-            if not db_port or not backend_port:
+            default_ports: dict[str, int] = {
+                "db": db_port or 5432,
+                "backend": backend_port or 8000,
+            }
+            if enable_ui:
+                default_ports["ui"] = 3000
+            if not db_port or not backend_port or enable_ui:
                 busy = _check_ports(list(default_ports.values()))
-                for label, port in default_ports.items():
+                for label, port in list(default_ports.items()):
                     if port in busy:
                         new_port = port + 1
                         while new_port in busy or new_port in default_ports.values():
@@ -998,6 +1013,8 @@ def install(
             custom_ports = default_ports
             llm_config["MYCELIUM_DB_PORT"] = str(custom_ports["db"])
             llm_config["MYCELIUM_BACKEND_PORT"] = str(custom_ports["backend"])
+            if enable_ui:
+                llm_config["MYCELIUM_UI_PORT"] = str(custom_ports["ui"])
             llm_config["MYCELIUM_DATA_DIR"] = str(Path.home() / ".mycelium")
 
             typer.secho(
@@ -1085,6 +1102,11 @@ def install(
                 _report_llm_probe_result(status, model, msg, remediation, interactive=False)
 
             typer.secho("  ✓ Done.", fg=typer.colors.GREEN, bold=True)
+            typer.echo(f"  mycelium-backend  → {api_url}")
+            if enable_ui:
+                ui_url = f"http://localhost:{custom_ports['ui']}"
+                typer.echo(f"  mycelium-frontend → {ui_url}")
+                typer.echo("  Open it with: mycelium ui open")
             return
 
         if not sys.stdin.isatty():
@@ -1243,8 +1265,18 @@ def install(
             llm_config["COGNITION_FABRIC_NODE_URL"] = "http://ioc-cognition-fabric-node-svc:9002"
             compose_profiles.append("cfn")
 
+        # Frontend prompt — default to the --ui flag value (True unless --no-ui).
+        enable_ui = ui and typer.confirm(
+            "  Bring up the frontend (browser at http://localhost:3000)?",
+            default=True,
+        )
+        if enable_ui:
+            compose_profiles.append("ui")
+
         # Port check — allow user to pick alternatives
-        default_ports = {"db": 5432, "backend": 8000}
+        default_ports: dict[str, int] = {"db": 5432, "backend": 8000}
+        if enable_ui:
+            default_ports["ui"] = 3000
         ports_to_check = list(default_ports.values())
         busy_ports = _check_ports(ports_to_check)
         custom_ports = dict(default_ports)
@@ -1263,6 +1295,8 @@ def install(
             # Update llm_config with custom ports for env file
             llm_config["MYCELIUM_DB_PORT"] = str(custom_ports["db"])
             llm_config["MYCELIUM_BACKEND_PORT"] = str(custom_ports["backend"])
+            if enable_ui:
+                llm_config["MYCELIUM_UI_PORT"] = str(custom_ports["ui"])
 
         # Set MYCELIUM_DATA_DIR so compose mounts the host's .mycelium/ into the container
         llm_config["MYCELIUM_DATA_DIR"] = str(Path.home() / ".mycelium")
@@ -1383,11 +1417,16 @@ def install(
         typer.echo("  Services:")
         typer.echo(f"    mycelium-backend  → {api_url}")
         typer.echo(f"    mycelium-db       → localhost:{custom_ports['db']}")
+        if enable_ui:
+            ui_url = f"http://localhost:{custom_ports['ui']}"
+            typer.echo(f"    mycelium-frontend → {ui_url}")
         typer.echo("    graph-db-viewer   → http://localhost:5457  (dev profile only)")
         print()
         typer.echo("  Next steps:")
         typer.echo("    mycelium adapter add openclaw   # wire openclaw agents")
         typer.echo("    mycelium room create <name>     # create your first room")
+        if enable_ui:
+            typer.echo("    mycelium ui open                # open the frontend in your browser")
         print()
 
     except KeyboardInterrupt:

--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -296,13 +296,14 @@ def init(
 
 
 @doc_ref(
-    usage="mycelium up [--build]",
+    usage="mycelium up [--build] [--ui]",
     desc="Start the Mycelium stack via <code>docker compose up</code>.",
     group="setup",
 )
 def start(
     ctx: typer.Context,
     build: bool = typer.Option(False, "--build", help="Rebuild images before starting"),
+    ui: bool = typer.Option(False, "--ui", help="Also start the frontend (mycelium-frontend)"),
 ) -> None:
     """
     Start Mycelium services.
@@ -313,6 +314,7 @@ def start(
     Examples:
         mycelium up          # start all services
         mycelium up --build  # rebuild images first
+        mycelium up --ui     # also start the frontend at http://localhost:3000
     """
     try:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
@@ -327,6 +329,8 @@ def start(
         base = _compose_base_cmd(compose_path)
         if cfn:
             base = base + ["--profile", "cfn"]
+        if ui:
+            base = base + ["--profile", "ui"]
         up_args = ["up", "-d", "--remove-orphans"]
         if build:
             up_args.append("--build")
@@ -381,6 +385,8 @@ def start(
 
         typer.secho("Services started.", fg=typer.colors.GREEN)
         typer.echo("  mycelium-backend  → http://localhost:8000")
+        if ui:
+            typer.echo("  mycelium-frontend → http://localhost:3000")
 
     except typer.Exit:
         raise

--- a/mycelium-cli/src/mycelium/commands/ui.py
+++ b/mycelium-cli/src/mycelium/commands/ui.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""
+`mycelium ui` — manage the optional frontend.
+
+The frontend ships as a separate Docker image gated behind the `ui` profile
+in the bundled compose file. It runs at http://localhost:3000 by default and
+talks to the backend at http://localhost:<backend_port> (baked into the
+image at build time — see mycelium-frontend/Dockerfile).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import webbrowser
+
+import typer
+
+from mycelium.config import MyceliumConfig
+from mycelium.doc_ref import doc_ref
+
+app = typer.Typer(
+    name="ui",
+    help="Manage the optional frontend.",
+    no_args_is_help=True,
+)
+
+# Container name set in the bundled compose.yml.
+_FRONTEND_CONTAINER = "mycelium-frontend"
+_DEFAULT_PORT = 3000
+
+
+def _ui_url() -> str:
+    """The URL the user opens in their browser. Honors MYCELIUM_UI_PORT."""
+    port = os.environ.get("MYCELIUM_UI_PORT") or str(_DEFAULT_PORT)
+    return f"http://localhost:{port}"
+
+
+def _container_running(name: str) -> bool:
+    """True if a Docker container with this name is currently running."""
+    if not shutil.which("docker"):
+        return False
+    r = subprocess.run(
+        ["docker", "ps", "--filter", f"name=^{name}$", "--format", "{{.Names}}"],
+        capture_output=True,
+        text=True,
+    )
+    return r.returncode == 0 and name in r.stdout.strip().splitlines()
+
+
+@doc_ref(
+    usage="mycelium ui open",
+    desc="Open the frontend in your default browser.",
+    group="setup",
+)
+def ui_open() -> None:
+    """Open the frontend in your default browser.
+
+    Tries to launch the OS default browser at http://localhost:<port>.
+    Doesn't check whether the frontend container is actually up — use
+    `mycelium ui status` for that.
+
+    Examples:
+        mycelium ui open
+    """
+    url = _ui_url()
+    if not _container_running(_FRONTEND_CONTAINER):
+        typer.secho(
+            f"⚠ {_FRONTEND_CONTAINER} is not running — opening anyway.",
+            fg=typer.colors.YELLOW,
+        )
+        typer.echo("  Start it with: mycelium up --ui")
+    typer.echo(f"Opening {url}")
+    webbrowser.open(url)
+
+
+@doc_ref(
+    usage="mycelium ui status",
+    desc="Show whether the frontend container is running.",
+    group="setup",
+)
+def ui_status() -> None:
+    """Show whether the frontend container is running.
+
+    Examples:
+        mycelium ui status
+    """
+    url = _ui_url()
+    if _container_running(_FRONTEND_CONTAINER):
+        typer.secho(f"✓ {_FRONTEND_CONTAINER} is running", fg=typer.colors.GREEN)
+        typer.echo(f"  URL: {url}")
+    else:
+        typer.secho(f"✗ {_FRONTEND_CONTAINER} is not running", fg=typer.colors.RED)
+        typer.echo("  Start it with: mycelium up --ui")
+        # Surface the configured backend so the user can sanity-check.
+        try:
+            cfg = MyceliumConfig.load()
+            typer.echo(f"  Backend: {cfg.server.api_url}")
+        except Exception:
+            pass
+
+
+app.command(name="open")(ui_open)
+app.command(name="status")(ui_status)

--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -68,6 +68,31 @@ services:
       retries: 6
       start_period: 15s
 
+  # ── Frontend (profile: ui) ───────────────────────────────────────────────
+  #
+  # Next.js frontend for browsing rooms, sessions, memory, and live negotiation.
+  # Opt-in via `mycelium up --ui` (or `--profile ui` directly). The browser
+  # reads the backend at the URL baked into the image at build time —
+  # http://localhost:<backend_port> for the standard local install.
+
+  mycelium-frontend:
+    build:
+      context: ../../../../mycelium-frontend
+      dockerfile: Dockerfile
+    image: ghcr.io/mycelium-io/mycelium-frontend:${MYCELIUM_IMAGE_TAG:-latest}
+    pull_policy: always
+    container_name: mycelium-frontend
+    restart: unless-stopped
+    profiles: [ui]
+    env_file:
+      - path: ../.env
+        required: false
+    depends_on:
+      mycelium-backend:
+        condition: service_healthy
+    ports:
+      - "${MYCELIUM_UI_PORT:-3000}:3000"
+
   # ── Graph Viewer (optional, for development) ─────────────────────────────────
 
   mycelium-graph-viewer:

--- a/mycelium-cli/src/mycelium/docs/architecture.md
+++ b/mycelium-cli/src/mycelium/docs/architecture.md
@@ -66,7 +66,7 @@ with multi-model support. No external message broker, no separate vector databas
 | LLM | litellm | synthesis, extraction, negotiation (100+ providers) |
 | Backend | FastAPI + asyncpg + SQLAlchemy | coordination engine API |
 | CLI | Typer + Rich | agent interface |
-| Frontend | Next.js + Tailwind | room viewer UI |
+| Frontend | Next.js + Tailwind | frontend UI |
 
 ## Adapters
 

--- a/mycelium-frontend/.env.example
+++ b/mycelium-frontend/.env.example
@@ -1,7 +1,10 @@
 # Mycelium room viewer — environment variables
 #
-# Point the frontend at your running mycelium backend. Local `mycelium
-# backend` serves on 8001 by default; the fastapi-backend Dockerfile / start
-# script listens on 8000. Match whichever is actually running on your box.
+# Optional. By default `next.config.ts` reads `server.api_url` from
+# ~/.mycelium/config.toml (the same source the CLI + adapters use), and
+# falls back to http://localhost:8000.
+#
+# Set this to override — e.g. when pointing the frontend at a remote
+# backend or running multiple stacks side by side.
 
-NEXT_PUBLIC_API_URL=http://localhost:8001
+# NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/mycelium-frontend/Dockerfile
+++ b/mycelium-frontend/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1.7
+#
+# Mycelium frontend — Next.js production build.
+#
+# The browser-side bundle has the backend URL baked in at build time
+# (NEXT_PUBLIC_API_URL is replaced by Next during `next build`). For the
+# default `mycelium install` path the browser runs on the host and reaches
+# the backend at http://localhost:<backend_port>, so that's the bake-time
+# default. Override at build time for non-default setups:
+#
+#   docker build --build-arg API_URL=http://my-backend.internal:8000 .
+#
+# This is the cheapest possible "ship the UI to users" path. A future PR
+# can add runtime URL injection (server-side /api/_config endpoint that
+# reads the env at request time) for users with remote backends.
+
+# ─── deps ─────────────────────────────────────────────────────────────────────
+FROM node:22-alpine AS deps
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ─── build ────────────────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+WORKDIR /app
+
+ARG API_URL=http://localhost:8000
+ENV NEXT_PUBLIC_API_URL=${API_URL}
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN npm run build
+
+# ─── runtime ──────────────────────────────────────────────────────────────────
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser --system --uid 1001 nextjs
+
+# next.config.ts has output: "standalone", so .next/standalone is a self-
+# contained server bundle (small subset of node_modules + server.js).
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/mycelium-frontend/next.config.ts
+++ b/mycelium-frontend/next.config.ts
@@ -36,6 +36,8 @@ const apiUrl = resolveApiUrl();
 console.log(`[mycelium-frontend] backend → ${apiUrl}`);
 
 const nextConfig: NextConfig = {
+  // Standalone output → minimal Docker image (no full node_modules in runtime layer)
+  output: "standalone",
   env: {
     NEXT_PUBLIC_API_URL: apiUrl,
   },

--- a/mycelium-frontend/next.config.ts
+++ b/mycelium-frontend/next.config.ts
@@ -1,6 +1,44 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Julia Valenti
 
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { NextConfig } from "next";
-const nextConfig: NextConfig = {};
+
+/**
+ * Resolve the backend URL with the same precedence the rest of the project uses:
+ *   1. NEXT_PUBLIC_API_URL  (.env.local override / CI / prod)
+ *   2. server.api_url from ~/.mycelium/config.toml  (matches the CLI + adapters)
+ *   3. http://localhost:8000  (mycelium install default)
+ *
+ * Config-toml read is best-effort and only happens at `next dev` / `next build`
+ * — failures fall through silently to the default.
+ */
+function resolveApiUrl(): string {
+  if (process.env.NEXT_PUBLIC_API_URL) return process.env.NEXT_PUBLIC_API_URL;
+  try {
+    const path = join(homedir(), ".mycelium", "config.toml");
+    const text = readFileSync(path, "utf8");
+    // Match `api_url = "..."` under any section. Prefer [server].api_url if present.
+    const serverMatch = text.match(/\[server\][\s\S]*?\n\s*api_url\s*=\s*"([^"]+)"/);
+    if (serverMatch) return serverMatch[1];
+    const anyMatch = text.match(/^\s*api_url\s*=\s*"([^"]+)"/m);
+    if (anyMatch) return anyMatch[1];
+  } catch {
+    /* no config — fall through */
+  }
+  return "http://localhost:8000";
+}
+
+const apiUrl = resolveApiUrl();
+// eslint-disable-next-line no-console
+console.log(`[mycelium-frontend] backend → ${apiUrl}`);
+
+const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_API_URL: apiUrl,
+  },
+};
+
 export default nextConfig;

--- a/mycelium-frontend/package-lock.json
+++ b/mycelium-frontend/package-lock.json
@@ -12,6 +12,9 @@
         "next": "^16.2.4",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-markdown": "^10.1.0",
+        "react-resizable-panels": "^4.10.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -26,6 +29,8 @@
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -35,8 +40,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -45,6 +62,8 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -63,8 +82,32 @@
         "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -73,6 +116,402 @@
       "os": [
         "darwin"
       ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -263,6 +702,8 @@
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -491,70 +932,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
@@ -603,8 +980,58 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -613,7 +1040,8 @@
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -621,14 +1049,40 @@
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.18",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -638,7 +1092,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001787",
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -655,28 +1111,147 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
     "node_modules/clsx": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -693,12 +1268,152 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -971,6 +1686,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -981,8 +1706,859 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
@@ -1052,6 +2628,8 @@
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1076,8 +2654,35 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/postcss": {
@@ -1109,8 +2714,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1118,6 +2735,8 @@
     },
     "node_modules/react-dom": {
       "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
@@ -1126,12 +2745,119 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.10.0.tgz",
+      "integrity": "sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -1143,6 +2869,8 @@
     },
     "node_modules/sharp": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -1186,13 +2914,59 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
@@ -1214,6 +2988,8 @@
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1241,8 +3017,30 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/typescript": {
@@ -1261,8 +3059,135 @@
     },
     "node_modules/undici-types": {
       "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/mycelium-frontend/package.json
+++ b/mycelium-frontend/package.json
@@ -12,6 +12,9 @@
     "next": "^16.2.4",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-markdown": "^10.1.0",
+    "react-resizable-panels": "^4.10.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {

--- a/mycelium-frontend/src/app/globals.css
+++ b/mycelium-frontend/src/app/globals.css
@@ -1,41 +1,82 @@
 @import "tailwindcss";
 
 @theme {
-  --color-bg: #050a12;
-  --color-surface: #0c1524;
-  --color-border: #162035;
-  --color-accent: #38bdf8;
-  --color-muted: #4a6080;
+  --color-bg: #0c0d10;
+  --color-surface: #111216;
+  --color-paper: #14161b;
+  --color-border: rgba(234, 234, 234, 0.10);
+  --color-border2: rgba(234, 234, 234, 0.22);
+  --color-accent: #5dd4e0;
+  --color-text: #eaeaea;
+  --color-text2: #a8a6a0;
+  --color-muted: #898781;
+  --color-dim: #46443e;
 }
 
 :root {
-  --bg: #050a12;
-  --surface: #0c1524;
-  --card: #0c1524;
-  --border: #162035;
-  --accent: #38bdf8;
+  --bg: #0c0d10;
+  --surface: #111216;
+  --paper: #14161b;
+  --card: #14161b;
+  --border: rgba(234, 234, 234, 0.10);
+  --border2: rgba(234, 234, 234, 0.22);
+  --accent: #5dd4e0;
+  --accent2: #7dd3fc;
   --green: #34d399;
   --purple: #c084fc;
   --yellow: #fbbf24;
-  --text: #e2eaf6;
-  --muted: #4a6080;
+  --text: #eaeaea;
+  --text2: #a8a6a0;
+  --muted: #898781;
+  --dim: #46443e;
 }
 
 body {
   background: var(--bg);
   color: var(--text);
+  font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 ::-webkit-scrollbar {
   width: 6px;
+  height: 6px;
 }
-::-webkit-scrollbar-track {
-  background: transparent;
-}
+::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
-  background: #1e2d42;
-  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.10);
+  border-radius: 0;
 }
-::-webkit-scrollbar-thumb:hover {
-  background: #2a3f5a;
+::-webkit-scrollbar-thumb:hover { background: rgba(255, 255, 255, 0.18); }
+
+/* ── Onyx atoms (used by RM-000 + future screens) ── */
+
+.caps-mono {
+  font-family: 'SF Mono', 'JetBrains Mono', 'Fira Mono', Menlo, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
+.caps-mono-sm {
+  font-family: 'SF Mono', 'JetBrains Mono', 'Fira Mono', Menlo, monospace;
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.square-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: transparent;
+  border: 1.5px solid currentColor;
+  flex-shrink: 0;
+}
+.square-dot.filled { background: currentColor; }
+.square-dot.pulse { animation: myc-pulse 1.6s ease-in-out infinite; }
+@keyframes myc-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.tabular { font-variant-numeric: tabular-nums; }

--- a/mycelium-frontend/src/app/globals.css
+++ b/mycelium-frontend/src/app/globals.css
@@ -9,8 +9,26 @@
   --color-accent: #5dd4e0;
   --color-text: #eaeaea;
   --color-text2: #a8a6a0;
-  --color-muted: #898781;
+  --color-muted: #b8b5ae;
   --color-dim: #46443e;
+
+  /* ── font-size scale ─────────────────────────────────────────────────
+   * Five semantic tokens. Pick by role, not pixels.
+   *   text-micro   counts, timestamps, tabular nums, decorations
+   *   text-label   caps-mono labels (uppercase, tracked)
+   *   text-body    default table cells, secondary copy
+   *   text-ui      room names, prominent identifiers
+   *   text-display serif brand wordmark
+   * ──────────────────────────────────────────────────────────────────── */
+  --text-micro:   12px;
+  --text-label:   14px;
+  --text-body:    15px;
+  --text-ui:      16px;
+  --text-display: 25px;
+
+  --font-mono: "Geist Mono", "SF Mono", "JetBrains Mono", Menlo, monospace;
+  --font-sans: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-serif: "Cormorant Garamond", Georgia, serif;
 }
 
 :root {
@@ -27,10 +45,14 @@
   --yellow: #fbbf24;
   --text: #eaeaea;
   --text2: #a8a6a0;
-  --muted: #898781;
+  --muted: #b8b5ae;
   --dim: #46443e;
 }
 
+html {
+  /* +25% — scales rem-based Tailwind defaults (text-xs/sm/base etc) */
+  font-size: 20px;
+}
 body {
   background: var(--bg);
   color: var(--text);
@@ -51,15 +73,15 @@ body {
 /* ── Onyx atoms (used by RM-000 + future screens) ── */
 
 .caps-mono {
-  font-family: 'SF Mono', 'JetBrains Mono', 'Fira Mono', Menlo, monospace;
-  font-size: 11px;
+  font-family: 'Geist Mono', 'SF Mono', 'JetBrains Mono', Menlo, monospace;
+  font-size: var(--text-label);
   font-weight: 600;
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
 .caps-mono-sm {
-  font-family: 'SF Mono', 'JetBrains Mono', 'Fira Mono', Menlo, monospace;
-  font-size: 9.5px;
+  font-family: 'Geist Mono', 'SF Mono', 'JetBrains Mono', Menlo, monospace;
+  font-size: var(--text-micro);
   font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -80,3 +102,76 @@ body {
 }
 
 .tabular { font-variant-numeric: tabular-nums; }
+
+/* ── markdown body ── */
+.markdown-body { color: inherit; }
+.markdown-body > *:first-child { margin-top: 0; }
+.markdown-body > *:last-child { margin-bottom: 0; }
+.markdown-body p { margin: 0.5em 0; line-height: 1.55; color: var(--text2); }
+.markdown-body strong { color: var(--text); font-weight: 600; }
+.markdown-body em { font-style: italic; color: var(--text); }
+.markdown-body ul, .markdown-body ol { margin: 0.5em 0; padding-left: 1.5em; }
+.markdown-body ul { list-style: disc; }
+.markdown-body ol { list-style: decimal; }
+.markdown-body li { margin: 0.15em 0; line-height: 1.55; color: var(--text2); }
+.markdown-body li::marker { color: var(--muted); }
+.markdown-body h1, .markdown-body h2, .markdown-body h3, .markdown-body h4 {
+  margin: 0.8em 0 0.4em; color: var(--text); font-weight: 700; line-height: 1.25;
+  font-family: 'IBM Plex Sans', sans-serif;
+}
+.markdown-body h1 { font-size: var(--text-ui); }
+.markdown-body h2 { font-size: var(--text-body); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text2); }
+.markdown-body h3 { font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); }
+.markdown-body h4 { font-size: var(--text-label); color: var(--text2); }
+.markdown-body code {
+  font-family: 'Geist Mono', 'SF Mono', Menlo, monospace;
+  font-size: 0.9em;
+  padding: 1px 5px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 3px;
+  color: var(--accent);
+}
+.markdown-body pre {
+  margin: 0.5em 0;
+  padding: 10px 12px;
+  background: rgba(255,255,255,0.04);
+  border-left: 2px solid var(--border2);
+  overflow-x: auto;
+  font-family: 'Geist Mono', 'SF Mono', Menlo, monospace;
+  font-size: var(--text-micro);
+  line-height: 1.5;
+}
+.markdown-body pre code {
+  background: none;
+  padding: 0;
+  color: var(--text);
+}
+.markdown-body blockquote {
+  margin: 0.5em 0;
+  padding-left: 12px;
+  border-left: 2px solid var(--border2);
+  color: var(--muted);
+  font-style: italic;
+}
+.markdown-body table {
+  border-collapse: collapse;
+  margin: 0.5em 0;
+  font-size: var(--text-label);
+}
+.markdown-body th, .markdown-body td {
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  text-align: left;
+}
+.markdown-body th {
+  background: rgba(255,255,255,0.04);
+  font-weight: 600;
+  color: var(--text);
+  text-transform: uppercase;
+  font-family: 'Geist Mono', 'SF Mono', Menlo, monospace;
+  font-size: var(--text-micro);
+  letter-spacing: 0.08em;
+}
+.markdown-body td { color: var(--text2); }
+.markdown-body hr { border: none; border-top: 1px solid var(--border); margin: 0.8em 0; }
+.markdown-body a { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; }

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -12,7 +12,14 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="dark">
-      <body className="min-h-screen bg-bg text-[#e2eaf6] antialiased">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,600&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body className="min-h-screen bg-bg text-text antialiased">
         {children}
       </body>
     </html>

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
-          href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,600&family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,600&family=IBM+Plex+Sans:wght@400;500;600&family=Geist+Mono:wght@400;500;600;700&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/mycelium-frontend/src/app/page.tsx
+++ b/mycelium-frontend/src/app/page.tsx
@@ -3,54 +3,19 @@
 
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import Image from "next/image";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { fetchRooms } from "@/lib/api";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
+import { MainTopBar } from "@/components/main-top-bar";
+import { IDChip } from "@/components/id-chip";
 
 interface Room {
   name: string;
-  coordination_state: string;
   created_at: string;
   parent_namespace: string | null;
   is_namespace: boolean;
   is_persistent: boolean;
-}
-
-const NAV_TABS = [
-  { id: "rooms", label: "ROOMS", href: "/" },
-  { id: "memory", label: "MEMORY" },
-  { id: "agents", label: "AGENTS" },
-  { id: "logs", label: "LOGS" },
-];
-
-const ACTIVITY_FILTERS: { id: string; label: string; predicate: (r: Room) => boolean }[] = [
-  { id: "all", label: "all", predicate: () => true },
-  { id: "negotiating", label: "negotiating", predicate: r => r.coordination_state === "negotiating" },
-  { id: "waiting", label: "waiting", predicate: r => r.coordination_state === "waiting" },
-  { id: "synthesizing", label: "synthesizing", predicate: r => r.coordination_state === "synthesizing" },
-  { id: "complete", label: "complete", predicate: r => r.coordination_state === "complete" },
-  { id: "idle", label: "idle", predicate: r => r.coordination_state === "idle" || !r.coordination_state },
-];
-
-const STATE_TONE: Record<string, "accent" | "muted" | "warn" | "ok"> = {
-  negotiating: "accent",
-  waiting: "warn",
-  synthesizing: "accent",
-  complete: "ok",
-  idle: "muted",
-  failed: "warn",
-};
-
-function namespaceOf(room: Room): string {
-  if (room.parent_namespace) return room.parent_namespace;
-  // Derive a namespace from the leftmost segment of the name.
-  const slash = room.name.indexOf("/");
-  if (slash > 0) return room.name.slice(0, slash);
-  const colon = room.name.indexOf(":");
-  if (colon > 0) return room.name.slice(0, colon);
-  return room.name;
 }
 
 function relativeTime(iso: string): string {
@@ -72,8 +37,6 @@ function relativeTime(iso: string): string {
 export default function Dashboard() {
   const [rooms, setRooms] = useState<Room[]>([]);
   const [showCreate, setShowCreate] = useState(false);
-  const [activity, setActivity] = useState("all");
-  const [ns, setNs] = useState("all");
 
   const load = () =>
     fetchRooms()
@@ -86,220 +49,70 @@ export default function Dashboard() {
     return () => clearInterval(interval);
   }, []);
 
-  const namespaces = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const r of rooms) {
-      const k = namespaceOf(r);
-      counts.set(k, (counts.get(k) ?? 0) + 1);
-    }
-    return Array.from(counts.entries()).sort((a, b) => a[0].localeCompare(b[0]));
-  }, [rooms]);
-
-  const activityCounts = useMemo(() => {
-    return ACTIVITY_FILTERS.map(f => [f.id, rooms.filter(f.predicate).length] as const);
-  }, [rooms]);
-
-  const visible = useMemo(() => {
-    let out = rooms;
-    const filter = ACTIVITY_FILTERS.find(f => f.id === activity);
-    if (filter && activity !== "all") out = out.filter(filter.predicate);
-    if (ns !== "all") out = out.filter(r => namespaceOf(r) === ns);
-    return out;
-  }, [rooms, activity, ns]);
-
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-bg text-text">
-      <TopBar onCreate={() => setShowCreate(true)} />
+      <MainTopBar
+        activeTab="rooms"
+        actions={
+          <button
+            onClick={() => setShowCreate(true)}
+            className="flex items-center gap-2 border border-accent/40 bg-accent/[0.06] px-3 py-1.5 text-accent caps-mono-sm transition-colors hover:bg-accent/[0.12] hover:border-accent/60"
+          >
+            + NEW ROOM
+          </button>
+        }
+      />
 
-      <div className="flex flex-1 overflow-hidden">
-        {/* ── Filter rail ──────────────────────────────────────────── */}
-        <aside className="w-[220px] flex-shrink-0 overflow-y-auto border-r border-border bg-surface/60 py-4">
-          <div className="px-4 pb-2">
-            <span className="caps-mono-sm text-muted">ACTIVITY</span>
-          </div>
-          {ACTIVITY_FILTERS.map(({ id, label }) => {
-            const count = activityCounts.find(([k]) => k === id)?.[1] ?? 0;
-            const isActive = activity === id;
-            return (
-              <button
-                key={id}
-                onClick={() => setActivity(id)}
-                className={`flex w-full items-center gap-2 px-3.5 py-1.5 text-left transition-colors ${
-                  isActive ? "bg-white/[0.04] text-text" : "text-text2 hover:text-text"
-                }`}
-                style={{
-                  borderLeft: `2px solid ${isActive ? "var(--accent)" : "transparent"}`,
-                }}
-              >
-                <span
-                  className={`square-dot ${isActive ? "filled" : ""}`}
-                  style={{ width: 6, height: 6, color: isActive ? "var(--accent)" : "var(--muted)" }}
-                />
-                <span className="caps-mono-sm">{label.replace(/-/g, " ")}</span>
-                <span className="ml-auto text-[10px] text-muted tabular">{count}</span>
-              </button>
-            );
-          })}
-
-          <div className="mt-4 border-t border-border px-4 pt-4 pb-2">
-            <span className="caps-mono-sm text-muted">NAMESPACE</span>
-          </div>
-          <NamespaceButton id="all" label="all" count={rooms.length} active={ns === "all"} onClick={() => setNs("all")} />
-          {namespaces.map(([n, c]) => (
-            <NamespaceButton key={n} id={n} label={`${n}/`} count={c} active={ns === n} onClick={() => setNs(n)} />
-          ))}
-        </aside>
-
-        {/* ── Body table ──────────────────────────────────────────── */}
-        <main className="flex flex-1 flex-col overflow-hidden">
-          <TableHeader />
-          <div className="flex-1 overflow-y-auto">
-            {visible.length === 0 ? (
-              <div className="px-6 py-16 text-center italic text-muted">
-                {rooms.length === 0 ? "no rooms yet — create one to get started" : "no rooms match this filter"}
-              </div>
-            ) : (
-              visible.map((room, i) => <RoomRow key={room.name} room={room} index={i} />)
-            )}
-          </div>
-          <FooterCount visible={visible} />
-        </main>
-      </div>
+      <main className="flex flex-1 flex-col overflow-hidden">
+        <TableHeader />
+        <div className="flex-1 overflow-y-auto">
+          {rooms.length === 0 ? (
+            <div className="px-6 py-16 text-center italic text-muted">
+              no rooms yet — create one to get started
+            </div>
+          ) : (
+            rooms.map((room, i) => <RoomRow key={room.name} room={room} index={i} />)
+          )}
+        </div>
+        <FooterCount visible={rooms} />
+      </main>
 
       <CreateRoomDialog open={showCreate} onClose={() => setShowCreate(false)} onCreated={load} />
     </div>
   );
 }
 
-// ─── Top bar (instrument-panel cells) ─────────────────────────────────────────
-
-function TopBar({ onCreate }: { onCreate: () => void }) {
-  return (
-    <header className="flex h-[52px] flex-shrink-0 items-stretch border-b border-border2 bg-surface/80 backdrop-blur">
-      <div className="flex items-center gap-3 border-r border-border px-5">
-        <Image src="/logo.png" alt="Mycelium" width={22} height={22} className="opacity-90" />
-        <span
-          className="text-[20px] leading-none text-text"
-          style={{ fontFamily: "'Cormorant Garamond', Georgia, serif", fontStyle: "italic", fontWeight: 600 }}
-        >
-          mycelium
-        </span>
-      </div>
-      <nav className="flex items-stretch border-r border-border px-3">
-        {NAV_TABS.map(t => {
-          const active = t.id === "rooms";
-          const className = `flex items-center px-3 caps-mono-sm transition-colors ${
-            active ? "text-accent" : "text-text2/70 hover:text-text"
-          }`;
-          return t.href ? (
-            <Link key={t.id} href={t.href} className={className}>
-              {t.label}
-            </Link>
-          ) : (
-            <span key={t.id} className={`${className} cursor-default`}>{t.label}</span>
-          );
-        })}
-      </nav>
-      <div className="flex flex-1 items-center justify-end gap-3 px-5">
-        <button
-          onClick={onCreate}
-          className="flex items-center gap-2 border border-accent/40 bg-accent/[0.06] px-3 py-1.5 text-accent caps-mono-sm transition-colors hover:bg-accent/[0.12] hover:border-accent/60"
-        >
-          <span className="square-dot filled" style={{ width: 6, height: 6, color: "var(--accent)" }} />
-          NEW ROOM
-        </button>
-      </div>
-    </header>
-  );
-}
-
-// ─── Filter rail item ─────────────────────────────────────────────────────────
-
-function NamespaceButton({
-  label, count, active, onClick,
-}: { id: string; label: string; count: number; active: boolean; onClick: () => void }) {
-  return (
-    <button
-      onClick={onClick}
-      className={`flex w-full items-center gap-2 px-3.5 py-1.5 text-left transition-colors ${
-        active ? "bg-white/[0.04] text-text" : "text-text2 hover:text-text"
-      }`}
-      style={{ borderLeft: `2px solid ${active ? "var(--accent)" : "transparent"}` }}
-    >
-      <span
-        className="font-mono text-[11px] tabular"
-        style={{ color: active ? "var(--text)" : "var(--text2)" }}
-      >
-        {label}
-      </span>
-      <span className="ml-auto text-[10px] text-muted tabular">{count}</span>
-    </button>
-  );
-}
-
 // ─── Table ────────────────────────────────────────────────────────────────────
 
-const COL_TEMPLATE = "32px minmax(0, 1.6fr) 130px minmax(0, 1fr) 110px";
+const COL_TEMPLATE = "32px minmax(0, 1fr) 110px";
 
 function TableHeader() {
   return (
     <div
-      className="grid items-center gap-3 border-b border-border2 bg-surface/40 px-6 py-2.5"
+      className="grid items-center gap-3 border-b border-border2 bg-paper px-6 py-2.5"
       style={{ gridTemplateColumns: COL_TEMPLATE }}
     >
       <span className="caps-mono-sm text-muted">#</span>
       <span className="caps-mono-sm text-muted">ROOM</span>
-      <span className="caps-mono-sm text-muted">STATE</span>
-      <span className="caps-mono-sm text-muted">NAMESPACE</span>
       <span className="caps-mono-sm text-muted">CREATED</span>
     </div>
   );
 }
 
 function RoomRow({ room, index }: { room: Room; index: number }) {
-  const tone = STATE_TONE[room.coordination_state] ?? "muted";
-  const toneColor =
-    tone === "accent" ? "var(--accent)" :
-    tone === "ok"     ? "var(--green)" :
-    tone === "warn"   ? "var(--yellow)" :
-                        "var(--muted)";
-  const pulse = tone === "accent" || tone === "warn";
-
   return (
     <Link
       href={`/room/${encodeURIComponent(room.name)}`}
       className="grid cursor-pointer items-center gap-3 border-b border-border px-6 py-3 transition-colors hover:bg-white/[0.025]"
       style={{ gridTemplateColumns: COL_TEMPLATE }}
     >
-      <span className="text-[10px] text-dim tabular">{String(index + 1).padStart(2, "0")}</span>
+      <span className="text-micro text-dim tabular">{String(index + 1).padStart(2, "0")}</span>
 
-      <div className="flex min-w-0 items-center gap-2.5">
-        <span
-          className="square-dot"
-          style={{ color: "var(--muted)" }}
-          aria-hidden
-        />
-        <span className="text-[10px] uppercase tracking-[0.08em] text-muted">rm:</span>
-        <span className="truncate font-mono text-[12.5px] font-semibold text-text">
-          {room.name}
-        </span>
+      <div className="flex min-w-0 items-center">
+        <IDChip kind="room" name={room.name} />
       </div>
 
-      <div className="flex items-center gap-2">
-        <span
-          className={`square-dot filled ${pulse ? "pulse" : ""}`}
-          style={{ width: 6, height: 6, color: toneColor }}
-        />
-        <span className="caps-mono-sm" style={{ color: toneColor }}>
-          {room.coordination_state || "idle"}
-        </span>
-      </div>
-
-      <span className="truncate text-[12px] text-text2 tabular">
-        {namespaceOf(room)}/
-      </span>
-
-      <span className="text-[10.5px] text-muted">{relativeTime(room.created_at)}</span>
+      <span className="text-label text-muted">{relativeTime(room.created_at)}</span>
     </Link>
   );
 }
@@ -307,13 +120,10 @@ function RoomRow({ room, index }: { room: Room; index: number }) {
 // ─── Footer count ─────────────────────────────────────────────────────────────
 
 function FooterCount({ visible }: { visible: Room[] }) {
-  const namespaces = new Set(visible.map(namespaceOf)).size;
   return (
-    <div className="flex flex-shrink-0 items-center gap-6 border-t border-border2 bg-surface/40 px-6 py-2.5">
+    <div className="flex flex-shrink-0 items-center gap-6 border-t border-border2 bg-paper px-6 py-2.5">
       <span className="caps-mono-sm text-muted">
         <span className="text-text font-semibold tabular">{visible.length}</span> rooms
-        <span className="mx-1.5 text-dim">·</span>
-        <span className="text-text font-semibold tabular">{namespaces}</span> namespaces
       </span>
     </div>
   );

--- a/mycelium-frontend/src/app/page.tsx
+++ b/mycelium-frontend/src/app/page.tsx
@@ -3,17 +3,82 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { fetchRooms } from "@/lib/api";
-import { RoomCard } from "@/components/room-card";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 
-export default function Dashboard() {
-  const [rooms, setRooms] = useState<any[]>([]);
-  const [showCreate, setShowCreate] = useState(false);
+interface Room {
+  name: string;
+  coordination_state: string;
+  created_at: string;
+  parent_namespace: string | null;
+  is_namespace: boolean;
+  is_persistent: boolean;
+}
 
-  const load = () => fetchRooms().then(setRooms).catch(() => {});
+const NAV_TABS = [
+  { id: "rooms", label: "ROOMS", href: "/" },
+  { id: "memory", label: "MEMORY" },
+  { id: "agents", label: "AGENTS" },
+  { id: "logs", label: "LOGS" },
+];
+
+const ACTIVITY_FILTERS: { id: string; label: string; predicate: (r: Room) => boolean }[] = [
+  { id: "all", label: "all", predicate: () => true },
+  { id: "negotiating", label: "negotiating", predicate: r => r.coordination_state === "negotiating" },
+  { id: "waiting", label: "waiting", predicate: r => r.coordination_state === "waiting" },
+  { id: "synthesizing", label: "synthesizing", predicate: r => r.coordination_state === "synthesizing" },
+  { id: "complete", label: "complete", predicate: r => r.coordination_state === "complete" },
+  { id: "idle", label: "idle", predicate: r => r.coordination_state === "idle" || !r.coordination_state },
+];
+
+const STATE_TONE: Record<string, "accent" | "muted" | "warn" | "ok"> = {
+  negotiating: "accent",
+  waiting: "warn",
+  synthesizing: "accent",
+  complete: "ok",
+  idle: "muted",
+  failed: "warn",
+};
+
+function namespaceOf(room: Room): string {
+  if (room.parent_namespace) return room.parent_namespace;
+  // Derive a namespace from the leftmost segment of the name.
+  const slash = room.name.indexOf("/");
+  if (slash > 0) return room.name.slice(0, slash);
+  const colon = room.name.indexOf(":");
+  if (colon > 0) return room.name.slice(0, colon);
+  return room.name;
+}
+
+function relativeTime(iso: string): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "—";
+  const diff = Date.now() - t;
+  const min = Math.floor(diff / 60_000);
+  if (min < 1) return "now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  if (d === 1) return "yesterday";
+  if (d < 7) return `${d}d ago`;
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
+export default function Dashboard() {
+  const [rooms, setRooms] = useState<Room[]>([]);
+  const [showCreate, setShowCreate] = useState(false);
+  const [activity, setActivity] = useState("all");
+  const [ns, setNs] = useState("all");
+
+  const load = () =>
+    fetchRooms()
+      .then((data: Room[]) => setRooms(data.filter(r => r.is_namespace !== false)))
+      .catch(() => {});
 
   useEffect(() => {
     load();
@@ -21,38 +86,235 @@ export default function Dashboard() {
     return () => clearInterval(interval);
   }, []);
 
+  const namespaces = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const r of rooms) {
+      const k = namespaceOf(r);
+      counts.set(k, (counts.get(k) ?? 0) + 1);
+    }
+    return Array.from(counts.entries()).sort((a, b) => a[0].localeCompare(b[0]));
+  }, [rooms]);
+
+  const activityCounts = useMemo(() => {
+    return ACTIVITY_FILTERS.map(f => [f.id, rooms.filter(f.predicate).length] as const);
+  }, [rooms]);
+
+  const visible = useMemo(() => {
+    let out = rooms;
+    const filter = ACTIVITY_FILTERS.find(f => f.id === activity);
+    if (filter && activity !== "all") out = out.filter(filter.predicate);
+    if (ns !== "all") out = out.filter(r => namespaceOf(r) === ns);
+    return out;
+  }, [rooms, activity, ns]);
+
   return (
-    <div className="min-h-screen p-8 max-w-6xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center gap-4 mb-12">
-        <Image src="/logo.png" alt="Mycelium" width={48} height={48} className="opacity-90" />
-        <div>
-          <h1 className="text-2xl font-bold">mycelium</h1>
-          <p className="text-sm text-muted">Multi-agent coordination + persistent memory</p>
-        </div>
-        <button
-          onClick={() => setShowCreate(true)}
-          className="ml-auto px-4 py-2 bg-accent/10 text-accent border border-accent/25 rounded-lg text-sm font-bold hover:bg-accent/20 hover:border-accent/40 transition-all"
-        >
-          + Create Room
-        </button>
+    <div className="flex h-screen flex-col overflow-hidden bg-bg text-text">
+      <TopBar onCreate={() => setShowCreate(true)} />
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* ── Filter rail ──────────────────────────────────────────── */}
+        <aside className="w-[220px] flex-shrink-0 overflow-y-auto border-r border-border bg-surface/60 py-4">
+          <div className="px-4 pb-2">
+            <span className="caps-mono-sm text-muted">ACTIVITY</span>
+          </div>
+          {ACTIVITY_FILTERS.map(({ id, label }) => {
+            const count = activityCounts.find(([k]) => k === id)?.[1] ?? 0;
+            const isActive = activity === id;
+            return (
+              <button
+                key={id}
+                onClick={() => setActivity(id)}
+                className={`flex w-full items-center gap-2 px-3.5 py-1.5 text-left transition-colors ${
+                  isActive ? "bg-white/[0.04] text-text" : "text-text2 hover:text-text"
+                }`}
+                style={{
+                  borderLeft: `2px solid ${isActive ? "var(--accent)" : "transparent"}`,
+                }}
+              >
+                <span
+                  className={`square-dot ${isActive ? "filled" : ""}`}
+                  style={{ width: 6, height: 6, color: isActive ? "var(--accent)" : "var(--muted)" }}
+                />
+                <span className="caps-mono-sm">{label.replace(/-/g, " ")}</span>
+                <span className="ml-auto text-[10px] text-muted tabular">{count}</span>
+              </button>
+            );
+          })}
+
+          <div className="mt-4 border-t border-border px-4 pt-4 pb-2">
+            <span className="caps-mono-sm text-muted">NAMESPACE</span>
+          </div>
+          <NamespaceButton id="all" label="all" count={rooms.length} active={ns === "all"} onClick={() => setNs("all")} />
+          {namespaces.map(([n, c]) => (
+            <NamespaceButton key={n} id={n} label={`${n}/`} count={c} active={ns === n} onClick={() => setNs(n)} />
+          ))}
+        </aside>
+
+        {/* ── Body table ──────────────────────────────────────────── */}
+        <main className="flex flex-1 flex-col overflow-hidden">
+          <TableHeader />
+          <div className="flex-1 overflow-y-auto">
+            {visible.length === 0 ? (
+              <div className="px-6 py-16 text-center italic text-muted">
+                {rooms.length === 0 ? "no rooms yet — create one to get started" : "no rooms match this filter"}
+              </div>
+            ) : (
+              visible.map((room, i) => <RoomRow key={room.name} room={room} index={i} />)
+            )}
+          </div>
+          <FooterCount visible={visible} />
+        </main>
       </div>
 
-      {/* Room grid */}
-      {rooms.length === 0 ? (
-        <div className="text-center text-muted/50 py-20">
-          <p className="text-lg mb-2">No rooms yet</p>
-          <p className="text-sm">Create a room to get started</p>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {rooms.filter((r: any) => r.is_namespace !== false).map((room: any) => (
-            <RoomCard key={room.name} room={room} />
-          ))}
-        </div>
-      )}
-
       <CreateRoomDialog open={showCreate} onClose={() => setShowCreate(false)} onCreated={load} />
+    </div>
+  );
+}
+
+// ─── Top bar (instrument-panel cells) ─────────────────────────────────────────
+
+function TopBar({ onCreate }: { onCreate: () => void }) {
+  return (
+    <header className="flex h-[52px] flex-shrink-0 items-stretch border-b border-border2 bg-surface/80 backdrop-blur">
+      <div className="flex items-center gap-3 border-r border-border px-5">
+        <Image src="/logo.png" alt="Mycelium" width={22} height={22} className="opacity-90" />
+        <span
+          className="text-[20px] leading-none text-text"
+          style={{ fontFamily: "'Cormorant Garamond', Georgia, serif", fontStyle: "italic", fontWeight: 600 }}
+        >
+          mycelium
+        </span>
+      </div>
+      <nav className="flex items-stretch border-r border-border px-3">
+        {NAV_TABS.map(t => {
+          const active = t.id === "rooms";
+          const className = `flex items-center px-3 caps-mono-sm transition-colors ${
+            active ? "text-accent" : "text-text2/70 hover:text-text"
+          }`;
+          return t.href ? (
+            <Link key={t.id} href={t.href} className={className}>
+              {t.label}
+            </Link>
+          ) : (
+            <span key={t.id} className={`${className} cursor-default`}>{t.label}</span>
+          );
+        })}
+      </nav>
+      <div className="flex flex-1 items-center justify-end gap-3 px-5">
+        <button
+          onClick={onCreate}
+          className="flex items-center gap-2 border border-accent/40 bg-accent/[0.06] px-3 py-1.5 text-accent caps-mono-sm transition-colors hover:bg-accent/[0.12] hover:border-accent/60"
+        >
+          <span className="square-dot filled" style={{ width: 6, height: 6, color: "var(--accent)" }} />
+          NEW ROOM
+        </button>
+      </div>
+    </header>
+  );
+}
+
+// ─── Filter rail item ─────────────────────────────────────────────────────────
+
+function NamespaceButton({
+  label, count, active, onClick,
+}: { id: string; label: string; count: number; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex w-full items-center gap-2 px-3.5 py-1.5 text-left transition-colors ${
+        active ? "bg-white/[0.04] text-text" : "text-text2 hover:text-text"
+      }`}
+      style={{ borderLeft: `2px solid ${active ? "var(--accent)" : "transparent"}` }}
+    >
+      <span
+        className="font-mono text-[11px] tabular"
+        style={{ color: active ? "var(--text)" : "var(--text2)" }}
+      >
+        {label}
+      </span>
+      <span className="ml-auto text-[10px] text-muted tabular">{count}</span>
+    </button>
+  );
+}
+
+// ─── Table ────────────────────────────────────────────────────────────────────
+
+const COL_TEMPLATE = "32px minmax(0, 1.6fr) 130px minmax(0, 1fr) 110px";
+
+function TableHeader() {
+  return (
+    <div
+      className="grid items-center gap-3 border-b border-border2 bg-surface/40 px-6 py-2.5"
+      style={{ gridTemplateColumns: COL_TEMPLATE }}
+    >
+      <span className="caps-mono-sm text-muted">#</span>
+      <span className="caps-mono-sm text-muted">ROOM</span>
+      <span className="caps-mono-sm text-muted">STATE</span>
+      <span className="caps-mono-sm text-muted">NAMESPACE</span>
+      <span className="caps-mono-sm text-muted">CREATED</span>
+    </div>
+  );
+}
+
+function RoomRow({ room, index }: { room: Room; index: number }) {
+  const tone = STATE_TONE[room.coordination_state] ?? "muted";
+  const toneColor =
+    tone === "accent" ? "var(--accent)" :
+    tone === "ok"     ? "var(--green)" :
+    tone === "warn"   ? "var(--yellow)" :
+                        "var(--muted)";
+  const pulse = tone === "accent" || tone === "warn";
+
+  return (
+    <Link
+      href={`/room/${encodeURIComponent(room.name)}`}
+      className="grid cursor-pointer items-center gap-3 border-b border-border px-6 py-3 transition-colors hover:bg-white/[0.025]"
+      style={{ gridTemplateColumns: COL_TEMPLATE }}
+    >
+      <span className="text-[10px] text-dim tabular">{String(index + 1).padStart(2, "0")}</span>
+
+      <div className="flex min-w-0 items-center gap-2.5">
+        <span
+          className="square-dot"
+          style={{ color: "var(--muted)" }}
+          aria-hidden
+        />
+        <span className="text-[10px] uppercase tracking-[0.08em] text-muted">rm:</span>
+        <span className="truncate font-mono text-[12.5px] font-semibold text-text">
+          {room.name}
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span
+          className={`square-dot filled ${pulse ? "pulse" : ""}`}
+          style={{ width: 6, height: 6, color: toneColor }}
+        />
+        <span className="caps-mono-sm" style={{ color: toneColor }}>
+          {room.coordination_state || "idle"}
+        </span>
+      </div>
+
+      <span className="truncate text-[12px] text-text2 tabular">
+        {namespaceOf(room)}/
+      </span>
+
+      <span className="text-[10.5px] text-muted">{relativeTime(room.created_at)}</span>
+    </Link>
+  );
+}
+
+// ─── Footer count ─────────────────────────────────────────────────────────────
+
+function FooterCount({ visible }: { visible: Room[] }) {
+  const namespaces = new Set(visible.map(namespaceOf)).size;
+  return (
+    <div className="flex flex-shrink-0 items-center gap-6 border-t border-border2 bg-surface/40 px-6 py-2.5">
+      <span className="caps-mono-sm text-muted">
+        <span className="text-text font-semibold tabular">{visible.length}</span> rooms
+        <span className="mx-1.5 text-dim">·</span>
+        <span className="text-text font-semibold tabular">{namespaces}</span> namespaces
+      </span>
     </div>
   );
 }

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -3,60 +3,99 @@
 
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
-import { useEffect, useState, useCallback } from "react";
-import Image from "next/image";
+import { useParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 import { fetchRoom } from "@/lib/api";
 import { EventStream } from "@/components/event-stream";
 import { MemoryPanel } from "@/components/memory-panel";
+import { SessionsRail } from "@/components/sessions-rail";
+import { MainTopBar } from "@/components/main-top-bar";
+import { SubNav, type Crumb } from "@/components/sub-nav";
+import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from "react-resizable-panels";
+
+interface Room {
+  name: string;
+  coordination_state: string;
+  mas_id?: string | null;
+  is_persistent?: boolean;
+  parent_namespace?: string | null;
+}
 
 export default function RoomPage() {
   const params = useParams();
-  const router = useRouter();
   const roomName = params.name as string;
-  const [room, setRoom] = useState<any>(null);
+  const [room, setRoom] = useState<Room | null>(null);
   const [memoryRefresh, setMemoryRefresh] = useState(0);
 
   useEffect(() => {
-    fetchRoom(roomName).then(setRoom).catch(() => {});
+    let cancelled = false;
+    const load = () =>
+      fetchRoom(roomName).then((r: Room) => { if (!cancelled) setRoom(r); }).catch(() => {});
+    load();
+    const t = setInterval(load, 8000);
+    return () => { cancelled = true; clearInterval(t); };
   }, [roomName]);
 
   const handleMemoryChanged = useCallback(() => {
     setMemoryRefresh(n => n + 1);
   }, []);
 
+  const crumbs: Crumb[] = [
+    { label: "rooms", href: "/" },
+    { sigil: "rm:", label: roomName },
+  ];
+
   return (
-    <div className="h-screen flex flex-col">
-      {/* Header */}
-      <div className="flex items-center gap-3 px-6 py-3 border-b border-border bg-surface/50 backdrop-blur-sm">
-        <button onClick={() => router.push("/")} className="text-muted hover:text-white transition-colors">
-          <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M12 4L6 10L12 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
-        </button>
-        <Image src="/logo.png" alt="" width={24} height={24} className="opacity-70" />
-        <h1 className="font-bold font-mono text-lg">{roomName}</h1>
-        {room && (
-          <span className="text-xs text-muted font-mono ml-2">
-            {room.coordination_state}
-          </span>
-        )}
-      </div>
+    <div className="flex h-screen flex-col overflow-hidden bg-bg text-text">
+      <MainTopBar activeTab="rooms" />
+      <SubNav crumbs={crumbs} />
 
-      {/* Split layout */}
-      <div className="flex-1 flex overflow-hidden">
-        {/* Left: Channel + event stream */}
-        <div className="w-[60%] border-r border-border flex flex-col overflow-hidden">
-          <EventStream roomName={roomName} onMemoryChanged={handleMemoryChanged} />
-        </div>
+      <div className="flex flex-1 overflow-hidden">
+        <aside className="w-[240px] flex-shrink-0 border-r border-border">
+          <SessionsRail roomName={roomName} activeSessionName={null} />
+        </aside>
 
-        {/* Right: Memory / Synthesis / Knowledge */}
-        <div className="w-[40%] flex flex-col overflow-hidden">
-          <MemoryPanel
-            roomName={roomName}
-            masId={room?.mas_id ?? null}
-            refreshTrigger={memoryRefresh}
-          />
-        </div>
+        <PanelGroup orientation="horizontal" className="flex-1" style={{ width: "100%", height: "100%" }}>
+          <Panel id="activity" defaultSize={62} minSize={30} className="overflow-hidden" style={{ minWidth: 0 }}>
+            <main className="flex flex-col h-full overflow-hidden" style={{ minWidth: 0 }}>
+              <PaneHeader>
+                <span className="caps-mono-sm text-muted">ROOM ACTIVITY</span>
+              </PaneHeader>
+              <div className="flex-1 overflow-hidden">
+                <EventStream roomName={roomName} onMemoryChanged={handleMemoryChanged} />
+              </div>
+            </main>
+          </Panel>
+          <PanelResizeHandle
+            className="w-px bg-border hover:bg-accent transition-colors flex-shrink-0 relative"
+            style={{ cursor: "col-resize" }}
+          >
+            <span aria-hidden className="absolute inset-y-0 -left-1.5 -right-1.5" />
+          </PanelResizeHandle>
+          <Panel id="memory" defaultSize={38} minSize={22} className="overflow-hidden" style={{ minWidth: 0 }}>
+            <aside className="flex flex-col h-full bg-surface/40 overflow-hidden" style={{ minWidth: 0 }}>
+              <PaneHeader>
+                <span className="caps-mono-sm text-muted">MEMORY</span>
+              </PaneHeader>
+              <div className="flex-1 overflow-hidden">
+                <MemoryPanel
+                  roomName={roomName}
+                  masId={room?.mas_id ?? null}
+                  refreshTrigger={memoryRefresh}
+                />
+              </div>
+            </aside>
+          </Panel>
+        </PanelGroup>
       </div>
+    </div>
+  );
+}
+
+function PaneHeader({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-shrink-0 items-center gap-2 border-b border-border bg-paper px-4 py-2.5 min-w-0">
+      {children}
     </div>
   );
 }

--- a/mycelium-frontend/src/app/room/[name]/session/[session]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/session/[session]/page.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+"use client";
+
+import { useParams } from "next/navigation";
+import { SessionsRail } from "@/components/sessions-rail";
+import { SessionView } from "@/components/session-view";
+import { MainTopBar } from "@/components/main-top-bar";
+import { SubNav, type Crumb } from "@/components/sub-nav";
+
+function shortSessionName(sessionRoom: string): string {
+  const tail = sessionRoom.split(":").pop() ?? sessionRoom;
+  return tail.length > 12 ? `${tail.slice(0, 8)}…${tail.slice(-3)}` : tail;
+}
+
+export default function SessionPage() {
+  const params = useParams();
+  const roomName = params.name as string;
+  const sessionId = params.session as string;
+  const sessionRoom = `${roomName}:session:${sessionId}`;
+
+  const crumbs: Crumb[] = [
+    { label: "rooms", href: "/" },
+    { sigil: "rm:", label: roomName, href: `/room/${encodeURIComponent(roomName)}` },
+    { sigil: "ss:", label: shortSessionName(sessionRoom) },
+  ];
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-bg text-text">
+      <MainTopBar activeTab="rooms" />
+      <SubNav crumbs={crumbs} />
+
+      <div className="flex flex-1 overflow-hidden">
+        <aside className="w-[240px] flex-shrink-0 border-r border-border">
+          <SessionsRail roomName={roomName} activeSessionName={sessionRoom} />
+        </aside>
+
+        <main className="flex flex-1 flex-col overflow-hidden">
+          <SessionView sessionRoom={sessionRoom} />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -4,8 +4,8 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { getSSEUrl, fetchMessages, fetchChildRooms } from "@/lib/api";
-import { SessionsView } from "./sessions-view";
+import { getSSEUrl, fetchMessages } from "@/lib/api";
+import { MarkdownContent } from "@/components/markdown-content";
 
 interface Event {
   id: string;
@@ -105,20 +105,28 @@ function parseEvent(msg: Record<string, unknown>): Event {
   };
 }
 
-const typeStyles: Record<string, { border: string; badge: string; badgeText: string }> = {
-  broadcast:              { border: "border-l-sky-400",     badge: "bg-sky-500/10 text-sky-300",      badgeText: "broadcast" },
-  direct:                 { border: "border-l-sky-400",     badge: "bg-sky-500/15 text-sky-200",      badgeText: "direct" },
-  announce:               { border: "border-l-sky-300",     badge: "bg-sky-500/10 text-sky-200",      badgeText: "announce" },
-  delegate:               { border: "border-l-fuchsia-400", badge: "bg-fuchsia-500/10 text-fuchsia-300", badgeText: "delegate" },
-  coordination_join:      { border: "border-l-cyan-400",    badge: "bg-cyan-500/10 text-cyan-400",    badgeText: "join" },
-  coordination_start:     { border: "border-l-cyan-400",    badge: "bg-cyan-500/15 text-cyan-300",    badgeText: "start" },
-  coordination_tick:      { border: "border-l-indigo-400",  badge: "bg-indigo-500/10 text-indigo-400", badgeText: "tick" },
-  coordination_consensus: { border: "border-l-emerald-400", badge: "bg-emerald-500/10 text-emerald-400", badgeText: "consensus" },
-  memory_changed:         { border: "border-l-yellow-400",  badge: "bg-yellow-500/10 text-yellow-400", badgeText: "memory" },
-  synthesis_complete:     { border: "border-l-emerald-400", badge: "bg-emerald-500/10 text-emerald-400", badgeText: "synthesis" },
+// Per-event-type styling. Tone drives the accent color of the label + bar.
+const typeStyles: Record<string, { tone: "accent" | "ok" | "warn" | "muted" | "ink"; label: string }> = {
+  broadcast:              { tone: "ink",    label: "BROADCAST" },
+  direct:                 { tone: "accent", label: "DIRECT" },
+  announce:               { tone: "ink",    label: "ANNOUNCE" },
+  delegate:               { tone: "accent", label: "DELEGATE" },
+  coordination_join:      { tone: "accent", label: "JOIN" },
+  coordination_start:     { tone: "accent", label: "START" },
+  coordination_tick:      { tone: "muted",  label: "TICK" },
+  coordination_consensus: { tone: "ok",     label: "CONSENSUS" },
+  memory_changed:         { tone: "warn",   label: "MEMORY" },
+  synthesis_complete:     { tone: "ok",     label: "SYNTHESIS" },
 };
+const defaultStyle = { tone: "muted" as const, label: "MSG" };
 
-const defaultStyle = { border: "border-l-muted", badge: "bg-muted/10 text-muted", badgeText: "msg" };
+function toneColor(t: "accent" | "ok" | "warn" | "muted" | "ink"): string {
+  return t === "accent" ? "var(--accent)"
+       : t === "ok"     ? "var(--green)"
+       : t === "warn"   ? "var(--yellow)"
+       : t === "ink"    ? "var(--text)"
+                        : "var(--muted)";
+}
 
 const MENTION_RE = /(@[\w-]+)/g;
 
@@ -135,7 +143,7 @@ function renderWithMentions(text: string): React.ReactNode {
   );
 }
 
-type View = "channel" | "events" | "sessions";
+type View = "channel" | "events";
 
 interface Props {
   roomName: string;
@@ -146,22 +154,7 @@ export function EventStream({ roomName, onMemoryChanged }: Props) {
   const [events, setEvents] = useState<Event[]>([]);
   const [connected, setConnected] = useState(false);
   const [view, setView] = useState<View>("channel");
-  const [sessionCount, setSessionCount] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
-
-  // Poll child sessions for the tab count
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const rooms = await fetchChildRooms(roomName);
-        if (!cancelled) setSessionCount(rooms.length);
-      } catch {}
-    };
-    load();
-    const id = setInterval(load, 5000);
-    return () => { cancelled = true; clearInterval(id); };
-  }, [roomName]);
 
   // Load initial messages
   useEffect(() => {
@@ -216,89 +209,89 @@ export function EventStream({ roomName, onMemoryChanged }: Props) {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-border shrink-0">
-        <span className={`w-2 h-2 rounded-full ${connected ? "bg-emerald-400 animate-pulse" : "bg-red-400"}`} />
-        <span className="text-xs text-muted font-mono">{connected ? "connected" : "reconnecting..."}</span>
-        <div className="ml-auto flex gap-1">
-          <button
-            onClick={() => setView("channel")}
-            className={`text-[10px] font-bold uppercase tracking-wider px-2 py-1 rounded transition-colors ${
-              view === "channel"
-                ? "bg-sky-500/15 text-sky-300"
-                : "text-muted/60 hover:text-white"
-            }`}
-          >
-            Channel <span className="text-muted/50">({channelCount})</span>
-          </button>
-          <button
-            onClick={() => setView("events")}
-            className={`text-[10px] font-bold uppercase tracking-wider px-2 py-1 rounded transition-colors ${
-              view === "events"
-                ? "bg-accent/15 text-accent"
-                : "text-muted/60 hover:text-white"
-            }`}
-          >
-            Events <span className="text-muted/50">({events.length})</span>
-          </button>
-          <button
-            onClick={() => setView("sessions")}
-            className={`text-[10px] font-bold uppercase tracking-wider px-2 py-1 rounded transition-colors ${
-              view === "sessions"
-                ? "bg-indigo-500/15 text-indigo-300"
-                : "text-muted/60 hover:text-white"
-            }`}
-          >
-            Sessions <span className="text-muted/50">({sessionCount})</span>
-          </button>
+      <div className="flex items-stretch border-b border-border shrink-0 h-[44px] bg-paper">
+        <div className="flex items-center gap-2 px-4">
+          <span
+            aria-hidden
+            style={{
+              width: 6, height: 6,
+              background: connected ? "var(--green)" : "var(--yellow)",
+              animation: connected ? "myc-pulse 2s ease-in-out infinite" : undefined,
+            }}
+          />
+          <span className="caps-mono-sm" style={{ color: connected ? "var(--green)" : "var(--yellow)" }}>
+            {connected ? "LIVE" : "RECONNECTING"}
+          </span>
+        </div>
+        <div className="ml-auto flex items-stretch">
+          {([
+            { id: "channel" as const, label: "CHANNEL", count: channelCount },
+            { id: "events" as const,  label: "EVENTS",  count: events.length },
+          ]).map(t => {
+            const active = view === t.id;
+            return (
+              <button
+                key={t.id}
+                onClick={() => setView(t.id)}
+                className={`flex items-center gap-2 px-4 caps-mono-sm border-l border-border transition-colors ${
+                  active ? "text-accent" : "text-text2 hover:text-text"
+                }`}
+                style={{ borderBottom: `2px solid ${active ? "var(--accent)" : "transparent"}` }}
+              >
+                {t.label}
+                <span className="text-micro tabular" style={{ color: active ? "var(--accent)" : "var(--muted)" }}>
+                  {t.count}
+                </span>
+              </button>
+            );
+          })}
         </div>
       </div>
-      {view === "sessions" ? (
-        <div className="flex-1 overflow-hidden">
-          <SessionsView roomName={roomName} />
-        </div>
-      ) : (
-      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3 space-y-2">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto">
         {visible.length === 0 && (
-          <div className="text-center text-muted/50 py-20 text-sm">
-            {view === "channel" ? "No channel messages yet" : "Waiting for events..."}
+          <div className="text-center caps-mono-sm text-muted py-16 italic">
+            {view === "channel" ? "no channel messages yet" : "waiting for events…"}
           </div>
         )}
         {view === "channel"
           ? visible.map(ev => (
-              <div key={ev.id} className="py-2 border-b border-border/20 last:border-b-0">
-                <div className="flex items-baseline gap-2 mb-1">
-                  <span className="font-mono text-sm text-sky-300 font-semibold">{ev.sender}</span>
-                  {ev.recipient && (
-                    <span className="text-[10px] text-muted">→ {ev.recipient}</span>
-                  )}
-                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-sky-500/10 text-sky-300/70 font-bold uppercase tracking-wider">
-                    {ev.type}
+              <div key={ev.id} className="px-5 py-3 border-b border-border last:border-b-0">
+                <div className="flex items-baseline gap-2 mb-1.5">
+                  <span className="font-mono text-label text-accent font-semibold truncate">
+                    {ev.sender}
                   </span>
-                  <span className="ml-auto text-[10px] text-muted/40 font-mono">{ev.time}</span>
+                  {ev.recipient && (
+                    <span className="caps-mono-sm text-muted">→ {ev.recipient}</span>
+                  )}
+                  <span className="ml-auto text-micro text-muted font-mono tabular">{ev.time}</span>
                 </div>
-                <p className="text-sm text-white/90 whitespace-pre-wrap leading-relaxed">
-                  {renderWithMentions(ev.content)}
-                </p>
+                <MarkdownContent className="text-body text-text2 leading-relaxed">
+                  {ev.content}
+                </MarkdownContent>
               </div>
             ))
           : visible.map(ev => {
               const style = typeStyles[ev.type] || defaultStyle;
+              const color = toneColor(style.tone);
               return (
-                <div key={ev.id} className={`border-l-2 ${style.border} pl-3 py-2 group`}>
-                  <div className="flex items-center gap-2">
-                    <span className={`text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${style.badge}`}>
-                      {style.badgeText}
+                <div
+                  key={ev.id}
+                  className="px-5 py-2 border-b border-border hover:bg-white/[0.02]"
+                  style={{ borderLeft: `2px solid ${color}` }}
+                >
+                  <div className="flex items-baseline gap-3">
+                    <span className="caps-mono-sm flex-shrink-0" style={{ color, minWidth: 90 }}>
+                      {style.label}
                     </span>
-                    <span className="flex-1 text-sm">
+                    <span className="flex-1 text-body text-text2 leading-snug min-w-0 break-words">
                       {CHAT_TYPES.has(ev.type) ? renderWithMentions(ev.content) : ev.content}
                     </span>
-                    <span className="text-xs text-muted/40 font-mono">{ev.time}</span>
+                    <span className="text-micro text-muted font-mono tabular flex-shrink-0">{ev.time}</span>
                   </div>
                 </div>
               );
             })}
       </div>
-      )}
     </div>
   );
 }

--- a/mycelium-frontend/src/components/id-chip.tsx
+++ b/mycelium-frontend/src/components/id-chip.tsx
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+"use client";
+
+interface Props {
+  kind: "room" | "session";
+  name: string;
+  /** Optional dim/active state (active = chalk-white text) */
+  active?: boolean;
+  className?: string;
+}
+
+/**
+ * Visual treatment for room and session identifiers.
+ *
+ * Just the name in mono — context (page, crumb position, sidebar header)
+ * already tells the reader whether it's a room or a session. The `kind`
+ * prop drives the title attribute for accessibility but no visual marker.
+ */
+export function IDChip({ kind, name, active, className }: Props) {
+  return (
+    <span
+      className={`font-mono text-label truncate ${className ?? ""}`}
+      title={kind}
+      style={{ color: active === false ? "var(--text2)" : "var(--text)", fontWeight: 600 }}
+    >
+      {name}
+    </span>
+  );
+}

--- a/mycelium-frontend/src/components/knowledge-panel.tsx
+++ b/mycelium-frontend/src/components/knowledge-panel.tsx
@@ -62,9 +62,9 @@ export function KnowledgePanel({ masId }: Props) {
 
   if (!masId) {
     return (
-      <div className="px-4 py-10 text-center text-muted/60 text-sm">
+      <div className="px-4 py-10 text-center text-muted text-sm">
         Room is not linked to a MAS.
-        <div className="text-xs text-muted/40 mt-2 font-mono">
+        <div className="text-xs text-muted mt-2 font-mono">
           Set <code className="text-accent/70">mas_id</code> on the room to view CFN knowledge.
         </div>
       </div>
@@ -72,14 +72,14 @@ export function KnowledgePanel({ masId }: Props) {
   }
 
   if (state === "loading") {
-    return <div className="px-4 py-10 text-center text-muted/60 text-sm">Loading CFN graph…</div>;
+    return <div className="px-4 py-10 text-center text-muted text-sm">Loading CFN graph…</div>;
   }
 
   if (state === "error") {
     return (
-      <div className="px-4 py-10 text-center text-muted/60 text-sm">
+      <div className="px-4 py-10 text-center text-muted text-sm">
         <div className="text-red-400/80">CFN graph unavailable</div>
-        {error && <div className="text-xs text-muted/40 mt-2 font-mono">{error}</div>}
+        {error && <div className="text-xs text-muted mt-2 font-mono">{error}</div>}
         <button
           onClick={load}
           className="mt-4 text-xs text-accent/80 hover:text-accent underline-offset-2 hover:underline"
@@ -92,9 +92,9 @@ export function KnowledgePanel({ masId }: Props) {
 
   if (state === "empty") {
     return (
-      <div className="px-4 py-10 text-center text-muted/60 text-sm">
+      <div className="px-4 py-10 text-center text-muted text-sm">
         No concepts ingested yet.
-        <div className="text-xs text-muted/40 mt-2 font-mono">
+        <div className="text-xs text-muted mt-2 font-mono">
           Graph exists but is empty for <span className="text-accent/70">{masId}</span>
         </div>
       </div>
@@ -111,12 +111,12 @@ export function KnowledgePanel({ masId }: Props) {
         >
           {masId}
         </code>
-        <span className="text-[10px] text-muted/50 font-mono whitespace-nowrap shrink-0">
+        <span className="text-micro text-muted font-mono whitespace-nowrap shrink-0">
           {concepts.length} concepts
         </span>
         <button
           onClick={load}
-          className="text-[10px] text-muted hover:text-white font-bold uppercase tracking-wider whitespace-nowrap shrink-0"
+          className="text-micro text-muted hover:text-white font-bold uppercase tracking-wider whitespace-nowrap shrink-0"
         >
           refresh
         </button>
@@ -146,12 +146,12 @@ export function KnowledgePanel({ masId }: Props) {
                   {c.name || c.id || c.vid || "(unnamed)"}
                 </span>
                 {c.label && (
-                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-muted/10 text-muted font-bold shrink-0">
+                  <span className="text-micro px-1.5 py-0.5 rounded bg-muted/10 text-muted font-bold shrink-0">
                     {c.label}
                   </span>
                 )}
                 <span
-                  className="text-[10px] text-muted/30 font-mono truncate max-w-[120px] shrink-0"
+                  className="text-micro text-muted font-mono truncate max-w-[120px] shrink-0"
                   title={c.id}
                 >
                   {c.id}
@@ -160,18 +160,18 @@ export function KnowledgePanel({ masId }: Props) {
               {isExpanded && (
                 <div className="ml-5 mt-2 space-y-1">
                   {neigh === undefined ? (
-                    <div className="text-[11px] text-muted/60">Loading neighbors…</div>
+                    <div className="text-label text-muted">Loading neighbors…</div>
                   ) : neighList.length === 0 ? (
-                    <div className="text-[11px] text-muted/60">No neighbors</div>
+                    <div className="text-label text-muted">No neighbors</div>
                   ) : (
                     neighList.map((n, ni) => {
                       const name = (n.name as string) || (n.id as string) || "(unnamed)";
                       const rel = (n.relation as string) || (n.edge as string) || "";
                       return (
-                        <div key={ni} className="flex items-center gap-2 text-[11px]">
+                        <div key={ni} className="flex items-center gap-2 text-label">
                           <span className="w-1 h-1 rounded-full bg-accent/50 shrink-0" />
                           <span className="font-mono text-white/70">{name}</span>
-                          {rel && <span className="text-muted/60 italic">{rel}</span>}
+                          {rel && <span className="text-muted italic">{rel}</span>}
                         </div>
                       );
                     })

--- a/mycelium-frontend/src/components/main-top-bar.tsx
+++ b/mycelium-frontend/src/components/main-top-bar.tsx
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+const NAV_TABS = [
+  { id: "rooms", label: "ROOMS", href: "/" },
+  { id: "memory", label: "MEMORY" },
+  { id: "agents", label: "AGENTS" },
+  { id: "logs", label: "LOGS" },
+];
+
+interface MainTopBarProps {
+  activeTab?: "rooms" | "memory" | "agents" | "logs";
+  actions?: ReactNode;
+}
+
+export function MainTopBar({ activeTab = "rooms", actions }: MainTopBarProps) {
+  return (
+    <header className="flex h-[52px] flex-shrink-0 items-stretch border-b border-border2 bg-surface/80 backdrop-blur">
+      <Link href="/" className="flex items-center gap-3 border-r border-border px-5 transition-colors hover:bg-white/[0.025]">
+        <Image src="/logo.png" alt="Mycelium" width={22} height={22} className="opacity-90" />
+        <span
+          className="text-display leading-none text-text"
+          style={{ fontFamily: "'Cormorant Garamond', Georgia, serif", fontStyle: "italic", fontWeight: 600 }}
+        >
+          mycelium
+        </span>
+      </Link>
+
+      <nav className="flex items-stretch border-r border-border px-3">
+        {NAV_TABS.map(t => {
+          const active = t.id === activeTab;
+          if (t.href) {
+            return (
+              <Link
+                key={t.id}
+                href={t.href}
+                className={`flex items-center px-3 caps-mono-sm transition-colors ${
+                  active ? "text-accent" : "text-text2 hover:text-text"
+                }`}
+              >
+                {t.label}
+              </Link>
+            );
+          }
+          return (
+            <span
+              key={t.id}
+              aria-disabled="true"
+              title="coming soon"
+              className="flex items-center px-3 caps-mono-sm text-dim cursor-not-allowed select-none"
+            >
+              {t.label}
+            </span>
+          );
+        })}
+      </nav>
+
+      <div className="flex flex-1 items-center justify-end gap-3 px-5">
+        {actions}
+      </div>
+    </header>
+  );
+}

--- a/mycelium-frontend/src/components/markdown-content.tsx
+++ b/mycelium-frontend/src/components/markdown-content.tsx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+"use client";
+
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+const MENTION_RE = /(@[\w-]+)/g;
+
+function withMentions(text: string): React.ReactNode {
+  const parts = text.split(MENTION_RE);
+  return parts.map((part, i) =>
+    i % 2 === 1
+      ? <span key={i} className="text-accent font-semibold">{part}</span>
+      : part,
+  );
+}
+
+function processNode(node: React.ReactNode): React.ReactNode {
+  if (typeof node === "string") return withMentions(node);
+  if (Array.isArray(node)) return node.map((n, i) => <React.Fragment key={i}>{processNode(n)}</React.Fragment>);
+  if (React.isValidElement(node)) {
+    const props = node.props as { children?: React.ReactNode };
+    return React.cloneElement(node as React.ReactElement<{ children?: React.ReactNode }>, undefined, processNode(props.children));
+  }
+  return node;
+}
+
+interface Props {
+  children: string;
+  className?: string;
+}
+
+export function MarkdownContent({ children, className }: Props) {
+  return (
+    <div className={`markdown-body ${className ?? ""}`}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          p: ({ children }) => <p>{processNode(children)}</p>,
+          li: ({ children }) => <li>{processNode(children)}</li>,
+          strong: ({ children }) => <strong>{processNode(children)}</strong>,
+          em: ({ children }) => <em>{processNode(children)}</em>,
+          td: ({ children }) => <td>{processNode(children)}</td>,
+          th: ({ children }) => <th>{processNode(children)}</th>,
+          h1: ({ children }) => <h1>{processNode(children)}</h1>,
+          h2: ({ children }) => <h2>{processNode(children)}</h2>,
+          h3: ({ children }) => <h3>{processNode(children)}</h3>,
+          h4: ({ children }) => <h4>{processNode(children)}</h4>,
+          // Plain code spans use the underlying renderer (no mentions inside code)
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { fetchMemories, searchMemories, fetchCatchup } from "@/lib/api";
 import { KnowledgePanel } from "./knowledge-panel";
+import { MarkdownContent } from "./markdown-content";
 
 interface Memory {
   key: string;
@@ -39,6 +40,12 @@ interface Props {
 }
 
 type Tab = "memories" | "synthesis" | "knowledge";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "memories",  label: "MEMORIES" },
+  { id: "synthesis", label: "SYNTHESIS" },
+  { id: "knowledge", label: "KNOWLEDGE" },
+];
 
 export function MemoryPanel({ roomName, masId, refreshTrigger }: Props) {
   const [memories, setMemories] = useState<Memory[]>([]);
@@ -85,20 +92,24 @@ export function MemoryPanel({ roomName, masId, refreshTrigger }: Props) {
   const synthText = catchup?.latest_synthesis?.content ?? null;
 
   return (
-    <div className="flex flex-col h-full">
-      {/* Room info header */}
-      <div className="px-4 py-3 border-b border-border">
-        <div className="flex items-center gap-3 text-sm">
-          <span className="font-bold">{catchup?.total_memories || 0}</span>
-          <span className="text-muted">memories</span>
-          <span className="text-muted/30">|</span>
-          <span className="font-bold">{catchup?.contributors?.length || 0}</span>
-          <span className="text-muted">contributors</span>
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Stats row */}
+      <div className="px-4 py-3 border-b border-border bg-paper">
+        <div className="flex items-baseline gap-3 caps-mono-sm text-muted">
+          <span className="text-text font-semibold tabular">{catchup?.total_memories ?? 0}</span>
+          <span>memories</span>
+          <span className="text-dim">·</span>
+          <span className="text-text font-semibold tabular">{catchup?.contributors?.length ?? 0}</span>
+          <span>contributors</span>
         </div>
         {catchup?.contributors && catchup.contributors.length > 0 && (
-          <div className="flex gap-1.5 mt-2 flex-wrap">
+          <div className="flex flex-wrap gap-1.5 mt-2">
             {catchup.contributors.map(c => (
-              <span key={c} className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-accent/5 text-accent/70 border border-accent/10">
+              <span
+                key={c}
+                className="font-mono text-micro px-2 py-0.5 text-text2 border border-border"
+                style={{ background: "rgba(255,255,255,0.02)" }}
+              >
                 {c}
               </span>
             ))}
@@ -107,41 +118,32 @@ export function MemoryPanel({ roomName, masId, refreshTrigger }: Props) {
       </div>
 
       {/* Tabs */}
-      <div className="flex border-b border-border">
-        <button
-          onClick={() => setTab("memories")}
-          className={`flex-1 py-2 text-xs font-bold uppercase tracking-wider transition-colors ${
-            tab === "memories" ? "text-accent border-b-2 border-accent" : "text-muted hover:text-white"
-          }`}
-        >
-          Memories
-        </button>
-        <button
-          onClick={() => setTab("synthesis")}
-          className={`flex-1 py-2 text-xs font-bold uppercase tracking-wider transition-colors ${
-            tab === "synthesis" ? "text-emerald-400 border-b-2 border-emerald-400" : "text-muted hover:text-white"
-          }`}
-        >
-          Synthesis
-        </button>
-        <button
-          onClick={() => setTab("knowledge")}
-          className={`flex-1 py-2 text-xs font-bold uppercase tracking-wider transition-colors ${
-            tab === "knowledge" ? "text-fuchsia-400 border-b-2 border-fuchsia-400" : "text-muted hover:text-white"
-          }`}
-        >
-          Knowledge
-        </button>
+      <div className="flex items-stretch border-b border-border bg-paper">
+        {TABS.map(t => {
+          const active = tab === t.id;
+          return (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`flex-1 py-2 caps-mono-sm transition-colors ${
+                active ? "text-accent" : "text-text2 hover:text-text"
+              }`}
+              style={{ borderBottom: `2px solid ${active ? "var(--accent)" : "transparent"}` }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
       </div>
 
       {tab === "memories" && (
         <div className="flex-1 overflow-y-auto">
           {/* Search */}
-          <div className="px-4 py-3 border-b border-border">
+          <div className="px-4 py-3 border-b border-border bg-paper">
             <div className="flex gap-2">
               <input
-                className="flex-1 bg-bg border border-border rounded-lg px-3 py-1.5 text-sm font-mono focus:border-accent/50 focus:outline-none"
-                placeholder="semantic search..."
+                className="flex-1 bg-bg border border-border px-3 py-1.5 text-label font-mono text-text placeholder:text-muted focus:border-accent focus:outline-none transition-colors"
+                placeholder="semantic search…"
                 value={searchQuery}
                 onChange={e => setSearchQuery(e.target.value)}
                 onKeyDown={e => e.key === "Enter" && handleSearch()}
@@ -149,59 +151,59 @@ export function MemoryPanel({ roomName, masId, refreshTrigger }: Props) {
               <button
                 onClick={handleSearch}
                 disabled={searching}
-                className="px-3 py-1.5 bg-accent/10 text-accent border border-accent/20 rounded-lg text-sm font-bold hover:bg-accent/20 transition-all disabled:opacity-50"
+                className="flex items-center gap-2 px-3 py-1.5 caps-mono-sm border border-accent/40 bg-accent/[0.06] text-accent transition-colors hover:bg-accent/[0.12] hover:border-accent/60 disabled:opacity-50"
               >
-                {searching ? "..." : "Search"}
+                {searching ? "…" : "SEARCH"}
               </button>
             </div>
           </div>
 
           {/* Search results */}
           {searchResults && (
-            <div className="px-4 py-2 border-b border-border bg-accent/[0.02]">
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-xs text-muted font-bold uppercase tracking-wider">
-                  {searchResults.length} result{searchResults.length !== 1 ? "s" : ""}
+            <div className="border-b border-border" style={{ background: "rgba(93,212,224,0.03)" }}>
+              <div className="flex items-center gap-2 px-4 py-2 border-b border-border">
+                <span className="caps-mono-sm text-muted">
+                  <span className="text-text font-semibold tabular">{searchResults.length}</span> RESULTS
                 </span>
-                <button onClick={() => setSearchResults(null)} className="text-xs text-muted hover:text-white">
-                  clear
+                <button
+                  onClick={() => setSearchResults(null)}
+                  className="ml-auto caps-mono-sm text-text2 hover:text-accent transition-colors"
+                >
+                  CLEAR
                 </button>
               </div>
               {searchResults.map((r, i) => (
-                <div key={i} className="py-2 border-t border-border/50 first:border-t-0">
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-sm text-accent">{r.memory.key}</span>
-                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-400 font-bold">
+                <div key={i} className="px-4 py-2 border-b border-border last:border-b-0">
+                  <div className="flex items-baseline gap-2 mb-1">
+                    <span className="font-mono text-label text-accent truncate">{r.memory.key}</span>
+                    <span className="caps-mono-sm tabular ml-auto" style={{ color: "var(--yellow)" }}>
                       {(r.similarity * 100).toFixed(0)}%
                     </span>
                   </div>
-                  <p className="text-xs text-muted mt-1 line-clamp-2">{formatValue(r.memory.value)}</p>
+                  <p className="text-label text-text2 line-clamp-2">{formatValue(r.memory.value)}</p>
                 </div>
               ))}
             </div>
           )}
 
           {/* Memory list */}
-          <div className="px-4 py-2 space-y-1">
+          <div>
             {memories.map(mem => (
-              <div key={mem.key} className="py-2.5 border-b border-border/30 last:border-b-0">
-                <div className="flex items-center gap-2 mb-1">
-                  <span className="font-mono text-sm text-accent">{mem.key}</span>
-                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface text-muted border border-border font-bold">
-                    v{mem.version}
-                  </span>
-                  <span className="ml-auto text-[10px] text-muted/40">{mem.created_by}</span>
+              <div key={mem.key} className="px-4 py-2.5 border-b border-border last:border-b-0">
+                <div className="flex items-baseline gap-2 mb-1">
+                  <span className="font-mono text-label text-accent truncate min-w-0">{mem.key}</span>
+                  <span className="caps-mono-sm text-muted tabular flex-shrink-0">v{mem.version}</span>
+                  <span className="ml-auto caps-mono-sm text-muted truncate flex-shrink-0">{mem.created_by}</span>
                 </div>
-                <p className="text-xs text-muted line-clamp-2 font-mono">
+                <p className="text-label text-text2 line-clamp-2 font-mono leading-snug">
                   {formatValue(mem.value)}
                 </p>
-                {mem.file_path && (
-                  <p className="text-[10px] text-muted/30 mt-1 font-mono">{mem.file_path}</p>
-                )}
               </div>
             ))}
             {memories.length === 0 && (
-              <div className="text-center text-muted/50 py-10 text-sm">No memories yet</div>
+              <div className="text-center caps-mono-sm text-muted italic py-10">
+                no memories yet
+              </div>
             )}
           </div>
         </div>
@@ -211,17 +213,17 @@ export function MemoryPanel({ roomName, masId, refreshTrigger }: Props) {
         <div className="flex-1 overflow-y-auto px-4 py-4">
           {synthText ? (
             <>
-              <div className="text-xs text-muted font-mono mb-3">
-                {catchup?.latest_synthesis?.key} — {catchup?.latest_synthesis?.created_at?.slice(0, 16)}
+              <div className="caps-mono-sm text-muted mb-3 truncate">
+                {catchup?.latest_synthesis?.key} · {catchup?.latest_synthesis?.created_at?.slice(0, 16)}
               </div>
-              <div className="prose prose-invert prose-sm max-w-none text-sm text-[#c0cce0] leading-relaxed whitespace-pre-wrap">
-                {synthText}
-              </div>
+              <MarkdownContent>{synthText}</MarkdownContent>
             </>
           ) : (
-            <div className="text-center text-muted/50 py-10 text-sm">
-              No synthesis yet.<br />
-              <span className="text-xs">Run <code className="bg-surface px-1 rounded">mycelium synthesize</code></span>
+            <div className="text-center caps-mono-sm text-muted italic py-10">
+              no synthesis yet
+              <div className="font-mono text-label text-text2 mt-3 normal-case tracking-normal not-italic">
+                run <code className="bg-surface px-1.5 py-0.5 text-accent border border-border">mycelium synthesize</code>
+              </div>
             </div>
           )}
         </div>

--- a/mycelium-frontend/src/components/room-card.tsx
+++ b/mycelium-frontend/src/components/room-card.tsx
@@ -35,7 +35,7 @@ export function RoomCard({ room }: RoomCardProps) {
           <span className={`w-2 h-2 rounded-full ${stateIndicator[room.coordination_state] || stateIndicator.idle}`} />
           <span>{room.coordination_state}</span>
         </div>
-        <div className="mt-2 text-xs text-muted/60">
+        <div className="mt-2 text-xs text-muted">
           {room.created_at?.slice(0, 10)}
         </div>
       </div>

--- a/mycelium-frontend/src/components/session-view.tsx
+++ b/mycelium-frontend/src/components/session-view.tsx
@@ -1,0 +1,638 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from "react-resizable-panels";
+import { fetchMessages, getSSEUrl } from "@/lib/api";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface RawMessage {
+  id: string;
+  room_name: string;
+  sender_handle: string | null;
+  recipient_handle: string | null;
+  message_type: string;
+  content: string | Record<string, unknown>;
+  created_at: string;
+}
+
+type Action = "propose" | "counter" | "accept" | "reject" | "tick" | "consensus" | "broken" | "start";
+
+interface Event {
+  id: string;
+  time: string;
+  iso: string;
+  agent: string;        // who acted (or who the tick was addressed to)
+  round: number;
+  action: Action;
+  offer?: Record<string, string>;
+  issueOptions?: Record<string, string[]>;
+  note?: string;
+  raw: RawMessage;
+}
+
+interface DerivedState {
+  events: Event[];
+  agents: string[];
+  rounds: number;
+  maxRounds: number;
+  currentRound: number;
+  currentOffer: Record<string, string> | null;
+  issueOptions: Record<string, string[]> | null;
+  proposerId: string | null;
+  nextProposerId: string | null;
+  state: "negotiating" | "complete" | "broken" | "starting";
+  consensus: { plan: string; assignments: Record<string, string>; broken: boolean } | null;
+}
+
+// ─── Parsing ──────────────────────────────────────────────────────────────────
+
+function parseContent(c: string | Record<string, unknown>): Record<string, unknown> {
+  if (typeof c === "string") {
+    try { return JSON.parse(c); } catch { return { _text: c }; }
+  }
+  return c ?? {};
+}
+
+function parseEvents(messages: RawMessage[]): Event[] {
+  const out: Event[] = [];
+  // Track latest tick per agent so we can attribute their next 'direct' to the right round
+  const lastTickFor = new Map<string, { round: number; iso: string }>();
+
+  for (const m of messages) {
+    const content = parseContent(m.content);
+    const time = m.created_at.slice(11, 19);
+    const iso = m.created_at;
+
+    if (m.message_type === "coordination_start") {
+      out.push({
+        id: m.id, time, iso, agent: "CognitiveEngine",
+        round: (content.round as number) ?? 0,
+        action: "start",
+        note: `${content.agent_count ?? "?"} agents`,
+        raw: m,
+      });
+      continue;
+    }
+
+    if (m.message_type === "coordination_tick") {
+      const payload = (content.payload as Record<string, unknown>) ?? content;
+      const target = String(payload.participant_id ?? "?");
+      const round = Number(payload.round ?? 0);
+      lastTickFor.set(target, { round, iso });
+      out.push({
+        id: m.id, time, iso, agent: target,
+        round,
+        action: "tick",
+        offer: payload.current_offer as Record<string, string> | undefined,
+        issueOptions: payload.issue_options as Record<string, string[]> | undefined,
+        note: `${payload.action ?? "respond"} · proposer=${payload.proposer_id ?? "—"}`,
+        raw: m,
+      });
+      continue;
+    }
+
+    if (m.message_type === "coordination_consensus") {
+      const broken = Boolean(content.broken);
+      out.push({
+        id: m.id, time, iso, agent: "CognitiveEngine",
+        round: 0,
+        action: broken ? "broken" : "consensus",
+        offer: (content.assignments as Record<string, string>) ?? undefined,
+        note: typeof content.plan === "string" ? content.plan : undefined,
+        raw: m,
+      });
+      continue;
+    }
+
+    if (m.message_type === "direct" && m.sender_handle) {
+      const action = String(content.action ?? "propose").toLowerCase();
+      const lastTick = lastTickFor.get(m.sender_handle);
+      const round = lastTick?.round ?? 0;
+      let mapped: Action = "propose";
+      if (action === "accept") mapped = "accept";
+      else if (action === "reject") mapped = "reject";
+      else if (action === "counter_offer" || action === "counter") mapped = "counter";
+      else mapped = "propose";
+
+      out.push({
+        id: m.id, time, iso, agent: m.sender_handle,
+        round,
+        action: mapped,
+        offer: content.offer as Record<string, string> | undefined,
+        raw: m,
+      });
+    }
+  }
+  return out;
+}
+
+function deriveState(messages: RawMessage[]): DerivedState {
+  const events = parseEvents(messages);
+
+  // Agents: any sender_handle on a `direct`, plus participants from ticks
+  const agents = new Set<string>();
+  for (const e of events) {
+    if (["propose", "counter", "accept", "reject", "tick"].includes(e.action)) {
+      if (e.agent && e.agent !== "CognitiveEngine") agents.add(e.agent);
+    }
+  }
+
+  // Rounds + current offer/options come from latest tick
+  const ticks = events.filter(e => e.action === "tick");
+  const lastTick = ticks[ticks.length - 1];
+  const currentRound = lastTick?.round ?? 0;
+  const rounds = currentRound;
+
+  // Look at last tick payload for offer + options
+  const lastTickRaw = lastTick?.raw;
+  const tickContent = lastTickRaw ? parseContent(lastTickRaw.content) : {};
+  const tickPayload = (tickContent.payload as Record<string, unknown>) ?? tickContent;
+
+  const currentOffer = (lastTick?.offer ?? null) as Record<string, string> | null;
+  const issueOptions = (lastTick?.issueOptions ?? null) as Record<string, string[]> | null;
+  const proposerId = (tickPayload.proposer_id as string) ?? null;
+  const nextProposerId = (tickPayload.next_proposer_id as string) ?? null;
+
+  // State
+  const consensusEvent = events.find(e => e.action === "consensus" || e.action === "broken");
+  let state: DerivedState["state"] = "starting";
+  if (consensusEvent) state = consensusEvent.action === "broken" ? "broken" : "complete";
+  else if (lastTick) state = "negotiating";
+
+  let consensus: DerivedState["consensus"] = null;
+  if (consensusEvent) {
+    const c = parseContent(consensusEvent.raw.content);
+    consensus = {
+      plan: String(c.plan ?? ""),
+      assignments: (c.assignments as Record<string, string>) ?? {},
+      broken: Boolean(c.broken),
+    };
+  }
+
+  return {
+    events, agents: Array.from(agents).sort(), rounds, maxRounds: 20, currentRound,
+    currentOffer, issueOptions, proposerId, nextProposerId, state, consensus,
+  };
+}
+
+// ─── Hook: live session messages ──────────────────────────────────────────────
+
+function useSessionMessages(sessionRoom: string) {
+  const [messages, setMessages] = useState<RawMessage[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchMessages(sessionRoom, 500).then((data: unknown) => {
+      if (cancelled) return;
+      const arr = Array.isArray(data) ? data : (data as { messages?: RawMessage[] })?.messages ?? [];
+      // API returns newest-first; reverse to chronological.
+      setMessages([...arr].reverse());
+    }).catch(() => {});
+
+    const url = getSSEUrl(sessionRoom);
+    let es: EventSource | null = null;
+    try {
+      es = new EventSource(url);
+      es.onmessage = (ev) => {
+        try {
+          const msg = JSON.parse(ev.data) as RawMessage;
+          setMessages(prev => prev.some(m => m.id === msg.id) ? prev : [...prev, msg]);
+        } catch { /* ignore non-message frames */ }
+      };
+      es.onerror = () => { /* SSE may flap; periodic refetch covers it */ };
+    } catch { /* no-op */ }
+
+    const refetch = setInterval(() => {
+      fetchMessages(sessionRoom, 500).then((data: unknown) => {
+        if (cancelled) return;
+        const arr = Array.isArray(data) ? data : (data as { messages?: RawMessage[] })?.messages ?? [];
+        setMessages([...arr].reverse());
+      }).catch(() => {});
+    }, 5000);
+
+    return () => { cancelled = true; es?.close(); clearInterval(refetch); };
+  }, [sessionRoom]);
+
+  return messages;
+}
+
+// ─── Glyphs ───────────────────────────────────────────────────────────────────
+
+const ACTION_META: Record<Action, { label: string; tone: "accent" | "ok" | "warn" | "muted" | "ink" }> = {
+  start:     { label: "START",     tone: "muted" },
+  tick:      { label: "AWAITING",  tone: "accent" },
+  propose:   { label: "PROPOSE",   tone: "ink" },
+  counter:   { label: "COUNTER",   tone: "ink" },
+  accept:    { label: "ACCEPT",    tone: "ok" },
+  reject:    { label: "REJECT",    tone: "warn" },
+  consensus: { label: "CONSENSUS", tone: "ok" },
+  broken:    { label: "TIMEOUT",   tone: "warn" },
+};
+
+function toneVar(t: "accent" | "ok" | "warn" | "muted" | "ink"): string {
+  return t === "accent" ? "var(--accent)"
+       : t === "ok"     ? "var(--green)"
+       : t === "warn"   ? "var(--yellow)"
+       : t === "ink"    ? "var(--text)"
+                        : "var(--muted)";
+}
+
+function ActionGlyph({ action }: { action: Action }) {
+  const meta = ACTION_META[action];
+  const color = toneVar(meta.tone);
+  if (action === "reject" || action === "broken") {
+    return (
+      <svg
+        width="12" height="12" viewBox="0 0 12 12"
+        aria-hidden style={{ display: "inline-block", color, flexShrink: 0 }}
+      >
+        <line x1="2" y1="2" x2="10" y2="10" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+        <line x1="10" y1="2" x2="2" y2="10" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+      </svg>
+    );
+  }
+  if (action === "tick") {
+    // "waiting on this agent" — pulse to read as in-progress
+    return (
+      <span
+        aria-hidden
+        title="awaiting response"
+        style={{
+          display: "inline-block", width: 6, height: 6, borderRadius: "50%",
+          background: "var(--accent)",
+          animation: "myc-pulse 1.4s ease-in-out infinite",
+        }}
+      />
+    );
+  }
+  if (action === "counter") {
+    // Hollow diamond — distinct from PROPOSE (square) but same geometric family
+    return (
+      <span
+        aria-hidden
+        style={{
+          display: "inline-block", width: 11, height: 11,
+          background: "transparent",
+          border: `1.5px solid ${color}`,
+          transform: "rotate(45deg)",
+          flexShrink: 0,
+        }}
+      />
+    );
+  }
+  const filled = action === "accept" || action === "consensus";
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: "inline-block", width: 11, height: 11,
+        background: filled ? color : "transparent",
+        border: `1.5px solid ${color}`,
+      }}
+    />
+  );
+}
+
+// ─── Subcomponents ────────────────────────────────────────────────────────────
+
+function HeaderRow({ sessionRoom, derived }: { sessionRoom: string; derived: DerivedState }) {
+  const sigil = sessionRoom.split(":").pop() ?? sessionRoom;
+  const stateColor =
+    derived.state === "complete" ? "var(--green)" :
+    derived.state === "broken"   ? "var(--yellow)" :
+    derived.state === "negotiating" ? "var(--accent)" :
+                                      "var(--muted)";
+  const stateLabel =
+    derived.state === "complete" ? "CONSENSUS" :
+    derived.state === "broken"   ? "TIMEOUT" :
+    derived.state === "negotiating" ? "NEGOTIATING" :
+                                      "STARTING";
+  const awaiting = derived.state === "negotiating" && derived.nextProposerId
+    ? `awaiting ${derived.nextProposerId}` : null;
+
+  return (
+    <div className="grid items-end gap-6 px-6 py-4 border-b border-border2"
+         style={{ gridTemplateColumns: "1fr auto 1fr" }}>
+      <div>
+        <div className="caps-mono-sm text-muted">SESSION ID</div>
+        <div className="font-mono text-display text-text mt-1 truncate" style={{ lineHeight: 1.1 }}>
+          {sigil}
+        </div>
+        <div className="caps-mono-sm text-muted mt-1">
+          {derived.agents.length} agents · {derived.events.length} events
+        </div>
+      </div>
+      <div className="text-center">
+        <div className="caps-mono-sm text-muted">ROUND</div>
+        <div style={{ lineHeight: 1, marginTop: 4 }}>
+          <span style={{ color: "var(--accent)", fontFamily: "'SF Mono', monospace", fontSize: 56, fontWeight: 700, letterSpacing: "0.02em" }}>
+            {String(derived.currentRound).padStart(2, "0")}
+          </span>
+          <span style={{ color: "var(--dim)", fontFamily: "'SF Mono', monospace", fontSize: 28, fontWeight: 400 }}>
+            {" "}/ {derived.maxRounds}
+          </span>
+        </div>
+      </div>
+      <div className="text-right">
+        <div className="caps-mono-sm text-muted">STATE</div>
+        <div className="caps-mono mt-1" style={{ color: stateColor }}>{stateLabel}</div>
+        {awaiting && <div className="caps-mono-sm text-muted italic mt-1">{awaiting}</div>}
+      </div>
+    </div>
+  );
+}
+
+function NegotiationSpace({ derived }: { derived: DerivedState }) {
+  const offer = derived.currentOffer;
+  const options = derived.issueOptions;
+  const [expanded, setExpanded] = useState(false);
+
+  if (!offer || !options) {
+    return (
+      <div className="px-6 py-4 border-b border-border">
+        <div className="caps-mono-sm text-muted mb-2">CURRENT OFFER</div>
+        <div className="text-body text-muted italic">no offer yet — waiting for first tick</div>
+      </div>
+    );
+  }
+  const issues = Object.keys(options);
+
+  return (
+    <div className="px-6 py-4 border-b border-border">
+      <div className="flex items-center gap-3 mb-2">
+        <span className="caps-mono-sm text-muted">CURRENT OFFER · {issues.length} ISSUES</span>
+        <button
+          onClick={() => setExpanded(e => !e)}
+          className="ml-auto flex items-center gap-1.5 caps-mono-sm text-text2 hover:text-accent transition-colors"
+          aria-expanded={expanded}
+        >
+          <span aria-hidden style={{ fontSize: 11 }}>{expanded ? "−" : "+"}</span>
+          {expanded ? "HIDE OPTIONS" : "SHOW ALL OPTIONS"}
+        </button>
+      </div>
+      <div className="border border-border2" style={{ background: "rgba(255,255,255,0.015)" }}>
+        {issues.map((issue, i) => {
+          const current = offer[issue];
+          const opts = options[issue] ?? [];
+          return (
+            <div key={issue} className={`px-4 py-2.5 ${i < issues.length - 1 ? "border-b border-border" : ""}`}>
+              <div className="grid items-baseline gap-3" style={{ gridTemplateColumns: "180px 24px 1fr" }}>
+                <span className="caps-mono-sm text-muted truncate">
+                  {String(i + 1).padStart(2, "0")} · {issue}
+                </span>
+                <span className="text-dim caps-mono-sm text-center">=</span>
+                <span className="font-mono text-body text-accent break-words" style={{ fontWeight: 600 }}>
+                  {current ?? "—"}
+                </span>
+              </div>
+              {expanded && opts.length > 0 && (
+                <div className="mt-2 ml-[204px] space-y-0.5">
+                  {opts.filter(o => o !== current).map(opt => (
+                    <div key={opt} className="flex items-start gap-2">
+                      <span
+                        aria-hidden
+                        style={{
+                          width: 7, height: 7, marginTop: 7, flexShrink: 0,
+                          border: "1.5px solid var(--muted)",
+                        }}
+                      />
+                      <span className="font-mono text-label text-text2 leading-snug break-words">{opt}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function SwimLanes({ derived }: { derived: DerivedState }) {
+  const { agents, currentRound, maxRounds, events } = derived;
+  const rounds = Math.max(maxRounds, currentRound + 1);
+
+  // Build per-agent, per-round latest action (preferring agent response over tick)
+  const lanes = useMemo(() => {
+    const m = new Map<string, Map<number, Action>>();
+    for (const a of agents) m.set(a, new Map());
+    for (const e of events) {
+      if (e.agent === "CognitiveEngine") continue;
+      const lane = m.get(e.agent);
+      if (!lane) continue;
+      const existing = lane.get(e.round);
+      // Don't overwrite a real response with a later tick
+      if (existing && existing !== "tick" && e.action === "tick") continue;
+      lane.set(e.round, e.action);
+    }
+    return m;
+  }, [agents, events]);
+
+  if (agents.length === 0) {
+    return (
+      <div className="px-6 py-4 border-b border-border">
+        <div className="caps-mono-sm text-muted mb-2">SWIM LANES · AGENT × ROUND</div>
+        <div className="text-body text-muted italic">no agents have joined yet</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-6 py-4 border-b border-border">
+      <div className="caps-mono-sm text-muted mb-2">SWIM LANES · AGENT × ROUND</div>
+      <div className="border border-border2 overflow-x-auto" style={{ background: "rgba(255,255,255,0.015)" }}>
+        {/* Round axis */}
+        <div className="grid border-b border-border2" style={{ gridTemplateColumns: `140px repeat(${rounds}, minmax(0, 1fr))` }}>
+          <div className="px-3 py-2 caps-mono-sm text-muted">ROUND →</div>
+          {Array.from({ length: rounds }).map((_, i) => {
+            const r = i + 1;
+            const isCur = r === currentRound;
+            const isPast = r < currentRound;
+            return (
+              <div key={i} className="text-center py-2 border-l border-border tabular"
+                   style={{
+                     fontSize: "var(--text-micro)",
+                     color: isPast ? "var(--accent)" : isCur ? "var(--text)" : "var(--dim)",
+                     fontWeight: isPast || isCur ? 600 : 400,
+                     background: isCur ? "rgba(93,212,224,0.06)" : undefined,
+                   }}>
+                {String(r).padStart(2, "0")}
+              </div>
+            );
+          })}
+        </div>
+        {/* Lanes */}
+        {agents.map(agent => (
+          <div key={agent} className="grid border-b border-border last:border-b-0"
+               style={{ gridTemplateColumns: `140px repeat(${rounds}, minmax(0, 1fr))` }}>
+            <div className="px-3 py-2 flex items-center border-r border-border2 min-w-0">
+              <span className="font-mono text-label text-text truncate">{agent}</span>
+            </div>
+            {Array.from({ length: rounds }).map((_, i) => {
+              const r = i + 1;
+              const action = lanes.get(agent)?.get(r);
+              return (
+                <div key={i} className="flex items-center justify-center border-l border-border"
+                     style={{ height: 38, background: r === currentRound ? "rgba(93,212,224,0.06)" : undefined }}>
+                  {action && <ActionGlyph action={action} />}
+                </div>
+              );
+            })}
+          </div>
+        ))}
+        {/* Legend */}
+        <div className="flex flex-wrap gap-5 px-4 py-2 border-t border-border2 bg-bg/60">
+          {(["propose", "counter", "accept", "reject"] as Action[]).map(a => (
+            <div key={a} className="flex items-center gap-2">
+              <ActionGlyph action={a} />
+              <span className="caps-mono-sm" style={{ color: toneVar(ACTION_META[a].tone) }}>
+                {ACTION_META[a].label}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConsensusBanner({ derived }: { derived: DerivedState }) {
+  const c = derived.consensus;
+  if (!c) return null;
+  const tone = c.broken ? "warn" : "ok";
+  const color = toneVar(tone);
+  return (
+    <div className="mx-6 my-4 border" style={{
+      borderColor: color,
+      background: c.broken ? "rgba(251,191,36,0.04)" : "rgba(52,211,153,0.04)",
+      padding: 16,
+    }}>
+      <div className="flex items-center gap-2 mb-2">
+        <ActionGlyph action={c.broken ? "broken" : "consensus"} />
+        <span className="caps-mono" style={{ color }}>
+          {c.broken ? "NEGOTIATION TIMEOUT" : "CONSENSUS REACHED"}
+        </span>
+      </div>
+      {c.plan && <div className="text-body text-text2 mb-2">{c.plan}</div>}
+      {Object.keys(c.assignments).length > 0 && (
+        <div className="font-mono text-label space-y-1 mt-2">
+          {Object.entries(c.assignments).map(([k, v]) => (
+            <div key={k} className="flex items-baseline gap-3">
+              <span style={{ color, minWidth: 140 }}>{k}</span>
+              <span className="text-dim">=</span>
+              <span className="text-text">{String(v)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EventLog({ derived }: { derived: DerivedState }) {
+  const [order, setOrder] = useState<"desc" | "asc">("desc");
+  const events = order === "desc" ? [...derived.events].reverse() : derived.events;
+  return (
+    <div className="flex flex-col flex-1 overflow-hidden">
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-border bg-paper flex-shrink-0">
+        <span className="caps-mono-sm text-muted">EVENT LOG · {derived.events.length}</span>
+        <button
+          onClick={() => setOrder(o => o === "desc" ? "asc" : "desc")}
+          className="ml-auto flex items-center gap-1.5 caps-mono-sm text-text2 hover:text-accent transition-colors"
+          title={order === "desc" ? "Showing newest first — click for oldest first" : "Showing oldest first — click for newest first"}
+        >
+          <span aria-hidden style={{ fontSize: 11 }}>{order === "desc" ? "↓" : "↑"}</span>
+          {order === "desc" ? "NEWEST" : "OLDEST"}
+        </button>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {events.map(e => <EventRow key={e.id} event={e} />)}
+        {events.length === 0 && (
+          <div className="px-6 py-8 caps-mono-sm text-muted italic text-center">no events yet</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EventRow({ event }: { event: Event }) {
+  const meta = ACTION_META[event.action];
+  const color = toneVar(meta.tone);
+  return (
+    <div className="px-4 py-2 border-b border-border hover:bg-white/[0.02]">
+      {/* Top row: time · R## · agent · action */}
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-micro text-muted tabular font-mono flex-shrink-0">{event.time}</span>
+        <span className="text-micro text-dim tabular font-mono flex-shrink-0">R{String(event.round).padStart(2, "0")}</span>
+        <span className="font-mono text-label text-text2 truncate min-w-0 flex-1">{event.agent}</span>
+        <span className="flex items-center gap-1.5 flex-shrink-0">
+          <ActionGlyph action={event.action} />
+          <span className="caps-mono-sm" style={{ color }}>{meta.label}</span>
+        </span>
+      </div>
+      {/* Detail */}
+      {event.note && (
+        <div className="text-label text-text2 italic mt-1 pl-[58px]">{event.note}</div>
+      )}
+      {event.offer && Object.keys(event.offer).length > 0 && (
+        <div className="font-mono text-micro mt-1 pl-[58px] space-y-0.5">
+          {Object.entries(event.offer).slice(0, 4).map(([k, v]) => (
+            <div key={k} className="flex items-baseline gap-2 min-w-0">
+              <span className="text-muted truncate flex-shrink-0" style={{ maxWidth: 110 }}>{k}</span>
+              <span className="text-dim flex-shrink-0">=</span>
+              <span className="text-text2 truncate min-w-0">{String(v)}</span>
+            </div>
+          ))}
+          {Object.keys(event.offer).length > 4 && (
+            <div className="text-dim italic">…and {Object.keys(event.offer).length - 4} more</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+interface SessionViewProps {
+  sessionRoom: string;
+}
+
+export function SessionView({ sessionRoom }: SessionViewProps) {
+  const messages = useSessionMessages(sessionRoom);
+  const derived = useMemo(() => deriveState(messages), [messages]);
+
+  return (
+    <PanelGroup
+      orientation="horizontal"
+      className="flex-1"
+      style={{ width: "100%", height: "100%" }}
+    >
+      <Panel id="main" defaultSize={60} minSize={25} className="overflow-hidden" style={{ minWidth: 0 }}>
+        <div className="h-full overflow-y-auto" style={{ width: "100%", minWidth: 0 }}>
+          <HeaderRow sessionRoom={sessionRoom} derived={derived} />
+          <SwimLanes derived={derived} />
+          <NegotiationSpace derived={derived} />
+          {derived.consensus && <ConsensusBanner derived={derived} />}
+        </div>
+      </Panel>
+      <PanelResizeHandle
+        className="w-px bg-border hover:bg-accent transition-colors flex-shrink-0 relative"
+        style={{ cursor: "col-resize" }}
+      >
+        {/* invisible wider hit-target so dragging is forgiving */}
+        <span aria-hidden className="absolute inset-y-0 -left-1.5 -right-1.5" />
+      </PanelResizeHandle>
+      <Panel id="log" defaultSize={40} minSize={20} className="overflow-hidden" style={{ minWidth: 0 }}>
+        <aside className="h-full bg-surface/40 flex flex-col overflow-hidden">
+          <EventLog derived={derived} />
+        </aside>
+      </Panel>
+    </PanelGroup>
+  );
+}

--- a/mycelium-frontend/src/components/sessions-rail.tsx
+++ b/mycelium-frontend/src/components/sessions-rail.tsx
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { fetchChildRooms } from "@/lib/api";
+
+function sessionIdOf(sessionRoomName: string): string {
+  return sessionRoomName.split(":").pop() ?? sessionRoomName;
+}
+
+interface Session {
+  name: string;
+  coordination_state: string;
+  created_at: string;
+  parent_namespace?: string | null;
+}
+
+const STATE_TONE: Record<string, "accent" | "muted" | "warn" | "ok"> = {
+  negotiating: "accent",
+  waiting: "warn",
+  synthesizing: "accent",
+  complete: "ok",
+  idle: "muted",
+  failed: "warn",
+};
+
+function relativeTime(iso: string): string {
+  if (!iso) return "—";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "—";
+  const diff = Date.now() - t;
+  const min = Math.floor(diff / 60_000);
+  if (min < 1) return "now";
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const d = Math.floor(hr / 24);
+  return `${d}d`;
+}
+
+function shortSessionName(name: string): string {
+  // session names look like "<room>:session:<uuid>" — show the trailing chunk
+  const colon = name.lastIndexOf(":");
+  const tail = colon >= 0 ? name.slice(colon + 1) : name;
+  return tail.length > 12 ? `${tail.slice(0, 8)}…${tail.slice(-3)}` : tail;
+}
+
+function toneVar(t: "accent" | "muted" | "warn" | "ok"): string {
+  return t === "accent" ? "var(--accent)"
+       : t === "ok"     ? "var(--green)"
+       : t === "warn"   ? "var(--yellow)"
+                        : "var(--muted)";
+}
+
+interface SessionsRailProps {
+  roomName: string;
+  activeSessionName?: string | null;
+}
+
+export function SessionsRail({ roomName, activeSessionName }: SessionsRailProps) {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetchChildRooms(roomName)
+        .then((data: Session[]) => { if (!cancelled) { setSessions(data); setLoaded(true); } })
+        .catch(() => { if (!cancelled) setLoaded(true); });
+    load();
+    const t = setInterval(load, 5000);
+    return () => { cancelled = true; clearInterval(t); };
+  }, [roomName]);
+
+  const counts = useMemo(() => {
+    const live = sessions.filter(s => s.coordination_state === "negotiating" || s.coordination_state === "waiting").length;
+    const done = sessions.filter(s => s.coordination_state === "complete").length;
+    return { total: sessions.length, live, done };
+  }, [sessions]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-surface/40">
+      {/* Pane header */}
+      <div className="flex items-center gap-2 border-b border-border bg-paper px-4 py-2.5">
+        <span className="caps-mono-sm text-muted">SESSIONS</span>
+        <span className="ml-auto text-micro text-muted tabular">
+          {counts.total}
+          {counts.live > 0 && (
+            <span className="text-accent"> · {counts.live} live</span>
+          )}
+        </span>
+      </div>
+
+      {/* Session list */}
+      <div className="flex-1 overflow-y-auto py-1">
+        {!loaded ? (
+          <div className="px-4 py-8 text-center caps-mono-sm text-muted italic">loading…</div>
+        ) : sessions.length === 0 ? (
+          <div className="px-4 py-8 text-center caps-mono-sm text-muted italic">
+            no sessions yet
+          </div>
+        ) : (
+          sessions.map(s => {
+            const tone = STATE_TONE[s.coordination_state] ?? "muted";
+            const color = toneVar(tone);
+            const pulse = tone === "accent" || tone === "warn";
+            const isActive = s.name === activeSessionName;
+            const sessionId = sessionIdOf(s.name);
+            return (
+              <Link
+                key={s.name}
+                href={`/room/${encodeURIComponent(roomName)}/session/${encodeURIComponent(sessionId)}`}
+                className={`flex w-full flex-col gap-1 px-4 py-2 text-left transition-colors ${
+                  isActive ? "bg-white/[0.04]" : "hover:bg-white/[0.02]"
+                }`}
+                style={{ borderLeft: `2px solid ${isActive ? "var(--accent)" : "transparent"}` }}
+              >
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`square-dot filled ${pulse ? "pulse" : ""}`}
+                    style={{ width: 6, height: 6, color }}
+                  />
+                  <span className={`font-mono text-label ${isActive ? "text-text" : "text-text2"} truncate`}>
+                    {shortSessionName(s.name)}
+                  </span>
+                  <span className="ml-auto text-micro text-muted tabular">{relativeTime(s.created_at)}</span>
+                </div>
+                <div className="flex items-center gap-1.5 pl-3">
+                  <span className="caps-mono-sm" style={{ color, fontSize: 'var(--text-micro)' }}>
+                    {s.coordination_state || "idle"}
+                  </span>
+                </div>
+              </Link>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/sessions-view.tsx
+++ b/mycelium-frontend/src/components/sessions-view.tsx
@@ -92,7 +92,7 @@ function OfferBlock({ offer, tone = "indigo" }: { offer: Record<string, unknown>
       {entries.map(([k, v]) => (
         <div key={k} className="flex gap-2 items-start">
           <span className={toneColors[tone]}>{k}</span>
-          <span className="text-muted/40">=</span>
+          <span className="text-muted">=</span>
           <span className="text-white/80 break-all">{String(v)}</span>
         </div>
       ))}
@@ -106,9 +106,9 @@ function JoinCard({ event }: { event: Event }) {
   return (
     <div className="bg-cyan-500/5 border border-cyan-500/20 rounded-lg p-3">
       <div className="flex items-center gap-2 mb-1.5 flex-wrap">
-        <span className="text-[10px] px-1.5 py-0.5 rounded bg-cyan-500/15 text-cyan-300 font-bold uppercase tracking-wider">joined</span>
+        <span className="text-micro px-1.5 py-0.5 rounded bg-cyan-500/15 text-cyan-300 font-bold uppercase tracking-wider">joined</span>
         <span className="font-mono text-sm text-cyan-200 font-semibold">{handle}</span>
-        <span className="ml-auto text-[10px] text-muted/40 font-mono">{event.time}</span>
+        <span className="ml-auto text-micro text-muted font-mono">{event.time}</span>
       </div>
       {intent && (
         <p className="text-sm text-white/85 leading-relaxed whitespace-pre-wrap">{intent}</p>
@@ -124,7 +124,7 @@ function StartCard({ event }: { event: Event }) {
       <div className="flex items-center gap-2">
         <span className="text-cyan-300 font-bold uppercase tracking-wider text-xs">Session started</span>
         <span className="text-xs text-muted">{count} agents</span>
-        <span className="ml-auto text-[10px] text-muted/40 font-mono">{event.time}</span>
+        <span className="ml-auto text-micro text-muted font-mono">{event.time}</span>
       </div>
     </div>
   );
@@ -142,22 +142,22 @@ function TickCard({ event }: { event: Event }) {
   return (
     <div className="bg-indigo-500/5 border border-indigo-500/20 rounded-lg p-3">
       <div className="flex items-center gap-2 mb-1 flex-wrap">
-        <span className="text-[10px] px-1.5 py-0.5 rounded bg-indigo-500/15 text-indigo-300 font-bold uppercase tracking-wider whitespace-nowrap">
+        <span className="text-micro px-1.5 py-0.5 rounded bg-indigo-500/15 text-indigo-300 font-bold uppercase tracking-wider whitespace-nowrap">
           round {round}
         </span>
         <span className="font-mono text-sm text-indigo-200 font-semibold">{participant}</span>
-        <span className="text-[11px] text-muted/60">{action === "respond" ? "to respond" : action}</span>
+        <span className="text-label text-muted">{action === "respond" ? "to respond" : action}</span>
         {canCounter && (
-          <span className="text-[10px] px-1.5 py-0.5 rounded bg-fuchsia-500/15 text-fuchsia-300 font-bold uppercase tracking-wider whitespace-nowrap">
+          <span className="text-micro px-1.5 py-0.5 rounded bg-fuchsia-500/15 text-fuchsia-300 font-bold uppercase tracking-wider whitespace-nowrap">
             can counter
           </span>
         )}
-        <span className="ml-auto text-[10px] text-muted/40 font-mono">{event.time}</span>
+        <span className="ml-auto text-micro text-muted font-mono">{event.time}</span>
       </div>
       {allowed.length > 0 && (
         <div className="flex gap-1 mt-1 flex-wrap">
           {allowed.map((a) => (
-            <span key={a} className="text-[9px] px-1.5 py-0.5 rounded bg-white/5 text-muted/80 font-mono uppercase tracking-wider">
+            <span key={a} className="text-micro px-1.5 py-0.5 rounded bg-white/5 text-muted font-mono uppercase tracking-wider">
               {a}
             </span>
           ))}
@@ -165,7 +165,7 @@ function TickCard({ event }: { event: Event }) {
       )}
       {currentOffer && Object.keys(currentOffer).length > 0 && (
         <>
-          <div className="text-muted/50 uppercase tracking-wider text-[9px] mt-2">current offer</div>
+          <div className="text-muted uppercase tracking-wider text-micro mt-2">current offer</div>
           <OfferBlock offer={currentOffer} tone="indigo" />
         </>
       )}
@@ -189,10 +189,10 @@ function ResponseCard({ event }: { event: Event }) {
       <div className="flex items-center gap-2 flex-wrap">
         <span className="text-base leading-none">{s.icon}</span>
         <span className="font-mono text-sm text-white/90 font-semibold">{event.sender}</span>
-        <span className={`text-[10px] px-1.5 py-0.5 rounded font-bold uppercase tracking-wider whitespace-nowrap ${s.chip}`}>
+        <span className={`text-micro px-1.5 py-0.5 rounded font-bold uppercase tracking-wider whitespace-nowrap ${s.chip}`}>
           {s.text}
         </span>
-        <span className="ml-auto text-[10px] text-muted/40 font-mono">{event.time}</span>
+        <span className="ml-auto text-micro text-muted font-mono">{event.time}</span>
       </div>
       {offer && <OfferBlock offer={offer} tone="fuchsia" />}
     </div>
@@ -211,7 +211,7 @@ function ConsensusCard({ event }: { event: Event }) {
         <div className="flex items-center gap-2 mb-2">
           <span className="text-red-400 text-lg leading-none">✗</span>
           <span className="text-red-300 font-bold uppercase tracking-wider text-xs">Negotiation failed</span>
-          <span className="ml-auto text-[10px] text-muted/40 font-mono">{event.time}</span>
+          <span className="ml-auto text-micro text-muted font-mono">{event.time}</span>
         </div>
         {plan && <p className="text-sm text-white/90 leading-relaxed whitespace-pre-wrap">{plan}</p>}
       </div>
@@ -223,7 +223,7 @@ function ConsensusCard({ event }: { event: Event }) {
       <div className="flex items-center gap-2 mb-2">
         <span className="text-emerald-400 text-lg leading-none">✓</span>
         <span className="text-emerald-300 font-bold uppercase tracking-wider text-xs">Consensus reached</span>
-        <span className="ml-auto text-[10px] text-muted/40 font-mono">{event.time}</span>
+        <span className="ml-auto text-micro text-muted font-mono">{event.time}</span>
       </div>
       {plan && <p className="text-sm text-white/90 mb-2 leading-relaxed whitespace-pre-wrap">{plan}</p>}
       {hasAssignments && <OfferBlock offer={assignments} tone="emerald" />}
@@ -237,8 +237,8 @@ function ChatCard({ event }: { event: Event }) {
     <div className="py-2 border-b border-border/20">
       <div className="flex items-baseline gap-2 mb-1">
         <span className="font-mono text-sm text-sky-300 font-semibold">{event.sender}</span>
-        <span className="text-[10px] text-muted/50 uppercase">{event.type}</span>
-        <span className="ml-auto text-[10px] text-muted/40 font-mono">{event.time}</span>
+        <span className="text-micro text-muted uppercase">{event.type}</span>
+        <span className="ml-auto text-micro text-muted font-mono">{event.time}</span>
       </div>
       <p className="text-sm text-white/90 whitespace-pre-wrap leading-relaxed">{text}</p>
     </div>
@@ -250,11 +250,11 @@ function GenericCard({ event }: { event: Event }) {
   return (
     <div className="border-l-2 border-l-muted/30 pl-3 py-1.5">
       <div className="flex items-center gap-2">
-        <span className="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-muted/10 text-muted">
+        <span className="text-micro font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-muted/10 text-muted">
           {event.type}
         </span>
-        <span className="flex-1 text-xs text-muted/70 font-mono truncate" title={preview}>{preview}</span>
-        <span className="text-[10px] text-muted/40 font-mono">{event.time}</span>
+        <span className="flex-1 text-xs text-muted font-mono truncate" title={preview}>{preview}</span>
+        <span className="text-micro text-muted font-mono">{event.time}</span>
       </div>
     </div>
   );
@@ -335,13 +335,13 @@ function SessionFeed({ sessionName }: { sessionName: string }) {
     <div className="flex flex-col h-full">
       <div className="flex items-center gap-2 px-4 py-2 border-b border-border/50">
         <span className={`w-1.5 h-1.5 rounded-full ${connected ? "bg-emerald-400 animate-pulse" : "bg-red-400"}`} />
-        <span className="text-[10px] text-muted/60 font-mono">{connected ? "live" : "reconnecting"}</span>
-        <span className="text-[10px] text-muted/40 font-mono truncate" title={sessionName}>{sessionName}</span>
-        <span className="ml-auto text-[10px] text-muted/40 font-mono">{events.length}</span>
+        <span className="text-micro text-muted font-mono">{connected ? "live" : "reconnecting"}</span>
+        <span className="text-micro text-muted font-mono truncate" title={sessionName}>{sessionName}</span>
+        <span className="ml-auto text-micro text-muted font-mono">{events.length}</span>
       </div>
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3 space-y-2">
         {events.length === 0 ? (
-          <div className="text-center text-muted/50 py-20 text-sm">No events yet</div>
+          <div className="text-center text-muted py-20 text-sm">No events yet</div>
         ) : (
           <>
             {events.map((ev) => <div key={ev.id}>{renderEvent(ev)}</div>)}
@@ -386,9 +386,9 @@ export function SessionsView({ roomName }: Props) {
 
   if (sessions.length === 0) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center text-center text-muted/60 text-sm px-6">
+      <div className="flex-1 flex flex-col items-center justify-center text-center text-muted text-sm px-6">
         <div className="mb-2">No sessions in this room</div>
-        <div className="text-xs text-muted/40 font-mono">
+        <div className="text-xs text-muted font-mono">
           Spawn one with <code className="text-accent/70">mycelium session join</code>
         </div>
       </div>
@@ -410,12 +410,12 @@ export function SessionsView({ roomName }: Props) {
               className={`group relative flex items-center gap-2 px-3 py-2 text-xs font-mono border-r border-border/60 transition-colors whitespace-nowrap ${
                 isActive
                   ? "bg-bg text-white"
-                  : "text-muted/70 hover:text-white hover:bg-white/5"
+                  : "text-muted hover:text-white hover:bg-white/5"
               }`}
             >
               <span className={`w-1.5 h-1.5 rounded-full ${state.dot}`} />
               <span>{shortId}</span>
-              <span className={`text-[9px] uppercase tracking-wider ${state.label}`}>{s.coordination_state}</span>
+              <span className={`text-micro uppercase tracking-wider ${state.label}`}>{s.coordination_state}</span>
               {isActive && (
                 <span className="absolute left-0 right-0 bottom-0 h-[2px] bg-accent" />
               )}
@@ -429,7 +429,7 @@ export function SessionsView({ roomName }: Props) {
         {activeSession ? (
           <SessionFeed key={activeSession.name} sessionName={activeSession.name} />
         ) : (
-          <div className="text-center text-muted/50 py-20 text-sm">Pick a session</div>
+          <div className="text-center text-muted py-20 text-sm">Pick a session</div>
         )}
       </div>
     </div>

--- a/mycelium-frontend/src/components/sub-nav.tsx
+++ b/mycelium-frontend/src/components/sub-nav.tsx
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { IDChip } from "./id-chip";
+
+export interface Crumb {
+  label: string;
+  href?: string;
+  /** Use IDChip rendering for room/session ids. Maps "rm:" → room, "ss:" → session. */
+  sigil?: "rm:" | "ss:";
+}
+
+interface SubNavProps {
+  crumbs: Crumb[];
+  actions?: ReactNode;
+}
+
+export function SubNav({ crumbs, actions }: SubNavProps) {
+  return (
+    <div className="flex h-[40px] flex-shrink-0 items-center gap-3 border-b border-border bg-paper px-5 min-w-0">
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        {crumbs.map((c, i) => {
+          const kind = c.sigil === "rm:" ? "room" : c.sigil === "ss:" ? "session" : null;
+          const inner = kind
+            ? <IDChip kind={kind} name={c.label} active={!c.href} />
+            : <span className="font-mono text-label truncate" style={{ color: c.href ? "var(--text2)" : "var(--text)", fontWeight: 600 }}>{c.label}</span>;
+          return (
+            <span key={i} className="flex items-center gap-2 min-w-0">
+              {i > 0 && <span className="text-dim caps-mono-sm flex-shrink-0">/</span>}
+              {c.href
+                ? <Link href={c.href} className="hover:opacity-80 transition-opacity min-w-0">{inner}</Link>
+                : inner}
+            </span>
+          );
+        })}
+      </div>
+      {actions && <div className="flex items-center gap-2 flex-shrink-0">{actions}</div>}
+    </div>
+  );
+}

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -48,8 +48,11 @@ export async function reindexRoom(roomName: string) {
   return res.json();
 }
 
-export async function fetchMessages(roomName: string) {
-  const res = await fetch(`${API}/rooms/${roomName}/messages`, { cache: "no-store" });
+export async function fetchMessages(roomName: string, limit?: number) {
+  const url = limit
+    ? `${API}/rooms/${roomName}/messages?limit=${limit}`
+    : `${API}/rooms/${roomName}/messages`;
+  const res = await fetch(url, { cache: "no-store" });
   return res.json();
 }
 


### PR DESCRIPTION
Two threads landing together:

1. **Frontend redesign** — first-class room directory, session detail view, channel + memory panes, all in a denser monospaced aesthetic
2. **Surface the frontend** (closes #201) — Dockerfile, \`ui\` compose profile, \`mycelium up --ui\`, \`mycelium ui\` command group, install-time prompt

## Frontend

### Room directory (\`/\`)
Replaces the card grid with a top bar + table. Drops the \`coordination_state\` filter rail and STATE column — \`Room.coordination_state\` is vestigial (sessions carry the real state now), so filtering by it was misleading. Final columns: \`# | ROOM | CREATED\`.

### Room view (\`/room/[name]\`)
Split into resizable channel + memory panes (drag the 1px handle in the middle). SessionsRail on the left lists child sessions with state-tinted indicators.

- **Channel** — markdown rendering for agent narrative messages (react-markdown + remark-gfm), \`@mention\` highlighting via a node walker. Tabs: CHANNEL · EVENTS, with a \`● LIVE\` connection indicator. EVENTS rows have colored 2px left bars + caps-mono action labels for each event type.
- **Memory** — restyled tabs (memories / synthesis / knowledge), search input + button, hairline rows. Synthesis renders through MarkdownContent.

### Session detail (\`/room/[name]/session/[session]\`)
First-class route — sessions in the rail are real \`<Link>\`s, browser back/breadcrumbs work natively. Derives state from the session sub-room's message stream:

- Header: session id · big \`07/20\` round counter · STATE pill (NEGOTIATING / TIMEOUT / CONSENSUS / STARTING)
- **Swim lanes**: agent × round grid, hollow square = propose, hollow diamond = counter, filled square = accept, X = reject, pulsing dot = awaiting that agent's response
- **Negotiation space**: current offer as \`issue = value\` table; \`+ SHOW ALL OPTIONS\` expands alternatives
- **Consensus banner**: success or timeout, with assignments
- **Event log**: pretty-printed timeline in a resizable right rail

### Tokens + chrome
- Bumped \`--bg\` warmer (\`#0c0d10\`), chalk-white text (\`#eaeaea\`), neutral muted (\`#b8b5ae\`), pale-cyan accent (\`#5dd4e0\`), chalk-hairline borders
- 5 semantic font-size tokens (\`text-micro/label/body/ui/display\`) — 57 hardcoded \`text-[Npx]\` sites swept to tokens
- Geist Mono everywhere mono
- Header bars use \`bg-paper\` so they stand off transparent content
- Stripped opacity modifiers (\`text-muted/40\` etc.) — relics of the old navy palette that read as invisible

### Reusable atoms
\`MainTopBar\`, \`SubNav\`, \`IDChip\`, \`MarkdownContent\`, \`SessionsRail\`, \`session-view\` components.

### Backend resolver
\`next.config.ts\` reads \`server.api_url\` from \`~/.mycelium/config.toml\` so the frontend stays in sync with the CLI. \`NEXT_PUBLIC_API_URL\` env still wins.

## Ship the frontend

### Image + compose
- \`mycelium-frontend/Dockerfile\` — multi-stage Next.js standalone build, ~150MB final, non-root
- \`compose.yml\` — \`mycelium-frontend\` service under \`profiles: [ui]\`, port 3000, depends on backend health
- \`release.yml\` — publishes \`ghcr.io/mycelium-io/mycelium-frontend:<version>\` (and \`:latest\` for stable releases) on every tagged release. Mirrors backend's prerelease handling so \`mycelium pull\` doesn't ship previews to existing installs.
- \`NEXT_PUBLIC_API_URL\` is baked at build time. Default is \`http://localhost:8000\` — correct for the standard local install since the browser hits the host-exposed backend port. Users with custom setups rebuild with \`--build-arg API_URL=…\`. Runtime injection is a follow-up.

### CLI
- \`mycelium up --ui\` — passes \`--profile ui\` to compose, prints both backend + frontend URLs on success
- \`mycelium ui open\` — opens the browser at the configured URL, warns if the container isn't running
- \`mycelium ui status\` — shows whether the container is up
- \`mycelium install\` — interactive flow prompts to bring up the frontend (default Yes, suppressible via \`--no-ui\`); non-interactive trusts the flag. Includes the frontend in port-conflict auto-detection and prints \`mycelium ui open\` in the next-steps list.

## Test plan

- [x] \`npx tsc --noEmit\` clean across the frontend
- [x] \`uv run ty check .\` clean across the CLI
- [x] CI builds the frontend on every push (existing job)
- [ ] Manual: cut a release, verify \`ghcr.io/mycelium-io/mycelium-frontend:<tag>\` lands
- [ ] Manual: \`mycelium install --force\` — confirm UI prompt fires, \`mycelium ui open\` lands the browser on \`/\`
- [ ] Manual: navigate \`/\` → \`/room/<name>\` → session, verify resize, breadcrumbs, browser back

## Follow-ups

- Runtime URL injection so a single published image works against any backend
- \`mycelium doctor\` reachability check for the frontend
- Agents-present indicator on the room header (no clean signal yet — memory contributors empty for chat-only rooms)