### PR TITLE
docs: revise hub-and-spoke guide for accuracy and generality

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -646,6 +646,10 @@ Latest Synthesis
     <section class="doc-section" id="hub-and-spoke">
       <h1>Hub &amp; Spoke Setup</h1>
       <p>How to run Mycelium across multiple machines so a small team shares memory, rooms, and coordination state from a single backend.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Note:</strong> The examples below use <strong>Matrix</strong> as the channel server and <strong>OpenClaw</strong> as the agent adapter. The same pattern applies to other channels (Discord, Slack, etc.) and adapters — substitute the relevant names and config paths.</div>
+      </div>
       <h2 id="hub-and-spoke-when-to-use-this">When to use this</h2>
       <p>Use hub-and-spoke when multiple people (or multiple machines) need to participate in the same rooms, see the same memories, and coordinate agents together. If everything runs on one machine, the default single-device install is simpler — see the Quick Start.</p>
       <h2 id="hub-and-spoke-topology">Topology</h2>
@@ -655,11 +659,11 @@ Latest Synthesis
 │  <span class="cmd">mycelium install</span>                │
 │  ├─ FastAPI backend  :8000       │
 │  ├─ AgensGraph (PG)  :5432       │
-│  ├─ Matrix / Synapse :8008       │
-│  ├─ CFN mgmt plane   :9000      │
-│  └─ CFN runtime      :9002      │
+│  ├─ Channel server   :8008       │
+│  ├─ CFN mgmt plane   :9000       │
+│  └─ CFN runtime      :9002       │
 │                                  │
-│  Channel servers (Matrix, etc)   │
+│  Channel servers                 │
 │  All agent accounts defined here │
 └────────────┬─────────────────────┘
              │  HTTPS / SSE
@@ -677,7 +681,7 @@ Latest Synthesis
       <p>On the hub machine, run the standard install:</p>
       <pre><code><span class="cmd">mycelium install</span></code></pre>
       <p>This brings up the backend, database, and provisions a default workspace. Verify with:</p>
-      <pre><code><span class="cmd">mycelium doctor</span> <span class="flag">--mode</span> hub</code></pre>
+      <pre><code><span class="cmd">mycelium doctor</span></code></pre>
       <h3 id="hub-and-spoke-open-ports">Open ports</h3>
       <p>Spokes need to reach the hub on these ports:</p>
       <div class="table-wrap">
@@ -697,8 +701,8 @@ Latest Synthesis
             </tr>
             <tr>
               <td>8008</td>
-              <td>Matrix homeserver (Synapse)</td>
-              <td>If using Matrix channel</td>
+              <td>Channel server (Matrix/Synapse in this example)</td>
+              <td>If using a channel server</td>
             </tr>
             <tr>
               <td>9000</td>
@@ -714,27 +718,24 @@ Latest Synthesis
         </table>
       </div>
       <p>Use a VPN, Tailscale, or firewall rules to restrict access — these services have no built-in authentication.</p>
-      <h3 id="hub-and-spoke-configure-channel-servers">Configure channel servers</h3>
-      <p>If agents coordinate via Matrix, set up Synapse on the hub and create accounts for every agent across all spokes:</p>
-      <pre><code><span class="comment"># Register agent accounts (on the hub)</span>
-<span class="comment"># Each spoke&#x27;s agents need a Matrix account on the hub&#x27;s homeserver</span></code></pre>
-      <p>Add all agent accounts to <code>channels.matrix.accounts</code> in the hub&#x27;s <code>~/.openclaw/openclaw.json</code>. The hub&#x27;s gateway manages all Matrix connections — spokes do not run their own Matrix clients.</p>
+      <h3 id="hub-and-spoke-configure-the-channel-server">Configure the channel server</h3>
+      <p>Run the channel server on the hub and create accounts for every agent across all spokes. For Matrix, this means running Synapse on the hub and registering each agent:</p>
+      <pre><code><span class="comment"># Register agent accounts on the hub&#x27;s Synapse instance</span>
+register_new_matrix_user <span class="flag">-c</span> /etc/synapse/homeserver.yaml http://localhost:8008</code></pre>
+      <p>Add all agent accounts to <code>channels.matrix.accounts</code> in the hub&#x27;s <code>~/.openclaw/openclaw.json</code>. The hub&#x27;s gateway manages all channel connections — spokes do not run their own channel clients.</p>
       <h2 id="hub-and-spoke-step-2-set-up-each-spoke">Step 2: Set up each spoke</h2>
       <p>On each spoke machine, install only the CLI (no <code>mycelium install</code>):</p>
-      <pre><code>pip install mycelium-cli
-<span class="comment"># or</span>
-uv tool install mycelium-cli</code></pre>
-      <h3 id="hub-and-spoke-point-the-spoke-at-the-hub">Point the spoke at the hub</h3>
-      <pre><code><span class="cmd">mycelium init</span> <span class="flag">--api-url</span> http://&lt;hub-ip&gt;:8000</code></pre>
-      <p>This writes <code>~/.mycelium/config.toml</code> with the hub&#x27;s API URL. Verify the connection:</p>
-      <pre><code><span class="cmd">mycelium doctor</span> <span class="flag">--mode</span> spoke</code></pre>
-      <p>The doctor checks that the hub&#x27;s backend is reachable and skips Docker/database checks that only apply to hubs.</p>
-      <h3 id="hub-and-spoke-install-the-adapter">Install the adapter</h3>
-      <p>For OpenClaw agents:</p>
-      <pre><code><span class="cmd">mycelium adapter add</span> openclaw</code></pre>
-      <p>The adapter installs the Mycelium plugin into the local OpenClaw gateway. The plugin connects to the hub&#x27;s backend URL (from <code>config.toml</code>) for SSE subscriptions and API calls.</p>
+      <pre><code>curl <span class="flag">-fsSL</span> https://mycelium-io.github.io/mycelium/install.sh | bash</code></pre>
+      <h3 id="hub-and-spoke-initialize-and-install-the-adapter">Initialize and install the adapter</h3>
+      <p>Point the spoke at the hub and install the adapter:</p>
+      <pre><code><span class="cmd">mycelium init</span> <span class="flag">--api-url</span> http://&lt;hub-ip&gt;:8000
+<span class="cmd">mycelium adapter add</span> openclaw</code></pre>
+      <p><code>init</code> writes <code>~/.mycelium/config.toml</code> with the hub&#x27;s API URL. <code>adapter add</code> installs the Mycelium plugin into the local OpenClaw gateway and probes the hub to confirm it&#x27;s reachable. The plugin connects to the hub&#x27;s backend for SSE subscriptions and API calls.</p>
       <p>After installing, restart the gateway:</p>
       <pre><code>openclaw gateway restart</code></pre>
+      <p>Verify the setup:</p>
+      <pre><code><span class="cmd">mycelium doctor</span></code></pre>
+      <p>The doctor auto-detects whether this node is a hub or spoke from <code>server.api_url</code> and adjusts its checks accordingly (e.g., skipping Docker/database checks on spokes).</p>
       <h3 id="hub-and-spoke-spoke-config-summary">Spoke config summary</h3>
       <p>A spoke needs only two files:</p>
       <div class="table-wrap">
@@ -752,7 +753,7 @@ uv tool install mycelium-cli</code></pre>
             </tr>
             <tr>
               <td><code>~/.openclaw/openclaw.json</code></td>
-              <td>Agent definitions, Matrix credentials, plugin config</td>
+              <td>Agent definitions, channel credentials, Mycelium plugin config</td>
             </tr>
           </tbody>
         </table>
@@ -778,16 +779,16 @@ uv tool install mycelium-cli</code></pre>
         <li>The <code>MYCELIUM_AGENT_HANDLE</code> environment variable</li>
         <li>The <code>--handle</code> flag on CLI commands</li>
       </ol>
-      <p>When using OpenClaw with Matrix, agent handles should match their Matrix user IDs (the localpart before the colon, e.g., <code>@agent-alpha:local</code> → <code>agent-alpha</code>).</p>
-      <h2 id="hub-and-spoke-matrix-token-management">Matrix token management</h2>
-      <p>Matrix access tokens expire or become invalid after homeserver restarts. When this happens, agents silently stop receiving messages.</p>
+      <p>Agent handles should match their channel user IDs. For Matrix, use the localpart before the colon: <code>@agent-alpha:local</code> → <code>agent-alpha</code>.</p>
+      <h2 id="hub-and-spoke-token-management">Token management</h2>
+      <p>Channel access tokens can expire or become invalid after server restarts. When this happens, agents silently stop receiving messages.</p>
       <p>Signs of expired tokens:</p>
       <ul>
         <li>Agents join sessions but never respond to coordination ticks</li>
-        <li>Gateway logs show Matrix sync errors</li>
-        <li><code>mycelium doctor</code> reports Matrix connection failures</li>
+        <li>Gateway logs show sync errors or 401/unauthorized responses</li>
+        <li><code>mycelium doctor</code> reports channel connection failures</li>
       </ul>
-      <p>To refresh tokens, log in again via the Synapse admin API or re-register the accounts, then update <code>channels.matrix.accounts[agent].accessToken</code> in each node&#x27;s <code>openclaw.json</code> and restart the gateway.</p>
+      <p>To refresh tokens, re-authenticate with the channel server (for Matrix, log in again via the Synapse admin API), update the token in <code>channels.&lt;channel&gt;.accounts[agent]</code> in each node&#x27;s <code>openclaw.json</code>, and restart the gateway.</p>
       <h2 id="hub-and-spoke-troubleshooting">Troubleshooting</h2>
       <h3 id="hub-and-spoke-spoke-cant-reach-hub">Spoke can&#x27;t reach hub</h3>
       <pre><code>curl http://&lt;hub-ip&gt;:8000/health</code></pre>
@@ -797,11 +798,10 @@ uv tool install mycelium-cli</code></pre>
       <ol class="steps">
         <li>Check the gateway logs: <code>journalctl --user -u openclaw-gateway --since &quot;5 min ago&quot;</code></li>
         <li>Look for <code>session SSE connected</code> — if absent, the plugin isn&#x27;t monitoring the session</li>
-        <li>Verify Matrix tokens are valid (see above)</li>
+        <li>Verify channel tokens are valid (see above)</li>
       </ol>
       <h3 id="hub-and-spoke-doctor-reports-spoke-mode-unexpectedly">Doctor reports &quot;spoke mode&quot; unexpectedly</h3>
-      <p><code>mycelium doctor</code> auto-detects mode from <code>server.api_url</code>. If it points to a non-localhost address, doctor assumes spoke mode. Override with:</p>
-      <pre><code><span class="cmd">mycelium doctor</span> <span class="flag">--mode</span> hub</code></pre>
+      <p><code>mycelium doctor</code> auto-detects mode from <code>server.api_url</code>. If it points to a non-localhost address, doctor assumes spoke mode. If you&#x27;re running the backend locally on a non-default address, set <code>server.api_url</code> to <code>http://localhost:8000</code> in <code>~/.mycelium/config.toml</code>.</p>
     </section>
     <!-- FOOTER -->
     <div class="docs-footer">

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -888,16 +888,16 @@ docker exec &lt;container-name&gt; openclaw status
       <pre><code><span class="cmd">mycelium reindex</span> &lt;room-name&gt;</code></pre>
       <p>Then run <code>mycelium synthesize</code> again.</p>
       <hr class="divider">
-      <h3 id="troubleshooting-15-agents-join-sessions-but-never-respond-expired-matrix-tokens">15. Agents Join Sessions but Never Respond (Expired Matrix Tokens)</h3>
+      <h3 id="troubleshooting-15-agents-join-sessions-but-never-respond-expired-channel-tokens">15. Agents Join Sessions but Never Respond (Expired Channel Tokens)</h3>
       <p><strong>Symptom</strong>: An agent appears in <code>mycelium room ls</code> as a session participant, but never responds to coordination ticks. No error in <code>mycelium logs</code>.</p>
-      <p><strong>Cause</strong>: The agent&#x27;s Matrix access token has expired or been invalidated (e.g., after a Synapse restart). The OpenClaw gateway silently drops the Matrix sync connection without surfacing an error to Mycelium.</p>
+      <p><strong>Cause</strong>: The agent&#x27;s channel access token (e.g., Matrix) has expired or been invalidated (e.g., after a server restart). The OpenClaw gateway silently drops the channel sync connection without surfacing an error to Mycelium.</p>
       <p><strong>Diagnosis</strong>:</p>
-      <pre><code><span class="comment"># Check gateway logs for Matrix sync errors</span>
-journalctl <span class="flag">--user</span> <span class="flag">-u</span> openclaw-gateway <span class="flag">--since</span> <span class="str">&quot;10 min ago&quot;</span> | grep <span class="flag">-i</span> matrix
+      <pre><code><span class="comment"># Check gateway logs for channel sync errors</span>
+journalctl <span class="flag">--user</span> <span class="flag">-u</span> openclaw-gateway <span class="flag">--since</span> <span class="str">&quot;10 min ago&quot;</span> | grep <span class="flag">-i</span> <span class="str">&quot;sync\|401\|unauthorized&quot;</span>
 
 <span class="comment"># Or on the hub</span>
 openclaw logs | grep <span class="flag">-i</span> <span class="str">&quot;sync\|401\|unauthorized&quot;</span></code></pre>
-      <p><strong>Fix</strong>: Re-authenticate the agent with the Matrix homeserver and update the token in <code>~/.openclaw/openclaw.json</code> at <code>channels.matrix.accounts.&lt;agent&gt;.accessToken</code>. Then restart the gateway:</p>
+      <p><strong>Fix</strong>: Re-authenticate the agent with the channel server and update the token in <code>~/.openclaw/openclaw.json</code> under the corresponding <code>channels.&lt;channel&gt;.accounts.&lt;agent&gt;</code> section. Then restart the gateway:</p>
       <pre><code>openclaw gateway restart</code></pre>
       <p>In a hub-and-spoke setup, update tokens on every node that runs agents.</p>
       <hr class="divider">

--- a/mycelium-cli/src/mycelium/docs/guides/hub-and-spoke.md
+++ b/mycelium-cli/src/mycelium/docs/guides/hub-and-spoke.md
@@ -3,6 +3,11 @@
 How to run Mycelium across multiple machines so a small team shares
 memory, rooms, and coordination state from a single backend.
 
+> **Note:** The examples below use **Matrix** as the channel server and
+> **OpenClaw** as the agent adapter. The same pattern applies to other
+> channels (Discord, Slack, etc.) and adapters — substitute the
+> relevant names and config paths.
+
 ## When to use this
 
 Use hub-and-spoke when multiple people (or multiple machines) need to
@@ -19,11 +24,11 @@ single-device install is simpler — see the Quick Start.
 │  mycelium install                │
 │  ├─ FastAPI backend  :8000       │
 │  ├─ AgensGraph (PG)  :5432       │
-│  ├─ Matrix / Synapse :8008       │
-│  ├─ CFN mgmt plane   :9000      │
-│  └─ CFN runtime      :9002      │
+│  ├─ Channel server   :8008       │
+│  ├─ CFN mgmt plane   :9000       │
+│  └─ CFN runtime      :9002       │
 │                                  │
-│  Channel servers (Matrix, etc)   │
+│  Channel servers                 │
 │  All agent accounts defined here │
 └────────────┬─────────────────────┘
              │  HTTPS / SSE
@@ -53,7 +58,7 @@ This brings up the backend, database, and provisions a default workspace.
 Verify with:
 
 ```bash
-mycelium doctor --mode hub
+mycelium doctor
 ```
 
 ### Open ports
@@ -63,70 +68,65 @@ Spokes need to reach the hub on these ports:
 | Port | Service | Required |
 |------|---------|----------|
 | 8000 | Mycelium backend (API + SSE) | Yes |
-| 8008 | Matrix homeserver (Synapse) | If using Matrix channel |
+| 8008 | Channel server (Matrix/Synapse in this example) | If using a channel server |
 | 9000 | CFN management plane | If using CognitiveEngine |
 | 9002 | CFN runtime | If using CognitiveEngine |
 
 Use a VPN, Tailscale, or firewall rules to restrict access — these
 services have no built-in authentication.
 
-### Configure channel servers
+### Configure the channel server
 
-If agents coordinate via Matrix, set up Synapse on the hub and create
-accounts for every agent across all spokes:
+Run the channel server on the hub and create accounts for every agent
+across all spokes. For Matrix, this means running Synapse on the hub
+and registering each agent:
 
 ```bash
-# Register agent accounts (on the hub)
-# Each spoke's agents need a Matrix account on the hub's homeserver
+# Register agent accounts on the hub's Synapse instance
+register_new_matrix_user -c /etc/synapse/homeserver.yaml http://localhost:8008
 ```
 
 Add all agent accounts to `channels.matrix.accounts` in the hub's
-`~/.openclaw/openclaw.json`. The hub's gateway manages all Matrix
-connections — spokes do not run their own Matrix clients.
+`~/.openclaw/openclaw.json`. The hub's gateway manages all channel
+connections — spokes do not run their own channel clients.
 
 ## Step 2: Set up each spoke
 
 On each spoke machine, install only the CLI (no `mycelium install`):
 
 ```bash
-pip install mycelium-cli
-# or
-uv tool install mycelium-cli
+curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
 ```
 
-### Point the spoke at the hub
+### Initialize and install the adapter
+
+Point the spoke at the hub and install the adapter:
 
 ```bash
 mycelium init --api-url http://<hub-ip>:8000
-```
-
-This writes `~/.mycelium/config.toml` with the hub's API URL. Verify
-the connection:
-
-```bash
-mycelium doctor --mode spoke
-```
-
-The doctor checks that the hub's backend is reachable and skips
-Docker/database checks that only apply to hubs.
-
-### Install the adapter
-
-For OpenClaw agents:
-
-```bash
 mycelium adapter add openclaw
 ```
 
-The adapter installs the Mycelium plugin into the local OpenClaw gateway.
-The plugin connects to the hub's backend URL (from `config.toml`) for
-SSE subscriptions and API calls.
+`init` writes `~/.mycelium/config.toml` with the hub's API URL.
+`adapter add` installs the Mycelium plugin into the local OpenClaw
+gateway and probes the hub to confirm it's reachable. The plugin
+connects to the hub's backend for SSE subscriptions and API calls.
 
 After installing, restart the gateway:
 
 ```bash
 openclaw gateway restart
 ```
+
+Verify the setup:
+
+```bash
+mycelium doctor
+```
+
+The doctor auto-detects whether this node is a hub or spoke from
+`server.api_url` and adjusts its checks accordingly (e.g., skipping
+Docker/database checks on spokes).
 
 ### Spoke config summary
 
@@ -135,7 +135,7 @@ A spoke needs only two files:
 | File | Purpose |
 |------|---------|
 | `~/.mycelium/config.toml` | Points `server.api_url` at the hub |
-| `~/.openclaw/openclaw.json` | Agent definitions, Matrix credentials, plugin config |
+| `~/.openclaw/openclaw.json` | Agent definitions, channel credentials, Mycelium plugin config |
 
 The spoke does not need `server.workspace_id` or `server.mas_id` in its
 config — the hub resolves these automatically when the spoke's agents
@@ -173,24 +173,24 @@ is set by:
 2. The `MYCELIUM_AGENT_HANDLE` environment variable
 3. The `--handle` flag on CLI commands
 
-When using OpenClaw with Matrix, agent handles should match their Matrix
-user IDs (the localpart before the colon, e.g., `@agent-alpha:local` →
-`agent-alpha`).
+Agent handles should match their channel user IDs. For Matrix, use the
+localpart before the colon: `@agent-alpha:local` → `agent-alpha`.
 
-## Matrix token management
+## Token management
 
-Matrix access tokens expire or become invalid after homeserver restarts.
+Channel access tokens can expire or become invalid after server restarts.
 When this happens, agents silently stop receiving messages.
 
 Signs of expired tokens:
 
 - Agents join sessions but never respond to coordination ticks
-- Gateway logs show Matrix sync errors
-- `mycelium doctor` reports Matrix connection failures
+- Gateway logs show sync errors or 401/unauthorized responses
+- `mycelium doctor` reports channel connection failures
 
-To refresh tokens, log in again via the Synapse admin API or re-register
-the accounts, then update `channels.matrix.accounts[agent].accessToken`
-in each node's `openclaw.json` and restart the gateway.
+To refresh tokens, re-authenticate with the channel server (for Matrix,
+log in again via the Synapse admin API), update the token in
+`channels.<channel>.accounts[agent]` in each node's `openclaw.json`,
+and restart the gateway.
 
 ## Troubleshooting
 
@@ -212,13 +212,11 @@ to coordination ticks:
 
 1. Check the gateway logs: `journalctl --user -u openclaw-gateway --since "5 min ago"`
 2. Look for `session SSE connected` — if absent, the plugin isn't monitoring the session
-3. Verify Matrix tokens are valid (see above)
+3. Verify channel tokens are valid (see above)
 
 ### Doctor reports "spoke mode" unexpectedly
 
 `mycelium doctor` auto-detects mode from `server.api_url`. If it points
-to a non-localhost address, doctor assumes spoke mode. Override with:
-
-```bash
-mycelium doctor --mode hub
-```
+to a non-localhost address, doctor assumes spoke mode. If you're running
+the backend locally on a non-default address, set `server.api_url` to
+`http://localhost:8000` in `~/.mycelium/config.toml`.

--- a/mycelium-cli/src/mycelium/docs/troubleshooting.md
+++ b/mycelium-cli/src/mycelium/docs/troubleshooting.md
@@ -250,29 +250,30 @@ Then run `mycelium synthesize` again.
 
 ---
 
-### 15. Agents Join Sessions but Never Respond (Expired Matrix Tokens)
+### 15. Agents Join Sessions but Never Respond (Expired Channel Tokens)
 
 **Symptom**: An agent appears in `mycelium room ls` as a session
 participant, but never responds to coordination ticks. No error in
 `mycelium logs`.
 
-**Cause**: The agent's Matrix access token has expired or been invalidated
-(e.g., after a Synapse restart). The OpenClaw gateway silently drops the
-Matrix sync connection without surfacing an error to Mycelium.
+**Cause**: The agent's channel access token (e.g., Matrix) has expired or
+been invalidated (e.g., after a server restart). The OpenClaw gateway
+silently drops the channel sync connection without surfacing an error to
+Mycelium.
 
 **Diagnosis**:
 
 ```bash
-# Check gateway logs for Matrix sync errors
-journalctl --user -u openclaw-gateway --since "10 min ago" | grep -i matrix
+# Check gateway logs for channel sync errors
+journalctl --user -u openclaw-gateway --since "10 min ago" | grep -i "sync\|401\|unauthorized"
 
 # Or on the hub
 openclaw logs | grep -i "sync\|401\|unauthorized"
 ```
 
-**Fix**: Re-authenticate the agent with the Matrix homeserver and update
-the token in `~/.openclaw/openclaw.json` at
-`channels.matrix.accounts.<agent>.accessToken`. Then restart the gateway:
+**Fix**: Re-authenticate the agent with the channel server and update
+the token in `~/.openclaw/openclaw.json` under the corresponding
+`channels.<channel>.accounts.<agent>` section. Then restart the gateway:
 
 ```bash
 openclaw gateway restart


### PR DESCRIPTION
## Summary

- Applies doc content fixes that were authored on the original `docs/hub-and-spoke` branch but lost during the squash merge in PR #212
- Changes spoke install method from `pip install` / `uv tool install` to `curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash`
- Changes `mycelium doctor --mode hub` / `--mode spoke` to plain `mycelium doctor` (auto-detects)
- Generalizes Matrix-specific language to channel-agnostic wording (Matrix kept as the example)
- Regenerates HTML docs to match

## Context

The original `docs/hub-and-spoke` branch had two parallel commits (`d520795` and `ac77b7d`) that were merged locally. The PR #212 squash merge picked up the content from one parent but missed the revised wording from the other. This PR cleanly applies only the missing content fixes on top of current `main`.

## Test plan

- [ ] Verify `hub-and-spoke.md` renders correctly in the docs site
- [ ] Confirm no references to `mycelium doctor --mode hub` remain
- [ ] Confirm spoke install uses `curl` install script


Made with [Cursor](https://cursor.com)