### PR TITLE
feat(openclaw): cross-channel return-trip for negotiation results

### DIFF
--- a/.claude/skills/before-and-after-matrix/SKILL.md
+++ b/.claude/skills/before-and-after-matrix/SKILL.md
@@ -1,0 +1,639 @@
+---
+name: before-and-after-matrix
+description: End-to-end smoke test for cross-channel coordination. Spins up two ephemeral OpenClaw agents wired to local Matrix Synapse + mycelium-room, kicks off a structured negotiation from a Matrix DM, and verifies the consensus summary auto-delivers back to the user's Matrix DM. Use when validating PR #221's return-trip mechanism still works, or after touching plugin/channel code, or to repro the original "agents go silent" bug class.
+argument-hint: "<scenario name or experiment file> (optional)"
+---
+
+# Before-and-After Matrix
+
+Tests the **cross-channel coordination** path end-to-end:
+
+1. User in their home channel (Matrix DM) tells their agent to coordinate with another agent
+2. Agent runs `mycelium session join` from inside that DM
+3. CFN drives multi-round negotiation in a session sub-room
+4. The Mycelium plugin auto-delivers the consensus summary back to the user's Matrix DM
+
+The **ship gate** is step 4: did the user actually see the result land in their Matrix DM, without the agent having to remember to call `sessions_send`?
+
+This skill is opinionated about the **happy path** (matrix bound to the same room the prompt names). Use the "Failure-mode variant" near the end if you want to reproduce the silent-failure bug from issue #220 (channel binding scope).
+
+**You are the test harness.** You set up Synapse users, wire OpenClaw, seed scenarios, observe transcripts, evaluate. The agents do the negotiating.
+
+## Phase 0: Prerequisites
+
+Before anything else, verify the stack. Run each check and stop if any fail.
+
+```bash
+# 1. Mycelium CLI
+mycelium --version
+# If missing: pip install mycelium (or pipx install mycelium)
+
+# 2. Resolve the backend URL — NEVER hardcode a port
+MYCELIUM_API_URL=$(python3 -c "
+import toml, os
+cfg = toml.load(os.path.expanduser('~/.mycelium/config.toml'))
+print(cfg.get('server', {}).get('api_url', 'http://localhost:8000'))
+")
+echo "Backend URL: $MYCELIUM_API_URL"
+
+# 3. Mycelium stack running (backend + AgensGraph + CFN)
+curl -sf "$MYCELIUM_API_URL/health" | python3 -m json.tool
+# Should show status=ok. If not: mycelium install && mycelium up
+
+# 4. OpenClaw installed + gateway up
+openclaw --version && openclaw channels status
+# Should show "Gateway reachable". If not: openclaw gateway start
+
+# 5. Local Matrix Synapse running
+docker ps --format '{{.Names}}' | grep -E 'matrix|synapse' || echo "no matrix container running"
+# Synapse must be reachable on localhost (default 8008). The openclaw-matrix
+# container in the mycelium-cli docker stack is the canonical one.
+curl -sf http://localhost:8008/_matrix/client/v3/login | python3 -m json.tool >/dev/null \
+  && echo "matrix login endpoint OK" \
+  || { echo "matrix not reachable on localhost:8008"; exit 1; }
+
+# 6. Mycelium repo path (we read SKILL.md and verify install paths from here)
+MYCELIUM_REPO=$(pwd)
+ls "$MYCELIUM_REPO/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/index.ts" 2>/dev/null \
+  && echo "Repo OK: $MYCELIUM_REPO" \
+  || { echo "ERROR: not in the mycelium repo"; exit 1; }
+```
+
+If any prerequisite fails, fix it before proceeding. Throughout this skill, use `$MYCELIUM_API_URL` for backend requests; never hardcode a port.
+
+### 0a. Verify Synapse registration + admin
+
+This skill creates throwaway Matrix users via the public registration endpoint. Confirm registration is open on this Synapse:
+
+```bash
+docker exec $(docker ps --format '{{.Names}}' | grep -E 'matrix|synapse' | head -1) \
+  grep -E "enable_registration|server_name" /data/homeserver.yaml
+# Need: enable_registration: true (or enable_registration_without_verification: true).
+# Capture server_name — Matrix user IDs will be @<name>:<server_name>.
+```
+
+Stash the server name:
+
+```bash
+SYNAPSE_CONTAINER=$(docker ps --format '{{.Names}}' | grep -E 'matrix|synapse' | head -1)
+SYNAPSE_SERVER=$(docker exec "$SYNAPSE_CONTAINER" grep "^server_name:" /data/homeserver.yaml | awk '{print $2}' | tr -d '"')
+echo "SYNAPSE_SERVER=$SYNAPSE_SERVER"
+```
+
+If registration is locked down, you'll need either the `registration_shared_secret` from `homeserver.yaml` or pre-existing accounts. The version in this skill assumes open registration; adapt as needed.
+
+## Phase 0.5: Choose experiment LLM & API key
+
+Same logic as the standard `before-and-after` skill — default to Haiku unless the user explicitly wants Sonnet. Each negotiation fires 10–40+ LLM calls; cost differs ~12×.
+
+```bash
+CONFIGURED_MODEL=$(python3 -c "
+import json, os
+p = os.path.expanduser('~/.openclaw/openclaw.json')
+try:
+    cfg = json.load(open(p))
+    print(cfg.get('agents', {}).get('defaults', {}).get('model', ''))
+except Exception:
+    print('')
+")
+echo "Currently configured model: ${CONFIGURED_MODEL:-'(none)'}"
+```
+
+Use `AskUserQuestion` to pick: Haiku (default) / Sonnet / configured / different key.
+Set `EXP_MODEL` accordingly. Echo the choice into the transcript:
+
+```bash
+echo "Using model: $EXP_MODEL"
+```
+
+## Phase 1: Setup
+
+### 1a. Generate experiment IDs + handles
+
+```bash
+EXP_ID="xch-$(date +%s | tail -c 5)"  # e.g. xch-4821
+EXP_AGENT_A="${EXP_ID}-agent-a"
+EXP_AGENT_B="${EXP_ID}-agent-b"
+EXP_HUMAN="${EXP_ID}-human"
+EXP_ROOM="${EXP_ID}"
+echo "EXP_ID=$EXP_ID"
+echo "EXP_AGENT_A=$EXP_AGENT_A  EXP_AGENT_B=$EXP_AGENT_B  EXP_HUMAN=$EXP_HUMAN"
+echo "EXP_ROOM=$EXP_ROOM"
+```
+
+### 1b. Register Matrix users (3 of them: human + 2 agents)
+
+Public registration with the `m.login.dummy` flow. Captures the access token from each registration response — needed to log the agent into Matrix from OpenClaw and to send DMs as the human in later phases.
+
+```bash
+declare -A MATRIX_TOKENS
+for u in "$EXP_HUMAN" "$EXP_AGENT_A" "$EXP_AGENT_B"; do
+  RESP=$(curl -s -X POST "http://localhost:8008/_matrix/client/v3/register" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"$u\",\"password\":\"poc-pass-$u\",\"auth\":{\"type\":\"m.login.dummy\"},\"inhibit_login\":false,\"device_id\":\"openclaw\"}")
+  TOKEN=$(echo "$RESP" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('access_token',''))
+")
+  if [ -z "$TOKEN" ]; then
+    echo "FAILED to register $u: $RESP"; exit 1
+  fi
+  MATRIX_TOKENS[$u]="$TOKEN"
+  echo "$u  →  @$u:$SYNAPSE_SERVER  (token=${TOKEN:0:20}…)"
+done
+HUMAN_TOKEN="${MATRIX_TOKENS[$EXP_HUMAN]}"
+AGENT_A_TOKEN="${MATRIX_TOKENS[$EXP_AGENT_A]}"
+AGENT_B_TOKEN="${MATRIX_TOKENS[$EXP_AGENT_B]}"
+```
+
+> **Skill gotcha — registration is one-shot.** If the username already exists, registration returns 400. Either parse responses defensively or always use a fresh `${EXP_ID}-` prefix per run. We default to fresh prefixes.
+
+### 1c. Create the OpenClaw test agents
+
+```bash
+for a in "$EXP_AGENT_A" "$EXP_AGENT_B"; do
+  openclaw agents add "$a" \
+    --non-interactive \
+    --workspace ~/.openclaw/workspaces/"$a" \
+    --model "$EXP_MODEL"
+done
+```
+
+### 1d. Apply OpenClaw config invariants
+
+These are the four invariants that, if missed, cause silent or noisy failures. **All four are required**; doctor doesn't catch the combination today (see issue #220 for status).
+
+```bash
+python3 - <<PYEOF
+import json, os
+p = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(p))
+target_ids = {"$EXP_AGENT_A", "$EXP_AGENT_B"}
+for a in cfg['agents']['list']:
+    if a.get('id') in target_ids:
+        # 1. Sandbox off — needed for the agent to see host binaries
+        a['sandbox'] = {'mode': 'off'}
+        # 2. Exec on the gateway, not the sandbox
+        a.setdefault('tools', {}).setdefault('exec', {})
+        a['tools']['exec']['host'] = 'gateway'
+        a['tools']['exec']['security'] = 'full'  # for testing; tighten with allowlist in prod
+json.dump(cfg, open(p, 'w'), indent=2)
+print('agent invariants applied')
+PYEOF
+```
+
+Three more, applied via CLI:
+
+```bash
+# 3. Allowlist the mycelium binary so agents can run it without per-call approval prompts
+openclaw approvals allowlist add --agent "$EXP_AGENT_A" "$HOME/.local/bin/mycelium"
+openclaw approvals allowlist add --agent "$EXP_AGENT_B" "$HOME/.local/bin/mycelium"
+
+# 4. Enable elevated mode so the human user can grant elevated commands via DM
+python3 - <<'PYEOF'
+import json, os
+p = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(p))
+cfg.setdefault('tools', {}).setdefault('elevated', {})
+cfg['tools']['elevated']['enabled'] = True
+af = cfg['tools']['elevated'].setdefault('allowFrom', {})
+af['matrix'] = list(set((af.get('matrix') or []) + [f"@{os.environ['EXP_HUMAN']}:{os.environ['SYNAPSE_SERVER']}"]))
+json.dump(cfg, open(p, 'w'), indent=2)
+print('elevated allowFrom updated')
+PYEOF
+```
+
+### 1e. Wire Matrix accounts for each agent
+
+```bash
+openclaw channels add --channel matrix --account "$EXP_AGENT_A" \
+  --homeserver http://localhost:8008 \
+  --user-id "@$EXP_AGENT_A:$SYNAPSE_SERVER" \
+  --access-token "$AGENT_A_TOKEN" \
+  --device-name openclaw
+
+openclaw channels add --channel matrix --account "$EXP_AGENT_B" \
+  --homeserver http://localhost:8008 \
+  --user-id "@$EXP_AGENT_B:$SYNAPSE_SERVER" \
+  --access-token "$AGENT_B_TOKEN" \
+  --device-name openclaw
+```
+
+> **Skill gotcha — SSRF guard blocks `localhost`.** OpenClaw's HTTP guard rejects loopback/RFC1918 addresses by default. Per-account opt-in:
+
+```bash
+python3 - <<PYEOF
+import json, os
+p = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(p))
+for acct_id in ('$EXP_AGENT_A', '$EXP_AGENT_B'):
+    acct = cfg['channels']['matrix']['accounts'][acct_id]
+    acct['allowPrivateNetwork'] = True
+    # Auto-accept invite-on-DM-create from the human user
+    acct['autoJoin'] = 'always'
+json.dump(cfg, open(p, 'w'), indent=2)
+print('matrix accounts updated: allowPrivateNetwork + autoJoin')
+PYEOF
+```
+
+### 1f. Bind agents to their Matrix accounts
+
+Without this, Matrix DMs are routed to the default agent (typically `main`), which may be sandboxed and won't have the experiment persona. The agent appears to "respond in character" by reading the prompt — but it's actually `main` reading SOUL.md from the wrong workspace.
+
+```bash
+openclaw agents bind --agent "$EXP_AGENT_A" --bind "matrix:$EXP_AGENT_A"
+openclaw agents bind --agent "$EXP_AGENT_B" --bind "matrix:$EXP_AGENT_B"
+openclaw agents bindings   # confirm both show up
+```
+
+### 1g. Create the Mycelium room + bind the channel to it
+
+The single most important alignment: **`channels.mycelium-room.room` must equal the room you're going to negotiate in.** If they differ, the channel plugin won't subscribe to the session sub-room, ticks fall on the floor, and agents go silent. (Until issue #220 fixes the per-agent subscription, this is the only safe shape.)
+
+```bash
+mycelium room create "$EXP_ROOM"
+
+python3 - <<PYEOF
+import json, os
+p = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(p))
+cfg.setdefault('channels', {})['mycelium-room'] = {
+    'enabled': True,
+    'backendUrl': '$MYCELIUM_API_URL',
+    'room': '$EXP_ROOM',
+    'agents': ['$EXP_AGENT_A', '$EXP_AGENT_B'],
+    'requireMention': True,
+}
+json.dump(cfg, open(p, 'w'), indent=2)
+print('mycelium-room channel bound to $EXP_ROOM')
+PYEOF
+```
+
+### 1h. Write personas
+
+Derive personas from the user's scenario; `SOUL.md` per agent. Same guidance as the standard `before-and-after` skill — concrete experience, specific data, clear priorities.
+
+```bash
+cat > ~/.openclaw/workspaces/"$EXP_AGENT_A"/SOUL.md <<EOF
+{persona text — who agent-a is, what they value, specific experience/data}
+EOF
+
+cat > ~/.openclaw/workspaces/"$EXP_AGENT_B"/SOUL.md <<EOF
+{persona text — who agent-b is, what they value, specific experience/data}
+EOF
+```
+
+### 1i. Restart and verify
+
+```bash
+openclaw gateway restart
+sleep 6
+
+# Both Matrix accounts should be running
+openclaw channels status | grep -E "Matrix.*$EXP_ID"
+
+# Mycelium-room channel should be configured for our room
+grep "SSE connected.*$EXP_ROOM" /tmp/openclaw/openclaw-$(date +%Y-%m-%d).log | tail -1
+```
+
+If the matrix accounts show `error:Blocked hostname` or the SSE line isn't there, walk back through 1d–1h.
+
+## Phase 2: Pair the human → agent DMs
+
+OpenClaw's DM-pairing security model requires explicit approval the first time a sender DMs an agent. This skill auto-handles it — the test harness sees the pairing-code reply and approves it.
+
+For each agent, create a DM, send a sanity ping, capture the pairing code from the agent's auto-reply, approve.
+
+```bash
+HUMAN_USER="@$EXP_HUMAN:$SYNAPSE_SERVER"
+declare -A AGENT_DM_ROOMS
+
+for agent in "$EXP_AGENT_A" "$EXP_AGENT_B"; do
+  # Create DM
+  RESP=$(curl -s -X POST "http://localhost:8008/_matrix/client/v3/createRoom" \
+    -H "Authorization: Bearer $HUMAN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"is_direct\":true,\"invite\":[\"@$agent:$SYNAPSE_SERVER\"],\"preset\":\"trusted_private_chat\"}")
+  ROOM=$(echo "$RESP" | python3 -c "import sys, json; print(json.load(sys.stdin).get('room_id',''))")
+  AGENT_DM_ROOMS[$agent]="$ROOM"
+
+  # Send sanity ping
+  ROOM_ENC=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$ROOM")
+  TXN=$(date +%s%N)
+  curl -s -X PUT "http://localhost:8008/_matrix/client/v3/rooms/$ROOM_ENC/send/m.room.message/$TXN" \
+    -H "Authorization: Bearer $HUMAN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"msgtype":"m.text","body":"sanity ping"}' >/dev/null
+
+  # Wait up to 60s for pairing-code reply, then approve
+  for i in $(seq 1 20); do
+    sleep 3
+    BODY=$(curl -s "http://localhost:8008/_matrix/client/v3/rooms/$ROOM_ENC/messages?dir=b&limit=3" \
+      -H "Authorization: Bearer $HUMAN_TOKEN" \
+      | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read(), strict=False)
+for ev in d.get('chunk', []):
+    if ev.get('type') == 'm.room.message' and ev.get('sender') == '@$agent:$SYNAPSE_SERVER':
+        print(ev.get('content',{}).get('body',''))
+        break
+")
+    CODE=$(echo "$BODY" | grep -oE 'Pairing code:[^A-Z0-9]*([A-Z0-9]{8})' | grep -oE '[A-Z0-9]{8}' | head -1)
+    if [ -n "$CODE" ]; then
+      echo "  $agent  pairing code = $CODE → approving"
+      openclaw pairing approve matrix "$CODE"
+      break
+    fi
+  done
+done
+
+# Send a follow-up sanity message to each agent and confirm it actually replies in-character
+for agent in "$EXP_AGENT_A" "$EXP_AGENT_B"; do
+  ROOM="${AGENT_DM_ROOMS[$agent]}"
+  ROOM_ENC=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$ROOM")
+  TXN=$(date +%s%N)
+  curl -s -X PUT "http://localhost:8008/_matrix/client/v3/rooms/$ROOM_ENC/send/m.room.message/$TXN" \
+    -H "Authorization: Bearer $HUMAN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"msgtype":"m.text","body":"hello — confirm channel alive with one short sentence"}' >/dev/null
+done
+sleep 25
+# Validate: the most-recent agent reply must NOT be a pairing prompt anymore
+for agent in "$EXP_AGENT_A" "$EXP_AGENT_B"; do
+  ROOM="${AGENT_DM_ROOMS[$agent]}"
+  ROOM_ENC=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$ROOM")
+  curl -s "http://localhost:8008/_matrix/client/v3/rooms/$ROOM_ENC/messages?dir=b&limit=3" \
+    -H "Authorization: Bearer $HUMAN_TOKEN" \
+    | python3 -c "
+import sys, json
+d = json.loads(sys.stdin.read(), strict=False)
+for ev in d.get('chunk', []):
+    if ev.get('type') == 'm.room.message' and ev.get('sender') == '@$agent:$SYNAPSE_SERVER':
+        body = ev.get('content',{}).get('body','')
+        ok = 'Pairing code' not in body and 'access not configured' not in body
+        print(f\"$agent: {'✓ alive' if ok else '✗ still paired-out'} — {body[:80]}\")
+        break
+"
+done
+```
+
+> **Skill gotcha — pairing codes regenerate on each DM attempt that arrives before the previous code was approved.** If your approval call lands AFTER a second prompt was sent, the new code invalidates the old. The loop above approves the most-recent code; if that races, send another sanity ping and retry the loop.
+
+## Phase 3: Trigger the negotiation
+
+### 3a. Compose the seed prompt
+
+The prompt should explicitly tell the agents NOT to use `session await` (it would block the gateway thread). For OpenClaw this is the right guidance — channel plugin handles wakeup.
+
+```bash
+PROMPT_TEMPLATE='You are participating in a distributed cross-agent test. Topic: $SCENARIO_PROMPT. Coordinate with the other agent in the room "$EXP_ROOM" via Mycelium structured negotiation.
+
+You are AGENT_PERSONA. Your full position is in your SOUL.md.
+
+Run EXACTLY these commands — do NOT run any others:
+
+1. Join the coordination session as yourself:
+     mycelium session join --handle YOUR_HANDLE --room $EXP_ROOM -m "<your position in one sentence>"
+
+2. Do NOT run mycelium session await. The Mycelium channel plugin wakes you when CognitiveEngine addresses you — session await would block the gateway thread.
+
+3. When a tick arrives, respond via the CLI:
+     mycelium negotiate respond accept --room $EXP_ROOM --handle YOUR_HANDLE
+   or, only if the tick says can_counter_offer: true:
+     mycelium negotiate propose ISSUE=VALUE ISSUE=VALUE --room $EXP_ROOM --handle YOUR_HANDLE
+
+4. After responding, return control. Continue until the negotiation concludes.
+
+5. The result will be auto-delivered back to this DM by the Mycelium plugin — you do NOT need to relay it yourself.
+
+Briefly explain your reasoning before each CLI command.'
+```
+
+Substitute per-agent values and send to each Matrix DM.
+
+### 3b. Send the prompts
+
+```bash
+for agent in "$EXP_AGENT_A" "$EXP_AGENT_B"; do
+  ROOM="${AGENT_DM_ROOMS[$agent]}"
+  ROOM_ENC=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$ROOM")
+  PROMPT=$(echo "$PROMPT_TEMPLATE" | sed -e "s/AGENT_PERSONA/$agent's persona/" -e "s/YOUR_HANDLE/$agent/g")
+  TXN=$(date +%s%N)
+  curl -s -X PUT "http://localhost:8008/_matrix/client/v3/rooms/$ROOM_ENC/send/m.room.message/$TXN" \
+    -H "Authorization: Bearer $HUMAN_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$(python3 -c "import json, sys; print(json.dumps({'msgtype':'m.text','body':sys.argv[1]}))" "$PROMPT")" >/dev/null
+done
+echo "negotiation prompts sent at $(date +%H:%M:%S)"
+```
+
+### 3c. Watch for stash + dispatch
+
+The Mycelium plugin emits these log lines as the negotiation runs. Tail to confirm.
+
+```bash
+tail -F /tmp/openclaw/openclaw-$(date +%Y-%m-%d).log \
+  | python3 -c "
+import sys, re, json
+PATTERNS = re.compile(r'return-address|notify-home|🎯|🤝|📬', re.I)
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw: continue
+    try:
+        d = json.loads(raw)
+        msg = ' '.join(str(d.get(k,'')) for k in ('0','1','2'))
+        ts = d.get('time','')[11:19]
+    except Exception:
+        continue
+    if PATTERNS.search(msg):
+        out = re.sub(r'\\{\\\"(?:module|subsystem)\\\":\\\"[^\\\"]+\\\"\\}', '', msg).strip().strip(',').strip()
+        print(f'{ts} {out[:240]}', flush=True)
+"
+# Expected sequence (Ctrl-C to break):
+#   return-address stashed: $EXP_AGENT_A → matrix:room:!XXX:server
+#   return-address stashed: $EXP_AGENT_B → matrix:room:!YYY:server
+#   🎯 → $EXP_AGENT_A     (round 1 tick)
+#   🎯 → $EXP_AGENT_B
+#   ... rounds repeat ...
+#   🤝 → $EXP_AGENT_A     (consensus or timeout)
+#   🤝 → $EXP_AGENT_B
+#   📬 notify-home for [$EXP_AGENT_A, $EXP_AGENT_B] in $EXP_ROOM:session:<id>
+#   notify-home → $EXP_AGENT_A on matrix:room:!XXX:server
+#   notify-home → $EXP_AGENT_B on matrix:room:!YYY:server
+```
+
+## Phase 4: Verify the ship gate
+
+The single assertion that says "this works": the consensus summary lands as a new Matrix message in each agent's DM with the human.
+
+```bash
+PASS=0; FAIL=0
+for agent in "$EXP_AGENT_A" "$EXP_AGENT_B"; do
+  ROOM="${AGENT_DM_ROOMS[$agent]}"
+  ROOM_ENC=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$ROOM")
+  curl -s "http://localhost:8008/_matrix/client/v3/rooms/$ROOM_ENC/messages?dir=b&limit=10" \
+    -H "Authorization: Bearer $HUMAN_TOKEN" > /tmp/_matrix_$agent.json
+  GOT=$(python3 -c "
+import json
+d = json.loads(open('/tmp/_matrix_$agent.json').read(), strict=False)
+for ev in d.get('chunk', []):
+    if ev.get('type') == 'm.room.message' and ev.get('sender') == '@$agent:$SYNAPSE_SERVER':
+        body = ev.get('content',{}).get('body','') or ''
+        if 'Mycelium return trip' in body:
+            print('YES')
+            break
+")
+  if [ "$GOT" = "YES" ]; then
+    echo "✓ $agent — return-trip message landed"
+    PASS=$((PASS+1))
+  else
+    echo "✗ $agent — NO return-trip message in DM"
+    FAIL=$((FAIL+1))
+  fi
+done
+echo "result: pass=$PASS fail=$FAIL"
+[ "$FAIL" -eq 0 ]
+```
+
+If `FAIL > 0`, check Phase 3c log output for missing stash / notify-home events. Common causes:
+
+- Agent never received its first tick (didn't actually join the session). Check the agent's Matrix DM for replies — they may have errored out at `session join`.
+- Stash didn't capture (`sessions.json` for that agent had no recent non-mycelium-room entry). Confirm with `cat ~/.openclaw/agents/$agent/sessions/sessions.json | python3 -m json.tool`.
+- `runtime.channel.outbound.loadAdapter` returned no adapter. Should not happen on a working OpenClaw; if it does, OpenClaw's plugin SDK has shifted (this skill predates that version).
+- Channel binding mismatch — `channels.mycelium-room.room` ≠ `$EXP_ROOM`. If you customized the room name, fix the binding.
+
+## Phase 5: Capture artifacts (optional)
+
+Useful for follow-up review or filing as a regression artifact on a PR.
+
+```bash
+ARTIFACT_DIR="$HOME/.mycelium/rooms/$EXP_ROOM/_test-artifacts"
+mkdir -p "$ARTIFACT_DIR"
+
+# Mycelium room transcripts
+curl -s "$MYCELIUM_API_URL/rooms/$EXP_ROOM/messages?limit=200" > "$ARTIFACT_DIR/parent-room.json"
+
+# Session sub-room transcripts (there can be more than one if you re-ran)
+curl -s "$MYCELIUM_API_URL/rooms" | python3 -c "
+import sys, json
+rs = json.load(sys.stdin)
+for r in rs:
+    if r['name'].startswith('$EXP_ROOM:session:'):
+        print(r['name'])
+" | while read SR; do
+  SAFE=$(echo "$SR" | tr ':' '_')
+  curl -s "$MYCELIUM_API_URL/rooms/$SR/messages?limit=200" > "$ARTIFACT_DIR/${SAFE}.json"
+done
+
+# Both Matrix DMs
+for agent in "$EXP_AGENT_A" "$EXP_AGENT_B"; do
+  ROOM="${AGENT_DM_ROOMS[$agent]}"
+  ROOM_ENC=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$ROOM")
+  curl -s "http://localhost:8008/_matrix/client/v3/rooms/$ROOM_ENC/messages?dir=b&limit=100" \
+    -H "Authorization: Bearer $HUMAN_TOKEN" > "$ARTIFACT_DIR/dm-$agent.json"
+done
+
+# Gateway log slice (today only, filtered to plugin events)
+grep -E '"subsystem":"plugins"|"module":"matrix' /tmp/openclaw/openclaw-$(date +%Y-%m-%d).log \
+  > "$ARTIFACT_DIR/gateway.log" 2>/dev/null
+
+echo "artifacts at $ARTIFACT_DIR"
+```
+
+## Phase 6: Cleanup
+
+```bash
+# Remove temp agents and channel bindings
+python3 - <<PYEOF
+import json, os
+p = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(p))
+cfg['agents']['list'] = [a for a in cfg.get('agents', {}).get('list', [])
+                        if not a.get('id', '').startswith('$EXP_ID')]
+# Drop the matrix accounts
+matrix_accounts = cfg.get('channels', {}).get('matrix', {}).get('accounts', {})
+for k in list(matrix_accounts.keys()):
+    if k.startswith('$EXP_ID'):
+        matrix_accounts.pop(k, None)
+# Drop bindings
+cfg['bindings'] = [b for b in cfg.get('bindings', []) if not b.get('agentId','').startswith('$EXP_ID')]
+# Optionally drop the mycelium-room channel binding if it points at our test room
+mr = cfg.get('channels', {}).get('mycelium-room')
+if mr and mr.get('room') == '$EXP_ROOM':
+    cfg['channels'].pop('mycelium-room', None)
+json.dump(cfg, open(p, 'w'), indent=2)
+print('config cleaned')
+PYEOF
+
+# Workspaces + agent dirs
+rm -rf ~/.openclaw/workspaces/${EXP_ID}-*
+rm -rf ~/.openclaw/agents/${EXP_ID}-*
+
+# Mycelium room (data persists on disk under ~/.mycelium/rooms; backend has it too)
+curl -s -X DELETE "$MYCELIUM_API_URL/rooms/$EXP_ROOM" >/dev/null
+
+# Restart gateway to drop the matrix sessions cleanly
+openclaw gateway restart
+
+# Note: Synapse has no public deactivation API by default. The throwaway users
+# stay registered. Either deactivate via admin API (if you have a token) or
+# accept the residue — the next ${EXP_ID}- prefix avoids collisions.
+```
+
+## Failure-mode variant: reproduce issue #220
+
+If you want to reproduce the original "agents go silent" bug (channel binding scope, issue #220), modify Phase 1g so `channels.mycelium-room.room` does NOT match `$EXP_ROOM`:
+
+```bash
+# Run all of Phase 1, but in 1g, set the channel to a DIFFERENT room name
+python3 - <<PYEOF
+import json, os
+p = os.path.expanduser('~/.openclaw/openclaw.json')
+cfg = json.load(open(p))
+cfg['channels']['mycelium-room']['room'] = 'some-other-room'   # NOT $EXP_ROOM
+json.dump(cfg, open(p, 'w'), indent=2)
+PYEOF
+```
+
+Run Phase 3 normally. Expected outcome: agents `session join` succeeds, but no `🎯` ticks ever fire — the channel plugin isn't subscribed to `$EXP_ROOM:session:*`. Phase 4 fails as expected. This confirms #220 is still open; if it surprises you by passing, #220 has been fixed.
+
+## Input
+
+Describe the scenario however you want. Extract:
+
+- **Scenario**: What are the agents deciding?
+- **Personas**: Two personas in genuine conflict (REST vs GraphQL is a known-good shape)
+- **Success criteria**: What does a good outcome look like?
+
+For batch runs, provide a JSON file with the same `experiments[]` schema as the standard `before-and-after` skill.
+
+## Flags
+
+- `--phase=<0|0a|1|2|3|4|5|6>` — Run a single phase (e.g. `--phase=4` to re-verify ship gate against an already-running negotiation)
+- `--scenario-only` — Skip Synapse user creation and OpenClaw config; assume Phase 1 has been done and reuse `$EXP_ID` from a prior run
+- `--cleanup-only` — Skip everything; just run Phase 6
+- `--failure-mode` — Run the variant from above (intentionally misalign the channel binding to repro #220)
+- No flags — full run: 0 → 1 → 2 → 3 → 4 → 5 → 6
+
+## Troubleshooting
+
+| Problem | Likely cause | Fix |
+|---------|-------------|-----|
+| Matrix `account ... stopped, error:Blocked hostname` | SSRF guard blocking `localhost` | Add `allowPrivateNetwork: true` to matrix account (Phase 1e) |
+| Agent never joins matrix DM | `autoJoin` not set | Add `autoJoin: "always"` to matrix account |
+| Agent reply is "OpenClaw: access not configured / Pairing code: …" | Pairing not approved | `openclaw pairing approve matrix <CODE>` (Phase 2 auto-handles) |
+| Agent says "mycelium CLI isn't installed" but sandbox is off | `tools.exec.host` left at default `sandbox` | Set `tools.exec.host = "gateway"` and `security = "full"` (Phase 1d) |
+| Agent says "I need /approve for exec" mid-negotiation | `tools.exec.security` is `"deny"` or `"allowlist"` without the right binary listed | `security = "full"` for test agents, or add binary to allowlist (Phase 1d) |
+| Matrix DMs land but agent responds out of character | Account binding missing | `openclaw agents bind --agent X --bind matrix:X` (Phase 1f) |
+| Negotiation runs but no return-trip message lands in DM | Stash not captured (no `return-address stashed: …` log line) | Check sessions.json freshness for the agent before negotiation; reprime DMs |
+| `coordination_consensus` fires but Phase 4 still fails | `📬 notify-home` action not emitted by `routeConsensus` | Check `msg.room_name` in plugin log; usually means a stale plugin install (`mycelium adapter add openclaw --reinstall -y`) |
+| Matrix register returns 400 | Username already exists from prior run | Use a fresh `$EXP_ID` prefix |
+
+## Tips
+
+- **Use Haiku.** This skill fires 10–40+ LLM calls per negotiation; cost adds up fast on Sonnet.
+- **Strong opening positions matter.** The Mycelium-channel session is fresh — it has only SOUL.md and the `-m "..."` seed. Specific stake + concession + hard limit beats vague preference.
+- **Reset between runs by killing the gateway and the agents.** The in-memory return-address stash dies with the gateway, which is a feature for tests (no zombie state).
+- **Check the gateway log first** when something goes wrong. `/tmp/openclaw/openclaw-$(date +%Y-%m-%d).log` filtered for `[mycelium-room]` entries tells you exactly what the plugin saw and decided.
+- **The Phase 2 pairing dance is the most fragile part of this skill.** If you find yourself running the skill repeatedly during dev, consider extracting Phase 2 to a script that lives outside the skill so you don't reset pairing state every run.

--- a/.claude/skills/before-and-after-matrix/SKILL.md
+++ b/.claude/skills/before-and-after-matrix/SKILL.md
@@ -15,7 +15,7 @@ Tests the **cross-channel coordination** path end-to-end:
 
 The **ship gate** is step 4: did the user actually see the result land in their Matrix DM, without the agent having to remember to call `sessions_send`?
 
-This skill is opinionated about the **happy path** (matrix bound to the same room the prompt names). Use the "Failure-mode variant" near the end if you want to reproduce the silent-failure bug from issue #220 (channel binding scope).
+The negotiation can happen in any room name — the channel plugin watches every active session sub-room and routes ticks by `participant_id`, not by room. The skill exercises that: agents negotiate in a fresh per-test room (`$EXP_ROOM`), and the return-trip still lands.
 
 **You are the test harness.** You set up Synapse users, wire OpenClaw, seed scenarios, observe transcripts, evaluate. The agents do the negotiating.
 
@@ -247,9 +247,9 @@ openclaw agents bind --agent "$EXP_AGENT_B" --bind "matrix:$EXP_AGENT_B"
 openclaw agents bindings   # confirm both show up
 ```
 
-### 1g. Create the Mycelium room + bind the channel to it
+### 1g. Create the Mycelium room + register the channel
 
-The single most important alignment: **`channels.mycelium-room.room` must equal the room you're going to negotiate in.** If they differ, the channel plugin won't subscribe to the session sub-room, ticks fall on the floor, and agents go silent. (Until issue #220 fixes the per-agent subscription, this is the only safe shape.)
+The plugin watches every active session sub-room and routes ticks by `participant_id`, so `channels.mycelium-room.room` does not have to match the room your prompt names. It only sets the default for outbound `mycelium room send` calls and unaddressed broadcasts. Pick anything sensible.
 
 ```bash
 mycelium room create "$EXP_ROOM"
@@ -266,7 +266,7 @@ cfg.setdefault('channels', {})['mycelium-room'] = {
     'requireMention': True,
 }
 json.dump(cfg, open(p, 'w'), indent=2)
-print('mycelium-room channel bound to $EXP_ROOM')
+print('mycelium-room channel registered with default room $EXP_ROOM')
 PYEOF
 ```
 
@@ -581,22 +581,23 @@ openclaw gateway restart
 # accept the residue — the next ${EXP_ID}- prefix avoids collisions.
 ```
 
-## Failure-mode variant: reproduce issue #220
+## Variant: negotiate in an unbound room
 
-If you want to reproduce the original "agents go silent" bug (channel binding scope, issue #220), modify Phase 1g so `channels.mycelium-room.room` does NOT match `$EXP_ROOM`:
+Confirms the channel plugin's room-agnostic routing: agents negotiate in a room name that the channel was never told about. Should still work end-to-end.
+
+Modify Phase 1g so `channels.mycelium-room.room` is set to something *other* than `$EXP_ROOM`:
 
 ```bash
-# Run all of Phase 1, but in 1g, set the channel to a DIFFERENT room name
 python3 - <<PYEOF
 import json, os
 p = os.path.expanduser('~/.openclaw/openclaw.json')
 cfg = json.load(open(p))
-cfg['channels']['mycelium-room']['room'] = 'some-other-room'   # NOT $EXP_ROOM
+cfg['channels']['mycelium-room']['room'] = 'totally-unrelated'   # NOT $EXP_ROOM
 json.dump(cfg, open(p, 'w'), indent=2)
 PYEOF
 ```
 
-Run Phase 3 normally. Expected outcome: agents `session join` succeeds, but no `🎯` ticks ever fire — the channel plugin isn't subscribed to `$EXP_ROOM:session:*`. Phase 4 fails as expected. This confirms #220 is still open; if it surprises you by passing, #220 has been fixed.
+Run Phase 3 normally. Expected outcome: ticks dispatch as usual (`🎯 → ...`), consensus fires (`🤝 → ...`), notify-home delivers (`📬 ...`), and the return-trip Matrix message lands. Phase 4 passes. If the variant fails, the room-agnostic routing has regressed — the plugin is filtering session sub-rooms by parent room name again.
 
 ## Input
 
@@ -613,7 +614,7 @@ For batch runs, provide a JSON file with the same `experiments[]` schema as the 
 - `--phase=<0|0a|1|2|3|4|5|6>` — Run a single phase (e.g. `--phase=4` to re-verify ship gate against an already-running negotiation)
 - `--scenario-only` — Skip Synapse user creation and OpenClaw config; assume Phase 1 has been done and reuse `$EXP_ID` from a prior run
 - `--cleanup-only` — Skip everything; just run Phase 6
-- `--failure-mode` — Run the variant from above (intentionally misalign the channel binding to repro #220)
+- `--unbound-room` — Run the variant from above (negotiate in a room the channel was never told about; verifies room-agnostic routing)
 - No flags — full run: 0 → 1 → 2 → 3 → 4 → 5 → 6
 
 ## Troubleshooting

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -208,20 +208,27 @@
       <p>
         OpenClaw is an autonomous, channel-resident agent runtime — a long-running
         gateway process that listens for inbound messages and dispatches them to
-        agents in-process. That's the paradigm the Mycelium channel plugin was
-        built for, and why the OpenClaw adapter is the only one that ships the
-        <code>mycelium-channel</code> plugin. (Claude Code and other
-        interactive-session agents use the <a href="#adapter-claude-code">Claude
-        Code adapter</a> instead, which gives them memory and session access but
-        no channel binding — they're not daemons listening for room traffic.)
+        agents in-process. That's the paradigm the Mycelium plugin's channel
+        layer was built for, and why the OpenClaw adapter is the only one that
+        ships channel-side wake-up — agents in your gateway can be addressed
+        with <code>@handle</code> mentions and woken to respond. (Claude Code
+        and other interactive-session agents use the
+        <a href="#adapter-claude-code">Claude Code adapter</a> instead, which
+        gives them memory and session access but no channel binding — they're
+        not daemons listening for room traffic.)
       </p>
       <p>
-        The OpenClaw adapter installs two plugins, two hooks, and a skill into your
-        OpenClaw environment. The <code>mycelium</code> plugin handles session lifecycle
-        and forwards coordination state. The <code>mycelium-channel</code> plugin turns
-        a Mycelium room into an addressed message bus for the agents in your gateway —
-        so agents can DM each other without Discord, Slack, or any other third-party
-        chat platform.
+        The OpenClaw adapter installs one plugin, two hooks, and a skill into your
+        OpenClaw environment. The <code>mycelium</code> plugin does three things:
+        session lifecycle (per-turn context injection), channel messaging (turns a
+        Mycelium room into an addressed message bus for agents in your gateway, so
+        they can DM each other without Discord, Slack, or any other third-party
+        chat platform), and cross-channel return-trip delivery for structured
+        negotiations — when consensus is reached in a Mycelium negotiation,
+        the plugin posts a one-shot summary back to whichever channel session
+        each agent was active on when they joined (Matrix DM, Discord DM, etc.),
+        so the user sees the result in their own chat instead of having to come
+        find it.
       </p>
 
       <h2 id="oc-install">Install</h2>
@@ -234,8 +241,7 @@
             <tr><th>Asset</th><th>Type</th><th>Purpose</th></tr>
           </thead>
           <tbody>
-            <tr><td><code>mycelium</code></td><td>Plugin</td><td>Session lifecycle, coordination state, SSE tick subscription for structured negotiation</td></tr>
-            <tr><td><code>mycelium-channel</code></td><td>Plugin</td><td>Real-time addressed messaging — routes room messages to agent runtimes in-process via <code>runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher</code>. Enforces <code>@handle</code> addressing by default.</td></tr>
+            <tr><td><code>mycelium</code></td><td>Plugin</td><td>Session lifecycle, channel messaging (routes addressed room messages to agent runtimes in-process via <code>runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher</code>; enforces <code>@handle</code> addressing by default), SSE tick subscription for structured negotiation, and auto return-trip delivery of consensus summaries to each agent's home channel.</td></tr>
             <tr><td><code>mycelium-bootstrap</code></td><td>Hook</td><td>Injects MYCELIUM_API_URL, MYCELIUM_ROOM, and coordination instructions at agent bootstrap</td></tr>
             <tr><td><code>mycelium-knowledge-extract</code></td><td>Hook</td><td>On each <code>message:sent</code>, forwards finalized turns to mycelium-backend, which relays them to CFN's <code>shared-memories</code> endpoint for concept + relationship extraction. User-configurable gates (<code>knowledge_ingest.enabled</code> / <code>max_input_tokens</code> / <code>dedupe_ttl_seconds</code>) bound cost. Observability via <code>mycelium cfn log</code> / <code>cfn stats</code> / <code>cfn ls</code>.</td></tr>
             <tr><td><code>mycelium</code> SKILL.md</td><td>Skill</td><td>Coordination skill available to all OpenClaw agents</td></tr>
@@ -244,7 +250,7 @@
       </div>
 
       <h3 id="oc-channel-config">Channel config (<code>openclaw.json</code>)</h3>
-      <p>The <code>mycelium-channel</code> plugin reads its config from <code>channels.mycelium-room</code> in <code>~/.openclaw/openclaw.json</code>:</p>
+      <p>The Mycelium plugin reads its channel config from <code>channels.mycelium-room</code> in <code>~/.openclaw/openclaw.json</code> (<code>mycelium-room</code> is the OpenClaw channel id this plugin registers under):</p>
       <pre><code>{
   "channels": {
     "mycelium-room": {
@@ -267,6 +273,35 @@
         Coordination ticks from session sub-rooms are routed by <code>participant_id</code>
         and are unaffected by the <code>requireMention</code> setting — structured negotiation
         works identically whether broadcast chat is on or off.
+      </p>
+
+      <h3 id="oc-return-trip">Cross-channel return trip</h3>
+      <p>
+        When a user kicks off a Mycelium negotiation from their home chat (Matrix DM,
+        Discord DM, etc.), the agent is woken in a parallel mycelium-room session to
+        run the negotiation. When that negotiation concludes — agreement <em>or</em>
+        timeout — the plugin posts a one-shot summary back to whichever channel
+        session each agent was on when they joined.
+      </p>
+      <p>
+        Mechanically: when the first <code>coordination_tick</code> for an agent
+        lands in a session sub-room, the plugin freezes the agent's most-recent
+        non-mycelium-room session (channel + conversation id + account id) from
+        <code>~/.openclaw/agents/&lt;id&gt;/sessions/sessions.json</code>. On
+        <code>coordination_consensus</code>, it dispatches the summary via OpenClaw's
+        outbound runtime to that same session. Agents that didn't participate, or
+        whose home session wasn't recorded, are skipped silently — the negotiation
+        result still lives in the Mycelium room as a fallback.
+      </p>
+      <p>
+        Limitations to be aware of: in-memory only (gateway restart between
+        negotiation start and consensus loses the proactive notification), and
+        the "most recent home channel at first-tick time" heuristic can drift if
+        the agent receives inbound from a <em>different</em> home channel between
+        <code>session join</code> and the first tick. In practice the window is a
+        few seconds; for deterministic routing in adversarial conditions, capture
+        <code>OPENCLAW_SESSION_KEY</code> at CLI invocation time and forward it
+        through the join request.
       </p>
 
       <h2 id="oc-after-install">After install</h2>

--- a/mycelium-cli/src/mycelium/adapters/claude-code/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/adapters/claude-code/skills/mycelium/SKILL.md
@@ -71,112 +71,133 @@ mycelium room ls
 mycelium room synthesize
 ```
 
-## Structured Negotiation Protocol
+## Semantic negotiation
 
-For real-time negotiation (sessions spawned within rooms), the protocol is
-push-based. CognitiveEngine drives rounds and sends every agent a
-`coordination_tick` message when it's their turn.
+When two or more agents need to agree on a multi-issue trade-off — REST vs GraphQL, who owns what task, what budget/timeline/scope to ship — Mycelium runs a **structured negotiation** mediated by CognitiveEngine. It's a multi-round bargaining loop with a clear outcome: either consensus on every issue, or a clean "no agreement" timeout. Both are valid endings.
 
-Every tick payload tells you:
-- `current_offer` — the proposal on the table
-- `can_counter_offer: true/false` — whether you are the designated proposer this round
-- `issues` / `issue_options` — the full negotiation space
+Use it when "let's just chat about it" would spiral. Skip it for one-issue questions or quick coordination — `mycelium room send` (next section) is the right tool there.
 
-Claude Code agents don't have a persistent SSE plugin — use `session await`
-to block until CognitiveEngine addresses you:
+### The lifecycle
+
+Everything is CLI-driven. You declare your position, then respond when CognitiveEngine asks.
 
 ```bash
-# 1. Join — declare your position (returns immediately)
-mycelium session join --handle claude-agent -m "my position" -r sprint-room
+# 1. Join the negotiation with your one-sentence opening position.
+mycelium session join --handle claude-agent --room <room-name> \
+  -m "I want GraphQL with a 6-month timeline; REST is fine for public uploads only."
 
-# 2. Wait for your turn (blocks, prints JSON when CE addresses you)
+# 2. Block until it's your turn. `session await` returns when CognitiveEngine
+#    addresses you, prints a structured JSON payload, and exits.
 mycelium session await --handle claude-agent
 
-# 3. When your tick arrives:
+# Tick payload tells you:
+#   - current_offer       the proposal on the table
+#   - can_counter_offer   true ⇒ it's your turn to propose
+#                         false ⇒ you can only accept or reject
+#   - issues / issue_options
+#                         the canonical issue keys and their valid values
+#   - round / n_steps_total
+#                         where you are in the round budget
+#   - your_last_action    accept | reject | counter_offer | timeout | null
+#   - prior_round_outcome first_round | proposer_countered |
+#                         rejected_by_<id> | agreed | no_consensus
 
-#    If can_counter_offer is TRUE — you may propose a new offer OR accept/reject:
-mycelium negotiate propose budget=medium timeline=standard scope=full --handle claude-agent
+# 3a. Counter-propose (only when can_counter_offer is true):
+mycelium negotiate propose ISSUE=VALUE ISSUE=VALUE ... \
+  --room <room-name> --handle claude-agent
 
-#    If can_counter_offer is FALSE — you may only accept or reject the current offer:
-mycelium negotiate respond accept --handle claude-agent
-mycelium negotiate respond reject --handle claude-agent
+# 3b. Accept or reject the current offer:
+mycelium negotiate respond accept --room <room-name> --handle claude-agent
+mycelium negotiate respond reject --room <room-name> --handle claude-agent
 
-# 4. Wait for next tick or consensus
+# 4. await again for the next tick (or for the final consensus).
 mycelium session await --handle claude-agent
-# → {"type": "consensus", "plan": "budget=medium ...", "assignments": {...}}
+# → {"type": "consensus", "plan": "...", "assignments": {...}}
+# → or {"type": "consensus", "broken": true, "plan": "Negotiation ended: timeout"}
 ```
 
-`await` outputs structured JSON so you can parse it:
-- `{"type": "tick", "action": "propose", "round": 1, ...}` — your turn to propose
-- `{"type": "tick", "action": "respond", "current_offer": {...}, ...}` — evaluate an offer
-- `{"type": "consensus", "plan": "...", "assignments": {...}}` — negotiation complete
-- `{"type": "timeout"}` — no tick within timeout (default 120s)
+`session await` outputs structured JSON, parseable per turn:
 
-**Room discipline**: speak only when CognitiveEngine addresses you. Default to silence between turns.
+- `{"type": "tick", ...}` — your turn; act and `await` again.
+- `{"type": "consensus", ...}` — negotiation complete. `broken: true` means timeout/no-agreement (still a valid outcome).
+- `{"type": "timeout"}` — no tick within the await window (default 120s); call `await` again to keep waiting, or check status.
 
-### Counter-offer validity
+### Counter-offer rules
 
-Mycelium validates counter-offers before they reach CFN. Two things to know:
+Mycelium validates counter-offers before they reach CognitiveEngine:
 
-1. **Use exactly the issue keys from the tick's `issue_options`.** Do not invent
-   new fields (e.g. `api_style`, `migration_plan`) — key matching is
-   case-sensitive. If you submit an unrecognised key, Mycelium rejects the
-   offer immediately and sends you a corrective tick with the exact valid keys
-   so you can retry.
-2. **Partial offers are accepted.** You only need to include the issues you want
-   to change. Issues you omit are automatically filled from the current standing
-   offer. There is no need to copy every key.
-3. **Pick each value from that issue's option list.** Free-text values outside
-   the listed options are not validated by Mycelium but may be rejected by CFN.
-4. **Only counter when `can_counter_offer: true`.** A counter from the wrong
-   agent gets silently downgraded to a reject.
+1. **Use the exact issue keys from `issue_options`.** Case-sensitive. Made-up keys are rejected immediately and you'll get a corrective tick with the valid set.
+2. **Partial offers are fine.** You only need to include the issues you want to change. Omitted issues stay at the current standing offer's value.
+3. **Pick each value from that issue's option list.** Free-text outside the list isn't blocked locally but CFN may reject it.
+4. **Only counter when `can_counter_offer: true`.** A counter from the wrong agent gets silently downgraded to a reject — wasted turn.
 
-To see the current round, canonical issue list, and per-agent reply status at
-any time: `mycelium negotiate status`
+### Reading `prior_round_outcome`
 
-### Narrate your choices
+It tells you what just happened so you don't have to infer:
 
-When you accept, reject, or propose, explain your reasoning to the user so
-they can follow along. For example: "Rejecting because the timeline is too
-aggressive — proposing 6 months instead of 3" *before* running the mycelium
-command. This makes the negotiation legible to observers.
+- `rejected_by_<id>` — that agent rejected last round; the standing offer carries forward unchanged.
+- `proposer_countered` — last round's designated proposer overrode the standing offer with a new one. Look at `current_offer` for the change.
+- `first_round` — round 1, no prior context.
+- `agreed` / `no_consensus` — terminal states; `await` returns a `consensus` envelope.
 
-## Channel Messaging (Cross-Agent DMs)
+### Behavior
 
-Separate from structured negotiation, a room is also a real-time message bus
-for the agents bound to it. Agents can address each other with `@handle`
-mentions via `mycelium room send`. Messages without an `@mention` are ignored
-by default (requireMention is on).
+- **Narrate before each command.** Say *why* you're rejecting or what you're trying to push on. "Rejecting because the timeline is too tight — countering with 6 months." This makes the negotiation legible to the user watching your terminal.
+- **Walking away is legitimate.** Each session has a fixed `n_steps_total`. If you and another agent are flip-flopping the same issue, you're not converging — keep rejecting until timeout. That's a clean "couldn't agree" signal, not a failure.
+- **Strong opening positions matter.** Be specific in `-m "..."`: stake, top concession, hard limit. "I want GraphQL" is weak. "GraphQL primary for authenticated APIs; REST is fine for uploads/webhooks; hard limit: no public-facing GraphQL without persisted queries" is strong.
 
-> **Critical: sessions are NOT shared across channels.** When another agent
-> sends you a message via the mycelium channel, you receive it in a
-> *separate session* from whatever conversation you're currently in with the
-> user. The sender's prior conversation history is not visible to you, and
-> yours is not visible to them. Treat every cross-channel message as the
-> start of a new conversation.
+### Checking status
 
-**Write self-contained messages.** Include enough context for the recipient
-to act without asking what you meant. Bad: "what do you think about the
-thing we discussed?" Good: "we're deciding REST vs GraphQL for the public
-API; I'm leaning REST because of OpenAPI tooling — do you see a reason to
-go GraphQL?"
+If the user asks "what's happening with the negotiation?" or "did it finish?", don't try to infer from the room's broadcast log — that's free-form narration, not the structured outcome.
 
 ```bash
-# Drop a targeted DM into a room — addressed agents will receive it
-mycelium room send \
-  --room sprint-plan \
-  --handle claude-agent \
-  "@julia-agent heads up: found a redis eviction bug in staging — see ~/.mycelium/rooms/infra/failed/redis-eviction.md"
-
-# Broadcast to multiple agents
-mycelium room send "@julia-agent @selina-agent sync at 3pm re: sprint priorities"
+# Current round, valid issue keys, per-agent reply status, active or concluded:
+mycelium negotiate status --room <room-name>
 ```
 
-This is a one-way notification — addressed agents will receive the message
-in their mycelium-room session but there's no built-in reply loop. For
-structured multi-issue decisions use the **Structured Negotiation Protocol**
-above. For durable knowledge that outlives the session, write it to room
-memory instead.
+When `await` returns `{"type": "consensus", ...}`:
+
+- **Agreement** → consensus payload includes per-agent `assignments`.
+- **No agreement** → `broken: true` with `plan: "Negotiation ended: timeout"`. Report it as "no agreement" — it's not a system failure.
+
+The structured outcome lives in a session sub-room (`<room-name>:session:<id>`). `mycelium negotiate status` reads it automatically; don't go grepping the parent room.
+
+## Talking to other agents (outside negotiation)
+
+Structured negotiation is for "we have a multi-issue trade-off and need consensus." For everything else — quick question, heads-up, durable note — use the patterns below.
+
+### Sending a one-shot message to a room
+
+```bash
+mycelium room send --room <room-name> --handle claude-agent \
+  "@julia-agent heads up: redis eviction bug in staging"
+```
+
+Agents in that room receive your message addressed to them. One-way: no built-in reply loop — if the addressed agent replies in the room, you'll see it via `mycelium watch --room <room-name>` or by polling the room's messages, but they won't auto-deliver back into your terminal.
+
+Messages without an `@mention` are ignored by default (rooms set `requireMention: true`). Always tag who you're talking to.
+
+### Writing things down (memory)
+
+For decisions, failed approaches, status that future agents should see, write it to room memory:
+
+```bash
+mycelium memory set "decision/cache" \
+  '{"choice": "Redis", "rationale": "40ms p99 win, simpler ops"}' \
+  --handle claude-agent
+
+mycelium memory set "failed/memcached" \
+  "connection overhead too high, see staging test 2026-04-12" \
+  --handle claude-agent
+```
+
+Memories are markdown files under `~/.mycelium/rooms/<room>/`. Any agent who joins later can find them with `mycelium memory ls` or `mycelium memory search`.
+
+### A few things to remember
+
+- **No auto-wake.** Claude Code has no daemon listening to mycelium rooms on your behalf. You only see another agent's message in a room if you explicitly check (`mycelium watch --room X` to tail, or `mycelium room messages` to read the log). If a user asks "did anyone reply?" — go look.
+- **Write self-contained messages.** "What about the thing we discussed?" is useless to a recipient who doesn't share your history. Spell out the context.
+- **`session await` blocks your terminal.** During a negotiation you'll be sitting on `await` — that's expected for Claude Code. The user sees you waiting; narrate before and after each turn so they understand what's happening.
 
 ## What the Claude Code adapter actually installs
 
@@ -240,50 +261,6 @@ mycelium sync
 
 The adapter **does not auto-sync** — run `mycelium sync` yourself when you want fresh state.
 
-## Starting a Session (The "Catchup" Pattern)
-
-When you start working, get briefed on what's happened:
-
-```bash
-# Get the full briefing: latest synthesis + recent activity
-mycelium catchup
-
-# Or search for specific context
-mycelium memory search "what approaches have been tried for caching"
-
-# Trigger a fresh synthesis if the room has new contributions
-mycelium synthesize
-```
-
-`catchup` and `synthesize` are top-level shortcuts — no need to type `mycelium memory catchup` or `mycelium room synthesize` (though those work too).
-
-The catchup shows: latest CognitiveEngine synthesis (current state, what worked, what failed, open questions), plus any activity since that synthesis. This is how a new agent gets productive immediately.
-
-## Async Workflow (Typical for Claude Code)
-
-```bash
-# 1. Set your project room
-mycelium room use my-project
-
-# 2. Catch up on what others have done
-mycelium memory catchup
-
-# 3. Write your findings — both successes AND failures
-mycelium memory set "results/cache-redis" "Redis caching reduced p99 by 40ms" --handle claude-agent
-mycelium memory set "results/cache-memcached" "Memcached tested, no improvement over Redis — connection overhead too high" --handle claude-agent
-
-# 4. Log decisions
-mycelium memory set "decision/cache" '{"choice": "Redis", "rationale": "40ms p99 improvement, simpler ops"}' --handle claude-agent
-
-# 5. Search what others know
-mycelium memory search "performance bottlenecks"
-
-# 6. Request synthesis when enough context accumulates
-mycelium room synthesize
-```
-
-**Log failures too.** When something doesn't work, write it as a memory so other agents don't repeat the same dead end. Negative results are as valuable as positive ones.
-
 ## Environment Variables
 
 | Variable | Description |
@@ -307,15 +284,3 @@ below has a matching env var for ephemeral changes (no config edit needed).
 | `MYCELIUM_INGEST_MAX_INPUT_TOKENS` | `50000` | Backend circuit breaker — payloads above this estimated input token count get refused with HTTP 413. `0` disables. |
 | `MYCELIUM_INGEST_DEDUPE_TTL_SECONDS` | `300` | Backend content-hash dedupe window. Identical payloads within this many seconds short-circuit without re-hitting CFN. `0` disables dedupe. |
 
-## When to Use What
-
-| Situation | Action |
-|-----------|--------|
-| Just starting — what's going on? | `mycelium memory catchup` |
-| Share context that persists across sessions | `mycelium memory set` in a room |
-| Log a failed approach (prevent duplicated effort) | `mycelium memory set "failed/..."` |
-| Find what other agents know about a topic | `mycelium memory search` |
-| Need agents to agree on something right now | `session join` + structured negotiation protocol |
-| Send a one-way DM to another agent in a room | `mycelium room send "@handle ..."` |
-| Accumulate context then decide later | Room + `mycelium room synthesize` |
-| Watch the room in real time | `mycelium watch` |

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/skills/mycelium/SKILL.md
@@ -130,228 +130,145 @@ mycelium room ls
 mycelium room synthesize
 ```
 
-## Coordination Protocol (OpenClaw)
+## Semantic negotiation
 
-> **Do NOT use `session await`** — that command is for synchronous single-threaded agents that must poll for their turn.
-> OpenClaw agents are woken by the gateway when CognitiveEngine addresses them.
-> Using `session await` will block the gateway thread and prevent other agents from responding.
+When two or more agents need to agree on a multi-issue trade-off — REST vs GraphQL, who owns what task, what budget/timeline/scope to ship — Mycelium runs a **structured negotiation** mediated by CognitiveEngine. It's a multi-round bargaining loop with a clear outcome: either consensus on every issue, or a clean "no agreement" timeout. Both are valid endings.
 
-The coordination protocol is **non-blocking and push-based**. Every command returns immediately.
-CognitiveEngine will send you a message when it is your turn.
+Use it when "let's just chat about it" would spiral. Skip it for one-issue questions or quick coordination — those belong in plain channel messaging (next section).
 
-Every round CognitiveEngine sends every agent a `coordination_tick` with `action: respond`.
-The tick payload tells you:
-- `current_offer` — the proposal on the table
-- `can_counter_offer: true/false` — whether you are the designated proposer this round
-- `issues` / `issue_options` — the full negotiation space
-- `round` / `n_steps_total` — current round and the maximum rounds for this session
-- `your_last_action` — what you did last round (`accept`, `reject`, `counter_offer`, `timeout`, or `null` on round 1)
-- `prior_round_outcome` — what happened in the previous round (`first_round`, `proposer_countered`, `rejected_by_<id>`, `agreed`, or `no_consensus`)
+### The lifecycle
+
+Everything is CLI-driven. You declare your position, then respond when CognitiveEngine asks.
 
 ```bash
-# 1. Join — declare your position (returns immediately)
-mycelium session join --handle <your-handle> --room <room-name> -m "I want GraphQL with a 6-month timeline"
+# 1. Join the negotiation with your one-sentence opening position.
+mycelium session join --handle <your-handle> --room <room-name> \
+  -m "I want GraphQL with a 6-month timeline; REST is fine for public uploads only."
 
-# 2. Do nothing — CognitiveEngine will wake you when it's your turn
+# 2. CognitiveEngine sends a coordination_tick to each agent in turn.
+#    When it's your turn, the tick is delivered to you (see "Quirks" below
+#    for how that wake-up actually happens). The tick payload tells you:
+#
+#    - current_offer       the proposal on the table
+#    - can_counter_offer   true ⇒ it's your turn to propose
+#                          false ⇒ you can only accept or reject
+#    - issues / issue_options
+#                          the canonical issue keys and their valid values
+#    - round / n_steps_total
+#                          where you are in the round budget
+#    - your_last_action    accept | reject | counter_offer | timeout | null
+#    - prior_round_outcome first_round | proposer_countered |
+#                          rejected_by_<id> | agreed | no_consensus
 
-# 3. When your tick arrives:
+# 3a. Counter-propose (only when can_counter_offer is true):
+mycelium negotiate propose ISSUE=VALUE ISSUE=VALUE ... \
+  --room <room-name> --handle <your-handle>
 
-#    If can_counter_offer is TRUE — you may propose a new offer OR accept/reject:
-mycelium negotiate propose ISSUE=VALUE ISSUE=VALUE ... --room <room-name> --handle <your-handle>
-# example:
-mycelium negotiate propose budget=medium timeline=standard scope=full --room <room-name> --handle <your-handle>
-
-#    If can_counter_offer is FALSE — you may only accept or reject the current offer:
+# 3b. Accept or reject the current offer:
 mycelium negotiate respond accept --room <room-name> --handle <your-handle>
 mycelium negotiate respond reject --room <room-name> --handle <your-handle>
 
-# 4. [consensus] message arrives with the agreed values — proceed independently
+# 4. Negotiation ends with a coordination_consensus message — agreement
+#    or timeout. Either way, you're done.
 ```
 
-> **Key rule**: `can_counter_offer: true` means it's your turn to propose. Use `mycelium negotiate propose` to make a counter-offer, or `mycelium negotiate respond accept/reject` to accept/reject without changing the offer. When `can_counter_offer: false`, only accept or reject.
+### Counter-offer rules
 
-> **Counter-offer validity**: Mycelium validates counter-offers before they reach CFN. Two things to know:
-> 1. **Use exactly the issue keys from the tick's `issue_options`.** Do not invent new fields (e.g. `api_style`, `migration_plan`) — key matching is case-sensitive. If you submit an unrecognised key, Mycelium rejects the offer immediately and sends you a corrective tick with the exact valid keys so you can retry.
-> 2. **Partial offers are accepted.** You only need to include the issues you want to change. Issues you omit are automatically filled from the current standing offer. There is no need to copy every key.
-> 3. **Pick each value from that issue's option list.** Free-text values outside the listed options are not validated by Mycelium but may be rejected by CFN.
-> 4. **Only counter when `can_counter_offer: true`.** A counter from the wrong agent gets silently downgraded to a reject.
->
-> To see the current round, canonical issue list, and per-agent reply status at any time: `mycelium negotiate status`
+Mycelium validates counter-offers before they reach CognitiveEngine:
 
-> **Narrate your choices**: When you accept, reject, or propose, explain your reasoning in the chat so the human can follow along. For example: "Rejecting because the timeline is too aggressive — proposing 6 months instead of 3" before running the mycelium command. This makes the negotiation legible to observers.
+1. **Use the exact issue keys from `issue_options`.** Case-sensitive. Made-up keys are rejected immediately and you'll get a corrective tick with the valid set.
+2. **Partial offers are fine.** You only need to include the issues you want to change. Omitted issues stay at the current standing offer's value.
+3. **Pick each value from that issue's option list.** Free-text outside the list isn't blocked locally but CFN may reject it.
+4. **Only counter when `can_counter_offer: true`.** A counter from the wrong agent gets silently downgraded to a reject — wasted turn.
 
-> **Budget awareness, not pressure to accept**: Each session has a fixed `n_steps_total`. If the same value flips back and forth on a single issue across rounds, neither side is going to move — the protocol does not have a "concede gradually" mechanism for LLM agents. **Walking away with no agreement is a legitimate outcome.** It is better than accepting a deal that violates your hard constraints. Use the round budget to decide: are you genuinely converging, or are you re-asserting the same disagreement? If it's the latter, you can keep rejecting until the session times out — that's a clean "we couldn't agree" signal, not a failure.
+### Reading `prior_round_outcome`
 
-> **`prior_round_outcome` tells you what just happened**: When you see `rejected_by_<id>`, the named agent rejected last round's offer; the standing offer carries forward. When you see `proposer_countered`, last round's proposer overrode the standing offer with a new one — read `current_offer` to see what changed. You don't need to infer this from `can_counter_offer` flipping.
+It tells you what just happened so you don't have to infer:
 
-## Channel Messaging (Cross-Agent DMs)
+- `rejected_by_<id>` — that agent rejected last round; the standing offer carries forward unchanged.
+- `proposer_countered` — last round's designated proposer overrode the standing offer with a new one. Look at `current_offer` for the change.
+- `first_round` — round 1, no prior context.
+- `agreed` / `no_consensus` — terminal states; you'll see a consensus message right after.
 
-Separate from structured negotiation, the mycelium plugin also makes the room
-a real-time message bus for the agents bound to it. Agents can address each
-other with `@handle` mentions. Messages without an `@mention` are ignored
-(requireMention defaults to true).
+### Behavior
 
-> **Critical: sessions are NOT shared across channels.** When another agent
-> sends you a message via the mycelium channel, you receive it in a fresh
-> session (`agent:<you>:mycelium-room:group:<room>`) — NOT the session where
-> you're currently chatting with the user on Discord, Claude Code, etc. The
-> sender's prior conversation history is not visible to you, and yours is not
-> visible to them. Treat every cross-channel message as the start of a new
-> conversation.
+- **Narrate before each command.** Say *why* you're rejecting or what you're trying to push on. "Rejecting because the timeline is too tight — countering with 6 months." This makes the negotiation legible to anyone watching.
+- **Walking away is legitimate.** Each session has a fixed `n_steps_total`. If you and another agent are flip-flopping the same issue, you're not converging — the protocol has no "concede gradually" mechanism. Keep rejecting until timeout. That's a clean "couldn't agree" signal, not a failure.
+- **Strong opening positions matter a lot.** See OpenClaw quirks below — the negotiation runs in a parallel session of you that doesn't carry your home-channel context. Your `-m "..."` seed is the only context you can hand off to that parallel-self.
 
-**Write self-contained messages.** When you send or receive a message via the
-channel, include enough context for the recipient to act without asking what
-you meant. Bad: "what do you think about the thing we discussed?" Good:
-"we're deciding REST vs GraphQL for the public API; I'm leaning REST because
-of OpenAPI tooling — do you see a reason to go GraphQL?"
+### Checking status
 
-### Three ways to reach another agent
-
-OpenClaw gives you three primitives depending on whether you need a reply,
-broadcast, or a durable note:
-
-**1. `sessions_send` — targeted hand-off with a reply (best for "I need agent B's take on this")**
-
-Use the OpenClaw `sessions_send` tool. Construct or look up the target
-sessionKey via `sessions_list`, then:
-
-```
-sessions_send({
-  sessionKey: "agent:selina-agent:mycelium-room:group:my-project",
-  message: "@selina-agent I'm picking between Redis and Memcached for session cache. p99 matters more than memory. Do you know of any prior testing you've done on this?",
-  timeoutSeconds: 60
-})
-```
-
-What OpenClaw does for you here:
-
-- Wakes the target agent in its mycelium-room session with your message
-- Marks the message with `provenance.kind = "inter_session"` so the receiver
-  knows it's from another agent, not user input
-- Runs up to 5 rounds of ping-pong reply (configurable via
-  `session.agentToAgent.maxPingPongTurns`)
-- Reply exactly `REPLY_SKIP` to end the ping-pong early
-- After the loop, the target agent can post a summary back to its home
-  channel via the announce step (or stay silent with `ANNOUNCE_SKIP`)
-
-Use `timeoutSeconds: 0` for fire-and-forget (returns `runId` immediately,
-fetch history later with `sessions_history`).
-
-**2. Channel broadcast — `mycelium room send` or just reply in-room**
-
-If your current session is already a mycelium-room session (the plugin
-woke you because another agent or a human addressed you there), just
-write output normally with one or more `@mention`s — the plugin forwards
-it to the addressed agents via the channel dispatch path. No tool call
-required.
-
-If you need to drop a message into a mycelium room from a different
-session (Discord, Claude Code, a cron, etc.), use the CLI directly:
+If someone asks "what's happening with the negotiation?" or "did it finish?", don't try to infer from the room's broadcast log — that's free-form narration, not the structured outcome.
 
 ```bash
-mycelium room send \
-  --room <room-name> \
-  --handle <your-handle> \
-  "@julia-agent heads up: found a redis eviction bug in staging — see ~/.mycelium/rooms/infra/failed/redis-eviction.md"
+# Current round, valid issue keys, per-agent reply status, active or concluded:
+mycelium negotiate status --room <room-name>
+
+# Live tail of negotiation activity:
+mycelium watch --room <room-name>
 ```
 
-This is a one-way notification — addressed agents will receive the
-message in their mycelium-room session but there's no reply loop. If you
-need a reply, use `sessions_send` (option 1 above) instead.
+When the session has concluded:
 
-**3. Memory — durable, async, discoverable by future agents**
+- **Agreement** → consensus payload includes per-agent `assignments`.
+- **No agreement** → consensus payload has `broken: true` with `plan: "Negotiation ended: timeout"`. Report it as "no agreement" — it's not a system failure.
 
-If the recipient doesn't exist yet (a future agent who hasn't started) or
-the information is durable (a decision, a failed approach, a status update),
-write it to room memory instead of sending a message:
+The structured outcome lives in a session sub-room (`<room-name>:session:<id>`), not in the parent room's broadcast log. `mycelium negotiate status` reads the right place automatically; don't go grepping the parent room.
+
+### OpenClaw quirks
+
+This section only applies to OpenClaw-hosted agents. The Mycelium channel plugin (registered as `mycelium-room` in OpenClaw's channel system) is what wakes you during a negotiation; a few rules follow from that.
+
+- **Don't run `mycelium session await`.** That command blocks the calling shell waiting for the next tick — fine for a single CLI session, fatal for the OpenClaw gateway because it locks a thread that other agents need. The gateway will wake you for each tick on its own.
+- **The negotiation runs in a separate Mycelium-channel session of you.** When a negotiation starts, OpenClaw spins up an `agent:<you>:mycelium-room:group:<room-name>` session — a parallel instance of you bound to the Mycelium channel. Same identity, same SOUL.md, but **none of your home-channel short-term memory** (Discord/Matrix/Claude Code/etc.) carries over. Once that session is alive, every subsequent tick lands in *that same* session — short-term memory across rounds is fine; it's the cross-channel hop that's lossy.
+- **The opening position is load-bearing.** When the Mycelium-channel session starts, all it has is your SOUL.md, the room's memory, and your `-m "..."` seed. That seed is your only chance to import context the home-channel-you would have had in mind. Be specific: stake, top concession, hard limit. "I want GraphQL" is weak. "GraphQL primary for authenticated APIs; REST is fine for uploads/webhooks; hard limit: no public-facing GraphQL without persisted queries" is strong.
+- **The result delivers itself.** When negotiation ends (consensus or timeout), the plugin posts a summary back to whatever channel session woke you originally — Discord DM, Matrix DM, etc. You do not need to use `sessions_send` or post anything yourself. Just run the negotiation.
+
+## Talking to other agents (outside negotiation)
+
+Structured negotiation is for "we have a multi-issue trade-off and need consensus." For everything else — quick question, heads-up, durable note — use the patterns below.
+
+### Replying inside a mycelium room
+
+If you got woken because someone addressed you in a mycelium room, just write your reply normally with `@handle` mentions. The plugin forwards it to the agents you tagged. No special tool call.
+
+```text
+@julia-agent that redis eviction is the same one we hit in staging last sprint —
+see /failed/redis-eviction in this room.
+```
+
+Messages without an `@mention` are ignored by default. Always tag who you're talking to.
+
+### Sending into a room from elsewhere
+
+When you're in your home channel (Discord/Matrix/etc.) and want to drop a message into a mycelium room without joining a negotiation, use the CLI:
 
 ```bash
-mycelium memory set "decision/cache" '{"choice": "Redis", "rationale": "..."}' --handle <your-handle>
-mycelium memory set "failed/memcached" "connection overhead too high, see staging test 2026-04-12" --handle <your-handle>
+mycelium room send --room <room-name> --handle <your-handle> \
+  "@julia-agent heads up: redis eviction bug in staging"
 ```
 
-Any agent who joins the room later and runs `mycelium catchup` will see it.
-No reply loop, no urgency — this is how you make knowledge compound.
+One-way only. The addressed agents wake up in the room and see it; if you need a reply, use the OpenClaw primitive below.
 
-### Discovering other agents
+### Asking a specific agent and waiting for a reply
 
-Use OpenClaw's `sessions_list` tool to find other agents and their session
-keys without guessing the format:
+When you need another agent's take on something *now*, OpenClaw exposes a `sessions_send` tool. You give it a target session key and a question; the target agent wakes, replies, and the reply comes back to you. Use it for "agent B, what do you think of X?" — not for relaying negotiation results (the plugin handles those automatically).
 
-```
-sessions_list({ kinds: ["group"] })
-// → returns rows with key, channel, displayName, lastChannel — pick the
-//   one with channel="mycelium-room" and the right displayName
-```
+If you can't find the target session key, use `sessions_list` first.
 
-Your visibility is scoped by `tools.sessions.visibility` (default: `tree`).
-For cross-agent access you may need `tools.agentToAgent` enabled — if
-`sessions_send` returns a permission error, that's why.
+### Writing things down (memory)
 
-### When to use which
-
-| Situation | Use |
-|---|---|
-| "I need agent B's answer to this specific question right now" | `sessions_send` with timeout |
-| "I want to notify everyone in the room of something" | Channel broadcast |
-| "I want to record a decision/failure for future agents" | `mycelium memory set` |
-| "I need the team to agree on a trade-off with multiple issues" | Coordination session (see above) |
-| "I want to know what's happening in the room without interrupting" | `mycelium watch` or `mycelium catchup` |
-
-## Starting a Session (The "Catchup" Pattern)
-
-When you start working, get briefed on what's happened:
+For decisions, failed approaches, status that future agents should see, write it to room memory instead of pinging anyone:
 
 ```bash
-# Get the full briefing: latest synthesis + recent activity
-mycelium catchup
-
-# Or search for specific context
-mycelium memory search "what approaches have been tried for caching"
-
-# Trigger a fresh synthesis if the room has new contributions
-mycelium synthesize
+mycelium memory set "decision/cache" \
+  '{"choice": "Redis", "rationale": "40ms p99 win, simpler ops"}' \
+  --handle <your-handle>
 ```
 
-`catchup` and `synthesize` are top-level shortcuts — no need to type `mycelium memory catchup` or `mycelium room synthesize` (though those work too).
+Memories are markdown files under `~/.mycelium/rooms/<room>/`. Any agent who joins later can find them with `mycelium memory ls` or `mycelium memory search`.
 
-The catchup shows: latest CognitiveEngine synthesis (current state, what worked, what failed, open questions), plus any activity since that synthesis. This is how a new agent gets productive immediately.
+### A few things to remember
 
-## Async Workflow
-
-```bash
-# 1. Set your project room
-mycelium room use my-project
-
-# 2. Catch up on what others have done
-mycelium memory catchup
-
-# 3. Write your findings — both successes AND failures
-mycelium memory set "results/cache-redis" "Redis caching reduced p99 by 40ms" --handle my-agent
-mycelium memory set "results/cache-memcached" "Memcached tested, no improvement over Redis — connection overhead too high" --handle my-agent
-
-# 4. Log decisions
-mycelium memory set "decision/cache" '{"choice": "Redis", "rationale": "40ms p99 improvement, simpler ops"}' --handle my-agent
-
-# 5. Search what others know
-mycelium memory search "performance bottlenecks"
-
-# 6. Request synthesis when enough context accumulates
-mycelium room synthesize
-```
-
-**Log failures too.** When something doesn't work, write it as a memory so other agents don't repeat the same dead end. Negative results are as valuable as positive ones.
-
-## When to Use What
-
-| Situation | Action |
-|-----------|--------|
-| Just starting — what's going on? | `mycelium memory catchup` |
-| Share context that persists across sessions | `mycelium memory set` in a room |
-| Log a failed approach (prevent duplicated effort) | `mycelium memory set "failed/..."` |
-| Find what other agents know about a topic | `mycelium memory search` |
-| Need agents to agree on something right now | Spawn session + coordination protocol |
-| Accumulate context then decide later | Room + `mycelium room synthesize` |
-| Ask a specific other agent a direct question | `sessions_send` to their mycelium-room sessionKey |
-| Drop a notification into a room from outside | `mycelium room send --room X "@handle ..."` |
-| Watch the room in real time | `mycelium watch` |
+- **Negotiation results auto-deliver to your home channel.** When consensus arrives, the plugin posts a summary back to your Discord/Matrix/etc. session. You don't need to relay it yourself.
+- **Write self-contained messages.** "What about the thing we discussed?" is useless to a fresh-self or another agent. Spell out what you mean.

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -21,7 +21,7 @@ import { CHANNEL_ID, type ChannelConfig } from "../config.js";
 import { dispatchToAgent } from "./dispatch.js";
 import { executeNotifyHome } from "./notify-home.js";
 import { _ownMessageIds } from "./post-to-room.js";
-import { stashReturnAddress } from "./return-address.js";
+import { lookupReturnAddress, stashReturnAddress } from "./return-address.js";
 import { routeMessage, type RouteAction } from "./route.js";
 import { startRoomSSE } from "./room-sse.js";
 import { clearSubscribedSessions, startSessionSSE } from "./session-sse.js";
@@ -73,21 +73,33 @@ export function installChannel(
 
     startRoomSSE(runtime, cfg, _abort, handleMessage, log);
 
-    // Poll for session sub-rooms and subscribe to their SSE streams.
-    // Coordination ticks live in session sub-rooms, not the parent room.
+    // Poll for active session sub-rooms (anywhere in the backend) and
+    // subscribe to each one's SSE stream. Coordination ticks live in session
+    // sub-rooms, not parent rooms.
+    //
+    // We deliberately do NOT filter by `cfg.room` here — that scoping was the
+    // root cause of "agents go silent" when a negotiation was kicked off in a
+    // room name different from the channel's configured `room` (per-test
+    // ad-hoc rooms, teammate's room, dynamic topic rooms). All gating on
+    // "is this tick relevant to one of our agents?" already happens in
+    // routeTick (`cfg.agents.includes(participant_id)`) and in notify-home
+    // (per-session-sub-room stash). Subscribing broadly and filtering narrowly
+    // is safer than the reverse: irrelevant ticks become cheap ignored events;
+    // missed ticks become silent failures.
+    //
+    // startSessionSSE's subscribed-set is idempotent, so re-evaluating each
+    // poll tick is a no-op for already-subscribed rooms.
     const pollInterval = setInterval(async () => {
       try {
         const res = await fetch(`${cfg.backendUrl}/rooms`);
         if (!res.ok) return;
         const rooms: any[] = await res.json();
         for (const room of rooms) {
-          if (
-            room.name?.startsWith(cfg.room + ":session:") &&
-            (room.coordination_state === "waiting" ||
-              room.coordination_state === "negotiating")
-          ) {
-            startSessionSSE(runtime, cfg, room.name, _abort!, handleMessage, log);
-          }
+          const name: string | undefined = room.name;
+          if (!name || !name.includes(":session:")) continue;
+          const state = room.coordination_state;
+          if (state !== "waiting" && state !== "negotiating") continue;
+          startSessionSSE(runtime, cfg, name, _abort!, handleMessage, log);
         }
       } catch {
         /* polling failure is non-fatal */
@@ -134,6 +146,25 @@ function executeAction(
 ): void {
   switch (action.kind) {
     case "dispatch": {
+      // Consensus dispatch needs participant gating: now that we subscribe
+      // to every active session sub-room (not just sub-rooms of cfg.room),
+      // a coordination_consensus from a session our agents weren't part of
+      // would otherwise wake their mycelium-room sessions with someone
+      // else's outcome. The stash is our authoritative "did this agent
+      // participate in this session" signal — populated on first tick.
+      // Tick dispatch is already gated upstream by `cfg.agents.includes(participant_id)`
+      // in routeTick; only consensus needs this extra check.
+      if (
+        action.sender === "CognitiveEngine" &&
+        msg.message_type === "coordination_consensus" &&
+        msg.room_name &&
+        !lookupReturnAddress(msg.room_name, action.agentId)
+      ) {
+        log.info(
+          `[${CHANNEL_ID}] consensus skipped for ${action.agentId} — not a participant in ${msg.room_name}`,
+        );
+        return;
+      }
       if (action.sender === "CognitiveEngine") {
         // Tick or consensus — log with a distinguishing emoji
         log.info(

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -19,7 +19,9 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
 import { CHANNEL_ID, type ChannelConfig } from "../config.js";
 import { dispatchToAgent } from "./dispatch.js";
+import { executeNotifyHome } from "./notify-home.js";
 import { _ownMessageIds } from "./post-to-room.js";
+import { stashReturnAddress } from "./return-address.js";
 import { routeMessage, type RouteAction } from "./route.js";
 import { startRoomSSE } from "./room-sse.js";
 import { clearSubscribedSessions, startSessionSSE } from "./session-sse.js";
@@ -158,6 +160,24 @@ function executeAction(
       if (_abort) {
         startSessionSSE(runtime, cfg, action.roomName, _abort, handleMessage, log);
       }
+      return;
+    }
+    case "stash-return-address": {
+      stashReturnAddress(action.sessionRoom, action.agentId, log);
+      return;
+    }
+    case "notify-home": {
+      log.info(
+        `[${CHANNEL_ID}] 📬 notify-home for [${action.agentIds.join(", ")}] in ${action.sessionRoom}`,
+      );
+      void executeNotifyHome(
+        runtime,
+        cfg,
+        action.sessionRoom,
+        action.agentIds,
+        action.consensusSummary,
+        log,
+      );
       return;
     }
     case "ignore": {

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/notify-home.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/notify-home.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+/**
+ * Cross-channel return-trip notification.
+ *
+ * When a coordination negotiation reaches consensus (or times out) in a
+ * mycelium-room session sub-room, the agents that participated may have a
+ * "home" session elsewhere — e.g., a Matrix DM or Discord channel where
+ * their human asked them to coordinate. This module delivers a one-shot
+ * summary back to that home session via OpenClaw's outbound adapter API,
+ * so the user sees the result in their own chat rather than having to come
+ * find it in mycelium.
+ *
+ * The home address is captured at the moment the agent joins the negotiation
+ * (see ./return-address.ts) — frozen there to avoid drift between join and
+ * consensus.
+ *
+ * Best-effort only: no stashed address ⇒ skip silently. Outbound failure ⇒
+ * log and continue.
+ */
+
+import { CHANNEL_ID, type ChannelConfig } from "../config.js";
+import {
+  clearReturnAddresses,
+  lookupReturnAddress,
+} from "./return-address.js";
+
+type Logger = { info: (s: string) => void; warn: (s: string) => void };
+
+export async function executeNotifyHome(
+  runtime: any,
+  cfg: ChannelConfig,
+  sessionRoom: string,
+  agentIds: string[],
+  summary: string,
+  log: Logger,
+): Promise<void> {
+  let openclawConfig: any;
+  try {
+    openclawConfig = runtime.config.loadConfig();
+  } catch (err: any) {
+    log.warn(
+      `[${CHANNEL_ID}] notify-home: failed to load openclaw config — ${err?.message ?? err}`,
+    );
+    return;
+  }
+
+  const loadAdapter = runtime?.channel?.outbound?.loadAdapter;
+  if (typeof loadAdapter !== "function") {
+    log.warn(
+      `[${CHANNEL_ID}] notify-home: runtime.channel.outbound.loadAdapter not available — return-trip disabled`,
+    );
+    return;
+  }
+
+  for (const agentId of agentIds) {
+    const addr = lookupReturnAddress(sessionRoom, agentId);
+    if (!addr) {
+      log.info(
+        `[${CHANNEL_ID}] notify-home: no return address for ${agentId} in ${sessionRoom} — skipping`,
+      );
+      continue;
+    }
+
+    let adapter: any;
+    try {
+      adapter = await loadAdapter(addr.channelName);
+    } catch (err: any) {
+      log.warn(
+        `[${CHANNEL_ID}] notify-home: loadAdapter(${addr.channelName}) failed — ${err?.message ?? err}`,
+      );
+      continue;
+    }
+    if (!adapter || typeof adapter.sendText !== "function") {
+      log.warn(
+        `[${CHANNEL_ID}] notify-home: no sendText for channel ${addr.channelName} — skipping ${agentId}`,
+      );
+      continue;
+    }
+
+    const text = `[Mycelium return trip — ${cfg.room}]\n\n${summary}`;
+    try {
+      await adapter.sendText({
+        cfg: openclawConfig,
+        to: addr.to,
+        text,
+        accountId: addr.accountId,
+      });
+      log.info(
+        `[${CHANNEL_ID}] notify-home → ${agentId} on ${addr.channelName}:${addr.to}`,
+      );
+    } catch (err: any) {
+      log.warn(
+        `[${CHANNEL_ID}] notify-home failed for ${agentId} on ${addr.channelName}:${addr.to} — ${err?.message ?? err}`,
+      );
+    }
+  }
+
+  // Negotiation is over — drop the stash for this session sub-room.
+  clearReturnAddresses(sessionRoom);
+}

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/notify-home.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/notify-home.ts
@@ -79,7 +79,11 @@ export async function executeNotifyHome(
       continue;
     }
 
-    const text = `[Mycelium return trip — ${cfg.room}]\n\n${summary}`;
+    // Label with the actual room the negotiation happened in, derived from
+    // the session sub-room name (`<parent>:session:<id>` → `<parent>`).
+    // Falls back to cfg.room only if the session-room name is malformed.
+    const parentRoom = sessionRoom.split(":session:")[0] || cfg.room;
+    const text = `[Mycelium return trip — ${parentRoom}]\n\n${summary}`;
     try {
       await adapter.sendText({
         cfg: openclawConfig,

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/return-address.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/return-address.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+/**
+ * Return-address stash: per-(sessionSubRoom, agent) record of where the agent
+ * was active at the moment they joined the negotiation. Captured once on
+ * `coordination_join`, used at `coordination_consensus` to deliver the result
+ * back to whatever home channel the agent kicked the negotiation off from.
+ *
+ * Why "freeze at join time"?
+ *
+ * If we lookup the agent's most-recent session at consensus time, the answer
+ * could have drifted (the user may have ping'd that agent on a different
+ * channel mid-negotiation). Capturing at join time is deterministic for this
+ * negotiation: whoever woke the agent to run `mycelium session join` is the
+ * channel/conversation we want to deliver the consensus to.
+ *
+ * Source of truth: `~/.openclaw/agents/<agentId>/sessions/sessions.json`. We
+ * scan it once at join time, find the most recent non-mycelium-room session,
+ * and stash `lastChannel` / `lastTo` / `lastAccountId`. These are exactly the
+ * fields the OpenClaw outbound adapters expect on `sendText({to, accountId})`.
+ *
+ * Limitations:
+ *   - Gateway restart loses the stash. Document, then escalate to disk
+ *     persistence if it bites.
+ *   - Race: if the agent receives a different-channel inbound between
+ *     "user types in matrix" and "plugin observes coordination_join", the
+ *     stash will point at the wrong channel. Tight window in practice.
+ */
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { CHANNEL_ID } from "../config.js";
+
+type Logger = { info: (s: string) => void; warn: (s: string) => void };
+
+export type ReturnAddress = {
+  channelName: string;
+  to: string;
+  accountId: string;
+};
+
+const _stash = new Map<string, Map<string, ReturnAddress>>();
+
+function stashKey(sessionRoom: string): string {
+  return sessionRoom;
+}
+
+/**
+ * Read the agent's session store and pick the most-recent non-mycelium-room
+ * session entry. Returns its delivery context, or undefined if none found.
+ */
+export function readHomeAddress(agentId: string, log: Logger): ReturnAddress | undefined {
+  const path = join(homedir(), ".openclaw", "agents", agentId, "sessions", "sessions.json");
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    log.info(`[mycelium-room] no session store for ${agentId} at ${path}`);
+    return undefined;
+  }
+  let store: any;
+  try {
+    store = JSON.parse(raw);
+  } catch (err: any) {
+    log.warn(`[mycelium-room] sessions.json parse error for ${agentId}: ${err?.message ?? err}`);
+    return undefined;
+  }
+  let best:
+    | { entry: any; updatedAt: number }
+    | undefined;
+  for (const entry of Object.values(store)) {
+    const e = entry as any;
+    const channel = e?.lastChannel ?? e?.deliveryContext?.channel;
+    const to = e?.lastTo ?? e?.deliveryContext?.to;
+    const accountId = e?.lastAccountId ?? e?.deliveryContext?.accountId;
+    if (!channel || !to) continue;
+    if (channel === CHANNEL_ID) continue;
+    const updatedAt = typeof e.updatedAt === "number" ? e.updatedAt : 0;
+    if (!best || updatedAt > best.updatedAt) {
+      best = { entry: { channel, to, accountId }, updatedAt };
+    }
+  }
+  if (!best) return undefined;
+  return {
+    channelName: best.entry.channel,
+    to: best.entry.to,
+    accountId: best.entry.accountId ?? "default",
+  };
+}
+
+/**
+ * Capture the agent's home channel at join time. Idempotent — if we've
+ * already stashed for this (room, agent) pair, leave the original alone.
+ */
+export function stashReturnAddress(
+  sessionRoom: string,
+  agentId: string,
+  log: Logger,
+): void {
+  const key = stashKey(sessionRoom);
+  let perAgent = _stash.get(key);
+  if (!perAgent) {
+    perAgent = new Map();
+    _stash.set(key, perAgent);
+  }
+  if (perAgent.has(agentId)) return;
+  const addr = readHomeAddress(agentId, log);
+  if (!addr) {
+    log.info(
+      `[mycelium-room] return-address: no home channel for ${agentId} on join — will skip notify-home`,
+    );
+    return;
+  }
+  perAgent.set(agentId, addr);
+  log.info(
+    `[mycelium-room] return-address stashed: ${agentId} → ${addr.channelName}:${addr.to}`,
+  );
+}
+
+export function lookupReturnAddress(
+  sessionRoom: string,
+  agentId: string,
+): ReturnAddress | undefined {
+  return _stash.get(stashKey(sessionRoom))?.get(agentId);
+}
+
+export function clearReturnAddresses(sessionRoom: string): void {
+  _stash.delete(stashKey(sessionRoom));
+}
+
+/** Test/debug helper. */
+export function _allReturnAddresses(): Map<string, Map<string, ReturnAddress>> {
+  return _stash;
+}

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/route.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/route.ts
@@ -27,6 +27,14 @@ export type RouteAction =
       messageId: string | undefined;
     }
   | { kind: "subscribe-session"; roomName: string }
+  | { kind: "stash-return-address"; sessionRoom: string; agentId: string }
+  | {
+      kind: "notify-home";
+      sessionRoom: string;
+      agentIds: string[];
+      consensusSummary: string;
+      messageId: string | undefined;
+    }
   | { kind: "ignore"; reason: string };
 
 /**
@@ -91,15 +99,30 @@ export function routeTick(cfg: ChannelConfig, msg: any): RouteAction[] {
 
   const instruction = formatTickInstruction(payload, msg.room_name ?? cfg.room, targetAgent);
 
-  return [
-    {
-      kind: "dispatch",
+  const actions: RouteAction[] = [];
+
+  // Stash the agent's return address the first time we see a tick for them
+  // in this session sub-room. The stash is idempotent on the executor side,
+  // so emitting on every tick is fine — but only when room_name names a
+  // session sub-room (not the parent room).
+  const sessionRoom = msg.room_name ?? "";
+  if (sessionRoom.includes(":session:")) {
+    actions.push({
+      kind: "stash-return-address",
+      sessionRoom,
       agentId: targetAgent,
-      sender: "CognitiveEngine",
-      content: instruction,
-      messageId: msg.id,
-    },
-  ];
+    });
+  }
+
+  actions.push({
+    kind: "dispatch",
+    agentId: targetAgent,
+    sender: "CognitiveEngine",
+    content: instruction,
+    messageId: msg.id,
+  });
+
+  return actions;
 }
 
 export function formatTickInstruction(
@@ -181,13 +204,33 @@ export function routeConsensus(cfg: ChannelConfig, msg: any): RouteAction[] {
 
   const summary = formatConsensusSummary(consensusData);
 
-  return cfg.agents.map((agentId) => ({
+  const actions: RouteAction[] = cfg.agents.map((agentId) => ({
     kind: "dispatch" as const,
     agentId,
     sender: "CognitiveEngine",
     content: summary,
     messageId: msg.id,
   }));
+
+  // Also notify each agent's home channel session (Matrix/Discord/etc.)
+  // with the consensus summary. The notify-home executor checks whether a
+  // return address was stashed for each (session, agent) pair when the agent
+  // first showed up in the negotiation; agents without a stash are skipped.
+  // Passing all of cfg.agents is safe — the per-agent stash check is the
+  // real filter — and avoids fragile inference of who participated from
+  // assignment keys (which can be issue names rather than agent IDs).
+  const sessionRoom = msg.room_name ?? "";
+  if (cfg.agents.length > 0 && sessionRoom.includes(":session:")) {
+    actions.push({
+      kind: "notify-home",
+      sessionRoom,
+      agentIds: cfg.agents,
+      consensusSummary: summary,
+      messageId: msg.id,
+    });
+  }
+
+  return actions;
 }
 
 export function formatConsensusSummary(consensusData: any): string {
@@ -212,10 +255,25 @@ export function formatConsensusSummary(consensusData: any): string {
 
 export function routeJoin(msg: any): RouteAction[] {
   const roomName = msg.room_name;
-  if (roomName && typeof roomName === "string" && roomName.includes(":session:")) {
-    return [{ kind: "subscribe-session", roomName }];
+  if (!(roomName && typeof roomName === "string" && roomName.includes(":session:"))) {
+    return [{ kind: "ignore", reason: "join without session sub-room" }];
   }
-  return [{ kind: "ignore", reason: "join without session sub-room" }];
+  const actions: RouteAction[] = [{ kind: "subscribe-session", roomName }];
+
+  // Stash the return address for the joining agent so we can deliver
+  // consensus back to their home channel later. coordination_join carries
+  // the joiner's handle in sender_handle; coordination_start does not
+  // (it's CFN-broadcast for the whole session).
+  const sender =
+    msg.message_type === "coordination_join" ? msg.sender_handle : undefined;
+  if (sender && typeof sender === "string") {
+    actions.push({
+      kind: "stash-return-address",
+      sessionRoom: roomName,
+      agentId: sender,
+    });
+  }
+  return actions;
 }
 
 // ── Broadcast ─────────────────────────────────────────────────────────────

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/route.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/route.test.ts
@@ -282,14 +282,34 @@ describe("routeMessage — coordination_tick", () => {
 
   it("dispatches with CognitiveEngine as sender", () => {
     const actions = routeMessage(baseCfg, tickMsg("julia-agent"), freshOwnIds());
-    expect(actions[0]).toMatchObject({ kind: "dispatch", sender: "CognitiveEngine" });
+    const dispatch = actions.find((a) => a.kind === "dispatch") as any;
+    expect(dispatch).toMatchObject({ kind: "dispatch", sender: "CognitiveEngine" });
   });
 
   it("passes through the tick's own message id (for echo prevention)", () => {
     const actions = routeMessage(baseCfg, tickMsg("julia-agent"), freshOwnIds());
-    if (actions[0].kind === "dispatch") {
-      expect(actions[0].messageId).toBe("tick-1");
-    }
+    const dispatch = actions.find((a) => a.kind === "dispatch") as any;
+    expect(dispatch.messageId).toBe("tick-1");
+  });
+
+  it("emits stash-return-address alongside dispatch when room_name names a session sub-room", () => {
+    const actions = routeMessage(baseCfg, tickMsg("julia-agent"), freshOwnIds());
+    const stash = actions.find((a) => a.kind === "stash-return-address") as any;
+    expect(stash).toEqual({
+      kind: "stash-return-address",
+      sessionRoom: "test-room:session:abc123",
+      agentId: "julia-agent",
+    });
+  });
+
+  it("does NOT emit stash-return-address when the tick has no session sub-room name", () => {
+    const msg = {
+      id: "rootless-tick",
+      message_type: "coordination_tick",
+      content: JSON.stringify({ payload: { participant_id: "julia-agent", round: 1, action: "respond", current_offer: {} } }),
+    };
+    const actions = routeMessage(baseCfg, msg, freshOwnIds());
+    expect(actions.some((a) => a.kind === "stash-return-address")).toBe(false);
   });
 
   it("ignores ticks with unparseable content", () => {
@@ -332,6 +352,7 @@ describe("routeMessage — coordination_consensus", () => {
   const consensusMsg = (broken = false) => ({
     id: "consensus-1",
     message_type: "coordination_consensus",
+    room_name: "test-room:session:abc123",
     content: JSON.stringify({
       plan: "Ship v1 with core features only",
       assignments: { "julia-agent": "build API", "selina-agent": "ship frontend" },
@@ -365,6 +386,66 @@ describe("routeMessage — coordination_consensus", () => {
     const actions = routeMessage(baseCfg, msg, freshOwnIds());
     expect(actions[0].kind).toBe("ignore");
   });
+
+  it("emits a notify-home action with all cfg.agents and the session room", () => {
+    const actions = routeMessage(baseCfg, consensusMsg(), freshOwnIds());
+    const notify = actions.find((a) => a.kind === "notify-home") as any;
+    expect(notify).toBeDefined();
+    expect(notify.sessionRoom).toBe("test-room:session:abc123");
+    expect(notify.agentIds.sort()).toEqual(["arnold", "julia-agent", "selina-agent"]);
+    expect(notify.consensusSummary).toContain("Ship v1");
+    expect(notify.messageId).toBe("consensus-1");
+  });
+
+  it("emits notify-home for broken/timeout consensus too", () => {
+    const msg = {
+      id: "broken-consensus",
+      message_type: "coordination_consensus",
+      room_name: "test-room:session:xyz",
+      content: JSON.stringify({
+        plan: "Negotiation ended: timeout",
+        assignments: {},
+        broken: true,
+      }),
+    };
+    const actions = routeMessage(baseCfg, msg, freshOwnIds());
+    const notify = actions.find((a) => a.kind === "notify-home") as any;
+    expect(notify).toBeDefined();
+    expect(notify.agentIds.sort()).toEqual(["arnold", "julia-agent", "selina-agent"]);
+    expect(notify.consensusSummary).toContain("Negotiation FAILED");
+  });
+
+  it("emits notify-home with cfg.agents even when assignments are keyed by issue names", () => {
+    // Real-world case: CFN sometimes emits assignments keyed by issue name,
+    // not agent ID. The previous filter dropped everything; passing cfg.agents
+    // through unconditionally is the simpler, correct behavior.
+    const msg = {
+      id: "issue-keyed-consensus",
+      message_type: "coordination_consensus",
+      room_name: "test-room:session:abc",
+      content: JSON.stringify({
+        plan: "REST + OpenAPI as default",
+        assignments: {
+          "REST + OpenAPI is the right default": "REST + OpenAPI with graduated adoption",
+        },
+        broken: false,
+      }),
+    };
+    const actions = routeMessage(baseCfg, msg, freshOwnIds());
+    const notify = actions.find((a) => a.kind === "notify-home") as any;
+    expect(notify).toBeDefined();
+    expect(notify.agentIds.sort()).toEqual(["arnold", "julia-agent", "selina-agent"]);
+  });
+
+  it("does NOT emit notify-home when the consensus message has no session room_name", () => {
+    const msg = {
+      id: "rootless-consensus",
+      message_type: "coordination_consensus",
+      content: JSON.stringify({ plan: "X", assignments: { "julia-agent": "y" }, broken: false }),
+    };
+    const actions = routeMessage(baseCfg, msg, freshOwnIds());
+    expect(actions.some((a) => a.kind === "notify-home")).toBe(false);
+  });
 });
 
 // ── Coordination join (session sub-room discovery) ────────────────────────
@@ -379,12 +460,42 @@ describe("routeMessage — coordination_join", () => {
       },
       freshOwnIds(),
     );
-    expect(actions).toEqual([
-      { kind: "subscribe-session", roomName: "test-room:session:abc123" },
-    ]);
+    expect(actions[0]).toEqual({
+      kind: "subscribe-session",
+      roomName: "test-room:session:abc123",
+    });
   });
 
-  it("handles coordination_start the same as coordination_join", () => {
+  it("emits stash-return-address when coordination_join has a sender_handle", () => {
+    const actions = routeMessage(
+      baseCfg,
+      {
+        message_type: "coordination_join",
+        room_name: "test-room:session:abc123",
+        sender_handle: "julia-agent",
+      },
+      freshOwnIds(),
+    );
+    const stash = actions.find((a) => a.kind === "stash-return-address") as any;
+    expect(stash).toBeDefined();
+    expect(stash.sessionRoom).toBe("test-room:session:abc123");
+    expect(stash.agentId).toBe("julia-agent");
+  });
+
+  it("does NOT emit stash-return-address for coordination_start (no per-agent sender)", () => {
+    const actions = routeMessage(
+      baseCfg,
+      {
+        message_type: "coordination_start",
+        room_name: "test-room:session:xyz",
+        sender_handle: "CognitiveEngine",
+      },
+      freshOwnIds(),
+    );
+    expect(actions.some((a) => a.kind === "stash-return-address")).toBe(false);
+  });
+
+  it("handles coordination_start the same as coordination_join (subscribe only)", () => {
     const actions = routeMessage(
       baseCfg,
       {


### PR DESCRIPTION
Closes #219

## What

When a user kicks off a Mycelium negotiation from their home chat (Matrix DM, Discord DM, etc.), the agent gets woken in a fresh mycelium-room session, runs the negotiation, and — until this PR — silently stops there. Consensus lands in the mycelium room; the user in their home chat never hears back.

This PR closes that loop: when `coordination_consensus` (agreement *or* timeout) fires, the channel plugin auto-delivers a one-shot summary to whichever channel session the agent first showed up in for that negotiation. User in Matrix sees the result land in their Matrix DM. User in Discord sees it in Discord. No agent action required.

## Why

We dug into the architecture for [issue #219](https://github.com/mycelium-io/mycelium/issues/219) (matrix testing skill). The investigation revealed:

1. **The "Matrix coordination is broken" framing was wrong.** Channel-side wake works fine when configured correctly. Agents woken in fresh mycelium-room sessions, negotiation completes through CFN, multiple rounds, the whole thing.
2. **What was actually broken: the return trip.** The mycelium-room session that handles the negotiation is structurally a parallel instance of the agent — same SOUL, but no short-term memory from the home channel. After consensus fires there, no path delivers the result back to the user.
3. **`sessions_send` doesn't reliably solve it.** We tried instructing the agent to deliver back via `sessions_send` — even with explicit step-by-step guidance, the agent reasoned about it and didn't actually call the tool. Agent-volunteer return trips are too fragile.

The fix has to be system-level. This PR makes the channel plugin do it.

## How it works

Three small pieces, all in-process inside the plugin:

### 1. Stash on first tick (`channel/return-address.ts`)

When the first `coordination_tick` for an agent lands in a session sub-room, the plugin reads `~/.openclaw/agents/<id>/sessions/sessions.json` and freezes the most-recent non-mycelium-room entry's `{channelName, to, accountId}`. Stash key: `(sessionRoom, agentId)`. Idempotent.

We snap *at first tick* (not at consensus time) because the agent had to be active in their home channel right before joining — that's how they ran `mycelium session join`. Reading at consensus time would drift if the agent received inbound from another channel mid-negotiation.

### 2. Notify on consensus (`channel/route.ts`)

`routeConsensus` already emits a per-agent `dispatch` to wake the mycelium-room session with the consensus message. This PR adds a single `notify-home` action alongside, carrying the session sub-room name + the agents in `cfg.agents` + the formatted summary.

### 3. Deliver via OpenClaw outbound (`channel/notify-home.ts`)

The executor calls `runtime.channel.outbound.loadAdapter(channelName).sendText({cfg, to, text, accountId})` for each agent that has a stashed return address. Agents without a stash (e.g., never participated in this session) are skipped silently. Outbound failure is logged but not raised.

## Trade-offs

| Decision | Pro | Con |
|---|---|---|
| In-memory stash, no disk persistence | Simpler; gateway restart cleans up zombie return addresses naturally | Restart between negotiation start and consensus loses the proactive notification (negotiation result is still durable in the mycelium room) |
| Stash from local `sessions.json`, not backend metadata | No new schema, no privacy concerns about sending OpenClaw session keys to a central server, gateway-local data stays gateway-local | Requires the agent to actually have a recent home-channel session on this gateway (true for the realistic use case, false for some edge cases) |
| "Most recent non-mycelium-room session at first-tick time" | No need for explicit return-address plumbing through the CLI | Drifts if the agent receives inbound from a *different* home channel between `session join` and the first tick. Single-digit-second window in practice |
| Plugin auto-delivers (no agent involvement) | Reliable, no SKILL voodoo | Less customizable per-agent; agent can't easily opt out (could be added later if needed) |
| All `cfg.agents` passed to `notify-home`, executor filters by stash presence | Simple, robust to assignments-keyed-by-issue-name (which CFN does sometimes), no fragile inference of who "really" participated | Sends one outbound attempt per configured agent even if some weren't in this session — fine since the per-agent stash check is the real gate |

## Hardening paths (not in this PR)

If the limitations bite in practice:

1. **Capture `OPENCLAW_SESSION_KEY` at CLI invocation time.** Inject via the `mycelium-bootstrap` hook, forward in the `session join` request body, store on the backend session_participant, ship in tick payloads. Deterministic, no drift. Requires backend schema work + revisits the metadata-on-server tradeoff.
2. **Persist stash to `~/.mycelium/state/originators.json`** with TTL + revalidation on load. Survives gateway restart. Adds a "zombie return addresses to a now-stale session" failure mode to think about.
3. **Per-agent opt-out in SKILL** — agent prefixes its narration with `RETURN_TRIP_SKIP` to suppress the auto-delivery. Lets the agent take over delivery itself if it has reason to (e.g. wants to add custom framing).

## SKILL.md updates

Both adapter skills (openclaw and claude-code) got the same structural pass:

- Restructured the negotiation section into a clear flow: concept → lifecycle → counter-offer rules → `prior_round_outcome` → behavior → status checking → host-specific quirks (cleanly fenced).
- Trimmed the channel-messaging section; dropped operator-flavored config notes (`tools.sessions.visibility`, `agentToAgent`, `REPLY_SKIP`, etc.) that the agent can't act on anyway.
- Removed stale "Starting a Session (Catchup Pattern)", "Async Workflow", and "When to Use What" sections — they overlapped with sharper guidance elsewhere and were misleading agents into running `mycelium memory catchup` to check negotiation status (which returned narration, not the structured outcome → confabulated answers).
- **OpenClaw:** added a "Return trip is automatic" callout so agents don't try to relay results manually with `sessions_send`. Made the parallel-session-vs-home-session distinction explicit ("you can be running as a parallel self in the Mycelium channel").
- **claude-code:** kept `session await` as the *right* primitive (it's a single CLI session, no gateway thread to block — opposite of openclaw). Explicitly noted there's no auto-wake on inbound mycelium room messages — claude-code is pull-only.

## Test plan

- [x] **Unit:** 109 plugin tests pass (vitest), including new coverage for `stash-return-address` routing on `coordination_tick` and `notify-home` emission on `coordination_consensus`.
- [x] **End-to-end manual:** ran the full flow on a local gateway with Matrix Synapse — two agents (`agent-rho`, `agent-sigma`), both bound to a mycelium room *and* a Matrix DM with a `@human:local` user. Triggered negotiation from each agent's Matrix DM. Observed:
  - `[mycelium-room] return-address stashed: agent-rho → matrix:room:!XXX:local` on first tick ✓
  - `[mycelium-room] return-address stashed: agent-sigma → matrix:room:!YYY:local` on first tick ✓
  - Negotiation runs to consensus (REST-default agreement) ✓
  - `[mycelium-room] 📬 notify-home for [agent-rho, agent-sigma] in xch-test-001:session:88737eb2` ✓
  - `[mycelium-room] notify-home → agent-rho on matrix:room:!XXX:local` ✓
  - **The actual `[Mycelium return trip — xch-test-001] [CognitiveEngine — Consensus Reached!] ...` message lands in the user's Matrix DM.** ✓
- [x] **Negative path:** when an agent in `cfg.agents` doesn't actually participate in a session (no first tick → no stash), the executor logs `notify-home: no return address for X — skipping` and the negotiation completes cleanly. Confirmed.

Full investigation log + operational gotchas (allowlist, sandbox/exec.host invariant, matrix `allowPrivateNetwork` + `autoJoin`, pairing approval) live in `~/Documents/claude-scratchpad/cross-channel-setup-log.md` on my workstation; happy to attach excerpts to a followup discussion if useful.

## Followup

- A `before-and-after-matrix` skill (issue #219) is the immediate next thing — codifies the manual repro recipe so future cross-channel regressions get caught fast. Coming in a separate PR.
- The current `_sessions` map in `session/index.ts` was *not* repurposed for return-trip lookups; it stays scoped to its existing job (mycelium-room session-end announcement). Tried that path first; the `session_start` hook is channel-scoped and doesn't see Matrix DM sessions, so the disk-store approach was the workable shape.
- Worth a separate cleanup PR: the `before_agent_start` tick injection in `session/index.ts:170-185` is dead code (it queries the parent room for ticks, but ticks live in session sub-rooms; channel-side dispatch handles delivery now).