### PR TITLE
ci: replace client regen gate with openapi.json snapshot diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
           MYCELIUM_STUB_EMBEDDINGS: "1"
         run: uv run pytest tests/test_integration.py -x -q
 
-  client-staleness-mycelium:
-    name: Mycelium client staleness
+  openapi-staleness:
+    name: OpenAPI snapshot staleness
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -103,13 +103,11 @@ jobs:
             sleep 1
           done
 
-      - name: Regenerate client + diff
-        env:
-          BACKEND_URL: http://127.0.0.1:8000
+      - name: Diff live OpenAPI vs committed snapshot
         run: |
-          ./scripts/gen-mycelium-client.sh
-          if ! git diff --exit-code mycelium-client mycelium-cli/src/mycelium_backend_client; then
-            echo "::error::Committed mycelium client is stale vs. live OpenAPI. Run scripts/gen-mycelium-client.sh and commit." >&2
+          curl -sf http://127.0.0.1:8000/openapi.json | python3 -m json.tool > /tmp/openapi.live.json
+          if ! diff -u openapi.json /tmp/openapi.live.json; then
+            echo "::error::Committed openapi.json is stale vs. live backend. Run scripts/snapshot-openapi.sh and commit, then regen clients with scripts/gen-mycelium-client.sh." >&2
             exit 1
           fi
 

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,3450 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Mycelium Backend",
+        "version": "0.1.0"
+    },
+    "paths": {
+        "/rooms": {
+            "post": {
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Create Room",
+                "description": "Create a new room.",
+                "operationId": "create_room_rooms_post",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RoomCreate"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RoomRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "List Rooms",
+                "description": "List rooms with optional name filter.",
+                "operationId": "list_rooms_rooms_get",
+                "parameters": [
+                    {
+                        "name": "skip",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "title": "Skip"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "title": "Limit"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/RoomRead"
+                                    },
+                                    "title": "Response List Rooms Rooms Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}": {
+            "get": {
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Get Room",
+                "description": "Get a room by name.",
+                "operationId": "get_room_rooms__room_name__get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RoomRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Delete Room",
+                "description": "Delete a room and cascade to its child session rooms.\n\nCleanup order is important to avoid stale state firing against\nalready-deleted rows:\n\n  1. Enumerate child session rooms (``parent_namespace == room_name``).\n  2. Tear down all in-memory CFN coordination state for the namespace\n     and its children (cancels pending join timers and active round\n     timeouts, posts ``coordination_consensus broken=True`` to any\n     SSE subscribers).\n  3. Delete child ``Session`` rows, then child ``Room`` rows.\n  4. Mark any active child rooms as ``coordination_state=\"failed\"``\n     (defensive \u2014 if step 3 didn't catch them due to a race, the\n     state still reflects reality).\n  5. Delete the parent ``Room`` row.\n  6. Remove the filesystem directory.\n  7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN\n     error doesn't block the local cleanup).",
+                "operationId": "delete_room_rooms__room_name__delete",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/synthesize": {
+            "post": {
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Synthesize Room",
+                "description": "Trigger CognitiveEngine async synthesis for a room.",
+                "operationId": "synthesize_room_rooms__room_name__synthesize_post",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/catchup": {
+            "get": {
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Catchup Room",
+                "description": "Get a briefing for an agent joining a room: latest synthesis + recent activity.",
+                "operationId": "catchup_room_rooms__room_name__catchup_get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/reindex": {
+            "post": {
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Reindex Room",
+                "description": "Re-index a room's filesystem into the pgvector search index.\n\nScans .mycelium/rooms/{room_name}/ and upserts all markdown files\ninto the memories table with fresh embeddings.",
+                "operationId": "reindex_room_rooms__room_name__reindex_post",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/negotiation": {
+            "get": {
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Get Negotiation Status",
+                "description": "Return live negotiation state for an active session room.\n\nReturns ``{\"active\": false}`` when no negotiation is in progress.\n``pending_replies`` values are ``\"received\"`` or ``\"waiting\"``.",
+                "operationId": "get_negotiation_status",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "title": "Response Get Negotiation Status"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/messages": {
+            "post": {
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Send Message",
+                "description": "Send a message to a room.\n\nAfter persisting, fires NOTIFY on `room:{room_name}` so SSE subscribers\nreceive it without polling.",
+                "operationId": "send_message_rooms__room_name__messages_post",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MessageCreate"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "messages"
+                ],
+                "summary": "List Messages",
+                "description": "List messages in a room, newest first.",
+                "operationId": "list_messages_rooms__room_name__messages_get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 500,
+                            "default": 50,
+                            "title": "Limit"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "title": "Offset"
+                        }
+                    },
+                    {
+                        "name": "sender",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Sender"
+                        }
+                    },
+                    {
+                        "name": "message_type",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Message Type"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/sessions/spawn": {
+            "post": {
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Spawn Session",
+                "description": "Explicitly spawn a negotiation session within a namespace room.",
+                "operationId": "spawn_session_rooms__room_name__sessions_spawn_post",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "title": "Response Spawn Session Rooms  Room Name  Sessions Spawn Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/sessions": {
+            "post": {
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Join Room",
+                "description": "Join a room. If the room is a namespace, auto-spawns a session and joins that.",
+                "operationId": "join_room_rooms__room_name__sessions_post",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SessionCreate"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "List Sessions",
+                "description": "List agents currently in a room.",
+                "operationId": "list_sessions_rooms__room_name__sessions_get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SessionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/sessions/{session_id}": {
+            "delete": {
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "Leave Room",
+                "description": "Remove an agent session (leave room).",
+                "operationId": "leave_room_rooms__room_name__sessions__session_id__delete",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    },
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/messages/stream": {
+            "get": {
+                "tags": [
+                    "stream"
+                ],
+                "summary": "Stream Room Messages",
+                "description": "Server-Sent Events stream for a room.\n\nYields SSE events as messages arrive via Postgres NOTIFY.\nConnect with: curl -N http://localhost:8000/rooms/{room}/messages/stream",
+                "operationId": "stream_room_messages_rooms__room_name__messages_stream_get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/agents/{handle}/stream": {
+            "get": {
+                "tags": [
+                    "stream"
+                ],
+                "summary": "Stream Agent Events",
+                "description": "Server-Sent Events stream for a specific agent handle.\n\nDelivers coordination_tick and coordination_consensus events addressed to\nthis agent across all rooms \u2014 no room configuration required on the client.\nConnect with: curl -N http://localhost:8000/agents/{handle}/stream",
+                "operationId": "stream_agent_events_agents__handle__stream_get",
+                "parameters": [
+                    {
+                        "name": "handle",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Handle"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/memory": {
+            "post": {
+                "tags": [
+                    "memory"
+                ],
+                "summary": "Create Memories",
+                "description": "Create or upsert one or more memories (batch: 1-100 items).\n\nWrites markdown files to .mycelium/rooms/{room_name}/ and updates\nthe pgvector search index.",
+                "operationId": "create_memories_rooms__room_name__memory_post",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MemoryBatchCreate"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/MemoryRead"
+                                    },
+                                    "title": "Response Create Memories Rooms  Room Name  Memory Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "memory"
+                ],
+                "summary": "List Memories",
+                "description": "List memories in a room.\n\nReads from the filesystem, falls back to DB index.\nSupports ETag / If-None-Match for efficient sync \u2014 returns 304 if nothing changed.",
+                "operationId": "list_memories_rooms__room_name__memory_get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    },
+                    {
+                        "name": "prefix",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Key prefix filter",
+                            "title": "Prefix"
+                        },
+                        "description": "Key prefix filter"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 1000,
+                            "minimum": 1,
+                            "default": 100,
+                            "title": "Limit"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0,
+                            "title": "Offset"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/memory/search": {
+            "post": {
+                "tags": [
+                    "memory"
+                ],
+                "summary": "Search Memories",
+                "description": "Semantic vector search over memories in a room.\n\nSearch uses the pgvector index.",
+                "operationId": "search_memories_rooms__room_name__memory_search_post",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MemorySearchRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MemorySearchResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/memory/subscribe": {
+            "post": {
+                "tags": [
+                    "memory"
+                ],
+                "summary": "Subscribe",
+                "description": "Subscribe to memory change notifications for a key pattern.",
+                "operationId": "subscribe_rooms__room_name__memory_subscribe_post",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SubscriptionCreate"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SubscriptionRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/memory/subscribe/{subscription_id}": {
+            "delete": {
+                "tags": [
+                    "memory"
+                ],
+                "summary": "Unsubscribe",
+                "description": "Remove a memory subscription.",
+                "operationId": "unsubscribe_rooms__room_name__memory_subscribe__subscription_id__delete",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    },
+                    {
+                        "name": "subscription_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Subscription Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/memory/subscriptions": {
+            "get": {
+                "tags": [
+                    "memory"
+                ],
+                "summary": "List Subscriptions",
+                "description": "List active memory subscriptions for a room.",
+                "operationId": "list_subscriptions_rooms__room_name__memory_subscriptions_get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/SubscriptionRead"
+                                    },
+                                    "title": "Response List Subscriptions Rooms  Room Name  Memory Subscriptions Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/rooms/{room_name}/memory/{key}": {
+            "get": {
+                "tags": [
+                    "memory"
+                ],
+                "summary": "Get Memory",
+                "description": "Get a specific memory by key.\n\nReads from the filesystem first, falls back to DB index.",
+                "operationId": "get_memory_rooms__room_name__memory__key__get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Key"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MemoryRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "memory"
+                ],
+                "summary": "Delete Memory",
+                "description": "Delete a memory by key. Removes the file and the DB search index entry.\n\nEither the file or the DB entry (or both) must exist \u2014 404 only if neither is found.",
+                "operationId": "delete_memory_rooms__room_name__memory__key__delete",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    },
+                    {
+                        "name": "key",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Key"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/internal/audit-events": {
+            "post": {
+                "tags": [
+                    "audit"
+                ],
+                "summary": "Create Audit Event",
+                "description": "Create a new audit event.",
+                "operationId": "create_audit_event_api_internal_audit_events_post",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AuditEventCreate"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "audit"
+                ],
+                "summary": "List Audit Events",
+                "description": "List audit events with optional filters.",
+                "operationId": "list_audit_events_api_internal_audit_events_get",
+                "parameters": [
+                    {
+                        "name": "resource_type",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Resource Type"
+                        }
+                    },
+                    {
+                        "name": "audit_type",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Audit Type"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/AuditEventRead"
+                                    },
+                                    "title": "Response List Audit Events Api Internal Audit Events Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/internal/audit-events/{event_id}": {
+            "get": {
+                "tags": [
+                    "audit"
+                ],
+                "summary": "Get Audit Event",
+                "description": "Get a single audit event by UUID.",
+                "operationId": "get_audit_event_api_internal_audit_events__event_id__get",
+                "parameters": [
+                    {
+                        "name": "event_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Event Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuditEventRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "audit"
+                ],
+                "summary": "Delete Audit Event",
+                "description": "Delete an audit event by UUID.",
+                "operationId": "delete_audit_event_api_internal_audit_events__event_id__delete",
+                "parameters": [
+                    {
+                        "name": "event_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Event Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/workspaces/{workspace_id}/multi-agentic-systems/{mas_id}/agents/{agent_id}/memory-operations": {
+            "post": {
+                "tags": [
+                    "cfn-proxy"
+                ],
+                "summary": "Memory Operations",
+                "description": "Proxy an arbitrary HTTP request to an agent's memory provider.\n\nRequest envelope:\n    {\"payload\": {\"http-request-type\": \"POST\", \"http-url\": \"/v1/memories\",\n                 \"http-request-body\": {...}, \"http-headers\": {...}}}\n\nResponse envelope:\n    {\"http-status\": 200, \"http-headers\": {...}, \"http-response-body\": {...}}",
+                "operationId": "memory_operations_api_workspaces__workspace_id__multi_agentic_systems__mas_id__agents__agent_id__memory_operations_post",
+                "parameters": [
+                    {
+                        "name": "workspace_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Workspace Id"
+                        }
+                    },
+                    {
+                        "name": "mas_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Mas Id"
+                        }
+                    },
+                    {
+                        "name": "agent_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Agent Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "title": "Response Memory Operations Api Workspaces  Workspace Id  Multi Agentic Systems  Mas Id  Agents  Agent Id  Memory Operations Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cfn/knowledge/query": {
+            "post": {
+                "tags": [
+                    "cfn-read"
+                ],
+                "summary": "Cfn Query",
+                "description": "Semantic-graph query against CFN's shared memory.\n\nCFN returns a natural-language answer from its evidence agent\n(``{\"response_id\": str, \"message\": str}``), not a structured record\nlist. The ``mycelium cfn query`` CLI renders the message directly.",
+                "operationId": "cfn_query_api_cfn_knowledge_query_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/QueryRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": true,
+                                    "type": "object",
+                                    "title": "Response Cfn Query Api Cfn Knowledge Query Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cfn/knowledge/concepts": {
+            "post": {
+                "tags": [
+                    "cfn-read"
+                ],
+                "summary": "Cfn Concepts By Ids",
+                "description": "Fetch CFN concept records by explicit IDs.",
+                "operationId": "cfn_concepts_by_ids_api_cfn_knowledge_concepts_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ConceptsByIdsRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": true,
+                                    "type": "object",
+                                    "title": "Response Cfn Concepts By Ids Api Cfn Knowledge Concepts Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cfn/knowledge/concepts/{concept_id}/neighbors": {
+            "get": {
+                "tags": [
+                    "cfn-read"
+                ],
+                "summary": "Cfn Concept Neighbors",
+                "description": "Fetch a concept's graph neighbors from CFN.",
+                "operationId": "cfn_concept_neighbors_api_cfn_knowledge_concepts__concept_id__neighbors_get",
+                "parameters": [
+                    {
+                        "name": "concept_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Concept Id"
+                        }
+                    },
+                    {
+                        "name": "mas_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Mas Id"
+                        }
+                    },
+                    {
+                        "name": "workspace_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Workspace Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "title": "Response Cfn Concept Neighbors Api Cfn Knowledge Concepts  Concept Id  Neighbors Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cfn/knowledge/paths": {
+            "post": {
+                "tags": [
+                    "cfn-read"
+                ],
+                "summary": "Cfn Graph Paths",
+                "description": "Fetch paths between two CFN concepts by ID.",
+                "operationId": "cfn_graph_paths_api_cfn_knowledge_paths_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GraphPathsRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "additionalProperties": true,
+                                    "type": "object",
+                                    "title": "Response Cfn Graph Paths Api Cfn Knowledge Paths Post"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/cfn/knowledge/list": {
+            "get": {
+                "tags": [
+                    "cfn-read"
+                ],
+                "summary": "Cfn List",
+                "description": "Enumerate nodes in CFN's AgensGraph for a given MAS.\n\n**Not a CFN API**. Goes around CFN's HTTP surface and queries the\nunderlying AgensGraph directly, because CFN doesn't expose a list\nendpoint. Coupled to CFN's graph-naming convention\n(``graph_<mas_id_with_hyphens_underscored>``).",
+                "operationId": "cfn_list_api_cfn_knowledge_list_get",
+                "parameters": [
+                    {
+                        "name": "mas_id",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Mas Id"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 50,
+                            "title": "Limit"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "title": "Response Cfn List Api Cfn Knowledge List Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/knowledge/ingest": {
+            "post": {
+                "tags": [
+                    "knowledge"
+                ],
+                "summary": "Knowledge Ingest",
+                "description": "Forward openclaw turns to CFN's shared-memories endpoint.\n\nEnforces user-configured gates before hitting CFN:\n\n1. ``MYCELIUM_INGEST_ENABLED`` master switch \u2014 accept+discard when false.\n2. ``MYCELIUM_INGEST_MAX_INPUT_TOKENS`` circuit breaker \u2014 refuse with\n   HTTP 413 when the estimated input exceeds the threshold.\n3. Content-hash dedupe cache \u2014 short-circuit duplicate payloads within\n   ``MYCELIUM_INGEST_DEDUPE_TTL_SECONDS`` and return the cached\n   ``response_id`` without re-hitting CFN.\n\nEvery outcome is appended to the in-memory ingest log buffer so\n``mycelium cfn log`` / ``stats`` can surface cost and success signal.\nThe durable ``KNOWLEDGE_INGESTION`` audit event is still emitted for\nevery accepted attempt (ok, deduped, disabled) \u2014 it stays as the\ntamper-evident record and is unaffected by the in-memory buffer.",
+                "operationId": "knowledge_ingest_api_knowledge_ingest_post",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/KnowledgeIngestRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/KnowledgeIngestResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/knowledge/ingest/log": {
+            "get": {
+                "tags": [
+                    "knowledge"
+                ],
+                "summary": "Knowledge Ingest Log",
+                "description": "Return the most recent CFN shared-memories forward attempts.\n\nNewest first. Resets on backend restart. Captures both successes and\nfailures; ``error`` is set on failures, ``cfn_message`` on successes.",
+                "operationId": "knowledge_ingest_log_api_knowledge_ingest_log_get",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 500,
+                            "minimum": 1,
+                            "default": 50,
+                            "title": "Limit"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/IngestLogResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/knowledge/ingest/stats": {
+            "get": {
+                "tags": [
+                    "knowledge"
+                ],
+                "summary": "Knowledge Ingest Stats",
+                "description": "Aggregate CFN ingest activity across the current in-memory buffer.\n\nGrouped by ``mas_id`` and ``agent_id``. ``last_hour`` is a rolling window\nover the buffer. Buffer resets on backend restart, so these are\nprocess-lifetime numbers, not durable metrics.",
+                "operationId": "knowledge_ingest_stats_api_knowledge_ingest_stats_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/IngestStatsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/internal/coordination/round-traces": {
+            "get": {
+                "tags": [
+                    "coordination"
+                ],
+                "summary": "List Round Traces",
+                "description": "Return completed CFN round traces, oldest first.\n\nEach trace is one round of a CFN negotiation: who replied, when, whether\nany replies were synthesised because the watchdog fired, and how the\nround closed.  ``round_n`` is per-negotiation (resets to 0 when a new\nnegotiation starts in the same room), not per-room-lifetime.  Intended\nfor diagnosing coordination latency and synthesis behaviour (issue #162).",
+                "operationId": "list_round_traces_api_internal_coordination_round_traces_get",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "integer",
+                                    "minimum": 0
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Return at most the most-recent N traces.  Omit to return all traces currently in the buffer.  Values larger than the buffer capacity simply return the whole buffer.",
+                            "title": "Limit"
+                        },
+                        "description": "Return at most the most-recent N traces.  Omit to return all traces currently in the buffer.  Values larger than the buffer capacity simply return the whole buffer."
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "title": "Response List Round Traces Api Internal Coordination Round Traces Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "coordination"
+                ],
+                "summary": "Clear Round Traces",
+                "description": "Empty the round trace ring buffer.\n\nIntended for batch diagnostic runs that need each iteration's output to\nbe independent.  No-op if the buffer is already empty.",
+                "operationId": "clear_round_traces_api_internal_coordination_round_traces_delete",
+                "responses": {
+                    "204": {
+                        "description": "Successful Response"
+                    }
+                }
+            }
+        },
+        "/health": {
+            "get": {
+                "tags": [
+                    "health"
+                ],
+                "summary": "Root",
+                "description": "Health check.\n\nPass ``?check_llm=true`` to probe the LLM provider.  Without it, only local\nconfig status is included.\n\nProbe mode is selected by ``llm_probe`` (only relevant when check_llm=true):\n\n* ``provider`` (default) \u2014 zero-cost model-list call.  Free but only validates\n  openai/anthropic/ollama; returns \"unchecked\" for bedrock/vertex/etc.\n* ``completion`` \u2014 real ``litellm.acompletion(max_tokens=1)`` call.  Exercises\n  the same code path as inference and surfaces missing provider SDK extras\n  (e.g. boto3 for Bedrock), bad model strings, and endpoint-level auth\n  failures.  Costs a single token.",
+                "operationId": "root_health_get",
+                "parameters": [
+                    {
+                        "name": "check_llm",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Check Llm"
+                        }
+                    },
+                    {
+                        "name": "llm_probe",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "provider",
+                            "title": "Llm Probe"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/": {
+            "get": {
+                "tags": [
+                    "health"
+                ],
+                "summary": "Root",
+                "description": "Health check.\n\nPass ``?check_llm=true`` to probe the LLM provider.  Without it, only local\nconfig status is included.\n\nProbe mode is selected by ``llm_probe`` (only relevant when check_llm=true):\n\n* ``provider`` (default) \u2014 zero-cost model-list call.  Free but only validates\n  openai/anthropic/ollama; returns \"unchecked\" for bedrock/vertex/etc.\n* ``completion`` \u2014 real ``litellm.acompletion(max_tokens=1)`` call.  Exercises\n  the same code path as inference and surfaces missing provider SDK extras\n  (e.g. boto3 for Bedrock), bad model strings, and endpoint-level auth\n  failures.  Costs a single token.",
+                "operationId": "root__get",
+                "parameters": [
+                    {
+                        "name": "check_llm",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Check Llm"
+                        }
+                    },
+                    {
+                        "name": "llm_probe",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "default": "provider",
+                            "title": "Llm Probe"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "AuditEventCreate": {
+                "properties": {
+                    "operation_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Operation Id"
+                    },
+                    "resource_type": {
+                        "type": "string",
+                        "title": "Resource Type"
+                    },
+                    "resource_identifier": {
+                        "type": "string",
+                        "title": "Resource Identifier"
+                    },
+                    "audit_type": {
+                        "type": "string",
+                        "title": "Audit Type"
+                    },
+                    "audit_resource_identifier": {
+                        "type": "string",
+                        "title": "Audit Resource Identifier"
+                    },
+                    "audit_information": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Audit Information"
+                    },
+                    "audit_extra_information": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Audit Extra Information"
+                    },
+                    "created_by": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Created By"
+                    },
+                    "last_modified_by": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Last Modified By"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "resource_type",
+                    "resource_identifier",
+                    "audit_type",
+                    "audit_resource_identifier",
+                    "created_by",
+                    "last_modified_by"
+                ],
+                "title": "AuditEventCreate"
+            },
+            "AuditEventRead": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "operation_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Operation Id"
+                    },
+                    "resource_type": {
+                        "type": "string",
+                        "title": "Resource Type"
+                    },
+                    "resource_identifier": {
+                        "type": "string",
+                        "title": "Resource Identifier"
+                    },
+                    "audit_type": {
+                        "type": "string",
+                        "title": "Audit Type"
+                    },
+                    "audit_resource_identifier": {
+                        "type": "string",
+                        "title": "Audit Resource Identifier"
+                    },
+                    "audit_information": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Audit Information"
+                    },
+                    "audit_extra_information": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Audit Extra Information"
+                    },
+                    "created_by": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Created By"
+                    },
+                    "created_on": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created On"
+                    },
+                    "last_modified_by": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Last Modified By"
+                    },
+                    "last_modified_on": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Last Modified On"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "resource_type",
+                    "resource_identifier",
+                    "audit_type",
+                    "audit_resource_identifier",
+                    "created_by",
+                    "created_on",
+                    "last_modified_by",
+                    "last_modified_on"
+                ],
+                "title": "AuditEventRead"
+            },
+            "ConceptsByIdsRequest": {
+                "properties": {
+                    "ids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "minItems": 1,
+                        "title": "Ids"
+                    },
+                    "mas_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mas Id"
+                    },
+                    "workspace_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspace Id"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "ids"
+                ],
+                "title": "ConceptsByIdsRequest"
+            },
+            "GraphPathsRequest": {
+                "properties": {
+                    "source_id": {
+                        "type": "string",
+                        "title": "Source Id"
+                    },
+                    "target_id": {
+                        "type": "string",
+                        "title": "Target Id"
+                    },
+                    "mas_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mas Id"
+                    },
+                    "workspace_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspace Id"
+                    },
+                    "max_depth": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max Depth"
+                    },
+                    "relations": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Relations"
+                    },
+                    "limit": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Limit"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "source_id",
+                    "target_id"
+                ],
+                "title": "GraphPathsRequest"
+            },
+            "HTTPValidationError": {
+                "properties": {
+                    "detail": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValidationError"
+                        },
+                        "type": "array",
+                        "title": "Detail"
+                    }
+                },
+                "type": "object",
+                "title": "HTTPValidationError"
+            },
+            "IngestEvent": {
+                "properties": {
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Timestamp"
+                    },
+                    "workspace_id": {
+                        "type": "string",
+                        "title": "Workspace Id"
+                    },
+                    "mas_id": {
+                        "type": "string",
+                        "title": "Mas Id"
+                    },
+                    "agent_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Agent Id"
+                    },
+                    "request_id": {
+                        "type": "string",
+                        "title": "Request Id"
+                    },
+                    "record_count": {
+                        "type": "integer",
+                        "title": "Record Count"
+                    },
+                    "payload_bytes": {
+                        "type": "integer",
+                        "title": "Payload Bytes"
+                    },
+                    "estimated_cfn_knowledge_input_tokens": {
+                        "type": "integer",
+                        "title": "Estimated Cfn Knowledge Input Tokens"
+                    },
+                    "latency_ms": {
+                        "type": "number",
+                        "title": "Latency Ms"
+                    },
+                    "state": {
+                        "type": "string",
+                        "enum": [
+                            "ok",
+                            "deduped",
+                            "truncated",
+                            "refused",
+                            "disabled",
+                            "error"
+                        ],
+                        "title": "State",
+                        "default": "ok"
+                    },
+                    "reason": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Reason"
+                    },
+                    "cfn_status": {
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cfn Status"
+                    },
+                    "cfn_message": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cfn Message"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "timestamp",
+                    "workspace_id",
+                    "mas_id",
+                    "request_id",
+                    "record_count",
+                    "payload_bytes",
+                    "estimated_cfn_knowledge_input_tokens",
+                    "latency_ms"
+                ],
+                "title": "IngestEvent",
+                "description": "A single CFN shared-memories forward attempt, one of:\n\n- ``ok``        \u2014 forwarded to CFN successfully\n- ``deduped``   \u2014 hash matched in-process cache, returned prior response_id\n- ``truncated`` \u2014 forwarded OK, but the hook capped tool-call content\n- ``refused``   \u2014 refused locally (circuit breaker above max_input_tokens)\n- ``disabled``  \u2014 master switch off, accepted and discarded\n- ``error``     \u2014 CFN returned non-2xx or was unreachable"
+            },
+            "IngestLogResponse": {
+                "properties": {
+                    "buffer_started_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Buffer Started At"
+                    },
+                    "total_events": {
+                        "type": "integer",
+                        "title": "Total Events"
+                    },
+                    "events": {
+                        "items": {
+                            "$ref": "#/components/schemas/IngestEvent"
+                        },
+                        "type": "array",
+                        "title": "Events"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "buffer_started_at",
+                    "total_events",
+                    "events"
+                ],
+                "title": "IngestLogResponse"
+            },
+            "IngestStatsAggregate": {
+                "properties": {
+                    "events": {
+                        "type": "integer",
+                        "title": "Events"
+                    },
+                    "estimated_cfn_knowledge_input_tokens": {
+                        "type": "integer",
+                        "title": "Estimated Cfn Knowledge Input Tokens"
+                    },
+                    "payload_bytes": {
+                        "type": "integer",
+                        "title": "Payload Bytes"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "events",
+                    "estimated_cfn_knowledge_input_tokens",
+                    "payload_bytes"
+                ],
+                "title": "IngestStatsAggregate"
+            },
+            "IngestStatsResponse": {
+                "properties": {
+                    "buffer_started_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Buffer Started At"
+                    },
+                    "last_event_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Event At"
+                    },
+                    "total": {
+                        "$ref": "#/components/schemas/IngestStatsAggregate"
+                    },
+                    "last_hour": {
+                        "$ref": "#/components/schemas/IngestStatsAggregate"
+                    },
+                    "by_mas": {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/IngestStatsAggregate"
+                        },
+                        "type": "object",
+                        "title": "By Mas"
+                    },
+                    "by_agent": {
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/IngestStatsAggregate"
+                        },
+                        "type": "object",
+                        "title": "By Agent"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "buffer_started_at",
+                    "last_event_at",
+                    "total",
+                    "last_hour",
+                    "by_mas",
+                    "by_agent"
+                ],
+                "title": "IngestStatsResponse"
+            },
+            "KnowledgeIngestRequest": {
+                "properties": {
+                    "records": {
+                        "items": {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        "type": "array",
+                        "title": "Records"
+                    },
+                    "agent_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Agent Id"
+                    },
+                    "room_name": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Room Name"
+                    },
+                    "workspace_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspace Id"
+                    },
+                    "mas_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mas Id"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "records"
+                ],
+                "title": "KnowledgeIngestRequest"
+            },
+            "KnowledgeIngestResponse": {
+                "properties": {
+                    "cfn_response_id": {
+                        "type": "string",
+                        "title": "Cfn Response Id"
+                    },
+                    "cfn_message": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Cfn Message"
+                    },
+                    "ingested_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Ingested At"
+                    },
+                    "estimated_cfn_knowledge_input_tokens": {
+                        "type": "integer",
+                        "title": "Estimated Cfn Knowledge Input Tokens"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "cfn_response_id",
+                    "ingested_at",
+                    "estimated_cfn_knowledge_input_tokens"
+                ],
+                "title": "KnowledgeIngestResponse"
+            },
+            "MemoryBatchCreate": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/MemoryCreate"
+                        },
+                        "type": "array",
+                        "maxItems": 100,
+                        "minItems": 1,
+                        "title": "Items"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "items"
+                ],
+                "title": "MemoryBatchCreate"
+            },
+            "MemoryCreate": {
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "maxLength": 512,
+                        "minLength": 1,
+                        "title": "Key"
+                    },
+                    "value": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "title": "Value",
+                        "description": "Memory content (dict or string)"
+                    },
+                    "tags": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tags"
+                    },
+                    "content_text": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Content Text",
+                        "description": "Text for embedding; auto-generated from value if omitted"
+                    },
+                    "embed": {
+                        "type": "boolean",
+                        "title": "Embed",
+                        "description": "Generate vector embedding for semantic search",
+                        "default": true
+                    },
+                    "created_by": {
+                        "type": "string",
+                        "title": "Created By",
+                        "description": "Agent handle creating this memory"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "key",
+                    "value",
+                    "created_by"
+                ],
+                "title": "MemoryCreate"
+            },
+            "MemoryRead": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "room_name": {
+                        "type": "string",
+                        "title": "Room Name"
+                    },
+                    "key": {
+                        "type": "string",
+                        "title": "Key"
+                    },
+                    "value": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ],
+                        "title": "Value"
+                    },
+                    "content_text": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Content Text"
+                    },
+                    "created_by": {
+                        "type": "string",
+                        "title": "Created By"
+                    },
+                    "updated_by": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Updated By"
+                    },
+                    "version": {
+                        "type": "integer",
+                        "title": "Version"
+                    },
+                    "tags": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tags"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Updated At"
+                    },
+                    "file_path": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "File Path"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "room_name",
+                    "key",
+                    "value",
+                    "created_by",
+                    "version",
+                    "created_at",
+                    "updated_at"
+                ],
+                "title": "MemoryRead"
+            },
+            "MemorySearchRequest": {
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "minLength": 1,
+                        "title": "Query"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "maximum": 100.0,
+                        "minimum": 1.0,
+                        "title": "Limit",
+                        "default": 10
+                    },
+                    "tags_filter": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Tags Filter"
+                    },
+                    "min_similarity": {
+                        "type": "number",
+                        "maximum": 1.0,
+                        "minimum": 0.0,
+                        "title": "Min Similarity",
+                        "default": 0.0
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "query"
+                ],
+                "title": "MemorySearchRequest"
+            },
+            "MemorySearchResponse": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/MemorySearchResult"
+                        },
+                        "type": "array",
+                        "title": "Results"
+                    },
+                    "total": {
+                        "type": "integer",
+                        "title": "Total"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "results",
+                    "total"
+                ],
+                "title": "MemorySearchResponse"
+            },
+            "MemorySearchResult": {
+                "properties": {
+                    "memory": {
+                        "$ref": "#/components/schemas/MemoryRead"
+                    },
+                    "similarity": {
+                        "type": "number",
+                        "title": "Similarity"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "memory",
+                    "similarity"
+                ],
+                "title": "MemorySearchResult"
+            },
+            "MessageCreate": {
+                "properties": {
+                    "sender_handle": {
+                        "type": "string",
+                        "title": "Sender Handle",
+                        "description": "Sender handle (e.g., 'alpha#a8f3')"
+                    },
+                    "recipient_handle": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Recipient Handle",
+                        "description": "Recipient handle for direct messages; omit for broadcast"
+                    },
+                    "message_type": {
+                        "type": "string",
+                        "pattern": "^(announce|direct|broadcast|delegate)$",
+                        "title": "Message Type",
+                        "description": "Type: announce, direct, broadcast, or delegate"
+                    },
+                    "content": {
+                        "type": "string",
+                        "minLength": 1,
+                        "title": "Content"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "sender_handle",
+                    "message_type",
+                    "content"
+                ],
+                "title": "MessageCreate"
+            },
+            "MessageListResponse": {
+                "properties": {
+                    "messages": {
+                        "items": {
+                            "$ref": "#/components/schemas/MessageRead"
+                        },
+                        "type": "array",
+                        "title": "Messages"
+                    },
+                    "total": {
+                        "type": "integer",
+                        "title": "Total"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "messages",
+                    "total"
+                ],
+                "title": "MessageListResponse"
+            },
+            "MessageRead": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "room_name": {
+                        "type": "string",
+                        "title": "Room Name"
+                    },
+                    "sender_handle": {
+                        "type": "string",
+                        "title": "Sender Handle"
+                    },
+                    "recipient_handle": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Recipient Handle"
+                    },
+                    "message_type": {
+                        "type": "string",
+                        "title": "Message Type"
+                    },
+                    "content": {
+                        "type": "string",
+                        "title": "Content"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "room_name",
+                    "sender_handle",
+                    "message_type",
+                    "content",
+                    "created_at"
+                ],
+                "title": "MessageRead"
+            },
+            "QueryRequest": {
+                "properties": {
+                    "intent": {
+                        "type": "string",
+                        "title": "Intent"
+                    },
+                    "mas_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mas Id"
+                    },
+                    "workspace_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspace Id"
+                    },
+                    "agent_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Agent Id"
+                    },
+                    "search_strategy": {
+                        "type": "string",
+                        "title": "Search Strategy",
+                        "default": "semantic_graph_traversal"
+                    },
+                    "additional_context": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Additional Context"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "intent"
+                ],
+                "title": "QueryRequest"
+            },
+            "RoomCreate": {
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 100,
+                        "minLength": 1,
+                        "title": "Name"
+                    },
+                    "description": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "maxLength": 500
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Description"
+                    },
+                    "is_public": {
+                        "type": "boolean",
+                        "title": "Is Public",
+                        "default": true
+                    },
+                    "trigger_config": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Trigger Config"
+                    },
+                    "mas_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mas Id"
+                    },
+                    "workspace_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspace Id"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "name"
+                ],
+                "title": "RoomCreate"
+            },
+            "RoomRead": {
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "title": "Id"
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name"
+                    },
+                    "description": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Description"
+                    },
+                    "is_public": {
+                        "type": "boolean",
+                        "title": "Is Public"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At"
+                    },
+                    "coordination_state": {
+                        "type": "string",
+                        "title": "Coordination State",
+                        "default": "idle"
+                    },
+                    "join_deadline": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Join Deadline"
+                    },
+                    "mode": {
+                        "type": "string",
+                        "title": "Mode",
+                        "default": "sync"
+                    },
+                    "trigger_config": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Trigger Config"
+                    },
+                    "last_synthesis_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Synthesis At"
+                    },
+                    "is_persistent": {
+                        "type": "boolean",
+                        "title": "Is Persistent",
+                        "default": false
+                    },
+                    "is_namespace": {
+                        "type": "boolean",
+                        "title": "Is Namespace",
+                        "default": false
+                    },
+                    "parent_namespace": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Parent Namespace"
+                    },
+                    "mas_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mas Id"
+                    },
+                    "workspace_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspace Id"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "name",
+                    "is_public",
+                    "created_at"
+                ],
+                "title": "RoomRead"
+            },
+            "SessionCreate": {
+                "properties": {
+                    "agent_handle": {
+                        "type": "string",
+                        "title": "Agent Handle",
+                        "description": "Agent handle joining the room"
+                    },
+                    "intent": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Intent",
+                        "description": "Agent's requirements/intent for coordination"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "agent_handle"
+                ],
+                "title": "SessionCreate"
+            },
+            "SessionListResponse": {
+                "properties": {
+                    "sessions": {
+                        "items": {
+                            "$ref": "#/components/schemas/SessionRead"
+                        },
+                        "type": "array",
+                        "title": "Sessions"
+                    },
+                    "total": {
+                        "type": "integer",
+                        "title": "Total"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "sessions",
+                    "total"
+                ],
+                "title": "SessionListResponse"
+            },
+            "SessionRead": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "room_name": {
+                        "type": "string",
+                        "title": "Room Name"
+                    },
+                    "agent_handle": {
+                        "type": "string",
+                        "title": "Agent Handle"
+                    },
+                    "intent": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Intent"
+                    },
+                    "joined_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Joined At"
+                    },
+                    "last_seen": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Seen"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "room_name",
+                    "agent_handle",
+                    "joined_at"
+                ],
+                "title": "SessionRead"
+            },
+            "SubscriptionCreate": {
+                "properties": {
+                    "key_pattern": {
+                        "type": "string",
+                        "minLength": 1,
+                        "title": "Key Pattern",
+                        "description": "Glob pattern for keys to watch"
+                    },
+                    "subscriber": {
+                        "type": "string",
+                        "title": "Subscriber",
+                        "description": "Agent handle subscribing"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "key_pattern",
+                    "subscriber"
+                ],
+                "title": "SubscriptionCreate"
+            },
+            "SubscriptionRead": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "room_name": {
+                        "type": "string",
+                        "title": "Room Name"
+                    },
+                    "subscriber": {
+                        "type": "string",
+                        "title": "Subscriber"
+                    },
+                    "key_pattern": {
+                        "type": "string",
+                        "title": "Key Pattern"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "room_name",
+                    "subscriber",
+                    "key_pattern",
+                    "created_at"
+                ],
+                "title": "SubscriptionRead"
+            },
+            "ValidationError": {
+                "properties": {
+                    "loc": {
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "integer"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                        "title": "Location"
+                    },
+                    "msg": {
+                        "type": "string",
+                        "title": "Message"
+                    },
+                    "type": {
+                        "type": "string",
+                        "title": "Error Type"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "loc",
+                    "msg",
+                    "type"
+                ],
+                "title": "ValidationError"
+            }
+        }
+    }
+}

--- a/scripts/gen-mycelium-client.sh
+++ b/scripts/gen-mycelium-client.sh
@@ -45,12 +45,11 @@ echo "→ Copying to mycelium-cli/src/mycelium_backend_client/"
 rm -rf "$ROOT/mycelium-cli/src/mycelium_backend_client"
 cp -R "$OUT/mycelium_backend_client" "$ROOT/mycelium-cli/src/"
 
-# Format with the project's ruff config so committed output matches what
-# `ruff format --check` will accept in CI.
+# Format with a pinned ruff so committed output is byte-identical between
+# local devs and CI regardless of project lockfile drift.
 echo "→ Running ruff format on generated files"
-(cd "$ROOT/mycelium-cli" && uv run ruff format src/mycelium_backend_client >/dev/null) || true
-# mycelium-client/ is a poetry standalone package; format from the cli env
-# (its ruff config is what we ship under).
-(cd "$ROOT/mycelium-cli" && uv run ruff format ../mycelium-client/mycelium_backend_client >/dev/null) || true
+RUFF_PIN='ruff==0.15.10'
+(cd "$ROOT/mycelium-cli" && uv run --with "$RUFF_PIN" ruff format src/mycelium_backend_client >/dev/null)
+(cd "$ROOT/mycelium-cli" && uv run --with "$RUFF_PIN" ruff format ../mycelium-client/mycelium_backend_client >/dev/null)
 
 echo "✓ Done. Run \`git diff\` to see drift."

--- a/scripts/gen-mycelium-client.sh
+++ b/scripts/gen-mycelium-client.sh
@@ -45,11 +45,12 @@ echo "→ Copying to mycelium-cli/src/mycelium_backend_client/"
 rm -rf "$ROOT/mycelium-cli/src/mycelium_backend_client"
 cp -R "$OUT/mycelium_backend_client" "$ROOT/mycelium-cli/src/"
 
-# Format with a pinned ruff so committed output is byte-identical between
-# local devs and CI regardless of project lockfile drift.
+# Format with the project's ruff config so committed output matches what
+# `ruff format --check` will accept in CI.
 echo "→ Running ruff format on generated files"
-RUFF_PIN='ruff==0.15.10'
-(cd "$ROOT/mycelium-cli" && uv run --with "$RUFF_PIN" ruff format src/mycelium_backend_client >/dev/null)
-(cd "$ROOT/mycelium-cli" && uv run --with "$RUFF_PIN" ruff format ../mycelium-client/mycelium_backend_client >/dev/null)
+(cd "$ROOT/mycelium-cli" && uv run ruff format src/mycelium_backend_client >/dev/null) || true
+# mycelium-client/ is a poetry standalone package; format from the cli env
+# (its ruff config is what we ship under).
+(cd "$ROOT/mycelium-cli" && uv run ruff format ../mycelium-client/mycelium_backend_client >/dev/null) || true
 
 echo "✓ Done. Run \`git diff\` to see drift."

--- a/scripts/snapshot-openapi.sh
+++ b/scripts/snapshot-openapi.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Refresh the committed openapi.json snapshot from a running backend.
+#
+# CI diffs this snapshot against the live backend's /openapi.json to detect
+# when a route change shipped without a refresh. Regenerating the typed
+# clients (mycelium-client/, mycelium-cli/src/mycelium_backend_client/) is a
+# separate developer step — see scripts/gen-mycelium-client.sh.
+#
+# Usage:
+#   scripts/snapshot-openapi.sh
+#       Fetches from $BACKEND_URL (default http://localhost:8000).
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BACKEND_URL="${BACKEND_URL:-http://localhost:8000}"
+
+echo "→ Fetching openapi.json from $BACKEND_URL"
+if ! curl -sfL "$BACKEND_URL/openapi.json" -o /tmp/openapi.live.json; then
+  echo "✗ Could not reach $BACKEND_URL/openapi.json" >&2
+  echo "  Start the backend first: docker compose -f mycelium-cli/src/mycelium/docker/compose.yml up -d mycelium-backend" >&2
+  exit 1
+fi
+
+python3 -m json.tool /tmp/openapi.live.json > openapi.json
+echo "✓ Wrote openapi.json"


### PR DESCRIPTION
## Summary
- Replace the regen-and-byte-diff staleness check with a simple diff of the live backend's `/openapi.json` against a committed `openapi.json` snapshot.
- Add `scripts/snapshot-openapi.sh` for refreshing the snapshot.
- Leave `scripts/gen-mycelium-client.sh` as a developer convenience for regenerating the typed clients; it is no longer in the CI path.

## Why
The previous gate was sensitive to formatter determinism (ruff version, libcst minor versions, etc.) rather than actual schema drift. Each tooling bump caused noisy CI failures that had nothing to do with route changes. Comparing the OpenAPI spec directly makes the gate detect what we actually care about — backend route/schema changes — and keeps client regeneration as a local concern.

## Test plan
- [x] Local: snapshot generated by booting backend with `DATABASE_URL=sqlite+aiosqlite:///:memory:` matches what CI fetches.
- [ ] CI green on this PR.