### PR TITLE
chore: bump ioc-cognition-fabric-node-svc to 0.1.4

### DIFF
--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -125,7 +125,7 @@ services:
 
 
   ioc-cognition-fabric-node-svc:
-    image: ghcr.io/outshift-open/ioc-cognition-fabric-node-svc:0.1.2
+    image: ghcr.io/outshift-open/ioc-cognition-fabric-node-svc:0.1.4
     pull_policy: always
     platform: linux/amd64
     container_name: ioc-cognition-fabric-node-svc


### PR DESCRIPTION
Bumps `ioc-cognition-fabric-node-svc` from `0.1.2` → `0.1.4` in `compose.yml`.