### PR TITLE
chore: bump ioc-cfn-mgmt-plane-svc to 0.1.1

### DIFF
--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -92,7 +92,7 @@ services:
   # ── CFN Stack (profile: cfn) ──────────────────────────────────────────────────
 
   ioc-cfn-mgmt-plane-svc:
-    image: ghcr.io/outshift-open/ioc-cfn-mgmt-plane-svc:0.1.0
+    image: ghcr.io/outshift-open/ioc-cfn-mgmt-plane-svc:0.1.1
     container_name: ioc-cfn-mgmt-plane-svc
     restart: unless-stopped
     profiles: [cfn]


### PR DESCRIPTION
Bumps `ioc-cfn-mgmt-plane-svc` from `0.1.0` → `0.1.1`. This image re-enables ARM64 support so the CFN stack runs natively on Raspberry Pi (QEMU emulation was erroring out).