### PR TITLE
Add hero video walkthrough to documentation homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -77,6 +77,19 @@
         and semantic negotiation so agents can think together.
       </p>
 
+      <div class="hero-video" style="margin: 0 0 32px; text-align: center;">
+        <video
+          src="https://github.com/user-attachments/assets/2d3f5980-8d04-48a5-8f55-e25a09a5a460"
+          controls
+          playsinline
+          preload="metadata"
+          style="max-width: 100%; width: 800px; border-radius: 8px; border: 1px solid var(--border);"
+        ></video>
+        <div style="font-size: 0.9rem; color: var(--text2); margin-top: 8px;">
+          <em>~95s walkthrough — install → coordinate → consensus.</em>
+        </div>
+      </div>
+
       <div class="card-grid">
         <div class="card">
           <div class="card-icon"><i data-lucide="door-open"></i></div>


### PR DESCRIPTION
## Summary

Adds an embedded video walkthrough to the documentation homepage that demonstrates the core mycelium workflow (install → coordinate → consensus). This provides visitors with a quick visual introduction to the project's capabilities.

## Changes

- Added a hero video section to `docs/index.html` with a ~95 second walkthrough video
- Video is embedded with standard controls, responsive sizing (max 800px width), and rounded corners
- Includes a descriptive caption below the video
- Positioned between the introductory text and the feature cards section

## Testing

N/A - Documentation markup change with no functional code impact.

https://claude.ai/code/session_013C5MrUUgHprZbJP4KiDQSA