### PR TITLE
fix(metrics): handle stale PID file when collector port is already in use

### DIFF
--- a/mycelium-cli/src/mycelium/collector.py
+++ b/mycelium-cli/src/mycelium/collector.py
@@ -605,7 +605,10 @@ def run(
 
     try:
         server = _DualStackHTTPServer(("::", port), handler)
-    except OSError:
+    except OSError as exc:
+        if exc.errno == 98:  # EADDRINUSE
+            log.error("Port %d is already in use — is another collector running?", port)
+            raise SystemExit(1) from exc
         server = HTTPServer(("", port), handler)
     log.info("OTLP receiver listening on :%d", port)
     try:

--- a/mycelium-cli/src/mycelium/commands/metrics.py
+++ b/mycelium-cli/src/mycelium/commands/metrics.py
@@ -320,6 +320,21 @@ def collect(
             except OSError:
                 _PID_FILE.unlink(missing_ok=True)
 
+        # Guard: even without a valid PID file, check if the port is busy
+        import socket as _sock
+
+        _probe = _sock.socket(_sock.AF_INET, _sock.SOCK_STREAM)
+        try:
+            _probe.bind(("127.0.0.1", resolved_port))
+        except OSError:
+            typer.secho(
+                f"Collector already running on port {resolved_port} (stale PID file)",
+                fg=typer.colors.YELLOW,
+            )
+            return
+        finally:
+            _probe.close()
+
         log_file = _MYCELIUM_DIR / "collector.log"
         log_fh = open(log_file, "a")  # noqa: SIM115
 


### PR DESCRIPTION
## Summary

- When the collector's PID file is stale or missing but the process is still running on the port, `mycelium metrics collect` crashed with an `OSError: [Errno 98] Address already in use` traceback instead of the expected "already running" message.
- Two fixes:
  - **collector.py**: The dual-stack `_DualStackHTTPServer` fallback now distinguishes `EADDRINUSE` from "IPv6 not supported" -- exits cleanly with a log message instead of retrying and crashing
  - **metrics.py**: After the PID file check fails, probe the port with a socket bind before spawning a new subprocess

## Before

```
$ mycelium metrics collect
✗ Collector exited immediately (code 1). Check ~/.mycelium/collector.log
```
(log shows `OSError: [Errno 98] Address already in use` traceback)

## After

```
$ mycelium metrics collect
Collector already running on port 4318 (stale PID file)
```

## Test plan

- [x] Verified: collector running + stale PID file -> friendly "already running" message
- [x] Verified: no collector running -> starts normally
- [x] Verified: foreground mode (`--fg`) port check still works

Made with [Cursor](https://cursor.com)