### PR TITLE
feat(sessions): introduce CoordinationSession entity (#197, partial)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ cd mycelium-frontend && pnpm install && pnpm dev
 
 **AgensGraph** (PostgreSQL 16 fork) is the search index and coordination backend:
 - pgvector: semantic vector search over memory embeddings (updated on write)
-- SQL tables: rooms, sessions, messages, subscriptions, coordination state
+- SQL tables: rooms, coordination_sessions, sessions (presence), messages, subscriptions
 - openCypher: knowledge graph (optional enrichment layer)
 
 **Memory flow**:

--- a/fastapi-backend/alembic_migrations/versions/0011_coordination_sessions.py
+++ b/fastapi-backend/alembic_migrations/versions/0011_coordination_sessions.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""Promote sessions to first-class entity (#197).
+
+Creates the coordination_sessions table and backfills it from existing
+session-shaped rows in `rooms` (is_namespace=False, parent_namespace IS NOT NULL).
+
+Backwards compat: the session-shadow rows in `rooms` are kept so that
+messages.room_name and memories.room_name FKs continue to resolve. A follow-up
+release will remove the shadow rows and the deprecated columns
+(is_namespace, mode, parent_namespace).
+
+Revision ID: 0011
+Revises: 0010
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "coordination_sessions",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "parent_room_name",
+            sa.String(),
+            sa.ForeignKey("rooms.name", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("short_id", sa.String(length=16), nullable=False),
+        sa.Column("state", sa.String(length=20), nullable=False, server_default="idle"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("join_window_ends_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("mas_id", sa.String(), nullable=True, index=True),
+        sa.Column("workspace_id", sa.String(), nullable=True),
+    )
+
+    # Backfill: every session-shadow row in `rooms` becomes a coordination_sessions row.
+    # short_id is the suffix after `:session:` in the room name (8-char hex by convention).
+    op.execute(
+        """
+        INSERT INTO coordination_sessions
+            (id, parent_room_name, short_id, state, created_at, join_window_ends_at, mas_id, workspace_id)
+        SELECT
+            gen_random_uuid(),
+            parent_namespace,
+            COALESCE(NULLIF(split_part(name, ':session:', 2), ''), substr(md5(name), 1, 8)),
+            COALESCE(coordination_state, 'idle'),
+            created_at,
+            join_deadline,
+            mas_id,
+            workspace_id
+        FROM rooms
+        WHERE is_namespace = FALSE AND parent_namespace IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("coordination_sessions")

--- a/fastapi-backend/alembic_migrations/versions/0012_rename_sessions_to_participants.py
+++ b/fastapi-backend/alembic_migrations/versions/0012_rename_sessions_to_participants.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""Rename sessions → participants and re-FK to coordination_sessions (#197 follow-up).
+
+The old ``sessions`` table tracked agent participation in a coordination
+session (handle, intent, joined_at). Calling it ``sessions`` conflated it with
+the negotiation entity itself, which is now first-class in
+``coordination_sessions`` (migration 0011). This rename clarifies semantics
+and re-points the FK from ``rooms.name`` (which was always a session-shadow
+display name) to ``coordination_sessions.id``.
+
+Revision ID: 0012
+Revises: 0011
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Rename table.
+    op.rename_table("sessions", "participants")
+
+    # Add the new FK column nullable, backfill, then enforce NOT NULL.
+    op.add_column("participants", sa.Column("coordination_session_id", sa.Uuid(), nullable=True))
+
+    # Backfill: every participant row's room_name was a session-shadow display
+    # name like "{parent}:session:{short_id}". Resolve to coordination_sessions.id.
+    op.execute(
+        """
+        UPDATE participants p
+        SET coordination_session_id = cs.id
+        FROM coordination_sessions cs
+        WHERE cs.parent_room_name = split_part(p.room_name, ':session:', 1)
+          AND cs.short_id         = split_part(p.room_name, ':session:', 2)
+        """
+    )
+
+    # Drop any rows that didn't resolve — they reference rooms that aren't
+    # session-shadows, which the join_room flow should never produce. Logged
+    # for awareness rather than silently kept.
+    op.execute("DELETE FROM participants WHERE coordination_session_id IS NULL")
+
+    op.alter_column("participants", "coordination_session_id", nullable=False)
+    op.create_index(
+        "ix_participants_coordination_session_id",
+        "participants",
+        ["coordination_session_id"],
+    )
+    op.create_foreign_key(
+        "fk_participants_coordination_session",
+        "participants",
+        "coordination_sessions",
+        ["coordination_session_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Drop the old room_name FK + column.
+    op.drop_index("ix_sessions_room_name", table_name="participants")
+    op.drop_constraint("sessions_room_name_fkey", "participants", type_="foreignkey")
+    op.drop_column("participants", "room_name")
+
+
+def downgrade() -> None:
+    # Best-effort: this loses participants whose source rooms have been
+    # deleted. Coord_session.parent_room_name + short_id reconstructs the
+    # legacy display name.
+    op.add_column("participants", sa.Column("room_name", sa.String(), nullable=True))
+    op.execute(
+        """
+        UPDATE participants p
+        SET room_name = cs.parent_room_name || ':session:' || cs.short_id
+        FROM coordination_sessions cs
+        WHERE cs.id = p.coordination_session_id
+        """
+    )
+    op.alter_column("participants", "room_name", nullable=False)
+    op.create_index("ix_sessions_room_name", "participants", ["room_name"])
+    op.create_foreign_key(
+        "sessions_room_name_fkey",
+        "participants",
+        "rooms",
+        ["room_name"],
+        ["name"],
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint("fk_participants_coordination_session", "participants", type_="foreignkey")
+    op.drop_index("ix_participants_coordination_session_id", table_name="participants")
+    op.drop_column("participants", "coordination_session_id")
+
+    op.rename_table("participants", "sessions")

--- a/fastapi-backend/app/models.py
+++ b/fastapi-backend/app/models.py
@@ -4,7 +4,7 @@
 """
 Mycelium data models.
 
-Agent, Room, Message, Session, AuditEvent, Memory, MemorySubscription.
+Agent, Room, CoordinationSession, Participant, Message, AuditEvent, Memory, MemorySubscription.
 """
 
 from datetime import datetime
@@ -187,14 +187,23 @@ class Message(Base):
     )
 
 
-class Session(Base):
-    """Agent presence in a room — tracks who has joined."""
+class Participant(Base):
+    """Agent participating in a coordination session — the roster.
 
-    __tablename__ = "sessions"
+    One row per agent join. The CognitiveEngine reads this to learn the list
+    of agent handles + intents at tick 0 and to address per-agent ticks during
+    a round. Renamed from ``sessions`` (#197 follow-up); the old name conflated
+    "the negotiation entity" with "the agent roster for that negotiation".
+    """
+
+    __tablename__ = "participants"
 
     id: Mapped[UUID_Type] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    room_name: Mapped[str] = mapped_column(
-        String, ForeignKey("rooms.name", ondelete="CASCADE"), nullable=False, index=True
+    coordination_session_id: Mapped[UUID_Type] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("coordination_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     agent_handle: Mapped[str] = mapped_column(String, nullable=False, index=True)
     joined_at: Mapped[datetime] = mapped_column(

--- a/fastapi-backend/app/models.py
+++ b/fastapi-backend/app/models.py
@@ -123,6 +123,47 @@ class Room(Base):
     workspace_id: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
+class CoordinationSession(Base):
+    """Coordination session — first-class entity per #197.
+
+    A session is a single negotiation round inside a parent room. State lives
+    here; the parent room holds persistent memory and namespace identity.
+
+    A "shadow" row in `rooms` (is_namespace=False, parent_namespace=parent_room_name)
+    is also kept during the deprecation window so messages.room_name and
+    memories.room_name FKs continue to resolve. The shadow is scheduled for
+    removal in a follow-up release.
+    """
+
+    __tablename__ = "coordination_sessions"
+
+    id: Mapped[UUID_Type] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    parent_room_name: Mapped[str] = mapped_column(
+        String, ForeignKey("rooms.name", ondelete="CASCADE"), nullable=False, index=True
+    )
+    short_id: Mapped[str] = mapped_column(String(16), nullable=False)
+    # State machine: idle | waiting | negotiating | agreed | failed | complete
+    state: Mapped[str] = mapped_column(VARCHAR(20), nullable=False, server_default="idle")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    join_window_ends_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Inherited from parent at create time — see issue #237 for context.
+    mas_id: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+    workspace_id: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    @property
+    def display_name(self) -> str:
+        """Synthesize the legacy ``{parent}:session:{short_id}`` display string.
+
+        Kept for backward compatibility with messages.room_name and any caller
+        that still resolves sessions by name.
+        """
+        return f"{self.parent_room_name}:session:{self.short_id}"
+
+
 class Message(Base):
     """Agent-to-agent messages within a room."""
 

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -145,9 +145,20 @@ async def list_rooms(
     skip: int = 0,
     limit: int = 1000,
     name: str | None = None,
+    include_sessions: bool = False,
 ):
-    """List rooms with optional name filter."""
+    """List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
+    """
     query = select(Room).where(Room.is_public == True)  # noqa: E712
+
+    if not include_sessions:
+        # Session-shadow rows have parent_namespace set; real rooms don't.
+        query = query.where(Room.parent_namespace.is_(None))
 
     if name:
         query = query.where(Room.name.ilike(f"%{name}%"))

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database import get_async_session
-from app.models import Room, Session
+from app.models import Room
 from app.schemas import RoomCreate, RoomRead
 from app.services import coordination
 from app.services.filesystem import ensure_room_structure, get_room_dir, remove_room_dir
@@ -366,14 +366,10 @@ async def delete_room(
         # Teardown is best-effort cleanup; log but don't block the delete.
         logger.warning("coordination.teardown_for_namespace failed for %s: %s", room_name, exc)
 
-    # 3. Delete child Session rows for every child room (and the parent, in
-    #    case anyone joined it directly), then the child Room rows.
-    if child_room_names:
-        await session.execute(delete(Session).where(Session.room_name.in_(child_room_names)))
-    await session.execute(delete(Session).where(Session.room_name == room_name))
-
-    # 4. Defensive: mark any still-existing child rooms as failed before delete
-    #    so any concurrent reader sees a consistent state.
+    # 3. Mark any still-existing child rooms as failed before delete so any
+    #    concurrent reader sees a consistent state. Participant rows cascade
+    #    away via coordination_sessions.id (CASCADE) when the parent room is
+    #    deleted in step 4.
     if child_room_names:
         await session.execute(
             update(Room).where(Room.name.in_(child_room_names)).values(coordination_state="failed")

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -26,13 +26,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.bus import notify, room_channel
 from app.config import settings
 from app.database import get_async_session
-from app.models import CoordinationSession, Room, Session
+from app.models import CoordinationSession, Participant, Room
 from app.routes.rooms import _sync_create_mas
 from app.schemas import (
     CoordinationSessionRead,
-    SessionCreate,
-    SessionListResponse,
-    SessionRead,
+    ParticipantCreate,
+    ParticipantListResponse,
+    ParticipantRead,
 )
 
 logger = logging.getLogger(__name__)
@@ -69,22 +69,60 @@ async def _upsert_room(room_name: str, session: AsyncSession) -> Room:
     return room
 
 
-async def _spawn_session_room(parent_name: str, db: AsyncSession) -> Room:
-    """Create an ephemeral sync session room within a namespace.
+def _coord_short_id_from_display(name: str) -> str | None:
+    """Extract the short_id from a session-shadow display name."""
+    if ":session:" not in name:
+        return None
+    return name.split(":session:", 1)[1]
+
+
+async def _resolve_coord_session(target_room: Room, db: AsyncSession) -> CoordinationSession | None:
+    """Find the CoordinationSession for an existing session-shadow Room row."""
+    if target_room.is_namespace or not target_room.parent_namespace:
+        return None
+    short_id = _coord_short_id_from_display(target_room.name)
+    if not short_id:
+        return None
+    result = await db.execute(
+        select(CoordinationSession).where(
+            CoordinationSession.parent_room_name == target_room.parent_namespace,
+            CoordinationSession.short_id == short_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _spawn_session_room(
+    parent_name: str, db: AsyncSession
+) -> tuple[Room, CoordinationSession]:
+    """Create an ephemeral sync session room + CoordinationSession entity.
 
     If there's already a pending session (idle/waiting) in this namespace,
     return it instead of creating a new one.
     """
-    # Check for existing pending session in this namespace
+    # Check for existing pending session-shadow in this namespace
     result = await db.execute(
         select(Room).where(
             Room.parent_namespace == parent_name,
             Room.coordination_state.in_(["idle", "waiting", "negotiating"]),
         )
     )
-    existing = result.scalar_one_or_none()
-    if existing:
-        return existing
+    existing_room = result.scalar_one_or_none()
+    if existing_room:
+        existing_coord = await _resolve_coord_session(existing_room, db)
+        if existing_coord:
+            return existing_room, existing_coord
+        # Pre-0011 data without a backfilled coord_session — repair on the fly.
+        repair = CoordinationSession(
+            parent_room_name=parent_name,
+            short_id=_coord_short_id_from_display(existing_room.name) or uuid4().hex[:8],
+            state=existing_room.coordination_state or "idle",
+            mas_id=existing_room.mas_id,
+            workspace_id=existing_room.workspace_id,
+        )
+        db.add(repair)
+        await db.flush()
+        return existing_room, repair
 
     # Create a new session room, inheriting workspace/mas from parent
     short_id = uuid4().hex[:8]
@@ -107,7 +145,7 @@ async def _spawn_session_room(parent_name: str, db: AsyncSession) -> Room:
 
     # Dual-write the first-class CoordinationSession entity (#197). The shadow
     # Room row above stays during the deprecation window so messages.room_name
-    # and memories.room_name FKs keep resolving.
+    # FKs keep resolving.
     coord_session = CoordinationSession(
         parent_room_name=parent_name,
         short_id=short_id,
@@ -120,7 +158,7 @@ async def _spawn_session_room(parent_name: str, db: AsyncSession) -> Room:
     await db.flush()
     await db.refresh(session_room)
     logger.info("Spawned session %s in namespace %s", session_name, parent_name)
-    return session_room
+    return session_room, coord_session
 
 
 @router.post("/spawn", response_model=dict, status_code=201)
@@ -136,7 +174,7 @@ async def spawn_session(
     if not room.is_namespace:
         raise HTTPException(status_code=400, detail="Can only spawn sessions in namespace rooms")
 
-    session_room = await _spawn_session_room(room_name, db)
+    session_room, _ = await _spawn_session_room(room_name, db)
     await db.commit()
 
     cfn_enabled = bool(settings.COGNITION_FABRIC_NODE_URL and room.mas_id and room.workspace_id)
@@ -152,22 +190,34 @@ async def spawn_session(
     return result
 
 
-@router.post("", response_model=SessionRead, status_code=201)
+@router.post("", response_model=ParticipantRead, status_code=201)
 async def join_room(
     room_name: str,
-    payload: SessionCreate,
+    payload: ParticipantCreate,
     db: AsyncSession = Depends(get_async_session),
 ):
     """Join a room. If the room is a namespace, auto-spawns a session and joins that."""
     room = await _upsert_room(room_name, db)
 
-    # If joining a namespace (async room), auto-spawn a session within it
+    # Resolve the coordination session this join attaches to.
     target_room = room
+    coord_session: CoordinationSession | None = None
     if room.is_namespace:
-        target_room = await _spawn_session_room(room_name, db)
+        target_room, coord_session = await _spawn_session_room(room_name, db)
+    else:
+        coord_session = await _resolve_coord_session(target_room, db)
 
-    sess = Session(
-        room_name=target_room.name,
+    if coord_session is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"No coordination session found for room {room_name!r}. "
+                "Either pass a namespace to auto-spawn, or a session-shadow display name."
+            ),
+        )
+
+    sess = Participant(
+        coordination_session_id=coord_session.id,
         agent_handle=payload.agent_handle,
         intent=payload.intent,
     )
@@ -351,24 +401,39 @@ async def list_coordination_sessions(
     return [CoordinationSessionRead.model_validate(s) for s in result.scalars().all()]
 
 
-@router.get("", response_model=SessionListResponse)
+@router.get("", response_model=ParticipantListResponse)
 async def list_sessions(
     room_name: str,
     db: AsyncSession = Depends(get_async_session),
 ):
-    """List agents currently in a room."""
-    result = await db.execute(select(Room).where(Room.name == room_name))
-    if not result.scalar_one_or_none():
+    """List agents participating in a room's coordination session."""
+    room = (await db.execute(select(Room).where(Room.name == room_name))).scalar_one_or_none()
+    if not room:
         raise HTTPException(status_code=404, detail="Room not found")
 
-    result = await db.execute(
-        select(Session).where(Session.room_name == room_name).order_by(Session.joined_at.desc())
-    )
-    sessions = list(result.scalars().all())
+    # Resolve which coord_session(s) this room corresponds to. For a namespace,
+    # gather all participants across all its coord_sessions; for a session
+    # shadow, just that one.
+    if room.is_namespace:
+        coord_q = select(CoordinationSession.id).where(
+            CoordinationSession.parent_room_name == room_name
+        )
+    else:
+        coord = await _resolve_coord_session(room, db)
+        if coord is None:
+            return ParticipantListResponse(participants=[], total=0)
+        coord_q = select(CoordinationSession.id).where(CoordinationSession.id == coord.id)
 
-    return SessionListResponse(
-        sessions=[SessionRead.model_validate(s) for s in sessions],
-        total=len(sessions),
+    result = await db.execute(
+        select(Participant)
+        .where(Participant.coordination_session_id.in_(coord_q))
+        .order_by(Participant.joined_at.desc())
+    )
+    participants = list(result.scalars().all())
+
+    return ParticipantListResponse(
+        participants=[ParticipantRead.model_validate(p) for p in participants],
+        total=len(participants),
     )
 
 
@@ -378,16 +443,11 @@ async def leave_room(
     session_id: UUID,
     db: AsyncSession = Depends(get_async_session),
 ):
-    """Remove an agent session (leave room)."""
-    result = await db.execute(
-        select(Session).where(
-            Session.id == session_id,
-            Session.room_name == room_name,
-        )
-    )
-    session = result.scalar_one_or_none()
-    if not session:
-        raise HTTPException(status_code=404, detail="Session not found")
+    """Remove a participant (agent leaves the session)."""
+    result = await db.execute(select(Participant).where(Participant.id == session_id))
+    participant = result.scalar_one_or_none()
+    if not participant:
+        raise HTTPException(status_code=404, detail="Participant not found")
 
-    await db.delete(session)
+    await db.delete(participant)
     await db.commit()

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -339,9 +339,7 @@ async def list_coordination_sessions(
     Returns first-class CoordinationSession entities. The shadow rows in the
     rooms table are an implementation detail that callers shouldn't depend on.
     """
-    parent = (
-        await db.execute(select(Room).where(Room.name == room_name))
-    ).scalar_one_or_none()
+    parent = (await db.execute(select(Room).where(Room.name == room_name))).scalar_one_or_none()
     if not parent:
         raise HTTPException(status_code=404, detail="Room not found")
 

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -26,9 +26,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.bus import notify, room_channel
 from app.config import settings
 from app.database import get_async_session
-from app.models import Room, Session
+from app.models import CoordinationSession, Room, Session
 from app.routes.rooms import _sync_create_mas
-from app.schemas import SessionCreate, SessionListResponse, SessionRead
+from app.schemas import (
+    CoordinationSessionRead,
+    SessionCreate,
+    SessionListResponse,
+    SessionRead,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +104,19 @@ async def _spawn_session_room(parent_name: str, db: AsyncSession) -> Room:
         mas_id=parent_room.mas_id if parent_room else None,
     )
     db.add(session_room)
+
+    # Dual-write the first-class CoordinationSession entity (#197). The shadow
+    # Room row above stays during the deprecation window so messages.room_name
+    # and memories.room_name FKs keep resolving.
+    coord_session = CoordinationSession(
+        parent_room_name=parent_name,
+        short_id=short_id,
+        state="idle",
+        mas_id=parent_room.mas_id if parent_room else None,
+        workspace_id=parent_room.workspace_id if parent_room else None,
+    )
+    db.add(coord_session)
+
     await db.flush()
     await db.refresh(session_room)
     logger.info("Spawned session %s in namespace %s", session_name, parent_name)
@@ -309,6 +327,30 @@ async def _notify_join(room_name: str, handle: str, intent: str | None) -> None:
             await conn.close()
     except Exception as e:
         logger.warning("NOTIFY coordination_join failed: %s", e)
+
+
+@router.get("/coordination", response_model=list[CoordinationSessionRead])
+async def list_coordination_sessions(
+    room_name: str,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+    """
+    parent = (
+        await db.execute(select(Room).where(Room.name == room_name))
+    ).scalar_one_or_none()
+    if not parent:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    result = await db.execute(
+        select(CoordinationSession)
+        .where(CoordinationSession.parent_room_name == room_name)
+        .order_by(CoordinationSession.created_at.desc())
+    )
+    return [CoordinationSessionRead.model_validate(s) for s in result.scalars().all()]
 
 
 @router.get("", response_model=SessionListResponse)

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -111,6 +111,23 @@ class SessionListResponse(BaseModel):
     total: int
 
 
+# ── CoordinationSession (#197) ────────────────────────────────────────────────
+
+
+class CoordinationSessionRead(BaseModel):
+    id: UUID
+    parent_room_name: str
+    short_id: str
+    state: str
+    created_at: datetime
+    join_window_ends_at: datetime | None = None
+    mas_id: str | None = None
+    workspace_id: str | None = None
+    display_name: str
+
+    model_config = {"from_attributes": True}
+
+
 # ── AuditEvent ────────────────────────────────────────────────────────────────
 
 VALID_RESOURCE_TYPES = {

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -87,17 +87,17 @@ class MessageListResponse(BaseModel):
     total: int
 
 
-# ── Session ───────────────────────────────────────────────────────────────────
+# ── Participant (agent in a coordination session) ────────────────────────────
 
 
-class SessionCreate(BaseModel):
+class ParticipantCreate(BaseModel):
     agent_handle: str = Field(..., description="Agent handle joining the room")
     intent: str | None = Field(None, description="Agent's requirements/intent for coordination")
 
 
-class SessionRead(BaseModel):
+class ParticipantRead(BaseModel):
     id: UUID
-    room_name: str
+    coordination_session_id: UUID
     agent_handle: str
     intent: str | None = None
     joined_at: datetime
@@ -106,8 +106,8 @@ class SessionRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class SessionListResponse(BaseModel):
-    sessions: list[SessionRead]
+class ParticipantListResponse(BaseModel):
+    participants: list[ParticipantRead]
     total: int
 
 

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -35,7 +35,7 @@ from sqlalchemy import delete, select, update
 from app.bus import agent_channel, notify, room_channel
 from app.config import settings
 from app.database import async_session_maker
-from app.models import Message, Room, Session
+from app.models import CoordinationSession, Message, Participant, Room
 from app.services.metrics import (
     record_consensus,
     record_coordination_round,
@@ -351,13 +351,33 @@ def schedule_join_timer(room_name: str, deadline: datetime) -> asyncio.Task:
 async def _run_tick(room_name: str, tick: int) -> None:
     """Tick 0: launch CFN negotiation. Errors if CFN not configured on the room."""
     async with async_session_maker() as db:
+        # room_name here is the session-shadow display name like "{parent}:session:{short}".
+        # Look up the corresponding CoordinationSession to find its participants.
+        if ":session:" in room_name:
+            parent, _, short_id = room_name.partition(":session:")
+            coord_result = await db.execute(
+                select(CoordinationSession).where(
+                    CoordinationSession.parent_room_name == parent,
+                    CoordinationSession.short_id == short_id,
+                )
+            )
+            coord_session = coord_result.scalar_one_or_none()
+        else:
+            coord_session = None
+
+        if coord_session is None:
+            logger.warning("No coordination session for room %s at tick %d", room_name, tick)
+            return
+
         result = await db.execute(
-            select(Session).where(Session.room_name == room_name).order_by(Session.joined_at)
+            select(Participant)
+            .where(Participant.coordination_session_id == coord_session.id)
+            .order_by(Participant.joined_at)
         )
         sessions = list(result.scalars().all())
 
         if not sessions:
-            logger.warning("No sessions found for room %s at tick %d", room_name, tick)
+            logger.warning("No participants for room %s at tick %d", room_name, tick)
             return
 
         session_handles = [s.agent_handle for s in sessions]
@@ -1112,9 +1132,20 @@ async def _finish_cfn(room_name: str, plan: str, assignments: dict, broken: bool
             .where(Room.name == room_name)
             .values(coordination_state="complete" if not broken else "failed")
         )
-        # Clean up agent Session rows so a subsequent session in the same
+        # Clean up Participant rows so a subsequent session in the same
         # namespace doesn't see stale participants and cause CFN to fail.
-        await db.execute(delete(Session).where(Session.room_name == room_name))
+        if ":session:" in room_name:
+            parent, _, short_id = room_name.partition(":session:")
+            await db.execute(
+                delete(Participant).where(
+                    Participant.coordination_session_id.in_(
+                        select(CoordinationSession.id).where(
+                            CoordinationSession.parent_room_name == parent,
+                            CoordinationSession.short_id == short_id,
+                        )
+                    )
+                )
+            )
         await db.commit()
 
 
@@ -1366,10 +1397,21 @@ async def _post_message(room_name: str, message_type: str, content: str) -> None
             pass
     elif message_type == "coordination_consensus":
         async with async_session_maker() as db:
-            result = await db.execute(
-                select(Session.agent_handle).where(Session.room_name == room_name)
-            )
-            agent_handles = list(result.scalars().all())
+            if ":session:" in room_name:
+                parent, _, short_id = room_name.partition(":session:")
+                result = await db.execute(
+                    select(Participant.agent_handle).where(
+                        Participant.coordination_session_id.in_(
+                            select(CoordinationSession.id).where(
+                                CoordinationSession.parent_room_name == parent,
+                                CoordinationSession.short_id == short_id,
+                            )
+                        )
+                    )
+                )
+                agent_handles = list(result.scalars().all())
+            else:
+                agent_handles = []
 
     try:
         parsed_url = urlparse(settings.DATABASE_URL)

--- a/fastapi-backend/tests/test_coordination_sessions.py
+++ b/fastapi-backend/tests/test_coordination_sessions.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""Tests for the first-class CoordinationSession entity (#197)."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_spawn_creates_coordination_session_row(client):
+    """Spawning a session writes a CoordinationSession alongside the shadow Room."""
+    await client.post("/api/rooms", json={"name": "p1"})
+    spawn = await client.post("/api/rooms/p1/sessions/spawn")
+    assert spawn.status_code == 201
+    session_room_name = spawn.json()["session_room"]
+
+    # Shadow Room row still exists for FK compat with messages/memory.
+    shadow = await client.get(f"/api/rooms/{session_room_name}")
+    assert shadow.status_code == 200
+    assert shadow.json()["parent_namespace"] == "p1"
+
+    # First-class entity exists at the new endpoint.
+    coord = await client.get("/api/rooms/p1/sessions/coordination")
+    assert coord.status_code == 200
+    rows = coord.json()
+    assert len(rows) == 1
+    assert rows[0]["parent_room_name"] == "p1"
+    assert rows[0]["display_name"] == session_room_name
+
+
+@pytest.mark.asyncio
+async def test_list_rooms_hides_session_shadows_by_default(client):
+    """GET /api/rooms excludes session-shadow rows unless asked."""
+    await client.post("/api/rooms", json={"name": "p2"})
+    await client.post("/api/rooms/p2/sessions/spawn")
+
+    default = await client.get("/api/rooms")
+    names_default = {r["name"] for r in default.json()}
+    assert "p2" in names_default
+    assert not any(":session:" in n for n in names_default)
+
+    included = await client.get("/api/rooms?include_sessions=true")
+    names_included = {r["name"] for r in included.json()}
+    assert "p2" in names_included
+    assert any(":session:" in n for n in names_included)
+
+
+@pytest.mark.asyncio
+async def test_idempotent_spawn_does_not_duplicate_coordination_session(client):
+    """Re-spawning an already-pending session reuses the existing entity."""
+    await client.post("/api/rooms", json={"name": "p3"})
+    a = await client.post("/api/rooms/p3/sessions/spawn")
+    b = await client.post("/api/rooms/p3/sessions/spawn")
+    assert a.json()["session_room"] == b.json()["session_room"]
+
+    coord = await client.get("/api/rooms/p3/sessions/coordination")
+    assert len(coord.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_coordination_endpoint_404_for_unknown_room(client):
+    resp = await client.get("/api/rooms/nope/sessions/coordination")
+    assert resp.status_code == 404

--- a/fastapi-backend/tests/test_integration.py
+++ b/fastapi-backend/tests/test_integration.py
@@ -443,7 +443,7 @@ async def test_sync_multiple_agents_join(integration_client: AsyncClient):
     resp = await client.get(f"/api/rooms/{session_room_name}/sessions")
     sessions = resp.json()
     assert sessions["total"] == 2
-    handles = {s["agent_handle"] for s in sessions["sessions"]}
+    handles = {p["agent_handle"] for p in sessions["participants"]}
     assert handles == {"alpha", "beta"}
 
     # Session room should still be waiting (timer hasn't fired)

--- a/fastapi-backend/tests/test_integration.py
+++ b/fastapi-backend/tests/test_integration.py
@@ -24,6 +24,15 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+
+async def _session_display_name(client: AsyncClient, namespace: str) -> str:
+    """Return the most recent CoordinationSession's display_name for a namespace."""
+    resp = await client.get(f"/api/rooms/{namespace}/sessions/coordination")
+    rows = resp.json()
+    assert rows, f"no coordination sessions in {namespace}"
+    return rows[0]["display_name"]
+
+
 # Skip entire module if no real DB configured
 INTEGRATION_DB_URL = os.environ.get("DATABASE_URL", "")
 pytestmark = pytest.mark.skipif(
@@ -342,7 +351,7 @@ async def test_sync_room_still_works(integration_client: AsyncClient):
         },
     )
     assert resp.status_code == 201
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-sync")
     assert "e2e-sync:session:" in session_room_name
 
     # The spawned session room should be in waiting state
@@ -395,7 +404,7 @@ async def test_sync_join_starts_timer(integration_client: AsyncClient):
         },
     )
     assert resp.status_code == 201
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-timer")
 
     resp = await client.get(f"/api/rooms/{session_room_name}")
     session_room = resp.json()
@@ -419,7 +428,7 @@ async def test_sync_multiple_agents_join(integration_client: AsyncClient):
         },
     )
     assert resp1.status_code == 201
-    session_room_name = resp1.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-multi")
 
     resp2 = await client.post(
         "/api/rooms/e2e-multi/sessions",
@@ -462,7 +471,7 @@ async def test_sync_negotiation_produces_messages(integration_client: AsyncClien
             "intent": "I want scope=full and quality=premium",
         },
     )
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-negot")
 
     await client.post(
         "/api/rooms/e2e-negot/sessions",
@@ -532,7 +541,7 @@ async def test_namespace_room_supports_memory_and_sessions(integration_client: A
         },
     )
     assert resp.status_code == 201
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-ns-both")
 
     # Session room should be in waiting state
     resp = await client.get(f"/api/rooms/{session_room_name}")
@@ -562,7 +571,7 @@ async def test_messages_route_during_negotiation(integration_client: AsyncClient
             "intent": "testing message routing",
         },
     )
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-msg-route")
 
     # Manually set session room to negotiating state to test routing
     from sqlalchemy import update as sa_update

--- a/fastapi-backend/tests/test_session_spawn.py
+++ b/fastapi-backend/tests/test_session_spawn.py
@@ -3,12 +3,22 @@
 
 """Tests for session spawning within namespace rooms."""
 
+from uuid import UUID
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Room
+from app.models import CoordinationSession, Room
+
+
+async def _coord_for_room(client: AsyncClient, namespace: str) -> dict:
+    """Return the most recent CoordinationSession dict for a namespace room."""
+    resp = await client.get(f"/api/rooms/{namespace}/sessions/coordination")
+    rows = resp.json()
+    assert rows, f"no coordination sessions for {namespace}"
+    return rows[0]
 
 
 @pytest.mark.asyncio
@@ -25,20 +35,20 @@ async def test_create_room_without_mode(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_join_namespace_auto_spawns_session(client: AsyncClient):
     """Joining a namespace room should auto-spawn a sync session."""
-    # Create a room (always a namespace now)
     resp = await client.post("/api/rooms", json={"name": "ns-test"})
     assert resp.status_code == 201
     assert resp.json()["is_namespace"] is True
 
-    # Join it — should auto-spawn a session
     resp = await client.post(
         "/api/rooms/ns-test/sessions",
         json={"agent_handle": "agent-a", "intent": "Let's negotiate"},
     )
     assert resp.status_code == 201
     data = resp.json()
-    # Should be joined to a session room, not the namespace itself
-    assert data["room_name"].startswith("ns-test:session:")
+    # Participant has a coordination_session_id — the entity it joined.
+    coord = await _coord_for_room(client, "ns-test")
+    assert data["coordination_session_id"] == coord["id"]
+    assert coord["display_name"].startswith("ns-test:session:")
 
 
 @pytest.mark.asyncio
@@ -54,8 +64,7 @@ async def test_multiple_agents_join_same_session(client: AsyncClient):
         "/api/rooms/shared-ns/sessions",
         json={"agent_handle": "agent-2", "intent": "Second"},
     )
-
-    assert resp1.json()["room_name"] == resp2.json()["room_name"]
+    assert resp1.json()["coordination_session_id"] == resp2.json()["coordination_session_id"]
 
 
 @pytest.mark.asyncio
@@ -73,12 +82,10 @@ async def test_explicit_spawn(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_spawn_on_non_namespace_fails(client: AsyncClient):
     """Spawning a session on a non-namespace room should 400."""
-    # Create a namespace, then spawn a session (which is non-namespace)
     await client.post("/api/rooms", json={"name": "parent-ns"})
     resp = await client.post("/api/rooms/parent-ns/sessions/spawn")
     session_name = resp.json()["session_room"]
 
-    # Try to spawn inside the session room — should fail
     resp = await client.post(f"/api/rooms/{session_name}/sessions/spawn")
     assert resp.status_code == 400
     assert "namespace" in resp.json()["detail"].lower()
@@ -89,13 +96,13 @@ async def test_session_room_enters_waiting_on_join(client: AsyncClient):
     """Joining a session room should transition it to waiting."""
     await client.post("/api/rooms", json={"name": "wait-ns"})
 
-    resp = await client.post(
+    await client.post(
         "/api/rooms/wait-ns/sessions",
         json={"agent_handle": "agent-a", "intent": "testing"},
     )
-    session_name = resp.json()["room_name"]
+    coord = await _coord_for_room(client, "wait-ns")
+    session_name = coord["display_name"]
 
-    # Session room should be waiting
     resp = await client.get(f"/api/rooms/{session_name}")
     assert resp.json()["coordination_state"] == "waiting"
     assert resp.json()["join_deadline"] is not None
@@ -120,40 +127,44 @@ async def test_new_session_after_complete(client: AsyncClient, db_session: Async
     """Completing a session should allow spawning a new one in the same namespace."""
     await client.post("/api/rooms", json={"name": "multi-session-ns"})
 
-    # First session
-    resp = await client.post(
+    resp1 = await client.post(
         "/api/rooms/multi-session-ns/sessions",
         json={"agent_handle": "agent-a", "intent": "round 1"},
     )
-    session1 = resp.json()["room_name"]
+    coord1_id = resp1.json()["coordination_session_id"]
+    coord1 = await _coord_for_room(client, "multi-session-ns")
+    session1 = coord1["display_name"]
 
-    # Mark the first session as complete via DB
+    # Mark first session as complete via DB shadow row + coord_session row.
     await db_session.execute(
         sa_update(Room).where(Room.name == session1).values(coordination_state="complete")
     )
+    await db_session.execute(
+        sa_update(CoordinationSession)
+        .where(CoordinationSession.id == UUID(coord1_id))
+        .values(state="complete")
+    )
     await db_session.commit()
 
-    # Second join should spawn a NEW session (first is complete)
-    resp = await client.post(
+    resp2 = await client.post(
         "/api/rooms/multi-session-ns/sessions",
         json={"agent_handle": "agent-b", "intent": "round 2"},
     )
-    session2 = resp.json()["room_name"]
-
-    assert session2 != session1
-    assert session2.startswith("multi-session-ns:session:")
+    coord2_id = resp2.json()["coordination_session_id"]
+    assert coord2_id != coord1_id
 
 
 @pytest.mark.asyncio
 async def test_list_sessions_on_session_room(client: AsyncClient):
-    """Listing sessions on a session room returns the joined agents."""
+    """Listing participants on a session-shadow room returns the joined agents."""
     await client.post("/api/rooms", json={"name": "list-ns"})
 
-    resp = await client.post(
+    await client.post(
         "/api/rooms/list-ns/sessions",
         json={"agent_handle": "alpha", "intent": "first"},
     )
-    session_name = resp.json()["room_name"]
+    coord = await _coord_for_room(client, "list-ns")
+    session_name = coord["display_name"]
 
     await client.post(
         "/api/rooms/list-ns/sessions",
@@ -163,20 +174,21 @@ async def test_list_sessions_on_session_room(client: AsyncClient):
     resp = await client.get(f"/api/rooms/{session_name}/sessions")
     data = resp.json()
     assert data["total"] == 2
-    handles = {s["agent_handle"] for s in data["sessions"]}
+    handles = {p["agent_handle"] for p in data["participants"]}
     assert handles == {"alpha", "beta"}
 
 
 @pytest.mark.asyncio
 async def test_session_room_is_not_namespace(client: AsyncClient):
-    """Session rooms should have is_namespace=False."""
+    """Session-shadow rooms should have is_namespace=False."""
     await client.post("/api/rooms", json={"name": "check-ns"})
 
-    resp = await client.post(
+    await client.post(
         "/api/rooms/check-ns/sessions",
         json={"agent_handle": "agent-a", "intent": "testing"},
     )
-    session_name = resp.json()["room_name"]
+    coord = await _coord_for_room(client, "check-ns")
+    session_name = coord["display_name"]
 
     resp = await client.get(f"/api/rooms/{session_name}")
     data = resp.json()

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -98,7 +98,10 @@ export function installChannel(
 
     const pollInterval = setInterval(async () => {
       try {
-        const res = await fetch(`${cfg.backendUrl}/api/rooms`);
+        // include_sessions=true: rooms endpoint hides session-shadow rows by
+        // default (#197). The plugin still addresses sessions by display name
+        // during the deprecation window, so it opts back in here.
+        const res = await fetch(`${cfg.backendUrl}/api/rooms?include_sessions=true`);
         if (!res.ok) return;
         const rooms: any[] = await res.json();
 

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -143,10 +143,10 @@ def join(
         from mycelium_backend_client.api.sessions import (
             join_room_api_rooms_room_name_sessions_post as join_api,
         )
-        from mycelium_backend_client.models import SessionCreate
+        from mycelium_backend_client.models import ParticipantCreate
 
         with _typed_client(config) as client:
-            body = SessionCreate(agent_handle=handle, intent=intent)
+            body = ParticipantCreate(agent_handle=handle, intent=intent)
             result = join_api.sync(room_name=room_name, client=client, body=body)
             data = result.to_dict() if result and hasattr(result, "to_dict") else {}
 
@@ -475,21 +475,21 @@ def list_sessions(
             if result and hasattr(result, "to_dict"):
                 data = result.to_dict()
             else:
-                data = {"sessions": [], "total": 0}
+                data = {"participants": [], "total": 0}
 
         if json_output:
             typer.echo(json_module.dumps(data, indent=2, default=str))
             return
 
-        sessions = data.get("sessions", [])
-        if not isinstance(sessions, list) or not sessions:
-            typer.echo(f"  No active sessions in {room_name}")
+        participants = data.get("participants", [])
+        if not isinstance(participants, list) or not participants:
+            typer.echo(f"  No active participants in {room_name}")
             return
 
-        typer.echo(f"  {room_name} — {len(sessions)} session(s)\n")
-        for s in sessions:
+        typer.echo(f"  {room_name} — {len(participants)} participant(s)\n")
+        for p in participants:
             typer.echo(
-                f"    {s.get('agent_handle', '?')}  joined {str(s.get('joined_at', ''))[:16]}"
+                f"    {p.get('agent_handle', '?')}  joined {str(p.get('joined_at', ''))[:16]}"
             )
 
     except Exception as e:

--- a/mycelium-cli/src/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
@@ -15,6 +15,7 @@ def _get_kwargs(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -28,6 +29,8 @@ def _get_kwargs(
     else:
         json_name = name
     params["name"] = json_name
+
+    params["include_sessions"] = include_sessions
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -81,15 +84,22 @@ def sync_detailed(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> Response[HTTPValidationError | list[RoomRead]]:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -103,6 +113,7 @@ def sync_detailed(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     )
 
     response = client.get_httpx_client().request(
@@ -118,15 +129,22 @@ def sync(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> HTTPValidationError | list[RoomRead] | None:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,6 +159,7 @@ def sync(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     ).parsed
 
 
@@ -150,15 +169,22 @@ async def asyncio_detailed(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> Response[HTTPValidationError | list[RoomRead]]:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,6 +198,7 @@ async def asyncio_detailed(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -185,15 +212,22 @@ async def asyncio(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> HTTPValidationError | list[RoomRead] | None:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -209,5 +243,6 @@ async def asyncio(
             skip=skip,
             limit=limit,
             name=name,
+            include_sessions=include_sessions,
         )
     ).parsed

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
@@ -7,15 +7,15 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.session_create import SessionCreate
-from ...models.session_read import SessionRead
+from ...models.participant_create import ParticipantCreate
+from ...models.participant_read import ParticipantRead
 from ...types import Response
 
 
 def _get_kwargs(
     room_name: str,
     *,
-    body: SessionCreate,
+    body: ParticipantCreate,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -36,9 +36,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | SessionRead | None:
+) -> HTTPValidationError | ParticipantRead | None:
     if response.status_code == 201:
-        response_201 = SessionRead.from_dict(response.json())
+        response_201 = ParticipantRead.from_dict(response.json())
 
         return response_201
 
@@ -55,7 +55,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | SessionRead]:
+) -> Response[HTTPValidationError | ParticipantRead]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -68,22 +68,22 @@ def sync_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> Response[HTTPValidationError | SessionRead]:
+    body: ParticipantCreate,
+) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionRead]
+        Response[HTTPValidationError | ParticipantRead]
     """
 
     kwargs = _get_kwargs(
@@ -102,22 +102,22 @@ def sync(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> HTTPValidationError | SessionRead | None:
+    body: ParticipantCreate,
+) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionRead
+        HTTPValidationError | ParticipantRead
     """
 
     return sync_detailed(
@@ -131,22 +131,22 @@ async def asyncio_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> Response[HTTPValidationError | SessionRead]:
+    body: ParticipantCreate,
+) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionRead]
+        Response[HTTPValidationError | ParticipantRead]
     """
 
     kwargs = _get_kwargs(
@@ -163,22 +163,22 @@ async def asyncio(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> HTTPValidationError | SessionRead | None:
+    body: ParticipantCreate,
+) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionRead
+        HTTPValidationError | ParticipantRead
     """
 
     return (

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/leave_room_api_rooms_room_name_sessions_session_id_delete.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/leave_room_api_rooms_room_name_sessions_session_id_delete.py
@@ -63,7 +63,7 @@ def sync_detailed(
 ) -> Response[Any | HTTPValidationError]:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -97,7 +97,7 @@ def sync(
 ) -> Any | HTTPValidationError | None:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -126,7 +126,7 @@ async def asyncio_detailed(
 ) -> Response[Any | HTTPValidationError]:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -158,7 +158,7 @@ async def asyncio(
 ) -> Any | HTTPValidationError | None:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/list_coordination_sessions_api_rooms_room_name_sessions_coordination_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/list_coordination_sessions_api_rooms_room_name_sessions_coordination_get.py
@@ -1,0 +1,185 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.coordination_session_read import CoordinationSessionRead
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    room_name: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/rooms/{room_name}/sessions/coordination".format(
+            room_name=quote(str(room_name), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = CoordinationSessionRead.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return sync_detailed(
+        room_name=room_name,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return (
+        await asyncio_detailed(
+            room_name=room_name,
+            client=client,
+        )
+    ).parsed

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.session_list_response import SessionListResponse
+from ...models.participant_list_response import ParticipantListResponse
 from ...types import Response
 
 
@@ -26,9 +26,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     if response.status_code == 200:
-        response_200 = SessionListResponse.from_dict(response.json())
+        response_200 = ParticipantListResponse.from_dict(response.json())
 
         return response_200
 
@@ -45,7 +45,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -58,10 +58,10 @@ def sync_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -71,7 +71,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionListResponse]
+        Response[HTTPValidationError | ParticipantListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -89,10 +89,10 @@ def sync(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -102,7 +102,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionListResponse
+        HTTPValidationError | ParticipantListResponse
     """
 
     return sync_detailed(
@@ -115,10 +115,10 @@ async def asyncio_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -128,7 +128,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionListResponse]
+        Response[HTTPValidationError | ParticipantListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -144,10 +144,10 @@ async def asyncio(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -157,7 +157,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionListResponse
+        HTTPValidationError | ParticipantListResponse
     """
 
     return (

--- a/mycelium-cli/src/mycelium_backend_client/models/__init__.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/__init__.py
@@ -20,6 +20,7 @@ from .cfn_query_api_cfn_knowledge_query_post_response_cfn_query_api_cfn_knowledg
     CfnQueryApiCfnKnowledgeQueryPostResponseCfnQueryApiCfnKnowledgeQueryPost,
 )
 from .concepts_by_ids_request import ConceptsByIdsRequest
+from .coordination_session_read import CoordinationSessionRead
 from .get_negotiation_status_response_get_negotiation_status import (
     GetNegotiationStatusResponseGetNegotiationStatus,
 )
@@ -79,6 +80,7 @@ __all__ = (
     "CfnListApiCfnKnowledgeListGetResponseCfnListApiCfnKnowledgeListGet",
     "CfnQueryApiCfnKnowledgeQueryPostResponseCfnQueryApiCfnKnowledgeQueryPost",
     "ConceptsByIdsRequest",
+    "CoordinationSessionRead",
     "GetNegotiationStatusResponseGetNegotiationStatus",
     "GraphPathsRequest",
     "HTTPValidationError",

--- a/mycelium-cli/src/mycelium_backend_client/models/__init__.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/__init__.py
@@ -53,15 +53,15 @@ from .memory_search_result import MemorySearchResult
 from .message_create import MessageCreate
 from .message_list_response import MessageListResponse
 from .message_read import MessageRead
+from .participant_create import ParticipantCreate
+from .participant_list_response import ParticipantListResponse
+from .participant_read import ParticipantRead
 from .query_request import QueryRequest
 from .query_request_additional_context_type_0 import QueryRequestAdditionalContextType0
 from .room_create import RoomCreate
 from .room_create_trigger_config_type_0 import RoomCreateTriggerConfigType0
 from .room_read import RoomRead
 from .room_read_trigger_config_type_0 import RoomReadTriggerConfigType0
-from .session_create import SessionCreate
-from .session_list_response import SessionListResponse
-from .session_read import SessionRead
 from .spawn_session_api_rooms_room_name_sessions_spawn_post_response_spawn_session_api_rooms_room_name_sessions_spawn_post import (
     SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost,
 )
@@ -107,15 +107,15 @@ __all__ = (
     "MessageCreate",
     "MessageListResponse",
     "MessageRead",
+    "ParticipantCreate",
+    "ParticipantListResponse",
+    "ParticipantRead",
     "QueryRequest",
     "QueryRequestAdditionalContextType0",
     "RoomCreate",
     "RoomCreateTriggerConfigType0",
     "RoomRead",
     "RoomReadTriggerConfigType0",
-    "SessionCreate",
-    "SessionListResponse",
-    "SessionRead",
     "SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost",
     "SubscriptionCreate",
     "SubscriptionRead",

--- a/mycelium-cli/src/mycelium_backend_client/models/coordination_session_read.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/coordination_session_read.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CoordinationSessionRead")
+
+
+@_attrs_define
+class CoordinationSessionRead:
+    """
+    Attributes:
+        id (UUID):
+        parent_room_name (str):
+        short_id (str):
+        state (str):
+        created_at (datetime.datetime):
+        display_name (str):
+        join_window_ends_at (datetime.datetime | None | Unset):
+        mas_id (None | str | Unset):
+        workspace_id (None | str | Unset):
+    """
+
+    id: UUID
+    parent_room_name: str
+    short_id: str
+    state: str
+    created_at: datetime.datetime
+    display_name: str
+    join_window_ends_at: datetime.datetime | None | Unset = UNSET
+    mas_id: None | str | Unset = UNSET
+    workspace_id: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        parent_room_name = self.parent_room_name
+
+        short_id = self.short_id
+
+        state = self.state
+
+        created_at = self.created_at.isoformat()
+
+        display_name = self.display_name
+
+        join_window_ends_at: None | str | Unset
+        if isinstance(self.join_window_ends_at, Unset):
+            join_window_ends_at = UNSET
+        elif isinstance(self.join_window_ends_at, datetime.datetime):
+            join_window_ends_at = self.join_window_ends_at.isoformat()
+        else:
+            join_window_ends_at = self.join_window_ends_at
+
+        mas_id: None | str | Unset
+        if isinstance(self.mas_id, Unset):
+            mas_id = UNSET
+        else:
+            mas_id = self.mas_id
+
+        workspace_id: None | str | Unset
+        if isinstance(self.workspace_id, Unset):
+            workspace_id = UNSET
+        else:
+            workspace_id = self.workspace_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "parent_room_name": parent_room_name,
+                "short_id": short_id,
+                "state": state,
+                "created_at": created_at,
+                "display_name": display_name,
+            }
+        )
+        if join_window_ends_at is not UNSET:
+            field_dict["join_window_ends_at"] = join_window_ends_at
+        if mas_id is not UNSET:
+            field_dict["mas_id"] = mas_id
+        if workspace_id is not UNSET:
+            field_dict["workspace_id"] = workspace_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        parent_room_name = d.pop("parent_room_name")
+
+        short_id = d.pop("short_id")
+
+        state = d.pop("state")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        display_name = d.pop("display_name")
+
+        def _parse_join_window_ends_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                join_window_ends_at_type_0 = isoparse(data)
+
+                return join_window_ends_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        join_window_ends_at = _parse_join_window_ends_at(d.pop("join_window_ends_at", UNSET))
+
+        def _parse_mas_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        mas_id = _parse_mas_id(d.pop("mas_id", UNSET))
+
+        def _parse_workspace_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        workspace_id = _parse_workspace_id(d.pop("workspace_id", UNSET))
+
+        coordination_session_read = cls(
+            id=id,
+            parent_room_name=parent_room_name,
+            short_id=short_id,
+            state=state,
+            created_at=created_at,
+            display_name=display_name,
+            join_window_ends_at=join_window_ends_at,
+            mas_id=mas_id,
+            workspace_id=workspace_id,
+        )
+
+        coordination_session_read.additional_properties = d
+        return coordination_session_read
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-cli/src/mycelium_backend_client/models/participant_create.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/participant_create.py
@@ -8,11 +8,11 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="SessionCreate")
+T = TypeVar("T", bound="ParticipantCreate")
 
 
 @_attrs_define
-class SessionCreate:
+class ParticipantCreate:
     """
     Attributes:
         agent_handle (str): Agent handle joining the room
@@ -58,13 +58,13 @@ class SessionCreate:
 
         intent = _parse_intent(d.pop("intent", UNSET))
 
-        session_create = cls(
+        participant_create = cls(
             agent_handle=agent_handle,
             intent=intent,
         )
 
-        session_create.additional_properties = d
-        return session_create
+        participant_create.additional_properties = d
+        return participant_create
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-cli/src/mycelium_backend_client/models/participant_list_response.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/participant_list_response.py
@@ -7,29 +7,29 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
-    from ..models.session_read import SessionRead
+    from ..models.participant_read import ParticipantRead
 
 
-T = TypeVar("T", bound="SessionListResponse")
+T = TypeVar("T", bound="ParticipantListResponse")
 
 
 @_attrs_define
-class SessionListResponse:
+class ParticipantListResponse:
     """
     Attributes:
-        sessions (list[SessionRead]):
+        participants (list[ParticipantRead]):
         total (int):
     """
 
-    sessions: list[SessionRead]
+    participants: list[ParticipantRead]
     total: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        sessions = []
-        for sessions_item_data in self.sessions:
-            sessions_item = sessions_item_data.to_dict()
-            sessions.append(sessions_item)
+        participants = []
+        for participants_item_data in self.participants:
+            participants_item = participants_item_data.to_dict()
+            participants.append(participants_item)
 
         total = self.total
 
@@ -37,7 +37,7 @@ class SessionListResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "sessions": sessions,
+                "participants": participants,
                 "total": total,
             }
         )
@@ -46,25 +46,25 @@ class SessionListResponse:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.session_read import SessionRead
+        from ..models.participant_read import ParticipantRead
 
         d = dict(src_dict)
-        sessions = []
-        _sessions = d.pop("sessions")
-        for sessions_item_data in _sessions:
-            sessions_item = SessionRead.from_dict(sessions_item_data)
+        participants = []
+        _participants = d.pop("participants")
+        for participants_item_data in _participants:
+            participants_item = ParticipantRead.from_dict(participants_item_data)
 
-            sessions.append(sessions_item)
+            participants.append(participants_item)
 
         total = d.pop("total")
 
-        session_list_response = cls(
-            sessions=sessions,
+        participant_list_response = cls(
+            participants=participants,
             total=total,
         )
 
-        session_list_response.additional_properties = d
-        return session_list_response
+        participant_list_response.additional_properties = d
+        return participant_list_response
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-cli/src/mycelium_backend_client/models/participant_read.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/participant_read.py
@@ -11,15 +11,15 @@ from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="SessionRead")
+T = TypeVar("T", bound="ParticipantRead")
 
 
 @_attrs_define
-class SessionRead:
+class ParticipantRead:
     """
     Attributes:
         id (UUID):
-        room_name (str):
+        coordination_session_id (UUID):
         agent_handle (str):
         joined_at (datetime.datetime):
         intent (None | str | Unset):
@@ -27,7 +27,7 @@ class SessionRead:
     """
 
     id: UUID
-    room_name: str
+    coordination_session_id: UUID
     agent_handle: str
     joined_at: datetime.datetime
     intent: None | str | Unset = UNSET
@@ -37,7 +37,7 @@ class SessionRead:
     def to_dict(self) -> dict[str, Any]:
         id = str(self.id)
 
-        room_name = self.room_name
+        coordination_session_id = str(self.coordination_session_id)
 
         agent_handle = self.agent_handle
 
@@ -62,7 +62,7 @@ class SessionRead:
         field_dict.update(
             {
                 "id": id,
-                "room_name": room_name,
+                "coordination_session_id": coordination_session_id,
                 "agent_handle": agent_handle,
                 "joined_at": joined_at,
             }
@@ -79,7 +79,7 @@ class SessionRead:
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
-        room_name = d.pop("room_name")
+        coordination_session_id = UUID(d.pop("coordination_session_id"))
 
         agent_handle = d.pop("agent_handle")
 
@@ -111,17 +111,17 @@ class SessionRead:
 
         last_seen = _parse_last_seen(d.pop("last_seen", UNSET))
 
-        session_read = cls(
+        participant_read = cls(
             id=id,
-            room_name=room_name,
+            coordination_session_id=coordination_session_id,
             agent_handle=agent_handle,
             joined_at=joined_at,
             intent=intent,
             last_seen=last_seen,
         )
 
-        session_read.additional_properties = d
-        return session_read
+        participant_read.additional_properties = d
+        return participant_read
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-client/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
+++ b/mycelium-client/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
@@ -15,6 +15,7 @@ def _get_kwargs(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -28,6 +29,8 @@ def _get_kwargs(
     else:
         json_name = name
     params["name"] = json_name
+
+    params["include_sessions"] = include_sessions
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -81,15 +84,22 @@ def sync_detailed(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> Response[HTTPValidationError | list[RoomRead]]:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -103,6 +113,7 @@ def sync_detailed(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     )
 
     response = client.get_httpx_client().request(
@@ -118,15 +129,22 @@ def sync(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> HTTPValidationError | list[RoomRead] | None:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,6 +159,7 @@ def sync(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     ).parsed
 
 
@@ -150,15 +169,22 @@ async def asyncio_detailed(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> Response[HTTPValidationError | list[RoomRead]]:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,6 +198,7 @@ async def asyncio_detailed(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -185,15 +212,22 @@ async def asyncio(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> HTTPValidationError | list[RoomRead] | None:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -209,5 +243,6 @@ async def asyncio(
             skip=skip,
             limit=limit,
             name=name,
+            include_sessions=include_sessions,
         )
     ).parsed

--- a/mycelium-client/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
+++ b/mycelium-client/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
@@ -7,15 +7,15 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.session_create import SessionCreate
-from ...models.session_read import SessionRead
+from ...models.participant_create import ParticipantCreate
+from ...models.participant_read import ParticipantRead
 from ...types import Response
 
 
 def _get_kwargs(
     room_name: str,
     *,
-    body: SessionCreate,
+    body: ParticipantCreate,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -36,9 +36,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | SessionRead | None:
+) -> HTTPValidationError | ParticipantRead | None:
     if response.status_code == 201:
-        response_201 = SessionRead.from_dict(response.json())
+        response_201 = ParticipantRead.from_dict(response.json())
 
         return response_201
 
@@ -55,7 +55,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | SessionRead]:
+) -> Response[HTTPValidationError | ParticipantRead]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -68,22 +68,22 @@ def sync_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> Response[HTTPValidationError | SessionRead]:
+    body: ParticipantCreate,
+) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionRead]
+        Response[HTTPValidationError | ParticipantRead]
     """
 
     kwargs = _get_kwargs(
@@ -102,22 +102,22 @@ def sync(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> HTTPValidationError | SessionRead | None:
+    body: ParticipantCreate,
+) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionRead
+        HTTPValidationError | ParticipantRead
     """
 
     return sync_detailed(
@@ -131,22 +131,22 @@ async def asyncio_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> Response[HTTPValidationError | SessionRead]:
+    body: ParticipantCreate,
+) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionRead]
+        Response[HTTPValidationError | ParticipantRead]
     """
 
     kwargs = _get_kwargs(
@@ -163,22 +163,22 @@ async def asyncio(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> HTTPValidationError | SessionRead | None:
+    body: ParticipantCreate,
+) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionRead
+        HTTPValidationError | ParticipantRead
     """
 
     return (

--- a/mycelium-client/mycelium_backend_client/api/sessions/leave_room_api_rooms_room_name_sessions_session_id_delete.py
+++ b/mycelium-client/mycelium_backend_client/api/sessions/leave_room_api_rooms_room_name_sessions_session_id_delete.py
@@ -63,7 +63,7 @@ def sync_detailed(
 ) -> Response[Any | HTTPValidationError]:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -97,7 +97,7 @@ def sync(
 ) -> Any | HTTPValidationError | None:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -126,7 +126,7 @@ async def asyncio_detailed(
 ) -> Response[Any | HTTPValidationError]:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -158,7 +158,7 @@ async def asyncio(
 ) -> Any | HTTPValidationError | None:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):

--- a/mycelium-client/mycelium_backend_client/api/sessions/list_coordination_sessions_api_rooms_room_name_sessions_coordination_get.py
+++ b/mycelium-client/mycelium_backend_client/api/sessions/list_coordination_sessions_api_rooms_room_name_sessions_coordination_get.py
@@ -1,0 +1,185 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.coordination_session_read import CoordinationSessionRead
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    room_name: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/rooms/{room_name}/sessions/coordination".format(
+            room_name=quote(str(room_name), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = CoordinationSessionRead.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return sync_detailed(
+        room_name=room_name,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return (
+        await asyncio_detailed(
+            room_name=room_name,
+            client=client,
+        )
+    ).parsed

--- a/mycelium-client/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
+++ b/mycelium-client/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.session_list_response import SessionListResponse
+from ...models.participant_list_response import ParticipantListResponse
 from ...types import Response
 
 
@@ -26,9 +26,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     if response.status_code == 200:
-        response_200 = SessionListResponse.from_dict(response.json())
+        response_200 = ParticipantListResponse.from_dict(response.json())
 
         return response_200
 
@@ -45,7 +45,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -58,10 +58,10 @@ def sync_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -71,7 +71,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionListResponse]
+        Response[HTTPValidationError | ParticipantListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -89,10 +89,10 @@ def sync(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -102,7 +102,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionListResponse
+        HTTPValidationError | ParticipantListResponse
     """
 
     return sync_detailed(
@@ -115,10 +115,10 @@ async def asyncio_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -128,7 +128,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionListResponse]
+        Response[HTTPValidationError | ParticipantListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -144,10 +144,10 @@ async def asyncio(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -157,7 +157,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionListResponse
+        HTTPValidationError | ParticipantListResponse
     """
 
     return (

--- a/mycelium-client/mycelium_backend_client/models/__init__.py
+++ b/mycelium-client/mycelium_backend_client/models/__init__.py
@@ -51,15 +51,15 @@ from .memory_search_result import MemorySearchResult
 from .message_create import MessageCreate
 from .message_list_response import MessageListResponse
 from .message_read import MessageRead
+from .participant_create import ParticipantCreate
+from .participant_list_response import ParticipantListResponse
+from .participant_read import ParticipantRead
 from .query_request import QueryRequest
 from .query_request_additional_context_type_0 import QueryRequestAdditionalContextType0
 from .room_create import RoomCreate
 from .room_create_trigger_config_type_0 import RoomCreateTriggerConfigType0
 from .room_read import RoomRead
 from .room_read_trigger_config_type_0 import RoomReadTriggerConfigType0
-from .session_create import SessionCreate
-from .session_list_response import SessionListResponse
-from .session_read import SessionRead
 from .spawn_session_api_rooms_room_name_sessions_spawn_post_response_spawn_session_api_rooms_room_name_sessions_spawn_post import (
     SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost,
 )
@@ -105,15 +105,15 @@ __all__ = (
     "MessageCreate",
     "MessageListResponse",
     "MessageRead",
+    "ParticipantCreate",
+    "ParticipantListResponse",
+    "ParticipantRead",
     "QueryRequest",
     "QueryRequestAdditionalContextType0",
     "RoomCreate",
     "RoomCreateTriggerConfigType0",
     "RoomRead",
     "RoomReadTriggerConfigType0",
-    "SessionCreate",
-    "SessionListResponse",
-    "SessionRead",
     "SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost",
     "SubscriptionCreate",
     "SubscriptionRead",

--- a/mycelium-client/mycelium_backend_client/models/__init__.py
+++ b/mycelium-client/mycelium_backend_client/models/__init__.py
@@ -20,6 +20,7 @@ from .cfn_query_api_cfn_knowledge_query_post_response_cfn_query_api_cfn_knowledg
     CfnQueryApiCfnKnowledgeQueryPostResponseCfnQueryApiCfnKnowledgeQueryPost,
 )
 from .concepts_by_ids_request import ConceptsByIdsRequest
+from .coordination_session_read import CoordinationSessionRead
 from .get_negotiation_status_response_get_negotiation_status import GetNegotiationStatusResponseGetNegotiationStatus
 from .graph_paths_request import GraphPathsRequest
 from .http_validation_error import HTTPValidationError
@@ -77,6 +78,7 @@ __all__ = (
     "CfnListApiCfnKnowledgeListGetResponseCfnListApiCfnKnowledgeListGet",
     "CfnQueryApiCfnKnowledgeQueryPostResponseCfnQueryApiCfnKnowledgeQueryPost",
     "ConceptsByIdsRequest",
+    "CoordinationSessionRead",
     "GetNegotiationStatusResponseGetNegotiationStatus",
     "GraphPathsRequest",
     "HTTPValidationError",

--- a/mycelium-client/mycelium_backend_client/models/coordination_session_read.py
+++ b/mycelium-client/mycelium_backend_client/models/coordination_session_read.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CoordinationSessionRead")
+
+
+@_attrs_define
+class CoordinationSessionRead:
+    """
+    Attributes:
+        id (UUID):
+        parent_room_name (str):
+        short_id (str):
+        state (str):
+        created_at (datetime.datetime):
+        display_name (str):
+        join_window_ends_at (datetime.datetime | None | Unset):
+        mas_id (None | str | Unset):
+        workspace_id (None | str | Unset):
+    """
+
+    id: UUID
+    parent_room_name: str
+    short_id: str
+    state: str
+    created_at: datetime.datetime
+    display_name: str
+    join_window_ends_at: datetime.datetime | None | Unset = UNSET
+    mas_id: None | str | Unset = UNSET
+    workspace_id: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        parent_room_name = self.parent_room_name
+
+        short_id = self.short_id
+
+        state = self.state
+
+        created_at = self.created_at.isoformat()
+
+        display_name = self.display_name
+
+        join_window_ends_at: None | str | Unset
+        if isinstance(self.join_window_ends_at, Unset):
+            join_window_ends_at = UNSET
+        elif isinstance(self.join_window_ends_at, datetime.datetime):
+            join_window_ends_at = self.join_window_ends_at.isoformat()
+        else:
+            join_window_ends_at = self.join_window_ends_at
+
+        mas_id: None | str | Unset
+        if isinstance(self.mas_id, Unset):
+            mas_id = UNSET
+        else:
+            mas_id = self.mas_id
+
+        workspace_id: None | str | Unset
+        if isinstance(self.workspace_id, Unset):
+            workspace_id = UNSET
+        else:
+            workspace_id = self.workspace_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "parent_room_name": parent_room_name,
+                "short_id": short_id,
+                "state": state,
+                "created_at": created_at,
+                "display_name": display_name,
+            }
+        )
+        if join_window_ends_at is not UNSET:
+            field_dict["join_window_ends_at"] = join_window_ends_at
+        if mas_id is not UNSET:
+            field_dict["mas_id"] = mas_id
+        if workspace_id is not UNSET:
+            field_dict["workspace_id"] = workspace_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        parent_room_name = d.pop("parent_room_name")
+
+        short_id = d.pop("short_id")
+
+        state = d.pop("state")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        display_name = d.pop("display_name")
+
+        def _parse_join_window_ends_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                join_window_ends_at_type_0 = isoparse(data)
+
+                return join_window_ends_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        join_window_ends_at = _parse_join_window_ends_at(d.pop("join_window_ends_at", UNSET))
+
+        def _parse_mas_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        mas_id = _parse_mas_id(d.pop("mas_id", UNSET))
+
+        def _parse_workspace_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        workspace_id = _parse_workspace_id(d.pop("workspace_id", UNSET))
+
+        coordination_session_read = cls(
+            id=id,
+            parent_room_name=parent_room_name,
+            short_id=short_id,
+            state=state,
+            created_at=created_at,
+            display_name=display_name,
+            join_window_ends_at=join_window_ends_at,
+            mas_id=mas_id,
+            workspace_id=workspace_id,
+        )
+
+        coordination_session_read.additional_properties = d
+        return coordination_session_read
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-client/mycelium_backend_client/models/participant_create.py
+++ b/mycelium-client/mycelium_backend_client/models/participant_create.py
@@ -8,11 +8,11 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="SessionCreate")
+T = TypeVar("T", bound="ParticipantCreate")
 
 
 @_attrs_define
-class SessionCreate:
+class ParticipantCreate:
     """
     Attributes:
         agent_handle (str): Agent handle joining the room
@@ -58,13 +58,13 @@ class SessionCreate:
 
         intent = _parse_intent(d.pop("intent", UNSET))
 
-        session_create = cls(
+        participant_create = cls(
             agent_handle=agent_handle,
             intent=intent,
         )
 
-        session_create.additional_properties = d
-        return session_create
+        participant_create.additional_properties = d
+        return participant_create
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-client/mycelium_backend_client/models/participant_list_response.py
+++ b/mycelium-client/mycelium_backend_client/models/participant_list_response.py
@@ -7,29 +7,29 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
-    from ..models.session_read import SessionRead
+    from ..models.participant_read import ParticipantRead
 
 
-T = TypeVar("T", bound="SessionListResponse")
+T = TypeVar("T", bound="ParticipantListResponse")
 
 
 @_attrs_define
-class SessionListResponse:
+class ParticipantListResponse:
     """
     Attributes:
-        sessions (list[SessionRead]):
+        participants (list[ParticipantRead]):
         total (int):
     """
 
-    sessions: list[SessionRead]
+    participants: list[ParticipantRead]
     total: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        sessions = []
-        for sessions_item_data in self.sessions:
-            sessions_item = sessions_item_data.to_dict()
-            sessions.append(sessions_item)
+        participants = []
+        for participants_item_data in self.participants:
+            participants_item = participants_item_data.to_dict()
+            participants.append(participants_item)
 
         total = self.total
 
@@ -37,7 +37,7 @@ class SessionListResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "sessions": sessions,
+                "participants": participants,
                 "total": total,
             }
         )
@@ -46,25 +46,25 @@ class SessionListResponse:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.session_read import SessionRead
+        from ..models.participant_read import ParticipantRead
 
         d = dict(src_dict)
-        sessions = []
-        _sessions = d.pop("sessions")
-        for sessions_item_data in _sessions:
-            sessions_item = SessionRead.from_dict(sessions_item_data)
+        participants = []
+        _participants = d.pop("participants")
+        for participants_item_data in _participants:
+            participants_item = ParticipantRead.from_dict(participants_item_data)
 
-            sessions.append(sessions_item)
+            participants.append(participants_item)
 
         total = d.pop("total")
 
-        session_list_response = cls(
-            sessions=sessions,
+        participant_list_response = cls(
+            participants=participants,
             total=total,
         )
 
-        session_list_response.additional_properties = d
-        return session_list_response
+        participant_list_response.additional_properties = d
+        return participant_list_response
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-client/mycelium_backend_client/models/participant_read.py
+++ b/mycelium-client/mycelium_backend_client/models/participant_read.py
@@ -11,15 +11,15 @@ from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="SessionRead")
+T = TypeVar("T", bound="ParticipantRead")
 
 
 @_attrs_define
-class SessionRead:
+class ParticipantRead:
     """
     Attributes:
         id (UUID):
-        room_name (str):
+        coordination_session_id (UUID):
         agent_handle (str):
         joined_at (datetime.datetime):
         intent (None | str | Unset):
@@ -27,7 +27,7 @@ class SessionRead:
     """
 
     id: UUID
-    room_name: str
+    coordination_session_id: UUID
     agent_handle: str
     joined_at: datetime.datetime
     intent: None | str | Unset = UNSET
@@ -37,7 +37,7 @@ class SessionRead:
     def to_dict(self) -> dict[str, Any]:
         id = str(self.id)
 
-        room_name = self.room_name
+        coordination_session_id = str(self.coordination_session_id)
 
         agent_handle = self.agent_handle
 
@@ -62,7 +62,7 @@ class SessionRead:
         field_dict.update(
             {
                 "id": id,
-                "room_name": room_name,
+                "coordination_session_id": coordination_session_id,
                 "agent_handle": agent_handle,
                 "joined_at": joined_at,
             }
@@ -79,7 +79,7 @@ class SessionRead:
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
-        room_name = d.pop("room_name")
+        coordination_session_id = UUID(d.pop("coordination_session_id"))
 
         agent_handle = d.pop("agent_handle")
 
@@ -111,17 +111,17 @@ class SessionRead:
 
         last_seen = _parse_last_seen(d.pop("last_seen", UNSET))
 
-        session_read = cls(
+        participant_read = cls(
             id=id,
-            room_name=room_name,
+            coordination_session_id=coordination_session_id,
             agent_handle=agent_handle,
             joined_at=joined_at,
             intent=intent,
             last_seen=last_seen,
         )
 
-        session_read.additional_properties = d
-        return session_read
+        participant_read.additional_properties = d
+        return participant_read
 
     @property
     def additional_keys(self) -> list[str]:

--- a/openapi.json
+++ b/openapi.json
@@ -51,7 +51,7 @@
                     "rooms"
                 ],
                 "summary": "List Rooms",
-                "description": "List rooms with optional name filter.",
+                "description": "List rooms.\n\nBy default returns only real rooms (namespaces). Session-shadow rows are\nexcluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``\nto include the shadow rows \u2014 used by callers (e.g. the OpenClaw channel\nplugin) that still address sessions by name during the deprecation window.",
                 "operationId": "list_rooms_api_rooms_get",
                 "parameters": [
                     {
@@ -88,6 +88,16 @@
                                 }
                             ],
                             "title": "Name"
+                        }
+                    },
+                    {
+                        "name": "include_sessions",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Include Sessions"
                         }
                     }
                 ],
@@ -633,6 +643,53 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/SessionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rooms/{room_name}/sessions/coordination": {
+            "get": {
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "List Coordination Sessions",
+                "description": "List negotiation sessions in a room (#197).\n\nReturns first-class CoordinationSession entities. The shadow rows in the\nrooms table are an implementation detail that callers shouldn't depend on.",
+                "operationId": "list_coordination_sessions_api_rooms__room_name__sessions_coordination_get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CoordinationSessionRead"
+                                    },
+                                    "title": "Response List Coordination Sessions Api Rooms  Room Name  Sessions Coordination Get"
                                 }
                             }
                         }
@@ -2262,6 +2319,80 @@
                     "ids"
                 ],
                 "title": "ConceptsByIdsRequest"
+            },
+            "CoordinationSessionRead": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "parent_room_name": {
+                        "type": "string",
+                        "title": "Parent Room Name"
+                    },
+                    "short_id": {
+                        "type": "string",
+                        "title": "Short Id"
+                    },
+                    "state": {
+                        "type": "string",
+                        "title": "State"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At"
+                    },
+                    "join_window_ends_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Join Window Ends At"
+                    },
+                    "mas_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mas Id"
+                    },
+                    "workspace_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspace Id"
+                    },
+                    "display_name": {
+                        "type": "string",
+                        "title": "Display Name"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "parent_room_name",
+                    "short_id",
+                    "state",
+                    "created_at",
+                    "display_name"
+                ],
+                "title": "CoordinationSessionRead"
             },
             "GraphPathsRequest": {
                 "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -590,7 +590,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SessionCreate"
+                                "$ref": "#/components/schemas/ParticipantCreate"
                             }
                         }
                     }
@@ -601,7 +601,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/SessionRead"
+                                    "$ref": "#/components/schemas/ParticipantRead"
                                 }
                             }
                         }
@@ -623,7 +623,7 @@
                     "sessions"
                 ],
                 "summary": "List Sessions",
-                "description": "List agents currently in a room.",
+                "description": "List agents participating in a room's coordination session.",
                 "operationId": "list_sessions_api_rooms__room_name__sessions_get",
                 "parameters": [
                     {
@@ -642,7 +642,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/SessionListResponse"
+                                    "$ref": "#/components/schemas/ParticipantListResponse"
                                 }
                             }
                         }
@@ -713,7 +713,7 @@
                     "sessions"
                 ],
                 "summary": "Leave Room",
-                "description": "Remove an agent session (leave room).",
+                "description": "Remove a participant (agent leaves the session).",
                 "operationId": "leave_room_api_rooms__room_name__sessions__session_id__delete",
                 "parameters": [
                     {
@@ -3169,6 +3169,107 @@
                 ],
                 "title": "MessageRead"
             },
+            "ParticipantCreate": {
+                "properties": {
+                    "agent_handle": {
+                        "type": "string",
+                        "title": "Agent Handle",
+                        "description": "Agent handle joining the room"
+                    },
+                    "intent": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Intent",
+                        "description": "Agent's requirements/intent for coordination"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "agent_handle"
+                ],
+                "title": "ParticipantCreate"
+            },
+            "ParticipantListResponse": {
+                "properties": {
+                    "participants": {
+                        "items": {
+                            "$ref": "#/components/schemas/ParticipantRead"
+                        },
+                        "type": "array",
+                        "title": "Participants"
+                    },
+                    "total": {
+                        "type": "integer",
+                        "title": "Total"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "participants",
+                    "total"
+                ],
+                "title": "ParticipantListResponse"
+            },
+            "ParticipantRead": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "coordination_session_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Coordination Session Id"
+                    },
+                    "agent_handle": {
+                        "type": "string",
+                        "title": "Agent Handle"
+                    },
+                    "intent": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Intent"
+                    },
+                    "joined_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Joined At"
+                    },
+                    "last_seen": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Seen"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "coordination_session_id",
+                    "agent_handle",
+                    "joined_at"
+                ],
+                "title": "ParticipantRead"
+            },
             "QueryRequest": {
                 "properties": {
                     "intent": {
@@ -3426,106 +3527,6 @@
                     "created_at"
                 ],
                 "title": "RoomRead"
-            },
-            "SessionCreate": {
-                "properties": {
-                    "agent_handle": {
-                        "type": "string",
-                        "title": "Agent Handle",
-                        "description": "Agent handle joining the room"
-                    },
-                    "intent": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Intent",
-                        "description": "Agent's requirements/intent for coordination"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "agent_handle"
-                ],
-                "title": "SessionCreate"
-            },
-            "SessionListResponse": {
-                "properties": {
-                    "sessions": {
-                        "items": {
-                            "$ref": "#/components/schemas/SessionRead"
-                        },
-                        "type": "array",
-                        "title": "Sessions"
-                    },
-                    "total": {
-                        "type": "integer",
-                        "title": "Total"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "sessions",
-                    "total"
-                ],
-                "title": "SessionListResponse"
-            },
-            "SessionRead": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id"
-                    },
-                    "room_name": {
-                        "type": "string",
-                        "title": "Room Name"
-                    },
-                    "agent_handle": {
-                        "type": "string",
-                        "title": "Agent Handle"
-                    },
-                    "intent": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Intent"
-                    },
-                    "joined_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Joined At"
-                    },
-                    "last_seen": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Last Seen"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "room_name",
-                    "agent_handle",
-                    "joined_at"
-                ],
-                "title": "SessionRead"
             },
             "SubscriptionCreate": {
                 "properties": {


### PR DESCRIPTION
First of two PRs for the privacy-first KXP work. Closes the minimum-viable shape of #197; the rest tracked in #244.

## Summary

Two related cleanups so the data model stops conflating "the negotiation" with "who's in the negotiation":

1. **`coordination_sessions` is now a first-class entity** — no longer flag combinations on the rooms table.
2. **`sessions → participants`** — the existing table that tracked agent participation was misnamed. Renamed and re-FK'd to point at `coordination_sessions(id)` directly, so the relationship is what it actually is: "this agent is a participant in this coordination session."

This unblocks PR 2 (#196 Part 1 + Part 2), which needs a place to attach `--context-files` per session.

## What changed

**New table: `coordination_sessions`**
- `app/models.py` — `CoordinationSession` model: `id`, `parent_room_name`, `short_id`, `state`, `created_at`, `join_window_ends_at`, `mas_id`, `workspace_id`, plus a `display_name` property that synthesizes the legacy `{parent}:session:{short_id}` string.
- `alembic_migrations/0011_coordination_sessions.py` — creates table, backfills from existing session-shaped rows.
- `_spawn_session_room` dual-writes the new entity alongside the existing shadow Room row (kept for FK compat with `messages.room_name`).
- `GET /api/rooms/{room}/sessions/coordination` — lists CoordinationSession entities for a room.
- `GET /api/rooms` hides session-shadow rows by default; pass `?include_sessions=true` to include them. The OpenClaw channel plugin opts back in for the deprecation window.

**Renamed: `sessions` → `participants`**
- `alembic_migrations/0012_rename_sessions_to_participants.py` — renames table; replaces the `room_name` FK (which always pointed at session-shadow display names) with a real `coordination_session_id` UUID FK to `coordination_sessions(id) ON DELETE CASCADE`. Backfills from the legacy display name parts. Drops `room_name`.
- `Session` model → `Participant`. `SessionCreate/Read/ListResponse` → `ParticipantCreate/Read/ListResponse`.
- `_spawn_session_room` returns `(Room, CoordinationSession)`; `join_room` writes a `Participant` with `coordination_session_id`. `list_sessions` resolves the right coord_session(s) before fetching participants.
- `coordination.py` — looks up `Participant` by `coordination_session_id` (resolves from session display name).
- `delete_room` — relies on the FK cascade chain (room → coord_session → participants) instead of explicit Participant deletes.

**Live migration verified**
- 11 historical session-shadows backfilled into `coordination_sessions`.
- 0 participants existed (none were live), but the schema migration applied cleanly.
- Smoke test against the dev DB confirmed: dual-write on spawn, participant attaches to coord_session_id, list endpoint returns `participants` array, cascade delete chain works.

## Scope intentionally narrow

Three pieces land in #244 instead of here:
1. Rekeying `coordination.py` state machine on `coordination_sessions.id` (touches a 1k-line service that just got #238 fixes — keeping that out of this PR).
2. Migrating `mycelium session ls` to query the new endpoint.
3. Dropping `is_namespace`, `mode`, `parent_namespace` from rooms and removing shadow rows.

## Test plan

- [x] `uv run pytest tests/ -x -q` (fastapi-backend) — 211 passed (+4 new in `test_coordination_sessions.py`)
- [x] `uv run pytest tests/ -x -q` (mycelium-cli) — 59 passed
- [x] `npm test` (openclaw plugin) — 109 passed
- [x] `uv run ty check .` (both projects) — clean
- [x] `uv run ruff check .` (both projects) — clean
- [x] CI all green
- [x] Live migration applied against dev DB; backups saved at `~/Documents/mycelium-backup-pre-0011-*.sql` and `mycelium-backup-pre-0012-*.sql`
- [x] Smoke test: room create, join (auto-spawn), 2-agent join, list participants, cascade delete