### PR TITLE
Bring #244 + #197 work into main (re-land #245 + #246)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ cd mycelium-frontend && pnpm install && pnpm dev
 
 **AgensGraph** (PostgreSQL 16 fork) is the search index and coordination backend:
 - pgvector: semantic vector search over memory embeddings (updated on write)
-- SQL tables: rooms, sessions, messages, subscriptions, coordination state
+- SQL tables: rooms, coordination_sessions, sessions (presence), messages, subscriptions
 - openCypher: knowledge graph (optional enrichment layer)
 
 **Memory flow**:

--- a/fastapi-backend/alembic_migrations/versions/0011_coordination_sessions.py
+++ b/fastapi-backend/alembic_migrations/versions/0011_coordination_sessions.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""Promote sessions to first-class entity (#197).
+
+Creates the coordination_sessions table and backfills it from existing
+session-shaped rows in `rooms` (is_namespace=False, parent_namespace IS NOT NULL).
+
+Backwards compat: the session-shadow rows in `rooms` are kept so that
+messages.room_name and memories.room_name FKs continue to resolve. A follow-up
+release will remove the shadow rows and the deprecated columns
+(is_namespace, mode, parent_namespace).
+
+Revision ID: 0011
+Revises: 0010
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "coordination_sessions",
+        sa.Column("id", sa.Uuid(), primary_key=True),
+        sa.Column(
+            "parent_room_name",
+            sa.String(),
+            sa.ForeignKey("rooms.name", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("short_id", sa.String(length=16), nullable=False),
+        sa.Column("state", sa.String(length=20), nullable=False, server_default="idle"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("join_window_ends_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("mas_id", sa.String(), nullable=True, index=True),
+        sa.Column("workspace_id", sa.String(), nullable=True),
+    )
+
+    # Backfill: every session-shadow row in `rooms` becomes a coordination_sessions row.
+    # short_id is the suffix after `:session:` in the room name (8-char hex by convention).
+    op.execute(
+        """
+        INSERT INTO coordination_sessions
+            (id, parent_room_name, short_id, state, created_at, join_window_ends_at, mas_id, workspace_id)
+        SELECT
+            gen_random_uuid(),
+            parent_namespace,
+            COALESCE(NULLIF(split_part(name, ':session:', 2), ''), substr(md5(name), 1, 8)),
+            COALESCE(coordination_state, 'idle'),
+            created_at,
+            join_deadline,
+            mas_id,
+            workspace_id
+        FROM rooms
+        WHERE is_namespace = FALSE AND parent_namespace IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("coordination_sessions")

--- a/fastapi-backend/alembic_migrations/versions/0012_rename_sessions_to_participants.py
+++ b/fastapi-backend/alembic_migrations/versions/0012_rename_sessions_to_participants.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""Rename sessions → participants and re-FK to coordination_sessions (#197 follow-up).
+
+The old ``sessions`` table tracked agent participation in a coordination
+session (handle, intent, joined_at). Calling it ``sessions`` conflated it with
+the negotiation entity itself, which is now first-class in
+``coordination_sessions`` (migration 0011). This rename clarifies semantics
+and re-points the FK from ``rooms.name`` (which was always a session-shadow
+display name) to ``coordination_sessions.id``.
+
+Revision ID: 0012
+Revises: 0011
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Rename table.
+    op.rename_table("sessions", "participants")
+
+    # Add the new FK column nullable, backfill, then enforce NOT NULL.
+    op.add_column("participants", sa.Column("coordination_session_id", sa.Uuid(), nullable=True))
+
+    # Backfill: every participant row's room_name was a session-shadow display
+    # name like "{parent}:session:{short_id}". Resolve to coordination_sessions.id.
+    op.execute(
+        """
+        UPDATE participants p
+        SET coordination_session_id = cs.id
+        FROM coordination_sessions cs
+        WHERE cs.parent_room_name = split_part(p.room_name, ':session:', 1)
+          AND cs.short_id         = split_part(p.room_name, ':session:', 2)
+        """
+    )
+
+    # Drop any rows that didn't resolve — they reference rooms that aren't
+    # session-shadows, which the join_room flow should never produce. Logged
+    # for awareness rather than silently kept.
+    op.execute("DELETE FROM participants WHERE coordination_session_id IS NULL")
+
+    op.alter_column("participants", "coordination_session_id", nullable=False)
+    op.create_index(
+        "ix_participants_coordination_session_id",
+        "participants",
+        ["coordination_session_id"],
+    )
+    op.create_foreign_key(
+        "fk_participants_coordination_session",
+        "participants",
+        "coordination_sessions",
+        ["coordination_session_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Drop the old room_name FK + column.
+    op.drop_index("ix_sessions_room_name", table_name="participants")
+    op.drop_constraint("sessions_room_name_fkey", "participants", type_="foreignkey")
+    op.drop_column("participants", "room_name")
+
+
+def downgrade() -> None:
+    # Best-effort: this loses participants whose source rooms have been
+    # deleted. Coord_session.parent_room_name + short_id reconstructs the
+    # legacy display name.
+    op.add_column("participants", sa.Column("room_name", sa.String(), nullable=True))
+    op.execute(
+        """
+        UPDATE participants p
+        SET room_name = cs.parent_room_name || ':session:' || cs.short_id
+        FROM coordination_sessions cs
+        WHERE cs.id = p.coordination_session_id
+        """
+    )
+    op.alter_column("participants", "room_name", nullable=False)
+    op.create_index("ix_sessions_room_name", "participants", ["room_name"])
+    op.create_foreign_key(
+        "sessions_room_name_fkey",
+        "participants",
+        "rooms",
+        ["room_name"],
+        ["name"],
+        ondelete="CASCADE",
+    )
+
+    op.drop_constraint("fk_participants_coordination_session", "participants", type_="foreignkey")
+    op.drop_index("ix_participants_coordination_session_id", table_name="participants")
+    op.drop_column("participants", "coordination_session_id")
+
+    op.rename_table("participants", "sessions")

--- a/fastapi-backend/alembic_migrations/versions/0013_messages_polymorphic.py
+++ b/fastapi-backend/alembic_migrations/versions/0013_messages_polymorphic.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""Make messages.room_name polymorphic with coordination_session_id (#244).
+
+Today every message FKs to ``rooms.name``; for session-bound messages that's
+the session-shadow display string ``{parent}:session:{short}``. Before we can
+drop shadow rows + the deprecated rooms columns, messages need to address a
+session via ``coordination_sessions.id`` directly.
+
+This migration:
+1. Makes ``messages.room_name`` nullable.
+2. Adds ``messages.coordination_session_id`` as a nullable FK to
+   ``coordination_sessions.id`` with CASCADE.
+3. Backfills: messages whose ``room_name`` is a session-shadow display string
+   move to ``coordination_session_id``; ``room_name`` is NULLed out.
+4. Adds a CHECK constraint that exactly one of the two columns is set.
+
+Revision ID: 0013
+Revises: 0012
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("messages", "room_name", nullable=True)
+
+    op.add_column(
+        "messages",
+        sa.Column("coordination_session_id", sa.Uuid(), nullable=True),
+    )
+    op.create_index(
+        "ix_messages_coordination_session_id",
+        "messages",
+        ["coordination_session_id"],
+    )
+    op.create_foreign_key(
+        "fk_messages_coordination_session",
+        "messages",
+        "coordination_sessions",
+        ["coordination_session_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+    # Backfill: route session messages from room_name display string to FK.
+    op.execute(
+        """
+        UPDATE messages m
+        SET coordination_session_id = cs.id,
+            room_name = NULL
+        FROM coordination_sessions cs
+        WHERE m.room_name IS NOT NULL
+          AND cs.parent_room_name = split_part(m.room_name, ':session:', 1)
+          AND cs.short_id         = split_part(m.room_name, ':session:', 2)
+          AND split_part(m.room_name, ':session:', 2) <> ''
+        """
+    )
+
+    # Exactly one of (room_name, coordination_session_id) must be set.
+    op.create_check_constraint(
+        "ck_messages_one_target",
+        "messages",
+        "(room_name IS NOT NULL)::int + (coordination_session_id IS NOT NULL)::int = 1",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_messages_one_target", "messages", type_="check")
+
+    # Restore room_name on session messages by reconstructing the display string.
+    op.execute(
+        """
+        UPDATE messages m
+        SET room_name = cs.parent_room_name || ':session:' || cs.short_id
+        FROM coordination_sessions cs
+        WHERE m.coordination_session_id = cs.id
+        """
+    )
+
+    op.drop_constraint("fk_messages_coordination_session", "messages", type_="foreignkey")
+    op.drop_index("ix_messages_coordination_session_id", table_name="messages")
+    op.drop_column("messages", "coordination_session_id")
+
+    op.alter_column("messages", "room_name", nullable=False)

--- a/fastapi-backend/alembic_migrations/versions/0014_drop_deprecated_rooms_columns.py
+++ b/fastapi-backend/alembic_migrations/versions/0014_drop_deprecated_rooms_columns.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""Drop session-shadow rows + deprecated rooms columns (#244 final).
+
+After 0013, messages can FK to coordination_sessions directly. The session
+shadow rows in ``rooms`` are no longer needed. This migration:
+1. Deletes shadow rows (parent_namespace IS NOT NULL).
+2. Drops the ``join_deadline`` column from rooms (state lives on
+   ``coordination_sessions.join_window_ends_at``).
+3. Drops ``is_namespace``, ``mode``, ``parent_namespace`` from rooms.
+
+Revision ID: 0014
+Revises: 0013
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Delete shadow rows. coordination_sessions, participants, and any
+    # session-keyed messages are unaffected because they FK to
+    # coordination_sessions.id, not to rooms.name. Messages whose room_name
+    # still pointed at a shadow were migrated to coordination_session_id in
+    # 0013, so cascading the shadow deletion here is safe.
+    op.execute("DELETE FROM rooms WHERE parent_namespace IS NOT NULL OR is_namespace = FALSE")
+
+    # Drop the index on parent_namespace if any tooling created one.
+    with op.batch_alter_table("rooms") as batch:
+        batch.drop_column("join_deadline")
+        batch.drop_column("parent_namespace")
+        batch.drop_column("mode")
+        batch.drop_column("is_namespace")
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("rooms") as batch:
+        batch.add_column(
+            sa.Column("is_namespace", sa.Boolean(), nullable=False, server_default="true")
+        )
+        batch.add_column(
+            sa.Column("mode", sa.String(length=10), nullable=False, server_default="async")
+        )
+        batch.add_column(sa.Column("parent_namespace", sa.String(), nullable=True))
+        batch.add_column(sa.Column("join_deadline", sa.DateTime(timezone=True), nullable=True))

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -35,6 +35,7 @@ from app.routes.audit import router as audit_router
 from app.routes.cfn_proxy import cfn_read_router
 from app.routes.cfn_proxy import router as cfn_proxy_router
 from app.routes.coordination import router as coordination_router
+from app.routes.coordination_sessions import router as coordination_sessions_router
 from app.routes.knowledge import router as knowledge_router
 from app.routes.memory import router as memory_router
 from app.routes.messages import router as messages_router
@@ -182,6 +183,11 @@ app.include_router(knowledge_router)
 
 # Coordination observability (round-trace ring buffer; see issue #162)
 app.include_router(coordination_router)
+
+# Coordination sessions as a top-level resource — used by OpenClaw plugin,
+# frontend, and CLI in place of addressing sessions by their parent room's
+# display name.
+app.include_router(coordination_sessions_router)
 
 
 @app.get("/", tags=["health"])

--- a/fastapi-backend/app/models.py
+++ b/fastapi-backend/app/models.py
@@ -4,7 +4,7 @@
 """
 Mycelium data models.
 
-Agent, Room, Message, Session, AuditEvent, Memory, MemorySubscription.
+Agent, Room, CoordinationSession, Participant, Message, AuditEvent, Memory, MemorySubscription.
 """
 
 from datetime import datetime
@@ -187,14 +187,23 @@ class Message(Base):
     )
 
 
-class Session(Base):
-    """Agent presence in a room — tracks who has joined."""
+class Participant(Base):
+    """Agent participating in a coordination session — the roster.
 
-    __tablename__ = "sessions"
+    One row per agent join. The CognitiveEngine reads this to learn the list
+    of agent handles + intents at tick 0 and to address per-agent ticks during
+    a round. Renamed from ``sessions`` (#197 follow-up); the old name conflated
+    "the negotiation entity" with "the agent roster for that negotiation".
+    """
+
+    __tablename__ = "participants"
 
     id: Mapped[UUID_Type] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    room_name: Mapped[str] = mapped_column(
-        String, ForeignKey("rooms.name", ondelete="CASCADE"), nullable=False, index=True
+    coordination_session_id: Mapped[UUID_Type] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("coordination_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     agent_handle: Mapped[str] = mapped_column(String, nullable=False, index=True)
     joined_at: Mapped[datetime] = mapped_column(

--- a/fastapi-backend/app/models.py
+++ b/fastapi-backend/app/models.py
@@ -123,6 +123,47 @@ class Room(Base):
     workspace_id: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
+class CoordinationSession(Base):
+    """Coordination session — first-class entity per #197.
+
+    A session is a single negotiation round inside a parent room. State lives
+    here; the parent room holds persistent memory and namespace identity.
+
+    A "shadow" row in `rooms` (is_namespace=False, parent_namespace=parent_room_name)
+    is also kept during the deprecation window so messages.room_name and
+    memories.room_name FKs continue to resolve. The shadow is scheduled for
+    removal in a follow-up release.
+    """
+
+    __tablename__ = "coordination_sessions"
+
+    id: Mapped[UUID_Type] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    parent_room_name: Mapped[str] = mapped_column(
+        String, ForeignKey("rooms.name", ondelete="CASCADE"), nullable=False, index=True
+    )
+    short_id: Mapped[str] = mapped_column(String(16), nullable=False)
+    # State machine: idle | waiting | negotiating | agreed | failed | complete
+    state: Mapped[str] = mapped_column(VARCHAR(20), nullable=False, server_default="idle")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    join_window_ends_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # Inherited from parent at create time — see issue #237 for context.
+    mas_id: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
+    workspace_id: Mapped[str | None] = mapped_column(String, nullable=True)
+
+    @property
+    def display_name(self) -> str:
+        """Synthesize the legacy ``{parent}:session:{short_id}`` display string.
+
+        Kept for backward compatibility with messages.room_name and any caller
+        that still resolves sessions by name.
+        """
+        return f"{self.parent_room_name}:session:{self.short_id}"
+
+
 class Message(Base):
     """Agent-to-agent messages within a room."""
 

--- a/fastapi-backend/app/models.py
+++ b/fastapi-backend/app/models.py
@@ -89,14 +89,11 @@ class Room(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    # Coordination state machine: idle | waiting | negotiating | complete | synthesizing
+    # Coordination state for async-room synthesis: idle | synthesizing.
+    # Session state lives on coordination_sessions.state; this column applies
+    # to async rooms only.
     coordination_state: Mapped[str] = mapped_column(
         VARCHAR(20), nullable=False, server_default="idle"
-    )
-    join_deadline: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
-    # Legacy column — kept for migration compat. Always "async" for rooms, "sync" for sessions.
-    mode: Mapped[str] = mapped_column(
-        VARCHAR(10), nullable=False, server_default="async", default="async"
     )
     # Trigger config for async CognitiveEngine activation
     # e.g. {"type": "threshold", "min_contributions": 5}
@@ -113,18 +110,13 @@ class Room(Base):
     is_persistent: Mapped[bool] = mapped_column(Boolean, server_default="false", nullable=False)
     # Namespace identifier (defaults to room name)
     namespace: Mapped[str | None] = mapped_column(String, nullable=True)
-    # True for persistent namespaces (async rooms), False for ephemeral sessions (sync)
-    is_namespace: Mapped[bool] = mapped_column(Boolean, server_default="false", nullable=False)
-    # For sessions spawned within a namespace, points to the parent room name.
-    # No FK constraint — validated in application code to avoid AgensGraph create_all ordering issues.
-    parent_namespace: Mapped[str | None] = mapped_column(String, nullable=True)
     # CFN MAS sync — foreign IDs in the cfn_mgmt DB (not FK-constrained)
     mas_id: Mapped[str | None] = mapped_column(String, nullable=True, index=True)
     workspace_id: Mapped[str | None] = mapped_column(String, nullable=True)
 
 
 class CoordinationSession(Base):
-    """Coordination session — first-class entity per #197.
+    """Coordination session — first-class negotiation entity.
 
     A session is a single negotiation round inside a parent room. State lives
     here; the parent room holds persistent memory and namespace identity.
@@ -170,8 +162,17 @@ class Message(Base):
     __tablename__ = "messages"
 
     id: Mapped[UUID_Type] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    room_name: Mapped[str] = mapped_column(
-        String, ForeignKey("rooms.name", ondelete="CASCADE"), nullable=False, index=True
+    # Polymorphic: exactly one of room_name or coordination_session_id is set.
+    # room_name → namespace-room messages (chat in a real room).
+    # coordination_session_id → negotiation session messages.
+    room_name: Mapped[str | None] = mapped_column(
+        String, ForeignKey("rooms.name", ondelete="CASCADE"), nullable=True, index=True
+    )
+    coordination_session_id: Mapped[UUID_Type | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("coordination_sessions.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
     )
 
     # Sender/recipient are handles (e.g., "kappa#203b")
@@ -192,8 +193,9 @@ class Participant(Base):
 
     One row per agent join. The CognitiveEngine reads this to learn the list
     of agent handles + intents at tick 0 and to address per-agent ticks during
-    a round. Renamed from ``sessions`` (#197 follow-up); the old name conflated
-    "the negotiation entity" with "the agent roster for that negotiation".
+    a round. The original name ``sessions`` conflated "the negotiation entity"
+    with "the agent roster for that negotiation"; renaming clarifies which is
+    which.
     """
 
     __tablename__ = "participants"

--- a/fastapi-backend/app/routes/coordination_sessions.py
+++ b/fastapi-backend/app/routes/coordination_sessions.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""
+Coordination-session API — top-level resource.
+
+Exposes negotiation sessions as first-class entities. Consumers (OpenClaw
+plugin, frontend, CLI) address sessions by id here rather than via their
+parent room's display name, so the ``/api/rooms/...`` surface no longer
+needs to know about session-name encoding.
+"""
+
+import asyncio
+import json
+import logging
+from urllib.parse import urlparse
+from uuid import UUID
+
+import asyncpg
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.bus import room_channel
+from app.config import settings
+from app.database import async_session_maker, get_async_session
+from app.models import CoordinationSession, Message
+from app.schemas import (
+    CoordinationSessionRead,
+    MessageCreate,
+    MessageListResponse,
+    MessageRead,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/coordination-sessions", tags=["coordination-sessions"])
+
+
+# ── Read ──────────────────────────────────────────────────────────────────────
+
+
+@router.get("", response_model=list[CoordinationSessionRead])
+async def list_coordination_sessions(
+    db: AsyncSession = Depends(get_async_session),
+    parent_room: str | None = Query(None, description="Filter by parent room name"),
+    state: str | None = Query(
+        None,
+        description="Comma-separated state filter (e.g. 'waiting,negotiating')",
+    ),
+    limit: int = Query(200, le=1000),
+):
+    """List coordination sessions, newest first.
+
+    Supports two filters used by the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``) and the frontend sessions rail
+    (``parent_room=<name>``).
+    """
+    query = select(CoordinationSession).order_by(CoordinationSession.created_at.desc())
+
+    if parent_room:
+        query = query.where(CoordinationSession.parent_room_name == parent_room)
+    if state:
+        wanted = [s.strip() for s in state.split(",") if s.strip()]
+        if wanted:
+            query = query.where(CoordinationSession.state.in_(wanted))
+
+    result = await db.execute(query.limit(limit))
+    return [CoordinationSessionRead.model_validate(s) for s in result.scalars().all()]
+
+
+@router.get("/{session_id}", response_model=CoordinationSessionRead)
+async def get_coordination_session(
+    session_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
+):
+    result = await db.execute(
+        select(CoordinationSession).where(CoordinationSession.id == session_id)
+    )
+    coord = result.scalar_one_or_none()
+    if not coord:
+        raise HTTPException(status_code=404, detail="CoordinationSession not found")
+    return CoordinationSessionRead.model_validate(coord)
+
+
+# ── Messages ──────────────────────────────────────────────────────────────────
+
+
+async def _resolve_session(session_id: UUID, db: AsyncSession) -> CoordinationSession:
+    result = await db.execute(
+        select(CoordinationSession).where(CoordinationSession.id == session_id)
+    )
+    coord = result.scalar_one_or_none()
+    if not coord:
+        raise HTTPException(status_code=404, detail="CoordinationSession not found")
+    return coord
+
+
+@router.post("/{session_id}/messages", response_model=MessageRead, status_code=201)
+async def post_session_message(
+    session_id: UUID,
+    payload: MessageCreate,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """Post a message to a coordination session.
+
+    Messages are stored with ``coordination_session_id`` set and ``room_name``
+    null. SSE subscribers on the session-display channel still receive them
+    via the same ``room:{display_name}`` NOTIFY topic during the deprecation
+    window so existing OpenClaw plugin / CLI subscribers don't break.
+    """
+    coord = await _resolve_session(session_id, db)
+
+    msg = Message(
+        room_name=None,
+        coordination_session_id=coord.id,
+        sender_handle=payload.sender_handle,
+        recipient_handle=payload.recipient_handle,
+        message_type=payload.message_type,
+        content=payload.content,
+    )
+    db.add(msg)
+    await db.commit()
+    await db.refresh(msg)
+
+    display_name = coord.display_name
+    try:
+        parsed = urlparse(settings.DATABASE_URL)
+        conn: asyncpg.Connection = await asyncpg.connect(
+            host=parsed.hostname,
+            port=parsed.port or 5432,
+            user=parsed.username,
+            password=parsed.password,
+            database=parsed.path.lstrip("/"),
+        )
+        try:
+            await conn.execute(
+                "SELECT pg_notify($1, $2)",
+                room_channel(display_name),
+                json.dumps(
+                    {
+                        "id": str(msg.id),
+                        "coordination_session_id": str(coord.id),
+                        "sender_handle": msg.sender_handle,
+                        "recipient_handle": msg.recipient_handle,
+                        "message_type": msg.message_type,
+                        "content": msg.content,
+                        "created_at": msg.created_at.isoformat(),
+                    }
+                ),
+            )
+        finally:
+            await conn.close()
+    except Exception as e:
+        logger.warning("NOTIFY failed for session %s: %s", coord.id, e)
+
+    if coord.state == "negotiating":
+        from app.services import coordination
+
+        # coordination.on_agent_response still keys on display name during the
+        # deprecation window; pass that. Internal rekey lands later in this PR.
+        asyncio.ensure_future(
+            coordination.on_agent_response(display_name, msg.sender_handle, msg.content)
+        )
+
+    return msg
+
+
+@router.get("/{session_id}/messages", response_model=MessageListResponse)
+async def list_session_messages(
+    session_id: UUID,
+    db: AsyncSession = Depends(get_async_session),
+    limit: int = Query(50, le=500),
+    offset: int = 0,
+    sender: str | None = None,
+    message_type: str | None = None,
+):
+    coord = await _resolve_session(session_id, db)
+
+    query = select(Message).where(
+        (Message.coordination_session_id == coord.id) | (Message.room_name == coord.display_name)
+    )
+    if sender:
+        query = query.where(Message.sender_handle == sender)
+    if message_type:
+        query = query.where(Message.message_type == message_type)
+
+    query = query.order_by(Message.created_at.desc()).offset(offset).limit(limit)
+    result = await db.execute(query)
+    messages: list[Message] = list(result.scalars().all())
+
+    return MessageListResponse(
+        messages=[MessageRead.model_validate(m) for m in messages],
+        total=len(messages),
+    )
+
+
+@router.get("/{session_id}/messages/stream")
+async def stream_session_messages(
+    session_id: UUID,
+    request: Request,
+):
+    """SSE stream for a coordination session.
+
+    Resolves the session and subscribes to the underlying ``room:{display_name}``
+    Postgres NOTIFY channel so any inbound message routed to either coord_session_id
+    or the legacy display name surfaces here.
+    """
+    async with async_session_maker() as db:
+        result = await db.execute(
+            select(CoordinationSession).where(CoordinationSession.id == session_id)
+        )
+        coord = result.scalar_one_or_none()
+    if not coord:
+        raise HTTPException(status_code=404, detail="CoordinationSession not found")
+
+    display_name = coord.display_name
+
+    async def event_gen():
+        parsed = urlparse(settings.DATABASE_URL)
+        conn = await asyncpg.connect(
+            host=parsed.hostname,
+            port=parsed.port or 5432,
+            user=parsed.username,
+            password=parsed.password,
+            database=parsed.path.lstrip("/"),
+        )
+        queue: asyncio.Queue = asyncio.Queue()
+
+        def _enqueue(_conn, _pid, _channel, payload):
+            queue.put_nowait(payload)
+
+        await conn.add_listener(room_channel(display_name), _enqueue)
+        try:
+            yield ": connected\n\n"
+            while True:
+                if await request.is_disconnected():
+                    return
+                try:
+                    payload = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    yield f"data: {payload}\n\n"
+                except TimeoutError:
+                    yield ": keepalive\n\n"
+        finally:
+            try:
+                await conn.remove_listener(room_channel(display_name), _enqueue)
+            except Exception:
+                pass
+            await conn.close()
+
+    return StreamingResponse(event_gen(), media_type="text/event-stream")

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.bus import notify, room_channel
 from app.config import settings
 from app.database import get_async_session
-from app.models import Message, Room
+from app.models import CoordinationSession, Message, Room
 from app.schemas import MessageCreate, MessageListResponse, MessageRead
 
 logger = logging.getLogger(__name__)
@@ -29,12 +29,33 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/rooms/{room_name}/messages", tags=["messages"])
 
 
-async def _get_room_or_404(room_name: str, session: AsyncSession) -> Room:
-    result = await session.execute(select(Room).where(Room.name == room_name))
+async def _resolve_target(
+    name: str, session: AsyncSession
+) -> tuple[Room | None, CoordinationSession | None]:
+    """Resolve a path name to either a real Room or a CoordinationSession.
+
+    Names with the legacy ``{parent}:session:{short}`` shape resolve to a
+    coordination session — there is no Room row for them. Real room names
+    resolve to the Room. 404 if neither matches.
+    """
+    if ":session:" in name:
+        parent, _, short_id = name.partition(":session:")
+        result = await session.execute(
+            select(CoordinationSession).where(
+                CoordinationSession.parent_room_name == parent,
+                CoordinationSession.short_id == short_id,
+            )
+        )
+        coord = result.scalar_one_or_none()
+        if coord:
+            return None, coord
+
+    result = await session.execute(select(Room).where(Room.name == name))
     room = result.scalar_one_or_none()
-    if not room:
-        raise HTTPException(status_code=404, detail="Room not found")
-    return room
+    if room:
+        return room, None
+
+    raise HTTPException(status_code=404, detail="Room or session not found")
 
 
 @router.post("", response_model=MessageRead, status_code=201)
@@ -49,10 +70,11 @@ async def send_message(
     After persisting, fires NOTIFY on `room:{room_name}` so SSE subscribers
     receive it without polling.
     """
-    room = await _get_room_or_404(room_name, session)
+    room, coord = await _resolve_target(room_name, session)
 
     msg = Message(
-        room_name=room_name,
+        room_name=room.name if room else None,
+        coordination_session_id=coord.id if coord else None,
         sender_handle=payload.sender_handle,
         recipient_handle=payload.recipient_handle,
         message_type=payload.message_type,
@@ -62,7 +84,24 @@ async def send_message(
     await session.commit()
     await session.refresh(msg)
 
-    # Fire NOTIFY for SSE stream consumers
+    # _resolve_target raises 404 if neither, so exactly one is non-None.
+    notify_payload: dict = {
+        "id": str(msg.id),
+        "sender_handle": msg.sender_handle,
+        "recipient_handle": msg.recipient_handle,
+        "message_type": msg.message_type,
+        "content": msg.content,
+        "created_at": msg.created_at.isoformat(),
+    }
+    if room is not None:
+        notify_channel = room_channel(room.name)
+        notify_payload["room_name"] = room.name
+    elif coord is not None:
+        notify_channel = room_channel(coord.display_name)
+        notify_payload["coordination_session_id"] = str(coord.id)
+        notify_payload["room_name"] = coord.display_name  # legacy compat
+    else:
+        raise HTTPException(status_code=500, detail="resolver returned (None, None)")
     try:
         from urllib.parse import urlparse
 
@@ -75,30 +114,17 @@ async def send_message(
             database=parsed.path.lstrip("/"),
         )
         try:
-            await notify(
-                conn,
-                room_channel(room_name),
-                {
-                    "id": str(msg.id),
-                    "room_name": room_name,
-                    "sender_handle": msg.sender_handle,
-                    "recipient_handle": msg.recipient_handle,
-                    "message_type": msg.message_type,
-                    "content": msg.content,
-                    "created_at": msg.created_at.isoformat(),
-                },
-            )
+            await notify(conn, notify_channel, notify_payload)
         finally:
             await conn.close()
     except Exception as e:
-        logger.warning(f"NOTIFY failed for room {room_name}: {e}")
+        logger.warning("NOTIFY failed for %s: %s", notify_channel, e)
 
-    # Hook coordination service if this room is in negotiating state
-    if room.coordination_state == "negotiating":
+    if coord and coord.state == "negotiating":
         from app.services import coordination
 
         asyncio.ensure_future(
-            coordination.on_agent_response(room_name, msg.sender_handle, msg.content)
+            coordination.on_agent_response(coord.display_name, msg.sender_handle, msg.content)
         )
 
     return msg
@@ -113,10 +139,18 @@ async def list_messages(
     sender: str | None = None,
     message_type: str | None = None,
 ):
-    """List messages in a room, newest first."""
-    await _get_room_or_404(room_name, session)
+    """List messages in a room (or coordination session), newest first."""
+    room, coord = await _resolve_target(room_name, session)
 
-    query = select(Message).where(Message.room_name == room_name)
+    if room is not None:
+        query = select(Message).where(Message.room_name == room.name)
+    else:
+        assert coord is not None
+        # Surface both new (coord_session_id) and legacy (display-name room_name) rows.
+        query = select(Message).where(
+            (Message.coordination_session_id == coord.id)
+            | (Message.room_name == coord.display_name)
+        )
 
     if sender:
         query = query.where(Message.sender_handle == sender)

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -145,9 +145,20 @@ async def list_rooms(
     skip: int = 0,
     limit: int = 1000,
     name: str | None = None,
+    include_sessions: bool = False,
 ):
-    """List rooms with optional name filter."""
+    """List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
+    """
     query = select(Room).where(Room.is_public == True)  # noqa: E712
+
+    if not include_sessions:
+        # Session-shadow rows have parent_namespace set; real rooms don't.
+        query = query.where(Room.parent_namespace.is_(None))
 
     if name:
         query = query.where(Room.name.ilike(f"%{name}%"))

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -8,7 +8,7 @@ import time
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import delete, select, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
@@ -119,7 +119,6 @@ async def create_room(
         trigger_config=room.trigger_config,
         is_persistent=True,
         namespace=room.name,
-        is_namespace=True,
         mas_id=room.mas_id,
         workspace_id=room.workspace_id,
     )
@@ -149,16 +148,12 @@ async def list_rooms(
 ):
     """List rooms.
 
-    By default returns only real rooms (namespaces). Session-shadow rows are
-    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
-    to include the shadow rows — used by callers (e.g. the OpenClaw channel
-    plugin) that still address sessions by name during the deprecation window.
+    Sessions live in ``coordination_sessions`` and are not surfaced here. The
+    ``include_sessions`` parameter is accepted for backward-compatible URLs
+    but is a no-op — there are no session-shadow rows in this table.
     """
+    _ = include_sessions  # accepted for compat; nothing to filter
     query = select(Room).where(Room.is_public == True)  # noqa: E712
-
-    if not include_sessions:
-        # Session-shadow rows have parent_namespace set; real rooms don't.
-        query = query.where(Room.parent_namespace.is_(None))
 
     if name:
         query = query.where(Room.name.ilike(f"%{name}%"))
@@ -191,8 +186,6 @@ async def synthesize_room(
     room = result.scalar_one_or_none()
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
-    if not room.is_namespace:
-        raise HTTPException(status_code=400, detail="Synthesis only available for async rooms")
     if room.coordination_state == "synthesizing":
         raise HTTPException(status_code=409, detail="Synthesis already in progress")
 
@@ -280,7 +273,6 @@ async def catchup_room(
 
     return {
         "room": room_name,
-        "mode": room.mode,
         "total_memories": len(non_synthesis),
         "contributors": contributors,
         "latest_synthesis": latest_synthesis_data,
@@ -325,71 +317,48 @@ async def delete_room(
 ):
     """Delete a room and cascade to its child session rooms.
 
-    Cleanup order is important to avoid stale state firing against
-    already-deleted rows:
+    Cleanup order:
 
-      1. Enumerate child session rooms (``parent_namespace == room_name``).
-      2. Tear down all in-memory CFN coordination state for the namespace
-         and its children (cancels pending join timers and active round
-         timeouts, posts ``coordination_consensus broken=True`` to any
-         SSE subscribers).
-      3. Delete child ``Session`` rows, then child ``Room`` rows.
-      4. Mark any active child rooms as ``coordination_state="failed"``
-         (defensive — if step 3 didn't catch them due to a race, the
-         state still reflects reality).
-      5. Delete the parent ``Room`` row.
-      6. Remove the filesystem directory.
-      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
-         error doesn't block the local cleanup).
+      1. Resolve all coordination sessions for this room (display names + IDs).
+      2. Tear down in-memory CFN coordination state. Doing this before DB
+         deletes prevents in-flight ticks from firing against half-deleted
+         state.
+      3. Delete the room row — coordination_sessions, participants, and
+         messages cascade automatically via FK ON DELETE CASCADE.
+      4. Remove the filesystem directory.
+      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
     """
     if room_name in RESERVED_ROOMS:
         raise HTTPException(status_code=400, detail=f"'{room_name}' is a reserved system room")
+
+    from app.models import CoordinationSession
 
     result = await session.execute(select(Room).where(Room.name == room_name))
     room = result.scalar_one_or_none()
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
 
-    # 1. Enumerate child session rooms.
-    child_result = await session.execute(
-        select(Room.name).where(Room.parent_namespace == room_name)
+    coord_result = await session.execute(
+        select(CoordinationSession).where(CoordinationSession.parent_room_name == room_name)
     )
-    child_room_names = [r for r in child_result.scalars().all()]
+    coord_sessions = list(coord_result.scalars().all())
+    child_display_names = [c.display_name for c in coord_sessions]
 
-    # 2. Tear down in-memory coordination state for namespace + all children.
-    # Do this BEFORE the DB deletes so any in-flight `_run_tick` that resolves
-    # against the DB sees the row gone and bails, rather than firing ticks
-    # against a half-deleted state.
     try:
-        await coordination.teardown_for_namespace(room_name, child_room_names)
+        await coordination.teardown_for_namespace(room_name, child_display_names)
     except Exception as exc:
-        # Teardown is best-effort cleanup; log but don't block the delete.
         logger.warning("coordination.teardown_for_namespace failed for %s: %s", room_name, exc)
 
-    # 3. Mark any still-existing child rooms as failed before delete so any
-    #    concurrent reader sees a consistent state. Participant rows cascade
-    #    away via coordination_sessions.id (CASCADE) when the parent room is
-    #    deleted in step 4.
-    if child_room_names:
-        await session.execute(
-            update(Room).where(Room.name.in_(child_room_names)).values(coordination_state="failed")
-        )
-        await session.execute(delete(Room).where(Room.name.in_(child_room_names)))
-
-    # 5. Delete the parent room row.
     await session.delete(room)
     await session.commit()
 
-    # 6. Remove filesystem directory for the parent (children share the parent
-    #    namespace's filesystem layout — no separate per-session directory).
     remove_room_dir(room_name)
     logger.info(
-        "Removed room %s and %d child session room(s)",
+        "Removed room %s and %d child coordination session(s)",
         room_name,
-        len(child_room_names),
+        len(coord_sessions),
     )
 
-    # 7. Delete MAS from CFN mgmt plane (non-fatal, last).
     await _sync_delete_mas(room)
 
 

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.database import get_async_session
-from app.models import Room, Session
+from app.models import Room
 from app.schemas import RoomCreate, RoomRead
 from app.services import coordination
 from app.services.filesystem import ensure_room_structure, get_room_dir, remove_room_dir
@@ -366,14 +366,10 @@ async def delete_room(
         # Teardown is best-effort cleanup; log but don't block the delete.
         logger.warning("coordination.teardown_for_namespace failed for %s: %s", room_name, exc)
 
-    # 3. Delete child Session rows for every child room (and the parent, in
-    #    case anyone joined it directly), then the child Room rows.
-    if child_room_names:
-        await session.execute(delete(Session).where(Session.room_name.in_(child_room_names)))
-    await session.execute(delete(Session).where(Session.room_name == room_name))
-
-    # 4. Defensive: mark any still-existing child rooms as failed before delete
-    #    so any concurrent reader sees a consistent state.
+    # 3. Mark any still-existing child rooms as failed before delete so any
+    #    concurrent reader sees a consistent state. Participant rows cascade
+    #    away via coordination_sessions.id (CASCADE) when the parent room is
+    #    deleted in step 4.
     if child_room_names:
         await session.execute(
             update(Room).where(Room.name.in_(child_room_names)).values(coordination_state="failed")

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -26,13 +26,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.bus import notify, room_channel
 from app.config import settings
 from app.database import get_async_session
-from app.models import CoordinationSession, Room, Session
+from app.models import CoordinationSession, Participant, Room
 from app.routes.rooms import _sync_create_mas
 from app.schemas import (
     CoordinationSessionRead,
-    SessionCreate,
-    SessionListResponse,
-    SessionRead,
+    ParticipantCreate,
+    ParticipantListResponse,
+    ParticipantRead,
 )
 
 logger = logging.getLogger(__name__)
@@ -69,22 +69,60 @@ async def _upsert_room(room_name: str, session: AsyncSession) -> Room:
     return room
 
 
-async def _spawn_session_room(parent_name: str, db: AsyncSession) -> Room:
-    """Create an ephemeral sync session room within a namespace.
+def _coord_short_id_from_display(name: str) -> str | None:
+    """Extract the short_id from a session-shadow display name."""
+    if ":session:" not in name:
+        return None
+    return name.split(":session:", 1)[1]
+
+
+async def _resolve_coord_session(target_room: Room, db: AsyncSession) -> CoordinationSession | None:
+    """Find the CoordinationSession for an existing session-shadow Room row."""
+    if target_room.is_namespace or not target_room.parent_namespace:
+        return None
+    short_id = _coord_short_id_from_display(target_room.name)
+    if not short_id:
+        return None
+    result = await db.execute(
+        select(CoordinationSession).where(
+            CoordinationSession.parent_room_name == target_room.parent_namespace,
+            CoordinationSession.short_id == short_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _spawn_session_room(
+    parent_name: str, db: AsyncSession
+) -> tuple[Room, CoordinationSession]:
+    """Create an ephemeral sync session room + CoordinationSession entity.
 
     If there's already a pending session (idle/waiting) in this namespace,
     return it instead of creating a new one.
     """
-    # Check for existing pending session in this namespace
+    # Check for existing pending session-shadow in this namespace
     result = await db.execute(
         select(Room).where(
             Room.parent_namespace == parent_name,
             Room.coordination_state.in_(["idle", "waiting", "negotiating"]),
         )
     )
-    existing = result.scalar_one_or_none()
-    if existing:
-        return existing
+    existing_room = result.scalar_one_or_none()
+    if existing_room:
+        existing_coord = await _resolve_coord_session(existing_room, db)
+        if existing_coord:
+            return existing_room, existing_coord
+        # Pre-0011 data without a backfilled coord_session — repair on the fly.
+        repair = CoordinationSession(
+            parent_room_name=parent_name,
+            short_id=_coord_short_id_from_display(existing_room.name) or uuid4().hex[:8],
+            state=existing_room.coordination_state or "idle",
+            mas_id=existing_room.mas_id,
+            workspace_id=existing_room.workspace_id,
+        )
+        db.add(repair)
+        await db.flush()
+        return existing_room, repair
 
     # Create a new session room, inheriting workspace/mas from parent
     short_id = uuid4().hex[:8]
@@ -107,7 +145,7 @@ async def _spawn_session_room(parent_name: str, db: AsyncSession) -> Room:
 
     # Dual-write the first-class CoordinationSession entity (#197). The shadow
     # Room row above stays during the deprecation window so messages.room_name
-    # and memories.room_name FKs keep resolving.
+    # FKs keep resolving.
     coord_session = CoordinationSession(
         parent_room_name=parent_name,
         short_id=short_id,
@@ -120,7 +158,7 @@ async def _spawn_session_room(parent_name: str, db: AsyncSession) -> Room:
     await db.flush()
     await db.refresh(session_room)
     logger.info("Spawned session %s in namespace %s", session_name, parent_name)
-    return session_room
+    return session_room, coord_session
 
 
 @router.post("/spawn", response_model=dict, status_code=201)
@@ -136,7 +174,7 @@ async def spawn_session(
     if not room.is_namespace:
         raise HTTPException(status_code=400, detail="Can only spawn sessions in namespace rooms")
 
-    session_room = await _spawn_session_room(room_name, db)
+    session_room, _ = await _spawn_session_room(room_name, db)
     await db.commit()
 
     cfn_enabled = bool(settings.COGNITION_FABRIC_NODE_URL and room.mas_id and room.workspace_id)
@@ -152,22 +190,34 @@ async def spawn_session(
     return result
 
 
-@router.post("", response_model=SessionRead, status_code=201)
+@router.post("", response_model=ParticipantRead, status_code=201)
 async def join_room(
     room_name: str,
-    payload: SessionCreate,
+    payload: ParticipantCreate,
     db: AsyncSession = Depends(get_async_session),
 ):
     """Join a room. If the room is a namespace, auto-spawns a session and joins that."""
     room = await _upsert_room(room_name, db)
 
-    # If joining a namespace (async room), auto-spawn a session within it
+    # Resolve the coordination session this join attaches to.
     target_room = room
+    coord_session: CoordinationSession | None = None
     if room.is_namespace:
-        target_room = await _spawn_session_room(room_name, db)
+        target_room, coord_session = await _spawn_session_room(room_name, db)
+    else:
+        coord_session = await _resolve_coord_session(target_room, db)
 
-    sess = Session(
-        room_name=target_room.name,
+    if coord_session is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"No coordination session found for room {room_name!r}. "
+                "Either pass a namespace to auto-spawn, or a session-shadow display name."
+            ),
+        )
+
+    sess = Participant(
+        coordination_session_id=coord_session.id,
         agent_handle=payload.agent_handle,
         intent=payload.intent,
     )
@@ -351,24 +401,39 @@ async def list_coordination_sessions(
     return [CoordinationSessionRead.model_validate(s) for s in result.scalars().all()]
 
 
-@router.get("", response_model=SessionListResponse)
+@router.get("", response_model=ParticipantListResponse)
 async def list_sessions(
     room_name: str,
     db: AsyncSession = Depends(get_async_session),
 ):
-    """List agents currently in a room."""
-    result = await db.execute(select(Room).where(Room.name == room_name))
-    if not result.scalar_one_or_none():
+    """List agents participating in a room's coordination session."""
+    room = (await db.execute(select(Room).where(Room.name == room_name))).scalar_one_or_none()
+    if not room:
         raise HTTPException(status_code=404, detail="Room not found")
 
-    result = await db.execute(
-        select(Session).where(Session.room_name == room_name).order_by(Session.joined_at.desc())
-    )
-    sessions = list(result.scalars().all())
+    # Resolve which coord_session(s) this room corresponds to. For a namespace,
+    # gather all participants across all its coord_sessions; for a session
+    # shadow, just that one.
+    if room.is_namespace:
+        coord_q = select(CoordinationSession.id).where(
+            CoordinationSession.parent_room_name == room_name
+        )
+    else:
+        coord = await _resolve_coord_session(room, db)
+        if coord is None:
+            return ParticipantListResponse(participants=[], total=0)
+        coord_q = select(CoordinationSession.id).where(CoordinationSession.id == coord.id)
 
-    return SessionListResponse(
-        sessions=[SessionRead.model_validate(s) for s in sessions],
-        total=len(sessions),
+    result = await db.execute(
+        select(Participant)
+        .where(Participant.coordination_session_id.in_(coord_q))
+        .order_by(Participant.joined_at.desc())
+    )
+    participants = list(result.scalars().all())
+
+    return ParticipantListResponse(
+        participants=[ParticipantRead.model_validate(p) for p in participants],
+        total=len(participants),
     )
 
 
@@ -378,16 +443,11 @@ async def leave_room(
     session_id: UUID,
     db: AsyncSession = Depends(get_async_session),
 ):
-    """Remove an agent session (leave room)."""
-    result = await db.execute(
-        select(Session).where(
-            Session.id == session_id,
-            Session.room_name == room_name,
-        )
-    )
-    session = result.scalar_one_or_none()
-    if not session:
-        raise HTTPException(status_code=404, detail="Session not found")
+    """Remove a participant (agent leaves the session)."""
+    result = await db.execute(select(Participant).where(Participant.id == session_id))
+    participant = result.scalar_one_or_none()
+    if not participant:
+        raise HTTPException(status_code=404, detail="Participant not found")
 
-    await db.delete(session)
+    await db.delete(participant)
     await db.commit()

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -339,9 +339,7 @@ async def list_coordination_sessions(
     Returns first-class CoordinationSession entities. The shadow rows in the
     rooms table are an implementation detail that callers shouldn't depend on.
     """
-    parent = (
-        await db.execute(select(Room).where(Room.name == room_name))
-    ).scalar_one_or_none()
+    parent = (await db.execute(select(Room).where(Room.name == room_name))).scalar_one_or_none()
     if not parent:
         raise HTTPException(status_code=404, detail="Room not found")
 

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -49,7 +49,6 @@ async def _upsert_room(room_name: str, session: AsyncSession) -> Room:
             name=room_name,
             is_public=True,
             namespace=room_name,
-            is_namespace=True,
         )
         session.add(room)
         try:
@@ -69,96 +68,58 @@ async def _upsert_room(room_name: str, session: AsyncSession) -> Room:
     return room
 
 
-def _coord_short_id_from_display(name: str) -> str | None:
-    """Extract the short_id from a session-shadow display name."""
-    if ":session:" not in name:
+async def _resolve_coord_session_by_display(
+    display_name: str, db: AsyncSession
+) -> CoordinationSession | None:
+    """Resolve a ``{parent}:session:{short}`` string to its CoordinationSession."""
+    if ":session:" not in display_name:
         return None
-    return name.split(":session:", 1)[1]
-
-
-async def _resolve_coord_session(target_room: Room, db: AsyncSession) -> CoordinationSession | None:
-    """Find the CoordinationSession for an existing session-shadow Room row."""
-    if target_room.is_namespace or not target_room.parent_namespace:
-        return None
-    short_id = _coord_short_id_from_display(target_room.name)
-    if not short_id:
+    parent, _, short_id = display_name.partition(":session:")
+    if not parent or not short_id:
         return None
     result = await db.execute(
         select(CoordinationSession).where(
-            CoordinationSession.parent_room_name == target_room.parent_namespace,
+            CoordinationSession.parent_room_name == parent,
             CoordinationSession.short_id == short_id,
         )
     )
     return result.scalar_one_or_none()
 
 
-async def _spawn_session_room(
-    parent_name: str, db: AsyncSession
-) -> tuple[Room, CoordinationSession]:
-    """Create an ephemeral sync session room + CoordinationSession entity.
+async def _spawn_coordination_session(parent_name: str, db: AsyncSession) -> CoordinationSession:
+    """Create or return a pending CoordinationSession in a namespace.
 
-    If there's already a pending session (idle/waiting) in this namespace,
-    return it instead of creating a new one.
+    Sessions live exclusively in ``coordination_sessions`` — there is no
+    backing row in ``rooms``. Display names are synthesized from
+    ``parent_room_name + ":session:" + short_id`` so the SSE and messages
+    URLs that address sessions by name keep working.
     """
-    # Check for existing pending session-shadow in this namespace
     result = await db.execute(
-        select(Room).where(
-            Room.parent_namespace == parent_name,
-            Room.coordination_state.in_(["idle", "waiting", "negotiating"]),
+        select(CoordinationSession)
+        .where(
+            CoordinationSession.parent_room_name == parent_name,
+            CoordinationSession.state.in_(["idle", "waiting", "negotiating"]),
         )
+        .order_by(CoordinationSession.created_at.desc())
     )
-    existing_room = result.scalar_one_or_none()
-    if existing_room:
-        existing_coord = await _resolve_coord_session(existing_room, db)
-        if existing_coord:
-            return existing_room, existing_coord
-        # Pre-0011 data without a backfilled coord_session — repair on the fly.
-        repair = CoordinationSession(
-            parent_room_name=parent_name,
-            short_id=_coord_short_id_from_display(existing_room.name) or uuid4().hex[:8],
-            state=existing_room.coordination_state or "idle",
-            mas_id=existing_room.mas_id,
-            workspace_id=existing_room.workspace_id,
-        )
-        db.add(repair)
-        await db.flush()
-        return existing_room, repair
-
-    # Create a new session room, inheriting workspace/mas from parent
-    short_id = uuid4().hex[:8]
-    session_name = f"{parent_name}:session:{short_id}"
+    existing = result.scalar_one_or_none()
+    if existing:
+        return existing
 
     parent_result = await db.execute(select(Room).where(Room.name == parent_name))
     parent_room = parent_result.scalar_one_or_none()
 
-    session_room = Room(
-        name=session_name,
-        is_public=True,
-        mode="sync",
-        is_namespace=False,
-        parent_namespace=parent_name,
-        namespace=parent_name,
-        workspace_id=parent_room.workspace_id if parent_room else None,
-        mas_id=parent_room.mas_id if parent_room else None,
-    )
-    db.add(session_room)
-
-    # Dual-write the first-class CoordinationSession entity (#197). The shadow
-    # Room row above stays during the deprecation window so messages.room_name
-    # FKs keep resolving.
-    coord_session = CoordinationSession(
+    coord = CoordinationSession(
         parent_room_name=parent_name,
-        short_id=short_id,
+        short_id=uuid4().hex[:8],
         state="idle",
         mas_id=parent_room.mas_id if parent_room else None,
         workspace_id=parent_room.workspace_id if parent_room else None,
     )
-    db.add(coord_session)
-
+    db.add(coord)
     await db.flush()
-    await db.refresh(session_room)
-    logger.info("Spawned session %s in namespace %s", session_name, parent_name)
-    return session_room, coord_session
+    logger.info("Spawned coordination session %s in namespace %s", coord.id, parent_name)
+    return coord
 
 
 @router.post("/spawn", response_model=dict, status_code=201)
@@ -166,20 +127,19 @@ async def spawn_session(
     room_name: str,
     db: AsyncSession = Depends(get_async_session),
 ):
-    """Explicitly spawn a negotiation session within a namespace room."""
+    """Explicitly spawn a negotiation session within a room."""
     result = await db.execute(select(Room).where(Room.name == room_name))
     room = result.scalar_one_or_none()
     if not room:
         raise HTTPException(status_code=404, detail="Room not found")
-    if not room.is_namespace:
-        raise HTTPException(status_code=400, detail="Can only spawn sessions in namespace rooms")
 
-    session_room, _ = await _spawn_session_room(room_name, db)
+    coord = await _spawn_coordination_session(room_name, db)
     await db.commit()
 
     cfn_enabled = bool(settings.COGNITION_FABRIC_NODE_URL and room.mas_id and room.workspace_id)
-    result = {
-        "session_room": session_room.name,
+    return {
+        "session_room": coord.display_name,
+        "coordination_session_id": str(coord.id),
         "parent": room_name,
         "cfn": {
             "enabled": cfn_enabled,
@@ -187,7 +147,6 @@ async def spawn_session(
             "workspace_id": str(room.workspace_id) if room.workspace_id else None,
         },
     }
-    return result
 
 
 @router.post("", response_model=ParticipantRead, status_code=201)
@@ -196,25 +155,11 @@ async def join_room(
     payload: ParticipantCreate,
     db: AsyncSession = Depends(get_async_session),
 ):
-    """Join a room. If the room is a namespace, auto-spawns a session and joins that."""
+    """Join a room. Auto-spawns a coordination session if one doesn't exist."""
     room = await _upsert_room(room_name, db)
 
-    # Resolve the coordination session this join attaches to.
-    target_room = room
-    coord_session: CoordinationSession | None = None
-    if room.is_namespace:
-        target_room, coord_session = await _spawn_session_room(room_name, db)
-    else:
-        coord_session = await _resolve_coord_session(target_room, db)
-
-    if coord_session is None:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"No coordination session found for room {room_name!r}. "
-                "Either pass a namespace to auto-spawn, or a session-shadow display name."
-            ),
-        )
+    # Auto-spawn or fetch the active coordination session for this room.
+    coord_session = await _spawn_coordination_session(room_name, db)
 
     sess = Participant(
         coordination_session_id=coord_session.id,
@@ -228,17 +173,23 @@ async def join_room(
     # Register agent handle in CFN mgmt plane (non-fatal, fire-and-forget)
     asyncio.ensure_future(_register_agent_cfn(room, payload.agent_handle))
 
-    # Post coordination_join notification
-    asyncio.ensure_future(_notify_join(target_room.name, payload.agent_handle, payload.intent))
+    # Post coordination_join notification on the session display channel.
+    asyncio.ensure_future(
+        _notify_join(coord_session.display_name, payload.agent_handle, payload.intent)
+    )
 
-    # Start join timer for sync session rooms
-    if not target_room.is_namespace and target_room.coordination_state == "idle":
+    # Drive the join-window state machine on the CoordinationSession itself
+    # (was previously on the shadow Room.coordination_state / join_deadline).
+    if coord_session.state == "idle":
         deadline = datetime.now(UTC) + timedelta(seconds=settings.COORDINATION_JOIN_WINDOW_SECONDS)
         result = await db.execute(
-            update(Room)
-            .where(Room.name == target_room.name, Room.coordination_state == "idle")
-            .values(coordination_state="waiting", join_deadline=deadline)
-            .returning(Room.id)
+            update(CoordinationSession)
+            .where(
+                CoordinationSession.id == coord_session.id,
+                CoordinationSession.state == "idle",
+            )
+            .values(state="waiting", join_window_ends_at=deadline)
+            .returning(CoordinationSession.id)
         )
         claimed = result.scalar_one_or_none()
         await db.commit()
@@ -246,29 +197,19 @@ async def join_room(
         if claimed is not None:
             from app.services import coordination
 
-            coordination.schedule_join_timer(target_room.name, deadline)
+            coordination.schedule_join_timer(coord_session.display_name, deadline)
             logger.info(
                 "Coordination join timer started for session %s (deadline=%s)",
-                target_room.name,
+                coord_session.display_name,
                 deadline,
             )
     elif (
-        not target_room.is_namespace
-        and target_room.coordination_state == "waiting"
-        and settings.COORDINATION_JOIN_WINDOW_EXTENSION_SECONDS > 0
+        coord_session.state == "waiting" and settings.COORDINATION_JOIN_WINDOW_EXTENSION_SECONDS > 0
     ):
-        # Subsequent joiner: extend the window so slow agents get a chance to
-        # join too. Cap at COORDINATION_JOIN_WINDOW_MAX_SECONDS measured from
-        # the session's first-join time (current join_deadline minus the
-        # initial window) to bound the total wait. Same pattern as the
-        # round-watchdog extension fix — extend on activity, hard cap.
         from app.services import coordination
 
         now = datetime.now(UTC)
-        current_deadline = target_room.join_deadline
-        # SQLite returns offset-naive datetimes from DateTime columns; coerce
-        # to UTC-aware before any arithmetic so we don't trip
-        # "can't compare offset-naive and offset-aware datetimes" in tests.
+        current_deadline = coord_session.join_window_ends_at
         if current_deadline is not None and current_deadline.tzinfo is None:
             current_deadline = current_deadline.replace(tzinfo=UTC)
         first_join_at = (
@@ -281,18 +222,20 @@ async def join_room(
         )
         proposed = now + timedelta(seconds=settings.COORDINATION_JOIN_WINDOW_EXTENSION_SECONDS)
         new_deadline = min(proposed, max_deadline)
-        # Only push forward — never shorten an already-longer deadline.
         if current_deadline is None or new_deadline > current_deadline:
             await db.execute(
-                update(Room)
-                .where(Room.name == target_room.name, Room.coordination_state == "waiting")
-                .values(join_deadline=new_deadline)
+                update(CoordinationSession)
+                .where(
+                    CoordinationSession.id == coord_session.id,
+                    CoordinationSession.state == "waiting",
+                )
+                .values(join_window_ends_at=new_deadline)
             )
             await db.commit()
-            coordination.schedule_join_timer(target_room.name, new_deadline)
+            coordination.schedule_join_timer(coord_session.display_name, new_deadline)
             logger.info(
                 "Coordination join window extended for %s on join by %s (deadline=%s, capped=%s)",
-                target_room.name,
+                coord_session.display_name,
                 payload.agent_handle,
                 new_deadline,
                 new_deadline >= max_deadline,
@@ -384,10 +327,9 @@ async def list_coordination_sessions(
     room_name: str,
     db: AsyncSession = Depends(get_async_session),
 ):
-    """List negotiation sessions in a room (#197).
+    """List negotiation sessions in a room.
 
-    Returns first-class CoordinationSession entities. The shadow rows in the
-    rooms table are an implementation detail that callers shouldn't depend on.
+    Returns first-class CoordinationSession entities scoped to ``room_name``.
     """
     parent = (await db.execute(select(Room).where(Room.name == room_name))).scalar_one_or_none()
     if not parent:
@@ -406,23 +348,22 @@ async def list_sessions(
     room_name: str,
     db: AsyncSession = Depends(get_async_session),
 ):
-    """List agents participating in a room's coordination session."""
-    room = (await db.execute(select(Room).where(Room.name == room_name))).scalar_one_or_none()
-    if not room:
-        raise HTTPException(status_code=404, detail="Room not found")
+    """List agents participating in a room's coordination session(s).
 
-    # Resolve which coord_session(s) this room corresponds to. For a namespace,
-    # gather all participants across all its coord_sessions; for a session
-    # shadow, just that one.
-    if room.is_namespace:
+    Accepts either a real room name (returns participants across all its
+    coord_sessions) or a legacy ``{parent}:session:{short}`` display name
+    (returns participants of just that one session).
+    """
+    coord = await _resolve_coord_session_by_display(room_name, db)
+    if coord is not None:
+        coord_q = select(CoordinationSession.id).where(CoordinationSession.id == coord.id)
+    else:
+        room = (await db.execute(select(Room).where(Room.name == room_name))).scalar_one_or_none()
+        if not room:
+            raise HTTPException(status_code=404, detail="Room or session not found")
         coord_q = select(CoordinationSession.id).where(
             CoordinationSession.parent_room_name == room_name
         )
-    else:
-        coord = await _resolve_coord_session(room, db)
-        if coord is None:
-            return ParticipantListResponse(participants=[], total=0)
-        coord_q = select(CoordinationSession.id).where(CoordinationSession.id == coord.id)
 
     result = await db.execute(
         select(Participant)

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -26,9 +26,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.bus import notify, room_channel
 from app.config import settings
 from app.database import get_async_session
-from app.models import Room, Session
+from app.models import CoordinationSession, Room, Session
 from app.routes.rooms import _sync_create_mas
-from app.schemas import SessionCreate, SessionListResponse, SessionRead
+from app.schemas import (
+    CoordinationSessionRead,
+    SessionCreate,
+    SessionListResponse,
+    SessionRead,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +104,19 @@ async def _spawn_session_room(parent_name: str, db: AsyncSession) -> Room:
         mas_id=parent_room.mas_id if parent_room else None,
     )
     db.add(session_room)
+
+    # Dual-write the first-class CoordinationSession entity (#197). The shadow
+    # Room row above stays during the deprecation window so messages.room_name
+    # and memories.room_name FKs keep resolving.
+    coord_session = CoordinationSession(
+        parent_room_name=parent_name,
+        short_id=short_id,
+        state="idle",
+        mas_id=parent_room.mas_id if parent_room else None,
+        workspace_id=parent_room.workspace_id if parent_room else None,
+    )
+    db.add(coord_session)
+
     await db.flush()
     await db.refresh(session_room)
     logger.info("Spawned session %s in namespace %s", session_name, parent_name)
@@ -309,6 +327,30 @@ async def _notify_join(room_name: str, handle: str, intent: str | None) -> None:
             await conn.close()
     except Exception as e:
         logger.warning("NOTIFY coordination_join failed: %s", e)
+
+
+@router.get("/coordination", response_model=list[CoordinationSessionRead])
+async def list_coordination_sessions(
+    room_name: str,
+    db: AsyncSession = Depends(get_async_session),
+):
+    """List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+    """
+    parent = (
+        await db.execute(select(Room).where(Room.name == room_name))
+    ).scalar_one_or_none()
+    if not parent:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    result = await db.execute(
+        select(CoordinationSession)
+        .where(CoordinationSession.parent_room_name == room_name)
+        .order_by(CoordinationSession.created_at.desc())
+    )
+    return [CoordinationSessionRead.model_validate(s) for s in result.scalars().all()]
 
 
 @router.get("", response_model=SessionListResponse)

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -29,13 +29,9 @@ class RoomRead(BaseModel):
     is_public: bool
     created_at: datetime
     coordination_state: str = "idle"
-    join_deadline: datetime | None = None
-    mode: str = "sync"
     trigger_config: dict | None = None
     last_synthesis_at: datetime | None = None
     is_persistent: bool = False
-    is_namespace: bool = False
-    parent_namespace: str | None = None
     mas_id: str | None = None
     workspace_id: str | None = None
 
@@ -72,7 +68,9 @@ class MessageCreate(BaseModel):
 
 class MessageRead(BaseModel):
     id: UUID
-    room_name: str
+    # Polymorphic: exactly one of room_name / coordination_session_id is set.
+    room_name: str | None = None
+    coordination_session_id: UUID | None = None
     sender_handle: str
     recipient_handle: str | None = None
     message_type: str
@@ -111,7 +109,7 @@ class ParticipantListResponse(BaseModel):
     total: int
 
 
-# ── CoordinationSession (#197) ────────────────────────────────────────────────
+# ── CoordinationSession ──────────────────────────────────────────────────────
 
 
 class CoordinationSessionRead(BaseModel):

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -111,6 +111,23 @@ class SessionListResponse(BaseModel):
     total: int
 
 
+# ── CoordinationSession (#197) ────────────────────────────────────────────────
+
+
+class CoordinationSessionRead(BaseModel):
+    id: UUID
+    parent_room_name: str
+    short_id: str
+    state: str
+    created_at: datetime
+    join_window_ends_at: datetime | None = None
+    mas_id: str | None = None
+    workspace_id: str | None = None
+    display_name: str
+
+    model_config = {"from_attributes": True}
+
+
 # ── AuditEvent ────────────────────────────────────────────────────────────────
 
 VALID_RESOURCE_TYPES = {

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -87,17 +87,17 @@ class MessageListResponse(BaseModel):
     total: int
 
 
-# ── Session ───────────────────────────────────────────────────────────────────
+# ── Participant (agent in a coordination session) ────────────────────────────
 
 
-class SessionCreate(BaseModel):
+class ParticipantCreate(BaseModel):
     agent_handle: str = Field(..., description="Agent handle joining the room")
     intent: str | None = Field(None, description="Agent's requirements/intent for coordination")
 
 
-class SessionRead(BaseModel):
+class ParticipantRead(BaseModel):
     id: UUID
-    room_name: str
+    coordination_session_id: UUID
     agent_handle: str
     intent: str | None = None
     joined_at: datetime
@@ -106,8 +106,8 @@ class SessionRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class SessionListResponse(BaseModel):
-    sessions: list[SessionRead]
+class ParticipantListResponse(BaseModel):
+    participants: list[ParticipantRead]
     total: int
 
 

--- a/fastapi-backend/app/services/async_coordination.py
+++ b/fastapi-backend/app/services/async_coordination.py
@@ -33,7 +33,7 @@ async def check_trigger(room_name: str) -> None:
     async with async_session_maker() as db:
         result = await db.execute(select(Room).where(Room.name == room_name))
         room = result.scalar_one_or_none()
-        if not room or not room.is_namespace:
+        if not room:
             return
 
         config = room.trigger_config

--- a/fastapi-backend/app/services/cfn_resolve.py
+++ b/fastapi-backend/app/services/cfn_resolve.py
@@ -17,7 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
-from app.models import Room
+from app.models import CoordinationSession, Room
 
 logger = logging.getLogger(__name__)
 
@@ -41,40 +41,55 @@ async def resolve_mas_id(
     room_name: str | None,
     db: AsyncSession,
 ) -> str:
-    """Resolve mas_id via: client value > room DB lookup > settings > 400.
+    """Resolve mas_id via: client value > DB lookup > settings > 400.
 
-    When room_name is provided, looks up the Room row and reads its mas_id.
-    If the room is a session sub-room (has parent_namespace), walks up to
-    the parent namespace which owns the MAS.
+    ``room_name`` may be either a real room name or a legacy session display
+    name (``{parent}:session:{short}``). For sessions, the mas_id lives on
+    the CoordinationSession row, which inherits it from the parent room at
+    spawn time. For real rooms, it lives on the Room row.
     """
     if client_value:
         return client_value
 
     if room_name:
+        # Try resolving as a session display name first.
+        if ":session:" in room_name:
+            parent, _, short_id = room_name.partition(":session:")
+            if parent and short_id:
+                coord_result = await db.execute(
+                    select(CoordinationSession).where(
+                        CoordinationSession.parent_room_name == parent,
+                        CoordinationSession.short_id == short_id,
+                    )
+                )
+                coord = coord_result.scalar_one_or_none()
+                if coord:
+                    if coord.mas_id:
+                        return coord.mas_id
+                    # Coord session missing mas_id — fall back to parent room.
+                    parent_result = await db.execute(select(Room).where(Room.name == parent))
+                    parent_room = parent_result.scalar_one_or_none()
+                    if parent_room and parent_room.mas_id:
+                        return parent_room.mas_id
+
         result = await db.execute(select(Room).where(Room.name == room_name))
         room = result.scalar_one_or_none()
         if room is None:
+            # Maybe it was a session display we couldn't resolve above.
             raise HTTPException(
                 status_code=400,
                 detail=f"room_name '{room_name}' not found — cannot resolve mas_id.",
             )
         if room.mas_id:
             return room.mas_id
-        # Session sub-rooms inherit mas_id from their parent namespace
-        if room.parent_namespace:
-            parent_result = await db.execute(select(Room).where(Room.name == room.parent_namespace))
-            parent = parent_result.scalar_one_or_none()
-            if parent and parent.mas_id:
-                return parent.mas_id
-        logger.warning("room '%s' exists but has no mas_id (and no parent with one)", room_name)
+        logger.warning("room '%s' exists but has no mas_id", room_name)
         if not settings.MAS_ID:
             raise HTTPException(
                 status_code=400,
                 detail=(
-                    f"Room '{room_name}' exists but has no mas_id configured "
-                    f"(and no parent namespace with one). Either create the room "
-                    f"via `mycelium room create` (which provisions a MAS), or set "
-                    f"MAS_ID in your backend .env as a fallback."
+                    f"Room '{room_name}' exists but has no mas_id configured. "
+                    f"Either create the room via `mycelium room create` (which "
+                    f"provisions a MAS), or set MAS_ID in your backend .env."
                 ),
             )
 

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -383,34 +383,34 @@ async def _run_tick(room_name: str, tick: int) -> None:
         session_handles = [s.agent_handle for s in sessions]
         intents = [s.intent or "" for s in sessions]
 
-        # Load room — mas_id lives on the namespace room, not the session room
-        room_result = await db.execute(select(Room).where(Room.name == room_name))
-        room = room_result.scalar_one_or_none()
-        if room is not None and room.mas_id is None and room.parent_namespace:
-            ns_result = await db.execute(select(Room).where(Room.name == room.parent_namespace))
-            ns_room = ns_result.scalar_one_or_none()
-            if ns_room is not None and ns_room.mas_id:
-                room = ns_room
+        # mas_id / workspace_id live on the coord session (inherited from parent
+        # at spawn). Fall back to the parent room if for any reason the coord
+        # session row is missing them (legacy data).
+        mas_id = coord_session.mas_id
+        workspace_id = coord_session.workspace_id
+        if not mas_id or not workspace_id:
+            parent_room_result = await db.execute(
+                select(Room).where(Room.name == coord_session.parent_room_name)
+            )
+            parent_room = parent_room_result.scalar_one_or_none()
+            if parent_room is not None:
+                mas_id = mas_id or parent_room.mas_id
+                workspace_id = workspace_id or parent_room.workspace_id
 
         await db.execute(
-            update(Room).where(Room.name == room_name).values(coordination_state="negotiating")
+            update(CoordinationSession)
+            .where(CoordinationSession.id == coord_session.id)
+            .values(state="negotiating")
         )
         await db.commit()
 
     if tick != 0:
         return
 
-    use_cfn = bool(
-        settings.COGNITION_FABRIC_NODE_URL
-        and room is not None
-        and room.mas_id
-        and room.workspace_id
-    )
-
-    if not use_cfn or room is None or not room.mas_id or not room.workspace_id:
+    if not settings.COGNITION_FABRIC_NODE_URL or mas_id is None or workspace_id is None:
         logger.error(
             "Coordination requested for %s but CFN not configured (no COGNITION_FABRIC_NODE_URL "
-            "or room.mas_id/workspace_id not set)",
+            "or coord_session mas_id/workspace_id not set)",
             room_name,
         )
         await _post_message(
@@ -422,16 +422,29 @@ async def _run_tick(room_name: str, tick: int) -> None:
         )
         async with async_session_maker() as db:
             await db.execute(
-                update(Room).where(Room.name == room_name).values(coordination_state="failed")
+                update(CoordinationSession)
+                .where(CoordinationSession.id == coord_session.id)
+                .values(state="failed")
             )
             await db.commit()
         return
 
+    # Build a lightweight namespace-resolver shim; the rest of the negotiation
+    # path only reads ``room.workspace_id`` / ``room.mas_id`` / ``room.name``,
+    # so a SimpleNamespace is sufficient and avoids re-loading the Room.
+    from types import SimpleNamespace
+
+    room_for_negotiation = SimpleNamespace(
+        name=coord_session.parent_room_name,
+        mas_id=mas_id,
+        workspace_id=workspace_id,
+    )
+
     await _run_cfn_negotiation(
         room_name,
-        room,
-        room.workspace_id,
-        room.mas_id,
+        room_for_negotiation,  # ty: ignore[invalid-argument-type]
+        workspace_id,
+        mas_id,
         session_handles,
         intents,
     )
@@ -1127,15 +1140,18 @@ async def _finish_cfn(room_name: str, plan: str, assignments: dict, broken: bool
             exc,
         )
     async with async_session_maker() as db:
-        await db.execute(
-            update(Room)
-            .where(Room.name == room_name)
-            .values(coordination_state="complete" if not broken else "failed")
-        )
-        # Clean up Participant rows so a subsequent session in the same
-        # namespace doesn't see stale participants and cause CFN to fail.
         if ":session:" in room_name:
             parent, _, short_id = room_name.partition(":session:")
+            await db.execute(
+                update(CoordinationSession)
+                .where(
+                    CoordinationSession.parent_room_name == parent,
+                    CoordinationSession.short_id == short_id,
+                )
+                .values(state="complete" if not broken else "failed")
+            )
+            # Clean up Participant rows so a subsequent session in the same
+            # namespace doesn't see stale participants and cause CFN to fail.
             await db.execute(
                 delete(Participant).where(
                     Participant.coordination_session_id.in_(

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -35,7 +35,7 @@ from sqlalchemy import delete, select, update
 from app.bus import agent_channel, notify, room_channel
 from app.config import settings
 from app.database import async_session_maker
-from app.models import Message, Room, Session
+from app.models import CoordinationSession, Message, Participant, Room
 from app.services.metrics import (
     record_consensus,
     record_coordination_round,
@@ -351,13 +351,33 @@ def schedule_join_timer(room_name: str, deadline: datetime) -> asyncio.Task:
 async def _run_tick(room_name: str, tick: int) -> None:
     """Tick 0: launch CFN negotiation. Errors if CFN not configured on the room."""
     async with async_session_maker() as db:
+        # room_name here is the session-shadow display name like "{parent}:session:{short}".
+        # Look up the corresponding CoordinationSession to find its participants.
+        if ":session:" in room_name:
+            parent, _, short_id = room_name.partition(":session:")
+            coord_result = await db.execute(
+                select(CoordinationSession).where(
+                    CoordinationSession.parent_room_name == parent,
+                    CoordinationSession.short_id == short_id,
+                )
+            )
+            coord_session = coord_result.scalar_one_or_none()
+        else:
+            coord_session = None
+
+        if coord_session is None:
+            logger.warning("No coordination session for room %s at tick %d", room_name, tick)
+            return
+
         result = await db.execute(
-            select(Session).where(Session.room_name == room_name).order_by(Session.joined_at)
+            select(Participant)
+            .where(Participant.coordination_session_id == coord_session.id)
+            .order_by(Participant.joined_at)
         )
         sessions = list(result.scalars().all())
 
         if not sessions:
-            logger.warning("No sessions found for room %s at tick %d", room_name, tick)
+            logger.warning("No participants for room %s at tick %d", room_name, tick)
             return
 
         session_handles = [s.agent_handle for s in sessions]
@@ -1112,9 +1132,20 @@ async def _finish_cfn(room_name: str, plan: str, assignments: dict, broken: bool
             .where(Room.name == room_name)
             .values(coordination_state="complete" if not broken else "failed")
         )
-        # Clean up agent Session rows so a subsequent session in the same
+        # Clean up Participant rows so a subsequent session in the same
         # namespace doesn't see stale participants and cause CFN to fail.
-        await db.execute(delete(Session).where(Session.room_name == room_name))
+        if ":session:" in room_name:
+            parent, _, short_id = room_name.partition(":session:")
+            await db.execute(
+                delete(Participant).where(
+                    Participant.coordination_session_id.in_(
+                        select(CoordinationSession.id).where(
+                            CoordinationSession.parent_room_name == parent,
+                            CoordinationSession.short_id == short_id,
+                        )
+                    )
+                )
+            )
         await db.commit()
 
 
@@ -1366,10 +1397,21 @@ async def _post_message(room_name: str, message_type: str, content: str) -> None
             pass
     elif message_type == "coordination_consensus":
         async with async_session_maker() as db:
-            result = await db.execute(
-                select(Session.agent_handle).where(Session.room_name == room_name)
-            )
-            agent_handles = list(result.scalars().all())
+            if ":session:" in room_name:
+                parent, _, short_id = room_name.partition(":session:")
+                result = await db.execute(
+                    select(Participant.agent_handle).where(
+                        Participant.coordination_session_id.in_(
+                            select(CoordinationSession.id).where(
+                                CoordinationSession.parent_room_name == parent,
+                                CoordinationSession.short_id == short_id,
+                            )
+                        )
+                    )
+                )
+                agent_handles = list(result.scalars().all())
+            else:
+                agent_handles = []
 
     try:
         parsed_url = urlparse(settings.DATABASE_URL)

--- a/fastapi-backend/tests/conftest.py
+++ b/fastapi-backend/tests/conftest.py
@@ -11,6 +11,7 @@ Sets MYCELIUM_DATA_DIR to a temp directory for filesystem tests.
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.database import get_async_session
@@ -30,6 +31,16 @@ def _set_data_dir(tmp_path, monkeypatch):
 async def db_session():
     """Ephemeral in-memory SQLite session, schema created fresh per test."""
     engine = create_async_engine(TEST_DATABASE_URL, connect_args={"check_same_thread": False})
+
+    # SQLite enforces FK constraints only when PRAGMA foreign_keys=ON. Without
+    # this the cascade-on-delete chain (room → coord_sessions → participants &
+    # messages) wouldn't fire in tests, hiding regressions.
+    @event.listens_for(engine.sync_engine, "connect")
+    def _enable_sqlite_fk(dbapi_conn, _conn_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 

--- a/fastapi-backend/tests/test_cascade_delete.py
+++ b/fastapi-backend/tests/test_cascade_delete.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""Cascade-delete invariants for the room → coord-session → participant chain.
+
+The chain is:
+    rooms.name → coordination_sessions.parent_room_name (CASCADE)
+              → participants.coordination_session_id    (CASCADE)
+              → messages.coordination_session_id        (CASCADE)
+              → messages.room_name                      (CASCADE)
+
+Deleting a room must take everything below it.
+"""
+
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import CoordinationSession, Message, Participant, Room
+
+
+async def _counts(db: AsyncSession) -> dict:
+    return {
+        "rooms": (await db.execute(select(func.count()).select_from(Room))).scalar(),
+        "coord": (await db.execute(select(func.count()).select_from(CoordinationSession))).scalar(),
+        "participants": (await db.execute(select(func.count()).select_from(Participant))).scalar(),
+        "messages": (await db.execute(select(func.count()).select_from(Message))).scalar(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_room_cascades_to_coord_sessions_participants_messages(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Deleting a parent room cascades through the entire chain."""
+    await client.post("/api/rooms", json={"name": "parent"})
+    await client.post(
+        "/api/rooms/parent/sessions",
+        json={"agent_handle": "alice", "intent": "x"},
+    )
+    await client.post(
+        "/api/rooms/parent/sessions",
+        json={"agent_handle": "bob", "intent": "y"},
+    )
+    coord = (await client.get("/api/rooms/parent/sessions/coordination")).json()[0]
+    sid = coord["id"]
+    display = coord["display_name"]
+
+    # Two flavors of session-bound message: one via the new endpoint, one via
+    # the legacy display-name URL. The polymorphic FK should pick them both up.
+    await client.post(
+        f"/api/coordination-sessions/{sid}/messages",
+        json={"sender_handle": "alice", "message_type": "direct", "content": "hi"},
+    )
+    await client.post(
+        f"/api/rooms/{display}/messages",
+        json={"sender_handle": "bob", "message_type": "direct", "content": "lo"},
+    )
+
+    before = await _counts(db_session)
+    assert before["rooms"] == 1
+    assert before["coord"] == 1
+    assert before["participants"] == 2
+    assert before["messages"] == 2
+
+    resp = await client.delete("/api/rooms/parent")
+    assert resp.status_code == 204
+
+    await db_session.commit()  # ensure we see the cascade
+    after = await _counts(db_session)
+    assert after == {"rooms": 0, "coord": 0, "participants": 0, "messages": 0}
+
+
+@pytest.mark.asyncio
+async def test_delete_room_does_not_cascade_to_unrelated_rooms(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """A delete on one room must not touch sibling rooms or their sessions."""
+    await client.post("/api/rooms", json={"name": "a"})
+    await client.post("/api/rooms", json={"name": "b"})
+    await client.post(
+        "/api/rooms/a/sessions",
+        json={"agent_handle": "alice", "intent": "x"},
+    )
+    await client.post(
+        "/api/rooms/b/sessions",
+        json={"agent_handle": "bob", "intent": "y"},
+    )
+
+    resp = await client.delete("/api/rooms/a")
+    assert resp.status_code == 204
+
+    after = await _counts(db_session)
+    # b plus its coord_session and participant must remain.
+    assert after == {"rooms": 1, "coord": 1, "participants": 1, "messages": 0}
+
+
+@pytest.mark.asyncio
+async def test_delete_coord_session_cascades_to_participants_and_messages(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Deleting a CoordinationSession alone reaps its participants + messages."""
+    await client.post("/api/rooms", json={"name": "p"})
+    await client.post(
+        "/api/rooms/p/sessions",
+        json={"agent_handle": "alice", "intent": "x"},
+    )
+    coord = (await client.get("/api/rooms/p/sessions/coordination")).json()[0]
+    sid = coord["id"]
+    await client.post(
+        f"/api/coordination-sessions/{sid}/messages",
+        json={"sender_handle": "alice", "message_type": "direct", "content": "hi"},
+    )
+
+    # Delete the coord session row directly via the DB.
+    coord_row = (
+        await db_session.execute(
+            select(CoordinationSession).where(CoordinationSession.id == UUID(coord["id"]))
+        )
+    ).scalar_one()
+    await db_session.delete(coord_row)
+    await db_session.commit()
+
+    after = await _counts(db_session)
+    # The room itself stays; its coord_session, participants, messages don't.
+    assert after == {"rooms": 1, "coord": 0, "participants": 0, "messages": 0}
+
+
+@pytest.mark.asyncio
+async def test_delete_room_keeps_namespace_messages_no_dangling_fks(
+    client: AsyncClient, db_session: AsyncSession
+):
+    """Namespace-level (non-session) messages are deleted with the parent room."""
+    await client.post("/api/rooms", json={"name": "ns"})
+    # Direct chat in the namespace room — uses room_name, not coord_session.
+    await client.post(
+        "/api/rooms/ns/messages",
+        json={"sender_handle": "alice", "message_type": "direct", "content": "lobby"},
+    )
+
+    before = await _counts(db_session)
+    assert before["messages"] == 1
+
+    await client.delete("/api/rooms/ns")
+    after = await _counts(db_session)
+    assert after == {"rooms": 0, "coord": 0, "participants": 0, "messages": 0}

--- a/fastapi-backend/tests/test_cfn_resolve.py
+++ b/fastapi-backend/tests/test_cfn_resolve.py
@@ -113,30 +113,32 @@ async def test_resolve_mas_id_from_room_lookup(
     assert resp.status_code == 200
 
 
-async def test_resolve_mas_id_from_parent_namespace(
+async def test_resolve_mas_id_from_session_display_name(
     client: AsyncClient, db_session: AsyncSession, monkeypatch
 ):
-    """Session sub-rooms inherit mas_id from parent namespace."""
+    """Session display names resolve mas_id via the CoordinationSession row."""
+    from app.models import CoordinationSession
+
     monkeypatch.setattr("app.config.settings.WORKSPACE_ID", "settings-ws")
-    monkeypatch.setattr("app.config.settings.MAS_ID", "")  # no fallback
+    monkeypatch.setattr("app.config.settings.MAS_ID", "")
     monkeypatch.setattr("app.config.settings.MYCELIUM_INGEST_ENABLED", False)
 
     parent = Room(
         name="parent-ns",
         mas_id="parent-mas-id",
         workspace_id="parent-ws-id",
-        is_namespace=True,
     )
     db_session.add(parent)
     await db_session.flush()
 
-    child = Room(
-        name="parent-ns:session:abc",
-        mas_id=None,  # session doesn't have its own mas_id
+    coord = CoordinationSession(
+        parent_room_name="parent-ns",
+        short_id="abc",
+        state="idle",
+        mas_id="parent-mas-id",
         workspace_id="parent-ws-id",
-        parent_namespace="parent-ns",
     )
-    db_session.add(child)
+    db_session.add(coord)
     await db_session.commit()
 
     resp = await client.post(

--- a/fastapi-backend/tests/test_coordination.py
+++ b/fastapi-backend/tests/test_coordination.py
@@ -60,7 +60,6 @@ def _make_room(room_name: str = "test-room", mas_id: str = "mas-1", workspace_id
     room.name = room_name
     room.mas_id = mas_id
     room.workspace_id = workspace_id
-    room.parent_namespace = None
     return room
 
 

--- a/fastapi-backend/tests/test_coordination_sessions.py
+++ b/fastapi-backend/tests/test_coordination_sessions.py
@@ -1,48 +1,51 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Julia Valenti
 
-"""Tests for the first-class CoordinationSession entity (#197)."""
+"""Tests for the first-class CoordinationSession entity."""
 
 import pytest
 
 
 @pytest.mark.asyncio
-async def test_spawn_creates_coordination_session_row(client):
-    """Spawning a session writes a CoordinationSession alongside the shadow Room."""
+async def test_spawn_creates_coordination_session(client):
+    """Spawning a session creates a CoordinationSession (no shadow Room)."""
     await client.post("/api/rooms", json={"name": "p1"})
     spawn = await client.post("/api/rooms/p1/sessions/spawn")
     assert spawn.status_code == 201
-    session_room_name = spawn.json()["session_room"]
+    body = spawn.json()
+    assert body["parent"] == "p1"
+    assert "coordination_session_id" in body
+    display_name = body["session_room"]
 
-    # Shadow Room row still exists for FK compat with messages/memory.
-    shadow = await client.get(f"/api/rooms/{session_room_name}")
-    assert shadow.status_code == 200
-    assert shadow.json()["parent_namespace"] == "p1"
+    # No shadow Room row — display name is synthesized from the coord session.
+    shadow = await client.get(f"/api/rooms/{display_name}")
+    assert shadow.status_code == 404
 
-    # First-class entity exists at the new endpoint.
+    # First-class entity is reachable on both endpoints.
     coord = await client.get("/api/rooms/p1/sessions/coordination")
     assert coord.status_code == 200
     rows = coord.json()
     assert len(rows) == 1
     assert rows[0]["parent_room_name"] == "p1"
-    assert rows[0]["display_name"] == session_room_name
+    assert rows[0]["display_name"] == display_name
+    assert rows[0]["id"] == body["coordination_session_id"]
+
+    # Top-level resource also returns it.
+    top = await client.get("/api/coordination-sessions?parent_room=p1")
+    assert top.status_code == 200
+    assert top.json()[0]["id"] == body["coordination_session_id"]
 
 
 @pytest.mark.asyncio
-async def test_list_rooms_hides_session_shadows_by_default(client):
-    """GET /api/rooms excludes session-shadow rows unless asked."""
+async def test_list_rooms_only_shows_real_rooms(client):
+    """GET /api/rooms only returns real rooms — no session display names ever."""
     await client.post("/api/rooms", json={"name": "p2"})
     await client.post("/api/rooms/p2/sessions/spawn")
 
-    default = await client.get("/api/rooms")
-    names_default = {r["name"] for r in default.json()}
-    assert "p2" in names_default
-    assert not any(":session:" in n for n in names_default)
-
-    included = await client.get("/api/rooms?include_sessions=true")
-    names_included = {r["name"] for r in included.json()}
-    assert "p2" in names_included
-    assert any(":session:" in n for n in names_included)
+    resp = await client.get("/api/rooms")
+    names = {r["name"] for r in resp.json()}
+    assert "p2" in names
+    assert not any(":session:" in n for n in names)
 
 
 @pytest.mark.asyncio
@@ -51,7 +54,7 @@ async def test_idempotent_spawn_does_not_duplicate_coordination_session(client):
     await client.post("/api/rooms", json={"name": "p3"})
     a = await client.post("/api/rooms/p3/sessions/spawn")
     b = await client.post("/api/rooms/p3/sessions/spawn")
-    assert a.json()["session_room"] == b.json()["session_room"]
+    assert a.json()["coordination_session_id"] == b.json()["coordination_session_id"]
 
     coord = await client.get("/api/rooms/p3/sessions/coordination")
     assert len(coord.json()) == 1
@@ -61,3 +64,52 @@ async def test_idempotent_spawn_does_not_duplicate_coordination_session(client):
 async def test_coordination_endpoint_404_for_unknown_room(client):
     resp = await client.get("/api/rooms/nope/sessions/coordination")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_top_level_get_by_id(client):
+    await client.post("/api/rooms", json={"name": "p4"})
+    spawn = await client.post("/api/rooms/p4/sessions/spawn")
+    sid = spawn.json()["coordination_session_id"]
+
+    resp = await client.get(f"/api/coordination-sessions/{sid}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == sid
+    assert resp.json()["display_name"].startswith("p4:session:")
+
+
+@pytest.mark.asyncio
+async def test_top_level_state_filter(client):
+    await client.post("/api/rooms", json={"name": "p5"})
+    await client.post("/api/rooms/p5/sessions/spawn")
+
+    # Newly spawned, idle.
+    resp = await client.get("/api/coordination-sessions?state=idle")
+    assert any(r["parent_room_name"] == "p5" for r in resp.json())
+
+    resp = await client.get("/api/coordination-sessions?state=agreed,failed")
+    assert not any(r["parent_room_name"] == "p5" for r in resp.json())
+
+
+@pytest.mark.asyncio
+async def test_sessions_are_a_subset_of_a_room(client):
+    """Filtering by parent_room returns only that room's sessions.
+
+    This is the contract ``mycelium session ls --room <name>`` relies on:
+    sessions are scoped under a parent room and never bleed across rooms.
+    """
+    await client.post("/api/rooms", json={"name": "alpha"})
+    await client.post("/api/rooms", json={"name": "beta"})
+    await client.post("/api/rooms/alpha/sessions/spawn")
+    await client.post("/api/rooms/beta/sessions/spawn")
+
+    alpha_only = (await client.get("/api/coordination-sessions?parent_room=alpha")).json()
+    beta_only = (await client.get("/api/coordination-sessions?parent_room=beta")).json()
+
+    assert {s["parent_room_name"] for s in alpha_only} == {"alpha"}
+    assert {s["parent_room_name"] for s in beta_only} == {"beta"}
+    assert len(alpha_only) == 1
+    assert len(beta_only) == 1
+    # display_name preserves the parent → session relationship for legacy URLs.
+    assert alpha_only[0]["display_name"].startswith("alpha:session:")
+    assert beta_only[0]["display_name"].startswith("beta:session:")

--- a/fastapi-backend/tests/test_coordination_sessions.py
+++ b/fastapi-backend/tests/test_coordination_sessions.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""Tests for the first-class CoordinationSession entity (#197)."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_spawn_creates_coordination_session_row(client):
+    """Spawning a session writes a CoordinationSession alongside the shadow Room."""
+    await client.post("/api/rooms", json={"name": "p1"})
+    spawn = await client.post("/api/rooms/p1/sessions/spawn")
+    assert spawn.status_code == 201
+    session_room_name = spawn.json()["session_room"]
+
+    # Shadow Room row still exists for FK compat with messages/memory.
+    shadow = await client.get(f"/api/rooms/{session_room_name}")
+    assert shadow.status_code == 200
+    assert shadow.json()["parent_namespace"] == "p1"
+
+    # First-class entity exists at the new endpoint.
+    coord = await client.get("/api/rooms/p1/sessions/coordination")
+    assert coord.status_code == 200
+    rows = coord.json()
+    assert len(rows) == 1
+    assert rows[0]["parent_room_name"] == "p1"
+    assert rows[0]["display_name"] == session_room_name
+
+
+@pytest.mark.asyncio
+async def test_list_rooms_hides_session_shadows_by_default(client):
+    """GET /api/rooms excludes session-shadow rows unless asked."""
+    await client.post("/api/rooms", json={"name": "p2"})
+    await client.post("/api/rooms/p2/sessions/spawn")
+
+    default = await client.get("/api/rooms")
+    names_default = {r["name"] for r in default.json()}
+    assert "p2" in names_default
+    assert not any(":session:" in n for n in names_default)
+
+    included = await client.get("/api/rooms?include_sessions=true")
+    names_included = {r["name"] for r in included.json()}
+    assert "p2" in names_included
+    assert any(":session:" in n for n in names_included)
+
+
+@pytest.mark.asyncio
+async def test_idempotent_spawn_does_not_duplicate_coordination_session(client):
+    """Re-spawning an already-pending session reuses the existing entity."""
+    await client.post("/api/rooms", json={"name": "p3"})
+    a = await client.post("/api/rooms/p3/sessions/spawn")
+    b = await client.post("/api/rooms/p3/sessions/spawn")
+    assert a.json()["session_room"] == b.json()["session_room"]
+
+    coord = await client.get("/api/rooms/p3/sessions/coordination")
+    assert len(coord.json()) == 1
+
+
+@pytest.mark.asyncio
+async def test_coordination_endpoint_404_for_unknown_room(client):
+    resp = await client.get("/api/rooms/nope/sessions/coordination")
+    assert resp.status_code == 404

--- a/fastapi-backend/tests/test_integration.py
+++ b/fastapi-backend/tests/test_integration.py
@@ -443,7 +443,7 @@ async def test_sync_multiple_agents_join(integration_client: AsyncClient):
     resp = await client.get(f"/api/rooms/{session_room_name}/sessions")
     sessions = resp.json()
     assert sessions["total"] == 2
-    handles = {s["agent_handle"] for s in sessions["sessions"]}
+    handles = {p["agent_handle"] for p in sessions["participants"]}
     assert handles == {"alpha", "beta"}
 
     # Session room should still be waiting (timer hasn't fired)

--- a/fastapi-backend/tests/test_integration.py
+++ b/fastapi-backend/tests/test_integration.py
@@ -24,6 +24,15 @@ import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+
+async def _session_display_name(client: AsyncClient, namespace: str) -> str:
+    """Return the most recent CoordinationSession's display_name for a namespace."""
+    resp = await client.get(f"/api/rooms/{namespace}/sessions/coordination")
+    rows = resp.json()
+    assert rows, f"no coordination sessions in {namespace}"
+    return rows[0]["display_name"]
+
+
 # Skip entire module if no real DB configured
 INTEGRATION_DB_URL = os.environ.get("DATABASE_URL", "")
 pytestmark = pytest.mark.skipif(
@@ -342,7 +351,7 @@ async def test_sync_room_still_works(integration_client: AsyncClient):
         },
     )
     assert resp.status_code == 201
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-sync")
     assert "e2e-sync:session:" in session_room_name
 
     # The spawned session room should be in waiting state
@@ -395,7 +404,7 @@ async def test_sync_join_starts_timer(integration_client: AsyncClient):
         },
     )
     assert resp.status_code == 201
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-timer")
 
     resp = await client.get(f"/api/rooms/{session_room_name}")
     session_room = resp.json()
@@ -419,7 +428,7 @@ async def test_sync_multiple_agents_join(integration_client: AsyncClient):
         },
     )
     assert resp1.status_code == 201
-    session_room_name = resp1.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-multi")
 
     resp2 = await client.post(
         "/api/rooms/e2e-multi/sessions",
@@ -462,7 +471,7 @@ async def test_sync_negotiation_produces_messages(integration_client: AsyncClien
             "intent": "I want scope=full and quality=premium",
         },
     )
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-negot")
 
     await client.post(
         "/api/rooms/e2e-negot/sessions",
@@ -532,7 +541,7 @@ async def test_namespace_room_supports_memory_and_sessions(integration_client: A
         },
     )
     assert resp.status_code == 201
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-ns-both")
 
     # Session room should be in waiting state
     resp = await client.get(f"/api/rooms/{session_room_name}")
@@ -562,7 +571,7 @@ async def test_messages_route_during_negotiation(integration_client: AsyncClient
             "intent": "testing message routing",
         },
     )
-    session_room_name = resp.json()["room_name"]
+    session_room_name = await _session_display_name(client, "e2e-msg-route")
 
     # Manually set session room to negotiating state to test routing
     from sqlalchemy import update as sa_update

--- a/fastapi-backend/tests/test_memory.py
+++ b/fastapi-backend/tests/test_memory.py
@@ -19,9 +19,7 @@ async def test_create_room_defaults(client: AsyncClient):
     assert resp.status_code == 201
     data = resp.json()
     assert data["name"] == "test-default-room"
-    assert data["mode"] == "async"
     assert data["is_persistent"] is True
-    assert data["is_namespace"] is True
 
 
 @pytest.mark.asyncio
@@ -239,16 +237,14 @@ async def test_async_room_join_no_timer(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_synthesize_non_namespace_rejected(client: AsyncClient):
-    """Test that non-namespace rooms reject synthesis requests."""
-    # All user-created rooms are namespaces now, so we test via a session room
+async def test_synthesize_session_display_404(client: AsyncClient):
+    """Synthesis on a session display name 404s — sessions don't have rooms."""
     await client.post("/api/rooms", json={"name": "synth-ns"})
     resp = await client.post("/api/rooms/synth-ns/sessions/spawn")
-    assert resp.status_code == 201
     session_room = resp.json()["session_room"]
 
     resp = await client.post(f"/api/rooms/{session_room}/synthesize")
-    assert resp.status_code == 400
+    assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
@@ -263,8 +259,6 @@ async def test_room_with_trigger(client: AsyncClient):
     )
     assert resp.status_code == 201
     data = resp.json()
-    assert data["mode"] == "async"
-    assert data["is_namespace"] is True
     assert data["trigger_config"]["type"] == "threshold"
     assert data["trigger_config"]["min_contributions"] == 3
 

--- a/fastapi-backend/tests/test_session_spawn.py
+++ b/fastapi-backend/tests/test_session_spawn.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Julia Valenti
 
-"""Tests for session spawning within namespace rooms."""
+"""Tests for coordination session spawning."""
 
 from uuid import UUID
 
@@ -10,7 +10,7 @@ from httpx import AsyncClient
 from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import CoordinationSession, Room
+from app.models import CoordinationSession
 
 
 async def _coord_for_room(client: AsyncClient, namespace: str) -> dict:
@@ -22,38 +22,31 @@ async def _coord_for_room(client: AsyncClient, namespace: str) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_create_room_without_mode(client: AsyncClient):
-    """Creating a room without mode field works — defaults to async namespace."""
+async def test_create_room_defaults(client: AsyncClient):
+    """Creating a room defaults to a persistent namespace."""
     resp = await client.post("/api/rooms", json={"name": "no-mode-test"})
     assert resp.status_code == 201
-    data = resp.json()
-    assert data["mode"] == "async"
-    assert data["is_namespace"] is True
-    assert data["is_persistent"] is True
+    assert resp.json()["is_persistent"] is True
 
 
 @pytest.mark.asyncio
 async def test_join_namespace_auto_spawns_session(client: AsyncClient):
-    """Joining a namespace room should auto-spawn a sync session."""
-    resp = await client.post("/api/rooms", json={"name": "ns-test"})
-    assert resp.status_code == 201
-    assert resp.json()["is_namespace"] is True
+    """Joining a room auto-spawns a coordination session."""
+    await client.post("/api/rooms", json={"name": "ns-test"})
 
     resp = await client.post(
         "/api/rooms/ns-test/sessions",
         json={"agent_handle": "agent-a", "intent": "Let's negotiate"},
     )
     assert resp.status_code == 201
-    data = resp.json()
-    # Participant has a coordination_session_id — the entity it joined.
     coord = await _coord_for_room(client, "ns-test")
-    assert data["coordination_session_id"] == coord["id"]
+    assert resp.json()["coordination_session_id"] == coord["id"]
     assert coord["display_name"].startswith("ns-test:session:")
 
 
 @pytest.mark.asyncio
 async def test_multiple_agents_join_same_session(client: AsyncClient):
-    """Multiple agents joining the same namespace should land in the same session."""
+    """Multiple agents joining the same room land in the same coord session."""
     await client.post("/api/rooms", json={"name": "shared-ns"})
 
     resp1 = await client.post(
@@ -69,7 +62,7 @@ async def test_multiple_agents_join_same_session(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_explicit_spawn(client: AsyncClient):
-    """Explicitly spawning a session in a namespace."""
+    """Explicitly spawning a coordination session."""
     await client.post("/api/rooms", json={"name": "spawn-ns"})
 
     resp = await client.post("/api/rooms/spawn-ns/sessions/spawn")
@@ -77,23 +70,23 @@ async def test_explicit_spawn(client: AsyncClient):
     data = resp.json()
     assert data["parent"] == "spawn-ns"
     assert data["session_room"].startswith("spawn-ns:session:")
+    assert "coordination_session_id" in data
 
 
 @pytest.mark.asyncio
-async def test_spawn_on_non_namespace_fails(client: AsyncClient):
-    """Spawning a session on a non-namespace room should 400."""
+async def test_spawn_on_session_display_404(client: AsyncClient):
+    """Spawning under a session display name returns 404 (no real room)."""
     await client.post("/api/rooms", json={"name": "parent-ns"})
     resp = await client.post("/api/rooms/parent-ns/sessions/spawn")
     session_name = resp.json()["session_room"]
 
     resp = await client.post(f"/api/rooms/{session_name}/sessions/spawn")
-    assert resp.status_code == 400
-    assert "namespace" in resp.json()["detail"].lower()
+    assert resp.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_session_room_enters_waiting_on_join(client: AsyncClient):
-    """Joining a session room should transition it to waiting."""
+async def test_join_transitions_coord_session_to_waiting(client: AsyncClient):
+    """Joining transitions the coord session state machine to waiting."""
     await client.post("/api/rooms", json={"name": "wait-ns"})
 
     await client.post(
@@ -101,16 +94,13 @@ async def test_session_room_enters_waiting_on_join(client: AsyncClient):
         json={"agent_handle": "agent-a", "intent": "testing"},
     )
     coord = await _coord_for_room(client, "wait-ns")
-    session_name = coord["display_name"]
-
-    resp = await client.get(f"/api/rooms/{session_name}")
-    assert resp.json()["coordination_state"] == "waiting"
-    assert resp.json()["join_deadline"] is not None
+    assert coord["state"] == "waiting"
+    assert coord["join_window_ends_at"] is not None
 
 
 @pytest.mark.asyncio
-async def test_namespace_stays_idle_after_join(client: AsyncClient):
-    """The namespace room should remain idle when agents join."""
+async def test_namespace_room_stays_idle_after_join(client: AsyncClient):
+    """The room itself stays idle; only the coord session enters waiting."""
     await client.post("/api/rooms", json={"name": "idle-ns"})
 
     await client.post(
@@ -124,7 +114,7 @@ async def test_namespace_stays_idle_after_join(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_new_session_after_complete(client: AsyncClient, db_session: AsyncSession):
-    """Completing a session should allow spawning a new one in the same namespace."""
+    """Completing a session lets a fresh one spawn in the same namespace."""
     await client.post("/api/rooms", json={"name": "multi-session-ns"})
 
     resp1 = await client.post(
@@ -132,13 +122,7 @@ async def test_new_session_after_complete(client: AsyncClient, db_session: Async
         json={"agent_handle": "agent-a", "intent": "round 1"},
     )
     coord1_id = resp1.json()["coordination_session_id"]
-    coord1 = await _coord_for_room(client, "multi-session-ns")
-    session1 = coord1["display_name"]
 
-    # Mark first session as complete via DB shadow row + coord_session row.
-    await db_session.execute(
-        sa_update(Room).where(Room.name == session1).values(coordination_state="complete")
-    )
     await db_session.execute(
         sa_update(CoordinationSession)
         .where(CoordinationSession.id == UUID(coord1_id))
@@ -150,13 +134,12 @@ async def test_new_session_after_complete(client: AsyncClient, db_session: Async
         "/api/rooms/multi-session-ns/sessions",
         json={"agent_handle": "agent-b", "intent": "round 2"},
     )
-    coord2_id = resp2.json()["coordination_session_id"]
-    assert coord2_id != coord1_id
+    assert resp2.json()["coordination_session_id"] != coord1_id
 
 
 @pytest.mark.asyncio
-async def test_list_sessions_on_session_room(client: AsyncClient):
-    """Listing participants on a session-shadow room returns the joined agents."""
+async def test_list_participants_via_session_display_name(client: AsyncClient):
+    """List participants by session display name returns the joined agents."""
     await client.post("/api/rooms", json={"name": "list-ns"})
 
     await client.post(
@@ -179,8 +162,8 @@ async def test_list_sessions_on_session_room(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_session_room_is_not_namespace(client: AsyncClient):
-    """Session-shadow rooms should have is_namespace=False."""
+async def test_session_display_name_is_not_a_room(client: AsyncClient):
+    """Session display names have no backing Room row — only a CoordinationSession."""
     await client.post("/api/rooms", json={"name": "check-ns"})
 
     await client.post(
@@ -190,7 +173,6 @@ async def test_session_room_is_not_namespace(client: AsyncClient):
     coord = await _coord_for_room(client, "check-ns")
     session_name = coord["display_name"]
 
+    # /api/rooms/{display_name} 404s because shadow rows are gone.
     resp = await client.get(f"/api/rooms/{session_name}")
-    data = resp.json()
-    assert data["is_namespace"] is False
-    assert data["parent_namespace"] == "check-ns"
+    assert resp.status_code == 404

--- a/fastapi-backend/tests/test_session_spawn.py
+++ b/fastapi-backend/tests/test_session_spawn.py
@@ -3,12 +3,22 @@
 
 """Tests for session spawning within namespace rooms."""
 
+from uuid import UUID
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Room
+from app.models import CoordinationSession, Room
+
+
+async def _coord_for_room(client: AsyncClient, namespace: str) -> dict:
+    """Return the most recent CoordinationSession dict for a namespace room."""
+    resp = await client.get(f"/api/rooms/{namespace}/sessions/coordination")
+    rows = resp.json()
+    assert rows, f"no coordination sessions for {namespace}"
+    return rows[0]
 
 
 @pytest.mark.asyncio
@@ -25,20 +35,20 @@ async def test_create_room_without_mode(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_join_namespace_auto_spawns_session(client: AsyncClient):
     """Joining a namespace room should auto-spawn a sync session."""
-    # Create a room (always a namespace now)
     resp = await client.post("/api/rooms", json={"name": "ns-test"})
     assert resp.status_code == 201
     assert resp.json()["is_namespace"] is True
 
-    # Join it — should auto-spawn a session
     resp = await client.post(
         "/api/rooms/ns-test/sessions",
         json={"agent_handle": "agent-a", "intent": "Let's negotiate"},
     )
     assert resp.status_code == 201
     data = resp.json()
-    # Should be joined to a session room, not the namespace itself
-    assert data["room_name"].startswith("ns-test:session:")
+    # Participant has a coordination_session_id — the entity it joined.
+    coord = await _coord_for_room(client, "ns-test")
+    assert data["coordination_session_id"] == coord["id"]
+    assert coord["display_name"].startswith("ns-test:session:")
 
 
 @pytest.mark.asyncio
@@ -54,8 +64,7 @@ async def test_multiple_agents_join_same_session(client: AsyncClient):
         "/api/rooms/shared-ns/sessions",
         json={"agent_handle": "agent-2", "intent": "Second"},
     )
-
-    assert resp1.json()["room_name"] == resp2.json()["room_name"]
+    assert resp1.json()["coordination_session_id"] == resp2.json()["coordination_session_id"]
 
 
 @pytest.mark.asyncio
@@ -73,12 +82,10 @@ async def test_explicit_spawn(client: AsyncClient):
 @pytest.mark.asyncio
 async def test_spawn_on_non_namespace_fails(client: AsyncClient):
     """Spawning a session on a non-namespace room should 400."""
-    # Create a namespace, then spawn a session (which is non-namespace)
     await client.post("/api/rooms", json={"name": "parent-ns"})
     resp = await client.post("/api/rooms/parent-ns/sessions/spawn")
     session_name = resp.json()["session_room"]
 
-    # Try to spawn inside the session room — should fail
     resp = await client.post(f"/api/rooms/{session_name}/sessions/spawn")
     assert resp.status_code == 400
     assert "namespace" in resp.json()["detail"].lower()
@@ -89,13 +96,13 @@ async def test_session_room_enters_waiting_on_join(client: AsyncClient):
     """Joining a session room should transition it to waiting."""
     await client.post("/api/rooms", json={"name": "wait-ns"})
 
-    resp = await client.post(
+    await client.post(
         "/api/rooms/wait-ns/sessions",
         json={"agent_handle": "agent-a", "intent": "testing"},
     )
-    session_name = resp.json()["room_name"]
+    coord = await _coord_for_room(client, "wait-ns")
+    session_name = coord["display_name"]
 
-    # Session room should be waiting
     resp = await client.get(f"/api/rooms/{session_name}")
     assert resp.json()["coordination_state"] == "waiting"
     assert resp.json()["join_deadline"] is not None
@@ -120,40 +127,44 @@ async def test_new_session_after_complete(client: AsyncClient, db_session: Async
     """Completing a session should allow spawning a new one in the same namespace."""
     await client.post("/api/rooms", json={"name": "multi-session-ns"})
 
-    # First session
-    resp = await client.post(
+    resp1 = await client.post(
         "/api/rooms/multi-session-ns/sessions",
         json={"agent_handle": "agent-a", "intent": "round 1"},
     )
-    session1 = resp.json()["room_name"]
+    coord1_id = resp1.json()["coordination_session_id"]
+    coord1 = await _coord_for_room(client, "multi-session-ns")
+    session1 = coord1["display_name"]
 
-    # Mark the first session as complete via DB
+    # Mark first session as complete via DB shadow row + coord_session row.
     await db_session.execute(
         sa_update(Room).where(Room.name == session1).values(coordination_state="complete")
     )
+    await db_session.execute(
+        sa_update(CoordinationSession)
+        .where(CoordinationSession.id == UUID(coord1_id))
+        .values(state="complete")
+    )
     await db_session.commit()
 
-    # Second join should spawn a NEW session (first is complete)
-    resp = await client.post(
+    resp2 = await client.post(
         "/api/rooms/multi-session-ns/sessions",
         json={"agent_handle": "agent-b", "intent": "round 2"},
     )
-    session2 = resp.json()["room_name"]
-
-    assert session2 != session1
-    assert session2.startswith("multi-session-ns:session:")
+    coord2_id = resp2.json()["coordination_session_id"]
+    assert coord2_id != coord1_id
 
 
 @pytest.mark.asyncio
 async def test_list_sessions_on_session_room(client: AsyncClient):
-    """Listing sessions on a session room returns the joined agents."""
+    """Listing participants on a session-shadow room returns the joined agents."""
     await client.post("/api/rooms", json={"name": "list-ns"})
 
-    resp = await client.post(
+    await client.post(
         "/api/rooms/list-ns/sessions",
         json={"agent_handle": "alpha", "intent": "first"},
     )
-    session_name = resp.json()["room_name"]
+    coord = await _coord_for_room(client, "list-ns")
+    session_name = coord["display_name"]
 
     await client.post(
         "/api/rooms/list-ns/sessions",
@@ -163,20 +174,21 @@ async def test_list_sessions_on_session_room(client: AsyncClient):
     resp = await client.get(f"/api/rooms/{session_name}/sessions")
     data = resp.json()
     assert data["total"] == 2
-    handles = {s["agent_handle"] for s in data["sessions"]}
+    handles = {p["agent_handle"] for p in data["participants"]}
     assert handles == {"alpha", "beta"}
 
 
 @pytest.mark.asyncio
 async def test_session_room_is_not_namespace(client: AsyncClient):
-    """Session rooms should have is_namespace=False."""
+    """Session-shadow rooms should have is_namespace=False."""
     await client.post("/api/rooms", json={"name": "check-ns"})
 
-    resp = await client.post(
+    await client.post(
         "/api/rooms/check-ns/sessions",
         json={"agent_handle": "agent-a", "intent": "testing"},
     )
-    session_name = resp.json()["room_name"]
+    coord = await _coord_for_room(client, "check-ns")
+    session_name = coord["display_name"]
 
     resp = await client.get(f"/api/rooms/{session_name}")
     data = resp.json()

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -98,31 +98,31 @@ export function installChannel(
 
     const pollInterval = setInterval(async () => {
       try {
-        // include_sessions=true: rooms endpoint hides session-shadow rows by
-        // default (#197). The plugin still addresses sessions by display name
-        // during the deprecation window, so it opts back in here.
-        const res = await fetch(`${cfg.backendUrl}/api/rooms?include_sessions=true`);
+        // Poll the first-class coord-sessions endpoint instead of /api/rooms
+        // (which no longer surfaces sessions). Display names are returned by
+        // the API so the rest of the SSE-by-display-name flow stays the same.
+        const res = await fetch(`${cfg.backendUrl}/api/coordination-sessions?limit=200`);
         if (!res.ok) return;
-        const rooms: any[] = await res.json();
+        const sessions: any[] = await res.json();
 
         const activeSessionRooms = new Set<string>();
 
-        for (const room of rooms) {
-          const name: string | undefined = room.name;
-          if (!name || !name.includes(":session:")) continue;
-          const state = room.coordination_state;
+        for (const s of sessions) {
+          const name: string | undefined = s.display_name;
+          if (!name) continue;
+          const state: string | undefined = s.state;
 
           activeSessionRooms.add(name);
 
           if (state === "waiting" || state === "negotiating") {
             startSessionSSE(runtime, cfg, name, _abort!, handleMessage, log);
-          } else if (TERMINAL_STATES.has(state)) {
+          } else if (state && TERMINAL_STATES.has(state)) {
             stopSessionSSE(name, log);
           }
         }
 
-        // Unsubscribe from sessions whose rooms no longer exist on the
-        // backend (deleted by test harness or coordination teardown).
+        // Unsubscribe from sessions that are no longer in the active list
+        // (removed by coordination teardown or parent-room delete).
         for (const subbed of subscribedSessionRooms()) {
           if (!activeSessionRooms.has(subbed)) {
             stopSessionSSE(subbed, log);

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -98,7 +98,10 @@ export function installChannel(
 
     const pollInterval = setInterval(async () => {
       try {
-        const res = await fetch(`${cfg.backendUrl}/api/rooms`);
+        // include_sessions=true: rooms endpoint hides session-shadow rows by
+        // default (#197). The plugin still addresses sessions by display name
+        // during the deprecation window, so it opts back in here.
+        const res = await fetch(`${cfg.backendUrl}/api/rooms?include_sessions=true`);
         if (!res.ok) return;
         const rooms: any[] = await res.json();
 

--- a/mycelium-cli/src/mycelium/commands/negotiate.py
+++ b/mycelium-cli/src/mycelium/commands/negotiate.py
@@ -42,31 +42,24 @@ app = typer.Typer(
 
 
 def _resolve_active_session_room(config: "MyceliumConfig", room_name: str) -> str:
-    """If room_name is a namespace room with an active negotiating session sub-room,
-    return the session room so agent replies route to the coordination service."""
+    """Return the active coordination-session display name for ``room_name``.
+
+    If a coordination session is currently in ``negotiating`` state, return
+    its display name so agent replies route through ``coordination.on_agent_response``.
+    Falls back to the input room name when no active session is found.
+    """
     import httpx
 
     try:
         resp = httpx.get(
-            f"{config.server.api_url}/api/rooms",
-            params={"limit": 200},
+            f"{config.server.api_url}/api/coordination-sessions",
+            params={"parent_room": room_name, "state": "negotiating", "limit": 1},
             timeout=5,
         )
-        if resp.status_code != 200:
-            return room_name
-        prefix = f"{room_name}:session:"
-        session_rooms = [r["name"] for r in resp.json() if r.get("name", "").startswith(prefix)]
-        if not session_rooms:
-            return room_name
-        # Pick the most-recently-created session room (last in list by created_at)
-        # If there are multiple, prefer the one in 'negotiating' state
-        for sr in reversed(session_rooms):
-            try:
-                r = httpx.get(f"{config.server.api_url}/api/rooms/{sr}", timeout=5)
-                if r.status_code == 200 and r.json().get("coordination_state") == "negotiating":
-                    return sr
-            except Exception:
-                pass
+        if resp.status_code == 200:
+            rows = resp.json()
+            if rows:
+                return rows[0]["display_name"]
     except Exception:
         pass
     return room_name

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -143,10 +143,10 @@ def join(
         from mycelium_backend_client.api.sessions import (
             join_room_api_rooms_room_name_sessions_post as join_api,
         )
-        from mycelium_backend_client.models import SessionCreate
+        from mycelium_backend_client.models import ParticipantCreate
 
         with _typed_client(config) as client:
-            body = SessionCreate(agent_handle=handle, intent=intent)
+            body = ParticipantCreate(agent_handle=handle, intent=intent)
             result = join_api.sync(room_name=room_name, client=client, body=body)
             data = result.to_dict() if result and hasattr(result, "to_dict") else {}
 
@@ -475,21 +475,21 @@ def list_sessions(
             if result and hasattr(result, "to_dict"):
                 data = result.to_dict()
             else:
-                data = {"sessions": [], "total": 0}
+                data = {"participants": [], "total": 0}
 
         if json_output:
             typer.echo(json_module.dumps(data, indent=2, default=str))
             return
 
-        sessions = data.get("sessions", [])
-        if not isinstance(sessions, list) or not sessions:
-            typer.echo(f"  No active sessions in {room_name}")
+        participants = data.get("participants", [])
+        if not isinstance(participants, list) or not participants:
+            typer.echo(f"  No active participants in {room_name}")
             return
 
-        typer.echo(f"  {room_name} — {len(sessions)} session(s)\n")
-        for s in sessions:
+        typer.echo(f"  {room_name} — {len(participants)} participant(s)\n")
+        for p in participants:
             typer.echo(
-                f"    {s.get('agent_handle', '?')}  joined {str(s.get('joined_at', ''))[:16]}"
+                f"    {p.get('agent_handle', '?')}  joined {str(p.get('joined_at', ''))[:16]}"
             )
 
     except Exception as e:

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -205,18 +205,17 @@ def await_tick(
         if resolved_room:
             with httpx.Client(timeout=10) as http:
                 try:
-                    # Ticks are posted to session sub-rooms (e.g. room:session:xxxx).
-                    # Find all session rooms under this namespace and scan them.
-                    rooms_resp = http.get(
-                        f"{config.server.api_url}/api/rooms",
-                        params={"limit": 200},
-                    )
+                    # Ticks are posted to coordination sessions (legacy display
+                    # name: ``{room}:session:{short}``). Pull the active sessions
+                    # from the first-class endpoint instead of scanning rooms.
                     rooms_to_scan = [resolved_room]
-                    if rooms_resp.status_code == 200:
-                        prefix = f"{resolved_room}:session:"
-                        for r in rooms_resp.json():
-                            if r.get("name", "").startswith(prefix):
-                                rooms_to_scan.append(r["name"])
+                    coord_resp = http.get(
+                        f"{config.server.api_url}/api/coordination-sessions",
+                        params={"parent_room": resolved_room, "limit": 200},
+                    )
+                    if coord_resp.status_code == 200:
+                        for c in coord_resp.json():
+                            rooms_to_scan.append(c["display_name"])
 
                     for scan_room in rooms_to_scan:
                         resp = http.get(
@@ -413,7 +412,6 @@ def watch_session(
     try:
         config = MyceliumConfig.load()
         room_name = _resolve_room(config, room)
-        prefix = f"{room_name}:session:"
         watched: set[str] = set()
         start = time.time()
 
@@ -424,15 +422,19 @@ def watch_session(
                 break
 
             try:
-                resp = httpx.get(f"{config.server.api_url}/api/rooms?limit=200", timeout=10)
+                resp = httpx.get(
+                    f"{config.server.api_url}/api/coordination-sessions",
+                    params={"parent_room": room_name, "limit": 200},
+                    timeout=10,
+                )
                 resp.raise_for_status()
-                all_rooms = resp.json()
+                coords = resp.json()
             except Exception:
                 time.sleep(2)
                 continue
 
-            session_rooms = [r["name"] for r in all_rooms if r["name"].startswith(prefix)]
-            for sr in session_rooms:
+            for c in coords:
+                sr = c["display_name"]
                 if sr not in watched:
                     watched.add(sr)
                     console.print(f"[dim]  + {sr}[/dim]")
@@ -452,7 +454,7 @@ def watch_session(
 
 @doc_ref(
     usage="mycelium session ls [-r <room>]",
-    desc="List active sessions in a room.",
+    desc="List negotiation sessions inside a room.",
     group="session",
 )
 @app.command(name="ls")
@@ -460,37 +462,36 @@ def list_sessions(
     ctx: typer.Context,
     room: str | None = typer.Option(None, "--room", "-r", help="Room"),
 ) -> None:
-    """List active negotiation sessions in a room."""
+    """List negotiation sessions inside a room (newest first)."""
+    import httpx
+
     try:
         json_output = ctx.obj.get("json", False) if ctx.obj else False
         config = MyceliumConfig.load()
         room_name = _resolve_room(config, room)
 
-        from mycelium_backend_client.api.sessions import (
-            list_sessions_api_rooms_room_name_sessions_get as list_api,
-        )
-
-        with _typed_client(config) as client:
-            result = list_api.sync(room_name=room_name, client=client)
-            if result and hasattr(result, "to_dict"):
-                data = result.to_dict()
-            else:
-                data = {"participants": [], "total": 0}
+        with httpx.Client(timeout=10) as http:
+            resp = http.get(
+                f"{config.server.api_url}/api/coordination-sessions",
+                params={"parent_room": room_name, "limit": 200},
+            )
+            resp.raise_for_status()
+            sessions = resp.json()
 
         if json_output:
-            typer.echo(json_module.dumps(data, indent=2, default=str))
+            typer.echo(json_module.dumps(sessions, indent=2, default=str))
             return
 
-        participants = data.get("participants", [])
-        if not isinstance(participants, list) or not participants:
-            typer.echo(f"  No active participants in {room_name}")
+        if not sessions:
+            typer.echo(f"  No sessions in {room_name}")
             return
 
-        typer.echo(f"  {room_name} — {len(participants)} participant(s)\n")
-        for p in participants:
-            typer.echo(
-                f"    {p.get('agent_handle', '?')}  joined {str(p.get('joined_at', ''))[:16]}"
-            )
+        typer.echo(f"  {room_name} — {len(sessions)} session(s)\n")
+        for s in sessions:
+            short = s.get("short_id", "?")
+            state = s.get("state", "?")
+            created = str(s.get("created_at", ""))[:16]
+            typer.echo(f"    :{short}  [{state}]  created {created}")
 
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False

--- a/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/__init__.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/get_coordination_session_api_coordination_sessions_session_id_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/get_coordination_session_api_coordination_sessions_session_id_get.py
@@ -1,25 +1,24 @@
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
+from uuid import UUID
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.coordination_session_read import CoordinationSessionRead
 from ...models.http_validation_error import HTTPValidationError
-from ...models.spawn_session_api_rooms_room_name_sessions_spawn_post_response_spawn_session_api_rooms_room_name_sessions_spawn_post import (
-    SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost,
-)
 from ...types import Response
 
 
 def _get_kwargs(
-    room_name: str,
+    session_id: UUID,
 ) -> dict[str, Any]:
     _kwargs: dict[str, Any] = {
-        "method": "post",
-        "url": "/api/rooms/{room_name}/sessions/spawn".format(
-            room_name=quote(str(room_name), safe=""),
+        "method": "get",
+        "url": "/api/coordination-sessions/{session_id}".format(
+            session_id=quote(str(session_id), safe=""),
         ),
     }
 
@@ -28,17 +27,11 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    if response.status_code == 201:
-        response_201 = SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost.from_dict(
-            response.json()
-        )
+) -> CoordinationSessionRead | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = CoordinationSessionRead.from_dict(response.json())
 
-        return response_201
+        return response_200
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
@@ -53,10 +46,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
+) -> Response[CoordinationSessionRead | HTTPValidationError]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -66,30 +56,25 @@ def _build_response(
 
 
 def sync_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
-    """Spawn Session
-
-     Explicitly spawn a negotiation session within a room.
+) -> Response[CoordinationSessionRead | HTTPValidationError]:
+    """Get Coordination Session
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost]
+        Response[CoordinationSessionRead | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
     )
 
     response = client.get_httpx_client().request(
@@ -100,60 +85,49 @@ def sync_detailed(
 
 
 def sync(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    """Spawn Session
-
-     Explicitly spawn a negotiation session within a room.
+) -> CoordinationSessionRead | HTTPValidationError | None:
+    """Get Coordination Session
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
+        CoordinationSessionRead | HTTPValidationError
     """
 
     return sync_detailed(
-        room_name=room_name,
+        session_id=session_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
-    """Spawn Session
-
-     Explicitly spawn a negotiation session within a room.
+) -> Response[CoordinationSessionRead | HTTPValidationError]:
+    """Get Coordination Session
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost]
+        Response[CoordinationSessionRead | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -162,32 +136,26 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    """Spawn Session
-
-     Explicitly spawn a negotiation session within a room.
+) -> CoordinationSessionRead | HTTPValidationError | None:
+    """Get Coordination Session
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
+        CoordinationSessionRead | HTTPValidationError
     """
 
     return (
         await asyncio_detailed(
-            room_name=room_name,
+            session_id=session_id,
             client=client,
         )
     ).parsed

--- a/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/list_coordination_sessions_api_coordination_sessions_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/list_coordination_sessions_api_coordination_sessions_get.py
@@ -1,0 +1,234 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.coordination_session_read import CoordinationSessionRead
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    json_parent_room: None | str | Unset
+    if isinstance(parent_room, Unset):
+        json_parent_room = UNSET
+    else:
+        json_parent_room = parent_room
+    params["parent_room"] = json_parent_room
+
+    json_state: None | str | Unset
+    if isinstance(state, Unset):
+        json_state = UNSET
+    else:
+        json_state = state
+    params["state"] = json_state
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/coordination-sessions",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = CoordinationSessionRead.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List coordination sessions, newest first.
+
+    Supports two filters used by the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``) and the frontend sessions rail
+    (``parent_room=<name>``).
+
+    Args:
+        parent_room (None | str | Unset): Filter by parent room name
+        state (None | str | Unset): Comma-separated state filter (e.g. 'waiting,negotiating')
+        limit (int | Unset):  Default: 200.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        parent_room=parent_room,
+        state=state,
+        limit=limit,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List coordination sessions, newest first.
+
+    Supports two filters used by the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``) and the frontend sessions rail
+    (``parent_room=<name>``).
+
+    Args:
+        parent_room (None | str | Unset): Filter by parent room name
+        state (None | str | Unset): Comma-separated state filter (e.g. 'waiting,negotiating')
+        limit (int | Unset):  Default: 200.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return sync_detailed(
+        client=client,
+        parent_room=parent_room,
+        state=state,
+        limit=limit,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List coordination sessions, newest first.
+
+    Supports two filters used by the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``) and the frontend sessions rail
+    (``parent_room=<name>``).
+
+    Args:
+        parent_room (None | str | Unset): Filter by parent room name
+        state (None | str | Unset): Comma-separated state filter (e.g. 'waiting,negotiating')
+        limit (int | Unset):  Default: 200.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        parent_room=parent_room,
+        state=state,
+        limit=limit,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List coordination sessions, newest first.
+
+    Supports two filters used by the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``) and the frontend sessions rail
+    (``parent_room=<name>``).
+
+    Args:
+        parent_room (None | str | Unset): Filter by parent room name
+        state (None | str | Unset): Comma-separated state filter (e.g. 'waiting,negotiating')
+        limit (int | Unset):  Default: 200.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            parent_room=parent_room,
+            state=state,
+            limit=limit,
+        )
+    ).parsed

--- a/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/list_session_messages_api_coordination_sessions_session_id_messages_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/list_session_messages_api_coordination_sessions_session_id_messages_get.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
+from uuid import UUID
 
 import httpx
 
@@ -12,7 +13,7 @@ from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
-    room_name: str,
+    session_id: UUID,
     *,
     limit: int | Unset = 50,
     offset: int | Unset = 0,
@@ -43,8 +44,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/api/rooms/{room_name}/messages".format(
-            room_name=quote(str(room_name), safe=""),
+        "url": "/api/coordination-sessions/{session_id}/messages".format(
+            session_id=quote(str(session_id), safe=""),
         ),
         "params": params,
     }
@@ -83,7 +84,7 @@ def _build_response(
 
 
 def sync_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 50,
@@ -91,12 +92,10 @@ def sync_detailed(
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | MessageListResponse]:
-    """List Messages
-
-     List messages in a room (or coordination session), newest first.
+    """List Session Messages
 
     Args:
-        room_name (str):
+        session_id (UUID):
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
@@ -111,7 +110,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
         limit=limit,
         offset=offset,
         sender=sender,
@@ -126,7 +125,7 @@ def sync_detailed(
 
 
 def sync(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 50,
@@ -134,12 +133,10 @@ def sync(
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
 ) -> HTTPValidationError | MessageListResponse | None:
-    """List Messages
-
-     List messages in a room (or coordination session), newest first.
+    """List Session Messages
 
     Args:
-        room_name (str):
+        session_id (UUID):
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
@@ -154,7 +151,7 @@ def sync(
     """
 
     return sync_detailed(
-        room_name=room_name,
+        session_id=session_id,
         client=client,
         limit=limit,
         offset=offset,
@@ -164,7 +161,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 50,
@@ -172,12 +169,10 @@ async def asyncio_detailed(
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | MessageListResponse]:
-    """List Messages
-
-     List messages in a room (or coordination session), newest first.
+    """List Session Messages
 
     Args:
-        room_name (str):
+        session_id (UUID):
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
@@ -192,7 +187,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
         limit=limit,
         offset=offset,
         sender=sender,
@@ -205,7 +200,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 50,
@@ -213,12 +208,10 @@ async def asyncio(
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
 ) -> HTTPValidationError | MessageListResponse | None:
-    """List Messages
-
-     List messages in a room (or coordination session), newest first.
+    """List Session Messages
 
     Args:
-        room_name (str):
+        session_id (UUID):
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
@@ -234,7 +227,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            room_name=room_name,
+            session_id=session_id,
             client=client,
             limit=limit,
             offset=offset,

--- a/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/post_session_message_api_coordination_sessions_session_id_messages_post.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/post_session_message_api_coordination_sessions_session_id_messages_post.py
@@ -1,28 +1,29 @@
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
+from uuid import UUID
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.participant_create import ParticipantCreate
-from ...models.participant_read import ParticipantRead
+from ...models.message_create import MessageCreate
+from ...models.message_read import MessageRead
 from ...types import Response
 
 
 def _get_kwargs(
-    room_name: str,
+    session_id: UUID,
     *,
-    body: ParticipantCreate,
+    body: MessageCreate,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/rooms/{room_name}/sessions".format(
-            room_name=quote(str(room_name), safe=""),
+        "url": "/api/coordination-sessions/{session_id}/messages".format(
+            session_id=quote(str(session_id), safe=""),
         ),
     }
 
@@ -36,9 +37,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | ParticipantRead | None:
+) -> HTTPValidationError | MessageRead | None:
     if response.status_code == 201:
-        response_201 = ParticipantRead.from_dict(response.json())
+        response_201 = MessageRead.from_dict(response.json())
 
         return response_201
 
@@ -55,7 +56,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | ParticipantRead]:
+) -> Response[HTTPValidationError | MessageRead]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,29 +66,34 @@ def _build_response(
 
 
 def sync_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-    body: ParticipantCreate,
-) -> Response[HTTPValidationError | ParticipantRead]:
-    """Join Room
+    body: MessageCreate,
+) -> Response[HTTPValidationError | MessageRead]:
+    """Post Session Message
 
-     Join a room. Auto-spawns a coordination session if one doesn't exist.
+     Post a message to a coordination session.
+
+    Messages are stored with ``coordination_session_id`` set and ``room_name``
+    null. SSE subscribers on the session-display channel still receive them
+    via the same ``room:{display_name}`` NOTIFY topic during the deprecation
+    window so existing OpenClaw plugin / CLI subscribers don't break.
 
     Args:
-        room_name (str):
-        body (ParticipantCreate):
+        session_id (UUID):
+        body (MessageCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | ParticipantRead]
+        Response[HTTPValidationError | MessageRead]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
         body=body,
     )
 
@@ -99,58 +105,68 @@ def sync_detailed(
 
 
 def sync(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-    body: ParticipantCreate,
-) -> HTTPValidationError | ParticipantRead | None:
-    """Join Room
+    body: MessageCreate,
+) -> HTTPValidationError | MessageRead | None:
+    """Post Session Message
 
-     Join a room. Auto-spawns a coordination session if one doesn't exist.
+     Post a message to a coordination session.
+
+    Messages are stored with ``coordination_session_id`` set and ``room_name``
+    null. SSE subscribers on the session-display channel still receive them
+    via the same ``room:{display_name}`` NOTIFY topic during the deprecation
+    window so existing OpenClaw plugin / CLI subscribers don't break.
 
     Args:
-        room_name (str):
-        body (ParticipantCreate):
+        session_id (UUID):
+        body (MessageCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | ParticipantRead
+        HTTPValidationError | MessageRead
     """
 
     return sync_detailed(
-        room_name=room_name,
+        session_id=session_id,
         client=client,
         body=body,
     ).parsed
 
 
 async def asyncio_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-    body: ParticipantCreate,
-) -> Response[HTTPValidationError | ParticipantRead]:
-    """Join Room
+    body: MessageCreate,
+) -> Response[HTTPValidationError | MessageRead]:
+    """Post Session Message
 
-     Join a room. Auto-spawns a coordination session if one doesn't exist.
+     Post a message to a coordination session.
+
+    Messages are stored with ``coordination_session_id`` set and ``room_name``
+    null. SSE subscribers on the session-display channel still receive them
+    via the same ``room:{display_name}`` NOTIFY topic during the deprecation
+    window so existing OpenClaw plugin / CLI subscribers don't break.
 
     Args:
-        room_name (str):
-        body (ParticipantCreate):
+        session_id (UUID):
+        body (MessageCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | ParticipantRead]
+        Response[HTTPValidationError | MessageRead]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
         body=body,
     )
 
@@ -160,30 +176,35 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-    body: ParticipantCreate,
-) -> HTTPValidationError | ParticipantRead | None:
-    """Join Room
+    body: MessageCreate,
+) -> HTTPValidationError | MessageRead | None:
+    """Post Session Message
 
-     Join a room. Auto-spawns a coordination session if one doesn't exist.
+     Post a message to a coordination session.
+
+    Messages are stored with ``coordination_session_id`` set and ``room_name``
+    null. SSE subscribers on the session-display channel still receive them
+    via the same ``room:{display_name}`` NOTIFY topic during the deprecation
+    window so existing OpenClaw plugin / CLI subscribers don't break.
 
     Args:
-        room_name (str):
-        body (ParticipantCreate):
+        session_id (UUID):
+        body (MessageCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | ParticipantRead
+        HTTPValidationError | MessageRead
     """
 
     return (
         await asyncio_detailed(
-            room_name=room_name,
+            session_id=session_id,
             client=client,
             body=body,
         )

--- a/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/stream_session_messages_api_coordination_sessions_session_id_messages_stream_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/coordination_sessions/stream_session_messages_api_coordination_sessions_session_id_messages_stream_get.py
@@ -1,25 +1,23 @@
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
+from uuid import UUID
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.spawn_session_api_rooms_room_name_sessions_spawn_post_response_spawn_session_api_rooms_room_name_sessions_spawn_post import (
-    SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost,
-)
 from ...types import Response
 
 
 def _get_kwargs(
-    room_name: str,
+    session_id: UUID,
 ) -> dict[str, Any]:
     _kwargs: dict[str, Any] = {
-        "method": "post",
-        "url": "/api/rooms/{room_name}/sessions/spawn".format(
-            room_name=quote(str(room_name), safe=""),
+        "method": "get",
+        "url": "/api/coordination-sessions/{session_id}/messages/stream".format(
+            session_id=quote(str(session_id), safe=""),
         ),
     }
 
@@ -28,17 +26,10 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    if response.status_code == 201:
-        response_201 = SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost.from_dict(
-            response.json()
-        )
-
-        return response_201
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
@@ -53,10 +44,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
+) -> Response[Any | HTTPValidationError]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -66,30 +54,31 @@ def _build_response(
 
 
 def sync_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
-    """Spawn Session
+) -> Response[Any | HTTPValidationError]:
+    """Stream Session Messages
 
-     Explicitly spawn a negotiation session within a room.
+     SSE stream for a coordination session.
+
+    Resolves the session and subscribes to the underlying ``room:{display_name}``
+    Postgres NOTIFY channel so any inbound message routed to either coord_session_id
+    or the legacy display name surfaces here.
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost]
+        Response[Any | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
     )
 
     response = client.get_httpx_client().request(
@@ -100,60 +89,61 @@ def sync_detailed(
 
 
 def sync(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    """Spawn Session
+) -> Any | HTTPValidationError | None:
+    """Stream Session Messages
 
-     Explicitly spawn a negotiation session within a room.
+     SSE stream for a coordination session.
+
+    Resolves the session and subscribes to the underlying ``room:{display_name}``
+    Postgres NOTIFY channel so any inbound message routed to either coord_session_id
+    or the legacy display name surfaces here.
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
+        Any | HTTPValidationError
     """
 
     return sync_detailed(
-        room_name=room_name,
+        session_id=session_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
-    """Spawn Session
+) -> Response[Any | HTTPValidationError]:
+    """Stream Session Messages
 
-     Explicitly spawn a negotiation session within a room.
+     SSE stream for a coordination session.
+
+    Resolves the session and subscribes to the underlying ``room:{display_name}``
+    Postgres NOTIFY channel so any inbound message routed to either coord_session_id
+    or the legacy display name surfaces here.
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost]
+        Response[Any | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -162,32 +152,32 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    """Spawn Session
+) -> Any | HTTPValidationError | None:
+    """Stream Session Messages
 
-     Explicitly spawn a negotiation session within a room.
+     SSE stream for a coordination session.
+
+    Resolves the session and subscribes to the underlying ``room:{display_name}``
+    Postgres NOTIFY channel so any inbound message routed to either coord_session_id
+    or the legacy display name surfaces here.
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
+        Any | HTTPValidationError
     """
 
     return (
         await asyncio_detailed(
-            room_name=room_name,
+            session_id=session_id,
             client=client,
         )
     ).parsed

--- a/mycelium-cli/src/mycelium_backend_client/api/messages/list_messages_api_rooms_room_name_messages_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/messages/list_messages_api_rooms_room_name_messages_get.py
@@ -93,7 +93,7 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | MessageListResponse]:
     """List Messages
 
-     List messages in a room, newest first.
+     List messages in a room (or coordination session), newest first.
 
     Args:
         room_name (str):
@@ -136,7 +136,7 @@ def sync(
 ) -> HTTPValidationError | MessageListResponse | None:
     """List Messages
 
-     List messages in a room, newest first.
+     List messages in a room (or coordination session), newest first.
 
     Args:
         room_name (str):
@@ -174,7 +174,7 @@ async def asyncio_detailed(
 ) -> Response[HTTPValidationError | MessageListResponse]:
     """List Messages
 
-     List messages in a room, newest first.
+     List messages in a room (or coordination session), newest first.
 
     Args:
         room_name (str):
@@ -215,7 +215,7 @@ async def asyncio(
 ) -> HTTPValidationError | MessageListResponse | None:
     """List Messages
 
-     List messages in a room, newest first.
+     List messages in a room (or coordination session), newest first.
 
     Args:
         room_name (str):

--- a/mycelium-cli/src/mycelium_backend_client/api/rooms/delete_room_api_rooms_room_name_delete.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/rooms/delete_room_api_rooms_room_name_delete.py
@@ -57,26 +57,20 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[Any | HTTPValidationError]:
-    r"""Delete Room
+    """Delete Room
 
      Delete a room and cascade to its child session rooms.
 
-    Cleanup order is important to avoid stale state firing against
-    already-deleted rows:
+    Cleanup order:
 
-      1. Enumerate child session rooms (``parent_namespace == room_name``).
-      2. Tear down all in-memory CFN coordination state for the namespace
-         and its children (cancels pending join timers and active round
-         timeouts, posts ``coordination_consensus broken=True`` to any
-         SSE subscribers).
-      3. Delete child ``Session`` rows, then child ``Room`` rows.
-      4. Mark any active child rooms as ``coordination_state=\"failed\"``
-         (defensive — if step 3 didn't catch them due to a race, the
-         state still reflects reality).
-      5. Delete the parent ``Room`` row.
-      6. Remove the filesystem directory.
-      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
-         error doesn't block the local cleanup).
+      1. Resolve all coordination sessions for this room (display names + IDs).
+      2. Tear down in-memory CFN coordination state. Doing this before DB
+         deletes prevents in-flight ticks from firing against half-deleted
+         state.
+      3. Delete the room row — coordination_sessions, participants, and
+         messages cascade automatically via FK ON DELETE CASCADE.
+      4. Remove the filesystem directory.
+      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
 
     Args:
         room_name (str):
@@ -105,26 +99,20 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
 ) -> Any | HTTPValidationError | None:
-    r"""Delete Room
+    """Delete Room
 
      Delete a room and cascade to its child session rooms.
 
-    Cleanup order is important to avoid stale state firing against
-    already-deleted rows:
+    Cleanup order:
 
-      1. Enumerate child session rooms (``parent_namespace == room_name``).
-      2. Tear down all in-memory CFN coordination state for the namespace
-         and its children (cancels pending join timers and active round
-         timeouts, posts ``coordination_consensus broken=True`` to any
-         SSE subscribers).
-      3. Delete child ``Session`` rows, then child ``Room`` rows.
-      4. Mark any active child rooms as ``coordination_state=\"failed\"``
-         (defensive — if step 3 didn't catch them due to a race, the
-         state still reflects reality).
-      5. Delete the parent ``Room`` row.
-      6. Remove the filesystem directory.
-      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
-         error doesn't block the local cleanup).
+      1. Resolve all coordination sessions for this room (display names + IDs).
+      2. Tear down in-memory CFN coordination state. Doing this before DB
+         deletes prevents in-flight ticks from firing against half-deleted
+         state.
+      3. Delete the room row — coordination_sessions, participants, and
+         messages cascade automatically via FK ON DELETE CASCADE.
+      4. Remove the filesystem directory.
+      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
 
     Args:
         room_name (str):
@@ -148,26 +136,20 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[Any | HTTPValidationError]:
-    r"""Delete Room
+    """Delete Room
 
      Delete a room and cascade to its child session rooms.
 
-    Cleanup order is important to avoid stale state firing against
-    already-deleted rows:
+    Cleanup order:
 
-      1. Enumerate child session rooms (``parent_namespace == room_name``).
-      2. Tear down all in-memory CFN coordination state for the namespace
-         and its children (cancels pending join timers and active round
-         timeouts, posts ``coordination_consensus broken=True`` to any
-         SSE subscribers).
-      3. Delete child ``Session`` rows, then child ``Room`` rows.
-      4. Mark any active child rooms as ``coordination_state=\"failed\"``
-         (defensive — if step 3 didn't catch them due to a race, the
-         state still reflects reality).
-      5. Delete the parent ``Room`` row.
-      6. Remove the filesystem directory.
-      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
-         error doesn't block the local cleanup).
+      1. Resolve all coordination sessions for this room (display names + IDs).
+      2. Tear down in-memory CFN coordination state. Doing this before DB
+         deletes prevents in-flight ticks from firing against half-deleted
+         state.
+      3. Delete the room row — coordination_sessions, participants, and
+         messages cascade automatically via FK ON DELETE CASCADE.
+      4. Remove the filesystem directory.
+      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
 
     Args:
         room_name (str):
@@ -194,26 +176,20 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
 ) -> Any | HTTPValidationError | None:
-    r"""Delete Room
+    """Delete Room
 
      Delete a room and cascade to its child session rooms.
 
-    Cleanup order is important to avoid stale state firing against
-    already-deleted rows:
+    Cleanup order:
 
-      1. Enumerate child session rooms (``parent_namespace == room_name``).
-      2. Tear down all in-memory CFN coordination state for the namespace
-         and its children (cancels pending join timers and active round
-         timeouts, posts ``coordination_consensus broken=True`` to any
-         SSE subscribers).
-      3. Delete child ``Session`` rows, then child ``Room`` rows.
-      4. Mark any active child rooms as ``coordination_state=\"failed\"``
-         (defensive — if step 3 didn't catch them due to a race, the
-         state still reflects reality).
-      5. Delete the parent ``Room`` row.
-      6. Remove the filesystem directory.
-      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
-         error doesn't block the local cleanup).
+      1. Resolve all coordination sessions for this room (display names + IDs).
+      2. Tear down in-memory CFN coordination state. Doing this before DB
+         deletes prevents in-flight ticks from firing against half-deleted
+         state.
+      3. Delete the room row — coordination_sessions, participants, and
+         messages cascade automatically via FK ON DELETE CASCADE.
+      4. Remove the filesystem directory.
+      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
 
     Args:
         room_name (str):

--- a/mycelium-cli/src/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
@@ -15,6 +15,7 @@ def _get_kwargs(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -28,6 +29,8 @@ def _get_kwargs(
     else:
         json_name = name
     params["name"] = json_name
+
+    params["include_sessions"] = include_sessions
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -81,15 +84,22 @@ def sync_detailed(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> Response[HTTPValidationError | list[RoomRead]]:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -103,6 +113,7 @@ def sync_detailed(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     )
 
     response = client.get_httpx_client().request(
@@ -118,15 +129,22 @@ def sync(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> HTTPValidationError | list[RoomRead] | None:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,6 +159,7 @@ def sync(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     ).parsed
 
 
@@ -150,15 +169,22 @@ async def asyncio_detailed(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> Response[HTTPValidationError | list[RoomRead]]:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,6 +198,7 @@ async def asyncio_detailed(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -185,15 +212,22 @@ async def asyncio(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> HTTPValidationError | list[RoomRead] | None:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -209,5 +243,6 @@ async def asyncio(
             skip=skip,
             limit=limit,
             name=name,
+            include_sessions=include_sessions,
         )
     ).parsed

--- a/mycelium-cli/src/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
@@ -90,10 +90,9 @@ def sync_detailed(
 
      List rooms.
 
-    By default returns only real rooms (namespaces). Session-shadow rows are
-    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
-    to include the shadow rows — used by callers (e.g. the OpenClaw channel
-    plugin) that still address sessions by name during the deprecation window.
+    Sessions live in ``coordination_sessions`` and are not surfaced here. The
+    ``include_sessions`` parameter is kept for backward-compatible URLs but is
+    a no-op now (#244 — session-shadow rows no longer exist).
 
     Args:
         skip (int | Unset):  Default: 0.
@@ -135,10 +134,9 @@ def sync(
 
      List rooms.
 
-    By default returns only real rooms (namespaces). Session-shadow rows are
-    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
-    to include the shadow rows — used by callers (e.g. the OpenClaw channel
-    plugin) that still address sessions by name during the deprecation window.
+    Sessions live in ``coordination_sessions`` and are not surfaced here. The
+    ``include_sessions`` parameter is kept for backward-compatible URLs but is
+    a no-op now (#244 — session-shadow rows no longer exist).
 
     Args:
         skip (int | Unset):  Default: 0.
@@ -175,10 +173,9 @@ async def asyncio_detailed(
 
      List rooms.
 
-    By default returns only real rooms (namespaces). Session-shadow rows are
-    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
-    to include the shadow rows — used by callers (e.g. the OpenClaw channel
-    plugin) that still address sessions by name during the deprecation window.
+    Sessions live in ``coordination_sessions`` and are not surfaced here. The
+    ``include_sessions`` parameter is kept for backward-compatible URLs but is
+    a no-op now (#244 — session-shadow rows no longer exist).
 
     Args:
         skip (int | Unset):  Default: 0.
@@ -218,10 +215,9 @@ async def asyncio(
 
      List rooms.
 
-    By default returns only real rooms (namespaces). Session-shadow rows are
-    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
-    to include the shadow rows — used by callers (e.g. the OpenClaw channel
-    plugin) that still address sessions by name during the deprecation window.
+    Sessions live in ``coordination_sessions`` and are not surfaced here. The
+    ``include_sessions`` parameter is kept for backward-compatible URLs but is
+    a no-op now (#244 — session-shadow rows no longer exist).
 
     Args:
         skip (int | Unset):  Default: 0.

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
@@ -72,7 +72,7 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
-     Join a room. If the room is a namespace, auto-spawns a session and joins that.
+     Join a room. Auto-spawns a coordination session if one doesn't exist.
 
     Args:
         room_name (str):
@@ -106,7 +106,7 @@ def sync(
 ) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
-     Join a room. If the room is a namespace, auto-spawns a session and joins that.
+     Join a room. Auto-spawns a coordination session if one doesn't exist.
 
     Args:
         room_name (str):
@@ -135,7 +135,7 @@ async def asyncio_detailed(
 ) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
-     Join a room. If the room is a namespace, auto-spawns a session and joins that.
+     Join a room. Auto-spawns a coordination session if one doesn't exist.
 
     Args:
         room_name (str):
@@ -167,7 +167,7 @@ async def asyncio(
 ) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
-     Join a room. If the room is a namespace, auto-spawns a session and joins that.
+     Join a room. Auto-spawns a coordination session if one doesn't exist.
 
     Args:
         room_name (str):

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
@@ -7,15 +7,15 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.session_create import SessionCreate
-from ...models.session_read import SessionRead
+from ...models.participant_create import ParticipantCreate
+from ...models.participant_read import ParticipantRead
 from ...types import Response
 
 
 def _get_kwargs(
     room_name: str,
     *,
-    body: SessionCreate,
+    body: ParticipantCreate,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -36,9 +36,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | SessionRead | None:
+) -> HTTPValidationError | ParticipantRead | None:
     if response.status_code == 201:
-        response_201 = SessionRead.from_dict(response.json())
+        response_201 = ParticipantRead.from_dict(response.json())
 
         return response_201
 
@@ -55,7 +55,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | SessionRead]:
+) -> Response[HTTPValidationError | ParticipantRead]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -68,22 +68,22 @@ def sync_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> Response[HTTPValidationError | SessionRead]:
+    body: ParticipantCreate,
+) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionRead]
+        Response[HTTPValidationError | ParticipantRead]
     """
 
     kwargs = _get_kwargs(
@@ -102,22 +102,22 @@ def sync(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> HTTPValidationError | SessionRead | None:
+    body: ParticipantCreate,
+) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionRead
+        HTTPValidationError | ParticipantRead
     """
 
     return sync_detailed(
@@ -131,22 +131,22 @@ async def asyncio_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> Response[HTTPValidationError | SessionRead]:
+    body: ParticipantCreate,
+) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionRead]
+        Response[HTTPValidationError | ParticipantRead]
     """
 
     kwargs = _get_kwargs(
@@ -163,22 +163,22 @@ async def asyncio(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> HTTPValidationError | SessionRead | None:
+    body: ParticipantCreate,
+) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionRead
+        HTTPValidationError | ParticipantRead
     """
 
     return (

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/leave_room_api_rooms_room_name_sessions_session_id_delete.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/leave_room_api_rooms_room_name_sessions_session_id_delete.py
@@ -63,7 +63,7 @@ def sync_detailed(
 ) -> Response[Any | HTTPValidationError]:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -97,7 +97,7 @@ def sync(
 ) -> Any | HTTPValidationError | None:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -126,7 +126,7 @@ async def asyncio_detailed(
 ) -> Response[Any | HTTPValidationError]:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -158,7 +158,7 @@ async def asyncio(
 ) -> Any | HTTPValidationError | None:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/list_coordination_sessions_api_rooms_room_name_sessions_coordination_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/list_coordination_sessions_api_rooms_room_name_sessions_coordination_get.py
@@ -1,0 +1,185 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.coordination_session_read import CoordinationSessionRead
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    room_name: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/rooms/{room_name}/sessions/coordination".format(
+            room_name=quote(str(room_name), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = CoordinationSessionRead.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return sync_detailed(
+        room_name=room_name,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return (
+        await asyncio_detailed(
+            room_name=room_name,
+            client=client,
+        )
+    ).parsed

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.session_list_response import SessionListResponse
+from ...models.participant_list_response import ParticipantListResponse
 from ...types import Response
 
 
@@ -26,9 +26,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     if response.status_code == 200:
-        response_200 = SessionListResponse.from_dict(response.json())
+        response_200 = ParticipantListResponse.from_dict(response.json())
 
         return response_200
 
@@ -45,7 +45,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -58,10 +58,10 @@ def sync_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -71,7 +71,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionListResponse]
+        Response[HTTPValidationError | ParticipantListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -89,10 +89,10 @@ def sync(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -102,7 +102,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionListResponse
+        HTTPValidationError | ParticipantListResponse
     """
 
     return sync_detailed(
@@ -115,10 +115,10 @@ async def asyncio_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -128,7 +128,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionListResponse]
+        Response[HTTPValidationError | ParticipantListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -144,10 +144,10 @@ async def asyncio(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -157,7 +157,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionListResponse
+        HTTPValidationError | ParticipantListResponse
     """
 
     return (

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
@@ -61,7 +61,11 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents participating in a room's coordination session.
+     List agents participating in a room's coordination session(s).
+
+    Accepts either a real room name (returns participants across all its
+    coord_sessions) or a legacy ``{parent}:session:{short}`` display name
+    (returns participants of just that one session).
 
     Args:
         room_name (str):
@@ -92,7 +96,11 @@ def sync(
 ) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents participating in a room's coordination session.
+     List agents participating in a room's coordination session(s).
+
+    Accepts either a real room name (returns participants across all its
+    coord_sessions) or a legacy ``{parent}:session:{short}`` display name
+    (returns participants of just that one session).
 
     Args:
         room_name (str):
@@ -118,7 +126,11 @@ async def asyncio_detailed(
 ) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents participating in a room's coordination session.
+     List agents participating in a room's coordination session(s).
+
+    Accepts either a real room name (returns participants across all its
+    coord_sessions) or a legacy ``{parent}:session:{short}`` display name
+    (returns participants of just that one session).
 
     Args:
         room_name (str):
@@ -147,7 +159,11 @@ async def asyncio(
 ) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents participating in a room's coordination session.
+     List agents participating in a room's coordination session(s).
+
+    Accepts either a real room name (returns participants across all its
+    coord_sessions) or a legacy ``{parent}:session:{short}`` display name
+    (returns participants of just that one session).
 
     Args:
         room_name (str):

--- a/mycelium-cli/src/mycelium_backend_client/api/sessions/spawn_session_api_rooms_room_name_sessions_spawn_post.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/sessions/spawn_session_api_rooms_room_name_sessions_spawn_post.py
@@ -75,7 +75,7 @@ def sync_detailed(
 ]:
     """Spawn Session
 
-     Explicitly spawn a negotiation session within a namespace room.
+     Explicitly spawn a negotiation session within a room.
 
     Args:
         room_name (str):
@@ -110,7 +110,7 @@ def sync(
 ):
     """Spawn Session
 
-     Explicitly spawn a negotiation session within a namespace room.
+     Explicitly spawn a negotiation session within a room.
 
     Args:
         room_name (str):
@@ -139,7 +139,7 @@ async def asyncio_detailed(
 ]:
     """Spawn Session
 
-     Explicitly spawn a negotiation session within a namespace room.
+     Explicitly spawn a negotiation session within a room.
 
     Args:
         room_name (str):
@@ -172,7 +172,7 @@ async def asyncio(
 ):
     """Spawn Session
 
-     Explicitly spawn a negotiation session within a namespace room.
+     Explicitly spawn a negotiation session within a room.
 
     Args:
         room_name (str):

--- a/mycelium-cli/src/mycelium_backend_client/models/__init__.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/__init__.py
@@ -20,6 +20,7 @@ from .cfn_query_api_cfn_knowledge_query_post_response_cfn_query_api_cfn_knowledg
     CfnQueryApiCfnKnowledgeQueryPostResponseCfnQueryApiCfnKnowledgeQueryPost,
 )
 from .concepts_by_ids_request import ConceptsByIdsRequest
+from .coordination_session_read import CoordinationSessionRead
 from .get_negotiation_status_response_get_negotiation_status import (
     GetNegotiationStatusResponseGetNegotiationStatus,
 )
@@ -79,6 +80,7 @@ __all__ = (
     "CfnListApiCfnKnowledgeListGetResponseCfnListApiCfnKnowledgeListGet",
     "CfnQueryApiCfnKnowledgeQueryPostResponseCfnQueryApiCfnKnowledgeQueryPost",
     "ConceptsByIdsRequest",
+    "CoordinationSessionRead",
     "GetNegotiationStatusResponseGetNegotiationStatus",
     "GraphPathsRequest",
     "HTTPValidationError",

--- a/mycelium-cli/src/mycelium_backend_client/models/__init__.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/__init__.py
@@ -53,15 +53,15 @@ from .memory_search_result import MemorySearchResult
 from .message_create import MessageCreate
 from .message_list_response import MessageListResponse
 from .message_read import MessageRead
+from .participant_create import ParticipantCreate
+from .participant_list_response import ParticipantListResponse
+from .participant_read import ParticipantRead
 from .query_request import QueryRequest
 from .query_request_additional_context_type_0 import QueryRequestAdditionalContextType0
 from .room_create import RoomCreate
 from .room_create_trigger_config_type_0 import RoomCreateTriggerConfigType0
 from .room_read import RoomRead
 from .room_read_trigger_config_type_0 import RoomReadTriggerConfigType0
-from .session_create import SessionCreate
-from .session_list_response import SessionListResponse
-from .session_read import SessionRead
 from .spawn_session_api_rooms_room_name_sessions_spawn_post_response_spawn_session_api_rooms_room_name_sessions_spawn_post import (
     SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost,
 )
@@ -107,15 +107,15 @@ __all__ = (
     "MessageCreate",
     "MessageListResponse",
     "MessageRead",
+    "ParticipantCreate",
+    "ParticipantListResponse",
+    "ParticipantRead",
     "QueryRequest",
     "QueryRequestAdditionalContextType0",
     "RoomCreate",
     "RoomCreateTriggerConfigType0",
     "RoomRead",
     "RoomReadTriggerConfigType0",
-    "SessionCreate",
-    "SessionListResponse",
-    "SessionRead",
     "SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost",
     "SubscriptionCreate",
     "SubscriptionRead",

--- a/mycelium-cli/src/mycelium_backend_client/models/coordination_session_read.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/coordination_session_read.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CoordinationSessionRead")
+
+
+@_attrs_define
+class CoordinationSessionRead:
+    """
+    Attributes:
+        id (UUID):
+        parent_room_name (str):
+        short_id (str):
+        state (str):
+        created_at (datetime.datetime):
+        display_name (str):
+        join_window_ends_at (datetime.datetime | None | Unset):
+        mas_id (None | str | Unset):
+        workspace_id (None | str | Unset):
+    """
+
+    id: UUID
+    parent_room_name: str
+    short_id: str
+    state: str
+    created_at: datetime.datetime
+    display_name: str
+    join_window_ends_at: datetime.datetime | None | Unset = UNSET
+    mas_id: None | str | Unset = UNSET
+    workspace_id: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        parent_room_name = self.parent_room_name
+
+        short_id = self.short_id
+
+        state = self.state
+
+        created_at = self.created_at.isoformat()
+
+        display_name = self.display_name
+
+        join_window_ends_at: None | str | Unset
+        if isinstance(self.join_window_ends_at, Unset):
+            join_window_ends_at = UNSET
+        elif isinstance(self.join_window_ends_at, datetime.datetime):
+            join_window_ends_at = self.join_window_ends_at.isoformat()
+        else:
+            join_window_ends_at = self.join_window_ends_at
+
+        mas_id: None | str | Unset
+        if isinstance(self.mas_id, Unset):
+            mas_id = UNSET
+        else:
+            mas_id = self.mas_id
+
+        workspace_id: None | str | Unset
+        if isinstance(self.workspace_id, Unset):
+            workspace_id = UNSET
+        else:
+            workspace_id = self.workspace_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "parent_room_name": parent_room_name,
+                "short_id": short_id,
+                "state": state,
+                "created_at": created_at,
+                "display_name": display_name,
+            }
+        )
+        if join_window_ends_at is not UNSET:
+            field_dict["join_window_ends_at"] = join_window_ends_at
+        if mas_id is not UNSET:
+            field_dict["mas_id"] = mas_id
+        if workspace_id is not UNSET:
+            field_dict["workspace_id"] = workspace_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        parent_room_name = d.pop("parent_room_name")
+
+        short_id = d.pop("short_id")
+
+        state = d.pop("state")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        display_name = d.pop("display_name")
+
+        def _parse_join_window_ends_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                join_window_ends_at_type_0 = isoparse(data)
+
+                return join_window_ends_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        join_window_ends_at = _parse_join_window_ends_at(d.pop("join_window_ends_at", UNSET))
+
+        def _parse_mas_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        mas_id = _parse_mas_id(d.pop("mas_id", UNSET))
+
+        def _parse_workspace_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        workspace_id = _parse_workspace_id(d.pop("workspace_id", UNSET))
+
+        coordination_session_read = cls(
+            id=id,
+            parent_room_name=parent_room_name,
+            short_id=short_id,
+            state=state,
+            created_at=created_at,
+            display_name=display_name,
+            join_window_ends_at=join_window_ends_at,
+            mas_id=mas_id,
+            workspace_id=workspace_id,
+        )
+
+        coordination_session_read.additional_properties = d
+        return coordination_session_read
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-cli/src/mycelium_backend_client/models/message_read.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/message_read.py
@@ -19,27 +19,27 @@ class MessageRead:
     """
     Attributes:
         id (UUID):
-        room_name (str):
         sender_handle (str):
         message_type (str):
         content (str):
         created_at (datetime.datetime):
+        room_name (None | str | Unset):
+        coordination_session_id (None | Unset | UUID):
         recipient_handle (None | str | Unset):
     """
 
     id: UUID
-    room_name: str
     sender_handle: str
     message_type: str
     content: str
     created_at: datetime.datetime
+    room_name: None | str | Unset = UNSET
+    coordination_session_id: None | Unset | UUID = UNSET
     recipient_handle: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         id = str(self.id)
-
-        room_name = self.room_name
 
         sender_handle = self.sender_handle
 
@@ -48,6 +48,20 @@ class MessageRead:
         content = self.content
 
         created_at = self.created_at.isoformat()
+
+        room_name: None | str | Unset
+        if isinstance(self.room_name, Unset):
+            room_name = UNSET
+        else:
+            room_name = self.room_name
+
+        coordination_session_id: None | str | Unset
+        if isinstance(self.coordination_session_id, Unset):
+            coordination_session_id = UNSET
+        elif isinstance(self.coordination_session_id, UUID):
+            coordination_session_id = str(self.coordination_session_id)
+        else:
+            coordination_session_id = self.coordination_session_id
 
         recipient_handle: None | str | Unset
         if isinstance(self.recipient_handle, Unset):
@@ -60,13 +74,16 @@ class MessageRead:
         field_dict.update(
             {
                 "id": id,
-                "room_name": room_name,
                 "sender_handle": sender_handle,
                 "message_type": message_type,
                 "content": content,
                 "created_at": created_at,
             }
         )
+        if room_name is not UNSET:
+            field_dict["room_name"] = room_name
+        if coordination_session_id is not UNSET:
+            field_dict["coordination_session_id"] = coordination_session_id
         if recipient_handle is not UNSET:
             field_dict["recipient_handle"] = recipient_handle
 
@@ -77,8 +94,6 @@ class MessageRead:
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
-        room_name = d.pop("room_name")
-
         sender_handle = d.pop("sender_handle")
 
         message_type = d.pop("message_type")
@@ -86,6 +101,34 @@ class MessageRead:
         content = d.pop("content")
 
         created_at = isoparse(d.pop("created_at"))
+
+        def _parse_room_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        room_name = _parse_room_name(d.pop("room_name", UNSET))
+
+        def _parse_coordination_session_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                coordination_session_id_type_0 = UUID(data)
+
+                return coordination_session_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        coordination_session_id = _parse_coordination_session_id(
+            d.pop("coordination_session_id", UNSET)
+        )
 
         def _parse_recipient_handle(data: object) -> None | str | Unset:
             if data is None:
@@ -98,11 +141,12 @@ class MessageRead:
 
         message_read = cls(
             id=id,
-            room_name=room_name,
             sender_handle=sender_handle,
             message_type=message_type,
             content=content,
             created_at=created_at,
+            room_name=room_name,
+            coordination_session_id=coordination_session_id,
             recipient_handle=recipient_handle,
         )
 

--- a/mycelium-cli/src/mycelium_backend_client/models/participant_create.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/participant_create.py
@@ -8,11 +8,11 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="SessionCreate")
+T = TypeVar("T", bound="ParticipantCreate")
 
 
 @_attrs_define
-class SessionCreate:
+class ParticipantCreate:
     """
     Attributes:
         agent_handle (str): Agent handle joining the room
@@ -58,13 +58,13 @@ class SessionCreate:
 
         intent = _parse_intent(d.pop("intent", UNSET))
 
-        session_create = cls(
+        participant_create = cls(
             agent_handle=agent_handle,
             intent=intent,
         )
 
-        session_create.additional_properties = d
-        return session_create
+        participant_create.additional_properties = d
+        return participant_create
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-cli/src/mycelium_backend_client/models/participant_list_response.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/participant_list_response.py
@@ -7,29 +7,29 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
-    from ..models.session_read import SessionRead
+    from ..models.participant_read import ParticipantRead
 
 
-T = TypeVar("T", bound="SessionListResponse")
+T = TypeVar("T", bound="ParticipantListResponse")
 
 
 @_attrs_define
-class SessionListResponse:
+class ParticipantListResponse:
     """
     Attributes:
-        sessions (list[SessionRead]):
+        participants (list[ParticipantRead]):
         total (int):
     """
 
-    sessions: list[SessionRead]
+    participants: list[ParticipantRead]
     total: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        sessions = []
-        for sessions_item_data in self.sessions:
-            sessions_item = sessions_item_data.to_dict()
-            sessions.append(sessions_item)
+        participants = []
+        for participants_item_data in self.participants:
+            participants_item = participants_item_data.to_dict()
+            participants.append(participants_item)
 
         total = self.total
 
@@ -37,7 +37,7 @@ class SessionListResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "sessions": sessions,
+                "participants": participants,
                 "total": total,
             }
         )
@@ -46,25 +46,25 @@ class SessionListResponse:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.session_read import SessionRead
+        from ..models.participant_read import ParticipantRead
 
         d = dict(src_dict)
-        sessions = []
-        _sessions = d.pop("sessions")
-        for sessions_item_data in _sessions:
-            sessions_item = SessionRead.from_dict(sessions_item_data)
+        participants = []
+        _participants = d.pop("participants")
+        for participants_item_data in _participants:
+            participants_item = ParticipantRead.from_dict(participants_item_data)
 
-            sessions.append(sessions_item)
+            participants.append(participants_item)
 
         total = d.pop("total")
 
-        session_list_response = cls(
-            sessions=sessions,
+        participant_list_response = cls(
+            participants=participants,
             total=total,
         )
 
-        session_list_response.additional_properties = d
-        return session_list_response
+        participant_list_response.additional_properties = d
+        return participant_list_response
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-cli/src/mycelium_backend_client/models/participant_read.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/participant_read.py
@@ -11,15 +11,15 @@ from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="SessionRead")
+T = TypeVar("T", bound="ParticipantRead")
 
 
 @_attrs_define
-class SessionRead:
+class ParticipantRead:
     """
     Attributes:
         id (UUID):
-        room_name (str):
+        coordination_session_id (UUID):
         agent_handle (str):
         joined_at (datetime.datetime):
         intent (None | str | Unset):
@@ -27,7 +27,7 @@ class SessionRead:
     """
 
     id: UUID
-    room_name: str
+    coordination_session_id: UUID
     agent_handle: str
     joined_at: datetime.datetime
     intent: None | str | Unset = UNSET
@@ -37,7 +37,7 @@ class SessionRead:
     def to_dict(self) -> dict[str, Any]:
         id = str(self.id)
 
-        room_name = self.room_name
+        coordination_session_id = str(self.coordination_session_id)
 
         agent_handle = self.agent_handle
 
@@ -62,7 +62,7 @@ class SessionRead:
         field_dict.update(
             {
                 "id": id,
-                "room_name": room_name,
+                "coordination_session_id": coordination_session_id,
                 "agent_handle": agent_handle,
                 "joined_at": joined_at,
             }
@@ -79,7 +79,7 @@ class SessionRead:
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
-        room_name = d.pop("room_name")
+        coordination_session_id = UUID(d.pop("coordination_session_id"))
 
         agent_handle = d.pop("agent_handle")
 
@@ -111,17 +111,17 @@ class SessionRead:
 
         last_seen = _parse_last_seen(d.pop("last_seen", UNSET))
 
-        session_read = cls(
+        participant_read = cls(
             id=id,
-            room_name=room_name,
+            coordination_session_id=coordination_session_id,
             agent_handle=agent_handle,
             joined_at=joined_at,
             intent=intent,
             last_seen=last_seen,
         )
 
-        session_read.additional_properties = d
-        return session_read
+        participant_read.additional_properties = d
+        return participant_read
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-cli/src/mycelium_backend_client/models/room_read.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/room_read.py
@@ -27,13 +27,9 @@ class RoomRead:
         created_at (datetime.datetime):
         description (None | str | Unset):
         coordination_state (str | Unset):  Default: 'idle'.
-        join_deadline (datetime.datetime | None | Unset):
-        mode (str | Unset):  Default: 'sync'.
         trigger_config (None | RoomReadTriggerConfigType0 | Unset):
         last_synthesis_at (datetime.datetime | None | Unset):
         is_persistent (bool | Unset):  Default: False.
-        is_namespace (bool | Unset):  Default: False.
-        parent_namespace (None | str | Unset):
         mas_id (None | str | Unset):
         workspace_id (None | str | Unset):
     """
@@ -44,13 +40,9 @@ class RoomRead:
     created_at: datetime.datetime
     description: None | str | Unset = UNSET
     coordination_state: str | Unset = "idle"
-    join_deadline: datetime.datetime | None | Unset = UNSET
-    mode: str | Unset = "sync"
     trigger_config: None | RoomReadTriggerConfigType0 | Unset = UNSET
     last_synthesis_at: datetime.datetime | None | Unset = UNSET
     is_persistent: bool | Unset = False
-    is_namespace: bool | Unset = False
-    parent_namespace: None | str | Unset = UNSET
     mas_id: None | str | Unset = UNSET
     workspace_id: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -74,16 +66,6 @@ class RoomRead:
 
         coordination_state = self.coordination_state
 
-        join_deadline: None | str | Unset
-        if isinstance(self.join_deadline, Unset):
-            join_deadline = UNSET
-        elif isinstance(self.join_deadline, datetime.datetime):
-            join_deadline = self.join_deadline.isoformat()
-        else:
-            join_deadline = self.join_deadline
-
-        mode = self.mode
-
         trigger_config: dict[str, Any] | None | Unset
         if isinstance(self.trigger_config, Unset):
             trigger_config = UNSET
@@ -101,14 +83,6 @@ class RoomRead:
             last_synthesis_at = self.last_synthesis_at
 
         is_persistent = self.is_persistent
-
-        is_namespace = self.is_namespace
-
-        parent_namespace: None | str | Unset
-        if isinstance(self.parent_namespace, Unset):
-            parent_namespace = UNSET
-        else:
-            parent_namespace = self.parent_namespace
 
         mas_id: None | str | Unset
         if isinstance(self.mas_id, Unset):
@@ -136,20 +110,12 @@ class RoomRead:
             field_dict["description"] = description
         if coordination_state is not UNSET:
             field_dict["coordination_state"] = coordination_state
-        if join_deadline is not UNSET:
-            field_dict["join_deadline"] = join_deadline
-        if mode is not UNSET:
-            field_dict["mode"] = mode
         if trigger_config is not UNSET:
             field_dict["trigger_config"] = trigger_config
         if last_synthesis_at is not UNSET:
             field_dict["last_synthesis_at"] = last_synthesis_at
         if is_persistent is not UNSET:
             field_dict["is_persistent"] = is_persistent
-        if is_namespace is not UNSET:
-            field_dict["is_namespace"] = is_namespace
-        if parent_namespace is not UNSET:
-            field_dict["parent_namespace"] = parent_namespace
         if mas_id is not UNSET:
             field_dict["mas_id"] = mas_id
         if workspace_id is not UNSET:
@@ -180,25 +146,6 @@ class RoomRead:
         description = _parse_description(d.pop("description", UNSET))
 
         coordination_state = d.pop("coordination_state", UNSET)
-
-        def _parse_join_deadline(data: object) -> datetime.datetime | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                join_deadline_type_0 = isoparse(data)
-
-                return join_deadline_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None | Unset, data)
-
-        join_deadline = _parse_join_deadline(d.pop("join_deadline", UNSET))
-
-        mode = d.pop("mode", UNSET)
 
         def _parse_trigger_config(data: object) -> None | RoomReadTriggerConfigType0 | Unset:
             if data is None:
@@ -236,17 +183,6 @@ class RoomRead:
 
         is_persistent = d.pop("is_persistent", UNSET)
 
-        is_namespace = d.pop("is_namespace", UNSET)
-
-        def _parse_parent_namespace(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        parent_namespace = _parse_parent_namespace(d.pop("parent_namespace", UNSET))
-
         def _parse_mas_id(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -272,13 +208,9 @@ class RoomRead:
             created_at=created_at,
             description=description,
             coordination_state=coordination_state,
-            join_deadline=join_deadline,
-            mode=mode,
             trigger_config=trigger_config,
             last_synthesis_at=last_synthesis_at,
             is_persistent=is_persistent,
-            is_namespace=is_namespace,
-            parent_namespace=parent_namespace,
             mas_id=mas_id,
             workspace_id=workspace_id,
         )

--- a/mycelium-client/mycelium_backend_client/api/coordination_sessions/__init__.py
+++ b/mycelium-client/mycelium_backend_client/api/coordination_sessions/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/mycelium-client/mycelium_backend_client/api/coordination_sessions/get_coordination_session_api_coordination_sessions_session_id_get.py
+++ b/mycelium-client/mycelium_backend_client/api/coordination_sessions/get_coordination_session_api_coordination_sessions_session_id_get.py
@@ -1,25 +1,24 @@
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
+from uuid import UUID
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
+from ...models.coordination_session_read import CoordinationSessionRead
 from ...models.http_validation_error import HTTPValidationError
-from ...models.spawn_session_api_rooms_room_name_sessions_spawn_post_response_spawn_session_api_rooms_room_name_sessions_spawn_post import (
-    SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost,
-)
 from ...types import Response
 
 
 def _get_kwargs(
-    room_name: str,
+    session_id: UUID,
 ) -> dict[str, Any]:
     _kwargs: dict[str, Any] = {
-        "method": "post",
-        "url": "/api/rooms/{room_name}/sessions/spawn".format(
-            room_name=quote(str(room_name), safe=""),
+        "method": "get",
+        "url": "/api/coordination-sessions/{session_id}".format(
+            session_id=quote(str(session_id), safe=""),
         ),
     }
 
@@ -28,17 +27,11 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    if response.status_code == 201:
-        response_201 = SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost.from_dict(
-            response.json()
-        )
+) -> CoordinationSessionRead | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = CoordinationSessionRead.from_dict(response.json())
 
-        return response_201
+        return response_200
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
@@ -53,10 +46,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
+) -> Response[CoordinationSessionRead | HTTPValidationError]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -66,30 +56,25 @@ def _build_response(
 
 
 def sync_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
-    """Spawn Session
-
-     Explicitly spawn a negotiation session within a room.
+) -> Response[CoordinationSessionRead | HTTPValidationError]:
+    """Get Coordination Session
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost]
+        Response[CoordinationSessionRead | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
     )
 
     response = client.get_httpx_client().request(
@@ -100,60 +85,49 @@ def sync_detailed(
 
 
 def sync(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    """Spawn Session
-
-     Explicitly spawn a negotiation session within a room.
+) -> CoordinationSessionRead | HTTPValidationError | None:
+    """Get Coordination Session
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
+        CoordinationSessionRead | HTTPValidationError
     """
 
     return sync_detailed(
-        room_name=room_name,
+        session_id=session_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
-    """Spawn Session
-
-     Explicitly spawn a negotiation session within a room.
+) -> Response[CoordinationSessionRead | HTTPValidationError]:
+    """Get Coordination Session
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost]
+        Response[CoordinationSessionRead | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -162,32 +136,26 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    """Spawn Session
-
-     Explicitly spawn a negotiation session within a room.
+) -> CoordinationSessionRead | HTTPValidationError | None:
+    """Get Coordination Session
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
+        CoordinationSessionRead | HTTPValidationError
     """
 
     return (
         await asyncio_detailed(
-            room_name=room_name,
+            session_id=session_id,
             client=client,
         )
     ).parsed

--- a/mycelium-client/mycelium_backend_client/api/coordination_sessions/list_coordination_sessions_api_coordination_sessions_get.py
+++ b/mycelium-client/mycelium_backend_client/api/coordination_sessions/list_coordination_sessions_api_coordination_sessions_get.py
@@ -1,0 +1,234 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.coordination_session_read import CoordinationSessionRead
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    json_parent_room: None | str | Unset
+    if isinstance(parent_room, Unset):
+        json_parent_room = UNSET
+    else:
+        json_parent_room = parent_room
+    params["parent_room"] = json_parent_room
+
+    json_state: None | str | Unset
+    if isinstance(state, Unset):
+        json_state = UNSET
+    else:
+        json_state = state
+    params["state"] = json_state
+
+    params["limit"] = limit
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/coordination-sessions",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = CoordinationSessionRead.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List coordination sessions, newest first.
+
+    Supports two filters used by the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``) and the frontend sessions rail
+    (``parent_room=<name>``).
+
+    Args:
+        parent_room (None | str | Unset): Filter by parent room name
+        state (None | str | Unset): Comma-separated state filter (e.g. 'waiting,negotiating')
+        limit (int | Unset):  Default: 200.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        parent_room=parent_room,
+        state=state,
+        limit=limit,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient | Client,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List coordination sessions, newest first.
+
+    Supports two filters used by the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``) and the frontend sessions rail
+    (``parent_room=<name>``).
+
+    Args:
+        parent_room (None | str | Unset): Filter by parent room name
+        state (None | str | Unset): Comma-separated state filter (e.g. 'waiting,negotiating')
+        limit (int | Unset):  Default: 200.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return sync_detailed(
+        client=client,
+        parent_room=parent_room,
+        state=state,
+        limit=limit,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient | Client,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List coordination sessions, newest first.
+
+    Supports two filters used by the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``) and the frontend sessions rail
+    (``parent_room=<name>``).
+
+    Args:
+        parent_room (None | str | Unset): Filter by parent room name
+        state (None | str | Unset): Comma-separated state filter (e.g. 'waiting,negotiating')
+        limit (int | Unset):  Default: 200.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        parent_room=parent_room,
+        state=state,
+        limit=limit,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient | Client,
+    parent_room: None | str | Unset = UNSET,
+    state: None | str | Unset = UNSET,
+    limit: int | Unset = 200,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List coordination sessions, newest first.
+
+    Supports two filters used by the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``) and the frontend sessions rail
+    (``parent_room=<name>``).
+
+    Args:
+        parent_room (None | str | Unset): Filter by parent room name
+        state (None | str | Unset): Comma-separated state filter (e.g. 'waiting,negotiating')
+        limit (int | Unset):  Default: 200.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            parent_room=parent_room,
+            state=state,
+            limit=limit,
+        )
+    ).parsed

--- a/mycelium-client/mycelium_backend_client/api/coordination_sessions/list_session_messages_api_coordination_sessions_session_id_messages_get.py
+++ b/mycelium-client/mycelium_backend_client/api/coordination_sessions/list_session_messages_api_coordination_sessions_session_id_messages_get.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
+from uuid import UUID
 
 import httpx
 
@@ -12,7 +13,7 @@ from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
-    room_name: str,
+    session_id: UUID,
     *,
     limit: int | Unset = 50,
     offset: int | Unset = 0,
@@ -43,8 +44,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/api/rooms/{room_name}/messages".format(
-            room_name=quote(str(room_name), safe=""),
+        "url": "/api/coordination-sessions/{session_id}/messages".format(
+            session_id=quote(str(session_id), safe=""),
         ),
         "params": params,
     }
@@ -83,7 +84,7 @@ def _build_response(
 
 
 def sync_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 50,
@@ -91,12 +92,10 @@ def sync_detailed(
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | MessageListResponse]:
-    """List Messages
-
-     List messages in a room (or coordination session), newest first.
+    """List Session Messages
 
     Args:
-        room_name (str):
+        session_id (UUID):
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
@@ -111,7 +110,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
         limit=limit,
         offset=offset,
         sender=sender,
@@ -126,7 +125,7 @@ def sync_detailed(
 
 
 def sync(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 50,
@@ -134,12 +133,10 @@ def sync(
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
 ) -> HTTPValidationError | MessageListResponse | None:
-    """List Messages
-
-     List messages in a room (or coordination session), newest first.
+    """List Session Messages
 
     Args:
-        room_name (str):
+        session_id (UUID):
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
@@ -154,7 +151,7 @@ def sync(
     """
 
     return sync_detailed(
-        room_name=room_name,
+        session_id=session_id,
         client=client,
         limit=limit,
         offset=offset,
@@ -164,7 +161,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 50,
@@ -172,12 +169,10 @@ async def asyncio_detailed(
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
 ) -> Response[HTTPValidationError | MessageListResponse]:
-    """List Messages
-
-     List messages in a room (or coordination session), newest first.
+    """List Session Messages
 
     Args:
-        room_name (str):
+        session_id (UUID):
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
@@ -192,7 +187,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
         limit=limit,
         offset=offset,
         sender=sender,
@@ -205,7 +200,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 50,
@@ -213,12 +208,10 @@ async def asyncio(
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
 ) -> HTTPValidationError | MessageListResponse | None:
-    """List Messages
-
-     List messages in a room (or coordination session), newest first.
+    """List Session Messages
 
     Args:
-        room_name (str):
+        session_id (UUID):
         limit (int | Unset):  Default: 50.
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
@@ -234,7 +227,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            room_name=room_name,
+            session_id=session_id,
             client=client,
             limit=limit,
             offset=offset,

--- a/mycelium-client/mycelium_backend_client/api/coordination_sessions/post_session_message_api_coordination_sessions_session_id_messages_post.py
+++ b/mycelium-client/mycelium_backend_client/api/coordination_sessions/post_session_message_api_coordination_sessions_session_id_messages_post.py
@@ -1,28 +1,29 @@
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
+from uuid import UUID
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.participant_create import ParticipantCreate
-from ...models.participant_read import ParticipantRead
+from ...models.message_create import MessageCreate
+from ...models.message_read import MessageRead
 from ...types import Response
 
 
 def _get_kwargs(
-    room_name: str,
+    session_id: UUID,
     *,
-    body: ParticipantCreate,
+    body: MessageCreate,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/api/rooms/{room_name}/sessions".format(
-            room_name=quote(str(room_name), safe=""),
+        "url": "/api/coordination-sessions/{session_id}/messages".format(
+            session_id=quote(str(session_id), safe=""),
         ),
     }
 
@@ -36,9 +37,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | ParticipantRead | None:
+) -> HTTPValidationError | MessageRead | None:
     if response.status_code == 201:
-        response_201 = ParticipantRead.from_dict(response.json())
+        response_201 = MessageRead.from_dict(response.json())
 
         return response_201
 
@@ -55,7 +56,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | ParticipantRead]:
+) -> Response[HTTPValidationError | MessageRead]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -65,29 +66,34 @@ def _build_response(
 
 
 def sync_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-    body: ParticipantCreate,
-) -> Response[HTTPValidationError | ParticipantRead]:
-    """Join Room
+    body: MessageCreate,
+) -> Response[HTTPValidationError | MessageRead]:
+    """Post Session Message
 
-     Join a room. Auto-spawns a coordination session if one doesn't exist.
+     Post a message to a coordination session.
+
+    Messages are stored with ``coordination_session_id`` set and ``room_name``
+    null. SSE subscribers on the session-display channel still receive them
+    via the same ``room:{display_name}`` NOTIFY topic during the deprecation
+    window so existing OpenClaw plugin / CLI subscribers don't break.
 
     Args:
-        room_name (str):
-        body (ParticipantCreate):
+        session_id (UUID):
+        body (MessageCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | ParticipantRead]
+        Response[HTTPValidationError | MessageRead]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
         body=body,
     )
 
@@ -99,58 +105,68 @@ def sync_detailed(
 
 
 def sync(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-    body: ParticipantCreate,
-) -> HTTPValidationError | ParticipantRead | None:
-    """Join Room
+    body: MessageCreate,
+) -> HTTPValidationError | MessageRead | None:
+    """Post Session Message
 
-     Join a room. Auto-spawns a coordination session if one doesn't exist.
+     Post a message to a coordination session.
+
+    Messages are stored with ``coordination_session_id`` set and ``room_name``
+    null. SSE subscribers on the session-display channel still receive them
+    via the same ``room:{display_name}`` NOTIFY topic during the deprecation
+    window so existing OpenClaw plugin / CLI subscribers don't break.
 
     Args:
-        room_name (str):
-        body (ParticipantCreate):
+        session_id (UUID):
+        body (MessageCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | ParticipantRead
+        HTTPValidationError | MessageRead
     """
 
     return sync_detailed(
-        room_name=room_name,
+        session_id=session_id,
         client=client,
         body=body,
     ).parsed
 
 
 async def asyncio_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-    body: ParticipantCreate,
-) -> Response[HTTPValidationError | ParticipantRead]:
-    """Join Room
+    body: MessageCreate,
+) -> Response[HTTPValidationError | MessageRead]:
+    """Post Session Message
 
-     Join a room. Auto-spawns a coordination session if one doesn't exist.
+     Post a message to a coordination session.
+
+    Messages are stored with ``coordination_session_id`` set and ``room_name``
+    null. SSE subscribers on the session-display channel still receive them
+    via the same ``room:{display_name}`` NOTIFY topic during the deprecation
+    window so existing OpenClaw plugin / CLI subscribers don't break.
 
     Args:
-        room_name (str):
-        body (ParticipantCreate):
+        session_id (UUID):
+        body (MessageCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | ParticipantRead]
+        Response[HTTPValidationError | MessageRead]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
         body=body,
     )
 
@@ -160,30 +176,35 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-    body: ParticipantCreate,
-) -> HTTPValidationError | ParticipantRead | None:
-    """Join Room
+    body: MessageCreate,
+) -> HTTPValidationError | MessageRead | None:
+    """Post Session Message
 
-     Join a room. Auto-spawns a coordination session if one doesn't exist.
+     Post a message to a coordination session.
+
+    Messages are stored with ``coordination_session_id`` set and ``room_name``
+    null. SSE subscribers on the session-display channel still receive them
+    via the same ``room:{display_name}`` NOTIFY topic during the deprecation
+    window so existing OpenClaw plugin / CLI subscribers don't break.
 
     Args:
-        room_name (str):
-        body (ParticipantCreate):
+        session_id (UUID):
+        body (MessageCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | ParticipantRead
+        HTTPValidationError | MessageRead
     """
 
     return (
         await asyncio_detailed(
-            room_name=room_name,
+            session_id=session_id,
             client=client,
             body=body,
         )

--- a/mycelium-client/mycelium_backend_client/api/coordination_sessions/stream_session_messages_api_coordination_sessions_session_id_messages_stream_get.py
+++ b/mycelium-client/mycelium_backend_client/api/coordination_sessions/stream_session_messages_api_coordination_sessions_session_id_messages_stream_get.py
@@ -1,25 +1,23 @@
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
+from uuid import UUID
 
 import httpx
 
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.spawn_session_api_rooms_room_name_sessions_spawn_post_response_spawn_session_api_rooms_room_name_sessions_spawn_post import (
-    SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost,
-)
 from ...types import Response
 
 
 def _get_kwargs(
-    room_name: str,
+    session_id: UUID,
 ) -> dict[str, Any]:
     _kwargs: dict[str, Any] = {
-        "method": "post",
-        "url": "/api/rooms/{room_name}/sessions/spawn".format(
-            room_name=quote(str(room_name), safe=""),
+        "method": "get",
+        "url": "/api/coordination-sessions/{session_id}/messages/stream".format(
+            session_id=quote(str(session_id), safe=""),
         ),
     }
 
@@ -28,17 +26,10 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    if response.status_code == 201:
-        response_201 = SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost.from_dict(
-            response.json()
-        )
-
-        return response_201
+) -> Any | HTTPValidationError | None:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
 
     if response.status_code == 422:
         response_422 = HTTPValidationError.from_dict(response.json())
@@ -53,10 +44,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
+) -> Response[Any | HTTPValidationError]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -66,30 +54,31 @@ def _build_response(
 
 
 def sync_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
-    """Spawn Session
+) -> Response[Any | HTTPValidationError]:
+    """Stream Session Messages
 
-     Explicitly spawn a negotiation session within a room.
+     SSE stream for a coordination session.
+
+    Resolves the session and subscribes to the underlying ``room:{display_name}``
+    Postgres NOTIFY channel so any inbound message routed to either coord_session_id
+    or the legacy display name surfaces here.
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost]
+        Response[Any | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
     )
 
     response = client.get_httpx_client().request(
@@ -100,60 +89,61 @@ def sync_detailed(
 
 
 def sync(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    """Spawn Session
+) -> Any | HTTPValidationError | None:
+    """Stream Session Messages
 
-     Explicitly spawn a negotiation session within a room.
+     SSE stream for a coordination session.
+
+    Resolves the session and subscribes to the underlying ``room:{display_name}``
+    Postgres NOTIFY channel so any inbound message routed to either coord_session_id
+    or the legacy display name surfaces here.
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
+        Any | HTTPValidationError
     """
 
     return sync_detailed(
-        room_name=room_name,
+        session_id=session_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-]:
-    """Spawn Session
+) -> Response[Any | HTTPValidationError]:
+    """Stream Session Messages
 
-     Explicitly spawn a negotiation session within a room.
+     SSE stream for a coordination session.
+
+    Resolves the session and subscribes to the underlying ``room:{display_name}``
+    Postgres NOTIFY channel so any inbound message routed to either coord_session_id
+    or the legacy display name surfaces here.
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost]
+        Response[Any | HTTPValidationError]
     """
 
     kwargs = _get_kwargs(
-        room_name=room_name,
+        session_id=session_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -162,32 +152,32 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    room_name: str,
+    session_id: UUID,
     *,
     client: AuthenticatedClient | Client,
-) -> (
-    HTTPValidationError
-    | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
-    | None
-):
-    """Spawn Session
+) -> Any | HTTPValidationError | None:
+    """Stream Session Messages
 
-     Explicitly spawn a negotiation session within a room.
+     SSE stream for a coordination session.
+
+    Resolves the session and subscribes to the underlying ``room:{display_name}``
+    Postgres NOTIFY channel so any inbound message routed to either coord_session_id
+    or the legacy display name surfaces here.
 
     Args:
-        room_name (str):
+        session_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost
+        Any | HTTPValidationError
     """
 
     return (
         await asyncio_detailed(
-            room_name=room_name,
+            session_id=session_id,
             client=client,
         )
     ).parsed

--- a/mycelium-client/mycelium_backend_client/api/rooms/delete_room_api_rooms_room_name_delete.py
+++ b/mycelium-client/mycelium_backend_client/api/rooms/delete_room_api_rooms_room_name_delete.py
@@ -57,26 +57,20 @@ def sync_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[Any | HTTPValidationError]:
-    r"""Delete Room
+    """Delete Room
 
      Delete a room and cascade to its child session rooms.
 
-    Cleanup order is important to avoid stale state firing against
-    already-deleted rows:
+    Cleanup order:
 
-      1. Enumerate child session rooms (``parent_namespace == room_name``).
-      2. Tear down all in-memory CFN coordination state for the namespace
-         and its children (cancels pending join timers and active round
-         timeouts, posts ``coordination_consensus broken=True`` to any
-         SSE subscribers).
-      3. Delete child ``Session`` rows, then child ``Room`` rows.
-      4. Mark any active child rooms as ``coordination_state=\"failed\"``
-         (defensive — if step 3 didn't catch them due to a race, the
-         state still reflects reality).
-      5. Delete the parent ``Room`` row.
-      6. Remove the filesystem directory.
-      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
-         error doesn't block the local cleanup).
+      1. Resolve all coordination sessions for this room (display names + IDs).
+      2. Tear down in-memory CFN coordination state. Doing this before DB
+         deletes prevents in-flight ticks from firing against half-deleted
+         state.
+      3. Delete the room row — coordination_sessions, participants, and
+         messages cascade automatically via FK ON DELETE CASCADE.
+      4. Remove the filesystem directory.
+      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
 
     Args:
         room_name (str):
@@ -105,26 +99,20 @@ def sync(
     *,
     client: AuthenticatedClient | Client,
 ) -> Any | HTTPValidationError | None:
-    r"""Delete Room
+    """Delete Room
 
      Delete a room and cascade to its child session rooms.
 
-    Cleanup order is important to avoid stale state firing against
-    already-deleted rows:
+    Cleanup order:
 
-      1. Enumerate child session rooms (``parent_namespace == room_name``).
-      2. Tear down all in-memory CFN coordination state for the namespace
-         and its children (cancels pending join timers and active round
-         timeouts, posts ``coordination_consensus broken=True`` to any
-         SSE subscribers).
-      3. Delete child ``Session`` rows, then child ``Room`` rows.
-      4. Mark any active child rooms as ``coordination_state=\"failed\"``
-         (defensive — if step 3 didn't catch them due to a race, the
-         state still reflects reality).
-      5. Delete the parent ``Room`` row.
-      6. Remove the filesystem directory.
-      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
-         error doesn't block the local cleanup).
+      1. Resolve all coordination sessions for this room (display names + IDs).
+      2. Tear down in-memory CFN coordination state. Doing this before DB
+         deletes prevents in-flight ticks from firing against half-deleted
+         state.
+      3. Delete the room row — coordination_sessions, participants, and
+         messages cascade automatically via FK ON DELETE CASCADE.
+      4. Remove the filesystem directory.
+      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
 
     Args:
         room_name (str):
@@ -148,26 +136,20 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[Any | HTTPValidationError]:
-    r"""Delete Room
+    """Delete Room
 
      Delete a room and cascade to its child session rooms.
 
-    Cleanup order is important to avoid stale state firing against
-    already-deleted rows:
+    Cleanup order:
 
-      1. Enumerate child session rooms (``parent_namespace == room_name``).
-      2. Tear down all in-memory CFN coordination state for the namespace
-         and its children (cancels pending join timers and active round
-         timeouts, posts ``coordination_consensus broken=True`` to any
-         SSE subscribers).
-      3. Delete child ``Session`` rows, then child ``Room`` rows.
-      4. Mark any active child rooms as ``coordination_state=\"failed\"``
-         (defensive — if step 3 didn't catch them due to a race, the
-         state still reflects reality).
-      5. Delete the parent ``Room`` row.
-      6. Remove the filesystem directory.
-      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
-         error doesn't block the local cleanup).
+      1. Resolve all coordination sessions for this room (display names + IDs).
+      2. Tear down in-memory CFN coordination state. Doing this before DB
+         deletes prevents in-flight ticks from firing against half-deleted
+         state.
+      3. Delete the room row — coordination_sessions, participants, and
+         messages cascade automatically via FK ON DELETE CASCADE.
+      4. Remove the filesystem directory.
+      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
 
     Args:
         room_name (str):
@@ -194,26 +176,20 @@ async def asyncio(
     *,
     client: AuthenticatedClient | Client,
 ) -> Any | HTTPValidationError | None:
-    r"""Delete Room
+    """Delete Room
 
      Delete a room and cascade to its child session rooms.
 
-    Cleanup order is important to avoid stale state firing against
-    already-deleted rows:
+    Cleanup order:
 
-      1. Enumerate child session rooms (``parent_namespace == room_name``).
-      2. Tear down all in-memory CFN coordination state for the namespace
-         and its children (cancels pending join timers and active round
-         timeouts, posts ``coordination_consensus broken=True`` to any
-         SSE subscribers).
-      3. Delete child ``Session`` rows, then child ``Room`` rows.
-      4. Mark any active child rooms as ``coordination_state=\"failed\"``
-         (defensive — if step 3 didn't catch them due to a race, the
-         state still reflects reality).
-      5. Delete the parent ``Room`` row.
-      6. Remove the filesystem directory.
-      7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN
-         error doesn't block the local cleanup).
+      1. Resolve all coordination sessions for this room (display names + IDs).
+      2. Tear down in-memory CFN coordination state. Doing this before DB
+         deletes prevents in-flight ticks from firing against half-deleted
+         state.
+      3. Delete the room row — coordination_sessions, participants, and
+         messages cascade automatically via FK ON DELETE CASCADE.
+      4. Remove the filesystem directory.
+      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
 
     Args:
         room_name (str):

--- a/mycelium-client/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
+++ b/mycelium-client/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
@@ -15,6 +15,7 @@ def _get_kwargs(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -28,6 +29,8 @@ def _get_kwargs(
     else:
         json_name = name
     params["name"] = json_name
+
+    params["include_sessions"] = include_sessions
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -81,15 +84,22 @@ def sync_detailed(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> Response[HTTPValidationError | list[RoomRead]]:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -103,6 +113,7 @@ def sync_detailed(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     )
 
     response = client.get_httpx_client().request(
@@ -118,15 +129,22 @@ def sync(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> HTTPValidationError | list[RoomRead] | None:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,6 +159,7 @@ def sync(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     ).parsed
 
 
@@ -150,15 +169,22 @@ async def asyncio_detailed(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> Response[HTTPValidationError | list[RoomRead]]:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,6 +198,7 @@ async def asyncio_detailed(
         skip=skip,
         limit=limit,
         name=name,
+        include_sessions=include_sessions,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -185,15 +212,22 @@ async def asyncio(
     skip: int | Unset = 0,
     limit: int | Unset = 1000,
     name: None | str | Unset = UNSET,
+    include_sessions: bool | Unset = False,
 ) -> HTTPValidationError | list[RoomRead] | None:
     """List Rooms
 
-     List rooms with optional name filter.
+     List rooms.
+
+    By default returns only real rooms (namespaces). Session-shadow rows are
+    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
+    to include the shadow rows — used by callers (e.g. the OpenClaw channel
+    plugin) that still address sessions by name during the deprecation window.
 
     Args:
         skip (int | Unset):  Default: 0.
         limit (int | Unset):  Default: 1000.
         name (None | str | Unset):
+        include_sessions (bool | Unset):  Default: False.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -209,5 +243,6 @@ async def asyncio(
             skip=skip,
             limit=limit,
             name=name,
+            include_sessions=include_sessions,
         )
     ).parsed

--- a/mycelium-client/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
+++ b/mycelium-client/mycelium_backend_client/api/rooms/list_rooms_api_rooms_get.py
@@ -90,10 +90,9 @@ def sync_detailed(
 
      List rooms.
 
-    By default returns only real rooms (namespaces). Session-shadow rows are
-    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
-    to include the shadow rows — used by callers (e.g. the OpenClaw channel
-    plugin) that still address sessions by name during the deprecation window.
+    Sessions live in ``coordination_sessions`` and are not surfaced here. The
+    ``include_sessions`` parameter is kept for backward-compatible URLs but is
+    a no-op now (#244 — session-shadow rows no longer exist).
 
     Args:
         skip (int | Unset):  Default: 0.
@@ -135,10 +134,9 @@ def sync(
 
      List rooms.
 
-    By default returns only real rooms (namespaces). Session-shadow rows are
-    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
-    to include the shadow rows — used by callers (e.g. the OpenClaw channel
-    plugin) that still address sessions by name during the deprecation window.
+    Sessions live in ``coordination_sessions`` and are not surfaced here. The
+    ``include_sessions`` parameter is kept for backward-compatible URLs but is
+    a no-op now (#244 — session-shadow rows no longer exist).
 
     Args:
         skip (int | Unset):  Default: 0.
@@ -175,10 +173,9 @@ async def asyncio_detailed(
 
      List rooms.
 
-    By default returns only real rooms (namespaces). Session-shadow rows are
-    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
-    to include the shadow rows — used by callers (e.g. the OpenClaw channel
-    plugin) that still address sessions by name during the deprecation window.
+    Sessions live in ``coordination_sessions`` and are not surfaced here. The
+    ``include_sessions`` parameter is kept for backward-compatible URLs but is
+    a no-op now (#244 — session-shadow rows no longer exist).
 
     Args:
         skip (int | Unset):  Default: 0.
@@ -218,10 +215,9 @@ async def asyncio(
 
      List rooms.
 
-    By default returns only real rooms (namespaces). Session-shadow rows are
-    excluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``
-    to include the shadow rows — used by callers (e.g. the OpenClaw channel
-    plugin) that still address sessions by name during the deprecation window.
+    Sessions live in ``coordination_sessions`` and are not surfaced here. The
+    ``include_sessions`` parameter is kept for backward-compatible URLs but is
+    a no-op now (#244 — session-shadow rows no longer exist).
 
     Args:
         skip (int | Unset):  Default: 0.

--- a/mycelium-client/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
+++ b/mycelium-client/mycelium_backend_client/api/sessions/join_room_api_rooms_room_name_sessions_post.py
@@ -7,15 +7,15 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.session_create import SessionCreate
-from ...models.session_read import SessionRead
+from ...models.participant_create import ParticipantCreate
+from ...models.participant_read import ParticipantRead
 from ...types import Response
 
 
 def _get_kwargs(
     room_name: str,
     *,
-    body: SessionCreate,
+    body: ParticipantCreate,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
 
@@ -36,9 +36,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | SessionRead | None:
+) -> HTTPValidationError | ParticipantRead | None:
     if response.status_code == 201:
-        response_201 = SessionRead.from_dict(response.json())
+        response_201 = ParticipantRead.from_dict(response.json())
 
         return response_201
 
@@ -55,7 +55,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | SessionRead]:
+) -> Response[HTTPValidationError | ParticipantRead]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -68,22 +68,22 @@ def sync_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> Response[HTTPValidationError | SessionRead]:
+    body: ParticipantCreate,
+) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionRead]
+        Response[HTTPValidationError | ParticipantRead]
     """
 
     kwargs = _get_kwargs(
@@ -102,22 +102,22 @@ def sync(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> HTTPValidationError | SessionRead | None:
+    body: ParticipantCreate,
+) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionRead
+        HTTPValidationError | ParticipantRead
     """
 
     return sync_detailed(
@@ -131,22 +131,22 @@ async def asyncio_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> Response[HTTPValidationError | SessionRead]:
+    body: ParticipantCreate,
+) -> Response[HTTPValidationError | ParticipantRead]:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionRead]
+        Response[HTTPValidationError | ParticipantRead]
     """
 
     kwargs = _get_kwargs(
@@ -163,22 +163,22 @@ async def asyncio(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-    body: SessionCreate,
-) -> HTTPValidationError | SessionRead | None:
+    body: ParticipantCreate,
+) -> HTTPValidationError | ParticipantRead | None:
     """Join Room
 
      Join a room. If the room is a namespace, auto-spawns a session and joins that.
 
     Args:
         room_name (str):
-        body (SessionCreate):
+        body (ParticipantCreate):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionRead
+        HTTPValidationError | ParticipantRead
     """
 
     return (

--- a/mycelium-client/mycelium_backend_client/api/sessions/leave_room_api_rooms_room_name_sessions_session_id_delete.py
+++ b/mycelium-client/mycelium_backend_client/api/sessions/leave_room_api_rooms_room_name_sessions_session_id_delete.py
@@ -63,7 +63,7 @@ def sync_detailed(
 ) -> Response[Any | HTTPValidationError]:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -97,7 +97,7 @@ def sync(
 ) -> Any | HTTPValidationError | None:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -126,7 +126,7 @@ async def asyncio_detailed(
 ) -> Response[Any | HTTPValidationError]:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):
@@ -158,7 +158,7 @@ async def asyncio(
 ) -> Any | HTTPValidationError | None:
     """Leave Room
 
-     Remove an agent session (leave room).
+     Remove a participant (agent leaves the session).
 
     Args:
         room_name (str):

--- a/mycelium-client/mycelium_backend_client/api/sessions/list_coordination_sessions_api_rooms_room_name_sessions_coordination_get.py
+++ b/mycelium-client/mycelium_backend_client/api/sessions/list_coordination_sessions_api_rooms_room_name_sessions_coordination_get.py
@@ -1,0 +1,185 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.coordination_session_read import CoordinationSessionRead
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    room_name: str,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/api/rooms/{room_name}/sessions/coordination".format(
+            room_name=quote(str(room_name), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = CoordinationSessionRead.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return sync_detailed(
+        room_name=room_name,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[HTTPValidationError | list[CoordinationSessionRead]]:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | list[CoordinationSessionRead]]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    room_name: str,
+    *,
+    client: AuthenticatedClient | Client,
+) -> HTTPValidationError | list[CoordinationSessionRead] | None:
+    """List Coordination Sessions
+
+     List negotiation sessions in a room (#197).
+
+    Returns first-class CoordinationSession entities. The shadow rows in the
+    rooms table are an implementation detail that callers shouldn't depend on.
+
+    Args:
+        room_name (str):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | list[CoordinationSessionRead]
+    """
+
+    return (
+        await asyncio_detailed(
+            room_name=room_name,
+            client=client,
+        )
+    ).parsed

--- a/mycelium-client/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
+++ b/mycelium-client/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
@@ -7,7 +7,7 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...models.session_list_response import SessionListResponse
+from ...models.participant_list_response import ParticipantListResponse
 from ...types import Response
 
 
@@ -26,9 +26,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     if response.status_code == 200:
-        response_200 = SessionListResponse.from_dict(response.json())
+        response_200 = ParticipantListResponse.from_dict(response.json())
 
         return response_200
 
@@ -45,7 +45,7 @@ def _parse_response(
 
 def _build_response(
     *, client: AuthenticatedClient | Client, response: httpx.Response
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -58,10 +58,10 @@ def sync_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -71,7 +71,7 @@ def sync_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionListResponse]
+        Response[HTTPValidationError | ParticipantListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -89,10 +89,10 @@ def sync(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -102,7 +102,7 @@ def sync(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionListResponse
+        HTTPValidationError | ParticipantListResponse
     """
 
     return sync_detailed(
@@ -115,10 +115,10 @@ async def asyncio_detailed(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> Response[HTTPValidationError | SessionListResponse]:
+) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -128,7 +128,7 @@ async def asyncio_detailed(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[HTTPValidationError | SessionListResponse]
+        Response[HTTPValidationError | ParticipantListResponse]
     """
 
     kwargs = _get_kwargs(
@@ -144,10 +144,10 @@ async def asyncio(
     room_name: str,
     *,
     client: AuthenticatedClient | Client,
-) -> HTTPValidationError | SessionListResponse | None:
+) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents currently in a room.
+     List agents participating in a room's coordination session.
 
     Args:
         room_name (str):
@@ -157,7 +157,7 @@ async def asyncio(
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        HTTPValidationError | SessionListResponse
+        HTTPValidationError | ParticipantListResponse
     """
 
     return (

--- a/mycelium-client/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
+++ b/mycelium-client/mycelium_backend_client/api/sessions/list_sessions_api_rooms_room_name_sessions_get.py
@@ -61,7 +61,11 @@ def sync_detailed(
 ) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents participating in a room's coordination session.
+     List agents participating in a room's coordination session(s).
+
+    Accepts either a real room name (returns participants across all its
+    coord_sessions) or a legacy ``{parent}:session:{short}`` display name
+    (returns participants of just that one session).
 
     Args:
         room_name (str):
@@ -92,7 +96,11 @@ def sync(
 ) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents participating in a room's coordination session.
+     List agents participating in a room's coordination session(s).
+
+    Accepts either a real room name (returns participants across all its
+    coord_sessions) or a legacy ``{parent}:session:{short}`` display name
+    (returns participants of just that one session).
 
     Args:
         room_name (str):
@@ -118,7 +126,11 @@ async def asyncio_detailed(
 ) -> Response[HTTPValidationError | ParticipantListResponse]:
     """List Sessions
 
-     List agents participating in a room's coordination session.
+     List agents participating in a room's coordination session(s).
+
+    Accepts either a real room name (returns participants across all its
+    coord_sessions) or a legacy ``{parent}:session:{short}`` display name
+    (returns participants of just that one session).
 
     Args:
         room_name (str):
@@ -147,7 +159,11 @@ async def asyncio(
 ) -> HTTPValidationError | ParticipantListResponse | None:
     """List Sessions
 
-     List agents participating in a room's coordination session.
+     List agents participating in a room's coordination session(s).
+
+    Accepts either a real room name (returns participants across all its
+    coord_sessions) or a legacy ``{parent}:session:{short}`` display name
+    (returns participants of just that one session).
 
     Args:
         room_name (str):

--- a/mycelium-client/mycelium_backend_client/models/__init__.py
+++ b/mycelium-client/mycelium_backend_client/models/__init__.py
@@ -51,15 +51,15 @@ from .memory_search_result import MemorySearchResult
 from .message_create import MessageCreate
 from .message_list_response import MessageListResponse
 from .message_read import MessageRead
+from .participant_create import ParticipantCreate
+from .participant_list_response import ParticipantListResponse
+from .participant_read import ParticipantRead
 from .query_request import QueryRequest
 from .query_request_additional_context_type_0 import QueryRequestAdditionalContextType0
 from .room_create import RoomCreate
 from .room_create_trigger_config_type_0 import RoomCreateTriggerConfigType0
 from .room_read import RoomRead
 from .room_read_trigger_config_type_0 import RoomReadTriggerConfigType0
-from .session_create import SessionCreate
-from .session_list_response import SessionListResponse
-from .session_read import SessionRead
 from .spawn_session_api_rooms_room_name_sessions_spawn_post_response_spawn_session_api_rooms_room_name_sessions_spawn_post import (
     SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost,
 )
@@ -105,15 +105,15 @@ __all__ = (
     "MessageCreate",
     "MessageListResponse",
     "MessageRead",
+    "ParticipantCreate",
+    "ParticipantListResponse",
+    "ParticipantRead",
     "QueryRequest",
     "QueryRequestAdditionalContextType0",
     "RoomCreate",
     "RoomCreateTriggerConfigType0",
     "RoomRead",
     "RoomReadTriggerConfigType0",
-    "SessionCreate",
-    "SessionListResponse",
-    "SessionRead",
     "SpawnSessionApiRoomsRoomNameSessionsSpawnPostResponseSpawnSessionApiRoomsRoomNameSessionsSpawnPost",
     "SubscriptionCreate",
     "SubscriptionRead",

--- a/mycelium-client/mycelium_backend_client/models/__init__.py
+++ b/mycelium-client/mycelium_backend_client/models/__init__.py
@@ -20,6 +20,7 @@ from .cfn_query_api_cfn_knowledge_query_post_response_cfn_query_api_cfn_knowledg
     CfnQueryApiCfnKnowledgeQueryPostResponseCfnQueryApiCfnKnowledgeQueryPost,
 )
 from .concepts_by_ids_request import ConceptsByIdsRequest
+from .coordination_session_read import CoordinationSessionRead
 from .get_negotiation_status_response_get_negotiation_status import GetNegotiationStatusResponseGetNegotiationStatus
 from .graph_paths_request import GraphPathsRequest
 from .http_validation_error import HTTPValidationError
@@ -77,6 +78,7 @@ __all__ = (
     "CfnListApiCfnKnowledgeListGetResponseCfnListApiCfnKnowledgeListGet",
     "CfnQueryApiCfnKnowledgeQueryPostResponseCfnQueryApiCfnKnowledgeQueryPost",
     "ConceptsByIdsRequest",
+    "CoordinationSessionRead",
     "GetNegotiationStatusResponseGetNegotiationStatus",
     "GraphPathsRequest",
     "HTTPValidationError",

--- a/mycelium-client/mycelium_backend_client/models/coordination_session_read.py
+++ b/mycelium-client/mycelium_backend_client/models/coordination_session_read.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CoordinationSessionRead")
+
+
+@_attrs_define
+class CoordinationSessionRead:
+    """
+    Attributes:
+        id (UUID):
+        parent_room_name (str):
+        short_id (str):
+        state (str):
+        created_at (datetime.datetime):
+        display_name (str):
+        join_window_ends_at (datetime.datetime | None | Unset):
+        mas_id (None | str | Unset):
+        workspace_id (None | str | Unset):
+    """
+
+    id: UUID
+    parent_room_name: str
+    short_id: str
+    state: str
+    created_at: datetime.datetime
+    display_name: str
+    join_window_ends_at: datetime.datetime | None | Unset = UNSET
+    mas_id: None | str | Unset = UNSET
+    workspace_id: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        id = str(self.id)
+
+        parent_room_name = self.parent_room_name
+
+        short_id = self.short_id
+
+        state = self.state
+
+        created_at = self.created_at.isoformat()
+
+        display_name = self.display_name
+
+        join_window_ends_at: None | str | Unset
+        if isinstance(self.join_window_ends_at, Unset):
+            join_window_ends_at = UNSET
+        elif isinstance(self.join_window_ends_at, datetime.datetime):
+            join_window_ends_at = self.join_window_ends_at.isoformat()
+        else:
+            join_window_ends_at = self.join_window_ends_at
+
+        mas_id: None | str | Unset
+        if isinstance(self.mas_id, Unset):
+            mas_id = UNSET
+        else:
+            mas_id = self.mas_id
+
+        workspace_id: None | str | Unset
+        if isinstance(self.workspace_id, Unset):
+            workspace_id = UNSET
+        else:
+            workspace_id = self.workspace_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "parent_room_name": parent_room_name,
+                "short_id": short_id,
+                "state": state,
+                "created_at": created_at,
+                "display_name": display_name,
+            }
+        )
+        if join_window_ends_at is not UNSET:
+            field_dict["join_window_ends_at"] = join_window_ends_at
+        if mas_id is not UNSET:
+            field_dict["mas_id"] = mas_id
+        if workspace_id is not UNSET:
+            field_dict["workspace_id"] = workspace_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        id = UUID(d.pop("id"))
+
+        parent_room_name = d.pop("parent_room_name")
+
+        short_id = d.pop("short_id")
+
+        state = d.pop("state")
+
+        created_at = isoparse(d.pop("created_at"))
+
+        display_name = d.pop("display_name")
+
+        def _parse_join_window_ends_at(data: object) -> datetime.datetime | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                join_window_ends_at_type_0 = isoparse(data)
+
+                return join_window_ends_at_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(datetime.datetime | None | Unset, data)
+
+        join_window_ends_at = _parse_join_window_ends_at(d.pop("join_window_ends_at", UNSET))
+
+        def _parse_mas_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        mas_id = _parse_mas_id(d.pop("mas_id", UNSET))
+
+        def _parse_workspace_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        workspace_id = _parse_workspace_id(d.pop("workspace_id", UNSET))
+
+        coordination_session_read = cls(
+            id=id,
+            parent_room_name=parent_room_name,
+            short_id=short_id,
+            state=state,
+            created_at=created_at,
+            display_name=display_name,
+            join_window_ends_at=join_window_ends_at,
+            mas_id=mas_id,
+            workspace_id=workspace_id,
+        )
+
+        coordination_session_read.additional_properties = d
+        return coordination_session_read
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-client/mycelium_backend_client/models/message_read.py
+++ b/mycelium-client/mycelium_backend_client/models/message_read.py
@@ -19,27 +19,27 @@ class MessageRead:
     """
     Attributes:
         id (UUID):
-        room_name (str):
         sender_handle (str):
         message_type (str):
         content (str):
         created_at (datetime.datetime):
+        room_name (None | str | Unset):
+        coordination_session_id (None | Unset | UUID):
         recipient_handle (None | str | Unset):
     """
 
     id: UUID
-    room_name: str
     sender_handle: str
     message_type: str
     content: str
     created_at: datetime.datetime
+    room_name: None | str | Unset = UNSET
+    coordination_session_id: None | Unset | UUID = UNSET
     recipient_handle: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         id = str(self.id)
-
-        room_name = self.room_name
 
         sender_handle = self.sender_handle
 
@@ -48,6 +48,20 @@ class MessageRead:
         content = self.content
 
         created_at = self.created_at.isoformat()
+
+        room_name: None | str | Unset
+        if isinstance(self.room_name, Unset):
+            room_name = UNSET
+        else:
+            room_name = self.room_name
+
+        coordination_session_id: None | str | Unset
+        if isinstance(self.coordination_session_id, Unset):
+            coordination_session_id = UNSET
+        elif isinstance(self.coordination_session_id, UUID):
+            coordination_session_id = str(self.coordination_session_id)
+        else:
+            coordination_session_id = self.coordination_session_id
 
         recipient_handle: None | str | Unset
         if isinstance(self.recipient_handle, Unset):
@@ -60,13 +74,16 @@ class MessageRead:
         field_dict.update(
             {
                 "id": id,
-                "room_name": room_name,
                 "sender_handle": sender_handle,
                 "message_type": message_type,
                 "content": content,
                 "created_at": created_at,
             }
         )
+        if room_name is not UNSET:
+            field_dict["room_name"] = room_name
+        if coordination_session_id is not UNSET:
+            field_dict["coordination_session_id"] = coordination_session_id
         if recipient_handle is not UNSET:
             field_dict["recipient_handle"] = recipient_handle
 
@@ -77,8 +94,6 @@ class MessageRead:
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
-        room_name = d.pop("room_name")
-
         sender_handle = d.pop("sender_handle")
 
         message_type = d.pop("message_type")
@@ -86,6 +101,32 @@ class MessageRead:
         content = d.pop("content")
 
         created_at = isoparse(d.pop("created_at"))
+
+        def _parse_room_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        room_name = _parse_room_name(d.pop("room_name", UNSET))
+
+        def _parse_coordination_session_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                coordination_session_id_type_0 = UUID(data)
+
+                return coordination_session_id_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(None | Unset | UUID, data)
+
+        coordination_session_id = _parse_coordination_session_id(d.pop("coordination_session_id", UNSET))
 
         def _parse_recipient_handle(data: object) -> None | str | Unset:
             if data is None:
@@ -98,11 +139,12 @@ class MessageRead:
 
         message_read = cls(
             id=id,
-            room_name=room_name,
             sender_handle=sender_handle,
             message_type=message_type,
             content=content,
             created_at=created_at,
+            room_name=room_name,
+            coordination_session_id=coordination_session_id,
             recipient_handle=recipient_handle,
         )
 

--- a/mycelium-client/mycelium_backend_client/models/participant_create.py
+++ b/mycelium-client/mycelium_backend_client/models/participant_create.py
@@ -8,11 +8,11 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="SessionCreate")
+T = TypeVar("T", bound="ParticipantCreate")
 
 
 @_attrs_define
-class SessionCreate:
+class ParticipantCreate:
     """
     Attributes:
         agent_handle (str): Agent handle joining the room
@@ -58,13 +58,13 @@ class SessionCreate:
 
         intent = _parse_intent(d.pop("intent", UNSET))
 
-        session_create = cls(
+        participant_create = cls(
             agent_handle=agent_handle,
             intent=intent,
         )
 
-        session_create.additional_properties = d
-        return session_create
+        participant_create.additional_properties = d
+        return participant_create
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-client/mycelium_backend_client/models/participant_list_response.py
+++ b/mycelium-client/mycelium_backend_client/models/participant_list_response.py
@@ -7,29 +7,29 @@ from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 if TYPE_CHECKING:
-    from ..models.session_read import SessionRead
+    from ..models.participant_read import ParticipantRead
 
 
-T = TypeVar("T", bound="SessionListResponse")
+T = TypeVar("T", bound="ParticipantListResponse")
 
 
 @_attrs_define
-class SessionListResponse:
+class ParticipantListResponse:
     """
     Attributes:
-        sessions (list[SessionRead]):
+        participants (list[ParticipantRead]):
         total (int):
     """
 
-    sessions: list[SessionRead]
+    participants: list[ParticipantRead]
     total: int
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        sessions = []
-        for sessions_item_data in self.sessions:
-            sessions_item = sessions_item_data.to_dict()
-            sessions.append(sessions_item)
+        participants = []
+        for participants_item_data in self.participants:
+            participants_item = participants_item_data.to_dict()
+            participants.append(participants_item)
 
         total = self.total
 
@@ -37,7 +37,7 @@ class SessionListResponse:
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "sessions": sessions,
+                "participants": participants,
                 "total": total,
             }
         )
@@ -46,25 +46,25 @@ class SessionListResponse:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.session_read import SessionRead
+        from ..models.participant_read import ParticipantRead
 
         d = dict(src_dict)
-        sessions = []
-        _sessions = d.pop("sessions")
-        for sessions_item_data in _sessions:
-            sessions_item = SessionRead.from_dict(sessions_item_data)
+        participants = []
+        _participants = d.pop("participants")
+        for participants_item_data in _participants:
+            participants_item = ParticipantRead.from_dict(participants_item_data)
 
-            sessions.append(sessions_item)
+            participants.append(participants_item)
 
         total = d.pop("total")
 
-        session_list_response = cls(
-            sessions=sessions,
+        participant_list_response = cls(
+            participants=participants,
             total=total,
         )
 
-        session_list_response.additional_properties = d
-        return session_list_response
+        participant_list_response.additional_properties = d
+        return participant_list_response
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-client/mycelium_backend_client/models/participant_read.py
+++ b/mycelium-client/mycelium_backend_client/models/participant_read.py
@@ -11,15 +11,15 @@ from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="SessionRead")
+T = TypeVar("T", bound="ParticipantRead")
 
 
 @_attrs_define
-class SessionRead:
+class ParticipantRead:
     """
     Attributes:
         id (UUID):
-        room_name (str):
+        coordination_session_id (UUID):
         agent_handle (str):
         joined_at (datetime.datetime):
         intent (None | str | Unset):
@@ -27,7 +27,7 @@ class SessionRead:
     """
 
     id: UUID
-    room_name: str
+    coordination_session_id: UUID
     agent_handle: str
     joined_at: datetime.datetime
     intent: None | str | Unset = UNSET
@@ -37,7 +37,7 @@ class SessionRead:
     def to_dict(self) -> dict[str, Any]:
         id = str(self.id)
 
-        room_name = self.room_name
+        coordination_session_id = str(self.coordination_session_id)
 
         agent_handle = self.agent_handle
 
@@ -62,7 +62,7 @@ class SessionRead:
         field_dict.update(
             {
                 "id": id,
-                "room_name": room_name,
+                "coordination_session_id": coordination_session_id,
                 "agent_handle": agent_handle,
                 "joined_at": joined_at,
             }
@@ -79,7 +79,7 @@ class SessionRead:
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
-        room_name = d.pop("room_name")
+        coordination_session_id = UUID(d.pop("coordination_session_id"))
 
         agent_handle = d.pop("agent_handle")
 
@@ -111,17 +111,17 @@ class SessionRead:
 
         last_seen = _parse_last_seen(d.pop("last_seen", UNSET))
 
-        session_read = cls(
+        participant_read = cls(
             id=id,
-            room_name=room_name,
+            coordination_session_id=coordination_session_id,
             agent_handle=agent_handle,
             joined_at=joined_at,
             intent=intent,
             last_seen=last_seen,
         )
 
-        session_read.additional_properties = d
-        return session_read
+        participant_read.additional_properties = d
+        return participant_read
 
     @property
     def additional_keys(self) -> list[str]:

--- a/mycelium-client/mycelium_backend_client/models/room_read.py
+++ b/mycelium-client/mycelium_backend_client/models/room_read.py
@@ -27,13 +27,9 @@ class RoomRead:
         created_at (datetime.datetime):
         description (None | str | Unset):
         coordination_state (str | Unset):  Default: 'idle'.
-        join_deadline (datetime.datetime | None | Unset):
-        mode (str | Unset):  Default: 'sync'.
         trigger_config (None | RoomReadTriggerConfigType0 | Unset):
         last_synthesis_at (datetime.datetime | None | Unset):
         is_persistent (bool | Unset):  Default: False.
-        is_namespace (bool | Unset):  Default: False.
-        parent_namespace (None | str | Unset):
         mas_id (None | str | Unset):
         workspace_id (None | str | Unset):
     """
@@ -44,13 +40,9 @@ class RoomRead:
     created_at: datetime.datetime
     description: None | str | Unset = UNSET
     coordination_state: str | Unset = "idle"
-    join_deadline: datetime.datetime | None | Unset = UNSET
-    mode: str | Unset = "sync"
     trigger_config: None | RoomReadTriggerConfigType0 | Unset = UNSET
     last_synthesis_at: datetime.datetime | None | Unset = UNSET
     is_persistent: bool | Unset = False
-    is_namespace: bool | Unset = False
-    parent_namespace: None | str | Unset = UNSET
     mas_id: None | str | Unset = UNSET
     workspace_id: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -74,16 +66,6 @@ class RoomRead:
 
         coordination_state = self.coordination_state
 
-        join_deadline: None | str | Unset
-        if isinstance(self.join_deadline, Unset):
-            join_deadline = UNSET
-        elif isinstance(self.join_deadline, datetime.datetime):
-            join_deadline = self.join_deadline.isoformat()
-        else:
-            join_deadline = self.join_deadline
-
-        mode = self.mode
-
         trigger_config: dict[str, Any] | None | Unset
         if isinstance(self.trigger_config, Unset):
             trigger_config = UNSET
@@ -101,14 +83,6 @@ class RoomRead:
             last_synthesis_at = self.last_synthesis_at
 
         is_persistent = self.is_persistent
-
-        is_namespace = self.is_namespace
-
-        parent_namespace: None | str | Unset
-        if isinstance(self.parent_namespace, Unset):
-            parent_namespace = UNSET
-        else:
-            parent_namespace = self.parent_namespace
 
         mas_id: None | str | Unset
         if isinstance(self.mas_id, Unset):
@@ -136,20 +110,12 @@ class RoomRead:
             field_dict["description"] = description
         if coordination_state is not UNSET:
             field_dict["coordination_state"] = coordination_state
-        if join_deadline is not UNSET:
-            field_dict["join_deadline"] = join_deadline
-        if mode is not UNSET:
-            field_dict["mode"] = mode
         if trigger_config is not UNSET:
             field_dict["trigger_config"] = trigger_config
         if last_synthesis_at is not UNSET:
             field_dict["last_synthesis_at"] = last_synthesis_at
         if is_persistent is not UNSET:
             field_dict["is_persistent"] = is_persistent
-        if is_namespace is not UNSET:
-            field_dict["is_namespace"] = is_namespace
-        if parent_namespace is not UNSET:
-            field_dict["parent_namespace"] = parent_namespace
         if mas_id is not UNSET:
             field_dict["mas_id"] = mas_id
         if workspace_id is not UNSET:
@@ -180,25 +146,6 @@ class RoomRead:
         description = _parse_description(d.pop("description", UNSET))
 
         coordination_state = d.pop("coordination_state", UNSET)
-
-        def _parse_join_deadline(data: object) -> datetime.datetime | None | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            try:
-                if not isinstance(data, str):
-                    raise TypeError()
-                join_deadline_type_0 = isoparse(data)
-
-                return join_deadline_type_0
-            except (TypeError, ValueError, AttributeError, KeyError):
-                pass
-            return cast(datetime.datetime | None | Unset, data)
-
-        join_deadline = _parse_join_deadline(d.pop("join_deadline", UNSET))
-
-        mode = d.pop("mode", UNSET)
 
         def _parse_trigger_config(data: object) -> None | RoomReadTriggerConfigType0 | Unset:
             if data is None:
@@ -236,17 +183,6 @@ class RoomRead:
 
         is_persistent = d.pop("is_persistent", UNSET)
 
-        is_namespace = d.pop("is_namespace", UNSET)
-
-        def _parse_parent_namespace(data: object) -> None | str | Unset:
-            if data is None:
-                return data
-            if isinstance(data, Unset):
-                return data
-            return cast(None | str | Unset, data)
-
-        parent_namespace = _parse_parent_namespace(d.pop("parent_namespace", UNSET))
-
         def _parse_mas_id(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -272,13 +208,9 @@ class RoomRead:
             created_at=created_at,
             description=description,
             coordination_state=coordination_state,
-            join_deadline=join_deadline,
-            mode=mode,
             trigger_config=trigger_config,
             last_synthesis_at=last_synthesis_at,
             is_persistent=is_persistent,
-            is_namespace=is_namespace,
-            parent_namespace=parent_namespace,
             mas_id=mas_id,
             workspace_id=workspace_id,
         )

--- a/mycelium-frontend/src/app/page.tsx
+++ b/mycelium-frontend/src/app/page.tsx
@@ -13,8 +13,6 @@ import { IDChip } from "@/components/id-chip";
 interface Room {
   name: string;
   created_at: string;
-  parent_namespace: string | null;
-  is_namespace: boolean;
   is_persistent: boolean;
 }
 
@@ -40,7 +38,7 @@ export default function Dashboard() {
 
   const load = () =>
     fetchRooms()
-      .then((data: Room[]) => setRooms(data.filter(r => r.is_namespace !== false)))
+      .then((data: Room[]) => setRooms(data))
       .catch(() => {});
 
   useEffect(() => {

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -63,10 +63,22 @@ export async function fetchSessions(roomName: string) {
 }
 
 export async function fetchChildRooms(parentName: string) {
-  const res = await fetch(`${API}/api/rooms?name=${encodeURIComponent(parentName + ":session:")}`, { cache: "no-store" });
+  // Sessions live in coordination_sessions. Return the per-session display
+  // name + state so callers that previously walked rooms by name pattern
+  // keep working with minimal changes.
+  const res = await fetch(
+    `${API}/api/coordination-sessions?parent_room=${encodeURIComponent(parentName)}&limit=200`,
+    { cache: "no-store" },
+  );
   if (!res.ok) return [];
-  const rooms = await res.json();
-  return rooms.filter((r: any) => r.parent_namespace === parentName);
+  const sessions = await res.json();
+  return sessions.map((s: any) => ({
+    name: s.display_name,
+    coordination_session_id: s.id,
+    coordination_state: s.state,
+    parent_namespace: s.parent_room_name,
+    created_at: s.created_at,
+  }));
 }
 
 export function getSSEUrl(roomName: string) {

--- a/openapi.json
+++ b/openapi.json
@@ -51,7 +51,7 @@
                     "rooms"
                 ],
                 "summary": "List Rooms",
-                "description": "List rooms with optional name filter.",
+                "description": "List rooms.\n\nBy default returns only real rooms (namespaces). Session-shadow rows are\nexcluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``\nto include the shadow rows \u2014 used by callers (e.g. the OpenClaw channel\nplugin) that still address sessions by name during the deprecation window.",
                 "operationId": "list_rooms_api_rooms_get",
                 "parameters": [
                     {
@@ -88,6 +88,16 @@
                                 }
                             ],
                             "title": "Name"
+                        }
+                    },
+                    {
+                        "name": "include_sessions",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "title": "Include Sessions"
                         }
                     }
                 ],
@@ -633,6 +643,53 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/SessionListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rooms/{room_name}/sessions/coordination": {
+            "get": {
+                "tags": [
+                    "sessions"
+                ],
+                "summary": "List Coordination Sessions",
+                "description": "List negotiation sessions in a room (#197).\n\nReturns first-class CoordinationSession entities. The shadow rows in the\nrooms table are an implementation detail that callers shouldn't depend on.",
+                "operationId": "list_coordination_sessions_api_rooms__room_name__sessions_coordination_get",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CoordinationSessionRead"
+                                    },
+                                    "title": "Response List Coordination Sessions Api Rooms  Room Name  Sessions Coordination Get"
                                 }
                             }
                         }
@@ -2262,6 +2319,80 @@
                     "ids"
                 ],
                 "title": "ConceptsByIdsRequest"
+            },
+            "CoordinationSessionRead": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "parent_room_name": {
+                        "type": "string",
+                        "title": "Parent Room Name"
+                    },
+                    "short_id": {
+                        "type": "string",
+                        "title": "Short Id"
+                    },
+                    "state": {
+                        "type": "string",
+                        "title": "State"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Created At"
+                    },
+                    "join_window_ends_at": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Join Window Ends At"
+                    },
+                    "mas_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Mas Id"
+                    },
+                    "workspace_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Workspace Id"
+                    },
+                    "display_name": {
+                        "type": "string",
+                        "title": "Display Name"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "parent_room_name",
+                    "short_id",
+                    "state",
+                    "created_at",
+                    "display_name"
+                ],
+                "title": "CoordinationSessionRead"
             },
             "GraphPathsRequest": {
                 "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -590,7 +590,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/SessionCreate"
+                                "$ref": "#/components/schemas/ParticipantCreate"
                             }
                         }
                     }
@@ -601,7 +601,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/SessionRead"
+                                    "$ref": "#/components/schemas/ParticipantRead"
                                 }
                             }
                         }
@@ -623,7 +623,7 @@
                     "sessions"
                 ],
                 "summary": "List Sessions",
-                "description": "List agents currently in a room.",
+                "description": "List agents participating in a room's coordination session.",
                 "operationId": "list_sessions_api_rooms__room_name__sessions_get",
                 "parameters": [
                     {
@@ -642,7 +642,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/SessionListResponse"
+                                    "$ref": "#/components/schemas/ParticipantListResponse"
                                 }
                             }
                         }
@@ -713,7 +713,7 @@
                     "sessions"
                 ],
                 "summary": "Leave Room",
-                "description": "Remove an agent session (leave room).",
+                "description": "Remove a participant (agent leaves the session).",
                 "operationId": "leave_room_api_rooms__room_name__sessions__session_id__delete",
                 "parameters": [
                     {
@@ -3169,6 +3169,107 @@
                 ],
                 "title": "MessageRead"
             },
+            "ParticipantCreate": {
+                "properties": {
+                    "agent_handle": {
+                        "type": "string",
+                        "title": "Agent Handle",
+                        "description": "Agent handle joining the room"
+                    },
+                    "intent": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Intent",
+                        "description": "Agent's requirements/intent for coordination"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "agent_handle"
+                ],
+                "title": "ParticipantCreate"
+            },
+            "ParticipantListResponse": {
+                "properties": {
+                    "participants": {
+                        "items": {
+                            "$ref": "#/components/schemas/ParticipantRead"
+                        },
+                        "type": "array",
+                        "title": "Participants"
+                    },
+                    "total": {
+                        "type": "integer",
+                        "title": "Total"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "participants",
+                    "total"
+                ],
+                "title": "ParticipantListResponse"
+            },
+            "ParticipantRead": {
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Id"
+                    },
+                    "coordination_session_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "title": "Coordination Session Id"
+                    },
+                    "agent_handle": {
+                        "type": "string",
+                        "title": "Agent Handle"
+                    },
+                    "intent": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Intent"
+                    },
+                    "joined_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "title": "Joined At"
+                    },
+                    "last_seen": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Last Seen"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "id",
+                    "coordination_session_id",
+                    "agent_handle",
+                    "joined_at"
+                ],
+                "title": "ParticipantRead"
+            },
             "QueryRequest": {
                 "properties": {
                     "intent": {
@@ -3426,106 +3527,6 @@
                     "created_at"
                 ],
                 "title": "RoomRead"
-            },
-            "SessionCreate": {
-                "properties": {
-                    "agent_handle": {
-                        "type": "string",
-                        "title": "Agent Handle",
-                        "description": "Agent handle joining the room"
-                    },
-                    "intent": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Intent",
-                        "description": "Agent's requirements/intent for coordination"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "agent_handle"
-                ],
-                "title": "SessionCreate"
-            },
-            "SessionListResponse": {
-                "properties": {
-                    "sessions": {
-                        "items": {
-                            "$ref": "#/components/schemas/SessionRead"
-                        },
-                        "type": "array",
-                        "title": "Sessions"
-                    },
-                    "total": {
-                        "type": "integer",
-                        "title": "Total"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "sessions",
-                    "total"
-                ],
-                "title": "SessionListResponse"
-            },
-            "SessionRead": {
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "title": "Id"
-                    },
-                    "room_name": {
-                        "type": "string",
-                        "title": "Room Name"
-                    },
-                    "agent_handle": {
-                        "type": "string",
-                        "title": "Agent Handle"
-                    },
-                    "intent": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Intent"
-                    },
-                    "joined_at": {
-                        "type": "string",
-                        "format": "date-time",
-                        "title": "Joined At"
-                    },
-                    "last_seen": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Last Seen"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "id",
-                    "room_name",
-                    "agent_handle",
-                    "joined_at"
-                ],
-                "title": "SessionRead"
             },
             "SubscriptionCreate": {
                 "properties": {

--- a/openapi.json
+++ b/openapi.json
@@ -51,7 +51,7 @@
                     "rooms"
                 ],
                 "summary": "List Rooms",
-                "description": "List rooms.\n\nBy default returns only real rooms (namespaces). Session-shadow rows are\nexcluded so ``mycelium room ls`` stays clean. Pass ``include_sessions=true``\nto include the shadow rows \u2014 used by callers (e.g. the OpenClaw channel\nplugin) that still address sessions by name during the deprecation window.",
+                "description": "List rooms.\n\nSessions live in ``coordination_sessions`` and are not surfaced here. The\n``include_sessions`` parameter is kept for backward-compatible URLs but is\na no-op now (#244 \u2014 session-shadow rows no longer exist).",
                 "operationId": "list_rooms_api_rooms_get",
                 "parameters": [
                     {
@@ -176,7 +176,7 @@
                     "rooms"
                 ],
                 "summary": "Delete Room",
-                "description": "Delete a room and cascade to its child session rooms.\n\nCleanup order is important to avoid stale state firing against\nalready-deleted rows:\n\n  1. Enumerate child session rooms (``parent_namespace == room_name``).\n  2. Tear down all in-memory CFN coordination state for the namespace\n     and its children (cancels pending join timers and active round\n     timeouts, posts ``coordination_consensus broken=True`` to any\n     SSE subscribers).\n  3. Delete child ``Session`` rows, then child ``Room`` rows.\n  4. Mark any active child rooms as ``coordination_state=\"failed\"``\n     (defensive \u2014 if step 3 didn't catch them due to a race, the\n     state still reflects reality).\n  5. Delete the parent ``Room`` row.\n  6. Remove the filesystem directory.\n  7. Delete the MAS in the CFN mgmt plane (non-fatal, last so a CFN\n     error doesn't block the local cleanup).",
+                "description": "Delete a room and cascade to its child session rooms.\n\nCleanup order:\n\n  1. Resolve all coordination sessions for this room (display names + IDs).\n  2. Tear down in-memory CFN coordination state. Doing this before DB\n     deletes prevents in-flight ticks from firing against half-deleted\n     state.\n  3. Delete the room row \u2014 coordination_sessions, participants, and\n     messages cascade automatically via FK ON DELETE CASCADE.\n  4. Remove the filesystem directory.\n  5. Delete the MAS in the CFN mgmt plane (non-fatal, last).",
                 "operationId": "delete_room_api_rooms__room_name__delete",
                 "parameters": [
                     {
@@ -431,7 +431,7 @@
                     "messages"
                 ],
                 "summary": "List Messages",
-                "description": "List messages in a room, newest first.",
+                "description": "List messages in a room (or coordination session), newest first.",
                 "operationId": "list_messages_api_rooms__room_name__messages_get",
                 "parameters": [
                     {
@@ -527,7 +527,7 @@
                     "sessions"
                 ],
                 "summary": "Spawn Session",
-                "description": "Explicitly spawn a negotiation session within a namespace room.",
+                "description": "Explicitly spawn a negotiation session within a room.",
                 "operationId": "spawn_session_api_rooms__room_name__sessions_spawn_post",
                 "parameters": [
                     {
@@ -572,7 +572,7 @@
                     "sessions"
                 ],
                 "summary": "Join Room",
-                "description": "Join a room. If the room is a namespace, auto-spawns a session and joins that.",
+                "description": "Join a room. Auto-spawns a coordination session if one doesn't exist.",
                 "operationId": "join_room_api_rooms__room_name__sessions_post",
                 "parameters": [
                     {
@@ -623,7 +623,7 @@
                     "sessions"
                 ],
                 "summary": "List Sessions",
-                "description": "List agents participating in a room's coordination session.",
+                "description": "List agents participating in a room's coordination session(s).\n\nAccepts either a real room name (returns participants across all its\ncoord_sessions) or a legacy ``{parent}:session:{short}`` display name\n(returns participants of just that one session).",
                 "operationId": "list_sessions_api_rooms__room_name__sessions_get",
                 "parameters": [
                     {
@@ -1968,6 +1968,324 @@
                 }
             }
         },
+        "/api/coordination-sessions": {
+            "get": {
+                "tags": [
+                    "coordination-sessions"
+                ],
+                "summary": "List Coordination Sessions",
+                "description": "List coordination sessions, newest first.\n\nSupports two filters used by the OpenClaw channel plugin's polling loop\n(``state=waiting,negotiating``) and the frontend sessions rail\n(``parent_room=<name>``).",
+                "operationId": "list_coordination_sessions_api_coordination_sessions_get",
+                "parameters": [
+                    {
+                        "name": "parent_room",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter by parent room name",
+                            "title": "Parent Room"
+                        },
+                        "description": "Filter by parent room name"
+                    },
+                    {
+                        "name": "state",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Comma-separated state filter (e.g. 'waiting,negotiating')",
+                            "title": "State"
+                        },
+                        "description": "Comma-separated state filter (e.g. 'waiting,negotiating')"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 1000,
+                            "default": 200,
+                            "title": "Limit"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/CoordinationSessionRead"
+                                    },
+                                    "title": "Response List Coordination Sessions Api Coordination Sessions Get"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/coordination-sessions/{session_id}": {
+            "get": {
+                "tags": [
+                    "coordination-sessions"
+                ],
+                "summary": "Get Coordination Session",
+                "operationId": "get_coordination_session_api_coordination_sessions__session_id__get",
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CoordinationSessionRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/coordination-sessions/{session_id}/messages": {
+            "post": {
+                "tags": [
+                    "coordination-sessions"
+                ],
+                "summary": "Post Session Message",
+                "description": "Post a message to a coordination session.\n\nMessages are stored with ``coordination_session_id`` set and ``room_name``\nnull. SSE subscribers on the session-display channel still receive them\nvia the same ``room:{display_name}`` NOTIFY topic during the deprecation\nwindow so existing OpenClaw plugin / CLI subscribers don't break.",
+                "operationId": "post_session_message_api_coordination_sessions__session_id__messages_post",
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MessageCreate"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "get": {
+                "tags": [
+                    "coordination-sessions"
+                ],
+                "summary": "List Session Messages",
+                "operationId": "list_session_messages_api_coordination_sessions__session_id__messages_get",
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 500,
+                            "default": 50,
+                            "title": "Limit"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "title": "Offset"
+                        }
+                    },
+                    {
+                        "name": "sender",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Sender"
+                        }
+                    },
+                    {
+                        "name": "message_type",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "title": "Message Type"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/coordination-sessions/{session_id}/messages/stream": {
+            "get": {
+                "tags": [
+                    "coordination-sessions"
+                ],
+                "summary": "Stream Session Messages",
+                "description": "SSE stream for a coordination session.\n\nResolves the session and subscribes to the underlying ``room:{display_name}``\nPostgres NOTIFY channel so any inbound message routed to either coord_session_id\nor the legacy display name surfaces here.",
+                "operationId": "stream_session_messages_api_coordination_sessions__session_id__messages_stream_get",
+                "parameters": [
+                    {
+                        "name": "session_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Session Id"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "tags": [
@@ -3126,8 +3444,27 @@
                         "title": "Id"
                     },
                     "room_name": {
-                        "type": "string",
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
                         "title": "Room Name"
+                    },
+                    "coordination_session_id": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "uuid"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Coordination Session Id"
                     },
                     "sender_handle": {
                         "type": "string",
@@ -3161,7 +3498,6 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "room_name",
                     "sender_handle",
                     "message_type",
                     "content",
@@ -3434,23 +3770,6 @@
                         "title": "Coordination State",
                         "default": "idle"
                     },
-                    "join_deadline": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Join Deadline"
-                    },
-                    "mode": {
-                        "type": "string",
-                        "title": "Mode",
-                        "default": "sync"
-                    },
                     "trigger_config": {
                         "anyOf": [
                             {
@@ -3479,22 +3798,6 @@
                         "type": "boolean",
                         "title": "Is Persistent",
                         "default": false
-                    },
-                    "is_namespace": {
-                        "type": "boolean",
-                        "title": "Is Namespace",
-                        "default": false
-                    },
-                    "parent_namespace": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Parent Namespace"
                     },
                     "mas_id": {
                         "anyOf": [


### PR DESCRIPTION
The previous PRs (#245, #246) merged into the \`feat/privacy-first-kxp\` branch instead of main due to stacked-PR base mistargeting. This PR brings their combined work into main.

## What's included

- **#245** (CoordinationSession as first-class entity, partial #197):
  - New \`coordination_sessions\` table + alembic 0011 with backfill
  - \`_spawn_session_room\` dual-writes
  - \`GET /api/rooms/{room}/sessions/coordination\` endpoint
  - \`mycelium room ls\` filters out shadows by default

- **#246** (#244 — full sessions/participants migration):
  - \`sessions\` → \`participants\` rename + alembic 0012
  - Polymorphic \`messages\` (room_name OR coord_session_id) + alembic 0013
  - \`/api/coordination-sessions\` top-level endpoint family
  - Drop session-shadow rows + deprecated rooms columns + alembic 0014
  - Cascade-delete tests, sessions-as-subset coverage
  - All consumers migrated (CLI, OpenClaw plugin, frontend)
  - Generated client regenerated

## Verification

All work was verified end-to-end on dev DB during the original PRs. CI green on both originals before they were merged.

If preferred, this can be merge-commit'd (no squash) to preserve the two original commits on main as separate units of history.