### PR TITLE
fix(adapter): compile plugin to dist/ before openclaw install

### DIFF
--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/package.json
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/package.json
@@ -3,13 +3,15 @@
   "version": "0.1.0",
   "type": "module",
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": ["./dist/index.js"]
   },
   "scripts": {
+    "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "typescript": "^5.0.0",
     "vitest": "^2.1.0"
   }
 }

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/tsconfig.json
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["test", "node_modules", "dist"]
+}

--- a/mycelium-cli/src/mycelium/commands/adapter.py
+++ b/mycelium-cli/src/mycelium/commands/adapter.py
@@ -886,7 +886,30 @@ def _install_openclaw(
     # Copying into place first keeps validation happy; openclaw's own install
     # step becomes a no-op on matching files.
     def _plugin_ignore(_src: str, names: list[str]) -> list[str]:
-        return [n for n in names if n in ("node_modules", "test", "package-lock.json")]
+        return [n for n in names if n in ("node_modules", "test", "dist", "package-lock.json")]
+
+    def _build_plugin(plugin_dir: Path) -> None:
+        """Run npm install + npm run build in the plugin directory.
+
+        OpenClaw 2026.5+ rejects TypeScript entry points — the plugin must be
+        compiled to dist/index.js before install.  Best-effort: warn on failure
+        so a missing npm doesn't hard-block the install on older OpenClaw.
+        """
+        for npm_cmd in (["npm", "install", "--prefer-offline", "--silent"],
+                        ["npm", "run", "build"]):
+            if verbose:
+                typer.echo(f"  {' '.join(npm_cmd)} (in {plugin_dir})")
+            result = subprocess.run(
+                npm_cmd, cwd=str(plugin_dir), text=True, capture_output=not verbose
+            )
+            if result.returncode != 0:
+                stderr = (result.stderr or "").strip()
+                typer.secho(
+                    f"  warning: plugin build step '{' '.join(npm_cmd)}' failed"
+                    + (f": {stderr}" if stderr else ""),
+                    fg=typer.colors.YELLOW,
+                )
+                return
 
     if reinstall:
         state_dir = _openclaw_state_dir(profile)
@@ -908,6 +931,10 @@ def _install_openclaw(
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copytree(str(src), str(dst), ignore=_plugin_ignore)
 
+        # Build the plugin after copying so openclaw gets compiled JS.
+        plugin_dst = state_dir / "extensions" / _OPENCLAW_PLUGIN_NAME
+        _build_plugin(plugin_dst)
+
         # Clean up hooks that earlier versions installed.
         for stale in _OPENCLAW_STALE_HOOKS:
             stale_path = state_dir / "hooks" / stale
@@ -917,6 +944,10 @@ def _install_openclaw(
                 shutil.rmtree(stale_path, ignore_errors=True)
 
     plugin_src = _resolve_asset(_MYCELIUM_PLUGIN_SRC)
+    # On a fresh install (not reinstall), build in the source tree before handing
+    # it to openclaw so the compiled dist/ is present when openclaw validates it.
+    if not reinstall:
+        _build_plugin(plugin_src)
     _run(["openclaw", "plugins", "install", str(plugin_src)], allow_already_exists=tolerate_exists)
 
     # Add plugin to plugins.allow so openclaw doesn't warn on every command

--- a/mycelium-cli/src/mycelium/commands/adapter.py
+++ b/mycelium-cli/src/mycelium/commands/adapter.py
@@ -895,8 +895,10 @@ def _install_openclaw(
         compiled to dist/index.js before install.  Best-effort: warn on failure
         so a missing npm doesn't hard-block the install on older OpenClaw.
         """
-        for npm_cmd in (["npm", "install", "--prefer-offline", "--silent"],
-                        ["npm", "run", "build"]):
+        for npm_cmd in (
+            ["npm", "install", "--prefer-offline", "--silent"],
+            ["npm", "run", "build"],
+        ):
             if verbose:
                 typer.echo(f"  {' '.join(npm_cmd)} (in {plugin_dir})")
             result = subprocess.run(


### PR DESCRIPTION
Fixes #213

## Summary

- OpenClaw 2026.5+ rejects TypeScript entry points (`./index.ts`) and requires compiled JS
- `package.json`: point `openclaw.extensions` at `./dist/index.js`, add `build` script, add `typescript` devDependency
- Add `tsconfig.json` targeting `NodeNext` ESM output to `./dist/`
- `adapter.py`: add `_build_plugin()` helper that runs `npm install && npm run build` in the plugin directory; called after copy on `--reinstall` and before `openclaw plugins install` on fresh install
- Exclude `dist/` from the copytree ignore list so we always build fresh at the destination

## Test plan

- [ ] `mycelium adapter add openclaw` on a machine with openclaw 2026.5+
- [ ] `mycelium adapter add openclaw --reinstall -y` works without "extension entry failed plugin directory boundary checks" error
- [ ] Verify `~/.openclaw/extensions/mycelium/dist/index.js` exists after install
- [ ] Confirm still works on older openclaw (build is best-effort, warns but doesn't hard-fail)