### PR TITLE
fix(coordination): use coordination_session_id FK for session messages

### DIFF
--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -1440,8 +1440,23 @@ def _parse_agent_reply(
 async def _post_message(room_name: str, message_type: str, content: str) -> None:
     """Insert a coordination message to DB and notify SSE subscribers."""
     async with async_session_maker() as db:
+        msg_room_name: str | None = room_name
+        msg_session_id: str | None = None
+        if ":session:" in room_name:
+            parent, _, short_id = room_name.partition(":session:")
+            result = await db.execute(
+                select(CoordinationSession.id).where(
+                    CoordinationSession.parent_room_name == parent,
+                    CoordinationSession.short_id == short_id,
+                )
+            )
+            session_id = result.scalar_one_or_none()
+            if session_id is not None:
+                msg_room_name = None
+                msg_session_id = str(session_id)
         msg = Message(
-            room_name=room_name,
+            room_name=msg_room_name,
+            coordination_session_id=msg_session_id,
             sender_handle="CognitiveEngine",
             message_type=message_type,
             content=content,


### PR DESCRIPTION
## Summary

- `_post_message` always set `room_name` on the `Message` insert, but session room names (e.g. `exp-6654-after:session:bd7038c5`) are not real rooms — the FK to `rooms.name` causes a `ForeignKeyViolationError`
- Fix: when `:session:` is in `room_name`, resolve `CoordinationSession.id` via `(parent_room_name, short_id)` and set `coordination_session_id=<uuid>` with `room_name=None`
- The NOTIFY channel string still uses the display name (SSE routing only, no FK constraint)
- Pattern follows the existing `:session:` parse already used in `coordination_consensus` at line 1469

## Test plan

- [ ] Post a coordination tick to a session room — no `ForeignKeyViolationError`, message inserted with `coordination_session_id` set
- [ ] Post a coordination tick to a real room — `room_name` FK still set correctly
- [ ] Unknown session (`:session:` in name but no matching row) — falls back to `room_name` as before rather than crashing