### PR TITLE
fix(pull,migration): version-pin backend image; skip orphan sessions in 0011

### DIFF
--- a/fastapi-backend/alembic_migrations/versions/0011_coordination_sessions.py
+++ b/fastapi-backend/alembic_migrations/versions/0011_coordination_sessions.py
@@ -50,6 +50,26 @@ def upgrade() -> None:
 
     # Backfill: every session-shadow row in `rooms` becomes a coordination_sessions row.
     # short_id is the suffix after `:session:` in the room name (8-char hex by convention).
+    # Skip orphans whose parent_namespace no longer exists in `rooms` — they would
+    # violate the FK we just declared. Surface them via NOTICE so operators know.
+    orphans = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+                SELECT name, parent_namespace FROM rooms
+                WHERE is_namespace = FALSE
+                  AND parent_namespace IS NOT NULL
+                  AND parent_namespace NOT IN (SELECT name FROM rooms)
+                """
+            )
+        )
+        .fetchall()
+    )
+    if orphans:
+        names = ", ".join(f"{n} (orphan parent={p})" for n, p in orphans)
+        print(f"[0011] Skipping {len(orphans)} orphan session row(s): {names}")
+
     op.execute(
         """
         INSERT INTO coordination_sessions
@@ -64,7 +84,9 @@ def upgrade() -> None:
             mas_id,
             workspace_id
         FROM rooms
-        WHERE is_namespace = FALSE AND parent_namespace IS NOT NULL
+        WHERE is_namespace = FALSE
+          AND parent_namespace IS NOT NULL
+          AND parent_namespace IN (SELECT name FROM rooms)
         """
     )
 

--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -35,11 +35,8 @@ services:
       retries: 10
 
   mycelium-backend:
-    build:
-      context: ../fastapi-backend
-      dockerfile: Dockerfile
-    image: mycelium-backend:local
-    pull_policy: never
+    image: ghcr.io/mycelium-io/mycelium-backend:${MYCELIUM_IMAGE_TAG:-latest}
+    pull_policy: always
     container_name: mycelium-backend
     restart: unless-stopped
     env_file:


### PR DESCRIPTION
## Summary
- `mycelium pull --version <tag>` now actually pins the backend image. compose.yml had `image: mycelium-backend:local` + `pull_policy: never` for the backend, so `MYCELIUM_IMAGE_TAG` only affected db/frontend and the backend silently stayed on whatever `:latest` was last. Switched to `ghcr.io/.../mycelium-backend:${MYCELIUM_IMAGE_TAG:-latest}` with `pull_policy: always`, matching the db/frontend pattern. `compose-dev.yml` still overrides image+build for local source builds.
- Migration `0011` (CoordinationSession backfill) no longer crashes on orphaned session rooms. If any `rooms` row has `is_namespace=FALSE` and a `parent_namespace` that no longer exists, the new `coordination_sessions.parent_room_name` FK rejects the backfill INSERT and aborts the whole upgrade. Filter those rows out and print a notice listing the orphans skipped, so operators can decide whether to clean them up after the migration completes.

## How this surfaced
Running `mycelium pull --version 1.0.10rc5` against an existing install:
1. CLI pinned to rc5 but the backend container kept running v1.0.9-era `:latest` (FK migration 0011–0015 not present → `mycelium pull` reported "Migration failed (non-fatal)").
2. After patching compose locally to honor `MYCELIUM_IMAGE_TAG` and re-pulling rc5, the backend came up but 0011 hit a `ForeignKeyViolationError` on four old `exp-*-after` / `repro-*` session rooms whose namespaces were long gone — a leftover from local `before-and-after` experiments.

## Test plan
- [ ] CI green
- [ ] On a stack with stale `MYCELIUM_IMAGE_TAG`, `mycelium pull --version <rc>` actually pulls the matching backend image (verify with `docker ps --format '{{.Image}}'`)
- [ ] Migration 0011 succeeds on a DB containing orphan session rows (no parent in `rooms`); orphans are reported in stdout; coordination_sessions only contains rows for sessions with extant parents
- [ ] Migration 0011 still succeeds on a clean DB (no orphans → no notice, all sessions backfilled)
- [ ] `compose-dev.yml` flow (`docker compose -f compose.yml -f compose-dev.yml up --build`) still builds backend from local source