### PR TITLE
fix(adapter): make openclaw plugin actually build + register cleanly under 2026.5.7

### DIFF
--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/openclaw.plugin.json
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/openclaw.plugin.json
@@ -10,5 +10,41 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {}
+  },
+  "channelConfigs": {
+    "mycelium-room": {
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["backendUrl", "room"],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Set false to disable the channel without removing config."
+          },
+          "backendUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Mycelium backend URL, e.g. http://localhost:8000."
+          },
+          "room": {
+            "type": "string",
+            "description": "Mycelium room name this channel fans messages into and out of."
+          },
+          "agents": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": [],
+            "description": "OpenClaw agent ids that participate in this room."
+          },
+          "requireMention": {
+            "type": "boolean",
+            "default": false,
+            "description": "If true, only deliver messages that explicitly @mention one of the configured agents."
+          }
+        }
+      }
+    }
   }
 }

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/package.json
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/package.json
@@ -11,6 +11,8 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
+    "openclaw": "^2026.5.7",
     "typescript": "^5.0.0",
     "vitest": "^2.1.0"
   }


### PR DESCRIPTION
Follow-up to #254. When testing rc6's adapter install against openclaw 2026.5.7 locally, two more issues surfaced:

## Summary
- **Plugin couldn't compile from scratch.** `_build_plugin()` in adapter.py runs `npm install` + `npm run build` during `mycelium adapter add openclaw`, but the plugin's `package.json` was missing the deps that `tsc` needs (`openclaw` for `openclaw/plugin-sdk` types, `@types/node` for `node:fs`/`process`/etc.). The build failed silently → no `dist/index.js` → openclaw 2026.5.7 then rejected the plugin install at validation time (\"requires compiled runtime output for TypeScript entry index.ts\"). Adding both as devDependencies makes the build pass and produces the `dist/index.js` that `package.json.openclaw.extensions` already points at.
- **Plugin manifest missing `channelConfigs` for `mycelium-room`.** openclaw 2026.5.7 emits a WARN at load time when a channel plugin declares a channel without a matching `channelConfigs.<id>.schema` — config validation and setup surfaces can't see the channel before the runtime loads it. Added a JSON Schema for the four fields `readChannelConfig()` in `src/config.ts` actually consumes (`backendUrl`, `room`, `agents`, `requireMention`), plus `enabled` for soft-disable. `backendUrl` + `room` are required; the channel won't activate without them.

## How this surfaced
After #254 landed and rc6 was cut, running `mycelium adapter add openclaw --reinstall -y` against openclaw 2026.5.7 → `warning: plugin build step 'npm run build' failed` → `openclaw plugins install` errored out. Manually running `npm install && npm run build` in the plugin dir reproduced the missing-types failure cleanly. With deps added, install completes; `openclaw doctor` then surfaced the missing `channelConfigs` warning, fixed in the second commit.

## Test plan
- [ ] CI green
- [ ] Fresh `npm install && npm run build` in the plugin dir succeeds and produces `dist/index.js`
- [ ] `mycelium adapter add openclaw --reinstall -y` completes cleanly against openclaw 2026.5.7
- [ ] `openclaw doctor` reports no warnings for the mycelium plugin (no `channelConfigs` warning, no missing-dist warning)