### PR TITLE
fix(backend): read version from pyproject.toml instead of hardcoding

### DIFF
--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -22,20 +22,6 @@ import tomllib
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-
-def _read_pkg_version() -> str:
-    """Read version from pyproject.toml so release.yml's tag bump (which seds
-    pyproject.toml::project.version) is reflected at /healthz without needing
-    a second sed against this file. Falls back to '0.0.0+unknown' if the file
-    can't be located (e.g. running from an unusual layout)."""
-    for candidate in (Path(__file__).resolve().parent.parent / "pyproject.toml",):
-        if candidate.exists():
-            try:
-                return tomllib.loads(candidate.read_text())["project"]["version"]
-            except (KeyError, tomllib.TOMLDecodeError):
-                break
-    return "0.0.0+unknown"
-
 # Must be set before sentence-transformers / huggingface_hub are imported.
 # Prevents network calls when the model is already cached locally.
 os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
@@ -162,6 +148,20 @@ async def lifespan(app: FastAPI):
     yield
     stop_watcher()
     logger.info("Mycelium backend shutting down")
+
+
+def _read_pkg_version() -> str:
+    """Read version from pyproject.toml so release.yml's tag bump (which seds
+    pyproject.toml::project.version) is reflected at /healthz without needing
+    a second sed against this file. Falls back to '0.0.0+unknown' if the file
+    can't be located (e.g. running from an unusual layout)."""
+    for candidate in (Path(__file__).resolve().parent.parent / "pyproject.toml",):
+        if candidate.exists():
+            try:
+                return tomllib.loads(candidate.read_text())["project"]["version"]
+            except (KeyError, tomllib.TOMLDecodeError):
+                break
+    return "0.0.0+unknown"
 
 
 app = FastAPI(

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -18,8 +18,23 @@ import asyncio
 import logging
 import os
 import sys
+import tomllib
 from contextlib import asynccontextmanager
 from pathlib import Path
+
+
+def _read_pkg_version() -> str:
+    """Read version from pyproject.toml so release.yml's tag bump (which seds
+    pyproject.toml::project.version) is reflected at /healthz without needing
+    a second sed against this file. Falls back to '0.0.0+unknown' if the file
+    can't be located (e.g. running from an unusual layout)."""
+    for candidate in (Path(__file__).resolve().parent.parent / "pyproject.toml",):
+        if candidate.exists():
+            try:
+                return tomllib.loads(candidate.read_text())["project"]["version"]
+            except (KeyError, tomllib.TOMLDecodeError):
+                break
+    return "0.0.0+unknown"
 
 # Must be set before sentence-transformers / huggingface_hub are imported.
 # Prevents network calls when the model is already cached locally.
@@ -151,7 +166,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Mycelium Backend",
-    version="0.1.0",
+    version=_read_pkg_version(),
     openapi_url=settings.OPENAPI_URL,
     lifespan=lifespan,
 )


### PR DESCRIPTION
## Summary
`mycelium doctor` always reports `Backend reachable v0.1.0` regardless of the actual release tag. Cause: the release pipeline (`release.yml`) seds `fastapi-backend/pyproject.toml::project.version` at build time, but `app/main.py:154` has its own hardcoded `version=\"0.1.0\"` on the `FastAPI(...)` constructor — that string never moves. So `/healthz`, `/docs`, and any client that reads the FastAPI version (mycelium doctor included) report stale data even on rc7.

Read the version from `pyproject.toml` at module load. The Dockerfile already COPYs `pyproject.toml` into `/app`, so the file is present at runtime. Falls back to `0.0.0+unknown` if the file is missing or malformed (unusual deployment layout) rather than pinning a stale literal. No `release.yml` change needed — the existing sed against pyproject.toml now reaches the running backend.

## Test plan
- [ ] CI green
- [ ] Build a backend image from a tagged commit (or sed pyproject.toml to e.g. `1.0.10rc8`, rebuild) and confirm `curl localhost:8000/healthz` returns the matching version
- [ ] `mycelium doctor` shows the real version instead of `v0.1.0`
- [ ] If pyproject.toml is removed/corrupt, backend still starts with version `0.0.0+unknown` (no crash)