### PR TITLE
fix(plugin): prevent silent reply suppression in group-chat dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- OpenClaw plugin: add `replyOptions: { sourceReplyDeliveryMode: "automatic" }` to
+  `dispatchReplyWithBufferedBlockDispatcher` so agent replies are delivered regardless
+  of the host's `messages.groupChat.visibleReplies` setting (fixes silent suppression
+  when set to `"message_tool"`)
+
 ## [0.1.9] - 2026-03-23
 
 ### Added

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/dispatch.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/dispatch.ts
@@ -60,6 +60,7 @@ export async function dispatchToAgent(
     await runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
       ctx,
       cfg: openclawConfig,
+      replyOptions: { sourceReplyDeliveryMode: "automatic" },
       dispatcherOptions: {
         deliver: async (payload: ReplyPayload) => {
           const text = payload.text?.trim();


### PR DESCRIPTION
## Problem

When a host `openclaw.json` has `messages.groupChat.visibleReplies` set to anything other than `"automatic"` (e.g. the WhatsApp default `"message_tool"`), the dispatcher's block-enqueue is suppressed and `deliver` is never called. Agent text is produced (visible in session `.jsonl` and trajectory files) but nothing appears in the Mycelium room. No error or warning is logged — suppression is completely silent.

Reported in Issue https://github.com/mycelium-io/mycelium/issues/266

Affects: plugin 1.0.9 and 1.0.10rc8 running against OpenClaw 2026.5.7 (eeef486).

## Fix

Add `replyOptions: { sourceReplyDeliveryMode: "automatic" }` to the `dispatchReplyWithBufferedBlockDispatcher` call in `dispatch.ts`. This makes the plugin's delivery intent explicit and independent of the host group-chat config.

## Test plan

- [ ] Deploy plugin against an OpenClaw install with `messages.groupChat.visibleReplies: "message_tool"` and verify agent replies appear in the Mycelium room
- [ ] Verify no regression on installs with the default `"automatic"` setting
- [ ] Confirm no error logs on either path