### PR TITLE
docs(readme): reframe The Problem for peer-agent coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ https://github.com/user-attachments/assets/1a5febbb-87e7-48a4-aa7d-8d1b116889c3
 
 ## The Problem
 
-AI agents are powerful individually, but they can't think together. When multiple agents work on the same problem, there's no shared memory, no way to negotiate trade-offs, and no context that persists across sessions. Every conversation starts from zero. Past decisions get re-litigated because no one remembers they were already made. Dead ends get re-explored because the agent that hit them is long gone.
+Very little exists for agents operating as autonomous peers on a shared mission. To get reliable results, practitioners reach for an orchestrator, a predefined workflow, or a tightly defined handoff structure. Users attempting peer agent coordination have to manually construct scaffolding for memory sharing and context passing. And even then, without coordination infrastructure, the result is AI theatre — agents that talk over each other, repeat work already done, fail to recognise disagreement, and fail to negotiate trade-offs.
 
 ## Who Mycelium Is For
 


### PR DESCRIPTION
## Summary

The current "The Problem" section overstates what Mycelium solves. "Can't think together" and "dead ends get re-explored" misframe what the system actually does.

This PR rewrites the section to accurately describe the market gap for peer-to-peer architectures. It also names the DIY tax users pay when they try to avoid the orchestrated architecture, and the AI theatre that results without coordination infrastructure. "Negotiate trade-offs" is preserved but repositioned as a consequence of missing coordination infrastructure rather than a general capability claim.

This is the third in a short series of PRs improving first-time reader orientation.

## Changes

Revision of "The Problem"

## Testing

<!-- How was this tested? Unit tests? Manual? -->

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Format check passes (`uv run ruff format --check .`)

## Related Issues

<!-- Closes #123 -->
