### PR TITLE
feat(doctor): check for pending alembic migrations

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -29,7 +29,13 @@ The release pipeline's "promote to latest" steps (Docker `:latest` tags, GH "Lat
    - **Stable (`/release`):** Run `gh release list --limit 5` to find the current "Latest" release tag. Increment the patch version (e.g. `v1.0.0` → `v1.0.1`).
    - **Preview (`/release --preview`):** Find the latest stable tag (highest non-prerelease in `gh release list`). Target version is `<latest-stable-patch+1>`. Then check existing prereleases for that target: if `vX.Y.Zrc1` exists, cut `vX.Y.Zrc2`, etc. First preview for a target version is always `rc1`. Use PEP 440 format with no separator (`vX.Y.ZrcN`, NOT `vX.Y.Z-rc.N`) so the wheel filename matches what `install.sh` expects.
 
-3. **Generate the CHANGELOG.md entry** — *Stable only. Skipped for `--preview`*: prerelease iterations get rolled up into the next stable's entry, not their own.
+3. **Check for new migrations** — *Stable only.* Run:
+   ```
+   git diff <prev-stable-tag>..HEAD -- fastapi-backend/alembic_migrations/versions/
+   ```
+   If any new migration files exist, note this in the changelog and **include `mycelium migrate` in the upgrade instructions** in the Webex message (before `mycelium doctor`).
+
+4. **Generate the CHANGELOG.md entry** — *Stable only. Skipped for `--preview`*: prerelease iterations get rolled up into the next stable's entry, not their own.
 
    No `[Unreleased]` block is maintained on `main`. Each release's section is derived from `git log <prev-stable-tag>..HEAD --no-merges --oneline` at release time. Group commits by conventional-commit prefix:
 
@@ -42,26 +48,28 @@ The release pipeline's "promote to latest" steps (Docker `:latest` tags, GH "Lat
 
    Commit the changelog update directly to `main` (admin push, no PR) with message `chore(release): changelog for <tag>`. **This commit must land before the tag is pushed** so the tag points at the commit that includes its own entry.
 
-4. **Tag and push** — Run:
+5. **Tag and push** — Run:
    ```
    git tag <new-tag> && git push origin <new-tag>
    ```
    The `release.yml` workflow detects whether the tag is a prerelease and gates the rest of the pipeline accordingly.
 
-5. **Create GitHub release** — The `release.yml` workflow handles this automatically (via `softprops/action-gh-release`), including setting `prerelease: true` for preview tags. No manual `gh release create` needed.
+6. **Create GitHub release** — The `release.yml` workflow handles this automatically (via `softprops/action-gh-release`), including setting `prerelease: true` for preview tags. No manual `gh release create` needed.
 
    Wait for the workflow to finish (`gh run watch` or `gh run list --workflow=release.yml --limit 1`). If it fails, fix and re-run before posting any notifications.
 
-6. **Webex notification** — Invoke `/webex` (no confirmation needed). Behavior depends on whether this is a stable or preview release.
+7. **Webex notification** — Invoke `/webex` (no confirmation needed). Behavior depends on whether this is a stable or preview release.
 
    **Stable release** — when `--with-webex` is passed, post a bullet-point changelog summary with the tag and release URL. Each bullet should include the PR link if one exists (e.g. `- feat: description ([#123](https://github.com/mycelium-io/mycelium/pull/123))`). Follow with upgrade instructions using triple-backtick code blocks so they're copyable:
    ```
    To upgrade:
    mycelium upgrade && mycelium pull
+   mycelium migrate              # if this release includes new migrations
    mycelium adapter add openclaw --reinstall   # if using openclaw
    mycelium adapter add claude-code --reinstall  # if using claude-code
    mycelium doctor  # to check health of services
    ```
+   Include `mycelium migrate` only if step 3 found new migration files. Omit the line otherwise.
    Post to:
    - `Mycelium Release Notes` — always (room ID in `/webex` skill)
    - `IoC::Mycelium Eng` — only if `--with-webex=eng` was passed (room ID in `/webex` skill)
@@ -91,7 +99,7 @@ The release pipeline's "promote to latest" steps (Docker `:latest` tags, GH "Lat
    ```
    `mycelium pull --version <tag>` is the critical second step — it pins both `mycelium-backend` and `mycelium-db` images via `MYCELIUM_IMAGE_TAG` in `~/.mycelium/.env`. Without it, the new CLI runs against stale stable containers. Stable users are unaffected — `install.sh` and `mycelium upgrade` (no `--version`) still resolve to the latest stable, and `mycelium pull` (no `--version`) still pulls `:latest`.
 
-7. **Mycelium patch notes** — Skipped for `--preview` (or scope to a `previews/<tag>` key if the user explicitly asks for it). Otherwise write the same changelog summary to the active Mycelium room:
+8. **Mycelium patch notes** — Skipped for `--preview` (or scope to a `previews/<tag>` key if the user explicitly asks for it). Otherwise write the same changelog summary to the active Mycelium room:
    ```bash
    mycelium memory set "releases/<tag>" "<same bullet-point summary as Webex>" --handle claude-code-agent
    ```

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -10,10 +10,11 @@ Checks:
   3. Runtime config drift — backend container env matches .env on disk
   4. Docker containers running and healthy
   5. Backend API reachable
-  6. LLM connectivity (real completion probe via backend)
-  7. Workspace ID in sync (CFN mgmt plane vs .env vs config.toml)
-  8. Room MAS IDs present (CFN-enabled installs)
-  9. OpenClaw adapter health (plugin, channel config, agent sandbox)
+  6. Pending migrations — DB revision vs latest alembic file
+  7. LLM connectivity (real completion probe via backend)
+  8. Workspace ID in sync (CFN mgmt plane vs .env vs config.toml)
+  9. Room MAS IDs present (CFN-enabled installs)
+  10. OpenClaw adapter health (plugin, channel config, agent sandbox)
 
 Single-device installs (the default) run the backend locally and exercise
 all checks. In the optional hub-and-spoke deployment mode, spoke nodes
@@ -776,6 +777,107 @@ def _check_room_mas_ids() -> CheckResult:
     )
 
 
+def _check_pending_migrations() -> CheckResult:
+    """Check whether the DB is behind the latest alembic revision."""
+    import importlib.resources
+
+    # Locate fastapi-backend the same way the migrate command does.
+    backend_dir: Path | None = None
+    try:
+        pkg_path = Path(str(importlib.resources.files("mycelium")))
+        for depth in range(2, 7):
+            candidate = pkg_path.parents[depth] / "fastapi-backend"
+            if (candidate / "alembic.ini").exists():
+                backend_dir = candidate
+                break
+    except Exception:
+        pass
+    if backend_dir is None:
+        for fallback in (Path.cwd(), Path.cwd() / "fastapi-backend"):
+            if (fallback / "alembic.ini").exists():
+                backend_dir = fallback
+                break
+
+    if backend_dir is None:
+        return CheckResult(
+            name="Migrations",
+            status="ok",
+            message="Skipped (fastapi-backend not found — installed mode)",
+        )
+
+    # Latest revision on disk: highest numbered file prefix in versions/.
+    versions_dir = backend_dir / "alembic_migrations" / "versions"
+    if not versions_dir.exists():
+        return CheckResult(
+            name="Migrations", status="ok", message="Skipped (versions dir not found)"
+        )
+
+    revision_files = sorted(versions_dir.glob("*.py"))
+    if not revision_files:
+        return CheckResult(name="Migrations", status="ok", message="No migration files found")
+    latest_file = revision_files[-1].stem.split("_")[0]  # e.g. "0015"
+
+    # Current DB revision via `alembic current`.
+    from mycelium.config import MyceliumConfig
+
+    try:
+        cfg = MyceliumConfig.load()
+        db_url = cfg.server.database_url or ""
+    except Exception:
+        db_url = ""
+
+    env = {**__import__("os").environ}
+    if db_url:
+        env["DATABASE_URL"] = db_url
+
+    try:
+        result = subprocess.run(
+            ["uv", "run", "alembic", "current"],
+            cwd=str(backend_dir),
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env=env,
+        )
+        output = result.stdout + result.stderr
+    except Exception as exc:
+        return CheckResult(
+            name="Migrations",
+            status="warning",
+            message=f"Could not run alembic current: {exc}",
+            details=["fix: mycelium migrate"],
+        )
+
+    # "head" in output means DB is current; otherwise extract the revision token.
+    if "head" in output.lower():
+        return CheckResult(
+            name="Migrations",
+            status="ok",
+            message=f"DB at head ({latest_file})",
+        )
+
+    # Parse current revision from output like "abc1234 (head)" or just "abc1234"
+    import re as _re
+
+    rev_match = _re.search(r"([0-9a-f]{4,})", output)
+    current_rev = rev_match.group(1) if rev_match else "unknown"
+
+    if not output.strip() or current_rev == "unknown":
+        return CheckResult(
+            name="Migrations",
+            status="warning",
+            message="Could not determine current DB revision",
+            details=[f"alembic output: {output.strip()[:120]}", "fix: mycelium migrate"],
+        )
+
+    return CheckResult(
+        name="Migrations",
+        status="warning",
+        message=f"DB at {current_rev}, latest is {latest_file} — pending migrations",
+        details=["fix: mycelium migrate"],
+    )
+
+
 # ── OpenClaw adapter checks ───────────────────────────────────────────────────
 #
 # All three openclaw checks are gated on whether the user has opted into the
@@ -1145,6 +1247,7 @@ def doctor(
         if local:
             service_checks.append(_check_docker_containers())
         service_checks.append(_check_backend_reachable(local_backend=local))
+        service_checks.append(_check_pending_migrations())
         service_checks.append(_check_llm_connectivity())
 
         sections: list[tuple[str, list[CheckResult]]] = [

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -70,6 +70,10 @@ class ServerConfig(BaseModel):
         default=None,
         description="Default MAS UUID (created during install)",
     )
+    database_url: str | None = Field(
+        default=None,
+        description="Database URL override (defaults to backend container default)",
+    )
 
     @field_validator("api_url")
     @classmethod


### PR DESCRIPTION
## Summary

- `mycelium doctor` now includes a **Migrations** check under Services — runs `alembic current` and compares against the latest revision file in `alembic_migrations/versions/`
- Warns with `fix: mycelium migrate` if the DB is behind
- Gracefully skips on spoke nodes (no `fastapi-backend` in the install path) and when alembic can't be reached
- Updated the `/release` skill to check for new migration files at release time and include `mycelium migrate` in upgrade instructions when present

## Test plan

- [ ] `mycelium doctor` on an up-to-date install — shows `✓ Migrations: DB at head (0015)`
- [ ] `mycelium doctor` after adding a new migration file without running it — shows warning with `fix: mycelium migrate`
- [ ] `mycelium doctor` on a spoke (no fastapi-backend) — shows `Migrations: Skipped`