### PR TITLE
fix(plugin): stash tick payload from channel for session/before_agent_start (#276)

### DIFF
--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -30,6 +30,7 @@ import {
   stopSessionSSE,
   subscribedSessionRooms,
 } from "./session-sse.js";
+import { clearAllTickStash, clearTickStashBySessionRoom, stashTick } from "./tick-stash.js";
 
 type Logger = { info: (s: string) => void; warn: (s: string) => void };
 
@@ -118,6 +119,7 @@ export function installChannel(
             startSessionSSE(runtime, cfg, name, _abort!, handleMessage, log);
           } else if (state && TERMINAL_STATES.has(state)) {
             stopSessionSSE(name, log);
+            clearTickStashBySessionRoom(name);
           }
         }
 
@@ -126,6 +128,7 @@ export function installChannel(
         for (const subbed of subscribedSessionRooms()) {
           if (!activeSessionRooms.has(subbed)) {
             stopSessionSSE(subbed, log);
+            clearTickStashBySessionRoom(subbed);
           }
         }
       } catch {
@@ -140,6 +143,7 @@ export function installChannel(
     _abort?.abort();
     _abort = null;
     clearSubscribedSessions();
+    clearAllTickStash();
     log.info(`[${CHANNEL_ID}] gateway stopping — SSE closed`);
   });
 }
@@ -222,6 +226,10 @@ function executeAction(
     }
     case "stash-return-address": {
       stashReturnAddress(action.sessionRoom, action.agentId, log);
+      return;
+    }
+    case "stash-tick": {
+      stashTick(action.agentId, action.sessionRoom, action.payload, log);
       return;
     }
     case "notify-home": {

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/route.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/route.ts
@@ -29,6 +29,12 @@ export type RouteAction =
   | { kind: "subscribe-session"; roomName: string }
   | { kind: "stash-return-address"; sessionRoom: string; agentId: string }
   | {
+      kind: "stash-tick";
+      sessionRoom: string;
+      agentId: string;
+      payload: any;
+    }
+  | {
       kind: "notify-home";
       sessionRoom: string;
       agentIds: string[];
@@ -111,6 +117,16 @@ export function routeTick(cfg: ChannelConfig, msg: any): RouteAction[] {
       kind: "stash-return-address",
       sessionRoom,
       agentId: targetAgent,
+    });
+    // Stash the raw tick payload so before_agent_start can inject it on the
+    // agent's next turn — the dispatched instruction below is a terse human
+    // summary that omits fields the agent needs (exact offer keys, valid_keys
+    // on error ticks, etc.).
+    actions.push({
+      kind: "stash-tick",
+      sessionRoom,
+      agentId: targetAgent,
+      payload,
     });
   }
 

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/tick-stash.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/tick-stash.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+/**
+ * Tick stash: latest coordination_tick payload observed per agent, keyed by
+ * agentId. Captured every time the channel SSE delivers a tick (overwrite —
+ * latest wins), used by `session/before_agent_start` to inject the full
+ * payload (current_offer keys, valid_keys on error ticks, etc.) into the
+ * agent's prompt.
+ *
+ * Why a stash and not an HTTP fetch?
+ *
+ * The channel module already holds the parsed tick when it dispatches the
+ * formatted instruction to the agent. Having `before_agent_start` re-query
+ * the backend by parent room (the prior design) doesn't work — ticks are
+ * attached to the CoordinationSession, not to any room. Rather than teach
+ * the session module to resolve coord-session display names and walk the
+ * `/api/coordination-sessions/{id}/messages` endpoint, we mirror the
+ * existing return-address pattern: channel observes once, stashes, session
+ * reads back.
+ *
+ * Keying:
+ *   - Return-address keys by (sessionRoom, agentId) because consensus
+ *     delivery has both in hand at lookup time.
+ *   - Tick stash keys by agentId alone — `before_agent_start` has the
+ *     agentId but not the session sub-room. If an agent ever participates
+ *     in two concurrent negotiations (not supported today), latest wins,
+ *     which is also what the prompt should reflect.
+ */
+
+type Logger = { info: (s: string) => void; warn: (s: string) => void };
+
+export type StashedTick = {
+  sessionRoom: string;
+  payload: any;
+  receivedAt: number;
+};
+
+const _stash = new Map<string, StashedTick>();
+
+export function stashTick(
+  agentId: string,
+  sessionRoom: string,
+  payload: any,
+  log: Logger,
+): void {
+  _stash.set(agentId, { sessionRoom, payload, receivedAt: Date.now() });
+  const round = payload?.round ?? "?";
+  log.info(`[mycelium-room] tick stashed: ${agentId} ← round ${round} (${sessionRoom})`);
+}
+
+export function lookupTick(agentId: string): StashedTick | undefined {
+  return _stash.get(agentId);
+}
+
+/**
+ * Drop any stashed ticks associated with a given session sub-room. Called
+ * when the session reaches a terminal state and SSE is torn down — same
+ * lifecycle point that clears the return-address stash.
+ */
+export function clearTickStashBySessionRoom(sessionRoom: string): void {
+  for (const [agentId, entry] of _stash) {
+    if (entry.sessionRoom === sessionRoom) _stash.delete(agentId);
+  }
+}
+
+export function clearAllTickStash(): void {
+  _stash.clear();
+}
+
+/** Test/debug helper. */
+export function _allStashedTicks(): Map<string, StashedTick> {
+  return _stash;
+}

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/session/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/session/index.ts
@@ -20,8 +20,9 @@
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
+import { lookupTick } from "../channel/tick-stash.js";
 import { type ChannelConfig, getApiUrl, readMemoryFileContent, resolveHandle } from "../config.js";
-import { apiGet, apiPost, fetchBackendHealth } from "../http.js";
+import { apiPost, fetchBackendHealth } from "../http.js";
 import { MYCELIUM_INSTRUCTIONS } from "../instructions.js";
 
 type Logger = { info: (s: string) => void; warn: (s: string) => void };
@@ -167,20 +168,21 @@ export function installSession(
 
       const contextParts: string[] = [];
 
-      const room = existing?.room;
-      if (room) {
-        const data = (await apiGet(`/api/rooms/${room}/messages?limit=30`, log)) as any;
-        const coord = data?.messages?.find(
-          (m: any) =>
-            m.message_type === "coordination_consensus" ||
-            m.message_type === "coordination_tick",
-        );
-        if (coord) {
-          const label =
-            coord.message_type === "coordination_consensus"
-              ? "[Mycelium — consensus]"
-              : "[Mycelium — coordination tick]";
-          contextParts.push(`${label}\nRoom: ${room}\n\n${coord.content}`);
+      // Coordination context: read the latest tick the channel module stashed
+      // for this agent. The channel sees the raw payload when it dispatches
+      // the formatted instruction; we inject the full JSON here so the agent
+      // has exact offer keys + valid_keys when composing a counter-offer.
+      //
+      // Prior behaviour fetched messages from the parent room — but ticks
+      // attach to the CoordinationSession, never to the parent room, so that
+      // path returned nothing useful (issue #276). Using the stash also keeps
+      // before_agent_start free of HTTP round-trips.
+      if (agentId) {
+        const stashed = lookupTick(agentId);
+        if (stashed) {
+          contextParts.push(
+            `[Mycelium — coordination tick]\nSession: ${stashed.sessionRoom}\n\n${JSON.stringify(stashed.payload, null, 2)}`,
+          );
         }
       }
 

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/route.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/route.test.ts
@@ -312,6 +312,34 @@ describe("routeMessage — coordination_tick", () => {
     expect(actions.some((a) => a.kind === "stash-return-address")).toBe(false);
   });
 
+  it("emits stash-tick carrying the raw tick payload so session/before_agent_start can inject it", () => {
+    const actions = routeMessage(baseCfg, tickMsg("julia-agent"), freshOwnIds());
+    const stash = actions.find((a) => a.kind === "stash-tick") as any;
+    expect(stash).toBeDefined();
+    expect(stash).toMatchObject({
+      kind: "stash-tick",
+      sessionRoom: "test-room:session:abc123",
+      agentId: "julia-agent",
+    });
+    // payload must include the fields the agent needs that aren't in the
+    // dispatched human-readable summary (exact offer keys, can_counter_offer).
+    expect(stash.payload).toMatchObject({
+      participant_id: "julia-agent",
+      round: 3,
+      current_offer: { price: "500", timeline: "30 days" },
+    });
+  });
+
+  it("does NOT emit stash-tick when the tick has no session sub-room name", () => {
+    const msg = {
+      id: "rootless-tick",
+      message_type: "coordination_tick",
+      content: JSON.stringify({ payload: { participant_id: "julia-agent", round: 1, action: "respond", current_offer: {} } }),
+    };
+    const actions = routeMessage(baseCfg, msg, freshOwnIds());
+    expect(actions.some((a) => a.kind === "stash-tick")).toBe(false);
+  });
+
   it("ignores ticks with unparseable content", () => {
     const msg = {
       message_type: "coordination_tick",

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/tick-stash.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/tick-stash.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  _allStashedTicks,
+  clearAllTickStash,
+  clearTickStashBySessionRoom,
+  lookupTick,
+  stashTick,
+} from "../src/channel/tick-stash.js";
+
+const log = { info: () => {}, warn: () => {} };
+
+describe("tick-stash", () => {
+  beforeEach(() => clearAllTickStash());
+
+  it("stash + lookup round trip returns the same payload", () => {
+    const payload = { round: 2, current_offer: { price: "500" }, valid_keys: ["price", "timeline"] };
+    stashTick("julia-agent", "room-a:session:abc", payload, log);
+    const got = lookupTick("julia-agent");
+    expect(got).toBeDefined();
+    expect(got!.sessionRoom).toBe("room-a:session:abc");
+    expect(got!.payload).toEqual(payload);
+  });
+
+  it("returns undefined for agents that have no stashed tick", () => {
+    stashTick("julia-agent", "room-a:session:abc", { round: 1 }, log);
+    expect(lookupTick("selina-agent")).toBeUndefined();
+  });
+
+  it("overwrites on subsequent stashes — latest tick wins", () => {
+    stashTick("julia-agent", "room-a:session:abc", { round: 1 }, log);
+    stashTick("julia-agent", "room-a:session:abc", { round: 2 }, log);
+    expect(lookupTick("julia-agent")!.payload).toEqual({ round: 2 });
+  });
+
+  it("clearTickStashBySessionRoom drops only entries matching that room", () => {
+    stashTick("julia-agent", "room-a:session:abc", { round: 1 }, log);
+    stashTick("selina-agent", "room-b:session:xyz", { round: 1 }, log);
+    clearTickStashBySessionRoom("room-a:session:abc");
+    expect(lookupTick("julia-agent")).toBeUndefined();
+    expect(lookupTick("selina-agent")).toBeDefined();
+  });
+
+  it("clearAllTickStash empties the stash", () => {
+    stashTick("julia-agent", "room-a:session:abc", { round: 1 }, log);
+    stashTick("selina-agent", "room-b:session:xyz", { round: 1 }, log);
+    clearAllTickStash();
+    expect(_allStashedTicks().size).toBe(0);
+  });
+
+  it("records a receivedAt timestamp so consumers can reason about freshness", () => {
+    const before = Date.now();
+    stashTick("julia-agent", "room-a:session:abc", { round: 1 }, log);
+    const after = Date.now();
+    const got = lookupTick("julia-agent")!;
+    expect(got.receivedAt).toBeGreaterThanOrEqual(before);
+    expect(got.receivedAt).toBeLessThanOrEqual(after);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #276 (the bug as filed; impact was masked by #271 fuzzy-snap).

`before_agent_start` was scanning the **parent** room's messages for the latest `coordination_tick` — but ticks attach to the `CoordinationSession`, never to the parent room, so the scan always returned nothing and `prependContext` stayed at **0 chars (dynamic)** on every turn. Agents had to guess CE offer key names; fuzzy-snap papers over the symptom but the context-injection path itself never worked.

Rather than teach `session/` to resolve coord-session display names and walk `/api/coordination-sessions/{id}/messages` (the path the original issue proposed), this mirrors the existing **return-address** pattern already in the codebase: channel observes the tick once on dispatch, stashes the raw payload keyed by `agentId`, `before_agent_start` reads it back. No HTTP in the hot path, no display-name parsing, no compat-route dependency.

## Changes

- New `channel/tick-stash.ts` — in-memory `Map<agentId, StashedTick>`, latest-tick-wins, mirroring `channel/return-address.ts` in structure and lifecycle.
- `routeTick` emits `stash-tick` alongside `stash-return-address` + `dispatch` when the tick's `room_name` names a session sub-room.
- `channel/index.ts` executor handles `stash-tick`; clears on session terminal state (alongside `stopSessionSSE`) and on `gateway_stop` (alongside `clearSubscribedSessions`).
- `session/index.ts` `before_agent_start` drops the parent-room HTTP fetch in favour of `lookupTick(agentId)`; injects the full payload as pretty-printed JSON.
- Tests: new `tick-stash.test.ts` (6 cases — stash/lookup, overwrite, per-room clear, all-clear, no-cross-contamination, freshness timestamp) and +2 cases on `route.test.ts` covering the new `stash-tick` action.

**95 plugin tests pass, `tsc --noEmit` clean.**

## Why this also fixes the second-order bug from #276

The reporter also called out that `formatTickInstruction` drops the `instruction`/`valid_keys` fields on error ticks, leaving recovering agents with a bare \"Action required: respond.\" Because the stash carries the **raw payload**, those fields are now available to the agent regardless of what the dispatched human-readable string includes — no `formatTickInstruction` change required.

## Verified live

Reinstalled the adapter, restarted the gateway, and ran a 2-agent cache-config negotiation against the running stack. Gateway log shows:

```
[mycelium-room] tick stashed: exp-7378-agent-a ← round 1 (exp-7378-after:session:1b9ab303)
[mycelium-room] 🎯 → exp-7378-agent-a
[mycelium] prependSystemContext: 2698 chars (cached), prependContext: 2049 chars (dynamic)
```

`prependContext: 2049 chars` — the same line that was `0 chars` on every turn before this change. The 2049-byte block is the full tick payload now in the agent's prompt.

## Test plan

- [x] Unit: `tick-stash.test.ts` (6) — stash/lookup, overwrite, per-room clear, all-clear, isolation, freshness
- [x] Unit: `route.test.ts` (+2) — emits `stash-tick` for session ticks; skips for parent-room ticks
- [x] Type: `tsc --noEmit` clean
- [x] Live: gateway log shows `tick stashed` and `prependContext: N chars (dynamic)` with N > 0 during real negotiation
- [ ] Run `before-and-after` skill end-to-end to confirm full negotiation completes (out of scope for this PR — fuzzy-snap already let it complete; this PR makes the agent reasoning better-grounded)

## Notes / follow-ups (not in this PR)

- Filed #278 — release.yml doesn't bump the plugin's `package.json` version on release, so `openclaw plugins list` shows `Version 0.1.0` even on tagged releases.
- During the live test, the two agents landed in **different** coordination session sub-rooms (`...:1b9ab303` and `...:31bd7676`) instead of sharing one. Unrelated to this fix, but worth filing separately.