### PR TITLE
Bump cognition-fabric-node-svc to 0.1.5

### DIFF
--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -147,7 +147,7 @@ services:
 
 
   ioc-cognition-fabric-node-svc:
-    image: ghcr.io/outshift-open/ioc-cognition-fabric-node-svc:0.1.4
+    image: ghcr.io/outshift-open/ioc-cognition-fabric-node-svc:0.1.5
     pull_policy: always
     platform: linux/amd64
     container_name: ioc-cognition-fabric-node-svc


### PR DESCRIPTION
Bump cognition-fabric-node-svc to 0.1.5 - should get us CFN token usage