### PR TITLE
Up node-svc to fix async calls; add UT

### DIFF
--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -147,7 +147,7 @@ services:
 
 
   ioc-cognition-fabric-node-svc:
-    image: ghcr.io/outshift-open/ioc-cognition-fabric-node-svc:0.1.5
+    image: ghcr.io/outshift-open/ioc-cognition-fabric-node-svc:0.1.6
     pull_policy: always
     platform: linux/amd64
     container_name: ioc-cognition-fabric-node-svc


### PR DESCRIPTION
node-services 0.1.5 exposed a couple of issues, which should now be fixed:

https://github.com/outshift-open/ioc-cfn-cognition-engines/issues/23, addressed in https://github.com/outshift-open/ioc-cfn-cognition-engines/pull/24 through https://github.com/outshift-open/ioc-cfn-cognition-engines/pull/26

https://github.com/outshift-open/ioc-cognition-fabric-node-svc/issues/16, addressed in https://github.com/outshift-open/ioc-cognition-fabric-node-svc/pull/16 and https://github.com/outshift-open/ioc-cognition-fabric-node-svc/pull/17

