### PR TITLE
feat(plugin): per-agent dispatch chain + timeout in mycelium-room channel

### DIFF
--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/dispatch-chain.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/dispatch-chain.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+/**
+ * Per-agent dispatch chain — guarantees that only one `dispatchToAgent` call
+ * is in flight per agentId at a time.
+ *
+ * Why this exists. The channel plugin invokes `dispatchToAgent` (which calls
+ * `runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher`) as
+ * fire-and-forget on every routed inbound message. In production traffic
+ * the same agent can legitimately receive multiple messages while its
+ * previous LLM turn is still in flight — a coordination_tick for the next
+ * round, the coordination_consensus that closes the session, an
+ * @-mention from another agent, etc. Without serialization at our layer,
+ * openclaw's lane queue sees q>1 for the same session-key.
+ *
+ * The lane is *supposed* to serialize, but we have observed wedges
+ * (openclaw/openclaw#48488) where a queued task never advances. Whether
+ * those are caused by openclaw bugs or by something we trigger, serializing
+ * at our layer:
+ *
+ *   - keeps openclaw's lane depth at ≤ 1 for our channel, narrowing the
+ *     surface where the upstream bug can fire;
+ *   - has zero observable effect when openclaw's lane is healthy (each
+ *     dispatch already had to wait for the previous LLM turn for the agent
+ *     to be useful — running them concurrently never produced sensible
+ *     behaviour);
+ *   - is purely local to this file.
+ *
+ * The chain has a per-dispatch timeout so a hung promise can never wedge
+ * an agent permanently — that would be the same failure shape this guard
+ * is trying to escape. On timeout we release the chain with a warn log;
+ * the in-flight task is *not* cancelled (we can't cancel an LLM turn
+ * mid-flight) but subsequent dispatches for that agent are no longer
+ * blocked behind it.
+ */
+
+export type Logger = {
+  info: (s: string) => void;
+  warn: (s: string) => void;
+};
+
+export const DEFAULT_DISPATCH_TIMEOUT_MS = 120_000; // 2 minutes
+
+/** Internal state. Exported via `_resetChainsForTest` for vitest. */
+const _chains = new Map<string, Promise<unknown>>();
+const _depth = new Map<string, number>();
+
+export class DispatchTimeoutError extends Error {
+  constructor(
+    public agentId: string,
+    public timeoutMs: number,
+  ) {
+    super(`dispatch timeout after ${timeoutMs}ms for ${agentId}`);
+    this.name = "DispatchTimeoutError";
+  }
+}
+
+function _withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  agentId: string,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const handle = setTimeout(() => {
+      reject(new DispatchTimeoutError(agentId, ms));
+    }, ms);
+    // Don't keep the event loop alive just for the timer.
+    (handle as { unref?: () => void }).unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(handle);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(handle);
+        reject(err);
+      },
+    );
+  });
+}
+
+export interface EnqueueOpts {
+  timeoutMs?: number;
+  log?: Logger;
+}
+
+/**
+ * Queue `fn` behind any in-flight or queued dispatch for `agentId`.
+ *
+ * Returns a promise that resolves when `fn` settles (or when the timeout
+ * fires). The promise never rejects — internal errors are logged so the
+ * fire-and-forget caller can `void` the return value without leaking
+ * unhandledrejection events.
+ */
+export function enqueueDispatch(
+  agentId: string,
+  fn: () => Promise<void>,
+  opts: EnqueueOpts = {},
+): Promise<void> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_DISPATCH_TIMEOUT_MS;
+  const log = opts.log;
+
+  const newDepth = (_depth.get(agentId) ?? 0) + 1;
+  _depth.set(agentId, newDepth);
+  if (newDepth > 1 && log) {
+    log.info(
+      `[mycelium-room] dispatch queued for ${agentId} (chain depth=${newDepth})`,
+    );
+  }
+
+  const prev = _chains.get(agentId) ?? Promise.resolve();
+  // Swallow prior errors so a failed predecessor never poisons the chain.
+  const next: Promise<void> = prev.catch(() => {}).then(async () => {
+    try {
+      await _withTimeout(fn(), timeoutMs, agentId);
+    } catch (err) {
+      if (err instanceof DispatchTimeoutError) {
+        log?.warn(
+          `[mycelium-room] dispatch timed out after ${timeoutMs}ms for ${agentId} — releasing chain (in-flight task not cancellable)`,
+        );
+      } else {
+        log?.warn(
+          `[mycelium-room] dispatch chain error for ${agentId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } finally {
+      const remaining = (_depth.get(agentId) ?? 1) - 1;
+      if (remaining <= 0) {
+        _depth.delete(agentId);
+        // Only delete the chain entry if we're still the tail. A later
+        // enqueue between settle and finally would have replaced it.
+        if (_chains.get(agentId) === next) {
+          _chains.delete(agentId);
+        }
+      } else {
+        _depth.set(agentId, remaining);
+      }
+    }
+  });
+  _chains.set(agentId, next);
+  return next;
+}
+
+/** Test-only: reset internal state between vitest cases. */
+export function _resetChainsForTest(): void {
+  _chains.clear();
+  _depth.clear();
+}
+
+/** Test-only: read current chain depth for an agent. */
+export function _chainDepthForTest(agentId: string): number {
+  return _depth.get(agentId) ?? 0;
+}

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/src/channel/index.ts
@@ -18,6 +18,7 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
 import { CHANNEL_ID, type ChannelConfig } from "../config.js";
+import { enqueueDispatch } from "./dispatch-chain.js";
 import { dispatchToAgent } from "./dispatch.js";
 import { executeNotifyHome } from "./notify-home.js";
 import { _ownMessageIds } from "./post-to-room.js";
@@ -203,14 +204,24 @@ function executeAction(
         );
         log.info(`[${CHANNEL_ID}] addressed to: ${action.agentId}`);
       }
-      void dispatchToAgent(
-        runtime,
-        cfg,
+      // Per-agent serialization: even though `dispatchReplyWithBufferedBlockDispatcher`
+      // is supposed to be safe to call concurrently, openclaw's lane queue has
+      // wedged under bursts (openclaw/openclaw#48488). Holding the queue depth
+      // at ≤ 1 per agent at our layer keeps that bug out of reach. See
+      // dispatch-chain.ts for the full rationale.
+      void enqueueDispatch(
         action.agentId,
-        action.sender,
-        action.content,
-        action.messageId,
-        log,
+        () =>
+          dispatchToAgent(
+            runtime,
+            cfg,
+            action.agentId,
+            action.sender,
+            action.content,
+            action.messageId,
+            log,
+          ),
+        { log },
       );
       return;
     }

--- a/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/dispatch-chain.test.ts
+++ b/mycelium-cli/src/mycelium/adapters/openclaw/mycelium/plugin/test/dispatch-chain.test.ts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+/**
+ * Tests for the per-agent dispatch chain. Behavioural contract:
+ *   - Same-agent dispatches run strictly serially.
+ *   - Different-agent dispatches run concurrently.
+ *   - Errors in one dispatch don't poison subsequent dispatches.
+ *   - Timeout releases the chain so a hung dispatch can't wedge the agent
+ *     permanently.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  DispatchTimeoutError,
+  _chainDepthForTest,
+  _resetChainsForTest,
+  enqueueDispatch,
+} from "../src/channel/dispatch-chain.js";
+
+const makeLogger = () => {
+  const lines: { level: "info" | "warn"; msg: string }[] = [];
+  return {
+    info: (msg: string) => lines.push({ level: "info", msg }),
+    warn: (msg: string) => lines.push({ level: "warn", msg }),
+    lines,
+  };
+};
+
+afterEach(() => {
+  _resetChainsForTest();
+});
+
+describe("enqueueDispatch — same-agent serialization", () => {
+  it("runs same-agent dispatches strictly serially", async () => {
+    const order: string[] = [];
+    const release: Array<() => void> = [];
+    const makeTask = (label: string) => async () => {
+      order.push(`${label}-start`);
+      await new Promise<void>((res) => release.push(res));
+      order.push(`${label}-end`);
+    };
+
+    const p1 = enqueueDispatch("alpha", makeTask("a"));
+    const p2 = enqueueDispatch("alpha", makeTask("b"));
+    const p3 = enqueueDispatch("alpha", makeTask("c"));
+
+    // Yield so the first task can enter.
+    await new Promise((res) => setTimeout(res, 0));
+    expect(order).toEqual(["a-start"]);
+
+    // Release tasks one at a time and assert nothing interleaves.
+    release[0]!();
+    await new Promise((res) => setTimeout(res, 0));
+    expect(order).toEqual(["a-start", "a-end", "b-start"]);
+
+    release[1]!();
+    await new Promise((res) => setTimeout(res, 0));
+    expect(order).toEqual(["a-start", "a-end", "b-start", "b-end", "c-start"]);
+
+    release[2]!();
+    await Promise.all([p1, p2, p3]);
+    expect(order).toEqual([
+      "a-start",
+      "a-end",
+      "b-start",
+      "b-end",
+      "c-start",
+      "c-end",
+    ]);
+  });
+
+  it("logs chain depth >1 at info level", async () => {
+    const log = makeLogger();
+    let allow = false;
+    const waitForAllow = async () => {
+      while (!allow) await new Promise((res) => setTimeout(res, 1));
+    };
+
+    const p1 = enqueueDispatch("alpha", waitForAllow, { log });
+    const p2 = enqueueDispatch("alpha", waitForAllow, { log });
+    const p3 = enqueueDispatch("alpha", waitForAllow, { log });
+
+    const depthLogs = log.lines.filter((l) => l.msg.includes("chain depth"));
+    expect(depthLogs).toHaveLength(2); // depths 2 and 3 logged; depth 1 is not
+    expect(depthLogs[0]!.msg).toContain("depth=2");
+    expect(depthLogs[1]!.msg).toContain("depth=3");
+
+    allow = true;
+    await Promise.all([p1, p2, p3]);
+  });
+});
+
+describe("enqueueDispatch — cross-agent concurrency", () => {
+  it("runs different-agent dispatches in parallel", async () => {
+    const order: string[] = [];
+    let alphaReleased = false;
+    const taskAlpha = async () => {
+      order.push("alpha-start");
+      while (!alphaReleased) {
+        await new Promise((res) => setTimeout(res, 1));
+      }
+      order.push("alpha-end");
+    };
+    const taskBeta = async () => {
+      order.push("beta-start");
+      order.push("beta-end");
+    };
+
+    const pa = enqueueDispatch("alpha", taskAlpha);
+    const pb = enqueueDispatch("beta", taskBeta);
+
+    // beta should be able to start + finish while alpha is still running
+    await pb;
+    expect(order).toEqual(["alpha-start", "beta-start", "beta-end"]);
+
+    alphaReleased = true;
+    await pa;
+    expect(order).toEqual([
+      "alpha-start",
+      "beta-start",
+      "beta-end",
+      "alpha-end",
+    ]);
+  });
+});
+
+describe("enqueueDispatch — error containment", () => {
+  it("does not poison the chain when a prior dispatch throws", async () => {
+    const log = makeLogger();
+    const order: string[] = [];
+
+    const p1 = enqueueDispatch(
+      "alpha",
+      async () => {
+        order.push("a-start");
+        throw new Error("kaboom");
+      },
+      { log },
+    );
+    const p2 = enqueueDispatch(
+      "alpha",
+      async () => {
+        order.push("b-start");
+        order.push("b-end");
+      },
+      { log },
+    );
+
+    await Promise.all([p1, p2]);
+    expect(order).toEqual(["a-start", "b-start", "b-end"]);
+    expect(log.lines.some((l) => l.level === "warn" && /chain error/.test(l.msg))).toBe(
+      true,
+    );
+  });
+
+  it("never rejects the returned promise (safe for fire-and-forget)", async () => {
+    // enqueueDispatch returns a promise that resolves whether or not the
+    // underlying fn threw — callers `void` the return value and unhandled
+    // rejections would crash the gateway. Assert: the promise resolves
+    // with undefined even when fn throws.
+    const result = await enqueueDispatch("alpha", async () => {
+      throw new Error("nope");
+    });
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("enqueueDispatch — timeout", () => {
+  it("releases the chain when a dispatch exceeds the timeout", async () => {
+    const log = makeLogger();
+    let bSawTimeoutLog = false;
+
+    // Task a hangs forever; task b should still run after the timeout fires.
+    const p1 = enqueueDispatch("alpha", () => new Promise<void>(() => {}), {
+      timeoutMs: 50,
+      log,
+    });
+    const p2 = enqueueDispatch(
+      "alpha",
+      async () => {
+        bSawTimeoutLog = log.lines.some(
+          (l) => l.level === "warn" && l.msg.includes("timed out"),
+        );
+      },
+      { timeoutMs: 50, log },
+    );
+
+    await p1; // resolves after timeout
+    await p2;
+    expect(bSawTimeoutLog).toBe(true);
+  });
+
+  it("emits a DispatchTimeoutError shape in the warn log", async () => {
+    const log = makeLogger();
+    await enqueueDispatch("alpha", () => new Promise<void>(() => {}), {
+      timeoutMs: 30,
+      log,
+    });
+    const warns = log.lines.filter((l) => l.level === "warn");
+    expect(warns.some((w) => w.msg.includes("alpha") && w.msg.includes("30ms"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("enqueueDispatch — internal accounting", () => {
+  it("returns chain depth to 0 after all dispatches settle", async () => {
+    let allow = false;
+    const waitForAllow = async () => {
+      while (!allow) await new Promise((res) => setTimeout(res, 1));
+    };
+    const p1 = enqueueDispatch("alpha", waitForAllow);
+    const p2 = enqueueDispatch("alpha", waitForAllow);
+    expect(_chainDepthForTest("alpha")).toBe(2);
+    allow = true;
+    await Promise.all([p1, p2]);
+    expect(_chainDepthForTest("alpha")).toBe(0);
+  });
+});
+
+describe("DispatchTimeoutError", () => {
+  it("preserves agentId and timeoutMs", () => {
+    const err = new DispatchTimeoutError("alpha", 5000);
+    expect(err.agentId).toBe("alpha");
+    expect(err.timeoutMs).toBe(5000);
+    expect(err.name).toBe("DispatchTimeoutError");
+  });
+});


### PR DESCRIPTION
## Summary

The `mycelium-room` channel plugin fires `runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher` via `dispatchToAgent` as fire-and-forget on every routed inbound message. Under normal LLM-paced traffic this produces **concurrent dispatches for the same agent**:

- round-N `coordination_tick` lands → plugin dispatches → agent LLM turn starts (~5–30s)
- agent's tool call `mycelium negotiate respond ...` posts a reply mid-turn (~2–8s in)
- backend fires the round-N+1 tick on `all_replied`
- next tick arrives in the plugin **while the previous LLM turn is still closing**
- plugin dispatches again → openclaw's lane queue now holds q ≥ 2 for the same agent

`openclaw/openclaw#48488` documents wedges where a queued task in that lane never advances. Whether those wedges are caused by openclaw bugs or by something we trigger, **holding queue depth ≤ 1 per agent at our layer narrows the surface where the upstream bug can fire**. If openclaw's lane is healthy, this change is a no-op behaviour-wise (concurrent LLM turns for one agent never produced sensible behaviour either way).

## How I reproduced the concurrent-dispatch condition

Instrumented `dispatch.ts` with a per-agent in-flight counter and timestamp probe, reinstalled the plugin into a local OpenClaw 2026.5.7 gateway, then drove `coordination_tick` messages straight into the backend at varying spacings:

| Tick spacing | Concurrent dispatch observed? |
|---|---|
| ~110ms (synthetic burst) | Yes, depth climbed 1 → 5 within 26ms |
| 5s (slower than real LLM cadence) | Yes, every subsequent tick arrived with the prior still in flight |

The 5s spacing matters: real CFN round cadence is governed by the slowest agent's reply latency (typically 10–15s), so the natural pattern in production has consecutive ticks landing within an LLM-turn window for nearly every round. The plugin will fire concurrent dispatches in that window today.

The probe is **not** in this PR — it stays on a separate branch as evidence only.

## Implementation

Added `channel/dispatch-chain.ts` with `enqueueDispatch(agentId, fn, opts)`:

- `Map<agentId, Promise>` chain; subsequent enqueues wait for the predecessor to settle before `fn()` runs.
- `Promise.race` timeout (default **120s**, configurable via opts) so a hung dispatch can't wedge the agent permanently — the in-flight task isn't cancellable, but the chain releases with a warn log so later dispatches still flow.
- Prior errors are caught inside the chain so a failed dispatch never poisons subsequent ones.
- Returns a **never-rejecting** `Promise<void>`, safe for the existing `void enqueueDispatch(...)` fire-and-forget pattern.

The only caller is `channel/index.ts`, which previously did:

```ts
void dispatchToAgent(runtime, cfg, action.agentId, ...);
```

Now:

```ts
void enqueueDispatch(action.agentId, () => dispatchToAgent(...), { log });
```

`dispatchToAgent` itself is unchanged.

## Observability

Two log lines added so we can verify the chain is doing real work in production:

- `info` when chain depth >1 on enqueue (`dispatch queued for <agent> (chain depth=N)`)
- `warn` on timeout (`dispatch timed out after 120000ms for <agent> — releasing chain`) and on chain errors

If we never see the depth>1 line in production logs over a week, the synthetic-test result didn't generalise and we can re-evaluate. If we do see it (expected, given the local repro), the line is proof the chain is preventing what would otherwise have been concurrent dispatches into openclaw's lane.

## Test plan

- [x] 9 new vitest cases in `test/dispatch-chain.test.ts`:
  - same-agent dispatches run strictly serially (start/end interleave is impossible)
  - chain-depth log fires only at depth >1
  - cross-agent dispatches run concurrently (no false serialization)
  - error in one dispatch doesn't poison the chain
  - `enqueueDispatch` never rejects (safe for `void`)
  - timeout releases the chain and the next dispatch runs
  - timeout warn carries `agentId` + `timeoutMs`
  - chain depth returns to 0 after all dispatches settle
- [x] All 101 plugin tests pass (`npx vitest run`)
- [x] `npx tsc` clean
- [ ] CI passes
- [ ] Soak: leave the depth>1 info log in for one release window, then revisit whether to demote to debug

## What this PR does NOT claim

- It does not assert openclaw's lane queue is buggy. `openclaw/openclaw#48488` is an open issue with a stalled fix PR (`#48690`) and the maintainers haven't confirmed root cause. The chain here is defensive — it doesn't depend on the upstream bug being real.
- It does not change `dispatchToAgent`, `routeMessage`, or any wire-format behaviour. Only the call site is wrapped.
- It does not address the unrelated openclaw multi-room schema (`channels.mycelium-room.rooms: [...]`) that the in-tree plugin doesn't yet parse — that's a separate cleanup.