### PR TITLE
Add --yes flag to `mycelium ui open` and auto-start frontend

### DIFF
--- a/mycelium-cli/src/mycelium/commands/ui.py
+++ b/mycelium-cli/src/mycelium/commands/ui.py
@@ -52,27 +52,43 @@ def _container_running(name: str) -> bool:
 
 
 @doc_ref(
-    usage="mycelium ui open",
+    usage="mycelium ui open [-y]",
     desc="Open the frontend in your default browser.",
     group="setup",
 )
-def ui_open() -> None:
+def ui_open(
+    ctx: typer.Context,
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the confirmation prompt and start the frontend if it isn't running",
+    ),
+) -> None:
     """Open the frontend in your default browser.
 
-    Tries to launch the OS default browser at http://localhost:<port>.
-    Doesn't check whether the frontend container is actually up — use
-    `mycelium ui status` for that.
+    If the frontend container isn't running, offers to start it with
+    `mycelium up --ui` first. Pass `-y` to skip the prompt and start it
+    automatically.
 
     Examples:
         mycelium ui open
+        mycelium ui open -y
     """
     url = _ui_url()
     if not _container_running(_FRONTEND_CONTAINER):
         typer.secho(
-            f"⚠ {_FRONTEND_CONTAINER} is not running — opening anyway.",
+            f"⚠ {_FRONTEND_CONTAINER} is not running.",
             fg=typer.colors.YELLOW,
         )
-        typer.echo("  Start it with: mycelium up --ui")
+        if not yes and not typer.confirm("Start it now with 'mycelium up --ui'?", default=True):
+            typer.echo("  Start it later with: mycelium up --ui")
+            return
+        # Proxy to `mycelium up --ui`. Imported lazily to avoid a circular
+        # import between the commands modules.
+        from mycelium.commands import instance
+
+        instance.start(ctx, build=False, ui=True)
     typer.echo(f"Opening {url}")
     webbrowser.open(url)
 


### PR DESCRIPTION
## Summary

Enhance the `mycelium ui open` command to automatically start the frontend container if it isn't running, with an optional `--yes` / `-y` flag to skip the confirmation prompt. This improves the user experience by reducing friction when opening the UI for the first time or after a restart.

## Changes

- Added `--yes` / `-y` option to `ui_open()` command to skip confirmation prompts
- Changed behavior when frontend container is not running:
  - Previously: warned and opened the browser anyway
  - Now: prompts user to start the container with `mycelium up --ui` (default: yes)
  - With `-y` flag: automatically starts the container without prompting
- Integrated `instance.start()` call to proxy to `mycelium up --ui` when needed
- Updated docstring and usage documentation to reflect new behavior and examples

## Testing

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Format check passes (`uv run ruff format --check .`)

https://claude.ai/code/session_01Ev652SDjaxaXoRdP9vvDfi