### PR TITLE
compose: set CFN_NAME on `ioc-cfn-mgmt-plane-svc` so Default Workspace auto-attaches to the CFN

### DIFF
--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -171,6 +171,13 @@ services:
       POSTGRES_PASSWORD: ${MYCELIUM_DB_PASSWORD:-password}
       PORT: 9000
       CFN_DEV_MODE: ${CFN_DEV_MODE:-false}
+      # Must match the node-svc's CFN_NAME below — the mgmt plane's
+      # Default-Workspace ↔ CFN auto-association branch (see #308) only
+      # fires when the registering node's cfn_name equals this env var.
+      # If unset, the mgmt plane silently falls back to "My Cognition
+      # Fabric Node", the strings don't match, and workspace.cfn_id stays
+      # NULL forever — breaking every CFN data-plane round trip.
+      CFN_NAME: ${CFN_NAME:-mycelium-cfn}
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:9000/health || exit 1"]
       interval: 10s


### PR DESCRIPTION
Closes #308.

## Summary

Single-line env fix (plus a 6-line comment explaining the invariant) to `mycelium-cli/src/mycelium/docker/compose.yml`.

The mgmt plane (`ioc-cfn-mgmt-plane-svc`) only auto-attaches the bootstrap `Default Workspace` to a freshly-registered CFN when the registering node's `cfn_name` equals the mgmt plane's own `CFN_NAME` env. Our compose set `CFN_NAME` on the node-svc but **not** on the mgmt plane, so the mgmt plane fell back to the upstream default `"My Cognition Fabric Node"`, the strings didn't match, the auto-association branch silently no-op'd, and `Default Workspace.cfn_id` stayed `NULL` for the lifetime of every fresh install.

After this PR both services see the same `${CFN_NAME:-mycelium-cfn}` default, the mgmt plane's auto-association branch fires on first CFN registration, and the wiring is correct out of the box.

## Why a comment block

The check is one `if` deep inside the mgmt plane and silently no-ops on mismatch — there's no error, no log, nothing in the API surface to tell you the wiring failed. A future cleanup pass that tidies the env block would almost certainly strip this line, so the 6-line block comment encodes the invariant where it'll be seen.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` on compose.yml — valid
- [ ] Fresh `mycelium install --mode=ioc && mycelium up --profile cfn`, wait for node-svc healthy, then:
      ```
      curl -s http://localhost:9000/api/workspaces | jq '.workspaces[0].cfn_id'
      ```
      → non-null UUID (matches the registered CFN's `cfn_id`)
- [ ] `mycelium-e2e-test::test_09_ioc_full_path` → "CFN has workspace assigned" passes without manual `PUT`

## Repro on existing installs (workaround until users redeploy)

```bash
WS_ID=$(curl -s http://localhost:9000/api/workspaces | jq -r '.workspaces[0].id')
CFN_ID=$(curl -s http://localhost:9000/api/cognition-fabric-nodes | jq -r '.nodes[0].cfn_id')
curl -X PUT "http://localhost:9000/api/workspaces/$WS_ID" \
  -H 'Content-Type: application/json' \
  -d "{\"cfn_id\": \"$CFN_ID\"}"
```

## Out of scope

- Surfacing a warning when the mgmt plane sees a CFN registration whose `cfn_name` doesn't match its `CFN_NAME` (would belong in `ioc-cfn-mgmt-backend-svc`, not here).
- Making `mycelium install` POST/PUT the workspace ↔ CFN pairing itself as belt-and-suspenders. The current design intentionally puts this in the mgmt plane; if we want to move it, that's its own design discussion.

Made with [Cursor](https://cursor.com)