### PR TITLE
feat(config): add frontend_port to RuntimeConfig

### DIFF
--- a/mycelium-cli/src/mycelium/commands/config.py
+++ b/mycelium-cli/src/mycelium/commands/config.py
@@ -344,6 +344,13 @@ def _migrate_env_to_config(config: "MyceliumConfig") -> None:
             changed = True
         except ValueError:
             pass
+    env_frontend_port = env.get("MYCELIUM_UI_PORT")
+    if env_frontend_port and config.runtime.frontend_port == 3000:  # still default
+        try:
+            config.runtime.frontend_port = int(env_frontend_port)
+            changed = True
+        except ValueError:
+            pass
 
     # Runtime — passwords
     env_db_pw = env.get("MYCELIUM_DB_PASSWORD")

--- a/mycelium-cli/src/mycelium/commands/ui.py
+++ b/mycelium-cli/src/mycelium/commands/ui.py
@@ -34,8 +34,15 @@ _DEFAULT_PORT = 3000
 
 
 def _ui_url() -> str:
-    """The URL the user opens in their browser. Honors MYCELIUM_UI_PORT."""
-    port = os.environ.get("MYCELIUM_UI_PORT") or str(_DEFAULT_PORT)
+    """The URL the user opens in their browser. Honors config.toml and MYCELIUM_UI_PORT."""
+    if env_port := os.environ.get("MYCELIUM_UI_PORT"):
+        port = env_port
+    else:
+        try:
+            cfg = MyceliumConfig.load()
+            port = str(cfg.runtime.frontend_port)
+        except Exception:
+            port = str(_DEFAULT_PORT)
     return f"http://localhost:{port}"
 
 

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -118,6 +118,10 @@ class RuntimeConfig(BaseModel):
         default=4318,
         description="Host port for the OTLP metrics collector",
     )
+    frontend_port: int = Field(
+        default=3000,
+        description="Host port for the frontend UI",
+    )
     data_dir: str | None = Field(
         default=None,
         description="Root directory for .mycelium/ data (defaults to ~/.mycelium)",


### PR DESCRIPTION
## Summary

- Adds `runtime.frontend_port` to `config.toml` (default `3000`) alongside `db_port`, `backend_port`, and `collector_port`
- `mycelium ui open` reads the port from config; `MYCELIUM_UI_PORT` env var still takes precedence
- `mycelium config apply` migrates `MYCELIUM_UI_PORT` from `.env` into config on the same pattern as the other ports
- Removes stale `mycelium/adapters/` directory (empty stub left over from the integrations refactor in #277; was breaking `test_no_legacy_adapter_packages`)

## Usage

```toml
[runtime]
frontend_port = 3001
```

Or:
```bash
mycelium config set runtime.frontend_port 3001
```

## Test plan
- [x] `uv run pytest tests/ -x -q` — 112 passed (contract test now green, stale `adapters/` removed)
- [x] ruff + ty clean