### PR TITLE
fix(frontend): same-origin proxy so cloud installs Just Work

### DIFF
--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -483,10 +483,22 @@ def start(
             if result.stderr:
                 typer.echo(result.stderr, err=True)
 
+        # Pull the configured ports from .env so the summary matches reality
+        # (MYCELIUM_BACKEND_PORT / MYCELIUM_UI_PORT are written by `config apply`).
+        backend_port = "8000"
+        ui_port = "3000"
+        env_path = _get_env_path()
+        if env_path and env_path.exists():
+            from dotenv import dotenv_values
+
+            vals = dotenv_values(env_path)
+            backend_port = vals.get("MYCELIUM_BACKEND_PORT") or backend_port
+            ui_port = vals.get("MYCELIUM_UI_PORT") or ui_port
+
         typer.secho("Services started.", fg=typer.colors.GREEN)
-        typer.echo("  mycelium-backend    → http://localhost:8000")
+        typer.echo(f"  mycelium-backend    → http://localhost:{backend_port}")
         if ui:
-            typer.echo("  mycelium-frontend   → http://localhost:3000")
+            typer.echo(f"  mycelium-frontend   → http://localhost:{ui_port}")
         if metrics:
             typer.echo("  mycelium-collector  → http://localhost:4318")
 

--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -75,8 +75,8 @@ services:
   #
   # Next.js frontend for browsing rooms, sessions, memory, and live negotiation.
   # Opt-in via `mycelium up --ui` (or `--profile ui` directly). The browser
-  # reads the backend at the URL baked into the image at build time —
-  # http://localhost:<backend_port> for the standard local install.
+  # only ever talks to its own origin (port MYCELIUM_UI_PORT) — the Next.js
+  # server proxies /api/* to the backend internally over the compose network.
 
   mycelium-frontend:
     build:
@@ -90,6 +90,8 @@ services:
     env_file:
       - path: ../.env
         required: false
+    environment:
+      MYCELIUM_INTERNAL_API_URL: http://mycelium-backend:8000
     depends_on:
       mycelium-backend:
         condition: service_healthy

--- a/mycelium-frontend/.env.example
+++ b/mycelium-frontend/.env.example
@@ -1,10 +1,21 @@
-# Mycelium room viewer — environment variables
+# Mycelium frontend — server-side environment variables.
 #
-# Optional. By default `next.config.ts` reads `server.api_url` from
-# ~/.mycelium/config.toml (the same source the CLI + adapters use), and
-# falls back to http://localhost:8000.
+# The browser only ever talks to its own origin. The Next.js server proxies
+# /api/* requests to the backend, so these are all server-side concerns —
+# none of them are baked into the browser bundle.
 #
-# Set this to override — e.g. when pointing the frontend at a remote
-# backend or running multiple stacks side by side.
+# MYCELIUM_INTERNAL_API_URL
+#   The backend URL the Next.js server uses for the proxy. Default resolution:
+#     1. this env var
+#     2. server.api_url from ~/.mycelium/config.toml
+#     3. http://localhost:8000
+#   Set this in compose / production (compose sets it to mycelium-backend:8000).
+#
+# MYCELIUM_INTERNAL_API_URL=http://localhost:8000
 
-# NEXT_PUBLIC_API_URL=http://localhost:8000
+# MYCELIUM_ALLOWED_DEV_ORIGINS
+#   `next dev` blocks cross-origin requests by default. If you must run dev
+#   mode behind a public IP, list allowed origins here (comma-separated).
+#   The Docker production path does not need this.
+#
+# MYCELIUM_ALLOWED_DEV_ORIGINS=http://203.0.113.42:3000,http://my-dev-host:3000

--- a/mycelium-frontend/Dockerfile
+++ b/mycelium-frontend/Dockerfile
@@ -2,17 +2,16 @@
 #
 # Mycelium frontend — Next.js production build.
 #
-# The browser-side bundle has the backend URL baked in at build time
-# (NEXT_PUBLIC_API_URL is replaced by Next during `next build`). For the
-# default `mycelium install` path the browser runs on the host and reaches
-# the backend at http://localhost:<backend_port>, so that's the bake-time
-# default. Override at build time for non-default setups:
+# The browser never talks to the backend directly. All `/api/*` requests are
+# proxied by the Next.js server (see next.config.ts `rewrites()`) so the
+# image is portable across deployments — no build-time URL baking.
 #
-#   docker build --build-arg API_URL=http://my-backend.internal:8000 .
+# At runtime, the Next.js server reaches the backend via
+# `MYCELIUM_INTERNAL_API_URL` (defaults to `http://mycelium-backend:8000`,
+# the compose service name). For host-mode deployments, override at
+# container start:
 #
-# This is the cheapest possible "ship the UI to users" path. A future PR
-# can add runtime URL injection (server-side /api/_config endpoint that
-# reads the env at request time) for users with remote backends.
+#   docker run -e MYCELIUM_INTERNAL_API_URL=http://host.docker.internal:8000 ...
 
 # ─── deps ─────────────────────────────────────────────────────────────────────
 FROM node:22-alpine AS deps
@@ -24,9 +23,6 @@ RUN npm ci
 # ─── build ────────────────────────────────────────────────────────────────────
 FROM node:22-alpine AS builder
 WORKDIR /app
-
-ARG API_URL=http://localhost:8000
-ENV NEXT_PUBLIC_API_URL=${API_URL}
 
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -40,6 +36,9 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
+# Default proxy target — matches the compose service name. Override at
+# container start for non-compose deployments.
+ENV MYCELIUM_INTERNAL_API_URL=http://mycelium-backend:8000
 
 RUN addgroup --system --gid 1001 nodejs \
  && adduser --system --uid 1001 nextjs

--- a/mycelium-frontend/next.config.ts
+++ b/mycelium-frontend/next.config.ts
@@ -7,20 +7,23 @@ import { join } from "node:path";
 import type { NextConfig } from "next";
 
 /**
- * Resolve the backend URL with the same precedence the rest of the project uses:
- *   1. NEXT_PUBLIC_API_URL  (.env.local override / CI / prod)
- *   2. server.api_url from ~/.mycelium/config.toml  (matches the CLI + adapters)
- *   3. http://localhost:8000  (mycelium install default)
+ * Internal backend URL used by the Next.js server to proxy `/api/*` requests.
  *
- * Config-toml read is best-effort and only happens at `next dev` / `next build`
- * — failures fall through silently to the default.
+ * The browser never sees this URL — it only talks to its own origin. The
+ * Next.js Node process is the one that reaches the backend, so this is a
+ * server-side concern resolved at startup with the following precedence:
+ *
+ *   1. MYCELIUM_INTERNAL_API_URL (preferred — set by compose / runtime env)
+ *   2. server.api_url from ~/.mycelium/config.toml (matches the CLI)
+ *   3. http://localhost:8000 (mycelium install default)
+ *
+ * Config-toml read is best-effort — failures fall through to the default.
  */
-function resolveApiUrl(): string {
-  if (process.env.NEXT_PUBLIC_API_URL) return process.env.NEXT_PUBLIC_API_URL;
+function resolveInternalApiUrl(): string {
+  if (process.env.MYCELIUM_INTERNAL_API_URL) return process.env.MYCELIUM_INTERNAL_API_URL;
   try {
     const path = join(homedir(), ".mycelium", "config.toml");
     const text = readFileSync(path, "utf8");
-    // Match `api_url = "..."` under any section. Prefer [server].api_url if present.
     const serverMatch = text.match(/\[server\][\s\S]*?\n\s*api_url\s*=\s*"([^"]+)"/);
     if (serverMatch) return serverMatch[1];
     const anyMatch = text.match(/^\s*api_url\s*=\s*"([^"]+)"/m);
@@ -31,15 +34,26 @@ function resolveApiUrl(): string {
   return "http://localhost:8000";
 }
 
-const apiUrl = resolveApiUrl();
+const internalApiUrl = resolveInternalApiUrl();
 // eslint-disable-next-line no-console
-console.log(`[mycelium-frontend] backend → ${apiUrl}`);
+console.log(`[mycelium-frontend] proxy /api/* → ${internalApiUrl}`);
+
+// `next dev` blocks cross-origin requests by default; opt-in via env when
+// running dev mode behind a public IP. The Docker production path doesn't
+// need this — the browser only ever hits its own origin.
+const allowedDevOrigins =
+  process.env.MYCELIUM_ALLOWED_DEV_ORIGINS?.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean) ?? [];
 
 const nextConfig: NextConfig = {
   // Standalone output → minimal Docker image (no full node_modules in runtime layer)
   output: "standalone",
-  env: {
-    NEXT_PUBLIC_API_URL: apiUrl,
+  allowedDevOrigins,
+  async rewrites() {
+    return [
+      { source: "/api/:path*", destination: `${internalApiUrl}/api/:path*` },
+    ];
   },
 };
 

--- a/mycelium-frontend/package.json
+++ b/mycelium-frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 3000",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start"
   },

--- a/mycelium-frontend/src/app/page.tsx
+++ b/mycelium-frontend/src/app/page.tsx
@@ -5,7 +5,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { fetchRooms } from "@/lib/api";
+import { fetchRooms, logFetchError } from "@/lib/api";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 import { MainTopBar } from "@/components/main-top-bar";
 import { IDChip } from "@/components/id-chip";
@@ -39,7 +39,7 @@ export default function Dashboard() {
   const load = () =>
     fetchRooms()
       .then((data: Room[]) => setRooms(data))
-      .catch(() => {});
+      .catch(logFetchError("fetchRooms"));
 
   useEffect(() => {
     load();

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -5,7 +5,7 @@
 
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
-import { fetchRoom } from "@/lib/api";
+import { fetchRoom, logFetchError } from "@/lib/api";
 import { AgentsPanel } from "@/components/agents-panel";
 import { EventStream } from "@/components/event-stream";
 import { CollapsibleRail } from "@/components/collapsible-rail";
@@ -34,7 +34,7 @@ export default function RoomPage() {
   useEffect(() => {
     let cancelled = false;
     const load = () =>
-      fetchRoom(roomName).then((r: Room) => { if (!cancelled) setRoom(r); }).catch(() => {});
+      fetchRoom(roomName).then((r: Room) => { if (!cancelled) setRoom(r); }).catch(logFetchError("fetchRoom"));
     load();
     const t = setInterval(load, 8000);
     return () => { cancelled = true; clearInterval(t); };

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -4,7 +4,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { fetchRoomAgents, type AgentSummary } from "@/lib/api";
+import { fetchRoomAgents, logFetchError, type AgentSummary } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -55,7 +55,10 @@ export function AgentsPanel({ roomName }: Props) {
         setAgents(a);
         setLoaded(true);
       })
-      .catch(() => setLoaded(true));
+      .catch((err) => {
+        logFetchError("fetchRoomAgents")(err);
+        setLoaded(true);
+      });
   }, [roomName]);
 
   useEffect(() => {

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -5,7 +5,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { getSSEUrl, fetchMessages, fetchRoomAgents } from "@/lib/api";
+import { getSSEUrl, fetchMessages, fetchRoomAgents, logFetchError } from "@/lib/api";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomPlanHeader } from "@/components/room-plan-header";
 
@@ -194,7 +194,7 @@ export function EventStream({ roomName, onMemoryChanged, planRefreshTrigger = 0 
         .then((a) => {
           if (!cancelled) setAgentHandles(new Set(a.map((x) => x.handle)));
         })
-        .catch(() => {});
+        .catch(logFetchError("fetchRoomAgents"));
     load();
     const t = setInterval(load, 30_000);
     return () => {
@@ -208,7 +208,7 @@ export function EventStream({ roomName, onMemoryChanged, planRefreshTrigger = 0 
     fetchMessages(roomName).then(data => {
       const msgs = (data.messages || []).reverse();
       setEvents(msgs.map(parseEvent));
-    }).catch(() => {});
+    }).catch(logFetchError("fetchMessages"));
   }, [roomName]);
 
   // SSE connection

--- a/mycelium-frontend/src/components/participants-panel.tsx
+++ b/mycelium-frontend/src/components/participants-panel.tsx
@@ -4,7 +4,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { fetchSessions } from "@/lib/api";
+import { fetchSessions, logFetchError } from "@/lib/api";
 
 interface Props {
   /** Session display name, e.g. ``my-room:session:abc12345`` */
@@ -47,7 +47,10 @@ export function ParticipantsPanel({ sessionRoom }: Props) {
         setParticipants(data.participants ?? []);
         setLoaded(true);
       })
-      .catch(() => setLoaded(true));
+      .catch((err) => {
+        logFetchError("fetchSessions")(err);
+        setLoaded(true);
+      });
   }, [sessionRoom]);
 
   useEffect(() => {

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -4,7 +4,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { fetchRoomAgents, sendRoomMessage, type AgentSummary } from "@/lib/api";
+import { fetchRoomAgents, logFetchError, sendRoomMessage, type AgentSummary } from "@/lib/api";
 
 interface Props {
   roomName: string;
@@ -38,7 +38,10 @@ export function RoomChatBox({ roomName, defaultSender, onSent }: Props) {
   }, [sender]);
 
   const refreshAgents = useCallback(() => {
-    fetchRoomAgents(roomName).then(setAgents).catch(() => setAgents([]));
+    fetchRoomAgents(roomName).then(setAgents).catch((err) => {
+      logFetchError("fetchRoomAgents")(err);
+      setAgents([]);
+    });
   }, [roomName]);
 
   useEffect(() => {

--- a/mycelium-frontend/src/components/session-view.tsx
+++ b/mycelium-frontend/src/components/session-view.tsx
@@ -5,7 +5,7 @@
 
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from "react-resizable-panels";
-import { fetchMessages, getSSEUrl } from "@/lib/api";
+import { fetchMessages, getSSEUrl, logFetchError } from "@/lib/api";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -211,7 +211,7 @@ function useSessionMessages(sessionRoom: string) {
       const arr = Array.isArray(data) ? data : (data as { messages?: RawMessage[] })?.messages ?? [];
       // API returns newest-first; reverse to chronological.
       setMessages([...arr].reverse());
-    }).catch(() => {});
+    }).catch(logFetchError("fetchMessages (session initial)"));
 
     const url = getSSEUrl(sessionRoom);
     let es: EventSource | null = null;
@@ -231,7 +231,7 @@ function useSessionMessages(sessionRoom: string) {
         if (cancelled) return;
         const arr = Array.isArray(data) ? data : (data as { messages?: RawMessage[] })?.messages ?? [];
         setMessages([...arr].reverse());
-      }).catch(() => {});
+      }).catch(logFetchError("fetchMessages (session poll)"));
     }, 5000);
 
     return () => { cancelled = true; es?.close(); clearInterval(refetch); };

--- a/mycelium-frontend/src/components/sessions-rail.tsx
+++ b/mycelium-frontend/src/components/sessions-rail.tsx
@@ -5,7 +5,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { fetchChildRooms } from "@/lib/api";
+import { fetchChildRooms, logFetchError } from "@/lib/api";
 
 function sessionIdOf(sessionRoomName: string): string {
   return sessionRoomName.split(":").pop() ?? sessionRoomName;
@@ -69,7 +69,10 @@ export function SessionsRail({ roomName, activeSessionName }: SessionsRailProps)
     const load = () =>
       fetchChildRooms(roomName)
         .then((data: Session[]) => { if (!cancelled) { setSessions(data); setLoaded(true); } })
-        .catch(() => { if (!cancelled) setLoaded(true); });
+        .catch((err) => {
+          logFetchError("fetchChildRooms")(err);
+          if (!cancelled) setLoaded(true);
+        });
     load();
     const t = setInterval(load, 5000);
     return () => { cancelled = true; clearInterval(t); };

--- a/mycelium-frontend/src/components/sessions-view.tsx
+++ b/mycelium-frontend/src/components/sessions-view.tsx
@@ -4,7 +4,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { fetchChildRooms, fetchMessages, getSSEUrl } from "@/lib/api";
+import { fetchChildRooms, fetchMessages, getSSEUrl, logFetchError } from "@/lib/api";
 
 interface ChildSession {
   name: string;
@@ -300,7 +300,7 @@ function SessionFeed({ sessionName }: { sessionName: string }) {
     fetchMessages(sessionName).then((data) => {
       const msgs = (data.messages || []).reverse();
       setEvents(msgs.map(parseSessionEvent));
-    }).catch(() => {});
+    }).catch(logFetchError("fetchMessages (sessions)"));
   }, [sessionName]);
 
   useEffect(() => {

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -1,20 +1,36 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Julia Valenti
 
-const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+// All fetches use relative `/api/*` paths. The Next.js server proxies them
+// to the backend (see next.config.ts `rewrites()`), so the browser only ever
+// talks to its own origin — no CORS, no second public port, no build-time
+// URL baking. The internal backend URL is a server-side concern.
+
+/**
+ * Attach to a fetch `.catch` to surface network failures in the browser
+ * console. Replaces the previous `.catch(() => {})` pattern that swallowed
+ * every error and made cloud-install debugging impossible.
+ */
+export const logFetchError =
+  (label: string) =>
+  (err: unknown): undefined => {
+    // eslint-disable-next-line no-console
+    console.error(`[mycelium] fetch failed: ${label}`, err);
+    return undefined;
+  };
 
 export async function fetchRooms() {
-  const res = await fetch(`${API}/api/rooms`, { cache: "no-store" });
+  const res = await fetch(`/api/rooms`, { cache: "no-store" });
   return res.json();
 }
 
 export async function fetchRoom(name: string) {
-  const res = await fetch(`${API}/api/rooms/${name}`, { cache: "no-store" });
+  const res = await fetch(`/api/rooms/${name}`, { cache: "no-store" });
   return res.json();
 }
 
 export async function createRoom(data: { name: string; trigger_config?: object; is_persistent?: boolean }) {
-  const res = await fetch(`${API}/api/rooms`, {
+  const res = await fetch(`/api/rooms`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ ...data, is_public: true }),
@@ -25,12 +41,12 @@ export async function createRoom(data: { name: string; trigger_config?: object; 
 export async function fetchMemories(roomName: string, prefix?: string) {
   const params = new URLSearchParams({ limit: "50" });
   if (prefix) params.set("prefix", prefix);
-  const res = await fetch(`${API}/api/rooms/${roomName}/memory?${params}`, { cache: "no-store" });
+  const res = await fetch(`/api/rooms/${roomName}/memory?${params}`, { cache: "no-store" });
   return res.json();
 }
 
 export async function searchMemories(roomName: string, query: string) {
-  const res = await fetch(`${API}/api/rooms/${roomName}/memory/search`, {
+  const res = await fetch(`/api/rooms/${roomName}/memory/search`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query, limit: 10 }),
@@ -39,7 +55,7 @@ export async function searchMemories(roomName: string, query: string) {
 }
 
 export async function fetchCatchup(roomName: string) {
-  const res = await fetch(`${API}/api/rooms/${roomName}/catchup`, { cache: "no-store" });
+  const res = await fetch(`/api/rooms/${roomName}/catchup`, { cache: "no-store" });
   return res.json();
 }
 
@@ -72,7 +88,7 @@ export interface PlanResponse {
 }
 
 export async function fetchPlan(roomName: string): Promise<PlanResponse> {
-  const res = await fetch(`${API}/api/rooms/${roomName}/plan`, { cache: "no-store" });
+  const res = await fetch(`/api/rooms/${roomName}/plan`, { cache: "no-store" });
   if (!res.ok) {
     return { room: roomName, title: null, files: [], tasks: [], open_count: 0, done_count: 0 };
   }
@@ -80,7 +96,7 @@ export async function fetchPlan(roomName: string): Promise<PlanResponse> {
 }
 
 export async function setPlanTitle(roomName: string, text: string): Promise<string | null> {
-  const res = await fetch(`${API}/api/rooms/${roomName}/plan/title`, {
+  const res = await fetch(`/api/rooms/${roomName}/plan/title`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text }),
@@ -92,7 +108,7 @@ export async function setPlanTitle(roomName: string, text: string): Promise<stri
 
 export async function togglePlanTask(roomName: string, taskId: string, done: boolean): Promise<PlanTask> {
   const res = await fetch(
-    `${API}/api/rooms/${roomName}/plan/tasks/${encodeURIComponent(taskId)}/toggle`,
+    `/api/rooms/${roomName}/plan/tasks/${encodeURIComponent(taskId)}/toggle`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -103,7 +119,7 @@ export async function togglePlanTask(roomName: string, taskId: string, done: boo
 }
 
 export async function addPlanTask(roomName: string, text: string, slug = "tasks"): Promise<PlanTask> {
-  const res = await fetch(`${API}/api/rooms/${roomName}/plan/tasks`, {
+  const res = await fetch(`/api/rooms/${roomName}/plan/tasks`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text, slug }),
@@ -112,20 +128,20 @@ export async function addPlanTask(roomName: string, text: string, slug = "tasks"
 }
 
 export async function reindexRoom(roomName: string) {
-  const res = await fetch(`${API}/api/rooms/${roomName}/reindex`, { method: "POST" });
+  const res = await fetch(`/api/rooms/${roomName}/reindex`, { method: "POST" });
   return res.json();
 }
 
 export async function fetchMessages(roomName: string, limit?: number) {
   const url = limit
-    ? `${API}/api/rooms/${roomName}/messages?limit=${limit}`
-    : `${API}/api/rooms/${roomName}/messages`;
+    ? `/api/rooms/${roomName}/messages?limit=${limit}`
+    : `/api/rooms/${roomName}/messages`;
   const res = await fetch(url, { cache: "no-store" });
   return res.json();
 }
 
 export async function fetchSessions(roomName: string) {
-  const res = await fetch(`${API}/api/rooms/${roomName}/sessions`, { cache: "no-store" });
+  const res = await fetch(`/api/rooms/${roomName}/sessions`, { cache: "no-store" });
   if (!res.ok) return { sessions: [], total: 0 };
   return res.json();
 }
@@ -135,7 +151,7 @@ export async function fetchChildRooms(parentName: string) {
   // name + state so callers that previously walked rooms by name pattern
   // keep working with minimal changes.
   const res = await fetch(
-    `${API}/api/coordination-sessions?parent_room=${encodeURIComponent(parentName)}&limit=200`,
+    `/api/coordination-sessions?parent_room=${encodeURIComponent(parentName)}&limit=200`,
     { cache: "no-store" },
   );
   if (!res.ok) return [];
@@ -150,14 +166,14 @@ export async function fetchChildRooms(parentName: string) {
 }
 
 export function getSSEUrl(roomName: string) {
-  return `${API}/api/rooms/${roomName}/messages/stream`;
+  return `/api/rooms/${roomName}/messages/stream`;
 }
 
 export async function sendRoomMessage(
   roomName: string,
   data: { sender_handle: string; content: string; message_type?: string },
 ) {
-  const res = await fetch(`${API}/api/rooms/${roomName}/messages`, {
+  const res = await fetch(`/api/rooms/${roomName}/messages`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ message_type: "broadcast", ...data }),
@@ -183,7 +199,7 @@ export interface AgentSummary {
  */
 export async function fetchRoomAgents(roomName: string): Promise<AgentSummary[]> {
   const res = await fetch(
-    `${API}/api/rooms/${roomName}/memory?prefix=agents/&limit=200`,
+    `/api/rooms/${roomName}/memory?prefix=agents/&limit=200`,
     { cache: "no-store" },
   );
   if (!res.ok) return [];
@@ -231,13 +247,13 @@ export async function fetchRoomAgents(roomName: string): Promise<AgentSummary[]>
 // ── Metrics ──────────────────────────────────────────────────────────────────
 
 export async function fetchBackendMetrics() {
-  const res = await fetch(`${API}/api/observability`, { cache: "no-store" });
+  const res = await fetch(`/api/observability`, { cache: "no-store" });
   if (!res.ok) return null;
   return res.json();
 }
 
 export async function fetchCollectorMetrics() {
-  const res = await fetch(`${API}/api/observability/collector`, { cache: "no-store" });
+  const res = await fetch(`/api/observability/collector`, { cache: "no-store" });
   if (!res.ok) return null;
   return res.json();
 }
@@ -276,7 +292,7 @@ export interface TraceSummary {
 export async function fetchRecentTraces(limit = 100, host?: string): Promise<{ traces: TraceSummary[]; count: number } | null> {
   const params = new URLSearchParams({ limit: String(limit) });
   if (host) params.set("host", host);
-  const res = await fetch(`${API}/api/observability/traces/recent?${params}`, { cache: "no-store" });
+  const res = await fetch(`/api/observability/traces/recent?${params}`, { cache: "no-store" });
   if (!res.ok) return null;
   return res.json();
 }
@@ -291,20 +307,20 @@ export interface HostInfo {
 }
 
 export async function fetchHosts(): Promise<{ hosts: HostInfo[] } | null> {
-  const res = await fetch(`${API}/api/observability/hosts`, { cache: "no-store" });
+  const res = await fetch(`/api/observability/hosts`, { cache: "no-store" });
   if (!res.ok) return null;
   return res.json();
 }
 
 export async function fetchRoundTraces(limit?: number): Promise<{ traces: unknown[]; count: number } | null> {
   const params = limit != null ? `?limit=${limit}` : "";
-  const res = await fetch(`${API}/api/internal/coordination/round-traces${params}`, { cache: "no-store" });
+  const res = await fetch(`/api/internal/coordination/round-traces${params}`, { cache: "no-store" });
   if (!res.ok) return null;
   return res.json();
 }
 
 export async function fetchIngestLog(limit = 50) {
-  const res = await fetch(`${API}/api/knowledge/ingest/log?limit=${limit}`, { cache: "no-store" });
+  const res = await fetch(`/api/knowledge/ingest/log?limit=${limit}`, { cache: "no-store" });
   if (!res.ok) return null;
   return res.json();
 }
@@ -335,7 +351,7 @@ export interface CfnNeighborsResponse {
 
 export async function fetchCfnConcepts(masId: string, limit = 50): Promise<CfnConceptListResponse | null> {
   const params = new URLSearchParams({ mas_id: masId, limit: String(limit) });
-  const res = await fetch(`${API}/api/cfn/knowledge/list?${params}`, { cache: "no-store" });
+  const res = await fetch(`/api/cfn/knowledge/list?${params}`, { cache: "no-store" });
   if (!res.ok) return null;
   return res.json();
 }
@@ -343,7 +359,7 @@ export async function fetchCfnConcepts(masId: string, limit = 50): Promise<CfnCo
 export async function fetchCfnNeighbors(masId: string, conceptId: string): Promise<CfnNeighborsResponse | null> {
   const params = new URLSearchParams({ mas_id: masId });
   const res = await fetch(
-    `${API}/api/cfn/knowledge/concepts/${encodeURIComponent(conceptId)}/neighbors?${params}`,
+    `/api/cfn/knowledge/concepts/${encodeURIComponent(conceptId)}/neighbors?${params}`,
     { cache: "no-store" },
   );
   if (!res.ok) return null;


### PR DESCRIPTION
## Summary

Addresses most of the frontend cluster from #326. The browser used to talk
directly to the backend at a build-baked URL; that broke every cloud deploy
in five overlapping ways, and the silent `.catch(() => {})` on every fetch
made it invisible.

After this PR the browser only ever talks to its own origin. The Next.js
server proxies `/api/*` to the backend internally. One public port, no
CORS, no rebuild to repoint at a different backend.

| Closes | What it was |
|---|---|
| #4  | `mycelium up` summary hardcoded `localhost:3000` |
| #6  | `NEXT_PUBLIC_API_URL` baked into the browser bundle at build time |
| #7  | `package.json` `dev` script hardcoded `--port 3000` |
| #8  | `NEXT_PUBLIC_API_URL` only worked in `.env.local`, not shell env |
| #9  | Next.js blocked cross-origin dev mode (no `allowedDevOrigins`) |
| #10 | Browser → backend port 8000 had to be publicly accessible + CORS |
| #11 | SSE `getSSEUrl()` used absolute `localhost:8000` |

## What changed

| File | Why |
|---|---|
| `mycelium-frontend/next.config.ts` | Drop `env` block; add `async rewrites()` proxying `/api/:path*`; add env-driven `allowedDevOrigins`; rename resolver to `resolveInternalApiUrl()`. |
| `mycelium-frontend/src/lib/api.ts` | Delete `API` constant; all 30+ fetch URLs + `getSSEUrl()` are now relative. Add `logFetchError(label)` helper. |
| 9 silent-catch sites | `page.tsx`, `room/[name]/page.tsx`, `event-stream.tsx` (×2), `session-view.tsx` (×2), `sessions-view.tsx`, `sessions-rail.tsx`, `agents-panel.tsx`, `participants-panel.tsx`, `room-chat-box.tsx` — now log via `console.error`. |
| `mycelium-frontend/package.json` | `"dev": "next dev"` — port is now configurable. |
| `mycelium-frontend/Dockerfile` | Remove `ARG API_URL` / `ENV NEXT_PUBLIC_API_URL`; add runtime default `MYCELIUM_INTERNAL_API_URL=http://mycelium-backend:8000`. |
| `mycelium-cli/src/mycelium/docker/compose.yml` | Set `MYCELIUM_INTERNAL_API_URL` explicitly on the frontend service. |
| `mycelium-frontend/.env.example` | Document `MYCELIUM_INTERNAL_API_URL` + `MYCELIUM_ALLOWED_DEV_ORIGINS`. |
| `mycelium-cli/src/mycelium/commands/instance.py` | `mycelium up` summary reads `MYCELIUM_BACKEND_PORT` / `MYCELIUM_UI_PORT` from `.env`. |

## Out of scope for this PR (still open from #326)

- #2 `mycelium upgrade` doesn't refresh `~/.mycelium/docker/compose.yml`
- #12 `openclaw doctor --fix` nukes `mycelium-room` channel config
- #13 `mycelium agent add` creates manifest files as root

## Test plan

- [ ] `pnpm build` clean (verified — 4 routes, TypeScript passed)
- [ ] Local dev: `pnpm dev` → open `http://localhost:3000`, rooms load, Network tab shows relative `/api/*` paths
- [ ] Local prod: `pnpm build && pnpm start` → same
- [ ] Docker compose: `mycelium up --ui` → frontend container reaches backend via internal DNS, only port 3000 exposed
- [ ] Cloud VPS: open `http://<vps-ip>:3000` from a laptop browser — every fetch works without `--build-arg API_URL=...`
- [ ] SSE: browser devtools → Network → EventSource stays connected on `/api/rooms/.../messages/stream`
- [ ] Trigger a fetch failure (e.g., backend down): confirm `[mycelium] fetch failed: ...` appears in console (previously silent)
- [ ] `mycelium up --ui` summary shows the configured ports, not hardcoded 3000/8000