### PR TITLE
fix(upgrade): refresh ~/.mycelium/docker/compose.yml on upgrade

### DIFF
--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -120,6 +120,7 @@ def skill(
 app.command(name="init")(instance.init)
 app.command(name="install")(install.install)
 app.command(name="upgrade")(install.upgrade)
+app.command(name="_refresh-templates", hidden=True)(install.refresh_templates)
 app.command(name="pull")(instance.pull)
 app.command(name="doctor")(doctor.doctor)
 app.command(name="up")(instance.start)

--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -306,6 +306,53 @@ def _remove_env_var(env_path: Path, key: str) -> None:
 # ── Docker compose ────────────────────────────────────────────────────────────
 
 
+def _refresh_compose_templates(*, backup: bool = True) -> list[Path]:
+    """Overwrite ``~/.mycelium/docker/`` with the templates bundled in the
+    currently-installed wheel.
+
+    Refreshes ``compose.yml`` and ``initdb/*``. When *backup* is True (the
+    default), the previous ``compose.yml`` is renamed to ``compose.yml.prev``
+    before overwrite — a single rolling backup that covers anyone who has
+    hand-edited the file.
+
+    The currently-running Python process loads ``importlib.resources`` from
+    its own ``site-packages``, so this should only be called from a process
+    running the NEW wheel after an upgrade. ``mycelium upgrade`` does that by
+    invoking ``mycelium _refresh-templates`` as a subprocess of the freshly-
+    installed binary.
+
+    Returns the list of paths that were (re)written.
+    """
+    import importlib.resources
+
+    refreshed: list[Path] = []
+    dest_dir = Path.home() / ".mycelium" / "docker"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    compose_dest = dest_dir / "compose.yml"
+    if backup and compose_dest.exists():
+        prev = dest_dir / "compose.yml.prev"
+        prev.write_bytes(compose_dest.read_bytes())
+    compose_ref = importlib.resources.files("mycelium.docker") / "compose.yml"
+    compose_dest.write_bytes(compose_ref.read_bytes())
+    refreshed.append(compose_dest)
+
+    # initdb/ scripts so Postgres entrypoint creates CFN databases on first
+    # volume init (compose mounts ./initdb as /docker-entrypoint-initdb.d).
+    initdb_dest = dest_dir / "initdb"
+    initdb_dest.mkdir(exist_ok=True)
+    initdb_pkg = importlib.resources.files("mycelium.docker") / "initdb"
+    for item in initdb_pkg.iterdir():
+        if item.name.startswith("_"):
+            continue
+        script_path = initdb_dest / item.name
+        script_path.write_bytes(item.read_bytes())
+        script_path.chmod(0o755)
+        refreshed.append(script_path)
+
+    return refreshed
+
+
 def _get_compose_path() -> Path:
     """
     Resolve the canonical compose file path.
@@ -338,28 +385,10 @@ def _get_compose_path() -> Path:
     except Exception:
         pass
 
-    # Fallback: extract bundled compose (relative build paths will be wrong)
-    compose_ref = importlib.resources.files("mycelium.docker") / "compose.yml"
-    dest = Path.home() / ".mycelium" / "docker" / "compose.yml"
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_bytes(compose_ref.read_bytes())
-
-    # Copy bundled initdb/ scripts so Postgres entrypoint creates CFN databases
-    # on first volume init (compose mounts ./initdb as /docker-entrypoint-initdb.d).
-    try:
-        initdb_dest = dest.parent / "initdb"
-        initdb_dest.mkdir(exist_ok=True)
-        initdb_pkg = importlib.resources.files("mycelium.docker") / "initdb"
-        for item in initdb_pkg.iterdir():
-            if item.name.startswith("_"):
-                continue
-            script_path = initdb_dest / item.name
-            script_path.write_bytes(item.read_bytes())
-            script_path.chmod(0o755)
-    except Exception:
-        pass  # non-fatal: _ensure_cfn_databases() handles it at runtime
-
-    return dest
+    # Fallback: extract bundled compose. No backup here — first-time install,
+    # nothing to preserve.
+    refreshed = _refresh_compose_templates(backup=False)
+    return refreshed[0]  # compose.yml is always first
 
 
 def _image_exists(image: str) -> bool:
@@ -1603,6 +1632,35 @@ def upgrade(
 
         typer.secho(f"  ✓ CLI updated to {latest_tag}", fg=typer.colors.GREEN)
 
+        # Refresh ~/.mycelium/docker/compose.yml + initdb/ to match the new
+        # wheel. The currently-running process still has the OLD package
+        # loaded, so we shell out to the freshly-installed binary — it'll
+        # importlib.resources from the NEW site-packages. Previous
+        # compose.yml is preserved as compose.yml.prev.
+        typer.echo("")
+        typer.echo("  Refreshing compose templates...")
+        try:
+            refresh = subprocess.run(
+                ["mycelium", "_refresh-templates"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if refresh.returncode == 0:
+                if refresh.stdout:
+                    typer.echo(refresh.stdout.rstrip())
+                typer.secho("  ✓ Compose templates refreshed", fg=typer.colors.GREEN)
+            else:
+                typer.secho(
+                    "  ⚠  Template refresh failed — run 'mycelium _refresh-templates' manually.",
+                    fg=typer.colors.YELLOW,
+                )
+                if refresh.stderr:
+                    typer.echo(f"    {refresh.stderr.strip()}")
+        except Exception as exc:
+            typer.secho(f"  ⚠  Template refresh failed: {exc}", fg=typer.colors.YELLOW)
+            typer.echo("    Run 'mycelium _refresh-templates' manually.")
+
         # Remind about containers
         typer.echo("")
         typer.echo("  Containers may also need updating.")
@@ -1610,6 +1668,26 @@ def upgrade(
 
     except typer.Exit:
         raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None
+
+
+def refresh_templates(ctx: typer.Context) -> None:
+    """Overwrite ~/.mycelium/docker/ templates with the bundled versions.
+
+    Hidden subcommand — invoked by ``mycelium upgrade`` after the new wheel
+    is installed, so the bundled compose.yml + initdb/ scripts on disk match
+    the running CLI. The previous compose.yml is preserved as compose.yml.prev.
+
+    Safe to call manually if the upgrade hook failed (e.g., subprocess
+    timeout) or if you want to revert to the bundled compose.yml.
+    """
+    try:
+        refreshed = _refresh_compose_templates()
+        for path in refreshed:
+            typer.echo(f"  ✓ {path}")
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False
         print_error(e, verbose=verbose)

--- a/mycelium-cli/tests/test_refresh_templates.py
+++ b/mycelium-cli/tests/test_refresh_templates.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""``mycelium upgrade`` must refresh ``~/.mycelium/docker/compose.yml``.
+
+The bug it fixes: previously the CLI binary was replaced but the on-disk
+compose template was never touched, so users running ``mycelium up`` after
+upgrade silently kept executing an old compose against a new CLI. The fix
+ships a hidden ``_refresh-templates`` subcommand that overwrites the on-disk
+template with the bundled one, with a ``compose.yml.prev`` backup.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mycelium.commands.install import _refresh_compose_templates
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+def test_refresh_writes_bundled_compose(home: Path) -> None:
+    refreshed = _refresh_compose_templates()
+
+    compose = home / ".mycelium" / "docker" / "compose.yml"
+    assert compose in refreshed
+    assert compose.exists()
+    body = compose.read_text(encoding="utf-8")
+    # Sanity: the bundled template defines the backend service.
+    assert "mycelium-backend" in body
+
+
+def test_refresh_overwrites_stale_template_and_backs_up(home: Path) -> None:
+    compose = home / ".mycelium" / "docker" / "compose.yml"
+    compose.parent.mkdir(parents=True)
+    compose.write_text("STALE TEMPLATE", encoding="utf-8")
+
+    _refresh_compose_templates()
+
+    # Fresh body replaced the stale one.
+    assert "STALE TEMPLATE" not in compose.read_text(encoding="utf-8")
+    # And the stale body is preserved one slot back.
+    backup = home / ".mycelium" / "docker" / "compose.yml.prev"
+    assert backup.exists()
+    assert backup.read_text(encoding="utf-8") == "STALE TEMPLATE"
+
+
+def test_refresh_no_backup_when_disabled(home: Path) -> None:
+    compose = home / ".mycelium" / "docker" / "compose.yml"
+    compose.parent.mkdir(parents=True)
+    compose.write_text("STALE", encoding="utf-8")
+
+    _refresh_compose_templates(backup=False)
+
+    assert "STALE" not in compose.read_text(encoding="utf-8")
+    assert not (home / ".mycelium" / "docker" / "compose.yml.prev").exists()
+
+
+def test_refresh_copies_initdb_scripts(home: Path) -> None:
+    _refresh_compose_templates()
+
+    initdb = home / ".mycelium" / "docker" / "initdb"
+    assert initdb.is_dir()
+    scripts = list(initdb.glob("*.sh"))
+    assert scripts, "expected at least one initdb script to be copied"
+    # CFN bootstrap script must land — Postgres needs it on first volume init.
+    assert any(s.name == "create-cfn-cp-db.sh" for s in scripts)


### PR DESCRIPTION
## Summary

`mycelium upgrade` previously replaced the binary but left
`~/.mycelium/docker/compose.yml` untouched. If the bundled compose template
changed between releases — new env vars, new services, edited mounts — users
running `mycelium up` after upgrade silently kept executing the old compose
against the new CLI. Closes #2 from #326 (v1.1.0 tracking bug).

## How

The currently-running upgrade process has the OLD wheel's `importlib`
resources loaded, so an inline copy would just rewrite the stale file with
itself. After `uv tool install --force` succeeds, the upgrade now shells out
to the freshly-installed binary via a hidden `mycelium _refresh-templates`
subcommand. That subprocess loads the NEW package and copies its bundled
`compose.yml` + `initdb/*` to `~/.mycelium/docker/`.

The previous `compose.yml` is preserved as `compose.yml.prev` — single
rolling backup for anyone who has hand-edited the file. The hidden command
is also safe to invoke manually if the upgrade hook fails (subprocess
timeout, weird PATH, etc.).

## Changes

| File | Change |
|---|---|
| `commands/install.py` | New `_refresh_compose_templates(backup=True)` helper. `_get_compose_path()` fallback path now calls it (deduplicates the inline copy logic). New `refresh_templates()` typer command. `upgrade()` subprocess-invokes `mycelium _refresh-templates` after install and reports the result (non-fatal on failure with a recovery hint). |
| `cli.py` | Register `_refresh-templates` as a hidden command. |
| `tests/test_refresh_templates.py` | 4 unit tests: writes bundled body, overwrites stale + backs up to `.prev`, no-backup mode, initdb scripts copied. |

## Test plan

- [x] `pytest tests/` — 124 passed
- [x] `ruff check`, `ruff format --check`, `ty check` — clean
- [x] End-to-end smoke test: invoke the hidden command against a stale
      seeded template, confirm fresh body written + backup created + initdb
      script copied
- [ ] Real upgrade test: install an older rc, run `mycelium upgrade`, verify
      that the compose.yml on disk matches the bundled one and `.prev` holds
      the old body
- [ ] Verify behavior when `uv tool install` succeeded but the new binary
      isn't on PATH yet (rare; CLI prints the recovery command)

## Out of scope (still open from #326)

- #12 `openclaw doctor --fix` nukes `mycelium-room` channel config
- #13 `mycelium agent add` creates manifest files as root