### PR TITLE
fix(agent): bail with chown guidance when ~/.mycelium is root-owned

### DIFF
--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -28,6 +28,7 @@ import json as json_module
 import logging
 import sys
 from datetime import UTC, datetime
+from pathlib import Path
 
 import typer
 import yaml
@@ -59,6 +60,73 @@ def _typed_client(config: MyceliumConfig):
     from mycelium_backend_client import Client
 
     return Client(base_url=config.server.api_url, raise_on_unexpected_status=True)
+
+
+def _bail_root_owned(target: Path, blocking: Path, owner_name: str) -> None:
+    """Print a chown-guidance error and exit 1.
+
+    Used when writing under ``~/.mycelium/`` would fail because some ancestor
+    of *target* is owned by a different user (typically root, from an earlier
+    sudo step or a containerized side-process). The previous symptom was a
+    raw ``PermissionError`` with no hint about what to do — this surfaces the
+    one-line fix every time it would have happened.
+    """
+    typer.secho(f"\n  ✗ Cannot write to {target}", fg=typer.colors.RED, err=True)
+    typer.echo(f"    {blocking} is owned by {owner_name}, not the current user.", err=True)
+    typer.echo("", err=True)
+    typer.echo(
+        "    This usually happens when an earlier step ran as a different",
+        err=True,
+    )
+    typer.echo(
+        "    user (sudo, a systemd service running as root, or an openclaw",
+        err=True,
+    )
+    typer.echo("    gateway container bind-mounting your home).", err=True)
+    typer.echo("", err=True)
+    typer.echo("    Fix with:", err=True)
+    typer.echo("", err=True)
+    typer.echo("      sudo chown -R $USER ~/.mycelium", err=True)
+    typer.echo("", err=True)
+    raise typer.Exit(1)
+
+
+def _owner_uid(path: Path) -> int | None:
+    """Return st_uid for *path*, or ``None`` if stat fails. Patchable in tests."""
+    try:
+        return path.stat().st_uid
+    except OSError:
+        return None
+
+
+def _check_writable_or_bail(target: Path) -> None:
+    """Bail out with chown guidance if any ancestor of *target* isn't ours.
+
+    Walks up to the closest existing ancestor of *target* and checks its
+    ``st_uid`` against ``os.getuid()``. Mismatch → :func:`_bail_root_owned`.
+    Windows has no uid concept; this no-ops there. Stat failures are
+    swallowed (let the real write raise its own error).
+    """
+    import os
+
+    if os.name == "nt":
+        return
+    uid = os.getuid()
+    p = target
+    while not p.exists():
+        if p.parent == p:
+            return
+        p = p.parent
+    owner_uid = _owner_uid(p)
+    if owner_uid is None or owner_uid == uid:
+        return
+    try:
+        import pwd
+
+        owner_name = pwd.getpwuid(owner_uid).pw_name
+    except (KeyError, ImportError):
+        owner_name = f"uid {owner_uid}"
+    _bail_root_owned(target, p, owner_name)
 
 
 def _resolve_room(config: MyceliumConfig, room: str | None) -> str:
@@ -146,14 +214,22 @@ def _write_manifest(
     version = 1
     if result and isinstance(result, list) and result:
         version = getattr(result[0], "version", 1) or 1
-    write_memory(
-        room_dir,
-        manifest.memory_key,
-        yaml_body,
-        created_by=created_by,
-        version=version,
-        tags=["agent-manifest"],
-    )
+    try:
+        write_memory(
+            room_dir,
+            manifest.memory_key,
+            yaml_body,
+            created_by=created_by,
+            version=version,
+            tags=["agent-manifest"],
+        )
+    except PermissionError:
+        # Pre-check missed it (e.g., correct dir ownership but a stale
+        # root-owned manifest file lurking from a previous run). Surface the
+        # chown guidance the user expects.
+        manifest_path = room_dir / f"{manifest.memory_key}.md"
+        _check_writable_or_bail(manifest_path)
+        raise
 
 
 # ── create (greenfield) ──────────────────────────────────────────────────────
@@ -170,6 +246,12 @@ def _persist_and_describe(
 ) -> None:
     """Shared tail: run runtime side effects, persist the manifest, print."""
     opts = AddOptions(room=room_name)
+    # Permission pre-check BEFORE any side effects — bailing here means we
+    # never allowlist or restart the gateway only to fail at the manifest
+    # write. Closes #13 from the v1.1.0 tracking bug (#326).
+    room_dir = get_room_dir(room_name)
+    manifest_path = room_dir / f"{manifest.memory_key}.md"
+    _check_writable_or_bail(manifest_path)
     # Runtime side effects FIRST — a failure here aborts without leaving a
     # dangling manifest.
     impl.register(manifest=manifest, config=config, opts=opts)

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -80,6 +80,66 @@ def _check_config_files() -> CheckResult:
     )
 
 
+def _check_mycelium_dir_ownership() -> CheckResult:
+    """Surface files under ``~/.mycelium/`` not owned by the current user.
+
+    Root-owned files in here are a common cloud-install symptom (sudo
+    install + non-sudo agent add, or an openclaw gateway running as root
+    bind-mounting the user's home into a container). They lead to opaque
+    ``PermissionError`` failures in later commands. Detect early and point
+    at the single ``chown`` that fixes it.
+    """
+    import os
+
+    if os.name == "nt":  # Windows has no uid
+        return CheckResult(
+            name="~/.mycelium ownership",
+            status="ok",
+            message="not applicable on this platform",
+        )
+
+    mycelium_dir = Path.home() / ".mycelium"
+    if not mycelium_dir.exists():
+        return CheckResult(
+            name="~/.mycelium ownership",
+            status="ok",
+            message="directory does not exist yet",
+        )
+
+    uid = os.getuid()
+    foreign: list[str] = []
+    # Cap the walk — a pathological room shouldn't make doctor hang.
+    seen = 0
+    for path in mycelium_dir.rglob("*"):
+        seen += 1
+        if seen > 5000:
+            break
+        try:
+            if path.stat().st_uid != uid:
+                # Show paths relative to ~ for readable output.
+                foreign.append(str(path.relative_to(Path.home())))
+        except OSError:
+            continue
+        if len(foreign) >= 5:
+            break
+
+    if not foreign:
+        return CheckResult(
+            name="~/.mycelium ownership",
+            status="ok",
+            message="all files owned by current user",
+        )
+
+    details = [f"~/{p}" for p in foreign]
+    details.append("Fix with: sudo chown -R $USER ~/.mycelium")
+    return CheckResult(
+        name="~/.mycelium ownership",
+        status="error",
+        message=f"{len(foreign)}+ file(s) owned by another user — agent/memory writes will fail",
+        details=details,
+    )
+
+
 def _check_llm_connectivity() -> CheckResult:
     """Probe the backend's LLM with a real ``litellm.completion(max_tokens=1)`` call.
 
@@ -1356,6 +1416,7 @@ def doctor(
         # .env port vs Docker port).
         config_checks: list[CheckResult] = [
             _check_config_files(),
+            _check_mycelium_dir_ownership(),
             _check_config_file_drift(local_backend=local),
         ]
         if local:

--- a/mycelium-cli/tests/test_agent_add_root_owned.py
+++ b/mycelium-cli/tests/test_agent_add_root_owned.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Julia Valenti
+
+"""``mycelium agent add`` bails with chown guidance when ~/.mycelium is
+root-owned, instead of raising a raw ``PermissionError`` halfway through.
+
+Cloud-install symptom (#13 from #326): something earlier in the install runs
+as root and root-owns part of ``~/.mycelium/`` (sudo step, gateway in a
+container with a bind mount, etc.). Later ``mycelium agent add`` fails with
+no signal about how to recover. The pre-check + the PermissionError catch
+both surface the same one-line fix: ``sudo chown -R $USER ~/.mycelium``.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from pathlib import Path
+
+import pytest
+import typer
+
+from mycelium.commands.agent import _check_writable_or_bail
+
+pytestmark = pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="uid ownership has no equivalent on Windows",
+)
+
+
+def test_passes_when_target_dir_is_ours(tmp_path: Path) -> None:
+    target = tmp_path / "rooms" / "demo" / "agents" / "alice.md"
+    # No file yet; closest existing ancestor is tmp_path, which we own.
+    _check_writable_or_bail(target)  # must not raise
+
+
+def test_passes_when_existing_file_is_ours(tmp_path: Path) -> None:
+    target = tmp_path / "alice.md"
+    target.write_text("hello", encoding="utf-8")
+    _check_writable_or_bail(target)  # must not raise
+
+
+def test_bails_when_ancestor_owned_by_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "rooms" / "demo" / "agents" / "alice.md"
+    target.parent.mkdir(parents=True)
+
+    # Closest existing ancestor "is owned by uid 0 (root)" while we're
+    # some other uid. The helper should bail with typer.Exit(1).
+    monkeypatch.setattr("mycelium.commands.agent._owner_uid", lambda p: 0)
+    monkeypatch.setattr(os, "getuid", lambda: 1000)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _check_writable_or_bail(target)
+    assert exc_info.value.exit_code == 1
+
+
+def test_silent_when_stat_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "alice.md"
+
+    # _owner_uid returns None when stat fails — fall through, let the real
+    # write surface its own error rather than confusing the user.
+    monkeypatch.setattr("mycelium.commands.agent._owner_uid", lambda p: None)
+    monkeypatch.setattr(os, "getuid", lambda: 1000)
+
+    _check_writable_or_bail(target)  # must not raise


### PR DESCRIPTION
## Summary

Closes #13 from #326 (v1.1.0 tracking bug). Pragmatic fix — turns a
confusing PermissionError mid-install into a one-line recovery.

The issue text describes the **mechanism** as the openclaw bootstrap hook
writing the manifest as root, but on inspection:
- `mycelium-bootstrap/handler.js` only sets env vars on the agent context;
  it never touches the manifest filesystem.
- The openclaw plugin never writes files anywhere (no `writeFileSync`).
- The openclaw gateway runs *inside* a Docker container — and if the
  openclaw image bind-mounts the host's home into the container, anything
  the gateway does as root inside the container surfaces as root-owned on
  the host.

We can't fix that upstream from mycelium (openclaw owns the gateway
lifecycle), but we *can* detect the symptom early and emit the one-line
fix every time it would have hit.

## What changed

| File | Change |
|---|---|
| `commands/agent.py` | New `_owner_uid()` + `_check_writable_or_bail()`. Pre-check in `_persist_and_describe` runs **before** `impl.register()`, so we don't allowlist + restart the gateway only to fail at the manifest write. The actual `write_memory` call is also wrapped to catch `PermissionError` for edge cases. |
| `commands/doctor.py` | New `~/.mycelium ownership` check — walks the tree (capped at 5000 entries / 5 surfaced), reports foreign-uid files with the same chown hint. |
| `tests/test_agent_add_root_owned.py` | 4 tests covering the helper: passes when ours, bails on foreign uid, silent on stat failure. |

## The error a user sees now

Instead of a raw `PermissionError` traceback:

```
  ✗ Cannot write to ~/.mycelium/rooms/demo/agents/alice.md
    ~/.mycelium/rooms/demo is owned by root, not the current user.

    This usually happens when an earlier step ran as a different
    user (sudo, a systemd service running as root, or an openclaw
    gateway container bind-mounting your home).

    Fix with:

      sudo chown -R $USER ~/.mycelium
```

## Test plan

- [x] `pytest tests/` — 124 passed
- [x] `ruff check`, `ruff format --check`, `ty check` — clean
- [x] Confirmed the upgrade-refresh PR's `_refresh-templates` hidden command is
      correctly absent from `docs/index.html` / `reference.html` / `adapters.html`
      because the docs generator only emits `@doc_ref`-decorated commands
- [ ] Manual: pre-seed a root-owned dir under `~/.mycelium/rooms/test/`
      and run `mycelium agent add @foo` — verify the chown guidance fires
      before any openclaw side effects
- [ ] Manual: `mycelium doctor` shows the new `~/.mycelium ownership` check
      with the same hint when foreign-uid files exist

## Out of scope (real root-cause fix)

The "make the gateway not run as root" angle would require either:
- A `User=` directive in mycelium's systemd template (we ship `--user`
  units already; the gateway runs out of process anyway), OR
- A change in the openclaw image / install path to drop privileges, OR
- Documentation directing users away from system-unit installs

None of those are in this PR.