### PR TITLE
fix(frontend): dedicated Route Handler for SSE stream

### DIFF
--- a/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
+++ b/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Julia Valenti
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+function getBackendUrl(): string {
+  if (process.env.MYCELIUM_INTERNAL_API_URL) return process.env.MYCELIUM_INTERNAL_API_URL;
+  try {
+    const text = readFileSync(join(homedir(), ".mycelium", "config.toml"), "utf8");
+    const m =
+      text.match(/\[server\][\s\S]*?\n\s*api_url\s*=\s*"([^"]+)"/) ??
+      text.match(/^\s*api_url\s*=\s*"([^"]+)"/m);
+    if (m) return m[1];
+  } catch {
+    /* fall through */
+  }
+  return "http://localhost:8000";
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  const upstream = `${getBackendUrl()}/api/rooms/${encodeURIComponent(name)}/messages/stream`;
+
+  const res = await fetch(upstream, {
+    headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+  });
+
+  if (!res.ok || !res.body) {
+    return new Response("upstream SSE unavailable", { status: 502 });
+  }
+
+  return new Response(res.body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}


### PR DESCRIPTION
## Problem

Next.js `rewrites()` buffer the upstream response before forwarding — this works fine for JSON but breaks SSE. The browser's `EventSource` sees no events until the connection closes (or the buffer flushes), making the room stream appear broken on cloud installs where the browser must go through the proxy.

Works locally because the browser can hit `http://localhost:8000` directly; remotely port 8000 isn't public so all traffic goes through the rewrite.

## Fix

Adds a Route Handler at `src/app/api/rooms/[name]/messages/stream/route.ts` that pipes the backend SSE stream directly using the Fetch/Response streaming API (`res.body` passthrough). The rewrite for `/api/:path*` still handles all other endpoints — this handler intercepts only the SSE path before Next.js routing reaches the rewrite.

Key headers: `X-Accel-Buffering: no` (disables nginx buffering if behind a reverse proxy), `Cache-Control: no-cache, no-transform`, `Connection: keep-alive`.

The backend URL uses the same resolution logic as `next.config.ts` (`MYCELIUM_INTERNAL_API_URL` → `config.toml` → `localhost:8000`).

## Test plan
- [ ] Cloud install: send a message in the room UI — it appears without a refresh
- [ ] Local install: SSE still works (no regression)