### PR TITLE
chore(copyright): replace Julia Valenti with Mycelium Contributors

### DIFF
--- a/docs/generate_cli_reference.py
+++ b/docs/generate_cli_reference.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Generate the CLI Reference HTML section for docs/index.html.

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Generate per-section docs HTML pages from markdown sources + CLI/config schemas.

--- a/fastapi-backend/alembic_migrations/__init__.py
+++ b/fastapi-backend/alembic_migrations/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 

--- a/fastapi-backend/alembic_migrations/env.py
+++ b/fastapi-backend/alembic_migrations/env.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 import asyncio
 import os

--- a/fastapi-backend/alembic_migrations/versions/0001_initial.py
+++ b/fastapi-backend/alembic_migrations/versions/0001_initial.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Initial schema — users, rooms, messages, sessions, presences.
 

--- a/fastapi-backend/alembic_migrations/versions/0002_coordination.py
+++ b/fastapi-backend/alembic_migrations/versions/0002_coordination.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Add coordination fields to rooms and sessions.
 

--- a/fastapi-backend/alembic_migrations/versions/0003_drop_presences_and_user_tables.py
+++ b/fastapi-backend/alembic_migrations/versions/0003_drop_presences_and_user_tables.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Drop presences and user tables.
 

--- a/fastapi-backend/alembic_migrations/versions/0004_add_audit_events.py
+++ b/fastapi-backend/alembic_migrations/versions/0004_add_audit_events.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Add audit_events table.
 

--- a/fastapi-backend/alembic_migrations/versions/0005_add_workspace_mas_agents.py
+++ b/fastapi-backend/alembic_migrations/versions/0005_add_workspace_mas_agents.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Add workspaces, mas, agents tables.
 

--- a/fastapi-backend/alembic_migrations/versions/0006_add_memory_and_room_modes.py
+++ b/fastapi-backend/alembic_migrations/versions/0006_add_memory_and_room_modes.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Add persistent memory system and room mode extensions.
 

--- a/fastapi-backend/alembic_migrations/versions/0007_add_notebook_scope_and_namespace_fields.py
+++ b/fastapi-backend/alembic_migrations/versions/0007_add_notebook_scope_and_namespace_fields.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Add notebook scope to memories and namespace fields to rooms.
 

--- a/fastapi-backend/alembic_migrations/versions/0008_add_file_path_to_memories.py
+++ b/fastapi-backend/alembic_migrations/versions/0008_add_file_path_to_memories.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Add file_path column to memories for filesystem-native storage.
 

--- a/fastapi-backend/alembic_migrations/versions/0009_room_mas_id.py
+++ b/fastapi-backend/alembic_migrations/versions/0009_room_mas_id.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Add mas_id and workspace_id to rooms for CFN MAS sync.
 

--- a/fastapi-backend/alembic_migrations/versions/0010_drop_notebook_scope.py
+++ b/fastapi-backend/alembic_migrations/versions/0010_drop_notebook_scope.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Drop notebook scope from memories.
 

--- a/fastapi-backend/alembic_migrations/versions/0011_coordination_sessions.py
+++ b/fastapi-backend/alembic_migrations/versions/0011_coordination_sessions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Promote sessions to first-class entity (#197).
 

--- a/fastapi-backend/alembic_migrations/versions/0012_rename_sessions_to_participants.py
+++ b/fastapi-backend/alembic_migrations/versions/0012_rename_sessions_to_participants.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Rename sessions → participants and re-FK to coordination_sessions (#197 follow-up).
 

--- a/fastapi-backend/alembic_migrations/versions/0013_messages_polymorphic.py
+++ b/fastapi-backend/alembic_migrations/versions/0013_messages_polymorphic.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Make messages.room_name polymorphic with coordination_session_id (#244).
 

--- a/fastapi-backend/alembic_migrations/versions/0014_drop_deprecated_rooms_columns.py
+++ b/fastapi-backend/alembic_migrations/versions/0014_drop_deprecated_rooms_columns.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Drop session-shadow rows + deprecated rooms columns (#244 final).
 

--- a/fastapi-backend/alembic_migrations/versions/0015_participant_context_files.py
+++ b/fastapi-backend/alembic_migrations/versions/0015_participant_context_files.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Add participants.context_files JSONB.
 

--- a/fastapi-backend/alembic_migrations/versions/0016_coord_session_unique_indexes.py
+++ b/fastapi-backend/alembic_migrations/versions/0016_coord_session_unique_indexes.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Add partial unique indexes to prevent coordination_session forking and participant double-counting.
 

--- a/fastapi-backend/app/__init__.py
+++ b/fastapi-backend/app/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 

--- a/fastapi-backend/app/bus.py
+++ b/fastapi-backend/app/bus.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Async Postgres LISTEN/NOTIFY bus.

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 from pathlib import Path
 

--- a/fastapi-backend/app/database.py
+++ b/fastapi-backend/app/database.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 from collections.abc import AsyncGenerator
 from urllib.parse import urlparse

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Mycelium FastAPI backend.

--- a/fastapi-backend/app/models.py
+++ b/fastapi-backend/app/models.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Mycelium data models.

--- a/fastapi-backend/app/routes/__init__.py
+++ b/fastapi-backend/app/routes/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 

--- a/fastapi-backend/app/routes/audit.py
+++ b/fastapi-backend/app/routes/audit.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Audit event endpoints (internal API).

--- a/fastapi-backend/app/routes/cfn_proxy.py
+++ b/fastapi-backend/app/routes/cfn_proxy.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 CFN proxy endpoints.

--- a/fastapi-backend/app/routes/coordination.py
+++ b/fastapi-backend/app/routes/coordination.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Coordination observability endpoints.

--- a/fastapi-backend/app/routes/coordination_sessions.py
+++ b/fastapi-backend/app/routes/coordination_sessions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Coordination-session API — top-level resource.

--- a/fastapi-backend/app/routes/knowledge.py
+++ b/fastapi-backend/app/routes/knowledge.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Knowledge graph endpoints.

--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Memory API — persistent namespaced key-value store with semantic vector search.

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Messages API — POST only.

--- a/fastapi-backend/app/routes/plan.py
+++ b/fastapi-backend/app/routes/plan.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Plan API — projection over the ``plan/`` namespace of a room.

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Room CRUD endpoints."""
 

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Sessions API — tracks agent presence in rooms.

--- a/fastapi-backend/app/routes/stream.py
+++ b/fastapi-backend/app/routes/stream.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 SSE stream endpoint — GET /rooms/{room}/messages/stream

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Minimal schemas for Mycelium's core models.

--- a/fastapi-backend/app/services/__init__.py
+++ b/fastapi-backend/app/services/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 

--- a/fastapi-backend/app/services/_cfn_call_timing.py
+++ b/fastapi-backend/app/services/_cfn_call_timing.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Mycelium-side per-call timing accumulator for the CFN ``/decide`` HTTP
 client path.

--- a/fastapi-backend/app/services/async_coordination.py
+++ b/fastapi-backend/app/services/async_coordination.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Async CognitiveEngine — synthesis for namespace rooms.

--- a/fastapi-backend/app/services/cfn_graph_read.py
+++ b/fastapi-backend/app/services/cfn_graph_read.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Direct AgensGraph read for CFN's knowledge graphs.
 

--- a/fastapi-backend/app/services/cfn_knowledge.py
+++ b/fastapi-backend/app/services/cfn_knowledge.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Async client for CFN's shared-memories knowledge API.
 

--- a/fastapi-backend/app/services/cfn_negotiation.py
+++ b/fastapi-backend/app/services/cfn_negotiation.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Async client for the CFN cognitive agents semantic negotiation API.

--- a/fastapi-backend/app/services/cfn_resolve.py
+++ b/fastapi-backend/app/services/cfn_resolve.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Resolve CFN identifiers (workspace_id, mas_id) from client input, room

--- a/fastapi-backend/app/services/coordination.py
+++ b/fastapi-backend/app/services/coordination.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Multi-agent coordination service.

--- a/fastapi-backend/app/services/embedding.py
+++ b/fastapi-backend/app/services/embedding.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Local embedding service using fastembed (ONNX-based).

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Memory storage — markdown files with YAML frontmatter.

--- a/fastapi-backend/app/services/indexer.py
+++ b/fastapi-backend/app/services/indexer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Filesystem → pgvector indexer.

--- a/fastapi-backend/app/services/ingest_dedupe.py
+++ b/fastapi-backend/app/services/ingest_dedupe.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Content-hash TTL dedupe cache for CFN shared-memories forwards.
 

--- a/fastapi-backend/app/services/ingest_log_buffer.py
+++ b/fastapi-backend/app/services/ingest_log_buffer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """In-memory ring buffer of CFN shared-memories ingest attempts.
 

--- a/fastapi-backend/app/services/knowledge_fanin.py
+++ b/fastapi-backend/app/services/knowledge_fanin.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Fire-and-forget fan-in to /api/knowledge/ingest.

--- a/fastapi-backend/app/services/metrics.py
+++ b/fastapi-backend/app/services/metrics.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Lightweight in-process metrics store for Mycelium backend.

--- a/fastapi-backend/app/services/plan.py
+++ b/fastapi-backend/app/services/plan.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Plan view over the ``plan/`` namespace of a room.

--- a/fastapi-backend/app/services/plan_compiler.py
+++ b/fastapi-backend/app/services/plan_compiler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Plan compiler — turns a negotiation consensus into a room plan.
 

--- a/fastapi-backend/app/services/reindex.py
+++ b/fastapi-backend/app/services/reindex.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Auto-reindex: startup scan + file watcher.

--- a/fastapi-backend/tests/__init__.py
+++ b/fastapi-backend/tests/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 

--- a/fastapi-backend/tests/conftest.py
+++ b/fastapi-backend/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Shared test fixtures.

--- a/fastapi-backend/tests/test_audit.py
+++ b/fastapi-backend/tests/test_audit.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for /api/internal/audit-events endpoints."""
 

--- a/fastapi-backend/tests/test_cascade_delete.py
+++ b/fastapi-backend/tests/test_cascade_delete.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Cascade-delete invariants for the room → coord-session → participant chain.
 

--- a/fastapi-backend/tests/test_cfn_proxy.py
+++ b/fastapi-backend/tests/test_cfn_proxy.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for the per-agent memory-operations CFN proxy.
 

--- a/fastapi-backend/tests/test_cfn_read_surface.py
+++ b/fastapi-backend/tests/test_cfn_read_surface.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for /api/cfn/knowledge/* — the CFN shared-memories read proxy."""
 

--- a/fastapi-backend/tests/test_cfn_resolve.py
+++ b/fastapi-backend/tests/test_cfn_resolve.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Tests for CFN identifier resolution (workspace_id, mas_id).

--- a/fastapi-backend/tests/test_context_files.py
+++ b/fastapi-backend/tests/test_context_files.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Opt-in shared context files via ``mycelium session join --context-files``.
 

--- a/fastapi-backend/tests/test_coordination.py
+++ b/fastapi-backend/tests/test_coordination.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Unit tests for app.services.coordination.

--- a/fastapi-backend/tests/test_coordination_routes.py
+++ b/fastapi-backend/tests/test_coordination_routes.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for /api/internal/coordination/* endpoints (#162).
 

--- a/fastapi-backend/tests/test_coordination_sessions.py
+++ b/fastapi-backend/tests/test_coordination_sessions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for the first-class CoordinationSession entity."""
 

--- a/fastapi-backend/tests/test_filesystem.py
+++ b/fastapi-backend/tests/test_filesystem.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for the filesystem-native memory service."""
 

--- a/fastapi-backend/tests/test_ingest_dedupe.py
+++ b/fastapi-backend/tests/test_ingest_dedupe.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for the content-hash TTL dedupe cache."""
 

--- a/fastapi-backend/tests/test_ingest_log_buffer.py
+++ b/fastapi-backend/tests/test_ingest_log_buffer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for the in-memory CFN ingest log buffer and its GET endpoints."""
 

--- a/fastapi-backend/tests/test_integration.py
+++ b/fastapi-backend/tests/test_integration.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Integration tests — require a running Postgres/AgensGraph with pgvector.

--- a/fastapi-backend/tests/test_knowledge_ingest.py
+++ b/fastapi-backend/tests/test_knowledge_ingest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for /api/knowledge/ingest gates: disabled, refused, deduped, ok, error."""
 

--- a/fastapi-backend/tests/test_memory.py
+++ b/fastapi-backend/tests/test_memory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Tests for the persistent memory API.

--- a/fastapi-backend/tests/test_metrics.py
+++ b/fastapi-backend/tests/test_metrics.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Unit tests for the in-process metrics store.

--- a/fastapi-backend/tests/test_plan.py
+++ b/fastapi-backend/tests/test_plan.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for the plan/ namespace + projection API."""
 

--- a/fastapi-backend/tests/test_plan_compiler.py
+++ b/fastapi-backend/tests/test_plan_compiler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for the consensus→plan compiler.
 

--- a/fastapi-backend/tests/test_privacy_first_kxp.py
+++ b/fastapi-backend/tests/test_privacy_first_kxp.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Privacy-first KXP wiring: channel + memory_set fan in to /api/knowledge/ingest.
 

--- a/fastapi-backend/tests/test_session_spawn.py
+++ b/fastapi-backend/tests/test_session_spawn.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for coordination session spawning."""
 

--- a/fastapi-backend/tests/test_structured_memory.py
+++ b/fastapi-backend/tests/test_structured_memory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Tests for structured memory conventions and synthesis grouping.

--- a/mycelium-cli/src/mycelium/__init__.py
+++ b/mycelium-cli/src/mycelium/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Mycelium CLI — IoC/CFN coordination layer."""
 

--- a/mycelium-cli/src/mycelium/__main__.py
+++ b/mycelium-cli/src/mycelium/__main__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Allow running mycelium as a module: python -m mycelium"""
 

--- a/mycelium-cli/src/mycelium/animations/__init__.py
+++ b/mycelium-cli/src/mycelium/animations/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Animation modules for Mycelium CLI."""
 

--- a/mycelium-cli/src/mycelium/animations/spores.py
+++ b/mycelium-cli/src/mycelium/animations/spores.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Twinkling spore starfield animation for the Mycelium CLI.

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Mycelium CLI — Multi-agent coordination + persistent memory.

--- a/mycelium-cli/src/mycelium/collector.py
+++ b/mycelium-cli/src/mycelium/collector.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Lightweight OTLP HTTP receiver for OpenClaw telemetry.

--- a/mycelium-cli/src/mycelium/collector_main.py
+++ b/mycelium-cli/src/mycelium/collector_main.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Entry point for the OTLP collector (used by Dockerfile.collector)."""
 

--- a/mycelium-cli/src/mycelium/commands/__init__.py
+++ b/mycelium-cli/src/mycelium/commands/__init__.py
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Mycelium CLI command modules."""

--- a/mycelium-cli/src/mycelium/commands/adapter.py
+++ b/mycelium-cli/src/mycelium/commands/adapter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Adapter commands — connect agent frameworks to Mycelium.

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Agent commands — name an addressable, durable agent inside a room.

--- a/mycelium-cli/src/mycelium/commands/cfn.py
+++ b/mycelium-cli/src/mycelium/commands/cfn.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 CFN observability commands — see what mycelium-backend is forwarding to

--- a/mycelium-cli/src/mycelium/commands/config.py
+++ b/mycelium-cli/src/mycelium/commands/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Config commands for Mycelium CLI."""
 

--- a/mycelium-cli/src/mycelium/commands/daemon.py
+++ b/mycelium-cli/src/mycelium/commands/daemon.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Daemon commands — manage the mycelium-cc-daemon service.

--- a/mycelium-cli/src/mycelium/commands/docs.py
+++ b/mycelium-cli/src/mycelium/commands/docs.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Documentation commands for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Doctor command — diagnose and fix common Mycelium configuration issues.

--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Install command for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Instance management commands for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Memory commands — persistent namespaced memory operations.

--- a/mycelium-cli/src/mycelium/commands/metrics.py
+++ b/mycelium-cli/src/mycelium/commands/metrics.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Metrics commands — collect, display, and manage OpenClaw telemetry data.

--- a/mycelium-cli/src/mycelium/commands/negotiate.py
+++ b/mycelium-cli/src/mycelium/commands/negotiate.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Structured negotiation commands for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/plan.py
+++ b/mycelium-cli/src/mycelium/commands/plan.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Plan commands — read and edit the room's plan/ namespace.

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Room management commands for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Session commands — breakout negotiation within rooms.

--- a/mycelium-cli/src/mycelium/commands/traces.py
+++ b/mycelium-cli/src/mycelium/commands/traces.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Trace viewer — query and pivot the spans collected in ``~/.mycelium/metrics/traces.db``.

--- a/mycelium-cli/src/mycelium/commands/ui.py
+++ b/mycelium-cli/src/mycelium/commands/ui.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 `mycelium ui` — manage the optional frontend.

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Configuration management for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/daemon/__init__.py
+++ b/mycelium-cli/src/mycelium/daemon/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Mycelium Claude Code daemon — the userlevel mirror of the OpenClaw gateway.

--- a/mycelium-cli/src/mycelium/daemon/__main__.py
+++ b/mycelium-cli/src/mycelium/daemon/__main__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Entry point — `python -m mycelium.daemon` runs the daemon."""
 

--- a/mycelium-cli/src/mycelium/daemon/config.py
+++ b/mycelium-cli/src/mycelium/daemon/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Daemon configuration — list of rooms to subscribe to, runtime knobs."""
 

--- a/mycelium-cli/src/mycelium/daemon/dispatch.py
+++ b/mycelium-cli/src/mycelium/daemon/dispatch.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """SSE subscription + @handle dispatch — the heart of the daemon."""
 

--- a/mycelium-cli/src/mycelium/daemon/health.py
+++ b/mycelium-cli/src/mycelium/daemon/health.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Minimal HTTP-over-unix-socket health endpoint.
 

--- a/mycelium-cli/src/mycelium/daemon/mentions.py
+++ b/mycelium-cli/src/mycelium/daemon/mentions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """@-mention parsing — Python port of the OpenClaw plugin's resolveMentions."""
 

--- a/mycelium-cli/src/mycelium/daemon/runner.py
+++ b/mycelium-cli/src/mycelium/daemon/runner.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Top-level daemon orchestrator: load config, fan out SSE subscribers, serve health."""
 

--- a/mycelium-cli/src/mycelium/daemon/state.py
+++ b/mycelium-cli/src/mycelium/daemon/state.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """In-memory daemon state — surfaced via the health endpoint."""
 

--- a/mycelium-cli/src/mycelium/doc_ref.py
+++ b/mycelium-cli/src/mycelium/doc_ref.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Decorator for registering CLI commands in the HTML docs reference.

--- a/mycelium-cli/src/mycelium/docker/__init__.py
+++ b/mycelium-cli/src/mycelium/docker/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 

--- a/mycelium-cli/src/mycelium/docker_utils.py
+++ b/mycelium-cli/src/mycelium/docker_utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Generate .env files from config.toml — makes .env a derived artifact.

--- a/mycelium-cli/src/mycelium/error_handler.py
+++ b/mycelium-cli/src/mycelium/error_handler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Error handler for formatting exceptions into user-friendly CLI messages."""
 

--- a/mycelium-cli/src/mycelium/exceptions.py
+++ b/mycelium-cli/src/mycelium/exceptions.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Custom exceptions for Mycelium CLI."""
 

--- a/mycelium-cli/src/mycelium/filesystem.py
+++ b/mycelium-cli/src/mycelium/filesystem.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Memory file operations for the CLI.

--- a/mycelium-cli/src/mycelium/http_client.py
+++ b/mycelium-cli/src/mycelium/http_client.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 HTTP client for Mycelium API.

--- a/mycelium-cli/src/mycelium/identity.py
+++ b/mycelium-cli/src/mycelium/identity.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Identity management for Mycelium CLI.

--- a/mycelium-cli/src/mycelium/integrations/__init__.py
+++ b/mycelium-cli/src/mycelium/integrations/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Integration registry — the single resolution point for a runtime family.

--- a/mycelium-cli/src/mycelium/integrations/_resources.py
+++ b/mycelium-cli/src/mycelium/integrations/_resources.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Bundled-asset resolution shared by every integration's install facet.
 

--- a/mycelium-cli/src/mycelium/integrations/base.py
+++ b/mycelium-cli/src/mycelium/integrations/base.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Integration — the single contract for a runtime family Mycelium integrates with.

--- a/mycelium-cli/src/mycelium/integrations/claude_code/__init__.py
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Claude Code integration — cc-daemon dispatch + (Stage 2) host install."""
 

--- a/mycelium-cli/src/mycelium/integrations/claude_code/assets/__init__.py
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/assets/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 

--- a/mycelium-cli/src/mycelium/integrations/claude_code/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/dispatch.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """ClaudeCode dispatch facet — the manifest IS the registration.
 

--- a/mycelium-cli/src/mycelium/integrations/claude_code/install.py
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/install.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Claude Code install facet — skill/hooks install + cc-daemon service core.
 

--- a/mycelium-cli/src/mycelium/integrations/openclaw/__init__.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """OpenClaw integration — gateway-channel dispatch + (Stage 2) host install."""
 

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/__init__.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/index.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * mycelium — OpenClaw plugin entry point.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/agent-context.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/agent-context.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Room plan briefing for `@handle` dispatch.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/dispatch-chain.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/dispatch-chain.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Per-agent dispatch chain — guarantees that only one `dispatchToAgent` call

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/dispatch.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/dispatch.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * In-process agent dispatch via runtime.channel.reply.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/index.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Channel concern entry point.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/mentions.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/mentions.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Return the subset of `agents` that are @-mentioned in `content`.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/notify-home.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/notify-home.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Cross-channel return-trip notification.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/post-to-room.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/post-to-room.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Outbound POST to a Mycelium room with echo-loop prevention.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/return-address.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/return-address.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Return-address stash: per-(sessionSubRoom, agent) record of where the agent

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/room-sse.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/room-sse.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Room SSE subscription — the single inbound surface for the channel plugin.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/route.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Pure routing logic for channel messages.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/session-sse.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/session-sse.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Session sub-room SSE subscription.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/config.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/config.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Environment + filesystem-backed config only. No HTTP (see http.ts).

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/http.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/http.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * HTTP helpers for talking to the Mycelium backend.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/instructions.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/instructions.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * System-prompt text injected into every agent turn via before_agent_start.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/register.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/register.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Unified plugin register function.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/session-key.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/session-key.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Mirrors OpenClaw's buildAgentPeerSessionKey format for group peers.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/session/index.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/session/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Session lifecycle + per-turn context injection.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/agent-context.test.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/agent-context.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Tests for the @handle-dispatch room-plan briefing: fetch + per-room cache

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/config.test.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/config.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 import { describe, expect, it } from "vitest";
 import { readChannelConfig, readChannelConfigs } from "../src/config.js";

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/dispatch-chain.test.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/dispatch-chain.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Tests for the per-agent dispatch chain. Behavioural contract:

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/mentions.test.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/mentions.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 import { describe, expect, it } from "vitest";
 import { resolveMentions } from "../src/channel/mentions.js";

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/route.test.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/route.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 /**
  * Tests for routeMessage — the pure routing logic that decides what to do

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/session-key.test.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/test/session-key.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 import { describe, expect, it } from "vitest";
 import { buildSessionKey } from "../src/session-key.js";

--- a/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """OpenClaw dispatch facet — agent runs in the OpenClaw gateway.
 

--- a/mycelium-cli/src/mycelium/integrations/openclaw/install.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/install.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """OpenClaw install facet — host-level install/uninstall/steps/status core.
 

--- a/mycelium-cli/src/mycelium/negotiate_snap.py
+++ b/mycelium-cli/src/mycelium/negotiate_snap.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Fuzzy issue/option snap for CLI-side negotiation pre-flight.
 

--- a/mycelium-cli/src/mycelium/prom_scrape.py
+++ b/mycelium-cli/src/mycelium/prom_scrape.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Minimal Prometheus text-format parser + scraper.

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Lightweight SSTP (Semantic State Transfer Protocol) models for the CLI.

--- a/mycelium-cli/src/mycelium/ui_status.py
+++ b/mycelium-cli/src/mycelium/ui_status.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Shared presentation helpers for ``mycelium status`` and ``mycelium doctor``.

--- a/mycelium-cli/src/mycelium/utils/__init__.py
+++ b/mycelium-cli/src/mycelium/utils/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Utility modules for Mycelium CLI."""
 

--- a/mycelium-cli/src/mycelium/utils/room.py
+++ b/mycelium-cli/src/mycelium/utils/room.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Room utilities for Mycelium CLI."""
 

--- a/mycelium-cli/tests/test_agent_add_root_owned.py
+++ b/mycelium-cli/tests/test_agent_add_root_owned.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """``mycelium agent add`` bails with chown guidance when ~/.mycelium is
 root-owned, instead of raising a raw ``PermissionError`` halfway through.

--- a/mycelium-cli/tests/test_agent_onboard.py
+++ b/mycelium-cli/tests/test_agent_onboard.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """`mycelium agent add` brownfield onboarding: discovery, batch-adopt, the
 non-interactive guard, and the create/add split."""

--- a/mycelium-cli/tests/test_collector_aggregation.py
+++ b/mycelium-cli/tests/test_collector_aggregation.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Regression tests for ``MetricsStore`` cross-host aggregation.

--- a/mycelium-cli/tests/test_config_database_url.py
+++ b/mycelium-cli/tests/test_config_database_url.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Unit tests for :py:meth:`MyceliumConfig.database_url`.
 

--- a/mycelium-cli/tests/test_daemon_agent_context.py
+++ b/mycelium-cli/tests/test_daemon_agent_context.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for the daemon's room-plan briefing: render + per-room fetch cache."""
 

--- a/mycelium-cli/tests/test_daemon_ownership.py
+++ b/mycelium-cli/tests/test_daemon_ownership.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for cc-daemon handle ownership.
 

--- a/mycelium-cli/tests/test_daemon_sse_timeout.py
+++ b/mycelium-cli/tests/test_daemon_sse_timeout.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Regression: a stalled SSE stream must reconnect, not hang forever.
 

--- a/mycelium-cli/tests/test_docker_env_image_tag_pin.py
+++ b/mycelium-cli/tests/test_docker_env_image_tag_pin.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Regression tests for the ``MYCELIUM_IMAGE_TAG`` round-trip behaviour.
 

--- a/mycelium-cli/tests/test_docker_env_materialization.py
+++ b/mycelium-cli/tests/test_docker_env_materialization.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Unit tests for ``generate_env_file`` DB-URL materialisation.
 

--- a/mycelium-cli/tests/test_doctor_migrations.py
+++ b/mycelium-cli/tests/test_doctor_migrations.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Regression tests for ``mycelium doctor`` migration-check parsing.
 

--- a/mycelium-cli/tests/test_instance_announce_image_tag.py
+++ b/mycelium-cli/tests/test_instance_announce_image_tag.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for the post-``mycelium up`` image-tag announcement.
 

--- a/mycelium-cli/tests/test_integration_contract.py
+++ b/mycelium-cli/tests/test_integration_contract.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Integration-contract conformance — the CI enforcement for #173.
 

--- a/mycelium-cli/tests/test_manifest_loader.py
+++ b/mycelium-cli/tests/test_manifest_loader.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """A corrupt agent manifest must log loudly rather than masquerade as "missing".
 

--- a/mycelium-cli/tests/test_metrics_math.py
+++ b/mycelium-cli/tests/test_metrics_math.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Unit tests for the metrics display math.

--- a/mycelium-cli/tests/test_negotiate_snap.py
+++ b/mycelium-cli/tests/test_negotiate_snap.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Tests for CLI-side fuzzy snap.
 

--- a/mycelium-cli/tests/test_openclaw_scanner_guard.py
+++ b/mycelium-cli/tests/test_openclaw_scanner_guard.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Static guard against OpenClaw's plugin security scanner.

--- a/mycelium-cli/tests/test_prom_scrape.py
+++ b/mycelium-cli/tests/test_prom_scrape.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """
 Unit tests for the minimal Prometheus text-format parser and the HTTP-RED

--- a/mycelium-cli/tests/test_refresh_templates.py
+++ b/mycelium-cli/tests/test_refresh_templates.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """``mycelium upgrade`` must refresh ``~/.mycelium/docker/compose.yml``.
 

--- a/mycelium-frontend/next.config.ts
+++ b/mycelium-frontend/next.config.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";

--- a/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
+++ b/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 import type { Metadata } from "next";
 import "./globals.css";

--- a/mycelium-frontend/src/app/metrics/page.tsx
+++ b/mycelium-frontend/src/app/metrics/page.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/app/page.tsx
+++ b/mycelium-frontend/src/app/page.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/app/room/[name]/session/[session]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/session/[session]/page.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/collapsible-rail.tsx
+++ b/mycelium-frontend/src/components/collapsible-rail.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/create-room-dialog.tsx
+++ b/mycelium-frontend/src/components/create-room-dialog.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/id-chip.tsx
+++ b/mycelium-frontend/src/components/id-chip.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/ingest-log-panel.tsx
+++ b/mycelium-frontend/src/components/ingest-log-panel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/knowledge-panel.tsx
+++ b/mycelium-frontend/src/components/knowledge-panel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/main-top-bar.tsx
+++ b/mycelium-frontend/src/components/main-top-bar.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/markdown-content.tsx
+++ b/mycelium-frontend/src/components/markdown-content.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/metrics-screen.tsx
+++ b/mycelium-frontend/src/components/metrics-screen.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 //
 // Metrics dashboard.
 //

--- a/mycelium-frontend/src/components/participants-panel.tsx
+++ b/mycelium-frontend/src/components/participants-panel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/room-card.tsx
+++ b/mycelium-frontend/src/components/room-card.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/room-plan-header.tsx
+++ b/mycelium-frontend/src/components/room-plan-header.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/round-traces-panel.tsx
+++ b/mycelium-frontend/src/components/round-traces-panel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/session-view.tsx
+++ b/mycelium-frontend/src/components/session-view.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/sessions-rail.tsx
+++ b/mycelium-frontend/src/components/sessions-rail.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/sessions-view.tsx
+++ b/mycelium-frontend/src/components/sessions-view.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/sub-nav.tsx
+++ b/mycelium-frontend/src/components/sub-nav.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/trace-explorer.tsx
+++ b/mycelium-frontend/src/components/trace-explorer.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/components/ui/chip.tsx
+++ b/mycelium-frontend/src/components/ui/chip.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 "use client";
 

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 // All fetches use relative `/api/*` paths. The Next.js server proxies them
 // to the backend (see next.config.ts `rewrites()`), so the browser only ever

--- a/mycelium-frontend/src/lib/metrics-format.ts
+++ b/mycelium-frontend/src/lib/metrics-format.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2026 Julia Valenti
+// Copyright 2026 Mycelium Contributors
 
 export function fmtNum(n: number | null | undefined): string {
   if (n == null) return "—";

--- a/scripts/update-pricing.py
+++ b/scripts/update-pricing.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2026 Julia Valenti
+# Copyright 2026 Mycelium Contributors
 
 """Extract model pricing from litellm and write pricing.json.
 


### PR DESCRIPTION
## Summary

Bulk rename across 213 files of \`Copyright 2026 Julia Valenti\` →
\`Copyright 2026 Mycelium Contributors\` in source-file copyright headers.

## What changed

- 213 files modified, exactly 1 line each
- Year (\`2026\`) and SPDX license identifier preserved
- Comment prefix (\`#\` or \`//\`) preserved
- No code or behavior changes

## Sweep used

\`\`\`
grep -rl "Copyright.*Julia Valenti" --include=... | \\
  xargs perl -i -pe 's/(Copyright \\d{4}) Julia Valenti/\$1 Mycelium Contributors/g'
\`\`\`

## Test plan

- [x] Zero stragglers: \`grep -r "Julia Valenti" --include="*.py" ...\` returns nothing
- [x] Diff stat is exactly \`213 insertions / 213 deletions\` — no collateral edits
- [ ] CI green