### PR TITLE
feat(room): sync-mas command + proper Docker app user

### DIFF
--- a/fastapi-backend/Dockerfile
+++ b/fastapi-backend/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.12-slim
 
+# Create a dedicated app user. UID 1000 matches the default host ubuntu user,
+# which keeps bind-mount ownership consistent without needing chown at runtime.
+RUN useradd -r -u 1000 -g 0 -s /sbin/nologin -d /home/mycelium mycelium \
+    && mkdir -p /home/mycelium \
+    && chown mycelium /home/mycelium
+
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -25,8 +31,10 @@ ENV FASTEMBED_CACHE_PATH=/opt/fastembed
 RUN python3 -c "from fastembed import TextEmbedding; TextEmbedding(model_name='BAAI/bge-small-en-v1.5', cache_dir='/opt/fastembed')" || true
 
 RUN chmod +x start.sh \
-    && mkdir -p logs && chown -R 1000:1000 logs \
-    && chmod 755 /root
+    && mkdir -p logs \
+    && chown -R mycelium /app
+
+USER mycelium
 
 EXPOSE 8000
 CMD ["./start.sh"]

--- a/fastapi-backend/Dockerfile
+++ b/fastapi-backend/Dockerfile
@@ -24,7 +24,9 @@ COPY . .
 ENV FASTEMBED_CACHE_PATH=/opt/fastembed
 RUN python3 -c "from fastembed import TextEmbedding; TextEmbedding(model_name='BAAI/bge-small-en-v1.5', cache_dir='/opt/fastembed')" || true
 
-RUN chmod +x start.sh
+RUN chmod +x start.sh \
+    && mkdir -p logs && chown -R 1000:1000 logs \
+    && chmod 755 /root
 
 EXPOSE 8000
 CMD ["./start.sh"]

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -26,6 +26,19 @@ router = APIRouter(prefix="/rooms", tags=["rooms"])
 RESERVED_ROOMS: frozenset[str] = frozenset()
 
 
+async def _fetch_mas_id_by_name(room_name: str) -> str | None:
+    """GET the MAS list and return the id for the entry matching room_name, or None."""
+    url = f"{settings.CFN_MGMT_URL}/api/workspaces/{settings.WORKSPACE_ID}/multi-agentic-systems"
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+    for system in data.get("systems", []):
+        if system.get("name") == room_name:
+            return system.get("id")
+    return None
+
+
 async def _sync_create_mas(db_room: Room, session: AsyncSession) -> None:
     """Create a MAS in CFN mgmt plane and store mas_id on the room. Non-fatal."""
     from app.services.metrics import record_cfn_call
@@ -65,6 +78,44 @@ async def _sync_create_mas(db_room: Room, session: AsyncSession) -> None:
             error=True,
         )
         logger.warning("CFN create MAS failed for room %s: %s", db_room.name, exc)
+
+
+async def _ensure_mas(db_room: Room, session: AsyncSession) -> str | None:
+    """Register room with CFN mgmt plane, handling the case where it already exists.
+
+    Returns the mas_id on success, None if CFN is not configured or the call fails.
+    On 409 (name already registered), fetches the existing id from the GET list.
+    """
+    if not settings.CFN_MGMT_URL or not settings.WORKSPACE_ID:
+        return None
+
+    base_url = f"{settings.CFN_MGMT_URL}/api/workspaces/{settings.WORKSPACE_ID}/multi-agentic-systems"
+    mas_id: str | None = None
+
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(base_url, json={"name": db_room.name})
+            if resp.status_code == 409:
+                mas_id = await _fetch_mas_id_by_name(db_room.name)
+            else:
+                resp.raise_for_status()
+                data = resp.json()
+                mas_id = data.get("id") or data.get("mas_id")
+    except Exception as exc:
+        logger.warning("CFN ensure MAS failed for room %s: %s", db_room.name, exc)
+        return None
+
+    if mas_id:
+        await session.execute(
+            update(Room)
+            .where(Room.name == db_room.name)
+            .values(mas_id=str(mas_id), workspace_id=settings.WORKSPACE_ID)
+        )
+        await session.commit()
+        await session.refresh(db_room)
+        logger.info("CFN MAS ensured for room %s: %s", db_room.name, mas_id)
+
+    return mas_id
 
 
 async def _sync_delete_mas(room: Room) -> None:
@@ -308,6 +359,35 @@ async def reindex_room(
 
     stats = await index_room(room_name, session)
     return {"status": "complete", **stats}
+
+
+@router.post("/{room_name}/sync-mas", response_model=RoomRead, status_code=200)
+async def sync_room_mas(
+    room_name: str,
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Register (or re-register) a room with the CFN mgmt plane.
+
+    Idempotent: if the MAS already exists in CFN, fetches its id from the list
+    endpoint rather than erroring. Updates the room's mas_id and workspace_id.
+    Returns 409 if CFN is not configured.
+    """
+    result = await session.execute(select(Room).where(Room.name == room_name))
+    room = result.scalar_one_or_none()
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    if not settings.CFN_MGMT_URL or not settings.WORKSPACE_ID:
+        raise HTTPException(
+            status_code=409,
+            detail="CFN not configured — set CFN_MGMT_URL and WORKSPACE_ID",
+        )
+
+    mas_id = await _ensure_mas(room, session)
+    if not mas_id:
+        raise HTTPException(status_code=502, detail="CFN registration failed — check backend logs")
+
+    return room
 
 
 @router.delete("/{room_name}", status_code=204)

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -89,7 +89,9 @@ async def _ensure_mas(db_room: Room, session: AsyncSession) -> str | None:
     if not settings.CFN_MGMT_URL or not settings.WORKSPACE_ID:
         return None
 
-    base_url = f"{settings.CFN_MGMT_URL}/api/workspaces/{settings.WORKSPACE_ID}/multi-agentic-systems"
+    base_url = (
+        f"{settings.CFN_MGMT_URL}/api/workspaces/{settings.WORKSPACE_ID}/multi-agentic-systems"
+    )
     mas_id: str | None = None
 
     try:

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -828,12 +828,37 @@ def _check_room_mas_ids() -> CheckResult:
             message=f"All {len(top_level)} room(s) have MAS IDs",
         )
 
+    def _fix_missing_mas() -> None:
+        import httpx
+
+        fixed, failed = [], []
+        for room_name in missing:
+            try:
+                with httpx.Client(base_url=api_url, timeout=15) as client:
+                    resp = client.post(f"/api/rooms/{room_name}/sync-mas")
+                    resp.raise_for_status()
+                    data = resp.json()
+                mas = data.get("mas_id") or "(unknown)"
+                typer.echo(f"    Registered {room_name}: MAS ID = {mas}")
+                fixed.append(room_name)
+            except Exception as exc:
+                typer.echo(f"    Failed {room_name}: {exc}")
+                failed.append(room_name)
+        if fixed:
+            typer.secho(f"  Registered {len(fixed)} room(s) with CFN.", fg=typer.colors.GREEN)
+        if failed:
+            typer.secho(
+                f"  {len(failed)} room(s) could not be registered — check that CFN is running.",
+                fg=typer.colors.YELLOW,
+            )
+
     return CheckResult(
         name="Room MAS IDs",
         status="warning",
         message=f"{len(missing)} room(s) missing MAS ID",
         details=[f"  {name}" for name in missing]
-        + ["Fix: run 'mycelium doctor --fix' after workspace ID is synced"],
+        + ["Fix: run 'mycelium doctor --fix' to register with CFN"],
+        fix_fn=_fix_missing_mas,
     )
 
 

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -15,6 +15,7 @@ Commands:
 - post: Post a message to a room
 - delegate: Delegate a task to an agent in a room
 - clone: Clone a room from a remote backend instance
+- sync-mas: Register (or re-register) a room with the CFN mgmt plane
 """
 
 import json as json_module
@@ -1055,6 +1056,62 @@ def delegate(
             typer.secho("Task delegated", fg=typer.colors.GREEN)
             typer.echo(f"  {sender} -> {to}: {task[:80]}")
 
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+
+
+@doc_ref(
+    usage="mycelium room sync-mas <name>",
+    desc="Register (or re-register) a room with the CFN mgmt plane.",
+    group="room",
+)
+@app.command("sync-mas")
+def sync_mas(
+    ctx: typer.Context,
+    name: str = typer.Argument(..., help="Room name to register with CFN"),
+) -> None:
+    """Register a room with the CFN mgmt plane and store its MAS ID.
+
+    Idempotent: if the room is already registered in CFN, the existing MAS ID
+    is fetched and linked. Use this to fix rooms created before CFN was configured
+    or when 'mycelium doctor' reports missing MAS IDs.
+
+    Examples:
+        mycelium room sync-mas mycelium_room
+        mycelium room sync-mas matrix-agents
+    """
+    try:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
+        json_output = ctx.obj.get("json", False) if ctx.obj else False
+
+        config = MyceliumConfig.load()
+
+        import httpx
+
+        api_url = (config.server.api_url or "http://localhost:8000").rstrip("/")
+        with httpx.Client(base_url=api_url, timeout=15) as client:
+            resp = client.post(f"/api/rooms/{name}/sync-mas")
+            if resp.status_code == 404:
+                raise MyceliumError(
+                    f"Room '{name}' not found — create it first with: mycelium room create {name}"
+                )
+            if resp.status_code == 409:
+                raise MyceliumError(
+                    "CFN not configured — set CFN_MGMT_URL and WORKSPACE_ID in ~/.mycelium/.env"
+                )
+            resp.raise_for_status()
+            room_data = resp.json()
+
+        if json_output:
+            typer.echo(json_module.dumps(room_data, indent=2, default=str))
+        else:
+            typer.secho(f"Registered room with CFN: {name}", fg=typer.colors.GREEN)
+            typer.echo(f"  MAS ID:  {room_data.get('mas_id')}")
+            typer.echo(f"  Workspace: {room_data.get('workspace_id')}")
+
+    except MyceliumError:
+        raise
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False
         print_error(e, verbose=verbose)

--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -67,9 +67,9 @@ services:
       # overlay FS and are lost on recreate. (The host-side MYCELIUM_DATA_DIR
       # env var is read separately by docker compose to resolve the volume
       # source path; the two values are different by design.)
-      MYCELIUM_DATA_DIR: /root/.mycelium
+      MYCELIUM_DATA_DIR: /home/mycelium/.mycelium
     volumes:
-      - ${MYCELIUM_DATA_DIR:-~/.mycelium}:/root/.mycelium
+      - ${MYCELIUM_DATA_DIR:-~/.mycelium}:/home/mycelium/.mycelium
     ports:
       - "${MYCELIUM_BACKEND_PORT:-8000}:8000"
     healthcheck:

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -167,7 +167,7 @@ class MemoryLogEntry(BaseModel):
 #                 runs inside OpenClaw; we just register it into the channel's
 #                 rooms[] fan-out — no daemon involvement, see the daemon
 #                 dispatch loop which skips non-cold_spawn families).
-AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "openclaw", "hermes"})
+AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "openclaw"})
 
 
 class AgentManifest(BaseModel):
@@ -178,7 +178,7 @@ class AgentManifest(BaseModel):
     manifest body — the bare minimum a dispatcher needs to route an
     ``@handle`` mention to the agent's runtime.
 
-    Four adapters:
+    Three adapters:
 
     - ``claude_code`` — cold-spawned by the daemon. Requires ``cwd`` (where
       ``claude -p`` runs).
@@ -188,17 +188,13 @@ class AgentManifest(BaseModel):
       (the OpenClaw agent id; usually == handle for create-mode). The
       OpenClaw gateway's channel plugin is the dispatcher; the daemon
       ignores these manifests entirely.
-    - ``hermes`` — a handle exposed through a long-lived hermes gateway. The
-      bundled ``mycelium-room`` hermes plugin subscribes to the configured
-      rooms and dispatches into the hermes agent loop; the daemon ignores
-      these manifests entirely.
 
     The handle slug doubles as the mention target (``@release-agent``), so it
     must match the same lowercase pattern other memory slugs use.
     """
 
     handle: str = Field(..., min_length=1, pattern=r"^[a-z0-9][a-z0-9._-]*$")
-    adapter: Literal["claude_code", "cursor", "openclaw", "hermes"] = "claude_code"
+    adapter: Literal["claude_code", "cursor", "openclaw"] = "claude_code"
     cwd: str | None = Field(
         default=None,
         description=(
@@ -227,7 +223,7 @@ class AgentManifest(BaseModel):
             "Sender handles allowed to invoke this agent (e.g. ['@julia', '@docs-agent']). "
             "Empty list means anyone in the room can invoke. "
             "Enforced by the daemon for claude_code; advisory for openclaw "
-            "and hermes (the gateway plugin gates on @-mention, not allow_from)."
+            "(the channel plugin gates on @-mention, not allow_from)."
         ),
     )
 

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -167,7 +167,7 @@ class MemoryLogEntry(BaseModel):
 #                 runs inside OpenClaw; we just register it into the channel's
 #                 rooms[] fan-out — no daemon involvement, see the daemon
 #                 dispatch loop which skips non-cold_spawn families).
-AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "openclaw"})
+AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "openclaw", "hermes"})
 
 
 class AgentManifest(BaseModel):
@@ -178,7 +178,7 @@ class AgentManifest(BaseModel):
     manifest body — the bare minimum a dispatcher needs to route an
     ``@handle`` mention to the agent's runtime.
 
-    Three adapters:
+    Four adapters:
 
     - ``claude_code`` — cold-spawned by the daemon. Requires ``cwd`` (where
       ``claude -p`` runs).
@@ -188,13 +188,17 @@ class AgentManifest(BaseModel):
       (the OpenClaw agent id; usually == handle for create-mode). The
       OpenClaw gateway's channel plugin is the dispatcher; the daemon
       ignores these manifests entirely.
+    - ``hermes`` — a handle exposed through a long-lived hermes gateway. The
+      bundled ``mycelium-room`` hermes plugin subscribes to the configured
+      rooms and dispatches into the hermes agent loop; the daemon ignores
+      these manifests entirely.
 
     The handle slug doubles as the mention target (``@release-agent``), so it
     must match the same lowercase pattern other memory slugs use.
     """
 
     handle: str = Field(..., min_length=1, pattern=r"^[a-z0-9][a-z0-9._-]*$")
-    adapter: Literal["claude_code", "cursor", "openclaw"] = "claude_code"
+    adapter: Literal["claude_code", "cursor", "openclaw", "hermes"] = "claude_code"
     cwd: str | None = Field(
         default=None,
         description=(
@@ -223,7 +227,7 @@ class AgentManifest(BaseModel):
             "Sender handles allowed to invoke this agent (e.g. ['@julia', '@docs-agent']). "
             "Empty list means anyone in the room can invoke. "
             "Enforced by the daemon for claude_code; advisory for openclaw "
-            "(the channel plugin gates on @-mention, not allow_from)."
+            "and hermes (the gateway plugin gates on @-mention, not allow_from)."
         ),
     )
 

--- a/openapi.json
+++ b/openapi.json
@@ -329,6 +329,49 @@
                 }
             }
         },
+        "/api/rooms/{room_name}/sync-mas": {
+            "post": {
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Sync Room Mas",
+                "description": "Register (or re-register) a room with the CFN mgmt plane.\n\nIdempotent: if the MAS already exists in CFN, fetches its id from the list\nendpoint rather than erroring. Updates the room's mas_id and workspace_id.\nReturns 409 if CFN is not configured.",
+                "operationId": "sync_room_mas_api_rooms__room_name__sync_mas_post",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RoomRead"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/rooms/{room_name}/negotiation": {
             "get": {
                 "tags": [


### PR DESCRIPTION
## Summary

- Adds `mycelium room sync-mas <name>` CLI command and `POST /rooms/{room_name}/sync-mas` backend endpoint to register (or re-register) an existing room with the CFN mgmt plane. Idempotent: on 409 it falls back to fetching the existing MAS ID from the GET list rather than erroring.
- Wires a `fix_fn` into `_check_room_mas_ids` in `doctor.py` so `mycelium doctor --fix` automatically registers all rooms missing a MAS ID.
- Replaces the `chown`/`chmod 755 /root` hack in the Dockerfile with a proper `mycelium` app user (uid 1000), `USER` directive, and `/home/mycelium` home directory. Drops the hardcoded `user: "1000:1000"` from `compose.yml` since the image now declares it, and moves the bind-mount target from `/root/.mycelium` to `/home/mycelium/.mycelium`.

## Test plan

- [ ] `mycelium room sync-mas <room>` registers a room that was created before CFN was configured and prints its new MAS ID
- [ ] `mycelium room sync-mas <room>` on a room already in CFN finds the existing MAS ID rather than erroring
- [ ] `mycelium doctor` reports missing MAS IDs; `mycelium doctor --fix` resolves them
- [ ] `docker compose ... up mycelium-backend` starts cleanly as the `mycelium` user with no PermissionError on logs or `.mycelium`
- [ ] `docker run --rm mycelium-backend:dev whoami` returns `mycelium`

🤖 Generated with [Claude Code](https://claude.com/claude-code)