### PR TITLE
docs: reframe README + docs around agent-coordination-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,41 +83,36 @@ mycelium plan tasks   # the - [ ] checklist the team now executes against
 
 ## Quick Start
 
-You'll need **Docker**, an **LLM API key** (required for negotiation — agents
-can't reach consensus without one), and **at least one agent runtime** (Claude
-Code, Cursor, or OpenClaw).
+You'll need **Docker**, an **LLM API key** (agents can't negotiate without
+one), and **at least one agent runtime** (Claude Code, Cursor, or OpenClaw).
 
 ```bash
-# 1. Install the CLI
+# 1. Install the CLI and bring up the stack
 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
+mycelium install      # pulls images, prompts for your LLM key, writes ~/.mycelium/config.toml
 
-# 2. Set up the stack (pulls images, prompts for your LLM key, writes ~/.mycelium/config.toml)
-mycelium install
-
-# 3. Create a room — a shared space for agents, memory, and coordination
-mycelium room create my-project
-mycelium room use my-project
-
-# 4. Add agents to the room (one per role)
-mycelium agent create planner --adapter openclaw \
-    --description "Sprint planner, optimizes for shipping speed"
-mycelium agent create builder --adapter openclaw \
-    --description "Implementer, optimizes for correctness"
-#    (claude-code and cursor agents work too — see Adapters below)
-
-# 5. Put them to work. When agents need to agree, CognitiveEngine negotiates a
-#    single shared answer and compiles it into the room's plan.
-mycelium agent invoke planner "draft a plan for the Q3 migration"
-mycelium plan tasks        # the shared - [ ] checklist the team executes against
+# 2. Open the app — this is where you work
+mycelium ui open
 ```
 
-Rooms are also persistent memory — anything you write is searchable by meaning
-and inherited by every agent that joins:
+From the UI you:
+
+1. **create a room** — a shared space for agents, memory, and the plan,
+2. **add agents** to it (one per role),
+3. **give them a mission** in the chat box and `@mention` them,
+4. **watch** them negotiate to a single shared answer that compiles into the room's **plan** — live.
+
+Your agents drive that same room from the **CLI** on their own — joining,
+negotiating, and writing to shared memory (that's what the `mycelium` skill
+teaches them). You don't run those by hand; they do.
+
+Prefer to script the human side too? Every UI action has a CLI equivalent:
 
 ```bash
-mycelium memory set "decisions/db" "AgensGraph with pgvector for embeddings"
-mycelium memory search "database decisions"
-mycelium memory ls
+mycelium room create my-project && mycelium room use my-project
+mycelium agent create planner --adapter openclaw --description "Sprint planner"
+mycelium agent invoke planner "draft a plan for the Q3 migration"
+mycelium plan tasks   # the shared - [ ] checklist the team executes against
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Mycelium provides coordination functions for autonomous agents operating as peer
 
 Mycelium gives agents **rooms** to coordinate in, **persistent memory** that accumulates within a room, and a **CognitiveEngine** that mediates negotiation so every agent has a voice and the team arrives at a single shared answer.
 
+**Do you need an agent runtime?** Yes. Mycelium coordinates agents; it doesn't replace them. You bring the agents — Claude Code, Cursor, or OpenClaw — and Mycelium is the room, shared memory, and negotiator they meet in. *(You can use the memory layer solo with no runtime, but coordination is the point.)*
+
 ```bash
 # Agent 1 shares context in a persistent room
 mycelium memory set "position/julia" "I think we should use REST, not GraphQL" --handle julia-agent
@@ -69,35 +71,52 @@ mycelium plan tasks   # the - [ ] checklist the team now executes against
 
 **1. Alignment** — When agents need to agree, a session is spawned within the room. CognitiveEngine orchestrates multi-issue negotiation through a structured state machine (`idle → waiting → negotiating → complete`). Agents respond to structured proposals and reach a single consensus — every agent has a voice, and the result is one shared answer, not parallel outputs a human has to reconcile. From that consensus Mycelium compiles a **shared plan** — a `- [ ]` checklist at `plan/tasks.md` the whole team executes against. The arc is one line: join → negotiate → **plan** → work. The negotiation decides *what*; the plan is *how the team carries it out*.
 
-**2. Room Memory** — Rooms are folders. Memories are markdown files at `.mycelium/rooms/{room}/{namespace}/{key}.md`. Any agent with file I/O can read and write room memory directly — the CLI is sugar. Memories accumulate across agents and sessions, and are searchable by meaning via a pgvector index in AgensGraph.
+**2. Room Memory** — Rooms are folders. Memories are markdown files at `~/.mycelium/rooms/{room}/{namespace}/{key}.md`. Any agent with file I/O can read and write room memory directly — the CLI is sugar. Memories accumulate across agents and sessions, and are searchable by meaning via a pgvector index in AgensGraph.
 
-**3. Peer Collaboration Environment** — Any agent joining a room reads from `.mycelium/rooms/{room}/` and instantly inherits everything the swarm has learned — decisions made, what failed, open questions, the room's shared plan. No repeated context-setting. Intelligence compounds instead of resetting.
+**3. Peer Collaboration Environment** — Any agent joining a room reads from `~/.mycelium/rooms/{room}/` and instantly inherits everything the swarm has learned — decisions made, what failed, open questions, the room's shared plan. No repeated context-setting. Intelligence compounds instead of resetting.
 
 ## Quick Start
+
+You'll need **Docker**, an **LLM API key** (required for negotiation — agents
+can't reach consensus without one), and **at least one agent runtime** (Claude
+Code, Cursor, or OpenClaw).
 
 ```bash
 # 1. Install the CLI
 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
 
-# 2. Set up the stack (pulls images, prompts for LLM config, writes ~/.mycelium/config.toml)
+# 2. Set up the stack (pulls images, prompts for your LLM key, writes ~/.mycelium/config.toml)
 mycelium install
 
-# 3. Create a room and start sharing context
+# 3. Create a room — a shared space for agents, memory, and coordination
 mycelium room create my-project
 mycelium room use my-project
-mycelium memory set "context/goal" "Build a REST API for the new service"
+
+# 4. Add agents to the room (one per role)
+mycelium agent create planner --adapter openclaw \
+    --description "Sprint planner, optimizes for shipping speed"
+mycelium agent create builder --adapter openclaw \
+    --description "Implementer, optimizes for correctness"
+#    (claude-code and cursor agents work too — see Adapters below)
+
+# 5. Put them to work. When agents need to agree, CognitiveEngine negotiates a
+#    single shared answer and compiles it into the room's plan.
+mycelium agent invoke planner "draft a plan for the Q3 migration"
+mycelium plan tasks        # the shared - [ ] checklist the team executes against
+```
+
+Rooms are also persistent memory — anything you write is searchable by meaning
+and inherited by every agent that joins:
+
+```bash
 mycelium memory set "decisions/db" "AgensGraph with pgvector for embeddings"
-
-# Search what's been shared
 mycelium memory search "database decisions"
-
-# See everything in the room
 mycelium memory ls
 ```
 
 ## Architecture
 
-**Memories live on the filesystem** — rooms are folders, memories are markdown files with YAML frontmatter at `.mycelium/rooms/{room}/{key}.md`. This is the source of truth. Direct writes (cat, editor, agent file I/O) always work; run `mycelium reindex` to refresh the search index after bypassing the CLI.
+**Memories live on the filesystem** — rooms are folders, memories are markdown files with YAML frontmatter at `~/.mycelium/rooms/{room}/{key}.md`. This is the source of truth. Direct writes (cat, editor, agent file I/O) always work; run `mycelium reindex` to refresh the search index after bypassing the CLI.
 
 **AgensGraph** (PostgreSQL 16 fork) is the coordination and search backend:
 - Rooms, sessions, messages, subscriptions — coordination state
@@ -106,14 +125,14 @@ mycelium memory ls
 
 No external message broker, no separate vector DB, no Redis. One database.
 
-**Rooms are git-friendly** — commit `.mycelium/rooms/` to share context across machines. Agents on different machines pull the folder and inherit the room's full memory.
+**Rooms are git-friendly** — commit `~/.mycelium/rooms/` to share context across machines. Agents on different machines pull the folder and inherit the room's full memory.
 
 **Deployment modes** — by default everything runs on a single device (your laptop): backend, database, agents, and CLI all on `localhost`. That's the primary target and what `mycelium install` sets up out of the box. For small teams that want to share memory and coordination state, Mycelium also supports a hub-and-spoke mode: one machine runs the backend (the **hub**), other teammates run only the CLI + agents (**spokes**) pointing at it over HTTPS/SSE. `mycelium doctor` auto-detects which mode you're in based on `server.api_url`; pass `--mode hub` or `--mode spoke` to override. See [`docs/architecture.md`](mycelium-cli/src/mycelium/docs/architecture.md#deployment-modes) for details.
 
 Room folders use standard namespaces:
 
 ```
-.mycelium/rooms/{room}/
+~/.mycelium/rooms/{room}/
 ├── plan/         Shared checklist — compiled from negotiation consensus
 ├── decisions/    Why choices were made
 ├── status/       Current state of things
@@ -136,7 +155,7 @@ mycelium-client/      Generated typed OpenAPI client
 
 Mycelium works with any agent that can make HTTP requests via the REST API. Native adapters are available for:
 
-**OpenClaw** — Two plugins + hooks for the OpenClaw agent runtime. The `mycelium` plugin delivers SSE-based coordination ticks that wake agents automatically when it's their turn. The `mycelium-channel` plugin turns any Mycelium room into an addressed message bus — agents DM each other via `@handle` mentions without Discord, Slack, or any third-party chat platform.
+**OpenClaw** — Two plugins + hooks for the OpenClaw agent runtime. The `mycelium` plugin delivers SSE-based coordination ticks that wake agents automatically when it's their turn. The `mycelium-channel` plugin turns any Mycelium room into an addressed message bus — agents DM each other via `@handle` mentions through the room itself, with no external chat platform required.
 
 ```bash
 mycelium adapter add openclaw
@@ -151,7 +170,7 @@ openclaw approvals allowlist add --agent "*" "~/.local/bin/mycelium"
 openclaw gateway restart
 ```
 
-**Claude Code** — Lifecycle hooks capture tool use and context automatically. The mycelium skill provides memory and coordination commands.
+**Claude Code** — Installs the `mycelium` skill (`~/.claude/skills/mycelium/SKILL.md`), giving Claude Code memory and coordination commands via `/mycelium`. (On reinstall it also backs up `~/.claude/settings.json` and clears any stale hook wiring from earlier versions.)
 
 ```bash
 mycelium adapter add claude-code

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Mycelium provides coordination functions for autonomous agents operating as peer
 
 Mycelium gives agents **rooms** to coordinate in, **persistent memory** that accumulates within a room, and a **CognitiveEngine** that mediates negotiation so every agent has a voice and the team arrives at a single shared answer.
 
-**Two surfaces, one room — built for each other.** You and your agents
+**Two surfaces, one room, built for each other.** You and your agents
 coordinate *together*:
 
-- **You** work in the **UI** — create a room, add agents, hand them a mission, and watch them reach a shared decision and a plan, live.
-- **Your agents** work through the **CLI** — they join the room, negotiate, and write to shared memory on their own (that's what the `mycelium` skill teaches them).
+- **You** work in the **UI**: create a room, add agents, hand them a mission, and watch them reach a shared decision and a plan, live.
+- **Your agents** work through the **CLI**: they join the room, negotiate, and write to shared memory on their own (that's what the `mycelium` skill teaches them).
 
 That's also why you need at least one **agent runtime** (Claude Code, Cursor, or OpenClaw): the agents aren't an optional add-on, they're half the system.
 
@@ -77,9 +77,9 @@ mycelium plan tasks   # the - [ ] checklist the team now executes against
 
 **1. Alignment** — When agents need to agree, a session is spawned within the room. CognitiveEngine orchestrates multi-issue negotiation through a structured state machine (`idle → waiting → negotiating → complete`). Agents respond to structured proposals and reach a single consensus — every agent has a voice, and the result is one shared answer, not parallel outputs a human has to reconcile. From that consensus Mycelium compiles a **shared plan** — a `- [ ]` checklist at `plan/tasks.md` the whole team executes against. The arc is one line: join → negotiate → **plan** → work. The negotiation decides *what*; the plan is *how the team carries it out*.
 
-**2. Room Memory** — Rooms are folders. Memories are markdown files at `~/.mycelium/rooms/{room}/{namespace}/{key}.md`. Any agent with file I/O can read and write room memory directly — the CLI is sugar. Memories accumulate across agents and sessions, and are searchable by meaning via a pgvector index in AgensGraph.
+**2. Room Memory** — Rooms are folders. Memories are markdown files at `~/.mycelium/rooms/{room}/{namespace}/{key}.md`. Any agent with file I/O can read and write room memory directly. The CLI is sugar. Memories accumulate across agents and sessions, and are searchable by meaning via a pgvector index in AgensGraph.
 
-**3. Peer Collaboration Environment** — Any agent joining a room reads from `~/.mycelium/rooms/{room}/` and instantly inherits everything the swarm has learned — decisions made, what failed, open questions, the room's shared plan. No repeated context-setting. Intelligence compounds instead of resetting.
+**3. Peer Collaboration Environment** — Any agent joining a room reads from `~/.mycelium/rooms/{room}/` and instantly inherits everything the swarm has learned: decisions made, what failed, open questions, the room's shared plan. No repeated context-setting. Intelligence compounds instead of resetting.
 
 ## Quick Start
 
@@ -91,7 +91,7 @@ one), and **at least one agent runtime** (Claude Code, Cursor, or OpenClaw).
 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
 mycelium install      # pulls images, prompts for your LLM key, writes ~/.mycelium/config.toml
 
-# 2. Open the app — this is where you work
+# 2. Open the app: this is where you work
 mycelium ui open
 ```
 
@@ -102,7 +102,7 @@ From the UI you:
 3. **give them a mission** in the chat box and `@mention` them,
 4. **watch** them negotiate to a single shared answer that compiles into the room's **plan** — live.
 
-Your agents drive that same room from the **CLI** on their own — joining,
+Your agents drive that same room from the **CLI** on their own, joining,
 negotiating, and writing to shared memory (that's what the `mycelium` skill
 teaches them). You don't run those by hand; they do.
 
@@ -156,7 +156,7 @@ mycelium-client/      Generated typed OpenAPI client
 
 Mycelium works with any agent that can make HTTP requests via the REST API. Native adapters are available for:
 
-**OpenClaw** — Two plugins + hooks for the OpenClaw agent runtime. The `mycelium` plugin delivers SSE-based coordination ticks that wake agents automatically when it's their turn. The `mycelium-channel` plugin turns any Mycelium room into an addressed message bus — agents DM each other via `@handle` mentions through the room itself, with no external chat platform required.
+**OpenClaw** — Two plugins + hooks for the OpenClaw agent runtime. The `mycelium` plugin delivers SSE-based coordination ticks that wake agents automatically when it's their turn. The `mycelium-channel` plugin turns any Mycelium room into an addressed message bus: agents DM each other via `@handle` mentions through the room itself, with no external chat platform required.
 
 ```bash
 mycelium adapter add openclaw

--- a/README.md
+++ b/README.md
@@ -45,7 +45,13 @@ Mycelium provides coordination functions for autonomous agents operating as peer
 
 Mycelium gives agents **rooms** to coordinate in, **persistent memory** that accumulates within a room, and a **CognitiveEngine** that mediates negotiation so every agent has a voice and the team arrives at a single shared answer.
 
-**Do you need an agent runtime?** Yes. Mycelium coordinates agents; it doesn't replace them. You bring the agents — Claude Code, Cursor, or OpenClaw — and Mycelium is the room, shared memory, and negotiator they meet in. *(You can use the memory layer solo with no runtime, but coordination is the point.)*
+**Two surfaces, one room — built for each other.** You and your agents
+coordinate *together*:
+
+- **You** work in the **UI** — create a room, add agents, hand them a mission, and watch them reach a shared decision and a plan, live.
+- **Your agents** work through the **CLI** — they join the room, negotiate, and write to shared memory on their own (that's what the `mycelium` skill teaches them).
+
+That's also why you need at least one **agent runtime** (Claude Code, Cursor, or OpenClaw): the agents aren't an optional add-on, they're half the system.
 
 ```bash
 # Agent 1 shares context in a persistent room

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -511,19 +511,19 @@ docker exec <span class="arg">&lt;container-name&gt;</span> openclaw status</cod
 
       <h2 id="api-docs">Interactive docs</h2>
       <p>When the backend is running, interactive API docs are available at:</p>
-      <pre><code>http://localhost:8888/docs</code></pre>
+      <pre><code>http://localhost:8000/docs</code></pre>
 
       <h2 id="api-example">Quick example</h2>
       <pre><code><span class="comment"># Write a memory</span>
-curl -X POST http://localhost:8888/api/memory \
+curl -X POST http://localhost:8000/api/memory \
   -H "Content-Type: application/json" \
   -d '{"room": "my-project", "key": "work/api", "value": "REST with OpenAPI client"}'
 
 <span class="comment"># Read it back</span>
-curl http://localhost:8888/api/memory/my-project/work/api
+curl http://localhost:8000/api/memory/my-project/work/api
 
 <span class="comment"># Semantic search</span>
-curl -X POST http://localhost:8888/api/memory/search \
+curl -X POST http://localhost:8000/api/memory/search \
   -H "Content-Type: application/json" \
   -d '{"room": "my-project", "query": "what was decided about the API"}'</code></pre>
     </section>

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -224,4 +224,4 @@ Give this to the second Claude Code instance:
 - Frontend: `http://localhost:3000`
 - Frontend: `http://localhost:3000/room/design-review`
 - Presentation deck: `docs/mycelium-dataflow.html`
-- Backend API docs: `http://localhost:8888/docs`
+- Backend API docs: `http://localhost:8000/docs`

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -220,7 +220,7 @@ export OPENCLAW_CONTAINER=openclaw-gateway-1
 <span class="cmd">mycelium adapter add</span> openclaw</code></pre>
       <p>This handles path resolution, file ownership (root UID), and <code>openclaw.json</code> load-path configuration automatically.</p>
       <h3 id="architecture-backend-api">Backend API</h3>
-      <p>Any agent that can make HTTP requests can use the REST API directly. Interactive API docs are available at <code>http://localhost:8888/docs</code> when the backend is running.</p>
+      <p>Any agent that can make HTTP requests can use the REST API directly. Interactive API docs are available at <code>http://localhost:8000/docs</code> when the backend is running.</p>
     </section>
 
     <hr class="divider">

--- a/mycelium-cli/src/mycelium/docs/architecture.md
+++ b/mycelium-cli/src/mycelium/docs/architecture.md
@@ -51,6 +51,20 @@ mycelium doctor --mode auto    # default — detect from api_url
 > cutover (no alias) to align with the standard hub-and-spoke vocabulary.
 > If you have scripts that pass `--mode leaf`, update them to `--mode spoke`.
 
+### Syncing room files (remote backend)
+
+When the backend runs on a remote server (EC2, Raspberry Pi, a hub), room files
+sync via the HTTP API. The adapter does not auto-sync; run `mycelium sync`
+yourself when you want fresh state.
+
+```bash
+# Clone a room from a remote backend
+mycelium room clone my-project --from http://ec2-host:8000
+
+# Fetch all memories from the backend and write local files
+mycelium sync
+```
+
 ## Stack
 
 Everything runs on a single **AgensGraph** instance — a PostgreSQL 16 fork
@@ -75,9 +89,9 @@ the same regardless of adapter — join, await, respond.
 
 ### Claude Code
 
-The Mycelium skill ships as a Claude Code hook set. Lifecycle hooks capture tool use
-and context automatically. The `mycelium` slash command provides memory
-and coordination commands inline.
+The Mycelium skill installs as a Claude Code skill (`~/.claude/skills/mycelium/SKILL.md`),
+invoked via the `/mycelium` slash command for memory and coordination commands.
+The adapter is skill-only; earlier hook-based versions were removed.
 
 ```bash
 # The skill is invoked automatically in Claude Code sessions

--- a/mycelium-cli/src/mycelium/docs/architecture.md
+++ b/mycelium-cli/src/mycelium/docs/architecture.md
@@ -153,5 +153,5 @@ load-path configuration automatically.
 ### Backend API
 
 Any agent that can make HTTP requests can use the REST API directly.
-Interactive API docs are available at `http://localhost:8888/docs`
+Interactive API docs are available at `http://localhost:8000/docs`
 when the backend is running.

--- a/mycelium-cli/src/mycelium/docs/cognitive-engine.md
+++ b/mycelium-cli/src/mycelium/docs/cognitive-engine.md
@@ -3,6 +3,11 @@
 CognitiveEngine is the mediator. It sits between all agents and drives negotiation.
 Agents never talk to each other directly — all coordination flows through CE.
 
+> **CE requires an LLM key and the IoC/CFN backend.** Both are provisioned by
+> `mycelium install` (interactive) by default. Without an LLM key the engine
+> can't synthesize proposals; without IoC/CFN, `session join` rejects the
+> negotiation outright. See **sessions** for the full prerequisite list.
+
 ## Negotiation flow
 
 In sessions:

--- a/mycelium-cli/src/mycelium/docs/memory.md
+++ b/mycelium-cli/src/mycelium/docs/memory.md
@@ -1,7 +1,32 @@
 # Memory
 
-Memory is a namespaced key-value store backed by AgensGraph + pgvector. Every write
-is embedded (384-dim, local, no API key) and indexed for semantic search.
+Room memory is markdown files on your filesystem: the shared source of truth,
+greppable and editable by any agent. The CFN knowledge graph is a derived index
+over those files, for recall by meaning and relationship, never an independent
+source of writes. Whatever stays private to one agent stays in that agent's own
+local memory, never indexed.
+
+## Three layers, one source of truth
+
+Mycelium memory has three layers, and only the middle one is "the memory":
+
+1. **Your private context** is yours alone: agent-native files like `SOUL.md`
+   or per-agent notes that never leave your machine and are never indexed or
+   shared. Anything only you need lives here.
+2. **Room memory** is the shared source of truth: markdown files under
+   `~/.mycelium/rooms/{room}/` that every agent in the room can read, `grep`,
+   edit, and `git`-track. If the team should know it, write it here.
+3. **The CFN knowledge graph** is a derived view, not a place you write to.
+   Mycelium indexes the room's public artifacts (memory files plus channel
+   messages) into it so agents can recall by meaning and by relationship. It
+   rebuilds from the files, so the files always win.
+
+Rule of thumb: if a teammate should find it, put it in room memory. The graph
+is how they find it; the filesystem is where it lives; your private notes stay
+yours.
+
+Every write to room memory is embedded (384-dim, local, no API key) and indexed
+for semantic search.
 
 ## Namespace Conventions
 

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -17,7 +17,7 @@ aren't an optional add-on, they're half the system.
 
 **Rooms** — Persistent coordination spaces. Agents join a room to share context, then spawn a session inside it to negotiate in real time.
 
-**Persistent Memory** — Markdown files with semantic vector search. Every agent that joins inherits what the others already know, so intelligence compounds across sessions instead of resetting.
+**Persistent Memory** — Markdown files on your filesystem are the shared source of truth, greppable and editable by any agent, and a CFN knowledge graph indexes them for recall by meaning and relationship. Every agent that joins inherits what the others already know, so intelligence compounds across sessions instead of resetting.
 
 **Structured negotiation** — When agents need to agree on a multi-issue trade-off, Mycelium runs a structured negotiation that ends in one shared answer, then compiles it into a `- [ ]` checklist the whole team executes against.
 

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -1,15 +1,24 @@
 # Overview
 
-A coordination layer for multi-agent systems — shared rooms, persistent memory,
-and semantic negotiation so agents can think together.
+Mycelium is a coordination layer for teams of autonomous AI agents. Give
+several agents a shared mission and Mycelium gets them to one agreed answer —
+and a shared plan they execute together — instead of talking over each other or
+redoing each other's work.
 
-**Rooms** — Namespaced coordination spaces. Agents join rooms to share context or negotiate in real time.
+**Do you need an agent runtime?** Yes. Mycelium coordinates agents; it doesn't
+replace them. You bring the agents — Claude Code, Cursor, or OpenClaw — and
+Mycelium is the room, shared memory, and negotiator they meet in. *(You can use
+the memory layer solo with no runtime, but coordination is the point.)*
 
-**Persistent Memory** — Namespaced key-value store with semantic vector search. Intelligence compounds across sessions.
+## What you get
 
-**CognitiveEngine** — Mediates all agent interaction. Drives structured negotiation — agents never talk directly.
+**Rooms** — Persistent coordination spaces. Agents join a room to share context, then spawn a session inside it to negotiate in real time.
 
-**Knowledge Graph** — LLM extraction turns conversations into concepts and relationships in an openCypher graph.
+**Persistent Memory** — Markdown files with semantic vector search. Every agent that joins inherits what the others already know — intelligence compounds across sessions instead of resetting.
+
+**Structured negotiation** — When agents need to agree on a multi-issue trade-off, Mycelium runs a structured negotiation that ends in one shared answer, then compiles it into a `- [ ]` checklist the whole team executes against.
+
+> Under the hood, negotiation is mediated by the **CognitiveEngine** (agents never talk directly), and deliberate room writes can be extracted into a **knowledge graph**. See **cognitive-engine** and **knowledge-graph**.
 
 ## The Problem
 
@@ -24,7 +33,7 @@ directly to each other.
 ## The Ratchet Effect
 
 When agents log decisions, failures, and findings to a shared room, any agent that joins
-later can read `.mycelium/rooms/{room}/` and the room's shared plan to instantly inherit
+later can read `~/.mycelium/rooms/{room}/` and the room's shared plan to instantly inherit
 what the swarm learned. Intelligence doesn't reset — it compounds.
 
 Negative results matter too. An agent that logs `failed/sqlite-testing: can't handle

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -5,10 +5,13 @@ several agents a shared mission and Mycelium gets them to one agreed answer —
 and a shared plan they execute together — instead of talking over each other or
 redoing each other's work.
 
-**Do you need an agent runtime?** Yes. Mycelium coordinates agents; it doesn't
-replace them. You bring the agents — Claude Code, Cursor, or OpenClaw — and
-Mycelium is the room, shared memory, and negotiator they meet in. *(You can use
-the memory layer solo with no runtime, but coordination is the point.)*
+**Two surfaces, one room — built for each other.** You and your agents
+coordinate *together*: **you** work in the **UI** (create a room, add agents,
+hand them a mission, watch them decide and plan, live), and **your agents** work
+through the **CLI** (they join, negotiate, and write to shared memory on their
+own — that's what the `mycelium` skill teaches them). That's why you need at
+least one **agent runtime** (Claude Code, Cursor, or OpenClaw): the agents
+aren't an optional add-on, they're half the system.
 
 ## What you get
 

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -1,15 +1,15 @@
 # Overview
 
 Mycelium is a coordination layer for teams of autonomous AI agents. Give
-several agents a shared mission and Mycelium gets them to one agreed answer —
-and a shared plan they execute together — instead of talking over each other or
+several agents a shared mission and Mycelium gets them to one agreed answer,
+and a shared plan they execute together, instead of talking over each other or
 redoing each other's work.
 
-**Two surfaces, one room — built for each other.** You and your agents
+**Two surfaces, one room, built for each other.** You and your agents
 coordinate *together*: **you** work in the **UI** (create a room, add agents,
 hand them a mission, watch them decide and plan, live), and **your agents** work
 through the **CLI** (they join, negotiate, and write to shared memory on their
-own — that's what the `mycelium` skill teaches them). That's why you need at
+own; that's what the `mycelium` skill teaches them). That's why you need at
 least one **agent runtime** (Claude Code, Cursor, or OpenClaw): the agents
 aren't an optional add-on, they're half the system.
 
@@ -17,7 +17,7 @@ aren't an optional add-on, they're half the system.
 
 **Rooms** — Persistent coordination spaces. Agents join a room to share context, then spawn a session inside it to negotiate in real time.
 
-**Persistent Memory** — Markdown files with semantic vector search. Every agent that joins inherits what the others already know — intelligence compounds across sessions instead of resetting.
+**Persistent Memory** — Markdown files with semantic vector search. Every agent that joins inherits what the others already know, so intelligence compounds across sessions instead of resetting.
 
 **Structured negotiation** — When agents need to agree on a multi-issue trade-off, Mycelium runs a structured negotiation that ends in one shared answer, then compiles it into a `- [ ]` checklist the whole team executes against.
 

--- a/mycelium-cli/src/mycelium/docs/plan.md
+++ b/mycelium-cli/src/mycelium/docs/plan.md
@@ -1,7 +1,7 @@
 # Plan
 
 A room's **plan** is the place to write down what the room is for and what's
-left to do. It lives in `.mycelium/rooms/{room}/plan/` as a small set of
+left to do. It lives in `~/.mycelium/rooms/{room}/plan/` as a small set of
 markdown files, plus the `- [ ]` / `- [x]` checklist lines inside them.
 
 Plan content is surfaced to every agent in the room — on every coordination

--- a/mycelium-cli/src/mycelium/docs/quickstart.md
+++ b/mycelium-cli/src/mycelium/docs/quickstart.md
@@ -11,7 +11,7 @@ the full stack (backend + AgensGraph) via `docker compose`.
 Run `mycelium --help` after install to verify.
 
 > **An LLM key is required for coordination.** Memory works without one, but
-> the CognitiveEngine needs an LLM to negotiate — if you pick "Skip" at the
+> the CognitiveEngine needs an LLM to negotiate; if you pick "Skip" at the
 > prompt, agents will join sessions but never reach consensus. You can add it
 > later with `mycelium config set llm.model <model>` and `mycelium config apply`.
 
@@ -49,8 +49,8 @@ message stream, add agents, chat with them, and track the shared plan. Open it:
 mycelium ui open   # starts the frontend if it isn't running, then opens it
 ```
 
-The UI is where **you** work — create rooms, add agents, hand them a mission,
-and watch them coordinate. The CLI is where **your agents** work — they join,
+The UI is where **you** work: create rooms, add agents, hand them a mission,
+and watch them coordinate. The CLI is where **your agents** work: they join,
 negotiate, and write memory on their own. Same rooms, two surfaces, built for
 each other. The commands shown below are the CLI equivalents of each UI action,
 so you can script or follow along in a terminal.
@@ -71,7 +71,7 @@ start talking to them.
 ## Add agents
 
 The **agent primitive** registers an addressable agent in the room. Mycelium
-wires up the underlying adapter for you — agents coordinate through the room's
+wires up the underlying adapter for you; agents coordinate through the room's
 own message stream, so there's nothing else to set up per agent.
 
 ```bash
@@ -83,7 +83,7 @@ mycelium agent create planner --adapter openclaw \
 mycelium agent add
 ```
 
-`claude_code` and `cursor` agents are cold-spawned by the Mycelium daemon —
+`claude_code` and `cursor` agents are cold-spawned by the Mycelium daemon;
 see the **Adapters** guide for the full list.
 
 ```bash

--- a/mycelium-cli/src/mycelium/docs/quickstart.md
+++ b/mycelium-cli/src/mycelium/docs/quickstart.md
@@ -49,8 +49,11 @@ message stream, add agents, chat with them, and track the shared plan. Open it:
 mycelium ui open   # starts the frontend if it isn't running, then opens it
 ```
 
-Everything below can be driven from the UI or the CLI — they act on the same
-rooms. The commands are shown so you can script or follow along in a terminal.
+The UI is where **you** work — create rooms, add agents, hand them a mission,
+and watch them coordinate. The CLI is where **your agents** work — they join,
+negotiate, and write memory on their own. Same rooms, two surfaces, built for
+each other. The commands shown below are the CLI equivalents of each UI action,
+so you can script or follow along in a terminal.
 
 ## Create a room
 

--- a/mycelium-cli/src/mycelium/docs/quickstart.md
+++ b/mycelium-cli/src/mycelium/docs/quickstart.md
@@ -10,6 +10,11 @@ The installer sets up the CLI, prompts for your LLM provider, then brings up
 the full stack (backend + AgensGraph) via `docker compose`.
 Run `mycelium --help` after install to verify.
 
+> **An LLM key is required for coordination.** Memory works without one, but
+> the CognitiveEngine needs an LLM to negotiate — if you pick "Skip" at the
+> prompt, agents will join sessions but never reach consensus. You can add it
+> later with `mycelium config set llm.model <model>` and `mycelium config apply`.
+
 The install command is interactive — it checks Docker, pulls base images, asks for
 your LLM config, then calls `docker compose up` and provisions a default
 workspace automatically. No manual backend setup required.
@@ -63,9 +68,8 @@ start talking to them.
 ## Add agents
 
 The **agent primitive** registers an addressable agent in the room. Mycelium
-wires up the underlying adapter for you — there's no per-agent chat account or
-homeserver to configure; agents coordinate through the room's own message
-stream.
+wires up the underlying adapter for you — agents coordinate through the room's
+own message stream, so there's nothing else to set up per agent.
 
 ```bash
 # Greenfield — provision a brand-new agent
@@ -76,8 +80,8 @@ mycelium agent create planner --adapter openclaw \
 mycelium agent add
 ```
 
-`claude_code` and `cursor` agents are cold-spawned by the Mycelium daemon and
-need no chat platform at all — see the **Adapters** guide for the full list.
+`claude_code` and `cursor` agents are cold-spawned by the Mycelium daemon —
+see the **Adapters** guide for the full list.
 
 ```bash
 # See who's in the room
@@ -99,7 +103,7 @@ runs a structured negotiation. On consensus, the agreement compiles into the
 room's shared plan — visible in the **PLAN** tab in the UI, or from the CLI:
 
 ```bash
-mycelium plan ls          # the room's shared task list
+mycelium plan tasks       # the room's shared task list
 ```
 
 The result lands back in the same room stream — no need to go hunting for it in

--- a/mycelium-cli/src/mycelium/docs/sessions.md
+++ b/mycelium-cli/src/mycelium/docs/sessions.md
@@ -3,6 +3,13 @@
 A session is an ephemeral sync negotiation round spawned within a room. Rooms hold
 persistent state (memories, knowledge graph). Sessions handle real-time coordination.
 
+> **Prerequisites for negotiation.** Sessions need two things that `mycelium
+> install` sets up by default: the **IoC/CFN** coordination backend (without it,
+> `session join` returns "CFN: not configured"), and an **LLM key** (the
+> CognitiveEngine uses it to generate proposals — in "stub mode" agents join but
+> never reach consensus). Memory and rooms work without either; negotiation does
+> not.
+
 ## Lifecycle
 
 1. **Create** — `mycelium session create` spawns a session within your active room.

--- a/mycelium-cli/src/mycelium/docs/sessions.md
+++ b/mycelium-cli/src/mycelium/docs/sessions.md
@@ -6,7 +6,7 @@ persistent state (memories, knowledge graph). Sessions handle real-time coordina
 > **Prerequisites for negotiation.** Sessions need two things that `mycelium
 > install` sets up by default: the **IoC/CFN** coordination backend (without it,
 > `session join` returns "CFN: not configured"), and an **LLM key** (the
-> CognitiveEngine uses it to generate proposals — in "stub mode" agents join but
+> CognitiveEngine uses it to generate proposals; in "stub mode" agents join but
 > never reach consensus). Memory and rooms work without either; negotiation does
 > not.
 

--- a/mycelium-cli/src/mycelium/docs/troubleshooting.md
+++ b/mycelium-cli/src/mycelium/docs/troubleshooting.md
@@ -351,6 +351,31 @@ mycelium init --api-url http://<correct-hub-ip>:8000
 All of these are written by `mycelium config apply` from the matching
 `runtime.*` config keys — don't edit `.env` by hand.
 
+### Agent environment variables
+
+Read by the CLI and adapters at runtime to identify the agent and locate the backend:
+
+| Variable | Description |
+|----------|-------------|
+| `MYCELIUM_API_URL` | Backend API URL (default: `http://localhost:8000`) |
+| `MYCELIUM_AGENT_HANDLE` | This agent's identity handle |
+| `MYCELIUM_ROOM` | Active room name |
+| `MYCELIUM_WORKSPACE_ID` | CFN workspace UUID, required for knowledge ingest |
+| `MYCELIUM_MAS_ID` | CFN MAS UUID, required for knowledge ingest |
+
+### Knowledge-ingest cost controls
+
+Overrides for `[knowledge_ingest]` in `~/.mycelium/config.toml`. Every key below
+has a matching env var for ephemeral changes (no config edit needed). Forwarding
+to the CFN graph is off by default.
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `MYCELIUM_INGEST_ENABLED` | `true` | Master kill switch. `0`/`false` short-circuits every ingest at the backend gate (no concept extraction, no CFN spend) and the endpoint returns 200 with a disabled marker. |
+| `MYCELIUM_INGEST_MIN_CONTENT_CHARS` | `32` | Skip ingest for trivially short content ("ack", emoji-only). `0` disables the gate. |
+| `MYCELIUM_INGEST_MAX_INPUT_TOKENS` | `50000` | Backend circuit breaker: payloads above this estimated input token count get refused with HTTP 413. `0` disables. |
+| `MYCELIUM_INGEST_DEDUPE_TTL_SECONDS` | `300` | Backend content-hash dedupe window. Identical payloads within this many seconds short-circuit without re-hitting CFN. `0` disables dedupe. |
+
 ---
 
 ## Log Locations

--- a/mycelium-cli/src/mycelium/docs/troubleshooting.md
+++ b/mycelium-cli/src/mycelium/docs/troubleshooting.md
@@ -127,6 +127,26 @@ mycelium room ls            # wrong active room?
 
 ---
 
+### 7b. Agents Join a Session but Never Reach Consensus
+
+**Symptom**: `session join` works and agents appear in the session, but
+negotiation never produces a plan — or `session join` reports
+`CFN: not configured`.
+
+Negotiation has two prerequisites that memory/rooms don't:
+
+```bash
+mycelium status            # is an LLM key configured? (CE needs one to propose)
+grep -i ioc ~/.mycelium/.env   # was the stack installed with IoC/CFN enabled?
+```
+
+- **No LLM key** → the CognitiveEngine can't generate proposals. Add one (see
+  *LLM Not Configured* above) and restart: `mycelium down && mycelium up`.
+- **IoC/CFN disabled** → re-run `mycelium install` (interactive enables IoC by
+  default), or reinstall without `--no-ioc`.
+
+---
+
 ### 8. Container Name Conflicts
 
 **Symptom**: `container name "mycelium-db" is already in use`

--- a/mycelium-cli/src/mycelium/docs/troubleshooting.md
+++ b/mycelium-cli/src/mycelium/docs/troubleshooting.md
@@ -130,7 +130,7 @@ mycelium room ls            # wrong active room?
 ### 7b. Agents Join a Session but Never Reach Consensus
 
 **Symptom**: `session join` works and agents appear in the session, but
-negotiation never produces a plan — or `session join` reports
+negotiation never produces a plan, or `session join` reports
 `CFN: not configured`.
 
 Negotiation has two prerequisites that memory/rooms don't:

--- a/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
@@ -27,6 +27,14 @@ Every memory is a readable, editable markdown file:
 
 You can read them with `cat`, edit with any tool, or `git` the directory. Changes are auto-indexed — no manual reindex needed.
 
+## The three memory layers: where to write what
+
+1. **Your private context**: your own agent-native memory (local notes, never indexed, never shared). Keep what is only relevant to you here.
+2. **Room memory**: the shared source of truth, markdown files under `~/.mycelium/rooms/{room}/`. Everything the team should see goes here, via `mycelium memory set` or a direct file write.
+3. **The CFN knowledge graph**: a derived index over room-public artifacts (memory files plus channel messages) for semantic and graph recall. You never write to it directly; it rebuilds from the files, so the files always win.
+
+Rule of thumb: if a teammate should find it, write it to room memory. The graph is how they find it; the filesystem is where it lives; your private notes stay yours.
+
 ## Memory Operations
 
 ```bash

--- a/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
@@ -9,72 +9,13 @@ Mycelium provides persistent shared memory and real-time coordination between AI
 All interaction flows through **rooms** (shared namespaces) and **CognitiveEngine** (the mediator).
 Agents never communicate directly with each other.
 
+Your core loop is the **negotiation protocol** below (join, await, respond, consensus, plan, work). Memory is the shared substrate underneath it.
+
 ## Core Concepts
 
 - **Rooms** are persistent namespaces. They hold memory that accumulates across sessions. Spawn sessions within rooms for real-time negotiation when needed.
 - **CognitiveEngine** mediates all coordination. It drives negotiation rounds and compiles consensus into the room's shared plan.
 - **Memory** is filesystem-native. Each memory is a markdown file at `~/.mycelium/rooms/{room}/{key}.md` with YAML frontmatter. The database is a search index that auto-syncs via file watcher.
-
-## Memory as Files
-
-Every memory is a readable, editable markdown file:
-
-```
-~/.mycelium/rooms/my-project/decisions/db.md
-~/.mycelium/rooms/my-project/work/api.md
-~/.mycelium/rooms/my-project/context/team.md
-```
-
-You can read them with `cat`, edit with any tool, or `git` the directory. Changes are auto-indexed — no manual reindex needed.
-
-## The three memory layers: where to write what
-
-1. **Your private context**: your own agent-native memory (local notes, never indexed, never shared). Keep what is only relevant to you here.
-2. **Room memory**: the shared source of truth, markdown files under `~/.mycelium/rooms/{room}/`. Everything the team should see goes here, via `mycelium memory set` or a direct file write.
-3. **The CFN knowledge graph**: a derived index over room-public artifacts (memory files plus channel messages) for semantic and graph recall. You never write to it directly; it rebuilds from the files, so the files always win.
-
-Rule of thumb: if a teammate should find it, write it to room memory. The graph is how they find it; the filesystem is where it lives; your private notes stay yours.
-
-## Memory Operations
-
-```bash
-# Write a memory (value can be plain text or JSON)
-mycelium memory set <key> <value> --handle <agent-handle>
-mycelium memory set "decision/api-style" '{"choice": "REST", "rationale": "simpler"}' --handle claude-agent
-
-# Read a memory by key
-mycelium memory get <key>
-
-# List memories (log-style output with values)
-mycelium memory ls
-mycelium memory ls --prefix "decision/"
-
-# Semantic search (natural language query against vector embeddings)
-mycelium memory search "what was decided about the API design"
-
-# Delete a memory
-mycelium memory rm <key>
-
-# Subscribe to changes on a key pattern
-mycelium memory subscribe "decision/*" --handle claude-agent
-```
-
-All memory commands use the active room. Set it with `mycelium room use <name>` or pass `--room <name>`.
-
-## Room Operations
-
-```bash
-# Create rooms
-mycelium room create my-project
-mycelium room create sprint-plan
-mycelium room create design-review
-
-# Set active room
-mycelium room use my-project
-
-# List rooms
-mycelium room ls
-```
 
 ## Semantic negotiation
 
@@ -224,47 +165,66 @@ Memories are markdown files under `~/.mycelium/rooms/<room>/`. Any agent who joi
 - **Write self-contained messages.** "What about the thing we discussed?" is useless to a recipient who doesn't share your history. Spell out the context.
 - **`session await` is for interactive (user-initiated) negotiations only.** When *you* start a negotiation in your terminal (the user asks "go negotiate in room X"), use the `session await` loop documented above — it blocks until your turn, you act, and loop. But when the **daemon spawns you for a tick**, your prompt already contains the full tick payload (round, current offer, valid commands). In that case do NOT call `session await` — just run the appropriate `mycelium negotiate` command and exit.
 
-## What the Claude Code adapter actually installs
+## Memory as Files
 
-`mycelium adapter add claude-code` installs one file:
+Every memory is a readable, editable markdown file:
 
-| Path | Purpose |
-|------|---------|
-| `~/.claude/skills/mycelium/SKILL.md` | This file. The skill Claude Code loads when you say `/mycelium`. |
-
-On reinstall it also **backs up** `~/.claude/settings.json` (to a timestamped
-copy) and removes any stale hook wiring left by earlier adapter versions. It
-does not add hooks of its own; the current adapter is skill-only.
-
-## Knowledge Ingest (CFN Graph) — only on deliberate room writes
-
-Mycelium ships content to CFN's `shared-memories` knowledge graph on **two paths only**:
-
-1. **Channel messages** — when an agent posts to a room via `POST /api/rooms/{room}/messages` (or `mycelium room send` / equivalents).
-2. **Memory writes** — when an agent calls `mycelium memory set` (or the underlying `POST /api/rooms/{room}/memory`).
-
-Both are deliberate. Both happen because the agent chose to put something into the room. Tool outputs, reasoning traces, and unsent thoughts never reach CFN.
-
-CFN has no delete API — anything ingested is permanent in the graph. Constraining ingest to deliberate room writes is the only correct privacy posture.
-
-To enable forwarding (off by default — costs CFN tokens), edit `~/.mycelium/config.toml`:
-
-```toml
-[server]
-workspace_id = "<uuid>"
-mas_id       = "<uuid>"
-
-[knowledge_ingest]
-enabled = true
+```
+~/.mycelium/rooms/my-project/decisions/db.md
+~/.mycelium/rooms/my-project/work/api.md
+~/.mycelium/rooms/my-project/context/team.md
 ```
 
-Cost-control knobs under `[knowledge_ingest]` (also env-overridable via `MYCELIUM_INGEST_*` — see **Environment Variables** below): `max_input_tokens` caps the per-payload size; `dedupe_ttl_seconds` short-circuits identical payloads; `min_content_chars` skips trivially short content (default 32 — covers "ack", emoji-only posts).
+You can read them with `cat`, edit with any tool, or `git` the directory. Changes are auto-indexed — no manual reindex needed.
 
-Observability: every forward attempt (ok, deduped, refused, skipped, disabled, error) surfaces via `mycelium cfn log` / `mycelium cfn stats`. What actually landed in the graph: `mycelium cfn ls --mas <uuid>`, `mycelium cfn query "<question>" --mas <uuid>`.
+## The three memory layers: where to write what
 
-Kill switches:
-- `export MYCELIUM_INGEST_ENABLED=0`
-- Flip `[knowledge_ingest] enabled = false` in config.toml
+1. **Your private context**: your own agent-native memory (local notes, never indexed, never shared). Keep what is only relevant to you here.
+2. **Room memory**: the shared source of truth, markdown files under `~/.mycelium/rooms/{room}/`. Everything the team should see goes here, via `mycelium memory set` or a direct file write.
+3. **The CFN knowledge graph**: a derived index over room-public artifacts (memory files plus channel messages) for semantic and graph recall. You never write to it directly; it rebuilds from the files, so the files always win.
+
+Rule of thumb: if a teammate should find it, write it to room memory. The graph is how they find it; the filesystem is where it lives; your private notes stay yours.
+
+## Memory Operations
+
+```bash
+# Write a memory (value can be plain text or JSON)
+mycelium memory set <key> <value> --handle <agent-handle>
+mycelium memory set "decision/api-style" '{"choice": "REST", "rationale": "simpler"}' --handle claude-agent
+
+# Read a memory by key
+mycelium memory get <key>
+
+# List memories (log-style output with values)
+mycelium memory ls
+mycelium memory ls --prefix "decision/"
+
+# Semantic search (natural language query against vector embeddings)
+mycelium memory search "what was decided about the API design"
+
+# Delete a memory
+mycelium memory rm <key>
+
+# Subscribe to changes on a key pattern
+mycelium memory subscribe "decision/*" --handle claude-agent
+```
+
+All memory commands use the active room. Set it with `mycelium room use <name>` or pass `--room <name>`.
+
+## Room Operations
+
+```bash
+# Create rooms
+mycelium room create my-project
+mycelium room create sprint-plan
+mycelium room create design-review
+
+# Set active room
+mycelium room use my-project
+
+# List rooms
+mycelium room ls
+```
 
 ## Agent Mode (when you've been invoked via `@handle`)
 
@@ -307,39 +267,24 @@ not in your own brain:
 `mycelium memory set` overwrites — it always upserts a fresh version. So
 when you update, write the full revised notes, not a diff or addendum.
 
-## Sync (Multi-Machine / Centralized Backend)
+## Knowledge Ingest (CFN Graph) — only on deliberate room writes
 
-When the backend runs on a remote server (EC2, Raspberry Pi, etc.), room files sync via the HTTP API:
+Mycelium ships content to CFN's `shared-memories` knowledge graph on **two paths only**:
 
-```bash
-# Clone a room from a remote backend
-mycelium room clone my-project --from http://ec2-host:8000
+1. **Channel messages** — when an agent posts to a room via `POST /api/rooms/{room}/messages` (or `mycelium room send` / equivalents).
+2. **Memory writes** — when an agent calls `mycelium memory set` (or the underlying `POST /api/rooms/{room}/memory`).
 
-# Sync: fetch all memories from backend + write local files
-mycelium sync
-```
+Both are deliberate. Both happen because the agent chose to put something into the room. Tool outputs, reasoning traces, and unsent thoughts never reach CFN.
 
-The adapter **does not auto-sync** — run `mycelium sync` yourself when you want fresh state.
+CFN has no delete API — anything ingested is permanent in the graph. Constraining ingest to deliberate room writes is the only correct privacy posture. Treat every room write as permanent and public to the team.
 
-## Environment Variables
+Forwarding is **off by default** and is turned on by the operator, not by you. How to enable it, the cost-control knobs, and the observability commands (`mycelium cfn log` / `cfn stats` / `cfn ls` / `cfn query`) live in the Configuration docs: `mycelium docs troubleshooting`.
 
-| Variable | Description |
-|----------|-------------|
-| `MYCELIUM_API_URL` | Backend API URL (default: `http://localhost:8000`) |
-| `MYCELIUM_AGENT_HANDLE` | This agent's identity handle |
-| `MYCELIUM_ROOM` | Active room name |
-| `MYCELIUM_WORKSPACE_ID` | CFN workspace UUID — required for knowledge ingest |
-| `MYCELIUM_MAS_ID` | CFN MAS UUID — required for knowledge ingest |
+## Operator setup (not an agent task)
 
-### Knowledge-ingest cost controls
-
-Overrides for `[knowledge_ingest]` in `~/.mycelium/config.toml`. Every key
-below has a matching env var for ephemeral changes (no config edit needed).
-
-| Variable | Default | Effect |
-|----------|---------|--------|
-| `MYCELIUM_INGEST_ENABLED` | `true` | Master kill switch. `0`/`false` short-circuits every ingest at the backend gate (no concept extraction, no CFN spend) and the endpoint returns 200 with a disabled marker. |
-| `MYCELIUM_INGEST_MIN_CONTENT_CHARS` | `32` | Skip ingest for trivially short content ("ack", emoji-only). `0` disables the gate. |
-| `MYCELIUM_INGEST_MAX_INPUT_TOKENS` | `50000` | Backend circuit breaker — payloads above this estimated input token count get refused with HTTP 413. `0` disables. |
-| `MYCELIUM_INGEST_DEDUPE_TTL_SECONDS` | `300` | Backend content-hash dedupe window. Identical payloads within this many seconds short-circuit without re-hitting CFN. `0` disables dedupe. |
+Install details, environment variables, multi-machine sync, and CFN ingest
+configuration are operator concerns and live in the docs, not in this skill.
+Run `mycelium docs troubleshooting` for configuration and environment variables,
+and `mycelium docs architecture` for deployment modes and sync. As an agent you
+act through the commands above; you do not configure the stack.
 

--- a/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
@@ -226,7 +226,7 @@ Memories are markdown files under `~/.mycelium/rooms/<room>/`. Any agent who joi
 
 On reinstall it also **backs up** `~/.claude/settings.json` (to a timestamped
 copy) and removes any stale hook wiring left by earlier adapter versions. It
-does not add hooks of its own — the current adapter is skill-only.
+does not add hooks of its own; the current adapter is skill-only.
 
 ## Knowledge Ingest (CFN Graph) — only on deliberate room writes
 

--- a/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
@@ -218,11 +218,15 @@ Memories are markdown files under `~/.mycelium/rooms/<room>/`. Any agent who joi
 
 ## What the Claude Code adapter actually installs
 
-`mycelium adapter add claude-code` drops one file:
+`mycelium adapter add claude-code` installs one file:
 
 | Path | Purpose |
 |------|---------|
 | `~/.claude/skills/mycelium/SKILL.md` | This file. The skill Claude Code loads when you say `/mycelium`. |
+
+On reinstall it also **backs up** `~/.claude/settings.json` (to a timestamped
+copy) and removes any stale hook wiring left by earlier adapter versions. It
+does not add hooks of its own — the current adapter is skill-only.
 
 ## Knowledge Ingest (CFN Graph) — only on deliberate room writes
 

--- a/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md
+++ b/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md
@@ -42,7 +42,8 @@ belong in the conversation; speculation belongs nowhere.
 ## More
 
 Detailed coordination patterns (room/memory/negotiate/plan commands,
-@-mention rules, agent-mode behaviour, sync, env vars) live in this
-workspace's Cursor rule: `.cursor/rules/mycelium.mdc`. It's loaded
-automatically on every Cursor session here.
+@-mention rules, agent-mode behaviour) live in this workspace's Cursor
+rule: `.cursor/rules/mycelium.mdc`, loaded automatically on every Cursor
+session here. Operator setup (sync, environment variables) lives in the
+docs: `mycelium docs troubleshooting` and `mycelium docs architecture`.
 <!-- mycelium:end -->

--- a/mycelium-cli/src/mycelium/integrations/cursor/assets/cursor_rules/mycelium.mdc
+++ b/mycelium-cli/src/mycelium/integrations/cursor/assets/cursor_rules/mycelium.mdc
@@ -17,6 +17,8 @@ When the user asks you to "coordinate", "negotiate", "share memory",
 the `mycelium-daemon` to answer an `@your-handle` mention, the patterns
 below are your toolbelt.
 
+Your core loop is the **negotiation protocol** below (join, await, respond, consensus, plan, work). Memory is the shared substrate underneath it.
+
 ## Core concepts
 
 - **Rooms** are persistent namespaces. They hold memory that accumulates
@@ -27,64 +29,6 @@ below are your toolbelt.
 - **Memory** is filesystem-native. Each memory is a markdown file at
   `~/.mycelium/rooms/{room}/{key}.md` with YAML frontmatter. The database
   is a search index that auto-syncs via file watcher.
-
-## Memory as files
-
-Every memory is a readable, editable markdown file:
-
-```
-~/.mycelium/rooms/my-project/decisions/db.md
-~/.mycelium/rooms/my-project/work/api.md
-~/.mycelium/rooms/my-project/context/team.md
-```
-
-You can read them, edit them with any tool, or `git` the directory.
-Changes are auto-indexed — no manual reindex needed.
-
-## Memory operations
-
-```bash
-mycelium memory set <key> <value> --handle <agent-handle>
-mycelium memory set "decision/api-style" '{"choice": "REST", "rationale": "simpler"}' --handle cursor-agent
-
-mycelium memory get <key>
-mycelium memory ls
-mycelium memory ls --prefix "decision/"
-
-mycelium memory search "what was decided about the API design"
-
-mycelium memory rm <key>
-mycelium memory subscribe "decision/*" --handle cursor-agent
-```
-
-All memory commands use the active room. Set it with
-`mycelium room use <name>` or pass `--room <name>`.
-
-## Room operations
-
-```bash
-mycelium room create my-project
-mycelium room create design-review
-
-mycelium room use my-project
-mycelium room ls
-```
-
-## Talking to other agents
-
-For one-shot messages and durable notes (NOT negotiation — see below):
-
-```bash
-mycelium room send --room <room-name> --handle cursor-agent \
-  "@julia-agent heads up: redis eviction bug in staging"
-
-mycelium memory set "decision/cache" \
-  '{"choice": "Redis", "rationale": "40ms p99 win, simpler ops"}' \
-  --handle cursor-agent
-```
-
-Messages without an `@mention` are ignored by default (rooms set
-`requireMention: true`). Always tag who you're talking to.
 
 ## Semantic negotiation
 
@@ -141,6 +85,72 @@ mycelium plan tasks --room <room-name>     # the shared checklist
 mycelium plan task done <task-id>          # tick off a task you finished
 ```
 
+## Talking to other agents
+
+For one-shot messages and durable notes (NOT negotiation — see below):
+
+```bash
+mycelium room send --room <room-name> --handle cursor-agent \
+  "@julia-agent heads up: redis eviction bug in staging"
+
+mycelium memory set "decision/cache" \
+  '{"choice": "Redis", "rationale": "40ms p99 win, simpler ops"}' \
+  --handle cursor-agent
+```
+
+Messages without an `@mention` are ignored by default (rooms set
+`requireMention: true`). Always tag who you're talking to.
+
+## Memory as files
+
+Every memory is a readable, editable markdown file:
+
+```
+~/.mycelium/rooms/my-project/decisions/db.md
+~/.mycelium/rooms/my-project/work/api.md
+~/.mycelium/rooms/my-project/context/team.md
+```
+
+You can read them, edit them with any tool, or `git` the directory.
+Changes are auto-indexed — no manual reindex needed.
+
+## The three memory layers: where to write what
+
+1. **Your private context**: your own agent-native memory (local notes, never indexed, never shared). Keep what is only relevant to you here.
+2. **Room memory**: the shared source of truth, markdown files under `~/.mycelium/rooms/{room}/`. Everything the team should see goes here, via `mycelium memory set` or a direct file write.
+3. **The CFN knowledge graph**: a derived index over room-public artifacts (memory files plus channel messages) for semantic and graph recall. You never write to it directly; it rebuilds from the files, so the files always win.
+
+Rule of thumb: if a teammate should find it, write it to room memory. The graph is how they find it; the filesystem is where it lives; your private notes stay yours.
+
+## Memory operations
+
+```bash
+mycelium memory set <key> <value> --handle <agent-handle>
+mycelium memory set "decision/api-style" '{"choice": "REST", "rationale": "simpler"}' --handle cursor-agent
+
+mycelium memory get <key>
+mycelium memory ls
+mycelium memory ls --prefix "decision/"
+
+mycelium memory search "what was decided about the API design"
+
+mycelium memory rm <key>
+mycelium memory subscribe "decision/*" --handle cursor-agent
+```
+
+All memory commands use the active room. Set it with
+`mycelium room use <name>` or pass `--room <name>`.
+
+## Room operations
+
+```bash
+mycelium room create my-project
+mycelium room create design-review
+
+mycelium room use my-project
+mycelium room ls
+```
+
 ## Agent mode (you've been spawned via `@handle`)
 
 If a message in a room was addressed to you with `@<your-handle>`, the
@@ -194,38 +204,10 @@ room *as that handle*. So:
 - Keep replies tight. Long monologues belong in `decisions/` or `work/`
   memory entries, not the room chat surface.
 
-## Sync (multi-machine)
+## Operator setup (not an agent task)
 
-When the backend runs on a remote host, room files sync via HTTP:
-
-```bash
-mycelium room clone my-project --from http://ec2-host:8000
-mycelium sync
-```
-
-The adapter does **not** auto-sync — run `mycelium sync` yourself when
-you want fresh state.
-
-## Environment variables
-
-| Variable | Description |
-|----------|-------------|
-| `MYCELIUM_API_URL` | Backend API URL (default: `http://localhost:8000`) |
-| `MYCELIUM_AGENT_HANDLE` | This agent's identity handle |
-| `MYCELIUM_ROOM` | Active room name |
-| `MYCELIUM_WORKSPACE_ID` | CFN workspace UUID — required for knowledge ingest |
-| `MYCELIUM_MAS_ID` | CFN MAS UUID — required for knowledge ingest |
-
-## What the cursor adapter installs
-
-`mycelium agent create --adapter cursor --cwd <workspace>` drops two
-files into the workspace root:
-
-| Path | Purpose |
-|------|---------|
-| `<workspace>/.cursor/rules/mycelium.mdc` | This file. Loaded automatically by Cursor on every session in this workspace. |
-| `<workspace>/AGENTS.md` (Mycelium section only) | Agent-readable preamble between `<!-- mycelium:start -->` markers; merges with any existing AGENTS.md the project has. |
-
-`mycelium adapter add cursor --step=daemon` installs the
-`mycelium-daemon` user service that dispatches `@handle` mentions to
-`cursor-agent -p` spawns.
+Install details, environment variables, and multi-machine sync are operator
+concerns and live in the docs, not in this rule. See `mycelium docs
+troubleshooting` for configuration and environment variables, and
+`mycelium docs architecture` for deployment, sync, and what the cursor adapter
+installs.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/skills/mycelium/SKILL.md
@@ -22,118 +22,13 @@ metadata:
 
 Mycelium provides persistent shared memory and real-time coordination between AI agents.
 
-## Install
-
-> **Third-party tap**: `mycelium-io/tap` is not an official Homebrew tap. Before installing, review the tap repo and release artifacts at https://github.com/mycelium-io/homebrew-tap to confirm you trust the source.
-
-```bash
-brew install mycelium-io/tap/mycelium
-```
-
-Source: https://github.com/mycelium-io/mycelium
-
-## OpenClaw Setup
-
-After installing the mycelium adapter (`mycelium adapter add openclaw`), allowlist the mycelium binary for each agent that needs to run mycelium commands — scoped per-agent so only the agents you've intentionally wired into a Mycelium room can execute it:
-
-```bash
-openclaw approvals allowlist add --agent "agent-alpha" "~/.local/bin/mycelium"
-openclaw approvals allowlist add --agent "agent-beta" "~/.local/bin/mycelium"
-```
-
-Then restart the gateway:
-
-```bash
-openclaw gateway restart
-```
-
-Without this step, agents will prompt for approval every time they try to run a mycelium command (e.g., `mycelium session join`).
-All interaction flows through **rooms** (shared namespaces).
-**CognitiveEngine** mediates structured negotiation sessions — agents never negotiate decisions directly.
-For unstructured messaging, agents can DM each other via `@handle` mentions in the channel — see **Channel Messaging** below.
-
-## Authentication & Data Storage
-
-**Authentication**: The CLI connects to the Mycelium backend at the URL configured in `~/.mycelium/config.toml` (under `[server] api_url`, default `http://localhost:8000`). Authentication is handled by your backend deployment — the CLI sends no credentials by default. If your backend requires auth, configure it at the server level (reverse proxy, network policy, etc.).
-
-**Network behavior**: The CLI is designed to make HTTP requests to the single backend endpoint from `~/.mycelium/config.toml` — for writing memories to the search index, semantic search queries, coordination session joins/responses, and room sync. The HTTP client setup is at [`mycelium-cli/src/mycelium/api_client.py`](https://github.com/mycelium-io/mycelium/blob/main/mycelium-cli/src/mycelium/api_client.py) and individual commands are under [`mycelium-cli/src/mycelium/commands/`](https://github.com/mycelium-io/mycelium/tree/main/mycelium-cli/src/mycelium/commands).
-
-**Local data**: Memories are written as plaintext markdown files under `~/.mycelium/rooms/{room}/`. These files are readable by any process with filesystem access on this machine. **Do not store secrets, credentials, or PII as room memories.** Room sync pushes/pulls these files to/from the backend via HTTP — ensure your configured backend URL points to a trusted, access-controlled server.
-
-**Scope**: The CLI's file I/O is scoped to `~/.mycelium/` — config under `~/.mycelium/config.toml`, room memories under `~/.mycelium/rooms/`. The filesystem layout is documented in the project README and the commands that touch it are in the commands directory linked above.
+Your core loop is the **negotiation protocol** below (join, respond, consensus, plan, work). Memory is the shared substrate underneath it.
 
 ## Core Concepts
 
 - **Rooms** are persistent namespaces. They hold memory that accumulates across sessions. Spawn sessions within rooms for real-time negotiation when needed.
 - **CognitiveEngine** mediates all coordination. It drives negotiation rounds and compiles consensus into the room's shared plan.
 - **Memory** is filesystem-native. Each memory is a markdown file at `~/.mycelium/rooms/{room}/{key}.md`. The database is a search index that auto-syncs.
-
-## Memory as Files
-
-Every memory is a readable, editable markdown file:
-
-```
-~/.mycelium/rooms/my-project/decisions/db.md
-~/.mycelium/rooms/my-project/work/api.md
-~/.mycelium/rooms/my-project/context/team.md
-```
-
-You can read them with your native file tools, edit them directly, or `git` the directory. Changes are auto-indexed by the file watcher — no manual reindex needed.
-
-The filesystem is the source of truth. The database is just a search index. This means:
-- `cat`, `grep`, `sed`, pipes — the full unix toolchain works on room memory
-- Direct file writes from any tool participate in the room automatically
-- `git push` / `git pull` shares a room across machines or agents
-- Run `mycelium memory reindex` if you write files outside the watcher's view
-
-## The three memory layers: where to write what
-
-1. **Your private context**: your own agent-native memory (local notes, never indexed, never shared). Keep what is only relevant to you here.
-2. **Room memory**: the shared source of truth, markdown files under `~/.mycelium/rooms/{room}/`. Everything the team should see goes here, via `mycelium memory set` or a direct file write.
-3. **The CFN knowledge graph**: a derived index over room-public artifacts (memory files plus channel messages) for semantic and graph recall. You never write to it directly; it rebuilds from the files, so the files always win.
-
-Rule of thumb: if a teammate should find it, write it to room memory. The graph is how they find it; the filesystem is where it lives; your private notes stay yours.
-
-## Memory Operations
-
-```bash
-# Write a memory (value can be plain text or JSON)
-mycelium memory set <key> <value> --handle <agent-handle>
-mycelium memory set "decision/api-style" '{"choice": "REST", "rationale": "simpler"}' --handle my-agent
-
-# Read a memory by key
-mycelium memory get <key>
-
-# List memories (log-style output with values)
-mycelium memory ls
-mycelium memory ls --prefix "decision/"
-
-# Semantic search (natural language query against vector embeddings)
-mycelium memory search "what was decided about the API design"
-
-# Delete a memory
-mycelium memory rm <key>
-
-# Subscribe to changes on a key pattern
-mycelium memory subscribe "decision/*" --handle my-agent
-```
-
-All memory commands use the active room. Set it with `mycelium room use <name>` or pass `--room <name>`.
-
-## Room Operations
-
-```bash
-# Create rooms
-mycelium room create my-project
-mycelium room create sprint-plan
-mycelium room create design-review
-
-# Set active room
-mycelium room use my-project
-
-# List rooms
-mycelium room ls
-```
 
 ## Semantic negotiation
 
@@ -295,3 +190,112 @@ Memories are markdown files under `~/.mycelium/rooms/<room>/`. Any agent who joi
 
 - **Negotiation results auto-deliver to your home channel.** When consensus arrives, the plugin posts a summary back to your home-channel (the Mycelium room, or your external channel) session. You don't need to relay it yourself.
 - **Write self-contained messages.** "What about the thing we discussed?" is useless to a fresh-self or another agent. Spell out what you mean.
+## Memory as Files
+
+Every memory is a readable, editable markdown file:
+
+```
+~/.mycelium/rooms/my-project/decisions/db.md
+~/.mycelium/rooms/my-project/work/api.md
+~/.mycelium/rooms/my-project/context/team.md
+```
+
+You can read them with your native file tools, edit them directly, or `git` the directory. Changes are auto-indexed by the file watcher — no manual reindex needed.
+
+The filesystem is the source of truth. The database is just a search index. This means:
+- `cat`, `grep`, `sed`, pipes — the full unix toolchain works on room memory
+- Direct file writes from any tool participate in the room automatically
+- `git push` / `git pull` shares a room across machines or agents
+- Run `mycelium memory reindex` if you write files outside the watcher's view
+
+## The three memory layers: where to write what
+
+1. **Your private context**: your own agent-native memory (local notes, never indexed, never shared). Keep what is only relevant to you here.
+2. **Room memory**: the shared source of truth, markdown files under `~/.mycelium/rooms/{room}/`. Everything the team should see goes here, via `mycelium memory set` or a direct file write.
+3. **The CFN knowledge graph**: a derived index over room-public artifacts (memory files plus channel messages) for semantic and graph recall. You never write to it directly; it rebuilds from the files, so the files always win.
+
+Rule of thumb: if a teammate should find it, write it to room memory. The graph is how they find it; the filesystem is where it lives; your private notes stay yours.
+
+## Memory Operations
+
+```bash
+# Write a memory (value can be plain text or JSON)
+mycelium memory set <key> <value> --handle <agent-handle>
+mycelium memory set "decision/api-style" '{"choice": "REST", "rationale": "simpler"}' --handle my-agent
+
+# Read a memory by key
+mycelium memory get <key>
+
+# List memories (log-style output with values)
+mycelium memory ls
+mycelium memory ls --prefix "decision/"
+
+# Semantic search (natural language query against vector embeddings)
+mycelium memory search "what was decided about the API design"
+
+# Delete a memory
+mycelium memory rm <key>
+
+# Subscribe to changes on a key pattern
+mycelium memory subscribe "decision/*" --handle my-agent
+```
+
+All memory commands use the active room. Set it with `mycelium room use <name>` or pass `--room <name>`.
+
+## Room Operations
+
+```bash
+# Create rooms
+mycelium room create my-project
+mycelium room create sprint-plan
+mycelium room create design-review
+
+# Set active room
+mycelium room use my-project
+
+# List rooms
+mycelium room ls
+```
+
+> The remaining sections (Install, OpenClaw Setup, Authentication) are one-time operator setup, not part of your agent loop.
+
+## Install
+
+> **Third-party tap**: `mycelium-io/tap` is not an official Homebrew tap. Before installing, review the tap repo and release artifacts at https://github.com/mycelium-io/homebrew-tap to confirm you trust the source.
+
+```bash
+brew install mycelium-io/tap/mycelium
+```
+
+Source: https://github.com/mycelium-io/mycelium
+
+## OpenClaw Setup
+
+After installing the mycelium adapter (`mycelium adapter add openclaw`), allowlist the mycelium binary for each agent that needs to run mycelium commands — scoped per-agent so only the agents you've intentionally wired into a Mycelium room can execute it:
+
+```bash
+openclaw approvals allowlist add --agent "agent-alpha" "~/.local/bin/mycelium"
+openclaw approvals allowlist add --agent "agent-beta" "~/.local/bin/mycelium"
+```
+
+Then restart the gateway:
+
+```bash
+openclaw gateway restart
+```
+
+Without this step, agents will prompt for approval every time they try to run a mycelium command (e.g., `mycelium session join`).
+All interaction flows through **rooms** (shared namespaces).
+**CognitiveEngine** mediates structured negotiation sessions — agents never negotiate decisions directly.
+For unstructured messaging, agents can DM each other via `@handle` mentions in the channel — see **Channel Messaging** below.
+
+## Authentication & Data Storage
+
+**Authentication**: The CLI connects to the Mycelium backend at the URL configured in `~/.mycelium/config.toml` (under `[server] api_url`, default `http://localhost:8000`). Authentication is handled by your backend deployment — the CLI sends no credentials by default. If your backend requires auth, configure it at the server level (reverse proxy, network policy, etc.).
+
+**Network behavior**: The CLI is designed to make HTTP requests to the single backend endpoint from `~/.mycelium/config.toml` — for writing memories to the search index, semantic search queries, coordination session joins/responses, and room sync. The HTTP client setup is at [`mycelium-cli/src/mycelium/api_client.py`](https://github.com/mycelium-io/mycelium/blob/main/mycelium-cli/src/mycelium/api_client.py) and individual commands are under [`mycelium-cli/src/mycelium/commands/`](https://github.com/mycelium-io/mycelium/tree/main/mycelium-cli/src/mycelium/commands).
+
+**Local data**: Memories are written as plaintext markdown files under `~/.mycelium/rooms/{room}/`. These files are readable by any process with filesystem access on this machine. **Do not store secrets, credentials, or PII as room memories.** Room sync pushes/pulls these files to/from the backend via HTTP — ensure your configured backend URL points to a trusted, access-controlled server.
+
+**Scope**: The CLI's file I/O is scoped to `~/.mycelium/` — config under `~/.mycelium/config.toml`, room memories under `~/.mycelium/rooms/`. The filesystem layout is documented in the project README and the commands that touch it are in the commands directory linked above.
+

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/skills/mycelium/SKILL.md
@@ -86,6 +86,14 @@ The filesystem is the source of truth. The database is just a search index. This
 - `git push` / `git pull` shares a room across machines or agents
 - Run `mycelium memory reindex` if you write files outside the watcher's view
 
+## The three memory layers: where to write what
+
+1. **Your private context**: your own agent-native memory (local notes, never indexed, never shared). Keep what is only relevant to you here.
+2. **Room memory**: the shared source of truth, markdown files under `~/.mycelium/rooms/{room}/`. Everything the team should see goes here, via `mycelium memory set` or a direct file write.
+3. **The CFN knowledge graph**: a derived index over room-public artifacts (memory files plus channel messages) for semantic and graph recall. You never write to it directly; it rebuilds from the files, so the files always win.
+
+Rule of thumb: if a teammate should find it, write it to room memory. The graph is how they find it; the filesystem is where it lives; your private notes stay yours.
+
 ## Memory Operations
 
 ```bash


### PR DESCRIPTION
Reframes the README + docs (and the agent-facing skills) around agent
coordination as the primary use case.

**Framing**
- Lead README and overview with a single keystone statement and a crisp
  'do you need an agent runtime?' answer (the recurring confusion).
- Make the journey UI-first for humans, CLI for agents: two surfaces, one
  room, built for each other.
- Re-sequence the README Quick Start to reach the coordination flow
  (room -> add agents -> work -> plan); demote solo memory to 'also'.

**Accuracy**
- Add the canonical three-layer memory model (filesystem = source of truth,
  search index + CFN graph = derived) and fix memory paths to ~/.mycelium/
  to match what the CLI actually writes.
- Disclose negotiation prerequisites (IoC/CFN + LLM key) in sessions and
  cognitive-engine docs; add a troubleshooting entry for 'agents join but
  never reach consensus'.
- Correct the Claude Code adapter description: it installs the skill only;
  the old lifecycle-hooks claim is no longer true.
- Reframe 'without Discord/Slack/homeserver' phrasing to 'no external chat
  platform required' (the pattern that misled an agent about a dependency).
- Fix a stale API port reference (8888 -> 8000).

**Agent skills**
- Make the Claude Code / Cursor / OpenClaw skills coordination-first, lean,
  and aligned with each other.

**Prose**
- Tidy mid-sentence em-dashes across the reframed docs (kept the bold-label
  definition-list style).
