### PR TITLE
docs: restructure site into intent-based pages + typographic system

### DIFF
--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -34,7 +34,8 @@
 </nav>
 <nav class="sectionnav">
   <div class="sectionnav-inner">
-    <a href="index.html" class=""><span class="square-dot"></span>LEARN</a>
+    <a href="index.html" class=""><span class="square-dot"></span>GET STARTED</a>
+    <a href="concepts.html" class=""><span class="square-dot"></span>CONCEPTS</a>
     <a href="adapters.html" class="active"><span class="square-dot"></span>ADAPTERS</a>
     <a href="reference.html" class=""><span class="square-dot"></span>REFERENCE</a>
     <div class="sectionnav-right">

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -1,0 +1,455 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Concepts — mycelium</title>
+<meta name="description" content="The core concepts behind Mycelium: rooms, sessions, memory, plan, CognitiveEngine, and the knowledge graph.">
+<meta property="og:title" content="Concepts — mycelium">
+<meta property="og:description" content="The core concepts behind Mycelium: rooms, sessions, memory, plan, CognitiveEngine, and the knowledge graph.">
+<meta property="og:image" content="https://mycelium-io.github.io/mycelium/og.png">
+<meta property="og:url" content="https://mycelium-io.github.io/mycelium/concepts.html">
+<meta property="og:type" content="website">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="https://mycelium-io.github.io/mycelium/og.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="stylesheet" href="mycelium.css">
+</head>
+<body>
+<canvas id="mycelium-bg"></canvas>
+<!-- TOP NAV -->
+<nav class="topnav">
+  <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
+    <img src="logo.png" alt="Mycelium">
+    <span class="brand-word">mycelium</span>
+  </a>
+  <span class="topnav-cell topnav-page-cell">
+    <span class="caps-mono">DOCS</span>
+  </span>
+  <div class="topnav-right">
+    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
+    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
+    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub" style="display:flex;align-items:center;"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
+  </div>
+</nav>
+<nav class="sectionnav">
+  <div class="sectionnav-inner">
+    <a href="index.html" class=""><span class="square-dot"></span>GET STARTED</a>
+    <a href="concepts.html" class="active"><span class="square-dot"></span>CONCEPTS</a>
+    <a href="adapters.html" class=""><span class="square-dot"></span>ADAPTERS</a>
+    <a href="reference.html" class=""><span class="square-dot"></span>REFERENCE</a>
+    <div class="sectionnav-right">
+    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/skills/mycelium/SKILL.md" target="_blank">SKILL.md ↗</a>
+    </div>
+  </div>
+</nav>
+<div class="layout">
+
+  <nav class="sidebar">
+    <div class="nav-section">
+      <div class="nav-section-label">Concepts</div>
+      <a href="#rooms" class="nav-link sub">Rooms</a>
+      <a href="#sessions" class="nav-link sub">Sessions</a>
+      <a href="#memory" class="nav-link sub">Memory</a>
+      <a href="#plan" class="nav-link sub">Plan</a>
+      <a href="#cognitive-engine" class="nav-link sub">CognitiveEngine</a>
+      <a href="#knowledge-graph" class="nav-link sub">Knowledge Graph</a>
+    </div>
+  </nav>
+
+  <!-- MAIN -->
+  <main class="main">
+  <div class="main-inner">
+    <section class="doc-section" id="rooms">
+      <h1>Rooms</h1>
+      <p>A room is a persistent coordination namespace. All memories, sessions, and messages are scoped to a room. A room IS its namespace — there&#x27;s no separation between the two.</p>
+      <p>Rooms hold persistent state (memories, knowledge graph). When agents need to negotiate in real time, they spawn <strong>sessions</strong> within a room. Sessions are ephemeral sync negotiation rounds; the room outlives them.</p>
+      <h2 id="rooms-rooms-are-directories">Rooms are Directories</h2>
+      <p>Each room maps to a directory at <code>~/.mycelium/rooms/{room_name}/</code>. Standard subdirectories are created automatically:</p>
+      <pre><code>~/.mycelium/rooms/design-review/
+  decisions/   context/   status/    plan/
+  work/        procedures/   log/   failed/</code></pre>
+      <p>The <code>plan/</code> subdir holds the room&#x27;s plan — a free-form set of markdown files plus the <code>- [ ]</code> / <code>- [x]</code> checklist lines those files contain. <code>plan/title.md</code> holds the room&#x27;s display title (shown italicised above room activity in the UI). The rest are arbitrary <code>plan/{slug}.md</code> files containing prose and tasks. See <a href="#"><code>mycelium plan</code></a> for read/write commands and <code>plan task add|done|undo</code> for checkbox edits.</p>
+      <p>You can browse, edit, or git-track these directories directly. The backend keeps its search index in sync via startup scans and file watching.</p>
+      <h2 id="rooms-session-state-machine">Session State Machine</h2>
+      <p>Sessions spawned within rooms follow a state machine:</p>
+      <pre><code>idle → waiting → negotiating → complete
+          ↑         ↓
+      (join window fires)</code></pre>
+      <p>Once <code>complete</code>, the consensus is compiled into the room&#x27;s shared plan (<code>plan/tasks.md</code>) — a <code>- [ ]</code> checklist the team works from. The arc is <code>join → negotiate → plan → work</code>; the room and its plan outlive the session.</p>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="sessions">
+      <h1>Sessions</h1>
+      <p>A session is an ephemeral sync negotiation round spawned within a room. Rooms hold persistent state (memories, knowledge graph). Sessions handle real-time coordination.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Prerequisites for negotiation.</strong> Sessions need two things that <code>mycelium install</code> sets up by default: the <strong>IoC/CFN</strong> coordination backend (without it, <code>session join</code> returns &quot;CFN: not configured&quot;), and an <strong>LLM key</strong> (the CognitiveEngine uses it to generate proposals; in &quot;stub mode&quot; agents join but never reach consensus). Memory and rooms work without either; negotiation does not.</div>
+      </div>
+      <h2 id="sessions-lifecycle">Lifecycle</h2>
+      <ol class="steps">
+        <li><strong>Create</strong> — <code>mycelium session create</code> spawns a session within your active room.</li>
+        <li><strong>Join</strong> — Agents join with <code>mycelium session join -m &quot;your position&quot;</code>. The first join starts a 60-second window for others to join.</li>
+        <li><strong>Await</strong> — <code>mycelium session await</code> blocks until the CognitiveEngine has an action for your agent (propose, respond, or done).</li>
+        <li><strong>Negotiate</strong> — Agents propose and respond in structured rounds mediated by the CognitiveEngine.</li>
+        <li><strong>Complete</strong> — The session reaches consensus. The agreement is compiled into the room&#x27;s <a href="#plan">shared plan</a> (<code>plan/tasks.md</code>); the session is done, the room and its plan persist.</li>
+      </ol>
+      <p>The arc doesn&#x27;t stop at consensus — it flows into work: <strong>join → negotiate → plan → work</strong>. A consensus decides *what*; the plan is *how the team carries it out*.</p>
+      <h2 id="sessions-state-machine">State Machine</h2>
+      <pre><code>idle → waiting → negotiating → complete
+          ↑         ↓
+      (first join)  (CE tick-0)</code></pre>
+      <ul>
+        <li><strong>idle</strong> — Session created, no agents yet.</li>
+        <li><strong>waiting</strong> — At least one agent joined. 60-second window for others.</li>
+        <li><strong>negotiating</strong> — CognitiveEngine is running the NegMAS pipeline.</li>
+        <li><strong>complete</strong> — Consensus reached and compiled into the room&#x27;s <code>plan/tasks.md</code>. Agents pick up the shared checklist and work it.</li>
+      </ul>
+      <h2 id="sessions-rooms-vs-sessions">Rooms vs Sessions</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              <th>Room</th>
+              <th>Session</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Lifetime</td>
+              <td>Persistent</td>
+              <td>Ephemeral</td>
+            </tr>
+            <tr>
+              <td>Purpose</td>
+              <td>Namespace for memory + coordination</td>
+              <td>Single negotiation round</td>
+            </tr>
+            <tr>
+              <td>State</td>
+              <td>Always idle</td>
+              <td>idle → waiting → negotiating → complete</td>
+            </tr>
+            <tr>
+              <td>Memory</td>
+              <td>Yes — scoped to room</td>
+              <td>No — uses parent room&#x27;s memory</td>
+            </tr>
+            <tr>
+              <td>Multiple</td>
+              <td>One room, many sessions over time</td>
+              <td>Each session is independent</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <h2 id="sessions-multiple-rounds">Multiple Rounds</h2>
+      <p>A room can host many sessions over time. When one session completes, agents can spawn a new one for the next decision. The room&#x27;s memory persists across all sessions, so each round starts with full context from previous rounds.</p>
+      <pre><code><span class="comment"># First negotiation</span>
+<span class="cmd">mycelium session create</span> <span class="flag">-r</span> sprint-plan
+<span class="cmd">mycelium session join</span> <span class="flag">-m</span> <span class="str">&quot;Prioritize database migration&quot;</span> <span class="flag">-r</span> sprint-plan
+
+<span class="comment"># ... negotiation completes ...</span>
+
+<span class="comment"># Second negotiation (room memory carries over)</span>
+<span class="cmd">mycelium session create</span> <span class="flag">-r</span> sprint-plan
+<span class="cmd">mycelium session join</span> <span class="flag">-m</span> &quot;Now let&#x27;s plan the API layer&quot; <span class="flag">-r</span> sprint-plan</code></pre>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="memory">
+      <h1>Memory</h1>
+      <p>Room memory is markdown files on your filesystem: the shared source of truth, greppable and editable by any agent. The CFN knowledge graph is a derived index over those files, for recall by meaning and relationship, never an independent source of writes. Whatever stays private to one agent stays in that agent&#x27;s own local memory, never indexed.</p>
+      <h2 id="memory-three-layers-one-source-of-truth">Three layers, one source of truth</h2>
+      <p>Mycelium memory has three layers, and only the middle one is &quot;the memory&quot;:</p>
+      <ol class="steps">
+        <li><strong>Your private context</strong> is yours alone: agent-native files like <code>SOUL.md</code></li>
+      </ol>
+      <p>or per-agent notes that never leave your machine and are never indexed or shared. Anything only you need lives here.</p>
+      <ol class="steps">
+        <li><strong>Room memory</strong> is the shared source of truth: markdown files under</li>
+      </ol>
+      <p><code>~/.mycelium/rooms/{room}/</code> that every agent in the room can read, <code>grep</code>, edit, and <code>git</code>-track. If the team should know it, write it here.</p>
+      <ol class="steps">
+        <li><strong>The CFN knowledge graph</strong> is a derived view, not a place you write to.</li>
+      </ol>
+      <p>Mycelium indexes the room&#x27;s public artifacts (memory files plus channel messages) into it so agents can recall by meaning and by relationship. It rebuilds from the files, so the files always win.</p>
+      <p>Rule of thumb: if a teammate should find it, put it in room memory. The graph is how they find it; the filesystem is where it lives; your private notes stay yours.</p>
+      <p>Every write to room memory is embedded (384-dim, local, no API key) and indexed for semantic search.</p>
+      <h2 id="memory-namespace-conventions">Namespace Conventions</h2>
+      <p>Keys use <code>/</code> as a separator. This is a convention, not enforced structure — but it makes <code>memory ls &lt;prefix&gt;/</code> very useful.</p>
+      <pre><code><span class="comment"># Decisions your team made</span>
+<span class="cmd">mycelium memory set</span> <span class="str">&quot;decisions/db&quot;</span> <span class="str">&quot;AgensGraph — SQL + graph + vector in one&quot;</span>
+
+<span class="comment"># Things that failed (so nobody repeats them)</span>
+<span class="cmd">mycelium memory set</span> <span class="str">&quot;failed/sqlite&quot;</span> &quot;Can&#x27;t handle pgvector or JSONB&quot;
+
+<span class="comment"># Per-agent status (handle is just attribution)</span>
+<span class="cmd">mycelium memory set</span> <span class="str">&quot;status/prometheus&quot;</span> <span class="str">&quot;Working on CFN integration&quot;</span> <span class="flag">--handle</span> prometheus-agent
+
+<span class="comment"># Browse a namespace</span>
+<span class="cmd">mycelium memory ls</span> decisions/
+<span class="cmd">mycelium memory ls</span> failed/</code></pre>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Always upserts.</strong> Calling <code>memory set</code> on an existing key overwrites it. The version number increments automatically so you can track changes.</div>
+      </div>
+      <h2 id="memory-filesystem-native-storage">Filesystem-Native Storage</h2>
+      <p>Every memory is a markdown file at <code>~/.mycelium/rooms/{room}/{key}.md</code> with YAML frontmatter. You can read, edit, or version-control these files directly.</p>
+      <pre><code><span class="comment"># View the raw file</span>
+cat ~/.mycelium/rooms/design-review/decisions/database.md
+
+<span class="comment"># Edit with any tool</span>
+vim ~/.mycelium/rooms/design-review/decisions/database.md
+
+<span class="comment"># Git-track a room&#x27;s memory</span>
+cd ~/.mycelium/rooms/design-review &amp;&amp; git init</code></pre>
+      <p>The pgvector search index auto-syncs when:</p>
+      <ul>
+        <li>You use <code>mycelium memory set</code> (immediate dual-write)</li>
+        <li>The backend starts up (incremental scan of changed files)</li>
+        <li>Files change on disk while the backend is running (file watcher)</li>
+      </ul>
+      <p>For bulk edits, you can also trigger a manual reindex:</p>
+      <pre><code><span class="cmd">mycelium memory reindex</span></code></pre>
+      <h2 id="memory-semantic-search">Semantic Search</h2>
+      <p>Search finds memories by meaning — cosine similarity on all-MiniLM-L6-v2 embeddings (384 dimensions, runs locally).</p>
+      <pre><code><span class="cmd">mycelium memory search</span> <span class="str">&quot;what database decisions were made&quot;</span>
+<span class="cmd">mycelium memory search</span> <span class="str">&quot;what failed and why&quot;</span>
+<span class="cmd">mycelium memory search</span> <span class="str">&quot;what is the current status&quot;</span></code></pre>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="plan">
+      <h1>Plan</h1>
+      <p>A room&#x27;s <strong>plan</strong> is the place to write down what the room is for and what&#x27;s left to do. It lives in <code>~/.mycelium/rooms/{room}/plan/</code> as a small set of markdown files, plus the <code>- [ ]</code> / <code>- [x]</code> checklist lines inside them.</p>
+      <p>Plan content is surfaced to every agent in the room — on every coordination tick (sync path) and in every agent-context briefing (async path) — so agents weigh their behaviour against work that&#x27;s already committed.</p>
+      <p>You can write the plan by hand (<code>plan set</code>, <code>plan task add</code>), but it also fills itself: when a <a href="#sessions">negotiation session</a> reaches consensus, Mycelium compiles the agreement into <code>plan/tasks.md</code> automatically — a <code>- [ ]</code> checklist the whole team then executes against. A re-negotiation updates that same plan, preserving tasks already completed. The arc is <strong>join → negotiate → plan → work</strong>.</p>
+      <h2 id="plan-anatomy">Anatomy</h2>
+      <pre><code>.mycelium/rooms/{room}/plan/
+├── title.md          # one-line italic display title (shown above room activity)
+├── tasks.md          # default todo file written by `plan task add`
+└── {slug}.md         # any number of additional plan files (prose + checklists)</code></pre>
+      <p><code>title.md</code> is special: its first non-empty line becomes the room&#x27;s displayed title (italic Cormorant Garamond in the UI, surfaced as a chip in the CLI). All other <code>plan/*.md</code> files are arbitrary — they appear as chips in the room header and as grouped task buckets in <code>plan tasks</code>.</p>
+      <h2 id="plan-cli">CLI</h2>
+      <pre><code><span class="comment"># Title</span>
+<span class="cmd">mycelium plan title</span>                                # read
+<span class="cmd">mycelium plan title</span> <span class="str">&quot;Plan the Q3 sprint priorities&quot;</span>  # set
+
+<span class="comment"># Files (each is a memory file under plan/&lt;slug&gt;)</span>
+<span class="cmd">mycelium plan ls</span>
+<span class="cmd">mycelium plan show</span> sprint
+<span class="cmd">mycelium plan set</span> sprint <span class="str">&quot;# Sprint\n\n- [ ] cut a release branch&quot;</span>
+<span class="cmd">mycelium plan rm</span> sprint
+
+<span class="comment"># Tasks (markdown checklist lines across every plan file)</span>
+<span class="cmd">mycelium plan tasks</span>                  # open tasks only
+<span class="cmd">mycelium plan tasks</span> <span class="flag">--all</span>            # include completed
+<span class="cmd">mycelium plan task</span> add <span class="str">&quot;ship the demo&quot;</span>          # appends to plan/tasks.md
+<span class="cmd">mycelium plan task</span> add <span class="str">&quot;draft API&quot;</span> <span class="flag">--file</span> sprint # appends to plan/sprint.md
+<span class="cmd">mycelium plan task</span> done              # interactive multi-select over open tasks
+<span class="cmd">mycelium plan task</span> done tasks:3 sprint:7
+<span class="cmd">mycelium plan task</span> undo              # interactive multi-select over done tasks</code></pre>
+      <p>Task IDs are <code>&lt;slug&gt;:&lt;line&gt;</code> and stable as long as the file isn&#x27;t reflowed.</p>
+      <h2 id="plan-how-agents-see-it">How agents see it</h2>
+      <p>Plan files share the same memory-style markdown-with-frontmatter convention, so they live alongside <code>work/</code>, <code>decisions/</code>, etc. and are readable to anyone opening the room directory.</p>
+      <p>During a live coordination tick, the open task list is also rendered into every agent&#x27;s prompt under a dedicated <strong>Open tasks</strong> header — both CLI agents (raw payload field <code>plan_open_tasks</code>) and OpenClaw agents (rendered into the dispatched instruction string).</p>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="cognitive-engine">
+      <h1>CognitiveEngine</h1>
+      <p>CognitiveEngine is the mediator. It sits between all agents and drives negotiation. Agents never talk to each other directly — all coordination flows through CE.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>CE requires an LLM key and the IoC/CFN backend.</strong> Both are provisioned by <code>mycelium install</code> (interactive) by default. Without an LLM key the engine can&#x27;t synthesize proposals; without IoC/CFN, <code>session join</code> rejects the negotiation outright. See <strong>sessions</strong> for the full prerequisite list.</div>
+      </div>
+      <h2 id="cognitive-engine-negotiation-flow">Negotiation flow</h2>
+      <p>In sessions:</p>
+      <ol class="steps">
+        <li>Agents call <code>session join</code> with their initial position and handle.</li>
+        <li>The join window stays open until no new agents have joined for the configured</li>
+      </ol>
+      <p>extension period (default 30s after each join, capped at 180s from first join). When the window closes, CE starts the <strong>SemanticNegotiationPipeline</strong> on the joined positions.</p>
+      <ol class="steps">
+        <li>CE sends each agent a <code>coordination_tick</code> with <code>action: respond</code>. The tick</li>
+      </ol>
+      <p>payload tells the agent everything it needs to decide:</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>What it tells you</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>current_offer</code></td>
+              <td>The proposal on the table this round</td>
+            </tr>
+            <tr>
+              <td><code>can_counter_offer</code></td>
+              <td>Whether *you* are the designated proposer this round</td>
+            </tr>
+            <tr>
+              <td><code>round</code> / <code>n_steps_total</code></td>
+              <td>Where you are in the round budget</td>
+            </tr>
+            <tr>
+              <td><code>your_last_action</code></td>
+              <td>What you (the recipient) did last round</td>
+            </tr>
+            <tr>
+              <td><code>prior_round_outcome</code></td>
+              <td>What happened previously: <code>first_round</code>, <code>proposer_countered</code>, <code>rejected_by_&lt;id&gt;</code>, <code>agreed</code>, <code>no_consensus</code></td>
+            </tr>
+            <tr>
+              <td><code>issues</code> / <code>issue_options</code></td>
+              <td>The full negotiation space</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <ol class="steps">
+        <li>Agents reply with <code>propose</code> (counter-offer, only when <code>can_counter_offer: true</code>)</li>
+      </ol>
+      <p>or <code>respond accept|reject</code>.</p>
+      <ol class="steps">
+        <li>Rounds continue until consensus or the round budget (<code>n_steps_total</code>) is</li>
+      </ol>
+      <p>exhausted. Consensus requires <strong>all agents</strong> to accept the same offer in the same round. The final tick is <code>coordination_consensus</code> with <code>broken: false</code> and the agreed plan; if no agreement is reached, <code>broken: true</code> is posted and the room moves to <code>failed</code> state.</p>
+      <ol class="steps">
+        <li>On consensus, the agreement is handed to the <strong>plan compiler</strong> — an LLM</li>
+      </ol>
+      <p>stage that turns the raw <code>issue=value</code> agreement into the room&#x27;s <a href="#plan">shared plan</a>, <code>plan/tasks.md</code>, a <code>- [ ]</code> checklist the team executes against. This runs before the <code>coordination_consensus</code> message is posted, so the plan exists by the time <code>session await</code> returns. The compiler is a separate stage that *consumes* the negotiation outcome — not part of the negotiation engine itself.</p>
+      <p>Walking away with no agreement is a legitimate outcome. The protocol does not have a &quot;concede gradually&quot; mechanism for LLM agents — if your hard constraints can&#x27;t be met, keep rejecting until the round budget is exhausted.</p>
+      <pre><code><span class="comment"># Propose / counter-offer (when can_counter_offer is true)</span>
+<span class="cmd">mycelium negotiate propose</span> \
+  budget=high timeline=standard \
+  scope=extended quality=standard \
+  <span class="flag">-r</span> sprint-plan <span class="flag">-H</span> julia-agent
+
+<span class="comment"># Respond (when can_counter_offer is false, or to accept the standing offer)</span>
+<span class="cmd">mycelium negotiate respond</span> accept \
+  <span class="flag">-r</span> sprint-plan <span class="flag">-H</span> selina-agent
+
+<span class="comment"># Keep awaiting between each action</span>
+<span class="cmd">mycelium session await</span> \
+  <span class="flag">-H</span> selina-agent <span class="flag">-r</span> sprint-plan</code></pre>
+      <h2 id="cognitive-engine-tunables">Tunables</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Config key</th>
+              <th>Default</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>negotiation.n_steps</code></td>
+              <td><code>20</code></td>
+              <td>Maximum SAO rounds per session. Set to <code>0</code> to fall through to CFN&#x27;s auto-computed budget (which scales with agent and issue count, but assumes Boulware-style time-based concession that LLM callback agents do not exhibit — a low fixed cap is preferred).</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <pre><code><span class="cmd">mycelium config set</span> negotiation.n_steps 30
+<span class="cmd">mycelium config apply</span>  # regenerates ~/.mycelium/.env</code></pre>
+      <p>CFN-side tunables (set via <code>~/.mycelium/.env</code> directly):</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Env var</th>
+              <th>Default</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>COORDINATION_JOIN_WINDOW_SECONDS</code></td>
+              <td><code>30</code></td>
+              <td>Initial join window starting from the first agent&#x27;s join</td>
+            </tr>
+            <tr>
+              <td><code>COORDINATION_JOIN_WINDOW_EXTENSION_SECONDS</code></td>
+              <td><code>30</code></td>
+              <td>How much each subsequent join pushes the deadline forward</td>
+            </tr>
+            <tr>
+              <td><code>COORDINATION_JOIN_WINDOW_MAX_SECONDS</code></td>
+              <td><code>180</code></td>
+              <td>Hard cap on total join window from first join</td>
+            </tr>
+            <tr>
+              <td><code>COORDINATION_TICK_TIMEOUT_SECONDS</code></td>
+              <td><code>30</code></td>
+              <td>Fallback per-tick timeout</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The round watchdog also extends on each agent&#x27;s first reply per round, so a slow agent doesn&#x27;t stall the round for everyone — only sustained silence (no replies for the full timeout window) ends the round prematurely.</p>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="knowledge-graph">
+      <h1>Knowledge Graph</h1>
+      <p>Every message written to a room passes through a two-stage LLM extraction pipeline that turns free-form agent output into structured graph data.</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Stage</th>
+              <th>What it extracts</th>
+              <th>Stored as</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Stage 1</td>
+              <td>Concepts, entities, decisions</td>
+              <td>Nodes in openCypher graph</td>
+            </tr>
+            <tr>
+              <td>Stage 2</td>
+              <td>Relationships between concepts</td>
+              <td>Edges in openCypher graph</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>CE queries the graph when running negotiation — historical decisions and known trade-offs inform proposals. The graph accumulates across all sessions in a room.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body">The knowledge graph lives in <strong>AgensGraph</strong> alongside the SQL tables — no separate graph database required.</div>
+      </div>
+    </section>
+    <!-- FOOTER -->
+    <div class="docs-footer">
+      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+      <span class="sep">·</span>
+      <span>Apache 2.0</span>
+      <span class="sep">·</span>
+      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+    </div>
+
+  </div>
+  </main>
+</div>
+
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<script src="site.js"></script>
+
+</body>
+</html>

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -28,15 +28,18 @@ from pathlib import Path
 # 3 pages, each a long doc with a grouped sidebar.
 # (page_id, file_name, page_title, top_nav_label, sheet_no, plate_title, meta_description)
 PAGES: list[tuple[str, str, str, str, str, str, str]] = [
-    ("learn", "index.html", "mycelium — Docs", "Learn",
-     "LRN-001", "LEARN · OVERVIEW · QUICKSTART · CONCEPTS · GUIDES",
-     "Coordination layer for multi-agent systems. Semantic negotiation, persistent memory, collective intelligence."),
+    ("start", "index.html", "mycelium — Docs", "Get Started",
+     "GET-001", "OVERVIEW · INSTALL · FIRST ROOM · COORDINATE",
+     "Coordination layer for multi-agent systems. Install and run your first multi-agent coordination flow: room, agents, negotiation, plan."),
+    ("concepts", "concepts.html", "Concepts — mycelium", "Concepts",
+     "CON-001", "CONCEPTS · ROOMS · SESSIONS · MEMORY · PLAN",
+     "The core concepts behind Mycelium: rooms, sessions, memory, plan, CognitiveEngine, and the knowledge graph."),
     ("adapters", "adapters.html", "Adapters — mycelium", "Adapters",
      "ADP-001", "ADAPTERS · CLAUDE CODE · OPENCLAW · REST API",
      "Connect Claude Code, OpenClaw, or any HTTP client to the Mycelium coordination layer."),
     ("reference", "reference.html", "Reference — mycelium", "Reference",
-     "REF-001", "REFERENCE · ARCHITECTURE · CLI · CONFIG · HELP",
-     "Architecture, CLI reference, configuration, and troubleshooting for Mycelium."),
+     "REF-001", "REFERENCE · ARCHITECTURE · CLI · CONFIG · GUIDES · HELP",
+     "Architecture, CLI reference, configuration, guides, and troubleshooting for Mycelium."),
 ]
 
 # Sections, in render order per page.
@@ -44,17 +47,16 @@ PAGES: list[tuple[str, str, str, str, str, str, str]] = [
 # md_file=None means the section is hand-coded (kept verbatim from source HTML).
 # If md_file is set AND a kept section with the same id exists, the kept HTML wins.
 SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
-    # ── learn (index.html) ──
-    ("overview.md",                 "overview",           "learn",     "Get Started",  "Overview"),
-    ("quickstart.md",               "quickstart",         "learn",     "Get Started",  "Quick Start"),
-    ("rooms.md",                    "rooms",              "learn",     "Concepts",     "Rooms"),
-    ("sessions.md",                 "sessions",           "learn",     "Concepts",     "Sessions"),
-    ("memory.md",                   "memory",             "learn",     "Concepts",     "Memory"),
-    ("plan.md",                     "plan",               "learn",     "Concepts",     "Plan"),
-    ("cognitive-engine.md",         "cognitive-engine",   "learn",     "Concepts",     "CognitiveEngine"),
-    ("knowledge-graph.md",          "knowledge-graph",    "learn",     "Concepts",     "Knowledge Graph"),
-    ("guides/structured-memory.md", "structured-memory",  "learn",     "Guides",       "Structured Memory"),
-    ("guides/hub-and-spoke.md",     "hub-and-spoke",      "learn",     "Guides",       "Hub & Spoke"),
+    # ── start (index.html) — overview + quickstart ──
+    ("overview.md",                 "overview",           "start",       "Get Started",  "Overview"),
+    ("quickstart.md",               "quickstart",         "start",       "Get Started",  "Quick Start"),
+    # ── concepts (concepts.html) ──
+    ("rooms.md",                    "rooms",              "concepts",    "Concepts",     "Rooms"),
+    ("sessions.md",                 "sessions",           "concepts",    "Concepts",     "Sessions"),
+    ("memory.md",                   "memory",             "concepts",    "Concepts",     "Memory"),
+    ("plan.md",                     "plan",               "concepts",    "Concepts",     "Plan"),
+    ("cognitive-engine.md",         "cognitive-engine",   "concepts",    "Concepts",     "CognitiveEngine"),
+    ("knowledge-graph.md",          "knowledge-graph",    "concepts",    "Concepts",     "Knowledge Graph"),
     # ── adapters (adapters.html) — all hand-coded ──
     (None,                          "adapters",           "adapters",  "Adapters",     "Overview"),
     (None,                          "adapter-claude-code","adapters",  "Adapters",     "Claude Code"),
@@ -63,7 +65,9 @@ SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
     (None,                          "adapter-api",        "adapters",  "Adapters",     "REST API"),
     # ── reference (reference.html) ──
     ("architecture.md",             "architecture",       "reference", "Architecture", "Architecture"),
-    # CLI + Config blocks injected after architecture, before troubleshooting.
+    # CLI + Config blocks injected after architecture, before guides/troubleshooting.
+    ("guides/structured-memory.md", "structured-memory",  "reference", "Guides",       "Structured Memory"),
+    ("guides/hub-and-spoke.md",     "hub-and-spoke",      "reference", "Guides",       "Hub & Spoke"),
     ("troubleshooting.md",          "troubleshooting",    "reference", "Help",         "Troubleshooting"),
 ]
 
@@ -825,7 +829,8 @@ def _render_and_write(
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--page", help="Regenerate a single page by id (learn|adapters|reference).",
+        "--page",
+        help="Regenerate a single page by id (start|concepts|adapters|reference).",
     )
     args = parser.parse_args()
 
@@ -857,7 +862,33 @@ def main() -> None:
             sheet_no, plate_title,
         )
 
+    if not args.page:
+        _write_llms_full()
+
     print("\nDone.")
+
+
+def _write_llms_full() -> None:
+    """Concatenate every markdown section into one file for LLM ingestion.
+
+    The multi-page split means no single HTML page holds all the docs anymore,
+    so this preserves the "feed the whole docs to an LLM" flow.
+    """
+    parts: list[str] = [
+        "# Mycelium Documentation (full)\n",
+        "Coordination layer for multi-agent systems. "
+        "Concatenated from the source docs; see https://mycelium-io.github.io/mycelium/\n",
+    ]
+    for md_file, _section_id, _page_id, _group, _label in SECTION_CONFIG:
+        if md_file is None:
+            continue
+        path = DOCS_DIR / md_file
+        if not path.exists():
+            continue
+        parts.append("\n\n---\n\n" + path.read_text().rstrip() + "\n")
+    out = OUT_DIR / "llms-full.txt"
+    out.write_text("".join(parts))
+    print(f"  wrote {out.name} ({out.stat().st_size:,} bytes)")
 
 
 if __name__ == "__main__":

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>mycelium — Docs</title>
-<meta name="description" content="Coordination layer for multi-agent systems. Semantic negotiation, persistent memory, collective intelligence.">
+<meta name="description" content="Coordination layer for multi-agent systems. Install and run your first multi-agent coordination flow: room, agents, negotiation, plan.">
 <meta property="og:title" content="mycelium — Docs">
-<meta property="og:description" content="Coordination layer for multi-agent systems. Semantic negotiation, persistent memory, collective intelligence.">
+<meta property="og:description" content="Coordination layer for multi-agent systems. Install and run your first multi-agent coordination flow: room, agents, negotiation, plan.">
 <meta property="og:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <meta property="og:url" content="https://mycelium-io.github.io/mycelium/index.html">
 <meta property="og:type" content="website">
@@ -34,7 +34,8 @@
 </nav>
 <nav class="sectionnav">
   <div class="sectionnav-inner">
-    <a href="index.html" class="active"><span class="square-dot"></span>LEARN</a>
+    <a href="index.html" class="active"><span class="square-dot"></span>GET STARTED</a>
+    <a href="concepts.html" class=""><span class="square-dot"></span>CONCEPTS</a>
     <a href="adapters.html" class=""><span class="square-dot"></span>ADAPTERS</a>
     <a href="reference.html" class=""><span class="square-dot"></span>REFERENCE</a>
     <div class="sectionnav-right">
@@ -49,20 +50,6 @@
       <div class="nav-section-label">Get Started</div>
       <a href="#overview" class="nav-link sub">Overview</a>
       <a href="#quickstart" class="nav-link sub">Quick Start</a>
-    </div>
-    <div class="nav-section">
-      <div class="nav-section-label">Concepts</div>
-      <a href="#rooms" class="nav-link sub">Rooms</a>
-      <a href="#sessions" class="nav-link sub">Sessions</a>
-      <a href="#memory" class="nav-link sub">Memory</a>
-      <a href="#plan" class="nav-link sub">Plan</a>
-      <a href="#cognitive-engine" class="nav-link sub">CognitiveEngine</a>
-      <a href="#knowledge-graph" class="nav-link sub">Knowledge Graph</a>
-    </div>
-    <div class="nav-section">
-      <div class="nav-section-label">Guides</div>
-      <a href="#structured-memory" class="nav-link sub">Structured Memory</a>
-      <a href="#hub-and-spoke" class="nav-link sub">Hub &amp; Spoke</a>
     </div>
   </nav>
 
@@ -148,32 +135,15 @@
 
 <section class="doc-section" id="quickstart">
       <!-- keep -->
-      <h2 id="install">Install</h2>
-
-      <div class="install-tabs">
-        <button class="install-tab active" onclick="setInstallTab('curl',this)">curl</button>
-        <button class="install-tab" onclick="setInstallTab('brew',this)">brew</button>
-        <button class="install-tab" onclick="setInstallTab('clawhub',this)">clawhub</button>
-      </div>
-      <div class="install-block">
-        <pre><code id="install-cmd">curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash</code></pre>
-        <button class="install-copy-btn" onclick="copyInstallCmd(this)" title="Copy">
-          <i data-lucide="copy"></i>
-        </button>
-      </div>
-
-      <div class="callout callout-info">
+      <h1>Quick Start</h1>
+      <h2 id="quickstart-install">Install</h2>
+      <pre><code>curl <span class="flag">-fsSL</span> https://mycelium-io.github.io/mycelium/install.sh | bash</code></pre>
+      <p>The installer sets up the CLI, prompts for your LLM provider, then brings up the full stack (backend + AgensGraph) via <code>docker compose</code>. Run <code>mycelium --help</code> after install to verify.</p>
+      <div class="callout callout-note">
         <div class="callout-bar"></div>
-        <div class="callout-body">The installer sets up the CLI, prompts for your LLM provider, then brings up
-        the full stack (backend + AgensGraph) via <code>docker compose</code>.
-        Run <code>mycelium --help</code> after install to verify.</div>
+        <div class="callout-body"><strong>An LLM key is required for coordination.</strong> Memory works without one, but the CognitiveEngine needs an LLM to negotiate; if you pick &quot;Skip&quot; at the prompt, agents will join sessions but never reach consensus. You can add it later with <code>mycelium config set llm.model &lt;model&gt;</code> and <code>mycelium config apply</code>.</div>
       </div>
-
-      <p>
-        The install command is interactive — it checks Docker, pulls base images, asks for
-        your LLM config, then calls <code>docker compose up</code> and provisions a default
-        workspace automatically. No manual backend setup required.
-      </p>
+      <p>The install command is interactive — it checks Docker, pulls base images, asks for your LLM config, then calls <code>docker compose up</code> and provisions a default workspace automatically. No manual backend setup required.</p>
       <pre><code><span class="comment"># What mycelium install does:</span>
 <span class="comment">#  1. Check Docker + disk space</span>
 <span class="comment">#  2. Pull base images (postgres, AgensGraph) in the background</span>
@@ -185,71 +155,39 @@
 
 <span class="cmd">mycelium install</span></code></pre>
       <p>Already installed? Use these commands instead:</p>
-      <pre><code><span class="cmd">mycelium upgrade</span>   <span class="comment"># update the CLI binary</span>
-<span class="cmd">mycelium pull</span>      <span class="comment"># pull latest images and restart services</span>
-<span class="cmd">mycelium doctor</span>    <span class="comment"># diagnose and fix configuration issues</span></code></pre>
-      <h2 id="open-the-ui">Open the UI</h2>
-      <p>
-        The Mycelium room view is where you do everything from here — watch the live
-        message stream, add agents, chat with them, and track the shared plan. Open it:
-      </p>
-      <pre><code><span class="cmd">mycelium ui open</span>   <span class="comment"># starts the frontend if it isn&#x27;t running, then opens it</span></code></pre>
-      <div class="callout callout-info">
-        <div class="callout-bar"></div>
-        <div class="callout-body">Everything below can be driven from the UI or the CLI — they act on the same
-        rooms. The commands are shown so you can script or follow along in a terminal.</div>
-      </div>
-
-      <h2 id="create-a-room">Create a room</h2>
+      <pre><code><span class="cmd">mycelium upgrade</span>   # update the CLI binary
+<span class="cmd">mycelium pull</span>      # pull latest images and restart services
+<span class="cmd">mycelium doctor</span>    # diagnose and fix configuration issues</code></pre>
+      <h2 id="quickstart-open-the-ui">Open the UI</h2>
+      <p>The Mycelium room view is where you do everything from here — watch the live message stream, add agents, chat with them, and track the shared plan. Open it:</p>
+      <pre><code><span class="cmd">mycelium ui open</span>   # starts the frontend if it isn&#x27;t running, then opens it</code></pre>
+      <p>The UI is where <strong>you</strong> work: create rooms, add agents, hand them a mission, and watch them coordinate. The CLI is where <strong>your agents</strong> work: they join, negotiate, and write memory on their own. Same rooms, two surfaces, built for each other. The commands shown below are the CLI equivalents of each UI action, so you can script or follow along in a terminal.</p>
+      <h2 id="quickstart-create-a-room">Create a room</h2>
       <p>A room is a persistent namespace for memory, agents, and coordination:</p>
       <pre><code><span class="comment"># Create a room and make it active</span>
 <span class="cmd">mycelium room create</span> my-project
 <span class="cmd">mycelium room use</span> my-project</code></pre>
       <p>Open <code>my-project</code> in the UI — it&#x27;s empty for now. Next we&#x27;ll add agents and start talking to them.</p>
-
-      <h2 id="add-agents">Add agents</h2>
-      <p>
-        The <strong>agent primitive</strong> registers an addressable agent in the room.
-        Mycelium wires up the underlying adapter for you — there&#x27;s no per-agent chat
-        account or homeserver to configure; agents coordinate through the room&#x27;s own
-        message stream.
-      </p>
+      <h2 id="quickstart-add-agents">Add agents</h2>
+      <p>The <strong>agent primitive</strong> registers an addressable agent in the room. Mycelium wires up the underlying adapter for you; agents coordinate through the room&#x27;s own message stream, so there&#x27;s nothing else to set up per agent.</p>
       <pre><code><span class="comment"># Greenfield — provision a brand-new agent</span>
-<span class="cmd">mycelium agent create</span> planner <span class="flag">--adapter</span> openclaw <span class="flag">--description</span> <span class="str">&quot;Sprint planner, optimizes for shipping speed&quot;</span>
+<span class="cmd">mycelium agent create</span> planner <span class="flag">--adapter</span> openclaw \
+    <span class="flag">--description</span> <span class="str">&quot;Sprint planner, optimizes for shipping speed&quot;</span>
 
 <span class="comment"># Brownfield — adopt agents that already exist in your OpenClaw gateway</span>
-<span class="cmd">mycelium agent add</span>
-
-<span class="comment"># See who&#x27;s in the room</span>
+<span class="cmd">mycelium agent add</span></code></pre>
+      <p><code>claude_code</code> and <code>cursor</code> agents are cold-spawned by the Mycelium daemon; see the <strong>Adapters</strong> guide for the full list.</p>
+      <pre><code><span class="comment"># See who&#x27;s in the room</span>
 <span class="cmd">mycelium agent ls</span></code></pre>
-      <p>
-        <code>claude_code</code> and <code>cursor</code> agents are cold-spawned by the
-        Mycelium daemon and need no chat platform at all — see the
-        <a href="adapters.html">Adapters</a> guide for the full list.
-      </p>
-
-      <h2 id="coordinate">Coordinate</h2>
-      <p>
-        In the UI room view, type in the chat box and <strong><code>@</code>-mention</strong>
-        an agent — it replies in the live message stream. The same message can be sent
-        from the CLI:
-      </p>
+      <h2 id="quickstart-coordinate">Coordinate</h2>
+      <p>In the UI room view, type in the chat box and <strong><code>@</code>-mention</strong> an agent — it replies in the live message stream. The same message can be sent from the CLI:</p>
       <pre><code><span class="comment"># Send an @-addressed message to a registered agent</span>
 <span class="cmd">mycelium agent invoke</span> planner <span class="str">&quot;draft a plan for the Q3 migration&quot;</span></code></pre>
-      <p>
-        When you ask multiple agents to reach a decision, Mycelium&#x27;s CognitiveEngine
-        runs a structured negotiation. On consensus, the agreement compiles into the
-        room&#x27;s shared plan — visible in the <strong>PLAN</strong> tab in the UI, or from
-        the CLI:
-      </p>
-      <pre><code><span class="cmd">mycelium plan ls</span>          <span class="comment"># the room&#x27;s shared task list</span></code></pre>
+      <p>When you ask multiple agents to reach a decision, Mycelium&#x27;s CognitiveEngine runs a structured negotiation. On consensus, the agreement compiles into the room&#x27;s shared plan — visible in the <strong>PLAN</strong> tab in the UI, or from the CLI:</p>
+      <pre><code><span class="cmd">mycelium plan tasks</span>       # the room&#x27;s shared task list</code></pre>
       <p>The result lands back in the same room stream — no need to go hunting for it in a separate chat.</p>
-
-      <h2 id="share-memory">Share memory</h2>
-      <p>
-        Rooms are also persistent memory. Anything you write is searchable by meaning
-        and visible to every agent in the room:
-      </p>
+      <h2 id="quickstart-share-memory">Share memory</h2>
+      <p>Rooms are also persistent memory. Anything you write is searchable by meaning and visible to every agent in the room:</p>
       <pre><code><span class="comment"># Share context</span>
 <span class="cmd">mycelium memory set</span> <span class="str">&quot;decisions/db&quot;</span> <span class="str">&quot;PostgreSQL with pgvector&quot;</span>
 <span class="cmd">mycelium memory set</span> <span class="str">&quot;decisions/api&quot;</span> <span class="str">&quot;REST with generated OpenAPI client&quot;</span>
@@ -260,627 +198,10 @@
 <span class="comment"># Browse the namespace</span>
 <span class="cmd">mycelium memory ls</span>
 <span class="cmd">mycelium memory ls</span> decisions/</code></pre>
-      <p>Now try a session — two agents negotiating a plan:</p>
-      <pre><code><span class="comment"># Terminal 1 — agent julia</span>
-<span class="cmd">mycelium room create</span> sprint-plan
-<span class="cmd">mycelium session create</span> <span class="flag">-r</span> sprint-plan
-<span class="cmd">mycelium session join</span> <span class="flag">--handle</span> julia-agent <span class="flag">-m</span> <span class="str">&quot;Prioritize the database migration first&quot;</span> <span class="flag">-r</span> sprint-plan
-<span class="cmd">mycelium session await</span> <span class="flag">--handle</span> julia-agent <span class="flag">-r</span> sprint-plan
-
-<span class="comment"># Terminal 2 — agent selina</span>
-<span class="cmd">mycelium session join</span> <span class="flag">--handle</span> selina-agent <span class="flag">-m</span> <span class="str">&quot;Focus on frontend polish, backend is solid&quot;</span> <span class="flag">-r</span> sprint-plan
-<span class="cmd">mycelium session await</span> <span class="flag">--handle</span> selina-agent <span class="flag">-r</span> sprint-plan
-
-<span class="comment"># CognitiveEngine runs negotiation — await returns ticks with actions</span></code></pre>
-    </section>
-
-    <hr class="divider">
-
-    <section class="doc-section" id="rooms">
-      <h1>Rooms</h1>
-      <p>A room is a persistent coordination namespace. All memories, sessions, and messages are scoped to a room. A room IS its namespace — there&#x27;s no separation between the two.</p>
-      <p>Rooms hold persistent state (memories, knowledge graph). When agents need to negotiate in real time, they spawn <strong>sessions</strong> within a room. Sessions are ephemeral sync negotiation rounds; the room outlives them.</p>
-      <h2 id="rooms-rooms-are-directories">Rooms are Directories</h2>
-      <p>Each room maps to a directory at <code>~/.mycelium/rooms/{room_name}/</code>. Standard subdirectories are created automatically:</p>
-      <pre><code>~/.mycelium/rooms/design-review/
-  decisions/   context/   status/    plan/
-  work/        procedures/   log/   failed/</code></pre>
-      <p>The <code>plan/</code> subdir holds the room&#x27;s plan — a free-form set of markdown files plus the <code>- [ ]</code> / <code>- [x]</code> checklist lines those files contain. <code>plan/title.md</code> holds the room&#x27;s display title (shown italicised above room activity in the UI). The rest are arbitrary <code>plan/{slug}.md</code> files containing prose and tasks. See <a href="#"><code>mycelium plan</code></a> for read/write commands and <code>plan task add|done|undo</code> for checkbox edits.</p>
-      <p>You can browse, edit, or git-track these directories directly. The backend keeps its search index in sync via startup scans and file watching.</p>
-      <h2 id="rooms-session-state-machine">Session State Machine</h2>
-      <p>Sessions spawned within rooms follow a state machine:</p>
-      <pre><code>idle → waiting → negotiating → complete
-          ↑         ↓
-      (join window fires)</code></pre>
-      <p>Once <code>complete</code>, the consensus is compiled into the room&#x27;s shared plan (<code>plan/tasks.md</code>) — a <code>- [ ]</code> checklist the team works from. The arc is <code>join → negotiate → plan → work</code>; the room and its plan outlive the session.</p>
-    </section>
-
-    <hr class="divider">
-
-    <section class="doc-section" id="sessions">
-      <h1>Sessions</h1>
-      <p>A session is an ephemeral sync negotiation round spawned within a room. Rooms hold persistent state (memories, knowledge graph). Sessions handle real-time coordination.</p>
-      <h2 id="sessions-lifecycle">Lifecycle</h2>
-      <ol class="steps">
-        <li><strong>Create</strong> — <code>mycelium session create</code> spawns a session within your active room.</li>
-        <li><strong>Join</strong> — Agents join with <code>mycelium session join -m &quot;your position&quot;</code>. The first join starts a 60-second window for others to join.</li>
-        <li><strong>Await</strong> — <code>mycelium session await</code> blocks until the CognitiveEngine has an action for your agent (propose, respond, or done).</li>
-        <li><strong>Negotiate</strong> — Agents propose and respond in structured rounds mediated by the CognitiveEngine.</li>
-        <li><strong>Complete</strong> — The session reaches consensus. The agreement is compiled into the room&#x27;s <a href="#plan">shared plan</a> (<code>plan/tasks.md</code>); the session is done, the room and its plan persist.</li>
-      </ol>
-      <p>The arc doesn&#x27;t stop at consensus — it flows into work: <strong>join → negotiate → plan → work</strong>. A consensus decides *what*; the plan is *how the team carries it out*.</p>
-      <h2 id="sessions-state-machine">State Machine</h2>
-      <pre><code>idle → waiting → negotiating → complete
-          ↑         ↓
-      (first join)  (CE tick-0)</code></pre>
-      <ul>
-        <li><strong>idle</strong> — Session created, no agents yet.</li>
-        <li><strong>waiting</strong> — At least one agent joined. 60-second window for others.</li>
-        <li><strong>negotiating</strong> — CognitiveEngine is running the NegMAS pipeline.</li>
-        <li><strong>complete</strong> — Consensus reached and compiled into the room&#x27;s <code>plan/tasks.md</code>. Agents pick up the shared checklist and work it.</li>
-      </ul>
-      <h2 id="sessions-rooms-vs-sessions">Rooms vs Sessions</h2>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th></th>
-              <th>Room</th>
-              <th>Session</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Lifetime</td>
-              <td>Persistent</td>
-              <td>Ephemeral</td>
-            </tr>
-            <tr>
-              <td>Purpose</td>
-              <td>Namespace for memory + coordination</td>
-              <td>Single negotiation round</td>
-            </tr>
-            <tr>
-              <td>State</td>
-              <td>Always idle</td>
-              <td>idle → waiting → negotiating → complete</td>
-            </tr>
-            <tr>
-              <td>Memory</td>
-              <td>Yes — scoped to room</td>
-              <td>No — uses parent room&#x27;s memory</td>
-            </tr>
-            <tr>
-              <td>Multiple</td>
-              <td>One room, many sessions over time</td>
-              <td>Each session is independent</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <h2 id="sessions-multiple-rounds">Multiple Rounds</h2>
-      <p>A room can host many sessions over time. When one session completes, agents can spawn a new one for the next decision. The room&#x27;s memory persists across all sessions, so each round starts with full context from previous rounds.</p>
-      <pre><code><span class="comment"># First negotiation</span>
-<span class="cmd">mycelium session create</span> <span class="flag">-r</span> sprint-plan
-<span class="cmd">mycelium session join</span> <span class="flag">-m</span> <span class="str">&quot;Prioritize database migration&quot;</span> <span class="flag">-r</span> sprint-plan
-
-<span class="comment"># ... negotiation completes ...</span>
-
-<span class="comment"># Second negotiation (room memory carries over)</span>
-<span class="cmd">mycelium session create</span> <span class="flag">-r</span> sprint-plan
-<span class="cmd">mycelium session join</span> <span class="flag">-m</span> &quot;Now let&#x27;s plan the API layer&quot; <span class="flag">-r</span> sprint-plan</code></pre>
-    </section>
-
-    <hr class="divider">
-
-    <section class="doc-section" id="memory">
-      <h1>Memory</h1>
-      <p>Memory is a namespaced key-value store backed by AgensGraph + pgvector. Every write is embedded (384-dim, local, no API key) and indexed for semantic search.</p>
-      <h2 id="memory-namespace-conventions">Namespace Conventions</h2>
-      <p>Keys use <code>/</code> as a separator. This is a convention, not enforced structure — but it makes <code>memory ls &lt;prefix&gt;/</code> very useful.</p>
-      <pre><code><span class="comment"># Decisions your team made</span>
-<span class="cmd">mycelium memory set</span> <span class="str">&quot;decisions/db&quot;</span> <span class="str">&quot;AgensGraph — SQL + graph + vector in one&quot;</span>
-
-<span class="comment"># Things that failed (so nobody repeats them)</span>
-<span class="cmd">mycelium memory set</span> <span class="str">&quot;failed/sqlite&quot;</span> &quot;Can&#x27;t handle pgvector or JSONB&quot;
-
-<span class="comment"># Per-agent status (handle is just attribution)</span>
-<span class="cmd">mycelium memory set</span> <span class="str">&quot;status/prometheus&quot;</span> <span class="str">&quot;Working on CFN integration&quot;</span> <span class="flag">--handle</span> prometheus-agent
-
-<span class="comment"># Browse a namespace</span>
-<span class="cmd">mycelium memory ls</span> decisions/
-<span class="cmd">mycelium memory ls</span> failed/</code></pre>
       <div class="callout callout-note">
         <div class="callout-bar"></div>
-        <div class="callout-body"><strong>Always upserts.</strong> Calling <code>memory set</code> on an existing key overwrites it. The version number increments automatically so you can track changes.</div>
+        <div class="callout-body">Prefer to script the low-level negotiation directly? The <code>mycelium session join</code> / <code>session await</code> commands drive the CognitiveEngine from the terminal — see the <strong>Sessions</strong> reference.</div>
       </div>
-      <h2 id="memory-filesystem-native-storage">Filesystem-Native Storage</h2>
-      <p>Every memory is a markdown file at <code>~/.mycelium/rooms/{room}/{key}.md</code> with YAML frontmatter. You can read, edit, or version-control these files directly.</p>
-      <pre><code><span class="comment"># View the raw file</span>
-cat ~/.mycelium/rooms/design-review/decisions/database.md
-
-<span class="comment"># Edit with any tool</span>
-vim ~/.mycelium/rooms/design-review/decisions/database.md
-
-<span class="comment"># Git-track a room&#x27;s memory</span>
-cd ~/.mycelium/rooms/design-review &amp;&amp; git init</code></pre>
-      <p>The pgvector search index auto-syncs when:</p>
-      <ul>
-        <li>You use <code>mycelium memory set</code> (immediate dual-write)</li>
-        <li>The backend starts up (incremental scan of changed files)</li>
-        <li>Files change on disk while the backend is running (file watcher)</li>
-      </ul>
-      <p>For bulk edits, you can also trigger a manual reindex:</p>
-      <pre><code><span class="cmd">mycelium memory reindex</span></code></pre>
-      <h2 id="memory-semantic-search">Semantic Search</h2>
-      <p>Search finds memories by meaning — cosine similarity on all-MiniLM-L6-v2 embeddings (384 dimensions, runs locally).</p>
-      <pre><code><span class="cmd">mycelium memory search</span> <span class="str">&quot;what database decisions were made&quot;</span>
-<span class="cmd">mycelium memory search</span> <span class="str">&quot;what failed and why&quot;</span>
-<span class="cmd">mycelium memory search</span> <span class="str">&quot;what is the current status&quot;</span></code></pre>
-    </section>
-
-    <hr class="divider">
-
-    <section class="doc-section" id="plan">
-      <h1>Plan</h1>
-      <p>A room&#x27;s <strong>plan</strong> is the place to write down what the room is for and what&#x27;s left to do. It lives in <code>.mycelium/rooms/{room}/plan/</code> as a small set of markdown files, plus the <code>- [ ]</code> / <code>- [x]</code> checklist lines inside them.</p>
-      <p>Plan content is surfaced to every agent in the room — on every coordination tick (sync path) and in every agent-context briefing (async path) — so agents weigh their behaviour against work that&#x27;s already committed.</p>
-      <p>You can write the plan by hand (<code>plan set</code>, <code>plan task add</code>), but it also fills itself: when a <a href="#sessions">negotiation session</a> reaches consensus, Mycelium compiles the agreement into <code>plan/tasks.md</code> automatically — a <code>- [ ]</code> checklist the whole team then executes against. A re-negotiation updates that same plan, preserving tasks already completed. The arc is <strong>join → negotiate → plan → work</strong>.</p>
-      <h2 id="plan-anatomy">Anatomy</h2>
-      <pre><code>.mycelium/rooms/{room}/plan/
-├── title.md          # one-line italic display title (shown above room activity)
-├── tasks.md          # default todo file written by `plan task add`
-└── {slug}.md         # any number of additional plan files (prose + checklists)</code></pre>
-      <p><code>title.md</code> is special: its first non-empty line becomes the room&#x27;s displayed title (italic Cormorant Garamond in the UI, surfaced as a chip in the CLI). All other <code>plan/*.md</code> files are arbitrary — they appear as chips in the room header and as grouped task buckets in <code>plan tasks</code>.</p>
-      <h2 id="plan-cli">CLI</h2>
-      <pre><code><span class="comment"># Title</span>
-<span class="cmd">mycelium plan title</span>                                # read
-<span class="cmd">mycelium plan title</span> <span class="str">&quot;Plan the Q3 sprint priorities&quot;</span>  # set
-
-<span class="comment"># Files (each is a memory file under plan/&lt;slug&gt;)</span>
-<span class="cmd">mycelium plan ls</span>
-<span class="cmd">mycelium plan show</span> sprint
-<span class="cmd">mycelium plan set</span> sprint <span class="str">&quot;# Sprint\n\n- [ ] cut a release branch&quot;</span>
-<span class="cmd">mycelium plan rm</span> sprint
-
-<span class="comment"># Tasks (markdown checklist lines across every plan file)</span>
-<span class="cmd">mycelium plan tasks</span>                  # open tasks only
-<span class="cmd">mycelium plan tasks</span> <span class="flag">--all</span>            # include completed
-<span class="cmd">mycelium plan task</span> add <span class="str">&quot;ship the demo&quot;</span>          # appends to plan/tasks.md
-<span class="cmd">mycelium plan task</span> add <span class="str">&quot;draft API&quot;</span> <span class="flag">--file</span> sprint # appends to plan/sprint.md
-<span class="cmd">mycelium plan task</span> done              # interactive multi-select over open tasks
-<span class="cmd">mycelium plan task</span> done tasks:3 sprint:7
-<span class="cmd">mycelium plan task</span> undo              # interactive multi-select over done tasks</code></pre>
-      <p>Task IDs are <code>&lt;slug&gt;:&lt;line&gt;</code> and stable as long as the file isn&#x27;t reflowed.</p>
-      <h2 id="plan-how-agents-see-it">How agents see it</h2>
-      <p>Plan files share the same memory-style markdown-with-frontmatter convention, so they live alongside <code>work/</code>, <code>decisions/</code>, etc. and are readable to anyone opening the room directory.</p>
-      <p>During a live coordination tick, the open task list is also rendered into every agent&#x27;s prompt under a dedicated <strong>Open tasks</strong> header — both CLI agents (raw payload field <code>plan_open_tasks</code>) and OpenClaw agents (rendered into the dispatched instruction string).</p>
-    </section>
-
-    <hr class="divider">
-
-    <section class="doc-section" id="cognitive-engine">
-      <h1>CognitiveEngine</h1>
-      <p>CognitiveEngine is the mediator. It sits between all agents and drives negotiation. Agents never talk to each other directly — all coordination flows through CE.</p>
-      <h2 id="cognitive-engine-negotiation-flow">Negotiation flow</h2>
-      <p>In sessions:</p>
-      <ol class="steps">
-        <li>Agents call <code>session join</code> with their initial position and handle.</li>
-        <li>The join window stays open until no new agents have joined for the configured</li>
-      </ol>
-      <p>extension period (default 30s after each join, capped at 180s from first join). When the window closes, CE starts the <strong>SemanticNegotiationPipeline</strong> on the joined positions.</p>
-      <ol class="steps">
-        <li>CE sends each agent a <code>coordination_tick</code> with <code>action: respond</code>. The tick</li>
-      </ol>
-      <p>payload tells the agent everything it needs to decide:</p>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Field</th>
-              <th>What it tells you</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>current_offer</code></td>
-              <td>The proposal on the table this round</td>
-            </tr>
-            <tr>
-              <td><code>can_counter_offer</code></td>
-              <td>Whether *you* are the designated proposer this round</td>
-            </tr>
-            <tr>
-              <td><code>round</code> / <code>n_steps_total</code></td>
-              <td>Where you are in the round budget</td>
-            </tr>
-            <tr>
-              <td><code>your_last_action</code></td>
-              <td>What you (the recipient) did last round</td>
-            </tr>
-            <tr>
-              <td><code>prior_round_outcome</code></td>
-              <td>What happened previously: <code>first_round</code>, <code>proposer_countered</code>, <code>rejected_by_&lt;id&gt;</code>, <code>agreed</code>, <code>no_consensus</code></td>
-            </tr>
-            <tr>
-              <td><code>issues</code> / <code>issue_options</code></td>
-              <td>The full negotiation space</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <ol class="steps">
-        <li>Agents reply with <code>propose</code> (counter-offer, only when <code>can_counter_offer: true</code>)</li>
-      </ol>
-      <p>or <code>respond accept|reject</code>.</p>
-      <ol class="steps">
-        <li>Rounds continue until consensus or the round budget (<code>n_steps_total</code>) is</li>
-      </ol>
-      <p>exhausted. Consensus requires <strong>all agents</strong> to accept the same offer in the same round. The final tick is <code>coordination_consensus</code> with <code>broken: false</code> and the agreed plan; if no agreement is reached, <code>broken: true</code> is posted and the room moves to <code>failed</code> state.</p>
-      <ol class="steps">
-        <li>On consensus, the agreement is handed to the <strong>plan compiler</strong> — an LLM</li>
-      </ol>
-      <p>stage that turns the raw <code>issue=value</code> agreement into the room&#x27;s <a href="#plan">shared plan</a>, <code>plan/tasks.md</code>, a <code>- [ ]</code> checklist the team executes against. This runs before the <code>coordination_consensus</code> message is posted, so the plan exists by the time <code>session await</code> returns. The compiler is a separate stage that *consumes* the negotiation outcome — not part of the negotiation engine itself.</p>
-      <p>Walking away with no agreement is a legitimate outcome. The protocol does not have a &quot;concede gradually&quot; mechanism for LLM agents — if your hard constraints can&#x27;t be met, keep rejecting until the round budget is exhausted.</p>
-      <pre><code><span class="comment"># Propose / counter-offer (when can_counter_offer is true)</span>
-<span class="cmd">mycelium negotiate propose</span> \
-  budget=high timeline=standard \
-  scope=extended quality=standard \
-  <span class="flag">-r</span> sprint-plan <span class="flag">-H</span> julia-agent
-
-<span class="comment"># Respond (when can_counter_offer is false, or to accept the standing offer)</span>
-<span class="cmd">mycelium negotiate respond</span> accept \
-  <span class="flag">-r</span> sprint-plan <span class="flag">-H</span> selina-agent
-
-<span class="comment"># Keep awaiting between each action</span>
-<span class="cmd">mycelium session await</span> \
-  <span class="flag">-H</span> selina-agent <span class="flag">-r</span> sprint-plan</code></pre>
-      <h2 id="cognitive-engine-tunables">Tunables</h2>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Config key</th>
-              <th>Default</th>
-              <th>Purpose</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>negotiation.n_steps</code></td>
-              <td><code>20</code></td>
-              <td>Maximum SAO rounds per session. Set to <code>0</code> to fall through to CFN&#x27;s auto-computed budget (which scales with agent and issue count, but assumes Boulware-style time-based concession that LLM callback agents do not exhibit — a low fixed cap is preferred).</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <pre><code><span class="cmd">mycelium config set</span> negotiation.n_steps 30
-<span class="cmd">mycelium config apply</span>  # regenerates ~/.mycelium/.env</code></pre>
-      <p>CFN-side tunables (set via <code>~/.mycelium/.env</code> directly):</p>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Env var</th>
-              <th>Default</th>
-              <th>Purpose</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>COORDINATION_JOIN_WINDOW_SECONDS</code></td>
-              <td><code>30</code></td>
-              <td>Initial join window starting from the first agent&#x27;s join</td>
-            </tr>
-            <tr>
-              <td><code>COORDINATION_JOIN_WINDOW_EXTENSION_SECONDS</code></td>
-              <td><code>30</code></td>
-              <td>How much each subsequent join pushes the deadline forward</td>
-            </tr>
-            <tr>
-              <td><code>COORDINATION_JOIN_WINDOW_MAX_SECONDS</code></td>
-              <td><code>180</code></td>
-              <td>Hard cap on total join window from first join</td>
-            </tr>
-            <tr>
-              <td><code>COORDINATION_TICK_TIMEOUT_SECONDS</code></td>
-              <td><code>30</code></td>
-              <td>Fallback per-tick timeout</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <p>The round watchdog also extends on each agent&#x27;s first reply per round, so a slow agent doesn&#x27;t stall the round for everyone — only sustained silence (no replies for the full timeout window) ends the round prematurely.</p>
-    </section>
-
-    <hr class="divider">
-
-    <section class="doc-section" id="knowledge-graph">
-      <h1>Knowledge Graph</h1>
-      <p>Every message written to a room passes through a two-stage LLM extraction pipeline that turns free-form agent output into structured graph data.</p>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Stage</th>
-              <th>What it extracts</th>
-              <th>Stored as</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Stage 1</td>
-              <td>Concepts, entities, decisions</td>
-              <td>Nodes in openCypher graph</td>
-            </tr>
-            <tr>
-              <td>Stage 2</td>
-              <td>Relationships between concepts</td>
-              <td>Edges in openCypher graph</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <p>CE queries the graph when running negotiation — historical decisions and known trade-offs inform proposals. The graph accumulates across all sessions in a room.</p>
-      <div class="callout callout-note">
-        <div class="callout-bar"></div>
-        <div class="callout-body">The knowledge graph lives in <strong>AgensGraph</strong> alongside the SQL tables — no separate graph database required.</div>
-      </div>
-    </section>
-
-    <hr class="divider">
-
-    <section class="doc-section" id="structured-memory">
-      <h1>Structured Memory Guide</h1>
-      <p>This guide shows how to use Mycelium&#x27;s structured memory conventions to give agents continuity across sessions.</p>
-      <h2 id="structured-memory-the-problem">The Problem</h2>
-      <p>An agent helps build something over a long session. The session ends. When the user (or another agent) comes back, there&#x27;s no memory of what happened. The new session starts from scratch.</p>
-      <h2 id="structured-memory-the-solution-category-conventions">The Solution: Category Conventions</h2>
-      <p>Instead of writing memories with arbitrary keys, use structured prefixes:</p>
-      <pre><code>work/        — What was built or changed
-decisions/   — Why choices were made
-context/     — User preferences and background
-status/      — Current state of ongoing work
-procedures/  — Reusable how-to steps (do this again later)</code></pre>
-      <p><code>memory set</code> validates these automatically — when the key starts with a known category prefix, it checks the slug format and auto-timestamps the content.</p>
-      <h2 id="structured-memory-workflow">Workflow</h2>
-      <h3 id="structured-memory-1-set-up-a-room">1. Set up a room</h3>
-      <pre><code><span class="cmd">mycelium room create</span> project-x
-<span class="cmd">mycelium room use</span> project-x</code></pre>
-      <h3 id="structured-memory-2-write-structured-memories-as-you-work">2. Write structured memories as you work</h3>
-      <pre><code><span class="comment"># Record what you built</span>
-<span class="cmd">mycelium memory set</span> work/api-server <span class="str">&quot;Set up FastAPI with auth endpoints&quot;</span>
-<span class="cmd">mycelium memory set</span> work/database <span class="str">&quot;Created PostgreSQL schema, 3 tables&quot;</span>
-
-<span class="comment"># Record why you made choices</span>
-<span class="cmd">mycelium memory set</span> decisions/framework <span class="str">&quot;FastAPI over Flask: async + type hints&quot;</span>
-<span class="cmd">mycelium memory set</span> decisions/auth <span class="str">&quot;JWT tokens, 1hr expiry, refresh via cookie&quot;</span>
-
-<span class="comment"># Record user context</span>
-<span class="cmd">mycelium memory set</span> context/goal <span class="str">&quot;Build MVP for investor demo by Friday&quot;</span>
-<span class="cmd">mycelium memory set</span> context/constraints <span class="str">&quot;Must run on single $20/mo VPS&quot;</span>
-
-<span class="comment"># Track current state</span>
-<span class="cmd">mycelium memory set</span> status/api <span class="str">&quot;PASSING — all 12 endpoints tested&quot;</span>
-<span class="cmd">mycelium memory set</span> status/deploy <span class="str">&quot;BLOCKED — waiting on DNS propagation&quot;</span>
-
-<span class="comment"># Save reusable procedures</span>
-<span class="cmd">mycelium memory set</span> procedures/deploy-vps &quot;1. ssh vps  2. cd /app &amp;&amp; git pull  3. systemctl restart app  4. curl healthcheck&quot;
-<span class="cmd">mycelium memory set</span> procedures/db-migrate &quot;1. uv run alembic upgrade head  2. Verify with psql <span class="flag">-c</span> &#x27;SELECT version()&#x27;&quot;</code></pre>
-      <h3 id="structured-memory-3-check-status-at-a-glance">3. Check status at a glance</h3>
-      <pre><code><span class="cmd">mycelium memory status</span>     # Table of all status/* memories
-<span class="cmd">mycelium memory work</span>       # What&#x27;s been built
-<span class="cmd">mycelium memory decisions</span>  # Why things are the way they are
-<span class="cmd">mycelium memory procedures</span> # How to do things again</code></pre>
-      <h3 id="structured-memory-4-update-status-as-things-change">4. Update status as things change</h3>
-      <pre><code><span class="comment"># memory set always upserts — just set the new value</span>
-<span class="cmd">mycelium memory set</span> status/deploy <span class="str">&quot;ACTIVE — deployed to vps.example.com&quot;</span></code></pre>
-      <h2 id="structured-memory-type-safety">Type Safety</h2>
-      <p><code>memory set</code> validates category keys against the <code>MemoryLogEntry</code> type (defined in <code>mycelium.protocol</code>). This is the same pattern used for negotiation payloads (<code>ProposeReply</code>, <code>RespondReply</code>) — Pydantic validation before the API call, so malformed slugs fail fast on the client side.</p>
-      <p>Valid slugs: lowercase alphanumeric, hyphens, dots, underscores.</p>
-      <ul>
-        <li><code>work/api-server</code> — valid</li>
-        <li><code>status/v2.deploy</code> — valid</li>
-        <li><code>decisions/Why We Chose X</code> — invalid (uppercase, spaces)</li>
-      </ul>
-      <p>Keys without a known category prefix skip validation entirely:</p>
-      <ul>
-        <li><code>custom/anything</code> — passes through, no slug check</li>
-        <li><code>research/pgvector-perf</code> — passes through</li>
-      </ul>
-    </section>
-
-    <hr class="divider">
-
-    <section class="doc-section" id="hub-and-spoke">
-      <h1>Hub &amp; Spoke Setup</h1>
-      <p>How to run Mycelium across multiple machines so a small team shares memory, rooms, and coordination state from a single backend.</p>
-      <div class="callout callout-note">
-        <div class="callout-bar"></div>
-        <div class="callout-body"><strong>Note:</strong> The examples below use the <strong>mycelium-room</strong> channel (the Mycelium room UI) as the agent surface and <strong>OpenClaw</strong> as the agent adapter. The same pattern applies to external channels and other adapters — substitute the relevant names and config paths.</div>
-      </div>
-      <h2 id="hub-and-spoke-when-to-use-this">When to use this</h2>
-      <p>Use hub-and-spoke when multiple people (or multiple machines) need to participate in the same rooms, see the same memories, and coordinate agents together. If everything runs on one machine, the default single-device install is simpler — see the Quick Start.</p>
-      <h2 id="hub-and-spoke-topology">Topology</h2>
-      <pre><code>┌──────────────────────────────────┐
-│  Hub  (one machine)              │
-│                                  │
-│  <span class="cmd">mycelium install</span>                │
-│  ├─ FastAPI backend  :8000       │
-│  ├─ AgensGraph (PG)  :5432       │
-│  ├─ CFN mgmt plane   :9000       │
-│  └─ CFN runtime      :9002       │
-│                                  │
-│  OpenClaw gateway                │
-│  All agents added here           │
-└────────────┬─────────────────────┘
-             │  HTTPS / SSE
-     ┌───────┴───────┐
-     │               │
-┌────┴─────┐   ┌─────┴────┐
-│ Spoke A  │   │ Spoke B  │
-│          │   │          │
-│ CLI only │   │ CLI only │
-│ + agents │   │ + agents │
-│ No Docker│   │ No Docker│
-└──────────┘   └──────────┘</code></pre>
-      <p>The hub runs the full stack. Spokes run only the CLI, agents, and the adapter plugin — no Docker, no database, no separate channel server.</p>
-      <h2 id="hub-and-spoke-step-1-set-up-the-hub">Step 1: Set up the hub</h2>
-      <p>On the hub machine, run the standard install:</p>
-      <pre><code><span class="cmd">mycelium install</span>
-<span class="cmd">mycelium up</span> <span class="flag">--metrics</span>            # include <span class="flag">--metrics</span> if you want spoke telemetry</code></pre>
-      <p>This brings up the backend, database, and provisions a default workspace. The <code>--metrics</code> flag also starts the dockerized OTLP collector listening on <code>:4318</code>. It serves two purposes on the hub: it collects telemetry from the hub&#x27;s own OpenClaw gateway (so <code>mycelium metrics show</code> on the hub has data even with zero spokes), and it accepts forwarded payloads from spokes once they&#x27;re configured in <a href="#hub-and-spoke-step-4-set-up-spoke-metrics">Step 4</a> — which is what powers the unified cross-host view (Spoke Sites table, <code>--host</code> filter). Skip the flag only if you don&#x27;t want metrics at all.</p>
-      <p>Verify with:</p>
-      <pre><code><span class="cmd">mycelium doctor</span></code></pre>
-      <h3 id="hub-and-spoke-open-ports">Open ports</h3>
-      <p>Spokes need to reach the hub on these ports:</p>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Port</th>
-              <th>Service</th>
-              <th>Required</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>8000</td>
-              <td>Mycelium backend (API + SSE)</td>
-              <td>Yes</td>
-            </tr>
-            <tr>
-              <td>9000</td>
-              <td>CFN management plane</td>
-              <td>If using CognitiveEngine</td>
-            </tr>
-            <tr>
-              <td>9002</td>
-              <td>CFN runtime</td>
-              <td>If using CognitiveEngine</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <p>Use a VPN, Tailscale, or firewall rules to restrict access — these services have no built-in authentication.</p>
-      <h3 id="hub-and-spoke-add-agents-on-the-hub">Add agents on the hub</h3>
-      <p>Agents talk through the <strong>mycelium-room</strong> channel — the chat box and live message stream in the Mycelium room UI, served by the Mycelium backend. There is no separate channel server and no per-agent chat account to provision. Add every agent (across all spokes) on the hub:</p>
-      <pre><code><span class="comment"># Add an agent and auto-wire the OpenClaw mycelium-room channel</span>
-<span class="cmd">mycelium agent add</span> agent-alpha</code></pre>
-      <p><code>mycelium agent add</code> (or <code>mycelium agent create</code>) registers the agent and auto-wires the OpenClaw <code>mycelium-room</code> channel into the hub&#x27;s <code>~/.openclaw/openclaw.json</code>. The hub&#x27;s gateway manages all channel connections — spokes do not run their own channel clients. (To wire in an *external* channel, add it under <code>channels.&lt;channel&gt;.accounts</code> instead.)</p>
-      <h2 id="hub-and-spoke-step-2-set-up-each-spoke">Step 2: Set up each spoke</h2>
-      <p>On each spoke machine, install only the CLI (no <code>mycelium install</code>):</p>
-      <pre><code>curl <span class="flag">-fsSL</span> https://mycelium-io.github.io/mycelium/install.sh | bash</code></pre>
-      <h3 id="hub-and-spoke-initialize-and-install-the-adapter">Initialize and install the adapter</h3>
-      <p>Point the spoke at the hub and install the adapter:</p>
-      <pre><code><span class="cmd">mycelium init</span> <span class="flag">--api-url</span> http://&lt;hub-ip&gt;:8000
-<span class="cmd">mycelium adapter add</span> openclaw</code></pre>
-      <p><code>init</code> writes <code>~/.mycelium/config.toml</code> with the hub&#x27;s API URL. <code>adapter add</code> installs the Mycelium plugin into the local OpenClaw gateway and probes the hub to confirm it&#x27;s reachable. The plugin connects to the hub&#x27;s backend for SSE subscriptions and API calls.</p>
-      <p>After installing, restart the gateway:</p>
-      <pre><code>openclaw gateway restart</code></pre>
-      <p>Verify the setup:</p>
-      <pre><code><span class="cmd">mycelium doctor</span></code></pre>
-      <p>The doctor auto-detects whether this node is a hub or spoke from <code>server.api_url</code> and adjusts its checks accordingly (e.g., skipping Docker/database checks on spokes).</p>
-      <h3 id="hub-and-spoke-spoke-config-summary">Spoke config summary</h3>
-      <p>A spoke needs only two files:</p>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>File</th>
-              <th>Purpose</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>~/.mycelium/config.toml</code></td>
-              <td>Points <code>server.api_url</code> at the hub</td>
-            </tr>
-            <tr>
-              <td><code>~/.openclaw/openclaw.json</code></td>
-              <td>Agent definitions, channel credentials, Mycelium plugin config</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <p>The spoke does not need <code>server.workspace_id</code> or <code>server.mas_id</code> in its config — the hub resolves these automatically when the spoke&#x27;s agents join rooms and sessions.</p>
-      <h2 id="hub-and-spoke-step-3-verify-the-setup">Step 3: Verify the setup</h2>
-      <p>From each spoke, confirm connectivity:</p>
-      <pre><code><span class="comment"># Should return rooms from the hub</span>
-<span class="cmd">mycelium room ls</span>
-
-<span class="comment"># Should show hub health</span>
-<span class="cmd">mycelium status</span></code></pre>
-      <p>Test agent participation by creating a room on the hub and joining from a spoke:</p>
-      <pre><code><span class="comment"># On the hub</span>
-<span class="cmd">mycelium room create</span> test-room
-
-<span class="comment"># On the spoke</span>
-<span class="cmd">mycelium session join</span> <span class="flag">--handle</span> spoke-agent <span class="flag">-m</span> <span class="str">&quot;Hello from spoke&quot;</span> <span class="flag">-r</span> test-room</code></pre>
-      <h2 id="hub-and-spoke-agent-identity">Agent identity</h2>
-      <p>Each agent needs a unique handle across the entire deployment. The handle is set by:</p>
-      <ol class="steps">
-        <li><code>identity.name</code> in <code>~/.mycelium/config.toml</code></li>
-        <li>The <code>MYCELIUM_AGENT_HANDLE</code> environment variable</li>
-        <li>The <code>--handle</code> flag on CLI commands</li>
-      </ol>
-      <p>For the mycelium-room channel, the handle *is* the agent&#x27;s identity in the room UI — <code>mycelium agent add agent-alpha</code> uses <code>agent-alpha</code> directly. For an external channel, the handle should match that channel&#x27;s user ID for the agent.</p>
-      <h2 id="hub-and-spoke-token-management">Token management</h2>
-      <p>Channel access tokens can expire or become invalid after server restarts. When this happens, agents silently stop receiving messages.</p>
-      <p>Signs of expired tokens:</p>
-      <ul>
-        <li>Agents join sessions but never respond to coordination ticks</li>
-        <li>Gateway logs show sync errors or 401/unauthorized responses</li>
-        <li><code>mycelium doctor</code> reports channel connection failures</li>
-      </ul>
-      <p>To refresh tokens, re-authenticate the agent with the channel, update the token in <code>channels.&lt;channel&gt;.accounts[agent]</code> in each node&#x27;s <code>openclaw.json</code>, and restart the gateway. (The mycelium-room channel authenticates through the Mycelium backend and has no separate channel token to rotate — this applies to external channels.)</p>
-      <h2 id="hub-and-spoke-step-4-set-up-spoke-metrics">Step 4: Set up spoke metrics</h2>
-      <p>Each spoke can run a lightweight local collector for OpenClaw telemetry. The collector stores data locally <strong>and</strong> forwards OTLP payloads to the hub so it can build a unified cross-host view.</p>
-      <div class="callout callout-note">
-        <div class="callout-bar"></div>
-        <div class="callout-body"><strong>Prerequisite:</strong> the hub must already be running with <code>mycelium up --metrics</code> (see <a href="#hub-and-spoke-step-1-set-up-the-hub">Step 1</a>) so that the hub collector is listening on <code>:4318</code> and can accept forwarded payloads. The spoke collector forwards fire-and-forget — silent failures will show up as gaps in the hub&#x27;s &quot;Spoke Sites&quot; table, not as errors on the spoke.</div>
-      </div>
-      <pre><code><span class="comment"># Point the spoke&#x27;s metrics at the hub collector. Use the hub&#x27;s</span>
-<span class="comment"># collector_port if you remapped it from the 4318 default.</span>
-<span class="cmd">mycelium config set</span> metrics.collector_url &quot;http://&lt;hub-ip&gt;:4318&quot;
-
-<span class="comment"># Configure OTLP plugin (endpoint defaults to localhost:4318)</span>
-<span class="cmd">mycelium adapter add</span> openclaw <span class="flag">--step</span>=otel
-
-<span class="comment"># Start the spoke collector (daemonizes into background). This is the</span>
-<span class="comment"># host-process variant — we don&#x27;t want to assume docker on spokes, so</span>
-<span class="comment"># the collector runs directly under the user instead of as a container.</span>
-<span class="cmd">mycelium metrics collect</span>
-
-<span class="comment"># Stop it later with:</span>
-<span class="cmd">mycelium metrics stop</span></code></pre>
-      <h3 id="hub-and-spoke-how-the-spoke-collector-works">How the spoke collector works</h3>
-      <p>The spoke pipeline is <strong>OpenClaw → local spoke collector → hub collector</strong>, not OpenClaw → hub directly. Three reasons:</p>
-      <ol class="steps">
-        <li><strong>No docker assumption on spokes.</strong> <code>mycelium install</code> only runs on the hub. We don&#x27;t want to assume docker is available on every spoke, so spokes get a host-process collector (<code>mycelium metrics collect</code>) that runs directly under the user — the only spoke prerequisite is the CLI itself.</li>
-        <li><strong>Local survives a hub outage.</strong> Every OTLP payload lands in <code>~/.mycelium/metrics/metrics.json</code> (and <code>traces.db</code>) on the spoke first, then forwards to the hub. If the hub is down or the network drops, local <code>mycelium metrics show</code> still works on the spoke — only the hub&#x27;s cross-host view loses that interval.</li>
-        <li><strong>Forwarding is fire-and-forget.</strong> The spoke pushes raw OTLP to the hub via background HTTP POSTs; failures are logged at debug level and never block local ingest. That&#x27;s why hub-side errors surface as gaps in the Spoke Sites table rather than as visible errors on the spoke (see <a href="../metrics.md#hub-and-spoke-setup">metrics docs</a> for the full architecture diagram).</li>
-      </ol>
-      <p><code>mycelium metrics show</code> on the spoke merges local OpenClaw data with backend/CFN data fetched from the hub. On the hub, the forwarded OTLP data appears in the &quot;Spoke Sites&quot; table and can be filtered with <code>mycelium metrics show --host &lt;hostname&gt;</code>.</p>
-      <p>For a span-level view of the activity each spoke is forwarding — drill down by host, agent, room, channel, model, tool, error, or latency, and render any single trace as a parent → child tree — use the trace viewer on the hub:</p>
-      <pre><code><span class="cmd">mycelium metrics traces</span> summary <span class="flag">--since</span>=1h     # rollup
-<span class="cmd">mycelium metrics traces</span> by-host <span class="flag">--since</span>=1h      # per-spoke
-<span class="cmd">mycelium metrics traces</span> show &lt;trace_id&gt;         # one trace as a tree</code></pre>
-      <p>See <a href="../metrics.md#viewing-traces">Viewing Traces</a> for the full command list and pivots.</p>
-      <p>See the <a href="../metrics.md#hub-and-spoke-setup">Metrics System docs</a> for full details.</p>
-      <h2 id="hub-and-spoke-troubleshooting">Troubleshooting</h2>
-      <h3 id="hub-and-spoke-spoke-cant-reach-hub">Spoke can&#x27;t reach hub</h3>
-      <pre><code>curl http://&lt;hub-ip&gt;:8000/health</code></pre>
-      <p>If this fails, check firewall rules, VPN connectivity, or security groups. The backend binds to <code>0.0.0.0</code> by default inside Docker, but the host firewall may block external access.</p>
-      <h3 id="hub-and-spoke-agent-joins-but-doesnt-respond">Agent joins but doesn&#x27;t respond</h3>
-      <p>The agent&#x27;s OpenClaw gateway plugin subscribes to SSE on the hub. If the agent joins a session (visible in <code>mycelium room ls</code>) but never responds to coordination ticks:</p>
-      <ol class="steps">
-        <li>Check the gateway logs: <code>journalctl --user -u openclaw-gateway --since &quot;5 min ago&quot;</code></li>
-        <li>Look for <code>session SSE connected</code> — if absent, the plugin isn&#x27;t monitoring the session</li>
-        <li>Verify channel tokens are valid (see above)</li>
-      </ol>
-      <h3 id="hub-and-spoke-doctor-reports-spoke-mode-unexpectedly">Doctor reports &quot;spoke mode&quot; unexpectedly</h3>
-      <p><code>mycelium doctor</code> auto-detects mode from <code>server.api_url</code>. If it points to a non-localhost address, doctor assumes spoke mode. If you&#x27;re running the backend locally on a non-default address, set <code>server.api_url</code> to <code>http://localhost:8000</code> in <code>~/.mycelium/config.toml</code>.</p>
     </section>
     <!-- FOOTER -->
     <div class="docs-footer">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,1541 @@
+# Mycelium Documentation (full)
+Coordination layer for multi-agent systems. Concatenated from the source docs; see https://mycelium-io.github.io/mycelium/
+
+
+---
+
+# Overview
+
+Mycelium is a coordination layer for teams of autonomous AI agents. Give
+several agents a shared mission and Mycelium gets them to one agreed answer,
+and a shared plan they execute together, instead of talking over each other or
+redoing each other's work.
+
+**Two surfaces, one room, built for each other.** You and your agents
+coordinate *together*: **you** work in the **UI** (create a room, add agents,
+hand them a mission, watch them decide and plan, live), and **your agents** work
+through the **CLI** (they join, negotiate, and write to shared memory on their
+own; that's what the `mycelium` skill teaches them). That's why you need at
+least one **agent runtime** (Claude Code, Cursor, or OpenClaw): the agents
+aren't an optional add-on, they're half the system.
+
+## What you get
+
+**Rooms** — Persistent coordination spaces. Agents join a room to share context, then spawn a session inside it to negotiate in real time.
+
+**Persistent Memory** — Markdown files on your filesystem are the shared source of truth, greppable and editable by any agent, and a CFN knowledge graph indexes them for recall by meaning and relationship. Every agent that joins inherits what the others already know, so intelligence compounds across sessions instead of resetting.
+
+**Structured negotiation** — When agents need to agree on a multi-issue trade-off, Mycelium runs a structured negotiation that ends in one shared answer, then compiles it into a `- [ ]` checklist the whole team executes against.
+
+> Under the hood, negotiation is mediated by the **CognitiveEngine** (agents never talk directly), and deliberate room writes can be extracted into a **knowledge graph**. See **cognitive-engine** and **knowledge-graph**.
+
+## The Problem
+
+AI agents are powerful individually, but they can't think together. When multiple agents work
+on the same problem there's no shared memory, no way to negotiate trade-offs, and no context
+that persists across sessions. Every conversation starts from zero.
+
+Mycelium gives agents rooms to coordinate in, persistent memory that accumulates across
+sessions, and a CognitiveEngine that mediates negotiation so agents never have to talk
+directly to each other.
+
+## The Ratchet Effect
+
+When agents log decisions, failures, and findings to a shared room, any agent that joins
+later can read `~/.mycelium/rooms/{room}/` and the room's shared plan to instantly inherit
+what the swarm learned. Intelligence doesn't reset — it compounds.
+
+Negative results matter too. An agent that logs `failed/sqlite-testing: can't handle
+pgvector` prevents every future agent from repeating the same dead end.
+
+
+---
+
+# Quick Start
+
+## Install
+
+```bash
+curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
+```
+
+The installer sets up the CLI, prompts for your LLM provider, then brings up
+the full stack (backend + AgensGraph) via `docker compose`.
+Run `mycelium --help` after install to verify.
+
+> **An LLM key is required for coordination.** Memory works without one, but
+> the CognitiveEngine needs an LLM to negotiate; if you pick "Skip" at the
+> prompt, agents will join sessions but never reach consensus. You can add it
+> later with `mycelium config set llm.model <model>` and `mycelium config apply`.
+
+The install command is interactive — it checks Docker, pulls base images, asks for
+your LLM config, then calls `docker compose up` and provisions a default
+workspace automatically. No manual backend setup required.
+
+```bash
+# What mycelium install does:
+#  1. Check Docker + disk space
+#  2. Pull base images (postgres, AgensGraph) in the background
+#  3. Prompt for LLM provider (Anthropic, OpenAI, Ollama, OpenRouter, ...)
+#  4. docker compose up --build -d
+#  5. Health-poll until services are ready
+#  6. Provision default workspace + MAS
+#  7. Write ~/.mycelium/config.toml
+
+mycelium install
+```
+
+Already installed? Use these commands instead:
+
+```bash
+mycelium upgrade   # update the CLI binary
+mycelium pull      # pull latest images and restart services
+mycelium doctor    # diagnose and fix configuration issues
+```
+
+## Open the UI
+
+The Mycelium room view is where you do everything from here — watch the live
+message stream, add agents, chat with them, and track the shared plan. Open it:
+
+```bash
+mycelium ui open   # starts the frontend if it isn't running, then opens it
+```
+
+The UI is where **you** work: create rooms, add agents, hand them a mission,
+and watch them coordinate. The CLI is where **your agents** work: they join,
+negotiate, and write memory on their own. Same rooms, two surfaces, built for
+each other. The commands shown below are the CLI equivalents of each UI action,
+so you can script or follow along in a terminal.
+
+## Create a room
+
+A room is a persistent namespace for memory, agents, and coordination:
+
+```bash
+# Create a room and make it active
+mycelium room create my-project
+mycelium room use my-project
+```
+
+Open `my-project` in the UI — it's empty for now. Next we'll add agents and
+start talking to them.
+
+## Add agents
+
+The **agent primitive** registers an addressable agent in the room. Mycelium
+wires up the underlying adapter for you; agents coordinate through the room's
+own message stream, so there's nothing else to set up per agent.
+
+```bash
+# Greenfield — provision a brand-new agent
+mycelium agent create planner --adapter openclaw \
+    --description "Sprint planner, optimizes for shipping speed"
+
+# Brownfield — adopt agents that already exist in your OpenClaw gateway
+mycelium agent add
+```
+
+`claude_code` and `cursor` agents are cold-spawned by the Mycelium daemon;
+see the **Adapters** guide for the full list.
+
+```bash
+# See who's in the room
+mycelium agent ls
+```
+
+## Coordinate
+
+In the UI room view, type in the chat box and **`@`-mention** an agent — it
+replies in the live message stream. The same message can be sent from the CLI:
+
+```bash
+# Send an @-addressed message to a registered agent
+mycelium agent invoke planner "draft a plan for the Q3 migration"
+```
+
+When you ask multiple agents to reach a decision, Mycelium's CognitiveEngine
+runs a structured negotiation. On consensus, the agreement compiles into the
+room's shared plan — visible in the **PLAN** tab in the UI, or from the CLI:
+
+```bash
+mycelium plan tasks       # the room's shared task list
+```
+
+The result lands back in the same room stream — no need to go hunting for it in
+a separate chat.
+
+## Share memory
+
+Rooms are also persistent memory. Anything you write is searchable by meaning
+and visible to every agent in the room:
+
+```bash
+# Share context
+mycelium memory set "decisions/db" "PostgreSQL with pgvector"
+mycelium memory set "decisions/api" "REST with generated OpenAPI client"
+
+# Search by meaning, not keywords
+mycelium memory search "what database decisions were made"
+
+# Browse the namespace
+mycelium memory ls
+mycelium memory ls decisions/
+```
+
+> Prefer to script the low-level negotiation directly? The
+> `mycelium session join` / `session await` commands drive the CognitiveEngine
+> from the terminal — see the **Sessions** reference.
+
+
+---
+
+# Rooms
+
+A room is a persistent coordination namespace. All memories, sessions, and messages
+are scoped to a room. A room IS its namespace — there's no separation between the two.
+
+Rooms hold persistent state (memories, knowledge graph). When agents need to negotiate
+in real time, they spawn **sessions** within a room. Sessions are ephemeral sync
+negotiation rounds; the room outlives them.
+
+## Rooms are Directories
+
+Each room maps to a directory at `~/.mycelium/rooms/{room_name}/`. Standard
+subdirectories are created automatically:
+
+```
+~/.mycelium/rooms/design-review/
+  decisions/   context/   status/    plan/
+  work/        procedures/   log/   failed/
+```
+
+The `plan/` subdir holds the room's plan — a free-form set of markdown files
+plus the `- [ ]` / `- [x]` checklist lines those files contain. `plan/title.md`
+holds the room's display title (shown italicised above room activity in the
+UI). The rest are arbitrary `plan/{slug}.md` files containing prose and tasks.
+See [`mycelium plan`](#) for read/write commands and `plan task add|done|undo`
+for checkbox edits.
+
+You can browse, edit, or git-track these directories directly. The backend
+keeps its search index in sync via startup scans and file watching.
+
+## Session State Machine
+
+Sessions spawned within rooms follow a state machine:
+
+```
+idle → waiting → negotiating → complete
+          ↑         ↓
+      (join window fires)
+```
+
+Once `complete`, the consensus is compiled into the room's shared plan
+(`plan/tasks.md`) — a `- [ ]` checklist the team works from. The arc is
+`join → negotiate → plan → work`; the room and its plan outlive the session.
+
+
+---
+
+# Sessions
+
+A session is an ephemeral sync negotiation round spawned within a room. Rooms hold
+persistent state (memories, knowledge graph). Sessions handle real-time coordination.
+
+> **Prerequisites for negotiation.** Sessions need two things that `mycelium
+> install` sets up by default: the **IoC/CFN** coordination backend (without it,
+> `session join` returns "CFN: not configured"), and an **LLM key** (the
+> CognitiveEngine uses it to generate proposals; in "stub mode" agents join but
+> never reach consensus). Memory and rooms work without either; negotiation does
+> not.
+
+## Lifecycle
+
+1. **Create** — `mycelium session create` spawns a session within your active room.
+2. **Join** — Agents join with `mycelium session join -m "your position"`. The first join starts a 60-second window for others to join.
+3. **Await** — `mycelium session await` blocks until the CognitiveEngine has an action for your agent (propose, respond, or done).
+4. **Negotiate** — Agents propose and respond in structured rounds mediated by the CognitiveEngine.
+5. **Complete** — The session reaches consensus. The agreement is compiled into the room's [shared plan](#plan) (`plan/tasks.md`); the session is done, the room and its plan persist.
+
+The arc doesn't stop at consensus — it flows into work: **join → negotiate → plan → work**. A consensus decides *what*; the plan is *how the team carries it out*.
+
+## State Machine
+
+```
+idle → waiting → negotiating → complete
+          ↑         ↓
+      (first join)  (CE tick-0)
+```
+
+- **idle** — Session created, no agents yet.
+- **waiting** — At least one agent joined. 60-second window for others.
+- **negotiating** — CognitiveEngine is running the NegMAS pipeline.
+- **complete** — Consensus reached and compiled into the room's `plan/tasks.md`. Agents pick up the shared checklist and work it.
+
+## Rooms vs Sessions
+
+| | Room | Session |
+|---|------|---------|
+| Lifetime | Persistent | Ephemeral |
+| Purpose | Namespace for memory + coordination | Single negotiation round |
+| State | Always idle | idle → waiting → negotiating → complete |
+| Memory | Yes — scoped to room | No — uses parent room's memory |
+| Multiple | One room, many sessions over time | Each session is independent |
+
+## Multiple Rounds
+
+A room can host many sessions over time. When one session completes, agents can
+spawn a new one for the next decision. The room's memory persists across all sessions,
+so each round starts with full context from previous rounds.
+
+```bash
+# First negotiation
+mycelium session create -r sprint-plan
+mycelium session join -m "Prioritize database migration" -r sprint-plan
+
+# ... negotiation completes ...
+
+# Second negotiation (room memory carries over)
+mycelium session create -r sprint-plan
+mycelium session join -m "Now let's plan the API layer" -r sprint-plan
+```
+
+
+---
+
+# Memory
+
+Room memory is markdown files on your filesystem: the shared source of truth,
+greppable and editable by any agent. The CFN knowledge graph is a derived index
+over those files, for recall by meaning and relationship, never an independent
+source of writes. Whatever stays private to one agent stays in that agent's own
+local memory, never indexed.
+
+## Three layers, one source of truth
+
+Mycelium memory has three layers, and only the middle one is "the memory":
+
+1. **Your private context** is yours alone: agent-native files like `SOUL.md`
+   or per-agent notes that never leave your machine and are never indexed or
+   shared. Anything only you need lives here.
+2. **Room memory** is the shared source of truth: markdown files under
+   `~/.mycelium/rooms/{room}/` that every agent in the room can read, `grep`,
+   edit, and `git`-track. If the team should know it, write it here.
+3. **The CFN knowledge graph** is a derived view, not a place you write to.
+   Mycelium indexes the room's public artifacts (memory files plus channel
+   messages) into it so agents can recall by meaning and by relationship. It
+   rebuilds from the files, so the files always win.
+
+Rule of thumb: if a teammate should find it, put it in room memory. The graph
+is how they find it; the filesystem is where it lives; your private notes stay
+yours.
+
+Every write to room memory is embedded (384-dim, local, no API key) and indexed
+for semantic search.
+
+## Namespace Conventions
+
+Keys use `/` as a separator. This is a convention, not enforced structure —
+but it makes `memory ls <prefix>/` very useful.
+
+```bash
+# Decisions your team made
+mycelium memory set "decisions/db" "AgensGraph — SQL + graph + vector in one"
+
+# Things that failed (so nobody repeats them)
+mycelium memory set "failed/sqlite" "Can't handle pgvector or JSONB"
+
+# Per-agent status (handle is just attribution)
+mycelium memory set "status/prometheus" "Working on CFN integration" --handle prometheus-agent
+
+# Browse a namespace
+mycelium memory ls decisions/
+mycelium memory ls failed/
+```
+
+> **Always upserts.** Calling `memory set` on an existing key overwrites it.
+> The version number increments automatically so you can track changes.
+
+## Filesystem-Native Storage
+
+Every memory is a markdown file at `~/.mycelium/rooms/{room}/{key}.md` with YAML
+frontmatter. You can read, edit, or version-control these files directly.
+
+```bash
+# View the raw file
+cat ~/.mycelium/rooms/design-review/decisions/database.md
+
+# Edit with any tool
+vim ~/.mycelium/rooms/design-review/decisions/database.md
+
+# Git-track a room's memory
+cd ~/.mycelium/rooms/design-review && git init
+```
+
+The pgvector search index auto-syncs when:
+- You use `mycelium memory set` (immediate dual-write)
+- The backend starts up (incremental scan of changed files)
+- Files change on disk while the backend is running (file watcher)
+
+For bulk edits, you can also trigger a manual reindex:
+```bash
+mycelium memory reindex
+```
+
+## Semantic Search
+
+Search finds memories by meaning — cosine similarity on all-MiniLM-L6-v2 embeddings
+(384 dimensions, runs locally).
+
+```bash
+mycelium memory search "what database decisions were made"
+mycelium memory search "what failed and why"
+mycelium memory search "what is the current status"
+```
+
+
+---
+
+# Plan
+
+A room's **plan** is the place to write down what the room is for and what's
+left to do. It lives in `~/.mycelium/rooms/{room}/plan/` as a small set of
+markdown files, plus the `- [ ]` / `- [x]` checklist lines inside them.
+
+Plan content is surfaced to every agent in the room — on every coordination
+tick (sync path) and in every agent-context briefing (async path) — so
+agents weigh their behaviour against work that's already committed.
+
+You can write the plan by hand (`plan set`, `plan task add`), but it also
+fills itself: when a [negotiation session](#sessions) reaches consensus,
+Mycelium compiles the agreement into `plan/tasks.md` automatically — a
+`- [ ]` checklist the whole team then executes against. A re-negotiation
+updates that same plan, preserving tasks already completed. The arc is
+**join → negotiate → plan → work**.
+
+## Anatomy
+
+```
+.mycelium/rooms/{room}/plan/
+├── title.md          # one-line italic display title (shown above room activity)
+├── tasks.md          # default todo file written by `plan task add`
+└── {slug}.md         # any number of additional plan files (prose + checklists)
+```
+
+`title.md` is special: its first non-empty line becomes the room's displayed
+title (italic Cormorant Garamond in the UI, surfaced as a chip in the CLI).
+All other `plan/*.md` files are arbitrary — they appear as chips in the room
+header and as grouped task buckets in `plan tasks`.
+
+## CLI
+
+```bash
+# Title
+mycelium plan title                                # read
+mycelium plan title "Plan the Q3 sprint priorities"  # set
+
+# Files (each is a memory file under plan/<slug>)
+mycelium plan ls
+mycelium plan show sprint
+mycelium plan set sprint "# Sprint\n\n- [ ] cut a release branch"
+mycelium plan rm sprint
+
+# Tasks (markdown checklist lines across every plan file)
+mycelium plan tasks                  # open tasks only
+mycelium plan tasks --all            # include completed
+mycelium plan task add "ship the demo"          # appends to plan/tasks.md
+mycelium plan task add "draft API" --file sprint # appends to plan/sprint.md
+mycelium plan task done              # interactive multi-select over open tasks
+mycelium plan task done tasks:3 sprint:7
+mycelium plan task undo              # interactive multi-select over done tasks
+```
+
+Task IDs are `<slug>:<line>` and stable as long as the file isn't reflowed.
+
+## How agents see it
+
+Plan files share the same memory-style markdown-with-frontmatter convention,
+so they live alongside `work/`, `decisions/`, etc. and are readable to anyone
+opening the room directory.
+
+During a live coordination tick, the open task list is also rendered into
+every agent's prompt under a dedicated **Open tasks** header — both CLI
+agents (raw payload field `plan_open_tasks`) and OpenClaw agents
+(rendered into the dispatched instruction string).
+
+
+---
+
+# CognitiveEngine
+
+CognitiveEngine is the mediator. It sits between all agents and drives negotiation.
+Agents never talk to each other directly — all coordination flows through CE.
+
+> **CE requires an LLM key and the IoC/CFN backend.** Both are provisioned by
+> `mycelium install` (interactive) by default. Without an LLM key the engine
+> can't synthesize proposals; without IoC/CFN, `session join` rejects the
+> negotiation outright. See **sessions** for the full prerequisite list.
+
+## Negotiation flow
+
+In sessions:
+
+1. Agents call `session join` with their initial position and handle.
+2. The join window stays open until no new agents have joined for the configured
+   extension period (default 30s after each join, capped at 180s from first join).
+   When the window closes, CE starts the **SemanticNegotiationPipeline** on the
+   joined positions.
+3. CE sends each agent a `coordination_tick` with `action: respond`. The tick
+   payload tells the agent everything it needs to decide:
+
+   | Field | What it tells you |
+   |---|---|
+   | `current_offer` | The proposal on the table this round |
+   | `can_counter_offer` | Whether *you* are the designated proposer this round |
+   | `round` / `n_steps_total` | Where you are in the round budget |
+   | `your_last_action` | What you (the recipient) did last round |
+   | `prior_round_outcome` | What happened previously: `first_round`, `proposer_countered`, `rejected_by_<id>`, `agreed`, `no_consensus` |
+   | `issues` / `issue_options` | The full negotiation space |
+
+4. Agents reply with `propose` (counter-offer, only when `can_counter_offer: true`)
+   or `respond accept|reject`.
+5. Rounds continue until consensus or the round budget (`n_steps_total`) is
+   exhausted. Consensus requires **all agents** to accept the same offer in the
+   same round. The final tick is `coordination_consensus` with `broken: false`
+   and the agreed plan; if no agreement is reached, `broken: true` is posted
+   and the room moves to `failed` state.
+6. On consensus, the agreement is handed to the **plan compiler** — an LLM
+   stage that turns the raw `issue=value` agreement into the room's
+   [shared plan](#plan), `plan/tasks.md`, a `- [ ]` checklist the team
+   executes against. This runs before the `coordination_consensus` message
+   is posted, so the plan exists by the time `session await` returns. The
+   compiler is a separate stage that *consumes* the negotiation outcome — not
+   part of the negotiation engine itself.
+
+Walking away with no agreement is a legitimate outcome. The protocol does not
+have a "concede gradually" mechanism for LLM agents — if your hard constraints
+can't be met, keep rejecting until the round budget is exhausted.
+
+```bash
+# Propose / counter-offer (when can_counter_offer is true)
+mycelium negotiate propose \
+  budget=high timeline=standard \
+  scope=extended quality=standard \
+  -r sprint-plan -H julia-agent
+
+# Respond (when can_counter_offer is false, or to accept the standing offer)
+mycelium negotiate respond accept \
+  -r sprint-plan -H selina-agent
+
+# Keep awaiting between each action
+mycelium session await \
+  -H selina-agent -r sprint-plan
+```
+
+## Tunables
+
+| Config key | Default | Purpose |
+|---|---|---|
+| `negotiation.n_steps` | `20` | Maximum SAO rounds per session. Set to `0` to fall through to CFN's auto-computed budget (which scales with agent and issue count, but assumes Boulware-style time-based concession that LLM callback agents do not exhibit — a low fixed cap is preferred). |
+
+```bash
+mycelium config set negotiation.n_steps 30
+mycelium config apply  # regenerates ~/.mycelium/.env
+```
+
+CFN-side tunables (set via `~/.mycelium/.env` directly):
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `COORDINATION_JOIN_WINDOW_SECONDS` | `30` | Initial join window starting from the first agent's join |
+| `COORDINATION_JOIN_WINDOW_EXTENSION_SECONDS` | `30` | How much each subsequent join pushes the deadline forward |
+| `COORDINATION_JOIN_WINDOW_MAX_SECONDS` | `180` | Hard cap on total join window from first join |
+| `COORDINATION_TICK_TIMEOUT_SECONDS` | `30` | Fallback per-tick timeout |
+
+The round watchdog also extends on each agent's first reply per round, so a slow
+agent doesn't stall the round for everyone — only sustained silence (no replies
+for the full timeout window) ends the round prematurely.
+
+
+---
+
+# Knowledge Graph
+
+Every message written to a room passes through a two-stage LLM extraction pipeline
+that turns free-form agent output into structured graph data.
+
+| Stage | What it extracts | Stored as |
+|-------|------------------|-----------|
+| Stage 1 | Concepts, entities, decisions | Nodes in openCypher graph |
+| Stage 2 | Relationships between concepts | Edges in openCypher graph |
+
+CE queries the graph when running negotiation — historical decisions and known trade-offs
+inform proposals. The graph accumulates across all sessions in a room.
+
+> The knowledge graph lives in **AgensGraph** alongside the SQL tables —
+> no separate graph database required.
+
+
+---
+
+# Architecture
+
+## Deployment Modes
+
+Mycelium supports two deployment modes. The backend and database are
+identical in both — what differs is *where the agents run* and *how they
+reach the backend*.
+
+### 1. Single-device (default)
+
+Everything — backend, database, agents, and CLI — runs on one machine,
+typically a developer's laptop. This is what `mycelium install` sets up
+out of the box. No network configuration, no remote services to point
+at, no shared infrastructure required. Agents talk to `localhost:8000`.
+
+This is the primary deployment target. Use it when one person (or one
+machine) owns the whole agent workflow.
+
+### 2. Hub-and-spoke (small teams)
+
+A second, optional mode for small teams that want to share memory, rooms,
+and coordination state across machines. One machine runs the full backend
+stack (the **hub**); other machines run only the CLI + agents (**spokes**)
+and connect to the hub over HTTPS/SSE.
+
+| Role  | What runs locally | When to use |
+|-------|-------------------|-------------|
+| **Hub**   | Full backend stack — FastAPI + AgensGraph (Postgres 16) + (optionally) the CFN management plane and cognition fabric node services. | The team's shared coordination server. One per team. |
+| **Spoke** | CLI + agents only. Talks to a remote hub via HTTPS / SSE. No Docker containers, no local database. | Each teammate's laptop. Agents on the spoke participate in shared rooms hosted by the hub. |
+
+Use this when a small team wants one place to look at shared memory,
+results, and ongoing coordinations — without each member running their
+own isolated stack. See the [Hub & Spoke Setup guide](#hub-and-spoke)
+for step-by-step instructions.
+
+`mycelium doctor` auto-detects which mode you're in by looking at
+`server.api_url` in `~/.mycelium/config.toml`: if it points to
+`localhost`/`127.0.0.1`, you're a hub; otherwise a spoke. The detection
+just tells the doctor which checks are relevant — Docker containers,
+runtime config drift, and the local CFN mgmt plane only matter on a hub.
+Override the auto-detection with:
+
+```bash
+mycelium doctor --mode hub     # force hub checks
+mycelium doctor --mode spoke   # force spoke checks (skip local-only)
+mycelium doctor --mode auto    # default — detect from api_url
+```
+
+> **Terminology note.** Earlier releases used "leaf" instead of "spoke".
+> The CLI flag `--mode leaf` was renamed to `--mode spoke` in a hard
+> cutover (no alias) to align with the standard hub-and-spoke vocabulary.
+> If you have scripts that pass `--mode leaf`, update them to `--mode spoke`.
+
+### Syncing room files (remote backend)
+
+When the backend runs on a remote server (EC2, Raspberry Pi, a hub), room files
+sync via the HTTP API. The adapter does not auto-sync; run `mycelium sync`
+yourself when you want fresh state.
+
+```bash
+# Clone a room from a remote backend
+mycelium room clone my-project --from http://ec2-host:8000
+
+# Fetch all memories from the backend and write local files
+mycelium sync
+```
+
+## Stack
+
+Everything runs on a single **AgensGraph** instance — a PostgreSQL 16 fork
+with multi-model support. No external message broker, no separate vector database.
+
+| Layer | Technology | Used for |
+|-------|-----------|----------|
+| SQL | AgensGraph (PG 16) | rooms, sessions, messages, memories |
+| Graph | openCypher (AgensGraph) | knowledge graph — concepts, relationships |
+| Vector | pgvector | semantic search on memory embeddings |
+| Real-time | LISTEN/NOTIFY → asyncpg → SSE | live watch stream |
+| Embeddings | sentence-transformers (all-MiniLM-L6-v2) | 384-dim local embeddings, no API key |
+| LLM | litellm | extraction, negotiation, plan compilation (100+ providers) |
+| Backend | FastAPI + asyncpg + SQLAlchemy | coordination engine API |
+| CLI | Typer + Rich | agent interface |
+| Frontend | Next.js + Tailwind | frontend UI |
+
+## Adapters
+
+Mycelium integrates with AI coding agents via adapters. The coordination model is
+the same regardless of adapter — join, await, respond.
+
+### Claude Code
+
+The Mycelium skill installs as a Claude Code skill (`~/.claude/skills/mycelium/SKILL.md`),
+invoked via the `/mycelium` slash command for memory and coordination commands.
+The adapter is skill-only; earlier hook-based versions were removed.
+
+```bash
+# The skill is invoked automatically in Claude Code sessions
+# or explicitly via the slash command
+/mycelium
+```
+
+### Cursor
+
+Same dispatch shape as Claude Code: each `@handle` mention is cold-spawned by
+the shared `mycelium-daemon` as a `cursor-agent -p` process in the agent's
+workspace. One daemon serves both cold-spawn families.
+
+```bash
+mycelium adapter add cursor
+mycelium adapter add cursor --step=daemon  # shared with claude-code
+cursor-agent login                          # one-time, interactive
+
+# Per agent: drops workspace-local rule + AGENTS.md section
+mycelium agent create design-agent --adapter cursor \
+    --cwd ~/repos/my-frontend --room my-project
+```
+
+### OpenClaw
+
+Plugin + hooks for the OpenClaw agent runtime. Same coordination model,
+same memory API.
+
+```bash
+mycelium adapter add openclaw
+
+# Allow agents to run mycelium commands without manual approval
+# For specific agents (recommended):
+openclaw approvals allowlist add --agent "<agent-id>" "~/.local/bin/mycelium"
+# Or for all agents (convenient but less restrictive):
+openclaw approvals allowlist add --agent "*" "~/.local/bin/mycelium"
+
+# Restart the gateway to pick up the plugin
+openclaw gateway restart
+```
+
+### Containerized gateway
+
+If OpenClaw runs inside Docker (VPS, self-hosted, Docker Compose), pass the
+container name so Mycelium stages assets and runs install commands inside the
+container via `docker exec`:
+
+```bash
+mycelium adapter add openclaw --openclaw-container openclaw-gateway-1
+
+# Or set via env var
+export OPENCLAW_CONTAINER=openclaw-gateway-1
+mycelium adapter add openclaw
+```
+
+This handles path resolution, file ownership (root UID), and `openclaw.json`
+load-path configuration automatically.
+
+### Backend API
+
+Any agent that can make HTTP requests can use the REST API directly.
+Interactive API docs are available at `http://localhost:8000/docs`
+when the backend is running.
+
+
+---
+
+# Structured Memory Guide
+
+This guide shows how to use Mycelium's structured memory conventions to give
+agents continuity across sessions.
+
+## The Problem
+
+An agent helps build something over a long session. The session ends. When the
+user (or another agent) comes back, there's no memory of what happened. The
+new session starts from scratch.
+
+## The Solution: Category Conventions
+
+Instead of writing memories with arbitrary keys, use structured prefixes:
+
+```
+work/        — What was built or changed
+decisions/   — Why choices were made
+context/     — User preferences and background
+status/      — Current state of ongoing work
+procedures/  — Reusable how-to steps (do this again later)
+```
+
+`memory set` validates these automatically — when the key starts with a known
+category prefix, it checks the slug format and auto-timestamps the content.
+
+## Workflow
+
+### 1. Set up a room
+
+```bash
+mycelium room create project-x
+mycelium room use project-x
+```
+
+### 2. Write structured memories as you work
+
+```bash
+# Record what you built
+mycelium memory set work/api-server "Set up FastAPI with auth endpoints"
+mycelium memory set work/database "Created PostgreSQL schema, 3 tables"
+
+# Record why you made choices
+mycelium memory set decisions/framework "FastAPI over Flask: async + type hints"
+mycelium memory set decisions/auth "JWT tokens, 1hr expiry, refresh via cookie"
+
+# Record user context
+mycelium memory set context/goal "Build MVP for investor demo by Friday"
+mycelium memory set context/constraints "Must run on single $20/mo VPS"
+
+# Track current state
+mycelium memory set status/api "PASSING — all 12 endpoints tested"
+mycelium memory set status/deploy "BLOCKED — waiting on DNS propagation"
+
+# Save reusable procedures
+mycelium memory set procedures/deploy-vps "1. ssh vps  2. cd /app && git pull  3. systemctl restart app  4. curl healthcheck"
+mycelium memory set procedures/db-migrate "1. uv run alembic upgrade head  2. Verify with psql -c 'SELECT version()'"
+```
+
+### 3. Check status at a glance
+
+```bash
+mycelium memory status     # Table of all status/* memories
+mycelium memory work       # What's been built
+mycelium memory decisions  # Why things are the way they are
+mycelium memory procedures # How to do things again
+```
+
+### 4. Update status as things change
+
+```bash
+# memory set always upserts — just set the new value
+mycelium memory set status/deploy "ACTIVE — deployed to vps.example.com"
+```
+
+## Type Safety
+
+`memory set` validates category keys against the `MemoryLogEntry` type
+(defined in `mycelium.protocol`). This is the same pattern used for negotiation
+payloads (`ProposeReply`, `RespondReply`) — Pydantic validation before the
+API call, so malformed slugs fail fast on the client side.
+
+Valid slugs: lowercase alphanumeric, hyphens, dots, underscores.
+- `work/api-server` — valid
+- `status/v2.deploy` — valid
+- `decisions/Why We Chose X` — invalid (uppercase, spaces)
+
+Keys without a known category prefix skip validation entirely:
+- `custom/anything` — passes through, no slug check
+- `research/pgvector-perf` — passes through
+
+
+---
+
+# Hub & Spoke Setup
+
+How to run Mycelium across multiple machines so a small team shares
+memory, rooms, and coordination state from a single backend.
+
+> **Note:** The examples below use the **mycelium-room** channel (the
+> Mycelium room UI) as the agent surface and **OpenClaw** as the agent
+> adapter. The same pattern applies to external channels and other
+> adapters — substitute the relevant names and config paths.
+
+## When to use this
+
+Use hub-and-spoke when multiple people (or multiple machines) need to
+participate in the same rooms, see the same memories, and coordinate
+agents together. If everything runs on one machine, the default
+single-device install is simpler — see the Quick Start.
+
+## Topology
+
+```
+┌──────────────────────────────────┐
+│  Hub  (one machine)              │
+│                                  │
+│  mycelium install                │
+│  ├─ FastAPI backend  :8000       │
+│  ├─ AgensGraph (PG)  :5432       │
+│  ├─ CFN mgmt plane   :9000       │
+│  └─ CFN runtime      :9002       │
+│                                  │
+│  OpenClaw gateway                │
+│  All agents added here           │
+└────────────┬─────────────────────┘
+             │  HTTPS / SSE
+     ┌───────┴───────┐
+     │               │
+┌────┴─────┐   ┌─────┴────┐
+│ Spoke A  │   │ Spoke B  │
+│          │   │          │
+│ CLI only │   │ CLI only │
+│ + agents │   │ + agents │
+│ No Docker│   │ No Docker│
+└──────────┘   └──────────┘
+```
+
+The hub runs the full stack. Spokes run only the CLI, agents, and the
+adapter plugin — no Docker, no database, no separate channel server.
+
+## Step 1: Set up the hub
+
+On the hub machine, run the standard install:
+
+```bash
+mycelium install
+mycelium up --metrics            # include --metrics if you want spoke telemetry
+```
+
+This brings up the backend, database, and provisions a default workspace.
+The `--metrics` flag also starts the dockerized OTLP collector listening
+on `:4318`. It serves two purposes on the hub: it collects telemetry
+from the hub's own OpenClaw gateway (so `mycelium metrics show` on the
+hub has data even with zero spokes), and it accepts forwarded payloads
+from spokes once they're configured in
+[Step 4](#hub-and-spoke-step-4-set-up-spoke-metrics) — which is what
+powers the unified cross-host view (Spoke Sites table, `--host` filter).
+Skip the flag only if you don't want metrics at all.
+
+Verify with:
+
+```bash
+mycelium doctor
+```
+
+### Open ports
+
+Spokes need to reach the hub on these ports:
+
+| Port | Service | Required |
+|------|---------|----------|
+| 8000 | Mycelium backend (API + SSE) | Yes |
+| 9000 | CFN management plane | If using CognitiveEngine |
+| 9002 | CFN runtime | If using CognitiveEngine |
+
+Use a VPN, Tailscale, or firewall rules to restrict access — these
+services have no built-in authentication.
+
+### Add agents on the hub
+
+Agents talk through the **mycelium-room** channel — the chat box and live
+message stream in the Mycelium room UI, served by the Mycelium backend.
+There is no separate channel server and no per-agent chat account to
+provision. Add every agent (across all spokes) on the hub:
+
+```bash
+# Add an agent and auto-wire the OpenClaw mycelium-room channel
+mycelium agent add agent-alpha
+```
+
+`mycelium agent add` (or `mycelium agent create`) registers the agent and
+auto-wires the OpenClaw `mycelium-room` channel into the hub's
+`~/.openclaw/openclaw.json`. The hub's gateway manages all channel
+connections — spokes do not run their own channel clients. (To wire in an
+*external* channel, add it under `channels.<channel>.accounts` instead.)
+
+## Step 2: Set up each spoke
+
+On each spoke machine, install only the CLI (no `mycelium install`):
+
+```bash
+curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
+```
+
+### Initialize and install the adapter
+
+Point the spoke at the hub and install the adapter:
+
+```bash
+mycelium init --api-url http://<hub-ip>:8000
+mycelium adapter add openclaw
+```
+
+`init` writes `~/.mycelium/config.toml` with the hub's API URL.
+`adapter add` installs the Mycelium plugin into the local OpenClaw
+gateway and probes the hub to confirm it's reachable. The plugin
+connects to the hub's backend for SSE subscriptions and API calls.
+
+After installing, restart the gateway:
+
+```bash
+openclaw gateway restart
+```
+
+Verify the setup:
+
+```bash
+mycelium doctor
+```
+
+The doctor auto-detects whether this node is a hub or spoke from
+`server.api_url` and adjusts its checks accordingly (e.g., skipping
+Docker/database checks on spokes).
+
+### Spoke config summary
+
+A spoke needs only two files:
+
+| File | Purpose |
+|------|---------|
+| `~/.mycelium/config.toml` | Points `server.api_url` at the hub |
+| `~/.openclaw/openclaw.json` | Agent definitions, channel credentials, Mycelium plugin config |
+
+The spoke does not need `server.workspace_id` or `server.mas_id` in its
+config — the hub resolves these automatically when the spoke's agents
+join rooms and sessions.
+
+## Step 3: Verify the setup
+
+From each spoke, confirm connectivity:
+
+```bash
+# Should return rooms from the hub
+mycelium room ls
+
+# Should show hub health
+mycelium status
+```
+
+Test agent participation by creating a room on the hub and joining from
+a spoke:
+
+```bash
+# On the hub
+mycelium room create test-room
+
+# On the spoke
+mycelium session join --handle spoke-agent -m "Hello from spoke" -r test-room
+```
+
+## Agent identity
+
+Each agent needs a unique handle across the entire deployment. The handle
+is set by:
+
+1. `identity.name` in `~/.mycelium/config.toml`
+2. The `MYCELIUM_AGENT_HANDLE` environment variable
+3. The `--handle` flag on CLI commands
+
+For the mycelium-room channel, the handle *is* the agent's identity in the
+room UI — `mycelium agent add agent-alpha` uses `agent-alpha` directly. For
+an external channel, the handle should match that channel's user ID for the
+agent.
+
+## Token management
+
+Channel access tokens can expire or become invalid after server restarts.
+When this happens, agents silently stop receiving messages.
+
+Signs of expired tokens:
+
+- Agents join sessions but never respond to coordination ticks
+- Gateway logs show sync errors or 401/unauthorized responses
+- `mycelium doctor` reports channel connection failures
+
+To refresh tokens, re-authenticate the agent with the channel, update the
+token in `channels.<channel>.accounts[agent]` in each node's
+`openclaw.json`, and restart the gateway. (The mycelium-room channel
+authenticates through the Mycelium backend and has no separate channel
+token to rotate — this applies to external channels.)
+
+## Step 4: Set up spoke metrics
+
+Each spoke can run a lightweight local collector for OpenClaw telemetry.
+The collector stores data locally **and** forwards OTLP payloads to the
+hub so it can build a unified cross-host view.
+
+> **Prerequisite:** the hub must already be running with `mycelium up
+> --metrics` (see [Step 1](#hub-and-spoke-step-1-set-up-the-hub)) so
+> that the hub collector is listening on `:4318` and can accept
+> forwarded payloads.
+> The spoke collector forwards fire-and-forget — silent failures will
+> show up as gaps in the hub's "Spoke Sites" table, not as errors on
+> the spoke.
+
+```bash
+# Point the spoke's metrics at the hub collector. Use the hub's
+# collector_port if you remapped it from the 4318 default.
+mycelium config set metrics.collector_url "http://<hub-ip>:4318"
+
+# Configure OTLP plugin (endpoint defaults to localhost:4318)
+mycelium adapter add openclaw --step=otel
+
+# Start the spoke collector (daemonizes into background). This is the
+# host-process variant — we don't want to assume docker on spokes, so
+# the collector runs directly under the user instead of as a container.
+mycelium metrics collect
+
+# Stop it later with:
+mycelium metrics stop
+```
+
+### How the spoke collector works
+
+The spoke pipeline is **OpenClaw → local spoke collector → hub
+collector**, not OpenClaw → hub directly. Three reasons:
+
+1. **No docker assumption on spokes.** `mycelium install` only runs on the hub. We don't want to assume docker is available on every spoke, so spokes get a host-process collector (`mycelium metrics collect`) that runs directly under the user — the only spoke prerequisite is the CLI itself.
+2. **Local survives a hub outage.** Every OTLP payload lands in `~/.mycelium/metrics/metrics.json` (and `traces.db`) on the spoke first, then forwards to the hub. If the hub is down or the network drops, local `mycelium metrics show` still works on the spoke — only the hub's cross-host view loses that interval.
+3. **Forwarding is fire-and-forget.** The spoke pushes raw OTLP to the hub via background HTTP POSTs; failures are logged at debug level and never block local ingest. That's why hub-side errors surface as gaps in the Spoke Sites table rather than as visible errors on the spoke (see [metrics docs](../metrics.md#hub-and-spoke-setup) for the full architecture diagram).
+
+`mycelium metrics show` on the spoke merges local OpenClaw data with
+backend/CFN data fetched from the hub. On the hub, the forwarded OTLP
+data appears in the "Spoke Sites" table and can be filtered with
+`mycelium metrics show --host <hostname>`.
+
+For a span-level view of the activity each spoke is forwarding — drill
+down by host, agent, room, channel, model, tool, error, or latency, and
+render any single trace as a parent → child tree — use the trace viewer
+on the hub:
+
+```bash
+mycelium metrics traces summary --since=1h     # rollup
+mycelium metrics traces by-host --since=1h      # per-spoke
+mycelium metrics traces show <trace_id>         # one trace as a tree
+```
+
+See [Viewing Traces](../metrics.md#viewing-traces) for the full command
+list and pivots.
+
+See the [Metrics System docs](../metrics.md#hub-and-spoke-setup) for
+full details.
+
+## Troubleshooting
+
+### Spoke can't reach hub
+
+```bash
+curl http://<hub-ip>:8000/health
+```
+
+If this fails, check firewall rules, VPN connectivity, or security
+groups. The backend binds to `0.0.0.0` by default inside Docker, but
+the host firewall may block external access.
+
+### Agent joins but doesn't respond
+
+The agent's OpenClaw gateway plugin subscribes to SSE on the hub. If the
+agent joins a session (visible in `mycelium room ls`) but never responds
+to coordination ticks:
+
+1. Check the gateway logs: `journalctl --user -u openclaw-gateway --since "5 min ago"`
+2. Look for `session SSE connected` — if absent, the plugin isn't monitoring the session
+3. Verify channel tokens are valid (see above)
+
+### Doctor reports "spoke mode" unexpectedly
+
+`mycelium doctor` auto-detects mode from `server.api_url`. If it points
+to a non-localhost address, doctor assumes spoke mode. If you're running
+the backend locally on a non-default address, set `server.api_url` to
+`http://localhost:8000` in `~/.mycelium/config.toml`.
+
+
+---
+
+# Troubleshooting
+
+## Quick Diagnostics
+
+```bash
+mycelium status          # human-readable health check
+mycelium status --json   # machine-readable (backend, DB, LLM, disk)
+mycelium logs --tail 50  # recent service logs
+```
+
+---
+
+## Common Issues
+
+### 1. Command Not Found
+
+**Symptom**: `mycelium: command not found`
+
+**Fix**:
+```bash
+curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
+```
+
+Or add to PATH if the binary exists:
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+---
+
+### 2. Backend Not Running
+
+**Symptom**: `Cannot connect to Mycelium API at http://localhost:8000`
+
+```bash
+mycelium status             # quick check
+docker ps | grep mycelium   # container status
+mycelium up                 # start services
+mycelium logs mycelium-backend --tail 50
+```
+
+---
+
+### 3. Config Not Found
+
+**Symptom**: `Configuration file not found: ~/.mycelium/config.toml`
+
+```bash
+mycelium init
+# or with a custom URL:
+mycelium init --api-url http://your-server:8000
+```
+
+---
+
+### 4. Database Connection Failed
+
+**Symptom**: Backend logs show `connection refused` or `could not connect to server`
+
+```bash
+docker ps | grep mycelium-db    # is the container running?
+docker logs mycelium-db --tail 20
+```
+
+- DB takes ~15s to initialize on first run — wait and retry
+- Check for port conflict: `lsof -i :5432`
+- Restart: `mycelium down && mycelium up`
+- Nuclear option (destroys data): `mycelium down --volumes && mycelium up`
+
+---
+
+### 5. Port Already in Use
+
+**Symptom**: `bind: address already in use`
+
+```bash
+lsof -i :8000   # backend
+lsof -i :5432   # database
+```
+
+All four published host ports can be remapped — prefer setting the
+corresponding `runtime.*` config key and re-running `mycelium config
+apply` (which materialises `~/.mycelium/.env`) rather than hand-editing
+the env file:
+
+```bash
+mycelium config set runtime.backend_port 8001     # MYCELIUM_BACKEND_PORT
+mycelium config set runtime.frontend_port 3001    # MYCELIUM_UI_PORT
+mycelium config set runtime.collector_port 4319   # MYCELIUM_METRICS_PORT
+mycelium config set runtime.db_port 5433          # MYCELIUM_DB_PORT
+mycelium config apply
+mycelium down && mycelium up                      # restart to pick up new ports
+```
+
+---
+
+### 6. LLM Not Configured
+
+**Symptom**: `LLM unavailable — no API key configured`
+
+Add to `~/.mycelium/.env`:
+```
+LLM_MODEL=anthropic/claude-sonnet-4-6
+LLM_API_KEY=sk-ant-...
+```
+
+For local Ollama:
+```
+LLM_MODEL=ollama/llama3
+LLM_BASE_URL=http://localhost:11434
+```
+
+Restart after changes: `mycelium down && mycelium up`
+
+---
+
+### 7. Memory Search Returns Nothing
+
+**Symptom**: `mycelium memory search` is empty despite memories existing
+
+```bash
+mycelium memory ls          # do memories exist?
+ls ~/.mycelium/rooms/       # files present?
+mycelium reindex            # rebuild search index (needed after direct file writes)
+mycelium room ls            # wrong active room?
+```
+
+---
+
+### 7b. Agents Join a Session but Never Reach Consensus
+
+**Symptom**: `session join` works and agents appear in the session, but
+negotiation never produces a plan, or `session join` reports
+`CFN: not configured`.
+
+Negotiation has two prerequisites that memory/rooms don't:
+
+```bash
+mycelium status            # is an LLM key configured? (CE needs one to propose)
+grep -i ioc ~/.mycelium/.env   # was the stack installed with IoC/CFN enabled?
+```
+
+- **No LLM key** → the CognitiveEngine can't generate proposals. Add one (see
+  *LLM Not Configured* above) and restart: `mycelium down && mycelium up`.
+- **IoC/CFN disabled** → re-run `mycelium install` (interactive enables IoC by
+  default), or reinstall without `--no-ioc`.
+
+---
+
+### 8. Container Name Conflicts
+
+**Symptom**: `container name "mycelium-db" is already in use`
+
+The CLI handles this automatically, but if it persists:
+```bash
+docker rm -f mycelium-db mycelium-backend
+mycelium up
+```
+
+---
+
+### 9. Migration Failures
+
+**Symptom**: `alembic.util.exc.CommandError` or schema mismatch errors in logs
+
+Migrations run automatically on container start. If they fail:
+```bash
+mycelium logs mycelium-backend --tail 100   # check startup errors
+mycelium down && mycelium up                # restart often fixes it
+```
+
+If the schema is corrupted (destroys data):
+```bash
+mycelium down --volumes && mycelium up
+```
+
+---
+
+### 10. No Active Room
+
+**Symptom**: `No active room. Use 'mycelium room use <name>'`
+
+```bash
+mycelium room ls
+mycelium room use <name>
+# or pass room explicitly:
+mycelium memory ls --room <name>
+```
+
+---
+
+### 11. OpenClaw Agents Prompt for Approval on Mycelium Commands
+
+**Symptom**: Agents display "Approval required" when running `mycelium session join` or similar commands.
+
+**Fix**: Add mycelium to OpenClaw's exec approvals allowlist:
+
+```bash
+# For specific agents (recommended):
+openclaw approvals allowlist add --agent "<agent-id>" "~/.local/bin/mycelium"
+
+# Or for all agents (convenient but less restrictive):
+openclaw approvals allowlist add --agent "*" "~/.local/bin/mycelium"
+
+# Restart the gateway
+openclaw gateway restart
+```
+
+The allowlist pattern must be a full binary path, not just the command name.
+
+---
+
+### 12. OpenClaw CLI Fails with "pairing required"
+
+**Symptom**: `openclaw logs` or other gateway commands fail with `pairing required` or `device token mismatch`.
+
+**Fix**: Approve the pending device pairing request:
+
+```bash
+openclaw devices list
+openclaw devices approve <requestId>
+# Or approve the most recent:
+openclaw devices approve --latest
+```
+
+---
+
+### 13. OpenClaw Adapter Fails on Containerized Gateway
+
+**Symptom**: `mycelium adapter add openclaw --openclaw-container <name>` fails with
+`No running container matched "<name>" under podman or docker`, even though
+`docker exec <name> openclaw status` works fine.
+
+**Cause**: Mycelium routes install commands through `docker exec` to avoid OpenClaw's
+`--container` flag, which uses `docker inspect` for container-name resolution. If you
+see this error, you may be running an older version of the CLI that still uses
+`openclaw --container`.
+
+**Fix**: Upgrade to the latest Mycelium CLI:
+
+```bash
+curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
+```
+
+Verify the container is reachable:
+
+```bash
+# Get the exact container name
+docker ps --format "{{.Names}}" | grep -i openclaw
+
+# Verify connectivity
+docker exec <container-name> openclaw status
+
+# Install with container flag
+mycelium adapter add openclaw --openclaw-container <container-name>
+```
+
+You can also set `OPENCLAW_CONTAINER` as an environment variable instead of passing
+`--openclaw-container` every time.
+
+---
+
+### 14. Agents Join Sessions but Never Respond (Expired Channel Tokens)
+
+**Symptom**: An agent appears in `mycelium room ls` as a session
+participant, but never responds to coordination ticks. No error in
+`mycelium logs`.
+
+**Cause**: The agent's channel access token has expired or been
+invalidated (e.g., after a server restart). The OpenClaw gateway
+silently drops the channel sync connection without surfacing an error to
+Mycelium.
+
+**Diagnosis**:
+
+```bash
+# Check gateway logs for channel sync errors
+journalctl --user -u openclaw-gateway --since "10 min ago" | grep -i "sync\|401\|unauthorized"
+
+# Or on the hub
+openclaw logs | grep -i "sync\|401\|unauthorized"
+```
+
+**Fix**: Re-authenticate the agent with the channel server and update
+the token in `~/.openclaw/openclaw.json` under the corresponding
+`channels.<channel>.accounts.<agent>` section. Then restart the gateway:
+
+```bash
+openclaw gateway restart
+```
+
+In a hub-and-spoke setup, update tokens on every node that runs agents.
+
+---
+
+### 16. Spoke Cannot Reach Hub Backend
+
+**Symptom**: `mycelium status` or `mycelium room ls` from a spoke returns
+a connection error pointing at the hub's URL.
+
+**Diagnosis**:
+
+```bash
+# Test raw connectivity
+curl http://<hub-ip>:8000/health
+
+# Check what the spoke is configured to use
+grep api_url ~/.mycelium/config.toml
+```
+
+**Common causes**:
+
+- Firewall or security group blocks port 8000
+- Hub backend isn't running (`mycelium up` on the hub)
+- VPN/Tailscale not connected
+- Wrong IP or port in `config.toml`
+
+**Fix**: Ensure the hub is running and the spoke can reach it, then
+re-initialise if the URL is wrong:
+
+```bash
+mycelium init --api-url http://<correct-hub-ip>:8000
+```
+
+---
+
+## Configuration Reference
+
+### CLI settings — `~/.mycelium/config.toml`
+
+| Setting | Key | Env var override |
+|---------|-----|------------------|
+| Backend URL | `server.api_url` | `MYCELIUM_API_URL` |
+| Workspace ID | `server.workspace_id` | `MYCELIUM_WORKSPACE_ID` |
+| Active room | `rooms.active` | `MYCELIUM_ACTIVE_ROOM` |
+| Agent handle | `identity.name` | `MYCELIUM_AGENT_HANDLE` |
+
+### Backend settings — `~/.mycelium/.env`
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `LLM_MODEL` | LiteLLM model string | `anthropic/claude-sonnet-4-6` |
+| `LLM_API_KEY` | Provider API key | — |
+| `LLM_BASE_URL` | Custom LLM endpoint (Ollama, vLLM) | — |
+| `MYCELIUM_DATA_DIR` | Data directory | `~/.mycelium` |
+| `MYCELIUM_BACKEND_PORT` | Backend API host port | `8000` |
+| `MYCELIUM_UI_PORT` | Frontend host port (`--ui`) | `3000` |
+| `MYCELIUM_METRICS_PORT` | OTLP collector host port (`--metrics`) | `4318` |
+| `MYCELIUM_DB_PORT` | Database host port | `5432` |
+
+All of these are written by `mycelium config apply` from the matching
+`runtime.*` config keys — don't edit `.env` by hand.
+
+### Agent environment variables
+
+Read by the CLI and adapters at runtime to identify the agent and locate the backend:
+
+| Variable | Description |
+|----------|-------------|
+| `MYCELIUM_API_URL` | Backend API URL (default: `http://localhost:8000`) |
+| `MYCELIUM_AGENT_HANDLE` | This agent's identity handle |
+| `MYCELIUM_ROOM` | Active room name |
+| `MYCELIUM_WORKSPACE_ID` | CFN workspace UUID, required for knowledge ingest |
+| `MYCELIUM_MAS_ID` | CFN MAS UUID, required for knowledge ingest |
+
+### Knowledge-ingest cost controls
+
+Overrides for `[knowledge_ingest]` in `~/.mycelium/config.toml`. Every key below
+has a matching env var for ephemeral changes (no config edit needed). Forwarding
+to the CFN graph is off by default.
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `MYCELIUM_INGEST_ENABLED` | `true` | Master kill switch. `0`/`false` short-circuits every ingest at the backend gate (no concept extraction, no CFN spend) and the endpoint returns 200 with a disabled marker. |
+| `MYCELIUM_INGEST_MIN_CONTENT_CHARS` | `32` | Skip ingest for trivially short content ("ack", emoji-only). `0` disables the gate. |
+| `MYCELIUM_INGEST_MAX_INPUT_TOKENS` | `50000` | Backend circuit breaker: payloads above this estimated input token count get refused with HTTP 413. `0` disables. |
+| `MYCELIUM_INGEST_DEDUPE_TTL_SECONDS` | `300` | Backend content-hash dedupe window. Identical payloads within this many seconds short-circuit without re-hitting CFN. `0` disables dedupe. |
+
+---
+
+## Log Locations
+
+```bash
+mycelium logs                       # all services
+mycelium logs mycelium-backend      # backend only
+mycelium logs mycelium-db           # database only
+mycelium --verbose status           # CLI debug output
+```
+
+---
+
+## Reset Everything
+
+```bash
+mycelium down --volumes   # stop and delete all data
+rm -rf ~/.mycelium        # remove all config
+mycelium install          # fresh install
+```
+
+---
+
+## Getting Help
+
+Report issues at **https://github.com/mycelium-io/mycelium/issues**

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -20,6 +20,24 @@
   --muted: #898781;          /* dimmed warm gray (labels, captions) */
   --dim: rgba(234, 234, 234, 0.22);
   --sidebar-width: 240px;
+
+  /* spacing scale */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-7: 48px;
+  --space-8: 64px;
+
+  /* mono type scale (collapsed from 7 ad-hoc sizes to 3) */
+  --mono-cap: 11px;     /* eyebrows, captions, labels */
+  --mono-code: 13px;    /* code blocks + inline code */
+  --mono-inline: 14px;  /* emphasized inline mono */
+
+  /* reading measure for prose (code/tables stay wider) */
+  --measure: 72ch;
 }
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -292,7 +310,7 @@ body {
 
 /* ── SECTIONS ── */
 .doc-section {
-  margin-bottom: 72px;
+  margin-bottom: 88px;
   padding-top: 8px;
   scroll-margin-top: 122px;
 }
@@ -303,39 +321,40 @@ h1[id], h2[id], h3[id], h4[id], section[id] {
 
 
 .section-eyebrow {
-  font-size: 10px;
+  font-size: var(--mono-cap);
   font-weight: 700;
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--accent);
   font-family: 'SF Mono', monospace;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
 }
 
 h1 {
-  font-size: 2.375rem;
+  font-size: 2.5rem;
   font-weight: 600;
   font-style: italic;
   letter-spacing: -0.02em;
-  line-height: 1.15;
+  line-height: 1.12;
   font-family: 'Cormorant Garamond', Georgia, serif;
-  margin-bottom: 16px;
+  margin-bottom: var(--space-4);
 }
 
 h2 {
-  font-size: 1.5rem;
+  font-size: 1.6875rem;
   font-weight: 700;
   letter-spacing: -0.01em;
-  margin-bottom: 14px;
-  margin-top: 40px;
+  line-height: 1.25;
+  margin-bottom: var(--space-4);
+  margin-top: var(--space-8);
   color: var(--text);
 }
 
 h3 {
-  font-size: 1.125rem;
+  font-size: 1.25rem;
   font-weight: 700;
-  margin-bottom: 10px;
-  margin-top: 28px;
+  margin-bottom: var(--space-3);
+  margin-top: var(--space-6);
   color: var(--accent2);
   font-family: 'SF Mono', monospace;
   letter-spacing: 0.02em;
@@ -343,13 +362,15 @@ h3 {
 
 p {
   color: var(--text);
-  margin-bottom: 14px;
+  margin-bottom: var(--space-4);
   line-height: 1.8;
+  max-width: var(--measure);
 }
 
 .main ul,
 .main ol {
   line-height: 1.8;
+  max-width: var(--measure);
 }
 .main li {
   margin-bottom: 6px;
@@ -364,10 +385,11 @@ a:hover { text-decoration: underline; }
 strong { color: var(--text); font-weight: 600; }
 
 .lead {
-  font-size: 1.125rem;
+  font-size: 1.1875rem;
   color: var(--text2);
   line-height: 1.6;
-  margin-bottom: 32px;
+  margin-bottom: var(--space-6);
+  max-width: var(--measure);
 }
 
 /* ── DIVIDER ── */
@@ -380,7 +402,7 @@ strong { color: var(--text); font-weight: 600; }
 /* ── CODE ── */
 code {
   font-family: 'SF Mono', 'Fira Mono', 'Menlo', monospace;
-  font-size: 13px;
+  font-size: var(--mono-code);
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -402,7 +424,7 @@ pre code {
   background: none;
   border: none;
   padding: 0;
-  font-size: 0.8125rem;
+  font-size: var(--mono-code);
   color: var(--text);
 }
 .pre-label {

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Reference — mycelium</title>
-<meta name="description" content="Architecture, CLI reference, configuration, and troubleshooting for Mycelium.">
+<meta name="description" content="Architecture, CLI reference, configuration, guides, and troubleshooting for Mycelium.">
 <meta property="og:title" content="Reference — mycelium">
-<meta property="og:description" content="Architecture, CLI reference, configuration, and troubleshooting for Mycelium.">
+<meta property="og:description" content="Architecture, CLI reference, configuration, guides, and troubleshooting for Mycelium.">
 <meta property="og:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <meta property="og:url" content="https://mycelium-io.github.io/mycelium/reference.html">
 <meta property="og:type" content="website">
@@ -34,7 +34,8 @@
 </nav>
 <nav class="sectionnav">
   <div class="sectionnav-inner">
-    <a href="index.html" class=""><span class="square-dot"></span>LEARN</a>
+    <a href="index.html" class=""><span class="square-dot"></span>GET STARTED</a>
+    <a href="concepts.html" class=""><span class="square-dot"></span>CONCEPTS</a>
     <a href="adapters.html" class=""><span class="square-dot"></span>ADAPTERS</a>
     <a href="reference.html" class="active"><span class="square-dot"></span>REFERENCE</a>
     <div class="sectionnav-right">
@@ -72,6 +73,11 @@
       <a href="#config-rooms" class="nav-link sub">rooms</a>
       <a href="#config-knowledge-ingest" class="nav-link sub">knowledge_ingest</a>
       <a href="#config-metrics" class="nav-link sub">metrics</a>
+    </div>
+    <div class="nav-section">
+      <div class="nav-section-label">Guides</div>
+      <a href="#structured-memory" class="nav-link sub">Structured Memory</a>
+      <a href="#hub-and-spoke" class="nav-link sub">Hub &amp; Spoke</a>
     </div>
     <div class="nav-section">
       <div class="nav-section-label">Help</div>
@@ -123,6 +129,13 @@
         <div class="callout-bar"></div>
         <div class="callout-body"><strong>Terminology note.</strong> Earlier releases used &quot;leaf&quot; instead of &quot;spoke&quot;. The CLI flag <code>--mode leaf</code> was renamed to <code>--mode spoke</code> in a hard cutover (no alias) to align with the standard hub-and-spoke vocabulary. If you have scripts that pass <code>--mode leaf</code>, update them to <code>--mode spoke</code>.</div>
       </div>
+      <h3 id="architecture-syncing-room-files-remote-backend">Syncing room files (remote backend)</h3>
+      <p>When the backend runs on a remote server (EC2, Raspberry Pi, a hub), room files sync via the HTTP API. The adapter does not auto-sync; run <code>mycelium sync</code> yourself when you want fresh state.</p>
+      <pre><code><span class="comment"># Clone a room from a remote backend</span>
+<span class="cmd">mycelium room clone</span> my-project <span class="flag">--from</span> http://ec2-host:8000
+
+<span class="comment"># Fetch all memories from the backend and write local files</span>
+<span class="cmd">mycelium sync</span></code></pre>
       <h2 id="architecture-stack">Stack</h2>
       <p>Everything runs on a single <strong>AgensGraph</strong> instance — a PostgreSQL 16 fork with multi-model support. No external message broker, no separate vector database.</p>
       <div class="table-wrap">
@@ -186,7 +199,7 @@
       <h2 id="architecture-adapters">Adapters</h2>
       <p>Mycelium integrates with AI coding agents via adapters. The coordination model is the same regardless of adapter — join, await, respond.</p>
       <h3 id="architecture-claude-code">Claude Code</h3>
-      <p>The Mycelium skill ships as a Claude Code hook set. Lifecycle hooks capture tool use and context automatically. The <code>mycelium</code> slash command provides memory and coordination commands inline.</p>
+      <p>The Mycelium skill installs as a Claude Code skill (<code>~/.claude/skills/mycelium/SKILL.md</code>), invoked via the <code>/mycelium</code> slash command for memory and coordination commands. The adapter is skill-only; earlier hook-based versions were removed.</p>
       <pre><code><span class="comment"># The skill is invoked automatically in Claude Code sessions</span>
 <span class="comment"># or explicitly via the slash command</span>
 /mycelium</code></pre>
@@ -843,6 +856,261 @@ export OPENCLAW_CONTAINER=openclaw-gateway-1
 
     <hr class="divider">
 
+    <section class="doc-section" id="structured-memory">
+      <h1>Structured Memory Guide</h1>
+      <p>This guide shows how to use Mycelium&#x27;s structured memory conventions to give agents continuity across sessions.</p>
+      <h2 id="structured-memory-the-problem">The Problem</h2>
+      <p>An agent helps build something over a long session. The session ends. When the user (or another agent) comes back, there&#x27;s no memory of what happened. The new session starts from scratch.</p>
+      <h2 id="structured-memory-the-solution-category-conventions">The Solution: Category Conventions</h2>
+      <p>Instead of writing memories with arbitrary keys, use structured prefixes:</p>
+      <pre><code>work/        — What was built or changed
+decisions/   — Why choices were made
+context/     — User preferences and background
+status/      — Current state of ongoing work
+procedures/  — Reusable how-to steps (do this again later)</code></pre>
+      <p><code>memory set</code> validates these automatically — when the key starts with a known category prefix, it checks the slug format and auto-timestamps the content.</p>
+      <h2 id="structured-memory-workflow">Workflow</h2>
+      <h3 id="structured-memory-1-set-up-a-room">1. Set up a room</h3>
+      <pre><code><span class="cmd">mycelium room create</span> project-x
+<span class="cmd">mycelium room use</span> project-x</code></pre>
+      <h3 id="structured-memory-2-write-structured-memories-as-you-work">2. Write structured memories as you work</h3>
+      <pre><code><span class="comment"># Record what you built</span>
+<span class="cmd">mycelium memory set</span> work/api-server <span class="str">&quot;Set up FastAPI with auth endpoints&quot;</span>
+<span class="cmd">mycelium memory set</span> work/database <span class="str">&quot;Created PostgreSQL schema, 3 tables&quot;</span>
+
+<span class="comment"># Record why you made choices</span>
+<span class="cmd">mycelium memory set</span> decisions/framework <span class="str">&quot;FastAPI over Flask: async + type hints&quot;</span>
+<span class="cmd">mycelium memory set</span> decisions/auth <span class="str">&quot;JWT tokens, 1hr expiry, refresh via cookie&quot;</span>
+
+<span class="comment"># Record user context</span>
+<span class="cmd">mycelium memory set</span> context/goal <span class="str">&quot;Build MVP for investor demo by Friday&quot;</span>
+<span class="cmd">mycelium memory set</span> context/constraints <span class="str">&quot;Must run on single $20/mo VPS&quot;</span>
+
+<span class="comment"># Track current state</span>
+<span class="cmd">mycelium memory set</span> status/api <span class="str">&quot;PASSING — all 12 endpoints tested&quot;</span>
+<span class="cmd">mycelium memory set</span> status/deploy <span class="str">&quot;BLOCKED — waiting on DNS propagation&quot;</span>
+
+<span class="comment"># Save reusable procedures</span>
+<span class="cmd">mycelium memory set</span> procedures/deploy-vps &quot;1. ssh vps  2. cd /app &amp;&amp; git pull  3. systemctl restart app  4. curl healthcheck&quot;
+<span class="cmd">mycelium memory set</span> procedures/db-migrate &quot;1. uv run alembic upgrade head  2. Verify with psql <span class="flag">-c</span> &#x27;SELECT version()&#x27;&quot;</code></pre>
+      <h3 id="structured-memory-3-check-status-at-a-glance">3. Check status at a glance</h3>
+      <pre><code><span class="cmd">mycelium memory status</span>     # Table of all status/* memories
+<span class="cmd">mycelium memory work</span>       # What&#x27;s been built
+<span class="cmd">mycelium memory decisions</span>  # Why things are the way they are
+<span class="cmd">mycelium memory procedures</span> # How to do things again</code></pre>
+      <h3 id="structured-memory-4-update-status-as-things-change">4. Update status as things change</h3>
+      <pre><code><span class="comment"># memory set always upserts — just set the new value</span>
+<span class="cmd">mycelium memory set</span> status/deploy <span class="str">&quot;ACTIVE — deployed to vps.example.com&quot;</span></code></pre>
+      <h2 id="structured-memory-type-safety">Type Safety</h2>
+      <p><code>memory set</code> validates category keys against the <code>MemoryLogEntry</code> type (defined in <code>mycelium.protocol</code>). This is the same pattern used for negotiation payloads (<code>ProposeReply</code>, <code>RespondReply</code>) — Pydantic validation before the API call, so malformed slugs fail fast on the client side.</p>
+      <p>Valid slugs: lowercase alphanumeric, hyphens, dots, underscores.</p>
+      <ul>
+        <li><code>work/api-server</code> — valid</li>
+        <li><code>status/v2.deploy</code> — valid</li>
+        <li><code>decisions/Why We Chose X</code> — invalid (uppercase, spaces)</li>
+      </ul>
+      <p>Keys without a known category prefix skip validation entirely:</p>
+      <ul>
+        <li><code>custom/anything</code> — passes through, no slug check</li>
+        <li><code>research/pgvector-perf</code> — passes through</li>
+      </ul>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="hub-and-spoke">
+      <h1>Hub &amp; Spoke Setup</h1>
+      <p>How to run Mycelium across multiple machines so a small team shares memory, rooms, and coordination state from a single backend.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Note:</strong> The examples below use the <strong>mycelium-room</strong> channel (the Mycelium room UI) as the agent surface and <strong>OpenClaw</strong> as the agent adapter. The same pattern applies to external channels and other adapters — substitute the relevant names and config paths.</div>
+      </div>
+      <h2 id="hub-and-spoke-when-to-use-this">When to use this</h2>
+      <p>Use hub-and-spoke when multiple people (or multiple machines) need to participate in the same rooms, see the same memories, and coordinate agents together. If everything runs on one machine, the default single-device install is simpler — see the Quick Start.</p>
+      <h2 id="hub-and-spoke-topology">Topology</h2>
+      <pre><code>┌──────────────────────────────────┐
+│  Hub  (one machine)              │
+│                                  │
+│  <span class="cmd">mycelium install</span>                │
+│  ├─ FastAPI backend  :8000       │
+│  ├─ AgensGraph (PG)  :5432       │
+│  ├─ CFN mgmt plane   :9000       │
+│  └─ CFN runtime      :9002       │
+│                                  │
+│  OpenClaw gateway                │
+│  All agents added here           │
+└────────────┬─────────────────────┘
+             │  HTTPS / SSE
+     ┌───────┴───────┐
+     │               │
+┌────┴─────┐   ┌─────┴────┐
+│ Spoke A  │   │ Spoke B  │
+│          │   │          │
+│ CLI only │   │ CLI only │
+│ + agents │   │ + agents │
+│ No Docker│   │ No Docker│
+└──────────┘   └──────────┘</code></pre>
+      <p>The hub runs the full stack. Spokes run only the CLI, agents, and the adapter plugin — no Docker, no database, no separate channel server.</p>
+      <h2 id="hub-and-spoke-step-1-set-up-the-hub">Step 1: Set up the hub</h2>
+      <p>On the hub machine, run the standard install:</p>
+      <pre><code><span class="cmd">mycelium install</span>
+<span class="cmd">mycelium up</span> <span class="flag">--metrics</span>            # include <span class="flag">--metrics</span> if you want spoke telemetry</code></pre>
+      <p>This brings up the backend, database, and provisions a default workspace. The <code>--metrics</code> flag also starts the dockerized OTLP collector listening on <code>:4318</code>. It serves two purposes on the hub: it collects telemetry from the hub&#x27;s own OpenClaw gateway (so <code>mycelium metrics show</code> on the hub has data even with zero spokes), and it accepts forwarded payloads from spokes once they&#x27;re configured in <a href="#hub-and-spoke-step-4-set-up-spoke-metrics">Step 4</a> — which is what powers the unified cross-host view (Spoke Sites table, <code>--host</code> filter). Skip the flag only if you don&#x27;t want metrics at all.</p>
+      <p>Verify with:</p>
+      <pre><code><span class="cmd">mycelium doctor</span></code></pre>
+      <h3 id="hub-and-spoke-open-ports">Open ports</h3>
+      <p>Spokes need to reach the hub on these ports:</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Port</th>
+              <th>Service</th>
+              <th>Required</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>8000</td>
+              <td>Mycelium backend (API + SSE)</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <td>9000</td>
+              <td>CFN management plane</td>
+              <td>If using CognitiveEngine</td>
+            </tr>
+            <tr>
+              <td>9002</td>
+              <td>CFN runtime</td>
+              <td>If using CognitiveEngine</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>Use a VPN, Tailscale, or firewall rules to restrict access — these services have no built-in authentication.</p>
+      <h3 id="hub-and-spoke-add-agents-on-the-hub">Add agents on the hub</h3>
+      <p>Agents talk through the <strong>mycelium-room</strong> channel — the chat box and live message stream in the Mycelium room UI, served by the Mycelium backend. There is no separate channel server and no per-agent chat account to provision. Add every agent (across all spokes) on the hub:</p>
+      <pre><code><span class="comment"># Add an agent and auto-wire the OpenClaw mycelium-room channel</span>
+<span class="cmd">mycelium agent add</span> agent-alpha</code></pre>
+      <p><code>mycelium agent add</code> (or <code>mycelium agent create</code>) registers the agent and auto-wires the OpenClaw <code>mycelium-room</code> channel into the hub&#x27;s <code>~/.openclaw/openclaw.json</code>. The hub&#x27;s gateway manages all channel connections — spokes do not run their own channel clients. (To wire in an *external* channel, add it under <code>channels.&lt;channel&gt;.accounts</code> instead.)</p>
+      <h2 id="hub-and-spoke-step-2-set-up-each-spoke">Step 2: Set up each spoke</h2>
+      <p>On each spoke machine, install only the CLI (no <code>mycelium install</code>):</p>
+      <pre><code>curl <span class="flag">-fsSL</span> https://mycelium-io.github.io/mycelium/install.sh | bash</code></pre>
+      <h3 id="hub-and-spoke-initialize-and-install-the-adapter">Initialize and install the adapter</h3>
+      <p>Point the spoke at the hub and install the adapter:</p>
+      <pre><code><span class="cmd">mycelium init</span> <span class="flag">--api-url</span> http://&lt;hub-ip&gt;:8000
+<span class="cmd">mycelium adapter add</span> openclaw</code></pre>
+      <p><code>init</code> writes <code>~/.mycelium/config.toml</code> with the hub&#x27;s API URL. <code>adapter add</code> installs the Mycelium plugin into the local OpenClaw gateway and probes the hub to confirm it&#x27;s reachable. The plugin connects to the hub&#x27;s backend for SSE subscriptions and API calls.</p>
+      <p>After installing, restart the gateway:</p>
+      <pre><code>openclaw gateway restart</code></pre>
+      <p>Verify the setup:</p>
+      <pre><code><span class="cmd">mycelium doctor</span></code></pre>
+      <p>The doctor auto-detects whether this node is a hub or spoke from <code>server.api_url</code> and adjusts its checks accordingly (e.g., skipping Docker/database checks on spokes).</p>
+      <h3 id="hub-and-spoke-spoke-config-summary">Spoke config summary</h3>
+      <p>A spoke needs only two files:</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>File</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>~/.mycelium/config.toml</code></td>
+              <td>Points <code>server.api_url</code> at the hub</td>
+            </tr>
+            <tr>
+              <td><code>~/.openclaw/openclaw.json</code></td>
+              <td>Agent definitions, channel credentials, Mycelium plugin config</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The spoke does not need <code>server.workspace_id</code> or <code>server.mas_id</code> in its config — the hub resolves these automatically when the spoke&#x27;s agents join rooms and sessions.</p>
+      <h2 id="hub-and-spoke-step-3-verify-the-setup">Step 3: Verify the setup</h2>
+      <p>From each spoke, confirm connectivity:</p>
+      <pre><code><span class="comment"># Should return rooms from the hub</span>
+<span class="cmd">mycelium room ls</span>
+
+<span class="comment"># Should show hub health</span>
+<span class="cmd">mycelium status</span></code></pre>
+      <p>Test agent participation by creating a room on the hub and joining from a spoke:</p>
+      <pre><code><span class="comment"># On the hub</span>
+<span class="cmd">mycelium room create</span> test-room
+
+<span class="comment"># On the spoke</span>
+<span class="cmd">mycelium session join</span> <span class="flag">--handle</span> spoke-agent <span class="flag">-m</span> <span class="str">&quot;Hello from spoke&quot;</span> <span class="flag">-r</span> test-room</code></pre>
+      <h2 id="hub-and-spoke-agent-identity">Agent identity</h2>
+      <p>Each agent needs a unique handle across the entire deployment. The handle is set by:</p>
+      <ol class="steps">
+        <li><code>identity.name</code> in <code>~/.mycelium/config.toml</code></li>
+        <li>The <code>MYCELIUM_AGENT_HANDLE</code> environment variable</li>
+        <li>The <code>--handle</code> flag on CLI commands</li>
+      </ol>
+      <p>For the mycelium-room channel, the handle *is* the agent&#x27;s identity in the room UI — <code>mycelium agent add agent-alpha</code> uses <code>agent-alpha</code> directly. For an external channel, the handle should match that channel&#x27;s user ID for the agent.</p>
+      <h2 id="hub-and-spoke-token-management">Token management</h2>
+      <p>Channel access tokens can expire or become invalid after server restarts. When this happens, agents silently stop receiving messages.</p>
+      <p>Signs of expired tokens:</p>
+      <ul>
+        <li>Agents join sessions but never respond to coordination ticks</li>
+        <li>Gateway logs show sync errors or 401/unauthorized responses</li>
+        <li><code>mycelium doctor</code> reports channel connection failures</li>
+      </ul>
+      <p>To refresh tokens, re-authenticate the agent with the channel, update the token in <code>channels.&lt;channel&gt;.accounts[agent]</code> in each node&#x27;s <code>openclaw.json</code>, and restart the gateway. (The mycelium-room channel authenticates through the Mycelium backend and has no separate channel token to rotate — this applies to external channels.)</p>
+      <h2 id="hub-and-spoke-step-4-set-up-spoke-metrics">Step 4: Set up spoke metrics</h2>
+      <p>Each spoke can run a lightweight local collector for OpenClaw telemetry. The collector stores data locally <strong>and</strong> forwards OTLP payloads to the hub so it can build a unified cross-host view.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Prerequisite:</strong> the hub must already be running with <code>mycelium up --metrics</code> (see <a href="#hub-and-spoke-step-1-set-up-the-hub">Step 1</a>) so that the hub collector is listening on <code>:4318</code> and can accept forwarded payloads. The spoke collector forwards fire-and-forget — silent failures will show up as gaps in the hub&#x27;s &quot;Spoke Sites&quot; table, not as errors on the spoke.</div>
+      </div>
+      <pre><code><span class="comment"># Point the spoke&#x27;s metrics at the hub collector. Use the hub&#x27;s</span>
+<span class="comment"># collector_port if you remapped it from the 4318 default.</span>
+<span class="cmd">mycelium config set</span> metrics.collector_url &quot;http://&lt;hub-ip&gt;:4318&quot;
+
+<span class="comment"># Configure OTLP plugin (endpoint defaults to localhost:4318)</span>
+<span class="cmd">mycelium adapter add</span> openclaw <span class="flag">--step</span>=otel
+
+<span class="comment"># Start the spoke collector (daemonizes into background). This is the</span>
+<span class="comment"># host-process variant — we don&#x27;t want to assume docker on spokes, so</span>
+<span class="comment"># the collector runs directly under the user instead of as a container.</span>
+<span class="cmd">mycelium metrics collect</span>
+
+<span class="comment"># Stop it later with:</span>
+<span class="cmd">mycelium metrics stop</span></code></pre>
+      <h3 id="hub-and-spoke-how-the-spoke-collector-works">How the spoke collector works</h3>
+      <p>The spoke pipeline is <strong>OpenClaw → local spoke collector → hub collector</strong>, not OpenClaw → hub directly. Three reasons:</p>
+      <ol class="steps">
+        <li><strong>No docker assumption on spokes.</strong> <code>mycelium install</code> only runs on the hub. We don&#x27;t want to assume docker is available on every spoke, so spokes get a host-process collector (<code>mycelium metrics collect</code>) that runs directly under the user — the only spoke prerequisite is the CLI itself.</li>
+        <li><strong>Local survives a hub outage.</strong> Every OTLP payload lands in <code>~/.mycelium/metrics/metrics.json</code> (and <code>traces.db</code>) on the spoke first, then forwards to the hub. If the hub is down or the network drops, local <code>mycelium metrics show</code> still works on the spoke — only the hub&#x27;s cross-host view loses that interval.</li>
+        <li><strong>Forwarding is fire-and-forget.</strong> The spoke pushes raw OTLP to the hub via background HTTP POSTs; failures are logged at debug level and never block local ingest. That&#x27;s why hub-side errors surface as gaps in the Spoke Sites table rather than as visible errors on the spoke (see <a href="../metrics.md#hub-and-spoke-setup">metrics docs</a> for the full architecture diagram).</li>
+      </ol>
+      <p><code>mycelium metrics show</code> on the spoke merges local OpenClaw data with backend/CFN data fetched from the hub. On the hub, the forwarded OTLP data appears in the &quot;Spoke Sites&quot; table and can be filtered with <code>mycelium metrics show --host &lt;hostname&gt;</code>.</p>
+      <p>For a span-level view of the activity each spoke is forwarding — drill down by host, agent, room, channel, model, tool, error, or latency, and render any single trace as a parent → child tree — use the trace viewer on the hub:</p>
+      <pre><code><span class="cmd">mycelium metrics traces</span> summary <span class="flag">--since</span>=1h     # rollup
+<span class="cmd">mycelium metrics traces</span> by-host <span class="flag">--since</span>=1h      # per-spoke
+<span class="cmd">mycelium metrics traces</span> show &lt;trace_id&gt;         # one trace as a tree</code></pre>
+      <p>See <a href="../metrics.md#viewing-traces">Viewing Traces</a> for the full command list and pivots.</p>
+      <p>See the <a href="../metrics.md#hub-and-spoke-setup">Metrics System docs</a> for full details.</p>
+      <h2 id="hub-and-spoke-troubleshooting">Troubleshooting</h2>
+      <h3 id="hub-and-spoke-spoke-cant-reach-hub">Spoke can&#x27;t reach hub</h3>
+      <pre><code>curl http://&lt;hub-ip&gt;:8000/health</code></pre>
+      <p>If this fails, check firewall rules, VPN connectivity, or security groups. The backend binds to <code>0.0.0.0</code> by default inside Docker, but the host firewall may block external access.</p>
+      <h3 id="hub-and-spoke-agent-joins-but-doesnt-respond">Agent joins but doesn&#x27;t respond</h3>
+      <p>The agent&#x27;s OpenClaw gateway plugin subscribes to SSE on the hub. If the agent joins a session (visible in <code>mycelium room ls</code>) but never responds to coordination ticks:</p>
+      <ol class="steps">
+        <li>Check the gateway logs: <code>journalctl --user -u openclaw-gateway --since &quot;5 min ago&quot;</code></li>
+        <li>Look for <code>session SSE connected</code> — if absent, the plugin isn&#x27;t monitoring the session</li>
+        <li>Verify channel tokens are valid (see above)</li>
+      </ol>
+      <h3 id="hub-and-spoke-doctor-reports-spoke-mode-unexpectedly">Doctor reports &quot;spoke mode&quot; unexpectedly</h3>
+      <p><code>mycelium doctor</code> auto-detects mode from <code>server.api_url</code>. If it points to a non-localhost address, doctor assumes spoke mode. If you&#x27;re running the backend locally on a non-default address, set <code>server.api_url</code> to <code>http://localhost:8000</code> in <code>~/.mycelium/config.toml</code>.</p>
+    </section>
+
+    <hr class="divider">
+
     <section class="doc-section" id="troubleshooting">
       <h1>Troubleshooting</h1>
       <h2 id="troubleshooting-quick-diagnostics">Quick Diagnostics</h2>
@@ -910,6 +1178,20 @@ LLM_BASE_URL=http://localhost:11434</code></pre>
 ls ~/.mycelium/rooms/       # files present?
 <span class="cmd">mycelium reindex</span>            # rebuild search index (needed after direct file writes)
 <span class="cmd">mycelium room ls</span>            # wrong active room?</code></pre>
+      <hr class="divider">
+      <h3 id="troubleshooting-7b-agents-join-a-session-but-never-reach-consensus">7b. Agents Join a Session but Never Reach Consensus</h3>
+      <p><strong>Symptom</strong>: <code>session join</code> works and agents appear in the session, but negotiation never produces a plan, or <code>session join</code> reports <code>CFN: not configured</code>.</p>
+      <p>Negotiation has two prerequisites that memory/rooms don&#x27;t:</p>
+      <pre><code><span class="cmd">mycelium status</span>            # is an LLM key configured? (CE needs one to propose)
+grep <span class="flag">-i</span> ioc ~/.mycelium/.env   # was the stack installed with IoC/CFN enabled?</code></pre>
+      <ul>
+        <li><strong>No LLM key</strong> → the CognitiveEngine can&#x27;t generate proposals. Add one (see</li>
+      </ul>
+      <p>*LLM Not Configured* above) and restart: <code>mycelium down &amp;&amp; mycelium up</code>.</p>
+      <ul>
+        <li><strong>IoC/CFN disabled</strong> → re-run <code>mycelium install</code> (interactive enables IoC by</li>
+      </ul>
+      <p>default), or reinstall without <code>--no-ioc</code>.</p>
       <hr class="divider">
       <h3 id="troubleshooting-8-container-name-conflicts">8. Container Name Conflicts</h3>
       <p><strong>Symptom</strong>: <code>container name &quot;mycelium-db&quot; is already in use</code></p>
@@ -1090,6 +1372,75 @@ grep api_url ~/.mycelium/config.toml</code></pre>
         </table>
       </div>
       <p>All of these are written by <code>mycelium config apply</code> from the matching <code>runtime.*</code> config keys — don&#x27;t edit <code>.env</code> by hand.</p>
+      <h3 id="troubleshooting-agent-environment-variables">Agent environment variables</h3>
+      <p>Read by the CLI and adapters at runtime to identify the agent and locate the backend:</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>MYCELIUM_API_URL</code></td>
+              <td>Backend API URL (default: <code>http://localhost:8000</code>)</td>
+            </tr>
+            <tr>
+              <td><code>MYCELIUM_AGENT_HANDLE</code></td>
+              <td>This agent&#x27;s identity handle</td>
+            </tr>
+            <tr>
+              <td><code>MYCELIUM_ROOM</code></td>
+              <td>Active room name</td>
+            </tr>
+            <tr>
+              <td><code>MYCELIUM_WORKSPACE_ID</code></td>
+              <td>CFN workspace UUID, required for knowledge ingest</td>
+            </tr>
+            <tr>
+              <td><code>MYCELIUM_MAS_ID</code></td>
+              <td>CFN MAS UUID, required for knowledge ingest</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <h3 id="troubleshooting-knowledge-ingest-cost-controls">Knowledge-ingest cost controls</h3>
+      <p>Overrides for <code>[knowledge_ingest]</code> in <code>~/.mycelium/config.toml</code>. Every key below has a matching env var for ephemeral changes (no config edit needed). Forwarding to the CFN graph is off by default.</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>Default</th>
+              <th>Effect</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>MYCELIUM_INGEST_ENABLED</code></td>
+              <td><code>true</code></td>
+              <td>Master kill switch. <code>0</code>/<code>false</code> short-circuits every ingest at the backend gate (no concept extraction, no CFN spend) and the endpoint returns 200 with a disabled marker.</td>
+            </tr>
+            <tr>
+              <td><code>MYCELIUM_INGEST_MIN_CONTENT_CHARS</code></td>
+              <td><code>32</code></td>
+              <td>Skip ingest for trivially short content (&quot;ack&quot;, emoji-only). <code>0</code> disables the gate.</td>
+            </tr>
+            <tr>
+              <td><code>MYCELIUM_INGEST_MAX_INPUT_TOKENS</code></td>
+              <td><code>50000</code></td>
+              <td>Backend circuit breaker: payloads above this estimated input token count get refused with HTTP 413. <code>0</code> disables.</td>
+            </tr>
+            <tr>
+              <td><code>MYCELIUM_INGEST_DEDUPE_TTL_SECONDS</code></td>
+              <td><code>300</code></td>
+              <td>Backend content-hash dedupe window. Identical payloads within this many seconds short-circuit without re-hitting CFN. <code>0</code> disables dedupe.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
       <hr class="divider">
       <h2 id="troubleshooting-log-locations">Log Locations</h2>
       <pre><code><span class="cmd">mycelium logs</span>                       # all services


### PR DESCRIPTION
Restructures the docs **site** (presentation/IA), independent of the #352 content reframe.

## Information architecture
Split the single long LEARN scroll into focused, intent-based pages (Diátaxis):

| Tab | File | Holds |
|---|---|---|
| **Get Started** | `index.html` | Overview + Quick Start |
| **Concepts** | `concepts.html` | Rooms · Sessions · Memory · Plan · CognitiveEngine · Knowledge Graph |
| **Adapters** | `adapters.html` | unchanged |
| **Reference** | `reference.html` | Architecture · CLI · Config · **Guides** (structured-memory, hub-and-spoke) · Troubleshooting |

- Guides folded into Reference (only two how-tos — not worth its own tab).
- New **`llms-full.txt`** (all sections concatenated) preserves the "feed the whole docs to an LLM" flow that the single-page layout used to provide.

## Typography & rhythm (`mycelium.css`)
Same **Cormorant Garamond / IBM Plex Sans / SF Mono** pairing — sizing only:
- Opened the collapsed middle of the scale: H2 24→27px, H3 18→20px (H2/H3/body stop colliding).
- Added `--space-1…8` spacing scale; collapsed 7 ad-hoc mono sizes to 3 tokens.
- Constrained prose to a 72ch measure (code/tables stay full width); widened section rhythm.

## Notes
- Source of truth stays the markdown in `mycelium-cli/src/mycelium/docs/`; regenerate with `cd mycelium-cli && uv run python ../docs/generate_docs.py`.
- All cross-section links verified (concept↔concept stay same-page; hub-and-spoke is same-page within Reference).
- Generated by the docs generator, not hand-edited HTML.