### PR TITLE
docs(quickstart): add "Running the stack" section

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -73,7 +73,7 @@ SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
 
 # IDs that should be looked up in kept HTML (have <!-- keep --> markers, or rescued by id).
 _KEPT_IDS: set[str] = {
-    "overview", "quickstart",
+    "overview",
     "adapters", "adapter-claude-code", "adapter-cursor", "adapter-openclaw", "adapter-api",
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -133,8 +133,7 @@
 
     <hr class="divider">
 
-<section class="doc-section" id="quickstart">
-      <!-- keep -->
+    <section class="doc-section" id="quickstart">
       <h1>Quick Start</h1>
       <h2 id="quickstart-install">Install</h2>
       <pre><code>curl <span class="flag">-fsSL</span> https://mycelium-io.github.io/mycelium/install.sh | bash</code></pre>
@@ -158,6 +157,13 @@
       <pre><code><span class="cmd">mycelium upgrade</span>   # update the CLI binary
 <span class="cmd">mycelium pull</span>      # pull latest images and restart services
 <span class="cmd">mycelium doctor</span>    # diagnose and fix configuration issues</code></pre>
+      <h2 id="quickstart-running-the-stack">Running the stack</h2>
+      <p><code>mycelium install</code> leaves the stack running, but it won&#x27;t survive a reboot or a Docker restart. Use these to bring it back up or check on it:</p>
+      <pre><code><span class="cmd">mycelium up</span>       # start the backend + AgensGraph stack
+<span class="cmd">mycelium status</span>   # health check — backend, database, LLM
+<span class="cmd">mycelium logs</span>     # tail service logs if something looks off
+<span class="cmd">mycelium down</span>     # stop the stack</code></pre>
+      <p>If <code>mycelium ui open</code> or any command reports it can&#x27;t reach the API at <code>localhost:8000</code>, the stack isn&#x27;t running — <code>mycelium up</code> fixes it.</p>
       <h2 id="quickstart-open-the-ui">Open the UI</h2>
       <p>The Mycelium room view is where you do everything from here — watch the live message stream, add agents, chat with them, and track the shared plan. Open it:</p>
       <pre><code><span class="cmd">mycelium ui open</span>   # starts the frontend if it isn&#x27;t running, then opens it</code></pre>

--- a/mycelium-cli/src/mycelium/docs/quickstart.md
+++ b/mycelium-cli/src/mycelium/docs/quickstart.md
@@ -40,6 +40,21 @@ mycelium pull      # pull latest images and restart services
 mycelium doctor    # diagnose and fix configuration issues
 ```
 
+## Running the stack
+
+`mycelium install` leaves the stack running, but it won't survive a reboot or a
+Docker restart. Use these to bring it back up or check on it:
+
+```bash
+mycelium up       # start the backend + AgensGraph stack
+mycelium status   # health check — backend, database, LLM
+mycelium logs     # tail service logs if something looks off
+mycelium down     # stop the stack
+```
+
+If `mycelium ui open` or any command reports it can't reach the API at
+`localhost:8000`, the stack isn't running — `mycelium up` fixes it.
+
 ## Open the UI
 
 The Mycelium room view is where you do everything from here — watch the live


### PR DESCRIPTION
## Why
Marc's backend was simply down, and the quickstart gave no path to start it. The quickstart only documents first-time `mycelium install` and the "already installed?" `upgrade`/`pull`/`doctor` commands — there was **no mention of `mycelium up`** for the common "installed, but the stack isn't running right now" case (reboot, Docker restart, etc.).

## What
- New **"Running the stack"** subsection right after Install:
  - `mycelium up` — start the backend + AgensGraph stack
  - `mycelium status` — health check (backend, DB, LLM)
  - `mycelium logs` — tail service logs
  - `mycelium down` — stop the stack
  - Note: an unreachable API at `localhost:8000` means the stack isn't running → `mycelium up`.
- **Un-froze the Quick Start section** so `quickstart.md` drives it again. It carried a `<!-- keep -->` marker (frozen generated HTML) that silently ignored markdown edits. Quick Start is plain prose + code blocks and round-trips cleanly, so it doesn't need freezing — only the hand-coded **Overview** (hero video + cards) and **Adapters** sections stay kept.

## Notes
- Source of truth is `quickstart.md`; `index.html` regenerated via the docs generator.
- Overview's `<!-- keep -->` marker verified still present (hero/cards intact).