### PR TITLE
Include the ui profile in logs/down/stop so the frontend isn't invisible

### DIFF
--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -106,6 +106,7 @@ def _compose_base_cmd(
     *,
     include_cfn_profile: bool = True,
     include_metrics_profile: bool = True,
+    include_ui_profile: bool = True,
 ) -> list[str]:
     """Build the docker compose prefix with consistent project name.
 
@@ -116,6 +117,11 @@ def _compose_base_cmd(
     When *include_metrics_profile* is True (the default) and the collector
     container is running, ``--profile metrics`` is appended so stop/logs/down
     commands include it without ad-hoc detection.
+
+    When *include_ui_profile* is True (the default) and the frontend container
+    is running, ``--profile ui`` is appended so stop/logs/down/status include
+    it too — otherwise the profile-gated frontend is invisible to those
+    commands (its logs don't show up, and it's left running on ``down``).
     """
     if compose_path is None:
         compose_path = _get_compose_path()
@@ -128,6 +134,8 @@ def _compose_base_cmd(
         cmd += ["--profile", "cfn"]
     if include_metrics_profile and _collector_container_running():
         cmd += ["--profile", "metrics"]
+    if include_ui_profile and _frontend_container_running():
+        cmd += ["--profile", "ui"]
     return cmd
 
 
@@ -232,6 +240,26 @@ def _collector_container_running() -> bool:
     try:
         result = subprocess.run(
             ["docker", "inspect", "-f", "{{.State.Running}}", "mycelium-collector"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        return result.returncode == 0 and result.stdout.strip().lower() == "true"
+    except Exception:
+        return False
+
+
+def _frontend_container_running() -> bool:
+    """Return True if the mycelium-frontend container is running.
+
+    The frontend lives behind the ``ui`` compose profile, so logs/down/stop/
+    status must enable that profile to see it — otherwise compose treats the
+    service as out of scope and silently skips it.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", "-f", "{{.State.Running}}", "mycelium-frontend"],
             capture_output=True,
             text=True,
             check=False,
@@ -446,7 +474,12 @@ def start(
             typer.echo("Run 'mycelium install' first.")
             raise typer.Exit(1)
 
-        base = _compose_base_cmd(compose_path, include_metrics_profile=False)
+        # `up` is flag-driven: the optional profiles are controlled by --ui /
+        # --metrics here, not by what happens to be running, so disable the
+        # auto-detection that logs/down/stop/status rely on.
+        base = _compose_base_cmd(
+            compose_path, include_metrics_profile=False, include_ui_profile=False
+        )
         if ui:
             base = base + ["--profile", "ui"]
         if metrics:

--- a/mycelium-cli/tests/test_compose_ui_profile.py
+++ b/mycelium-cli/tests/test_compose_ui_profile.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""`_compose_base_cmd` must enable the `ui` profile when the frontend is running.
+
+The frontend service is profile-gated (`profiles: [ui]`). Commands like
+`mycelium logs` / `down` / `stop` build their docker-compose invocation via
+`_compose_base_cmd`; if it doesn't pass `--profile ui`, compose treats the
+frontend as out of scope and silently skips it — so its logs never show up and
+`down` leaves it running. This mirrors the existing `metrics` auto-detection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mycelium.commands import instance
+
+
+def _has_profile(cmd: list[str], name: str) -> bool:
+    return any(cmd[i] == "--profile" and cmd[i + 1] == name for i in range(len(cmd) - 1))
+
+
+def _patch_profiles(
+    monkeypatch: pytest.MonkeyPatch, *, frontend: bool, collector: bool = False, cfn: bool = False
+) -> None:
+    monkeypatch.setattr(instance, "_cfn_enabled", lambda: cfn)
+    monkeypatch.setattr(instance, "_collector_container_running", lambda: collector)
+    monkeypatch.setattr(instance, "_frontend_container_running", lambda: frontend)
+
+
+def _cmd(tmp_path: Path, **kwargs) -> list[str]:
+    return instance._compose_base_cmd(
+        compose_path=tmp_path / "compose.yml",
+        env_path=tmp_path / ".env",
+        project_name="proj",
+        **kwargs,
+    )
+
+
+def test_ui_profile_added_when_frontend_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_profiles(monkeypatch, frontend=True)
+    assert _has_profile(_cmd(tmp_path), "ui")
+
+
+def test_ui_profile_omitted_when_frontend_not_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_profiles(monkeypatch, frontend=False)
+    assert not _has_profile(_cmd(tmp_path), "ui")
+
+
+def test_ui_profile_opt_out_even_when_running(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `up` opts out so it stays flag-driven (--ui), not driven by running state.
+    _patch_profiles(monkeypatch, frontend=True)
+    assert not _has_profile(_cmd(tmp_path, include_ui_profile=False), "ui")


### PR DESCRIPTION
## Problem

A teammate hit `Internal Server Error` on `localhost:3000/api/rooms` in the browser, but **nothing showed up in `mycelium logs`** and the backend container log was clean — which made it look like the error was coming from nowhere.

Root cause: the frontend service is profile-gated (`profiles: [ui]`), but `_compose_base_cmd` only auto-enabled the `cfn` and `metrics` profiles. So `mycelium logs` / `down` / `stop` invoked `docker compose …` **without `--profile ui`**, and Docker Compose silently skips services that aren't in scope.

Consequences:
- A frontend-side error (e.g. the Next.js `/api/*` proxy returning **500** when it can't reach `mycelium-backend:8000`) is logged in the `mycelium-frontend` container but **never appears in `mycelium logs`**.
- `mycelium down` doesn't stop the frontend — it's left running as an orphan.

(Confirmed: `docker compose config --services` omits `mycelium-frontend` unless `--profile ui` is passed.)

## Fix

Mirror the existing `metrics` auto-detection:
- add `_frontend_container_running()` and append `--profile ui` from `_compose_base_cmd` when the frontend container is up, so `logs` / `down` / `stop` include it;
- `up` opts out (`include_ui_profile=False`) so it stays driven by the explicit `--ui` flag rather than by whatever happens to be running;
- `status` already lists the container via `docker ps --filter name=mycelium`, so it's unaffected.

## Tests

Added `test_compose_ui_profile.py` covering the auto-detect (profile added when running / omitted when not) and the `up` opt-out. Full CLI suite: 369 passed.

## Note

This makes the frontend's logs visible to `mycelium logs`; it does **not** itself fix the underlying 500 (that's a frontend↔backend reachability issue revealed by `docker logs mycelium-frontend`). It stops the tooling from hiding it.