### PR TITLE
Show an error in the Create Room modal instead of failing silently

### DIFF
--- a/mycelium-frontend/src/components/create-room-dialog.tsx
+++ b/mycelium-frontend/src/components/create-room-dialog.tsx
@@ -15,23 +15,32 @@ interface Props {
 export function CreateRoomDialog({ open, onClose, onCreated }: Props) {
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   if (!open) return null;
 
+  const handleClose = () => {
+    setError(null);
+    onClose();
+  };
+
   const handleCreate = async () => {
     setLoading(true);
+    setError(null);
     try {
       await createRoom({ name, is_persistent: true });
       onCreated();
       onClose();
       setName("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create room");
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={handleClose}>
       <div className="bg-surface border border-border rounded-xl p-6 w-[420px] shadow-2xl" onClick={e => e.stopPropagation()}>
         <h2 className="text-lg font-bold mb-4">Create Room</h2>
 
@@ -39,12 +48,21 @@ export function CreateRoomDialog({ open, onClose, onCreated }: Props) {
         <input
           className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-sm font-mono focus:border-accent/50 focus:outline-none mb-4"
           value={name}
-          onChange={e => setName(e.target.value)}
+          onChange={e => {
+            setName(e.target.value);
+            if (error) setError(null);
+          }}
           placeholder="design-review"
         />
 
+        {error && (
+          <p role="alert" className="text-sm text-red-400 mb-4 break-words">
+            {error}
+          </p>
+        )}
+
         <div className="flex gap-3 justify-end">
-          <button onClick={onClose} className="px-4 py-2 text-sm text-muted hover:text-white transition-colors">
+          <button onClick={handleClose} className="px-4 py-2 text-sm text-muted hover:text-white transition-colors">
             Cancel
           </button>
           <button

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -35,6 +35,20 @@ export async function createRoom(data: { name: string; is_persistent?: boolean }
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ ...data, is_public: true }),
   });
+  if (!res.ok) {
+    // Surface the backend's reason (FastAPI returns `{ detail: ... }`) so the
+    // caller can show it instead of failing silently.
+    let detail = `Failed to create room (${res.status})`;
+    try {
+      const body = await res.json();
+      if (body?.detail) {
+        detail = typeof body.detail === "string" ? body.detail : JSON.stringify(body.detail);
+      }
+    } catch {
+      /* non-JSON error body — keep the status-based message */
+    }
+    throw new Error(detail);
+  }
   return res.json();
 }
 


### PR DESCRIPTION
## Problem

`createRoom()` returned `res.json()` regardless of status, so a failed request (e.g. duplicate name, validation error, backend 5xx) was treated as success: the modal closed, the room never appeared, and the user got **no feedback**.

## Fix

- `createRoom` now throws on `!res.ok`, carrying the backend's `detail` message (FastAPI's error shape), with a status-based fallback for non-JSON bodies.
- The Create Room dialog catches the error and renders it inline (`text-red-400`, `role="alert"`) — matching the app's existing error styling. The message clears when the user edits the name or reopens the dialog; the modal stays open on failure so they can retry.

Inline rather than a toast: the project has no toast/sonner set up, and an inline message is the better fit for a modal form (no new dependency or `<Toaster>` provider needed).

## Verified
`npx tsc --noEmit` clean, `npx next build` succeeds. Only caller of `createRoom` is this dialog (now handles the throw).