### PR TITLE
Fix Dockerized UI: proxy /api/* at request time (was baked to localhost at build)

### DIFF
--- a/mycelium-frontend/next.config.ts
+++ b/mycelium-frontend/next.config.ts
@@ -1,42 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Mycelium Contributors
 
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import type { NextConfig } from "next";
 
-/**
- * Internal backend URL used by the Next.js server to proxy `/api/*` requests.
- *
- * The browser never sees this URL — it only talks to its own origin. The
- * Next.js Node process is the one that reaches the backend, so this is a
- * server-side concern resolved at startup with the following precedence:
- *
- *   1. MYCELIUM_INTERNAL_API_URL (preferred — set by compose / runtime env)
- *   2. server.api_url from ~/.mycelium/config.toml (matches the CLI)
- *   3. http://localhost:8000 (mycelium install default)
- *
- * Config-toml read is best-effort — failures fall through to the default.
- */
-function resolveInternalApiUrl(): string {
-  if (process.env.MYCELIUM_INTERNAL_API_URL) return process.env.MYCELIUM_INTERNAL_API_URL;
-  try {
-    const path = join(homedir(), ".mycelium", "config.toml");
-    const text = readFileSync(path, "utf8");
-    const serverMatch = text.match(/\[server\][\s\S]*?\n\s*api_url\s*=\s*"([^"]+)"/);
-    if (serverMatch) return serverMatch[1];
-    const anyMatch = text.match(/^\s*api_url\s*=\s*"([^"]+)"/m);
-    if (anyMatch) return anyMatch[1];
-  } catch {
-    /* no config — fall through */
-  }
-  return "http://localhost:8000";
-}
-
-const internalApiUrl = resolveInternalApiUrl();
-// eslint-disable-next-line no-console
-console.log(`[mycelium-frontend] proxy /api/* → ${internalApiUrl}`);
+// `/api/*` is proxied to the backend by a runtime route handler
+// (src/app/api/[...path]/route.ts), NOT a next.config rewrite. Rewrites are
+// resolved at *build* time and frozen into the image, so a rewrite destination
+// ignored the runtime MYCELIUM_INTERNAL_API_URL and always pointed at the
+// build-time default (localhost:8000) — which broke the Dockerized UI. The
+// route handler resolves the backend per-request instead. See src/lib/backend.ts.
 
 // `next dev` blocks cross-origin requests by default; opt-in via env when
 // running dev mode behind a public IP. The Docker production path doesn't
@@ -56,11 +28,6 @@ const nextConfig: NextConfig = {
   // reverse proxy in production anyway).
   compress: false,
   allowedDevOrigins,
-  async rewrites() {
-    return [
-      { source: "/api/:path*", destination: `${internalApiUrl}/api/:path*` },
-    ];
-  },
 };
 
 export default nextConfig;

--- a/mycelium-frontend/src/app/api/[...path]/route.ts
+++ b/mycelium-frontend/src/app/api/[...path]/route.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { getBackendUrl } from "@/lib/backend";
+
+/**
+ * Catch-all proxy for `/api/*` → the backend, resolved at REQUEST time.
+ *
+ * Replaces the old next.config rewrite whose destination was frozen at build
+ * time (to localhost:8000), ignoring the runtime MYCELIUM_INTERNAL_API_URL and
+ * breaking the Dockerized UI. The more-specific SSE route handler
+ * (rooms/[name]/messages/stream) still takes precedence for the stream
+ * endpoint; everything else flows through here.
+ */
+export const dynamic = "force-dynamic";
+
+// Headers that must not be forwarded verbatim across the proxy hop.
+const STRIP_REQUEST = ["host", "connection", "keep-alive", "transfer-encoding", "upgrade", "content-length"];
+const STRIP_RESPONSE = ["connection", "keep-alive", "transfer-encoding", "upgrade", "content-length", "content-encoding"];
+
+async function proxy(req: Request): Promise<Response> {
+  const backend = getBackendUrl();
+  const { pathname, search } = new URL(req.url);
+  const target = `${backend}${pathname}${search}`;
+
+  const headers = new Headers(req.headers);
+  for (const h of STRIP_REQUEST) headers.delete(h);
+  // Ask upstream for plain bytes so we can stream the response straight through
+  // without a content-encoding/content-length mismatch.
+  headers.delete("accept-encoding");
+
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    cache: "no-store",
+    redirect: "manual",
+  };
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    init.body = await req.arrayBuffer();
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(target, init);
+  } catch {
+    return Response.json(
+      { detail: `Backend unreachable at ${backend}` },
+      { status: 502 },
+    );
+  }
+
+  const respHeaders = new Headers(res.headers);
+  for (const h of STRIP_RESPONSE) respHeaders.delete(h);
+
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers: respHeaders,
+  });
+}
+
+export const GET = proxy;
+export const POST = proxy;
+export const PUT = proxy;
+export const PATCH = proxy;
+export const DELETE = proxy;
+export const HEAD = proxy;
+export const OPTIONS = proxy;

--- a/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
+++ b/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
@@ -1,23 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Mycelium Contributors
 
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
-
-function getBackendUrl(): string {
-  if (process.env.MYCELIUM_INTERNAL_API_URL) return process.env.MYCELIUM_INTERNAL_API_URL;
-  try {
-    const text = readFileSync(join(homedir(), ".mycelium", "config.toml"), "utf8");
-    const m =
-      text.match(/\[server\][\s\S]*?\n\s*api_url\s*=\s*"([^"]+)"/) ??
-      text.match(/^\s*api_url\s*=\s*"([^"]+)"/m);
-    if (m) return m[1];
-  } catch {
-    /* fall through */
-  }
-  return "http://localhost:8000";
-}
+import { getBackendUrl } from "@/lib/backend";
 
 export async function GET(
   _req: Request,

--- a/mycelium-frontend/src/lib/backend.ts
+++ b/mycelium-frontend/src/lib/backend.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Resolve the internal backend URL — SERVER-SIDE, at REQUEST time.
+ *
+ * This MUST be evaluated per-request, never baked into the build: one image
+ * runs in dev, Docker, and cloud against different backends. (A next.config
+ * rewrite froze this at build time and ignored the runtime env, which broke the
+ * Dockerized UI — see next.config.ts.) Precedence:
+ *
+ *   1. MYCELIUM_INTERNAL_API_URL (compose / runtime env)
+ *   2. server.api_url from ~/.mycelium/config.toml (matches the CLI)
+ *   3. http://localhost:8000 (mycelium install default)
+ *
+ * Only import this from server code (route handlers) — it reads the filesystem.
+ */
+export function getBackendUrl(): string {
+  if (process.env.MYCELIUM_INTERNAL_API_URL) return process.env.MYCELIUM_INTERNAL_API_URL;
+  try {
+    const text = readFileSync(join(homedir(), ".mycelium", "config.toml"), "utf8");
+    const m =
+      text.match(/\[server\][\s\S]*?\n\s*api_url\s*=\s*"([^"]+)"/) ??
+      text.match(/^\s*api_url\s*=\s*"([^"]+)"/m);
+    if (m) return m[1];
+  } catch {
+    /* no config — fall through */
+  }
+  return "http://localhost:8000";
+}


### PR DESCRIPTION
## The bug (root cause of Marc's 500s)

The browser calls relative `/api/*` and the Next.js server proxies to the backend. That proxy was a `next.config.ts` `rewrites()` — but **`rewrites()` is resolved at *build* time and frozen into the image**. In CI (no env, no `config.toml`) it defaulted to `http://localhost:8000`, so the **released image always proxied to `localhost:8000` regardless of the runtime `MYCELIUM_INTERNAL_API_URL`**. Inside the frontend container that's itself → `ECONNREFUSED` → every `/api/*` returns **500**.

Reproduced against the real `ghcr.io/mycelium-io/mycelium-frontend:1.1.1` image:
- `MYCELIUM_INTERNAL_API_URL=http://mycelium-backend:8000` was correctly set in the container, **but** `.next/routes-manifest.json` had the rewrite baked to `http://localhost:8000`, and the startup `proxy →` log never ran at runtime.
- Bonus: that catch-all rewrite is `afterFiles`, which runs *before* dynamic routes, so it also **shadowed the SSE route handler** — streaming was broken the same way.

## The fix

Resolve the backend **per-request** instead of at build time:
- remove the `next.config.ts` rewrite;
- add a catch-all route handler `app/api/[...path]/route.ts` that forwards every method / body / streamed response to `${MYCELIUM_INTERNAL_API_URL}/api/...`, read at request time (and returns a clear `502` if the backend is unreachable);
- extract the shared `getBackendUrl()` into `src/lib/backend.ts`; the SSE route handler now imports it and — no longer shadowed — actually runs.

## Verification

Built this branch's image and ran it on the compose network with `MYCELIUM_INTERNAL_API_URL=http://mycelium-backend:8000`:
- `:3000/api/rooms` → **200** (was 500), real room data
- SSE stream → **200** (was 500), no `ECONNREFUSED` in logs

Also proved runtime resolution on the production build (same build, two envs): real backend → **200**, bogus URL → **502**. If the target were still baked, the bogus run would stay 200.

`npx tsc --noEmit` clean, `npx next build` succeeds.

## Related

This is the actual root cause behind #356 (made the frontend logs visible) and #357 (showed the create-room error instead of swallowing it). With this merged, room creation (and the rest of the UI) actually works in Docker.