### PR TITLE
docs: add evaluation results doc and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Alignment pays off at 3+ agents. At three it improves decision quality over unco
 
 If your system has a central orchestrator routing tasks to worker agents, you probably don't need Mycelium — your orchestrator is already the coordination layer. Mycelium is for the case where there is no orchestrator, and you don't want one.
 
+## Does It Work
+
+Mycelium was evaluated across 14 decision scenarios in a controlled A/B study. 
+See [Evaluation Results](docs/evaluation.md) for the full findings.
+
 ## What Mycelium Does
 
 Mycelium provides coordination functions for autonomous agents operating as peers. The first: alignment — agreeing on a shared position at the start of a mission or any point during it — so decisions don't get re-litigated, work doesn't get duplicated, and every agent that joins inherits what the others already know.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,36 @@
+# Evaluation Results — Mycelium v1.0.13z
+
+## What We Tested
+
+- We ran a controlled A/B study across 14 decision scenarios: the same agents, the same personas, the same goals — first without Mycelium, then with it — measuring consensus rate, outcome quality, and token cost against a withheld ground-truth benchmark.
+- Scenarios ranged from routine coordination (scheduling, expense approval, travel planning) to high-stakes decisions (AI deployment policy, data architecture, security trade-offs), testing whether the protocol holds across both everyday and adversarial conditions.
+
+## Results
+
+- **Agreement rate:** 93% of sessions ended in consensus with Mycelium mediation (13/14), compared to 36% without (5/14). The clearest result came from the high-stakes scenarios: five contested organizational policy decisions where unstructured agent chat produced zero decisions, and Mycelium produced five — each scored against a ground-truth benchmark the agents never saw.
+- **Quality of outcome:** Mycelium-mediated sessions surfaced 92% of the canonical decision dimensions versus 75% in unstructured chat. On the high-stakes scenarios, outcome quality scored 4.6/5 against the withheld benchmark, compared to 1/5 without the protocol.
+- **Derailment rate:** 22% of unmediated sessions were derailed by agents hallucinating protocol behavior they couldn't actually execute. 0% of Mycelium-mediated sessions produced off-protocol behavior. *(Measured at session level across the standard scenarios; turn-level analysis not yet run.)*
+- **Token cost:** ~32,300 tokens per session on average with Mycelium mediation, compared to ~19,700 without — a 64% overhead per session, offset by the elimination of inconclusive runs that require human re-intervention. *(High-stakes scenarios only; per-session before/after token splits are not available for the standard scenarios.)*
+
+## Methodology
+
+Each scenario was run twice under identical conditions — same agents, same personas, same goals — once without Mycelium (unstructured multi-turn chat) and once with Mycelium's CognitiveEngine mediating structured proposal/response/accept rounds. Outcomes were compared against a set of canonical issues and policy options defined per scenario before the experiments ran, withheld from agents during negotiation and used for post-hoc scoring only.
+
+**Model:** Claude Haiku (Bedrock)
+
+**Scenario breakdown:**
+
+| Series | Scenarios | Domain |
+|---|---|---|
+| Standard | Email automation, inbox workflow, personal planning, travel planning, healthcare treatment (NSCLC), expense submission, investment portfolio, supply chain stockout, CI/CD release | Operations, finance, healthcare |
+| High-stakes | AI model deployment policy, data platform architecture, open source vs. enterprise tooling, remote work and talent strategy, security vs. developer experience | Organizational policy |
+
+**Agents:** Standard scenarios used domain-specific personas; high-stakes scenarios used generic default-profile agents (cost-conscious, quality-focused, pragmatic) to test whether the protocol could produce quality outcomes independent of specialist persona knowledge.
+
+**Total data:** ~383,000 input tokens of negotiation data across 14 scenarios.
+
+## Notes and Caveats
+
+- **The CI/CD release scenario** ended in structured impasse rather than consensus — intentionally. The Mycelium protocol correctly identified an undecidable conflict (the deploy agent rejected consensus three times, seeking deployment regardless of error-rate conditions) and escalated for human judgment rather than forcing false agreement. This is counted as a non-consensus outcome in the agreement rate above, but is considered a correct protocol result.
+- **Issue coverage** shows a structural tradeoff worth understanding. "Issues" here means the distinct dimensions agents need to agree on — in a travel planning scenario, for example: flight class, hotel standard, daily pace, budget. Unstructured chat tends to identify the right issues at a high level but collapses related ones together. Mycelium breaks each issue into its component positions, which is why coverage rises to 92% — but also why it generates more issues than the benchmark expects. The extra issues are real negotiation positions, not noise.
+- **High-stakes scenario token counts** vary significantly: one scenario reached consensus in a single round (producing far fewer tokens than the unmediated run), while another cycled over 16 rounds due to genuine value conflicts between agents. The per-session average reflects this variance.


### PR DESCRIPTION
## Summary

  Adds an docs/evaluation.md file, and links to it from the README, so visitors
  can see evidence that Mycelium's structured negotiation actually improves
  multi-agent outcomes (not just a design claim).

## Changes

- Add docs/evaluation.md: results of a controlled A/B study across 14 decision
  scenarios (9 standard + 5 high-stakes), comparing unmediated agent chat
  against Mycelium-mediated negotiation on consensus rate, outcome quality,
  derailment rate, and token cost.
  - Add a "Does It Work" section to README.md linking to the new doc.

## Testing

  Docs-only change — no code paths affected.


- [ ] Unit tests pass (`uv run pytest tests/ -x -q`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Format check passes (`uv run ruff format --check .`)

## Related Issues

n/a