### PR TITLE
fix(cli): run migrations in mycelium-backend container for wheel installs

### DIFF
--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -960,7 +960,11 @@ def _check_pending_migrations() -> CheckResult:
                 details=["fix: mycelium up", "fix: mycelium migrate"],
             )
         if heads.returncode != 0:
-            err_tail = heads.stderr.strip().splitlines()[-1] if heads.stderr.strip() else "(no error output)"
+            err_tail = (
+                heads.stderr.strip().splitlines()[-1]
+                if heads.stderr.strip()
+                else "(no error output)"
+            )
             return CheckResult(
                 name="Migrations",
                 status="warning",

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -931,87 +931,48 @@ def _parse_alembic_current(stdout: str) -> str | None:
 
 def _check_pending_migrations() -> CheckResult:
     """Check whether the DB is behind the latest alembic revision."""
-    import importlib.resources
+    from mycelium.migrations import (
+        find_local_backend_dir,
+        run_alembic_current,
+        run_alembic_heads,
+    )
 
-    # Locate fastapi-backend the same way the migrate command does.
-    backend_dir: Path | None = None
-    try:
-        pkg_path = Path(str(importlib.resources.files("mycelium")))
-        for depth in range(2, 7):
-            candidate = pkg_path.parents[depth] / "fastapi-backend"
-            if (candidate / "alembic.ini").exists():
-                backend_dir = candidate
-                break
-    except Exception:
-        pass
-    if backend_dir is None:
-        for fallback in (Path.cwd(), Path.cwd() / "fastapi-backend"):
-            if (fallback / "alembic.ini").exists():
-                backend_dir = fallback
-                break
+    backend_dir = find_local_backend_dir()
+    latest_file: str | None = None
 
-    if backend_dir is None:
-        return CheckResult(
-            name="Migrations",
-            status="ok",
-            message="Skipped (fastapi-backend not found — installed mode)",
-        )
-
-    # Latest revision on disk: highest numbered file prefix in versions/.
-    versions_dir = backend_dir / "alembic_migrations" / "versions"
-    if not versions_dir.exists():
-        return CheckResult(
-            name="Migrations", status="ok", message="Skipped (versions dir not found)"
-        )
-
-    revision_files = sorted(versions_dir.glob("*.py"))
-    if not revision_files:
-        return CheckResult(name="Migrations", status="ok", message="No migration files found")
-    latest_file = revision_files[-1].stem.split("_")[0]  # e.g. "0015"
-
-    # Current DB revision via `alembic current`.  We have to set DATABASE_URL
-    # explicitly because alembic's env.py raises ValueError otherwise — and
-    # this used to be #287's root cause: doctor was reading the never-populated
-    # ``server.database_url`` field, so DATABASE_URL was never set, alembic's
-    # env.py raised "DATABASE_URL environment variable is not set!", and the
-    # resulting Python traceback contained the substring "Traceback" whose
-    # "aceback" hex tail was then parsed (incorrectly) as a DB revision.  Two
-    # fixes below address this end-to-end:
-    #
-    #   1. Source DATABASE_URL from the single MyceliumConfig.database_url
-    #      recipe (host_side=True → localhost:<published port>), so alembic
-    #      always has a real connection string to try.
-    #
-    #   2. Parse alembic stdout *separately* from stderr.  Alembic emits its
-    #      INFO logs and any tracebacks on stderr; the revision token comes
-    #      out on stdout alone.  This eliminates the regex-vs-traceback class
-    #      of false positives entirely; the tightened regex below is just
-    #      belt-and-suspenders.
-    import logging
-
-    from mycelium.docker_utils import resolve_host_database_url
-
-    env = {**__import__("os").environ}
-    host_url = resolve_host_database_url(env)
-    if host_url:
-        env["DATABASE_URL"] = host_url
+    if backend_dir is not None:
+        versions_dir = backend_dir / "alembic_migrations" / "versions"
+        if not versions_dir.exists():
+            return CheckResult(
+                name="Migrations", status="ok", message="Skipped (versions dir not found)"
+            )
+        revision_files = sorted(versions_dir.glob("*.py"))
+        if not revision_files:
+            return CheckResult(name="Migrations", status="ok", message="No migration files found")
+        latest_file = revision_files[-1].stem.split("_")[0]
     else:
-        logging.getLogger(__name__).debug(
-            "Could not resolve host-side DATABASE_URL from .env or config.toml; "
-            "falling through to alembic with whatever DATABASE_URL is in the environment"
-        )
+        heads = run_alembic_heads()
+        if heads.mode == "unavailable":
+            return CheckResult(
+                name="Migrations",
+                status="warning",
+                message="Cannot check migrations (backend container not running)",
+                details=["fix: mycelium up", "fix: mycelium migrate"],
+            )
+        if heads.returncode != 0:
+            err_tail = heads.stderr.strip().splitlines()[-1] if heads.stderr.strip() else "(no error output)"
+            return CheckResult(
+                name="Migrations",
+                status="warning",
+                message=f"alembic heads failed (exit {heads.returncode})",
+                details=[f"stderr: {err_tail[:160]}", "fix: mycelium migrate"],
+            )
+        latest_file = _parse_alembic_current(heads.stdout) or "head"
 
     try:
-        result = subprocess.run(
-            ["uv", "run", "alembic", "current"],
-            cwd=str(backend_dir),
-            capture_output=True,
-            text=True,
-            timeout=15,
-            env=env,
-        )
-        stdout = result.stdout or ""
-        stderr = result.stderr or ""
+        current = run_alembic_current()
+        stdout = current.stdout or ""
+        stderr = current.stderr or ""
     except Exception as exc:
         return CheckResult(
             name="Migrations",
@@ -1020,30 +981,32 @@ def _check_pending_migrations() -> CheckResult:
             details=["fix: mycelium migrate"],
         )
 
-    # If alembic itself errored out, surface the stderr summary instead of
-    # quietly returning "unknown".  This is what users actually want to see.
-    if result.returncode != 0:
+    if current.mode == "unavailable":
+        return CheckResult(
+            name="Migrations",
+            status="warning",
+            message="Cannot check migrations (backend container not running)",
+            details=["fix: mycelium up", "fix: mycelium migrate"],
+        )
+
+    if current.returncode != 0:
         err_tail = stderr.strip().splitlines()[-1] if stderr.strip() else "(no error output)"
         return CheckResult(
             name="Migrations",
             status="warning",
-            message=f"alembic current failed (exit {result.returncode})",
+            message=f"alembic current failed (exit {current.returncode})",
             details=[f"stderr: {err_tail[:160]}", "fix: mycelium migrate"],
         )
 
-    # "head" only appears in stdout alongside the revision when the DB is at
-    # the latest revision; checking stdout (not stdout+stderr) keeps INFO log
-    # lines mentioning "alembic.runtime" from triggering a false positive.
+    via = f" ({current.mode})" if current.mode == "container" else ""
+
     if "head" in stdout.lower():
         return CheckResult(
             name="Migrations",
             status="ok",
-            message=f"DB at head ({latest_file})",
+            message=f"DB at head ({latest_file}){via}",
         )
 
-    # Revision token: parse stdout via the tested helper.  We never touch
-    # stderr here — alembic's INFO logs and Python tracebacks land there,
-    # and feeding either through a hex-regex was #287's root cause.
     current_rev = _parse_alembic_current(stdout) or "unknown"
 
     if not stdout.strip() or current_rev == "unknown":

--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -468,50 +468,21 @@ def _compose_up(
 
 
 def _run_migrations() -> None:
-    """Run alembic migrations via the migrate command."""
-    from mycelium.commands.instance import _get_backend_dir, _get_env_path
+    """Run alembic migrations via host checkout or mycelium-backend container."""
+    from mycelium.migrations import echo_alembic_output, run_alembic_upgrade
 
-    backend_dir = _get_backend_dir()
-    if not (backend_dir / "alembic.ini").exists():
-        typer.echo("  ⚠  alembic.ini not found — skipping migrations")
-        return
-
-    import os
-
-    env = {**os.environ}
-    env_path = _get_env_path()
-    if env_path and env_path.exists():
-        from dotenv import dotenv_values
-
-        env.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
-
-    backend_env = backend_dir / ".env"
-    if backend_env.exists():
-        from dotenv import dotenv_values
-
-        env.update({k: v for k, v in dotenv_values(backend_env).items() if v is not None})
-
-    from mycelium.docker_utils import resolve_host_database_url
-
-    host_url = resolve_host_database_url(env)
-    if host_url:
-        env["DATABASE_URL"] = host_url
-    elif "DATABASE_URL" not in env:
-        typer.echo("  ⚠  DATABASE_URL not set — skipping migrations")
-        return
-
-    result = subprocess.run(
-        ["uv", "run", "alembic", "upgrade", "head"],
-        cwd=str(backend_dir),
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    result = run_alembic_upgrade("head")
     if result.returncode == 0:
+        echo_alembic_output(result)
         typer.secho("  ✓ Database migrations applied", fg=typer.colors.GREEN)
-    else:
-        typer.secho("  ⚠  Migration failed (non-fatal)", fg=typer.colors.YELLOW)
+        return
+
+    if result.mode == "unavailable":
+        typer.echo("  ⚠  Could not run migrations (backend container not running)")
+        return
+
+    echo_alembic_output(result)
+    typer.secho("  ⚠  Migration failed (non-fatal)", fg=typer.colors.YELLOW)
 
 
 def _ensure_cfn_databases(db_container: str = "mycelium-db") -> None:

--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -1032,25 +1032,9 @@ def logs(
 
 def _get_backend_dir() -> Path:
     """Find the fastapi-backend directory (for running alembic)."""
-    import importlib.resources
+    from mycelium.migrations import find_local_backend_dir
 
-    try:
-        pkg_path = Path(str(importlib.resources.files("mycelium")))
-        for depth in range(2, 7):
-            candidate = pkg_path.parents[depth] / "fastapi-backend"
-            if (candidate / "alembic.ini").exists():
-                return candidate
-    except Exception:
-        pass
-
-    if (Path.cwd() / "alembic.ini").exists():
-        return Path.cwd()
-
-    candidate = Path.cwd() / "fastapi-backend"
-    if (candidate / "alembic.ini").exists():
-        return candidate
-
-    return Path.cwd()
+    return find_local_backend_dir() or Path.cwd()
 
 
 @doc_ref(
@@ -1076,52 +1060,26 @@ def migrate(
         mycelium migrate -r 0008      # upgrade to specific revision
     """
     try:
-        backend_dir = _get_backend_dir()
-        if not (backend_dir / "alembic.ini").exists():
-            typer.secho(f"alembic.ini not found in {backend_dir}", fg=typer.colors.RED)
-            typer.echo("Run this from the repo root or set MYCELIUM_COMPOSE_FILE.")
-            raise typer.Exit(1)
-
-        env_path = _get_env_path()
-
-        import os
-
-        env = {**os.environ}
-        if env_path and env_path.exists():
-            from dotenv import dotenv_values
-
-            env.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
-
-        backend_env = backend_dir / ".env"
-        if backend_env.exists():
-            from dotenv import dotenv_values
-
-            env.update({k: v for k, v in dotenv_values(backend_env).items() if v is not None})
-
-        from mycelium.docker_utils import resolve_host_database_url
-
-        host_url = resolve_host_database_url(env)
-        if host_url:
-            env["DATABASE_URL"] = host_url
-        elif "DATABASE_URL" not in env:
-            typer.secho("DATABASE_URL not set.", fg=typer.colors.RED)
-            typer.echo("Set it in ~/.mycelium/.env (run `mycelium config apply`)")
-            raise typer.Exit(1)
-
-        typer.echo(f"Running migrations (target: {revision})...")
-        cmd = ["uv", "run", "alembic", "upgrade", revision]
-        result = subprocess.run(
-            cmd, cwd=str(backend_dir), env=env, check=False, capture_output=True, text=True
+        from mycelium.migrations import (
+            BACKEND_CONTAINER,
+            echo_alembic_output,
+            run_alembic_upgrade,
         )
 
-        if result.stdout:
-            typer.echo(result.stdout.rstrip())
-        if result.stderr:
-            for line in result.stderr.strip().split("\n"):
-                if "Running upgrade" in line:
-                    typer.secho(f"  {line.split('] ')[-1]}", fg=typer.colors.GREEN)
-                elif "ERROR" in line:
-                    typer.secho(f"  {line}", fg=typer.colors.RED)
+        result = run_alembic_upgrade(revision)
+        if result.mode == "unavailable":
+            typer.secho("Cannot run migrations.", fg=typer.colors.RED)
+            typer.echo(result.stderr)
+            typer.echo("Start the stack with: mycelium up")
+            typer.echo("Or run from a mycelium repo checkout for host-side alembic.")
+            raise typer.Exit(1)
+
+        if result.mode == "container":
+            typer.echo(f"Running migrations in {BACKEND_CONTAINER} (target: {revision})...")
+        else:
+            typer.echo(f"Running migrations (target: {revision})...")
+
+        echo_alembic_output(result)
 
         if result.returncode == 0:
             typer.secho("Migrations complete.", fg=typer.colors.GREEN)

--- a/mycelium-cli/src/mycelium/migrations.py
+++ b/mycelium-cli/src/mycelium/migrations.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Run Alembic migrations for Mycelium.
+
+Wheel installs do not ship ``fastapi-backend/`` on the host.  For those
+environments we run ``python -m alembic`` inside the ``mycelium-backend``
+container, which carries alembic.ini and the migration scripts.
+
+Dev/monorepo installs can still run host-side ``uv run alembic`` when a local
+``fastapi-backend/alembic.ini`` is discoverable.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+BACKEND_SERVICE = "mycelium-backend"
+BACKEND_CONTAINER = "mycelium-backend"
+
+
+@dataclass(frozen=True)
+class AlembicRunResult:
+    """Outcome of an alembic upgrade/current invocation."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    mode: str  # "host", "container", or "unavailable"
+
+
+def find_local_backend_dir() -> Path | None:
+    """Return fastapi-backend/ when running from a dev checkout, else None."""
+    import importlib.resources
+
+    try:
+        pkg_path = Path(str(importlib.resources.files("mycelium")))
+        for depth in range(2, 7):
+            candidate = pkg_path.parents[depth] / "fastapi-backend"
+            if (candidate / "alembic.ini").exists():
+                return candidate
+    except Exception:
+        pass
+
+    if (Path.cwd() / "alembic.ini").exists():
+        return Path.cwd()
+
+    candidate = Path.cwd() / "fastapi-backend"
+    if (candidate / "alembic.ini").exists():
+        return candidate
+
+    return None
+
+
+def backend_container_running() -> bool:
+    """True when the mycelium-backend container exists and is running."""
+    try:
+        result = subprocess.run(
+            [
+                "docker",
+                "inspect",
+                "-f",
+                "{{.State.Running}}",
+                BACKEND_CONTAINER,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        return result.returncode == 0 and result.stdout.strip().lower() == "true"
+    except Exception:
+        return False
+
+
+def _host_alembic_env(backend_dir: Path) -> dict[str, str]:
+    from dotenv import dotenv_values
+
+    from mycelium.commands.instance import _get_env_path
+    from mycelium.docker_utils import resolve_host_database_url
+
+    env = {**os.environ}
+    env_path = _get_env_path()
+    if env_path and env_path.exists():
+        env.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+
+    backend_env = backend_dir / ".env"
+    if backend_env.exists():
+        env.update({k: v for k, v in dotenv_values(backend_env).items() if v is not None})
+
+    host_url = resolve_host_database_url(env)
+    if host_url:
+        env["DATABASE_URL"] = host_url
+    return env
+
+
+def _run_host_alembic(backend_dir: Path, alembic_cmd: list[str]) -> AlembicRunResult:
+    alembic_args = ["uv", "run", "alembic", *alembic_cmd]
+    result = subprocess.run(
+        alembic_args,
+        cwd=str(backend_dir),
+        env=_host_alembic_env(backend_dir),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return AlembicRunResult(result.returncode, result.stdout, result.stderr, "host")
+
+
+def _run_container_alembic(alembic_cmd: list[str]) -> AlembicRunResult:
+    from mycelium.commands.instance import _compose_base_cmd, _get_compose_path, _get_env_path
+
+    compose_path = _get_compose_path()
+    if not compose_path.exists():
+        return AlembicRunResult(
+            1,
+            "",
+            f"Compose file not found at {compose_path}",
+            "unavailable",
+        )
+
+    env_path = _get_env_path()
+    cmd = _compose_base_cmd(
+        compose_path,
+        env_path,
+        include_cfn_profile=False,
+        include_metrics_profile=False,
+        include_ui_profile=False,
+    ) + ["exec", "-T", BACKEND_SERVICE, "python", "-m", "alembic", *alembic_cmd]
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    return AlembicRunResult(result.returncode, result.stdout, result.stderr, "container")
+
+
+def run_alembic_upgrade(revision: str = "head") -> AlembicRunResult:
+    """Apply alembic migrations using the best available backend."""
+    backend_dir = find_local_backend_dir()
+    if backend_dir is not None:
+        return _run_host_alembic(backend_dir, ["upgrade", revision])
+
+    if backend_container_running():
+        return _run_container_alembic(["upgrade", revision])
+
+    return AlembicRunResult(
+        1,
+        "",
+        "alembic.ini not found on the host and mycelium-backend is not running",
+        "unavailable",
+    )
+
+
+def run_alembic_current() -> AlembicRunResult:
+    """Return the current DB revision using the best available backend."""
+    backend_dir = find_local_backend_dir()
+    if backend_dir is not None:
+        return _run_host_alembic(backend_dir, ["current"])
+
+    if backend_container_running():
+        return _run_container_alembic(["current"])
+
+    return AlembicRunResult(
+        1,
+        "",
+        "alembic.ini not found on the host and mycelium-backend is not running",
+        "unavailable",
+    )
+
+
+def echo_alembic_output(result: AlembicRunResult) -> None:
+    """Print alembic stdout/stderr with basic success/error highlighting."""
+    import typer
+
+    if result.stdout:
+        typer.echo(result.stdout.rstrip())
+    if result.stderr:
+        for line in result.stderr.strip().split("\n"):
+            if "Running upgrade" in line:
+                typer.secho(f"  {line.split('] ')[-1]}", fg=typer.colors.GREEN)
+            elif "ERROR" in line:
+                typer.secho(f"  {line}", fg=typer.colors.RED)

--- a/mycelium-cli/src/mycelium/migrations.py
+++ b/mycelium-cli/src/mycelium/migrations.py
@@ -168,6 +168,23 @@ def run_alembic_current() -> AlembicRunResult:
     )
 
 
+def run_alembic_heads() -> AlembicRunResult:
+    """Return the latest alembic head revision using the best available backend."""
+    backend_dir = find_local_backend_dir()
+    if backend_dir is not None:
+        return _run_host_alembic(backend_dir, ["heads"])
+
+    if backend_container_running():
+        return _run_container_alembic(["heads"])
+
+    return AlembicRunResult(
+        1,
+        "",
+        "alembic.ini not found on the host and mycelium-backend is not running",
+        "unavailable",
+    )
+
+
 def echo_alembic_output(result: AlembicRunResult) -> None:
     """Print alembic stdout/stderr with basic success/error highlighting."""
     import typer

--- a/mycelium-cli/tests/test_doctor_cfn_intent.py
+++ b/mycelium-cli/tests/test_doctor_cfn_intent.py
@@ -85,9 +85,7 @@ def test_room_mas_ids_warns_when_api_rooms_returns_http_error(
     mycelium_dir = tmp_path / ".mycelium"
     mycelium_dir.mkdir()
     (mycelium_dir / ".env").write_text("WORKSPACE_ID=ws\n")
-    (mycelium_dir / "config.toml").write_text(
-        '[server]\napi_url = "http://10.0.50.125:8000"\n'
-    )
+    (mycelium_dir / "config.toml").write_text('[server]\napi_url = "http://10.0.50.125:8000"\n')
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 

--- a/mycelium-cli/tests/test_migrations.py
+++ b/mycelium-cli/tests/test_migrations.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Tests for mycelium.migrations — host vs container alembic routing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from mycelium.migrations import (
+    AlembicRunResult,
+    backend_container_running,
+    find_local_backend_dir,
+    run_alembic_upgrade,
+)
+
+
+def test_find_local_backend_dir_returns_none_without_checkout(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    class FakeFiles:
+        def __str__(self) -> str:
+            return str(tmp_path / "site-packages" / "mycelium")
+
+    monkeypatch.setattr(
+        "importlib.resources.files",
+        lambda _pkg: FakeFiles(),
+    )
+
+    assert find_local_backend_dir() is None
+
+
+def test_find_local_backend_dir_finds_fastapi_backend_under_cwd(monkeypatch, tmp_path):
+    backend = tmp_path / "fastapi-backend"
+    backend.mkdir()
+    (backend / "alembic.ini").write_text("[alembic]\n")
+    monkeypatch.chdir(tmp_path)
+
+    class FakeFiles:
+        def __str__(self) -> str:
+            return str(tmp_path / "site-packages" / "mycelium")
+
+        @property
+        def parents(self):
+            return []
+
+    monkeypatch.setattr("importlib.resources.files", lambda _pkg: FakeFiles())
+
+    assert find_local_backend_dir() == backend
+
+
+def test_run_alembic_upgrade_uses_container_when_no_local_backend(monkeypatch):
+    monkeypatch.setattr("mycelium.migrations.find_local_backend_dir", lambda: None)
+    monkeypatch.setattr("mycelium.migrations.backend_container_running", lambda: True)
+
+    expected = AlembicRunResult(0, "ok\n", "", "container")
+    with patch(
+        "mycelium.migrations._run_container_alembic", return_value=expected
+    ) as run_container:
+        result = run_alembic_upgrade("head")
+
+    assert result == expected
+    run_container.assert_called_once_with(["upgrade", "head"])
+
+
+def test_run_alembic_upgrade_prefers_local_backend(monkeypatch, tmp_path):
+    backend = tmp_path / "fastapi-backend"
+    backend.mkdir()
+    (backend / "alembic.ini").write_text("[alembic]\n")
+
+    monkeypatch.setattr("mycelium.migrations.find_local_backend_dir", lambda: backend)
+    expected = AlembicRunResult(0, "ok\n", "", "host")
+    with patch("mycelium.migrations._run_host_alembic", return_value=expected) as run_host:
+        result = run_alembic_upgrade("head")
+
+    assert result == expected
+    run_host.assert_called_once_with(backend, ["upgrade", "head"])
+
+
+def test_run_alembic_upgrade_unavailable_when_no_backend_and_container_down(monkeypatch):
+    monkeypatch.setattr("mycelium.migrations.find_local_backend_dir", lambda: None)
+    monkeypatch.setattr("mycelium.migrations.backend_container_running", lambda: False)
+
+    result = run_alembic_upgrade("head")
+
+    assert result.mode == "unavailable"
+    assert result.returncode == 1
+
+
+def test_backend_container_running_true(monkeypatch):
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *args, **kwargs: MagicMock(returncode=0, stdout="true\n"),
+    )
+    assert backend_container_running() is True


### PR DESCRIPTION
## Summary
- Add `mycelium.migrations` helper that runs Alembic from a dev checkout when `fastapi-backend/alembic.ini` exists, otherwise via `docker compose exec` on the running `mycelium-backend` container.
- Wire `mycelium install` and `mycelium migrate` through the shared helper so wheel installs no longer skip migrations when the host lacks a checkout.
- Add unit tests covering host vs container migration paths.

## Test plan
- [x] `pytest mycelium-cli/tests/test_migrations.py`
- [x] `mycelium install` on a wheel-only host with backend container up — migrations apply
- [x] `mycelium doctor` / startup on oclw4 lab — no migration skip warnings


Made with [Cursor](https://cursor.com)