### PR TITLE
fix(openclaw): un-sandbox created agents so they can exec the mycelium CLI

### DIFF
--- a/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
@@ -136,6 +136,68 @@ class OpenClawIntegration(Integration):
             f'"{mycelium_bin}"'
         )
 
+    def _disable_sandbox(self, agent_id: str) -> None:
+        """Set ``sandbox.mode = "off"`` for *agent_id* in openclaw.json.
+
+        A wired-in agent must be able to exec the host ``mycelium`` binary
+        (negotiate, memory writes, plan task ops). OpenClaw's default
+        per-agent sandbox runs every command inside a Linux container
+        (``openclaw-sandbox-python``) that has neither the host-installed
+        ``mycelium`` binary nor access to ``~/.mycelium`` — so the agent
+        reports ``mycelium: not found`` mid-conversation. Mounting the host
+        binary in via ``sandbox.docker.binds`` can't help: the host binary
+        is built for the host OS/arch and won't execute in the Linux
+        container. The only reliable fix today is to run the agent on the
+        host (``mode = "off"``), matching how existing wired-in agents are
+        configured. ``mycelium doctor`` would otherwise flag this after the
+        fact (``N channel agent(s) are sandboxed — mycelium CLI invisible``);
+        we apply it at create time so the agent works on first dispatch.
+
+        Un-sandboxing is a security-relevant change, so it's logged loudly.
+        Best-effort: a missing agent record or unreadable config warns rather
+        than aborting the registration.
+        """
+        oc, oc_json = self._read_block()
+        agents = ((oc.get("agents") or {}).get("list")) or []
+        record = next((a for a in agents if a.get("id") == agent_id), None)
+        if record is None:
+            console.print(
+                f"[yellow]could not set sandbox=off for {agent_id}[/yellow] "
+                f"(no agent record in {oc_json}). If the agent can't run the "
+                f"mycelium CLI, set sandbox.mode = 'off' for it manually and "
+                f"restart the gateway."
+            )
+            return
+        if (record.get("sandbox") or {}).get("mode") == "off":
+            return  # already on the host
+        record["sandbox"] = {"mode": "off"}
+        oc_json.write_text(json.dumps(oc, indent=2) + "\n")
+        console.print(
+            f"  [green]sandbox[/green] off for [cyan]{agent_id}[/cyan] "
+            f"[dim](runs on host so it can exec the mycelium CLI)[/dim]"
+        )
+
+    def _warn_if_sandboxed(self, agent_id: str) -> None:
+        """Warn (don't change) if an adopted agent's sandbox hides the CLI.
+
+        Adopted agents are user-owned; flipping their sandbox silently would
+        override a deliberate choice. We only surface the same diagnosis
+        ``mycelium doctor`` would, with the manual fix.
+        """
+        oc, _oc_json = self._read_block()
+        agents_cfg = oc.get("agents") or {}
+        default_mode = (((agents_cfg.get("defaults") or {}).get("sandbox")) or {}).get("mode")
+        record = next((a for a in (agents_cfg.get("list") or []) if a.get("id") == agent_id), None)
+        mode = ((record or {}).get("sandbox") or {}).get("mode") or default_mode
+        if mode and mode != "off":
+            console.print(
+                f"[yellow]heads up:[/yellow] @{agent_id} runs sandboxed "
+                f"(mode={mode}), so it can't exec the host mycelium CLI "
+                f"(session join/propose/respond will fail). To let it "
+                f"coordinate, set sandbox.mode = 'off' for it in openclaw.json "
+                f"and restart the gateway."
+            )
+
     # ── discovery (brownfield adopt) ────────────────────────────────────────
 
     def discover_local_agents(self) -> list[dict[str, str]]:
@@ -430,10 +492,17 @@ class OpenClawIntegration(Integration):
         assert agent_id  # guaranteed by AgentManifest validation
         if manifest.openclaw_created:
             self._create_agent(agent_id=agent_id, description=manifest.description)
+            # Greenfield agents inherit openclaw's default per-agent sandbox,
+            # which hides the host mycelium CLI (see _disable_sandbox). Run
+            # them on the host so they can coordinate on first dispatch.
+            self._disable_sandbox(agent_id)
         else:
             console.print(
                 f"  [green]adopting[/green] existing OpenClaw agent [cyan]{agent_id}[/cyan]"
             )
+            # Don't override a user's deliberate sandbox config on adopt; just
+            # warn if it'll hide the mycelium CLI (mirrors `mycelium doctor`).
+            self._warn_if_sandboxed(agent_id)
         self._register_channel(room=opts.room, agent_id=agent_id, backend_url=config.server.api_url)
         self._allowlist_mycelium(agent_id)
         self.restart_gateway()

--- a/mycelium-cli/tests/test_agent_onboard.py
+++ b/mycelium-cli/tests/test_agent_onboard.py
@@ -82,6 +82,104 @@ def test_register_adopted_batch_restarts_gateway_once(
     assert restarts == [1]
 
 
+def _write_oc(state, payload) -> None:
+    state.mkdir(exist_ok=True)
+    (state / "openclaw.json").write_text(json.dumps(payload))
+
+
+def test_disable_sandbox_flips_created_agent_to_host(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A greenfield openclaw agent inherits the default sandbox, which hides
+    the host mycelium CLI. `_disable_sandbox` must pin it to mode=off so it
+    can coordinate on first dispatch."""
+    state = tmp_path / ".openclaw"
+    _write_oc(
+        state,
+        {
+            "agents": {
+                "defaults": {"sandbox": {"mode": "all", "docker": {"image": "x"}}},
+                "list": [{"id": "devops", "workspace": "/w/d"}],
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "mycelium.integrations.openclaw.dispatch._openclaw_state_dir",
+        lambda _profile: state,
+    )
+
+    OpenClawIntegration()._disable_sandbox("devops")
+
+    written = json.loads((state / "openclaw.json").read_text())
+    record = next(a for a in written["agents"]["list"] if a["id"] == "devops")
+    assert record["sandbox"] == {"mode": "off"}
+
+
+def test_disable_sandbox_missing_record_does_not_raise(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the agent isn't in the list yet, warn — don't abort registration."""
+    state = tmp_path / ".openclaw"
+    _write_oc(state, {"agents": {"list": []}})
+    monkeypatch.setattr(
+        "mycelium.integrations.openclaw.dispatch._openclaw_state_dir",
+        lambda _profile: state,
+    )
+
+    # best-effort: must not raise even when the record is absent
+    OpenClawIntegration()._disable_sandbox("ghost")
+
+
+def test_register_created_agent_disables_sandbox(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """register() of a created agent must run _disable_sandbox; an adopted
+    agent must not (it only warns)."""
+    from mycelium.integrations.base import AddOptions
+    from mycelium.protocol import AgentManifest
+
+    state = tmp_path / ".openclaw"
+    _write_oc(state, {"agents": {"list": [{"id": "devops"}]}})
+    monkeypatch.setattr(
+        "mycelium.integrations.openclaw.dispatch._openclaw_state_dir",
+        lambda _profile: state,
+    )
+
+    impl = OpenClawIntegration()
+    disabled: list[str] = []
+    warned: list[str] = []
+    monkeypatch.setattr(impl, "_create_agent", lambda **_: None)
+    monkeypatch.setattr(impl, "_disable_sandbox", lambda aid: disabled.append(aid))
+    monkeypatch.setattr(impl, "_warn_if_sandboxed", lambda aid: warned.append(aid))
+    monkeypatch.setattr(impl, "_register_channel", lambda **_: None)
+    monkeypatch.setattr(impl, "_allowlist_mycelium", lambda _aid: None)
+    monkeypatch.setattr(impl, "restart_gateway", lambda: None)
+
+    cfg = type(
+        "C",
+        (),
+        {"server": type("S", (), {"api_url": "http://localhost:8000"})()},
+    )()
+    opts = AddOptions(room="demo")
+
+    created = AgentManifest(
+        handle="devops",
+        adapter="openclaw",
+        openclaw_agent="devops",
+        openclaw_created=True,
+    )
+    impl.register(manifest=created, config=cfg, opts=opts)  # ty: ignore[invalid-argument-type]
+    assert disabled == ["devops"] and warned == []
+
+    adopted = AgentManifest(
+        handle="legacy",
+        adapter="openclaw",
+        openclaw_agent="legacy",
+        openclaw_created=False,
+    )
+    impl.register(manifest=adopted, config=cfg, opts=opts)  # ty: ignore[invalid-argument-type]
+    assert disabled == ["devops"]  # unchanged — adopt doesn't disable
+    assert warned == ["legacy"]
+
+
 def test_agent_add_non_interactive_without_handle_errors() -> None:
     """CliRunner stdin/stdout aren't a TTY — bare `agent add` must refuse with
     guidance instead of hanging on a picker or silently doing nothing."""


### PR DESCRIPTION
Closes #376.

## Problem

`mycelium agent create --adapter openclaw` prints `allowlisted mycelium CLI for <agent>`, but the new agent inherits openclaw's default per-agent Docker sandbox (`agents.defaults.sandbox.mode = "all"`). Inside that Linux container the host `mycelium` binary doesn't exist, so the agent reports `mycelium: not found` on first dispatch — `session join`/`message propose`/`message respond` all fail. Allowlisting a command is meaningless when the binary isn't present in the execution environment.

We confirmed there's **no config-only escape**: openclaw's sandbox supports `docker.binds`, but the host is macOS and the sandbox is a Linux container, so a host-built binary can't be bind-mounted and executed across the OS/arch boundary. Putting the CLI *inside* the sandbox is a real feature (bake it into the image) tracked separately. The pragmatic, reliable fix is to run created agents on the host.

## Change

- **Created (greenfield) openclaw agents**: `register()` now calls `_disable_sandbox()`, pinning `sandbox.mode = "off"` in `openclaw.json` — matching how existing wired-in agents (e.g. `julia-agent`, `selina-agent`) are already configured, and what `mycelium doctor`'s `_check_openclaw_agent_sandbox()` recommends after the fact. We just apply it at create time so the agent works on first dispatch instead of failing silently until someone runs `doctor`.
- **Adopted agents**: user-owned, so we don't silently override their sandbox. `_warn_if_sandboxed()` surfaces the same diagnosis `doctor` would, with the manual fix.
- Un-sandboxing is logged loudly (it's security-relevant). Both helpers are best-effort — a missing record / unreadable config warns rather than aborting registration.

## Tests

- `_disable_sandbox` flips a created agent's `sandbox` to `{mode: off}`.
- `_disable_sandbox` on a missing record doesn't raise.
- `register()` calls `_disable_sandbox` for created agents and only `_warn_if_sandboxed` for adopted ones.

Full suite: 372 passed; ruff + ty clean.