### PR TITLE
fix(openclaw): route exec to gateway host instead of disabling sandbox

### DIFF
--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -178,7 +178,9 @@ mycelium session join --handle agent-delta -m "Ship safe" -r e2e-test-room
 
 Test that OpenClaw agents get woken by coordination ticks and respond autonomously.
 
-**Prerequisites**: OpenClaw gateway running, mycelium adapter installed, agents configured with sandbox=off.
+**Prerequisites**: OpenClaw gateway running, mycelium adapter installed, agents able to exec mycelium CLI. Two ways to achieve this per agent in `openclaw.json`:
+- Option A (simpler): `"sandbox": {"mode": "off"}`
+- Option B (preserves container isolation): `"tools": {"exec": {"host": "gateway"}}` — routes exec to the gateway host where mycelium is installed while keeping sandbox isolation for read/write/edit.
 
 ```bash
 # Verify gateway + plugin

--- a/.claude/skills/persona-before-and-after/SKILL.md
+++ b/.claude/skills/persona-before-and-after/SKILL.md
@@ -1323,12 +1323,12 @@ The skill always does `--depth 1` clone so it gets the latest version automatica
 | Strategy block missing from after-case SOUL.md | Profile only refs a preference file | Add a strategy to `persona_parts` in the profile YAML; the before case intentionally omits it |
 | `openclaw agents add` prompts interactively | Missing `--non-interactive` | Add `--non-interactive --workspace <path>` |
 | `mycelium room create` returns 400 | Room name already exists | Use unique `$EXP_ID` prefix or delete existing room first |
-| Agents don't respond in after case | Sandbox blocks `mycelium` CLI | Verify `sandbox: {mode: off}` was patched in Phase 1a |
+| Agents don't respond in after case | Sandbox blocks `mycelium` CLI | Verify `sandbox: {mode: off}` was patched in Phase 1a, or `tools.exec.host = 'gateway'` set |
 | After-case agents chat instead of using CLI | Strategy block not in SOUL.md | See above |
 | `curl` to backend fails | Wrong port | Read from `~/.mycelium/config.toml` |
 | No SSE connection | Plugin not loaded | Check plugin in `load.paths` and `allow` |
 | Ticks never arrive (after case) | Session room SSE not subscribed | Check poll found session room; verify CFN is running (`docker logs mycelium-backend`) |
 | Agent processes hang | `--local` flag or SSE loop in child | Ensure NOT using `--local`; check `MYCELIUM_CHANNEL_ONESHOT` env var |
-| After-case agents say "mycelium CLI isn't available" | Experiment agents are sandboxed | Set `sandbox: {mode: "off"}` on each `exp-*` agent in `openclaw.json` and restart gateway. See Phase 1a. |
+| After-case agents say "mycelium CLI isn't available" | Experiment agents are sandboxed | Set `sandbox: {mode: "off"}` or `tools.exec.host = "gateway"` on each `exp-*` agent in `openclaw.json` and restart gateway. See Phase 1a. |
 
 

--- a/docs/design/openclaw-exec-host-vs-sandbox.md
+++ b/docs/design/openclaw-exec-host-vs-sandbox.md
@@ -1,0 +1,142 @@
+# OpenClaw: `tools.exec.host=gateway` vs `sandbox.mode=off` for mycelium agents
+
+Status: **active** — documents the fix introduced in `fix/openclaw-sandbox-exec-host`.
+
+## Problem
+
+Mycelium agents registered in OpenClaw need to run the `mycelium` CLI (e.g.
+`mycelium negotiate respond accept`) in response to coordination ticks. When
+an agent's sandbox is enabled, those `exec` calls silently fail — the mycelium
+CLI is not installed inside the sandbox container, and the exec-approvals
+allowlist that `mycelium agent add openclaw` writes is never consulted.
+
+## Why sandbox mode breaks mycelium exec
+
+Two separate mechanisms compound to cause the failure.
+
+### 1. Process spawning — wrong host
+
+`resolveExecTarget` in OpenClaw resolves the effective exec host at call time:
+
+```typescript
+// bash-tools.exec-runtime.ts
+const effectiveHost =
+  resolvedTarget === "auto"
+    ? (params.sandboxAvailable ? "sandbox" : "gateway")
+    : resolvedTarget;
+```
+
+When sandbox is enabled and `tools.exec.host` is unset (`auto`), every exec
+call lands inside the sandbox container. The mycelium CLI is not installed
+there — the command fails with "not found."
+
+### 2. Allowlist skipped — wrong approval path
+
+`mycelium agent add openclaw` writes approved mycelium commands into
+`exec-approvals.json` via `_allowlist_mycelium()`. But OpenClaw only reads
+that file for gateway-hosted execs:
+
+```typescript
+// bash-tools.exec.ts
+const approvalPolicy =
+  host === "sandbox"
+    ? undefined                       // allowlist never loaded inside sandbox
+    : resolveExecApprovalsFromFile({  // reads exec-approvals.json
+        file: loadExecApprovals(),
+        agentId, ...
+      }).agent;
+```
+
+When exec is sandbox-hosted, `approvalPolicy = undefined` — the allowlist
+entries written by `_allowlist_mycelium()` are silently bypassed regardless
+of their content.
+
+## The two fixes
+
+Both fixes route `exec` to the gateway host (where mycelium is installed) and
+restore the exec-approvals allowlist path. They differ in scope.
+
+| | `sandbox.mode = 'off'` | `tools.exec.host = 'gateway'` |
+|---|---|---|
+| **How exec is routed** | `sandboxAvailable = false` → `auto` resolves to `gateway` | `configuredTarget = 'gateway'` → resolves directly, bypasses sandbox check |
+| **Allowlist consulted?** | Yes — `host != "sandbox"` | Yes — `host != "sandbox"` |
+| **Other tools (read/write/edit)** | Also run on host — no container isolation | Still run inside the sandbox container |
+| **Blast radius** | All tools leave the sandbox | Only `exec` leaves the sandbox |
+
+`tools.exec.host = 'gateway'` is the minimal correct fix: it routes only
+`exec` to the host where mycelium lives and keeps all other tools (file reads,
+writes, edits) inside the sandbox container.
+
+## Example agent config (`openclaw.json`)
+
+Both snippets show a single agent entry. Only the relevant keys are shown;
+all other config is unchanged.
+
+### Option A — disable sandbox entirely (simpler, less isolated)
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "lawyer-a",
+        "name": "Lawyer A",
+        "sandbox": {
+          "mode": "off"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Option B — gateway exec only (recommended, preserves container isolation)
+
+```json
+{
+  "agents": {
+    "list": [
+      {
+        "id": "lawyer-a",
+        "name": "Lawyer A",
+        "tools": {
+          "exec": {
+            "host": "gateway"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+With Option B, `read`, `write`, and `edit` still run inside the sandbox
+container. Only `exec` is routed to the gateway host, which is exactly what
+mycelium coordination requires.
+
+## How mycelium sets this automatically
+
+`mycelium agent add openclaw` (and `mycelium adapter add openclaw`) calls
+`_configure_exec_host_gateway(agent_id)` in
+`mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py` immediately
+after `_allowlist_mycelium()`. This writes `tools.exec.host = "gateway"` into
+the agent's entry in `openclaw.json` so new agents are configured correctly
+without manual intervention.
+
+The `main` agent is an implicit OpenClaw default that never appears in
+`agents.list` and therefore cannot be patched programmatically. If the `main`
+session needs to run mycelium commands, use Option A for that agent or run
+mycelium from a named agent instead.
+
+## Verification
+
+```bash
+# Check effective sandbox config for a named agent
+openclaw sandbox explain --agent lawyer-a
+
+# Doctor checks both options and reports which agents can exec the mycelium CLI
+mycelium doctor
+```
+
+`mycelium doctor` accepts either fix — it flags an agent only if both
+`sandbox.mode` is not `off` AND `tools.exec.host` is not `gateway`.

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1328,7 +1328,7 @@ def _check_openclaw_agent_sandbox() -> CheckResult:
             continue
         # exec.host=gateway routes exec to the host (where mycelium lives) without
         # disabling sandbox isolation for other tools — acceptable alternative to mode=off.
-        exec_host = (agent.get("tools") or {}).get("exec", {}).get("host")
+        exec_host = ((agent.get("tools") or {}).get("exec") or {}).get("host")
         if exec_host == "gateway":
             continue
         sandboxed.append(f"{agent_id} (sandbox.mode={mode}, exec.host={exec_host or 'auto'})")

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1324,26 +1324,39 @@ def _check_openclaw_agent_sandbox() -> CheckResult:
         if agent_id not in channel_agents:
             continue
         mode = (agent.get("sandbox") or {}).get("mode") or default_sandbox
-        if mode != "off":
-            sandboxed.append(f"{agent_id} (mode={mode})")
+        if mode == "off":
+            continue
+        # sandbox is on — check if exec is routed to the gateway host instead.
+        # tools.exec.host = "gateway" causes OpenClaw to bypass the sandbox exec
+        # context and run exec calls on the gateway host, where mycelium is
+        # installed and the approvals allowlist is evaluated. This is the
+        # fine-grained alternative to disabling the sandbox entirely.
+        exec_host = (agent.get("tools") or {}).get("exec", {}).get("host")
+        if exec_host == "gateway":
+            continue
+        sandboxed.append(f"{agent_id} (sandbox.mode={mode}, exec.host={exec_host or 'auto'})")
 
     if sandboxed:
         return CheckResult(
             name="agent sandbox",
             status="warning",
-            message=f"{len(sandboxed)} channel agent(s) are sandboxed — mycelium CLI invisible",
+            message=f"{len(sandboxed)} channel agent(s) block mycelium CLI exec",
             details=[
                 *sandboxed,
                 "sandboxed agents cannot execute `mycelium session join`, `message propose`,",
-                "or `message respond` because the mycelium binary isn't in their sandbox PATH.",
-                "fix: set sandbox.mode = 'off' in openclaw.json for each agent, restart gateway",
+                "or `message respond` — the exec approvals allowlist is bypassed in sandbox mode.",
+                "fix (option A — simpler): set sandbox.mode = 'off' in openclaw.json per agent",
+                "fix (option B — preserves sandbox): set tools.exec.host = 'gateway' per agent",
+                "  option B keeps container isolation for read/write/edit while routing exec",
+                "  calls to the gateway host where mycelium is installed and allowlisted.",
+                "restart the openclaw gateway after either change.",
             ],
         )
 
     return CheckResult(
         name="agent sandbox",
         status="ok",
-        message=f"all {len(channel_agents)} channel agent(s) have sandbox=off",
+        message=f"all {len(channel_agents)} channel agent(s) can exec mycelium CLI",
     )
 
 

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1326,11 +1326,8 @@ def _check_openclaw_agent_sandbox() -> CheckResult:
         mode = (agent.get("sandbox") or {}).get("mode") or default_sandbox
         if mode == "off":
             continue
-        # sandbox is on — check if exec is routed to the gateway host instead.
-        # tools.exec.host = "gateway" causes OpenClaw to bypass the sandbox exec
-        # context and run exec calls on the gateway host, where mycelium is
-        # installed and the approvals allowlist is evaluated. This is the
-        # fine-grained alternative to disabling the sandbox entirely.
+        # exec.host=gateway routes exec to the host (where mycelium lives) without
+        # disabling sandbox isolation for other tools — acceptable alternative to mode=off.
         exec_host = (agent.get("tools") or {}).get("exec", {}).get("host")
         if exec_host == "gateway":
             continue

--- a/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
@@ -137,23 +137,14 @@ class OpenClawIntegration(Integration):
     def _configure_exec_host_gateway(self, agent_id: str) -> None:
         """Set ``tools.exec.host = 'gateway'`` for *agent_id* in openclaw.json.
 
-        OpenClaw's exec approvals file is **bypassed** when the effective exec
-        host is "sandbox" (the default when ``sandbox.mode != 'off'``).
-        Routing exec to the gateway host instead means:
+        The exec-approvals allowlist is bypassed when exec runs in the sandbox
+        container. Routing exec to the gateway host restores allowlist evaluation
+        and puts ``mycelium`` on PATH — while keeping sandbox isolation for all
+        other tools. Trade-off: ALL exec calls route to the gateway, not just
+        mycelium; use ``sandbox.mode=off`` if per-binary routing is needed instead.
 
-        - ``mycelium`` executes on the gateway host where it is installed.
-        - The approvals allowlist (written by :meth:`_allowlist_mycelium`) is
-          now actually evaluated — gating which binaries the agent may run.
-        - Sandbox container isolation (filesystem, network) is preserved for
-          all other tools (read/write/edit/apply_patch).
-
-        Trade-off: ALL exec calls for this agent route to the gateway host,
-        not just mycelium. Operators who need per-binary exec routing should
-        set ``sandbox.mode = 'off'`` instead and rely solely on the approvals
-        allowlist.
-
-        Best-effort: skips silently if the agent is not in ``agents.list``
-        (e.g. the implicit ``main`` handle) or if the file cannot be written.
+        Best-effort: skips silently for implicit agents (e.g. ``main``, not in
+        ``agents.list``) or if the file cannot be written.
         """
         _state_dir, oc_json = self._paths()
         if not oc_json.exists():
@@ -175,7 +166,7 @@ class OpenClawIntegration(Integration):
 
         exec_cfg["host"] = "gateway"
         try:
-            oc_json.write_text(json.dumps(cfg, indent=2))
+            oc_json.write_text(json.dumps(cfg, indent=2) + "\n")
             console.print(
                 f"  [green]set exec.host=gateway[/green] for [cyan]{agent_id}[/cyan] "
                 "[dim](exec routes to gateway host; sandbox isolation preserved for other tools)[/dim]"

--- a/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
@@ -104,18 +104,16 @@ class OpenClawIntegration(Integration):
             )
 
     def _allowlist_mycelium(self, agent_id: str) -> None:
-        """Allowlist the ``mycelium`` binary for *agent_id*.
+        """Allowlist the ``mycelium`` binary for *agent_id* in the exec approvals file.
 
-        A wired-in agent has to be able to exec ``mycelium`` (negotiate,
-        memory writes, plan task ops). Without an allowlist entry a
-        sandboxed agent either gets per-call approval prompts or can't run
-        it at all — and reports "mycelium isn't available" mid-conversation.
-        Wiring the agent in is exactly when we know it'll need the binary,
-        so allowlist it here rather than leaving it as a manual step.
+        The approvals file is only consulted when the agent's effective exec
+        host is NOT "sandbox" — i.e. when ``sandbox.mode = 'off'`` or when
+        ``tools.exec.host = 'gateway'`` is set. Pair this call with
+        :meth:`_configure_exec_host_gateway` so the allowlist is actually
+        evaluated for sandboxed agents.
 
-        Best-effort: a failure (older openclaw without ``approvals
-        allowlist``, etc.) warns with the manual command rather than
-        aborting the registration.
+        Best-effort: warns with the manual command on failure rather than
+        aborting registration.
         """
         mycelium_bin = shutil.which("mycelium") or str(Path.home() / ".local" / "bin" / "mycelium")
         result = subprocess.run(
@@ -135,6 +133,58 @@ class OpenClawIntegration(Integration):
             f'  Add it manually: openclaw approvals allowlist add --agent "{agent_id}" '
             f'"{mycelium_bin}"'
         )
+
+    def _configure_exec_host_gateway(self, agent_id: str) -> None:
+        """Set ``tools.exec.host = 'gateway'`` for *agent_id* in openclaw.json.
+
+        OpenClaw's exec approvals file is **bypassed** when the effective exec
+        host is "sandbox" (the default when ``sandbox.mode != 'off'``).
+        Routing exec to the gateway host instead means:
+
+        - ``mycelium`` executes on the gateway host where it is installed.
+        - The approvals allowlist (written by :meth:`_allowlist_mycelium`) is
+          now actually evaluated — gating which binaries the agent may run.
+        - Sandbox container isolation (filesystem, network) is preserved for
+          all other tools (read/write/edit/apply_patch).
+
+        Trade-off: ALL exec calls for this agent route to the gateway host,
+        not just mycelium. Operators who need per-binary exec routing should
+        set ``sandbox.mode = 'off'`` instead and rely solely on the approvals
+        allowlist.
+
+        Best-effort: skips silently if the agent is not in ``agents.list``
+        (e.g. the implicit ``main`` handle) or if the file cannot be written.
+        """
+        _state_dir, oc_json = self._paths()
+        if not oc_json.exists():
+            return
+        try:
+            cfg = json.loads(oc_json.read_text())
+        except (OSError, ValueError):
+            return
+
+        agents_list: list[dict] = (cfg.get("agents") or {}).get("list") or []
+        agent_entry = next((a for a in agents_list if a.get("id") == agent_id), None)
+        if agent_entry is None:
+            # Implicit agents (e.g. main) are not in agents.list — skip.
+            return
+
+        exec_cfg: dict = agent_entry.setdefault("tools", {}).setdefault("exec", {})
+        if exec_cfg.get("host") == "gateway":
+            return  # Already set — idempotent.
+
+        exec_cfg["host"] = "gateway"
+        try:
+            oc_json.write_text(json.dumps(cfg, indent=2))
+            console.print(
+                f"  [green]set exec.host=gateway[/green] for [cyan]{agent_id}[/cyan] "
+                "[dim](exec routes to gateway host; sandbox isolation preserved for other tools)[/dim]"
+            )
+        except OSError as exc:
+            console.print(
+                f"[yellow]could not write exec.host for {agent_id}[/yellow]: {exc}\n"
+                f'  Set manually: tools.exec.host = "gateway" in openclaw.json for agent {agent_id}'
+            )
 
     # ── discovery (brownfield adopt) ────────────────────────────────────────
 
@@ -192,6 +242,7 @@ class OpenClawIntegration(Integration):
                 backend_url=backend_url,
             )
             self._allowlist_mycelium(handle)
+            self._configure_exec_host_gateway(handle)
         self.restart_gateway()
 
     # ── manifest ────────────────────────────────────────────────────────────
@@ -436,6 +487,7 @@ class OpenClawIntegration(Integration):
             )
         self._register_channel(room=opts.room, agent_id=agent_id, backend_url=config.server.api_url)
         self._allowlist_mycelium(agent_id)
+        self._configure_exec_host_gateway(agent_id)
         self.restart_gateway()
 
     def destroy(

--- a/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
@@ -160,7 +160,16 @@ class OpenClawIntegration(Integration):
             # Implicit agents (e.g. main) are not in agents.list — skip.
             return
 
-        exec_cfg: dict = agent_entry.setdefault("tools", {}).setdefault("exec", {})
+        # Defensive against explicit JSON nulls (e.g. "tools": null) — setdefault
+        # would return the existing None and the next .setdefault would crash.
+        tools_cfg = agent_entry.get("tools")
+        if not isinstance(tools_cfg, dict):
+            tools_cfg = {}
+            agent_entry["tools"] = tools_cfg
+        exec_cfg = tools_cfg.get("exec")
+        if not isinstance(exec_cfg, dict):
+            exec_cfg = {}
+            tools_cfg["exec"] = exec_cfg
         if exec_cfg.get("host") == "gateway":
             return  # Already set — idempotent.
 

--- a/mycelium-cli/tests/test_agent_onboard.py
+++ b/mycelium-cli/tests/test_agent_onboard.py
@@ -82,6 +82,146 @@ def test_register_adopted_batch_restarts_gateway_once(
     assert restarts == [1]
 
 
+def _write_oc(state, payload) -> None:
+    state.mkdir(exist_ok=True)
+    (state / "openclaw.json").write_text(json.dumps(payload))
+
+
+def _patch_state(monkeypatch, state) -> None:
+    monkeypatch.setattr(
+        "mycelium.integrations.openclaw.dispatch._openclaw_state_dir",
+        lambda _profile: state,
+    )
+
+
+def test_configure_exec_host_gateway_sets_host(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wired-in agent must get tools.exec.host=gateway so the exec-approvals
+    allowlist is consulted and mycelium runs on the host."""
+    state = tmp_path / ".openclaw"
+    _write_oc(state, {"agents": {"list": [{"id": "lawyer-a"}]}})
+    _patch_state(monkeypatch, state)
+
+    OpenClawIntegration()._configure_exec_host_gateway("lawyer-a")
+
+    written = json.loads((state / "openclaw.json").read_text())
+    entry = next(a for a in written["agents"]["list"] if a["id"] == "lawyer-a")
+    assert entry["tools"]["exec"]["host"] == "gateway"
+
+
+def test_configure_exec_host_gateway_is_idempotent(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-running must not clobber an already-correct config."""
+    state = tmp_path / ".openclaw"
+    _write_oc(
+        state,
+        {"agents": {"list": [{"id": "lawyer-a", "tools": {"exec": {"host": "gateway"}}}]}},
+    )
+    _patch_state(monkeypatch, state)
+
+    OpenClawIntegration()._configure_exec_host_gateway("lawyer-a")
+
+    written = json.loads((state / "openclaw.json").read_text())
+    entry = next(a for a in written["agents"]["list"] if a["id"] == "lawyer-a")
+    assert entry["tools"]["exec"]["host"] == "gateway"
+
+
+def test_configure_exec_host_gateway_preserves_sibling_tool_config(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Setting exec.host must not drop other keys under tools/exec."""
+    state = tmp_path / ".openclaw"
+    _write_oc(
+        state,
+        {
+            "agents": {
+                "list": [
+                    {"id": "lawyer-a", "tools": {"browser": {"on": True}, "exec": {"timeout": 30}}}
+                ]
+            }
+        },
+    )
+    _patch_state(monkeypatch, state)
+
+    OpenClawIntegration()._configure_exec_host_gateway("lawyer-a")
+
+    entry = next(
+        a
+        for a in json.loads((state / "openclaw.json").read_text())["agents"]["list"]
+        if a["id"] == "lawyer-a"
+    )
+    assert entry["tools"]["exec"] == {"timeout": 30, "host": "gateway"}
+    assert entry["tools"]["browser"] == {"on": True}  # sibling tool untouched
+
+
+def test_configure_exec_host_gateway_missing_agent_is_noop(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Implicit agents (e.g. `main`, not in agents.list) are skipped without
+    raising and without rewriting the file."""
+    state = tmp_path / ".openclaw"
+    payload = {"agents": {"list": [{"id": "lawyer-a"}]}}
+    _write_oc(state, payload)
+    _patch_state(monkeypatch, state)
+
+    OpenClawIntegration()._configure_exec_host_gateway("main")
+
+    # untouched — no exec.host injected for an absent agent
+    assert json.loads((state / "openclaw.json").read_text()) == payload
+
+
+def test_configure_exec_host_gateway_tolerates_null_tools(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A hand-edited `tools: null` must not crash the read-modify-write."""
+    state = tmp_path / ".openclaw"
+    _write_oc(state, {"agents": {"list": [{"id": "lawyer-a", "tools": None}]}})
+    _patch_state(monkeypatch, state)
+
+    OpenClawIntegration()._configure_exec_host_gateway("lawyer-a")  # must not raise
+
+    entry = next(
+        a
+        for a in json.loads((state / "openclaw.json").read_text())["agents"]["list"]
+        if a["id"] == "lawyer-a"
+    )
+    assert entry["tools"]["exec"]["host"] == "gateway"
+
+
+def test_register_wires_exec_host_for_created_and_adopted(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """register() must configure exec.host=gateway for both created and adopted
+    agents (paired with the allowlist), so they can exec mycelium on first tick."""
+    from mycelium.integrations.base import AddOptions
+    from mycelium.protocol import AgentManifest
+
+    _patch_state(monkeypatch, tmp_path / ".openclaw")
+    impl = OpenClawIntegration()
+    configured: list[str] = []
+    monkeypatch.setattr(impl, "_create_agent", lambda **_: None)
+    monkeypatch.setattr(impl, "_register_channel", lambda **_: None)
+    monkeypatch.setattr(impl, "_allowlist_mycelium", lambda _aid: None)
+    monkeypatch.setattr(impl, "_configure_exec_host_gateway", lambda aid: configured.append(aid))
+    monkeypatch.setattr(impl, "restart_gateway", lambda: None)
+
+    cfg = type("C", (), {"server": type("S", (), {"api_url": "http://localhost:8000"})()})()
+    opts = AddOptions(room="demo")
+
+    for created, handle in ((True, "fresh"), (False, "legacy")):
+        impl.register(
+            manifest=AgentManifest(
+                handle=handle,
+                adapter="openclaw",
+                openclaw_agent=handle,
+                openclaw_created=created,
+            ),
+            config=cfg,  # ty: ignore[invalid-argument-type]
+            opts=opts,
+        )
+    assert configured == ["fresh", "legacy"]
+
+
 def test_agent_add_non_interactive_without_handle_errors() -> None:
     """CliRunner stdin/stdout aren't a TTY — bare `agent add` must refuse with
     guidance instead of hanging on a picker or silently doing nothing."""

--- a/mycelium-cli/tests/test_doctor_openclaw_sandbox.py
+++ b/mycelium-cli/tests/test_doctor_openclaw_sandbox.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""`mycelium doctor` agent-sandbox check.
+
+A channel agent can only exec the mycelium CLI when its exec lands on the
+gateway host — either because the sandbox is off, or because
+``tools.exec.host = 'gateway'`` routes exec out of the sandbox container. The
+check must accept *either* fix and only warn when both are absent.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mycelium.commands.doctor import _check_openclaw_agent_sandbox
+
+
+def _setup(monkeypatch, tmp_path, agents_list) -> None:
+    state = tmp_path / ".openclaw"
+    state.mkdir()
+    (state / "openclaw.json").write_text(
+        json.dumps(
+            {
+                "channels": {"mycelium-room": {"agents": [a["id"] for a in agents_list]}},
+                "agents": {"list": agents_list},
+            }
+        )
+    )
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("mycelium.commands.doctor._openclaw_adapter_registered", lambda: True)
+
+
+def test_sandboxed_agent_without_either_fix_warns(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _setup(monkeypatch, tmp_path, [{"id": "lawyer-a", "sandbox": {"mode": "all"}}])
+    result = _check_openclaw_agent_sandbox()
+    assert result.status == "warning"
+    assert any("lawyer-a" in d for d in result.details)
+
+
+def test_exec_host_gateway_is_accepted(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Sandbox on, but exec routed to the gateway → the CLI works → green."""
+    _setup(
+        monkeypatch,
+        tmp_path,
+        [{"id": "lawyer-a", "sandbox": {"mode": "all"}, "tools": {"exec": {"host": "gateway"}}}],
+    )
+    assert _check_openclaw_agent_sandbox().status == "ok"
+
+
+def test_sandbox_off_is_accepted(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _setup(monkeypatch, tmp_path, [{"id": "lawyer-a", "sandbox": {"mode": "off"}}])
+    assert _check_openclaw_agent_sandbox().status == "ok"
+
+
+def test_null_exec_tools_does_not_crash(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hand-edited `exec: null` must be treated as 'no gateway routing', not
+    raise — the agent is still sandboxed, so it warns."""
+    _setup(
+        monkeypatch,
+        tmp_path,
+        [{"id": "lawyer-a", "sandbox": {"mode": "all"}, "tools": {"exec": None}}],
+    )
+    result = _check_openclaw_agent_sandbox()
+    assert result.status == "warning"
+    assert any("lawyer-a" in d for d in result.details)


### PR DESCRIPTION
## Problem

When an OpenClaw agent's sandbox is enabled (the default for non-main sessions), `mycelium` CLI calls fail silently in two compounding ways:

1. **Wrong spawn host** — exec lands inside the sandbox container where `mycelium` isn't installed.
2. **Allowlist bypassed** — the exec-approvals allowlist written by `mycelium agent add openclaw` is only consulted when exec is gateway-hosted; it's unconditionally skipped (`approvalPolicy = undefined`) for sandbox-hosted exec.

The existing guidance was to set `sandbox.mode = 'off'`, which lifts all sandbox isolation — a broader change than necessary.

## Fix

`tools.exec.host = 'gateway'` is the minimal correct alternative: it routes only the `exec` tool to the gateway host (where `mycelium` lives and the allowlist is evaluated), while keeping sandbox isolation intact for `read`, `write`, `edit`, and `apply_patch`.

- `_configure_exec_host_gateway(agent_id)` writes the setting into `openclaw.json` automatically during `mycelium agent add openclaw` and `mycelium adapter add openclaw`, paired with the existing `_allowlist_mycelium()` call.
- `mycelium doctor` now accepts either fix — it flags an agent only when both `sandbox.mode != 'off'` AND `tools.exec.host != 'gateway'`. Warning details explain both options.
- Agents not in `agents.list` (e.g. the implicit `main` handle) are skipped silently — they cannot be patched programmatically.

## Changes

- `dispatch.py` — new `_configure_exec_host_gateway()`, called alongside `_allowlist_mycelium()` in `register()` and `register_adopted_batch()`
- `doctor.py` — `_check_openclaw_agent_sandbox()` accepts either fix; updated warning details list both options
- `docs/design/openclaw-exec-host-vs-sandbox.md` — explains the two-layer failure, the comparison table between options A and B, and annotated `openclaw.json` examples
- Skill docs updated to mention both options

## Test plan

- [x] `uv run ruff check . && uv run ruff format --check . && uv run ty check .` — all pass
- [x] Live negotiation with `lawyer-a` (OpenClaw agent, sandbox enabled, `exec.host=gateway` set) reached consensus (`broken: false`, `plan/tasks.md` compiled) — verified on `negotiation-test` room session `91c3f034`
- [ ] `mycelium doctor` on a host with a sandboxed agent that has `exec.host=gateway` shows green
- [ ] `mycelium doctor` on a host with a sandboxed agent missing both fixes shows warning with both option A and B in details

🤖 Generated with [Claude Code](https://claude.com/claude-code)