### PR TITLE
fix(sse): prevent stale LISTEN connections from deleted/expired rooms

### DIFF
--- a/fastapi-backend/app/routes/coordination_sessions.py
+++ b/fastapi-backend/app/routes/coordination_sessions.py
@@ -26,6 +26,7 @@ from app.bus import room_channel
 from app.config import settings
 from app.database import async_session_maker, get_async_session
 from app.models import CoordinationSession, Message
+from app.routes.stream import _close_listen_conn, _open_listen_conn, _stream_with_disconnect_watcher
 from app.schemas import (
     CoordinationSessionRead,
     MessageCreate,
@@ -217,36 +218,30 @@ async def stream_session_messages(
 
     display_name = coord.display_name
 
+    channel = room_channel(display_name)
+    conn = await _open_listen_conn()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def _enqueue(_conn, _pid, _ch, payload):
+        queue.put_nowait(payload)
+
+    await conn.add_listener(channel, _enqueue)
+    await conn.execute(f'LISTEN "{channel}"')
+
+    async def _transform(payload: str) -> str:
+        return f"data: {payload}\n\n"
+
     async def event_gen():
-        parsed = urlparse(settings.DATABASE_URL)
-        conn = await asyncpg.connect(
-            host=parsed.hostname,
-            port=parsed.port or 5432,
-            user=parsed.username,
-            password=parsed.password,
-            database=parsed.path.lstrip("/"),
-        )
-        queue: asyncio.Queue = asyncio.Queue()
-
-        def _enqueue(_conn, _pid, _channel, payload):
-            queue.put_nowait(payload)
-
-        await conn.add_listener(room_channel(display_name), _enqueue)
         try:
-            yield ": connected\n\n"
-            while True:
-                if await request.is_disconnected():
-                    return
-                try:
-                    payload = await asyncio.wait_for(queue.get(), timeout=15.0)
-                    yield f"data: {payload}\n\n"
-                except TimeoutError:
-                    yield ": keepalive\n\n"
+            async for chunk in _stream_with_disconnect_watcher(request, queue, _transform):
+                yield chunk
+        except asyncio.CancelledError:
+            pass
         finally:
-            try:
-                await conn.remove_listener(room_channel(display_name), _enqueue)
-            except Exception:
-                pass
-            await conn.close()
+            await _close_listen_conn(conn, channel, _enqueue)
 
-    return StreamingResponse(event_gen(), media_type="text/event-stream")
+    return StreamingResponse(
+        event_gen(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/fastapi-backend/app/routes/stream.py
+++ b/fastapi-backend/app/routes/stream.py
@@ -22,6 +22,7 @@ from sqlalchemy import select
 from app.bus import agent_channel, room_channel
 from app.config import settings
 from app.database import async_session_maker
+from app.models import CoordinationSession, Room
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +173,25 @@ async def stream_room_messages(room_name: str, request: Request):
     Yields SSE events as messages arrive via Postgres NOTIFY.
     Connect with: curl -N http://localhost:8000/rooms/{room}/messages/stream
     """
+    async with async_session_maker() as db:
+        room_result = await db.execute(select(Room).where(Room.name == room_name))
+        if not room_result.scalar_one_or_none():
+            # Also accept coordination session display names, which follow the
+            # pattern "{parent_room_name}:session:{short_id}" but have no Room
+            # table entry of their own.  display_name is a @property so we
+            # parse the short_id from the tail of the URL segment instead.
+            short_id = room_name.rsplit(":session:", 1)[-1] if ":session:" in room_name else None
+            found = False
+            if short_id:
+                cs_result = await db.execute(
+                    select(CoordinationSession).where(
+                        CoordinationSession.short_id == short_id
+                    )
+                )
+                found = cs_result.scalar_one_or_none() is not None
+            if not found:
+                raise HTTPException(status_code=404, detail=f"Room '{room_name}' not found")
+
     try:
         conn: asyncpg.Connection = await _open_listen_conn()
     except Exception as e:

--- a/fastapi-backend/app/routes/stream.py
+++ b/fastapi-backend/app/routes/stream.py
@@ -180,12 +180,13 @@ async def stream_room_messages(room_name: str, request: Request):
             # pattern "{parent_room_name}:session:{short_id}" but have no Room
             # table entry of their own.  display_name is a @property so we
             # parse the short_id from the tail of the URL segment instead.
-            short_id = room_name.rsplit(":session:", 1)[-1] if ":session:" in room_name else None
             found = False
-            if short_id:
+            if ":session:" in room_name:
+                parent, _, short_id = room_name.partition(":session:")
                 cs_result = await db.execute(
                     select(CoordinationSession).where(
-                        CoordinationSession.short_id == short_id
+                        CoordinationSession.parent_room_name == parent,
+                        CoordinationSession.short_id == short_id,
                     )
                 )
                 found = cs_result.scalar_one_or_none() is not None

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -253,14 +253,30 @@ def ensure_room_structure(room_dir: Path) -> None:
 
 
 def remove_room_dir(room_name: str) -> bool:
-    """Remove a room's directory tree. Returns True if it existed."""
+    """Remove a room's directory tree and any session sub-room directories.
+
+    Session sub-rooms follow the pattern ``{room_name}:session:*`` and are
+    stored as sibling directories alongside the parent room directory.  They
+    are orphaned when the parent is deleted, so we clean them up here too.
+
+    Returns True if the primary room directory existed.
+    """
     import shutil
 
-    room_dir = get_data_dir() / "rooms" / room_name
-    if room_dir.exists():
+    rooms_dir = get_data_dir() / "rooms"
+    room_dir = rooms_dir / room_name
+    existed = room_dir.exists()
+    if existed:
         shutil.rmtree(room_dir)
-        return True
-    return False
+
+    # Remove session sub-rooms: same-prefix directories with ":session:" suffix.
+    prefix = room_name + ":session:"
+    if rooms_dir.exists():
+        for child in list(rooms_dir.iterdir()):
+            if child.is_dir() and child.name.startswith(prefix):
+                shutil.rmtree(child)
+
+    return existed
 
 
 def value_to_content(value: dict | str) -> str:

--- a/fastapi-backend/app/services/indexer.py
+++ b/fastapi-backend/app/services/indexer.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Memory, Room
+from app.models import CoordinationSession, Memory, Room
 from app.services.embedding import embed_text
 from app.services.filesystem import (
     get_data_dir,
@@ -35,25 +35,40 @@ def _file_mtime(base_dir: Path, key: str) -> datetime:
     return datetime.fromtimestamp(os.path.getmtime(path), tz=UTC)
 
 
-async def _ensure_room(db: AsyncSession, room_name: str) -> None:
-    """Create a Room row for room_name if one doesn't exist.
+async def _ensure_room(db: AsyncSession, room_name: str) -> bool:
+    """Ensure a Room row exists for room_name. Returns False if the directory
+    should be skipped entirely (confirmed coordination session sub-room).
 
-    Called by index_room before inserting Memory rows so the FK
-    memories.room_name → rooms.name is satisfied after a volume wipe or
-    when a room directory pre-dates its DB row.  Session sub-rooms
-    ({name}:session:{id}) are skipped — they are CoordinationSession
-    records, not Room rows, and should not be indexed.
+    After a volume wipe the filesystem survives but the DB is empty; this
+    upserts the Room row so the FK on memories.room_name → rooms.name is
+    satisfied.
+
+    Directories whose names contain ':session:' are validated against the
+    CoordinationSession table before skipping — a user room that happens to
+    contain ':session:' in its name is still indexed normally if no matching
+    CoordinationSession row exists.
     """
-    if ":session:" in room_name:
-        return
     result = await db.execute(select(Room).where(Room.name == room_name))
     if result.scalar_one_or_none() is not None:
-        return
+        return True
+
+    if ":session:" in room_name:
+        parent, _, short_id = room_name.partition(":session:")
+        cs_result = await db.execute(
+            select(CoordinationSession).where(
+                CoordinationSession.parent_room_name == parent,
+                CoordinationSession.short_id == short_id,
+            )
+        )
+        if cs_result.scalar_one_or_none() is not None:
+            return False
+
     db.add(Room(name=room_name, is_public=True, namespace=room_name))
     try:
         await db.flush()
     except Exception:
         await db.rollback()
+    return True
 
 
 async def index_room(room_name: str, db: AsyncSession, *, force: bool = False) -> dict:
@@ -72,15 +87,13 @@ async def index_room(room_name: str, db: AsyncSession, *, force: bool = False) -
     if not room_dir.exists():
         return {"indexed": 0, "skipped": 0, "pruned": 0, "errors": 0}
 
-    # Session sub-rooms are coordination contexts, not memory namespaces —
-    # they have no Room row and should not be indexed.
-    if ":session:" in room_name:
+    # Ensure the room has a DB row before inserting Memory rows, and confirm
+    # this isn't a coordination session sub-room (which has no Room row by
+    # design). _ensure_room does a DB-validated check rather than a string
+    # heuristic so rooms whose names happen to contain ':session:' are
+    # still indexed if no CoordinationSession record matches.
+    if not await _ensure_room(db, room_name):
         return {"indexed": 0, "skipped": 0, "pruned": 0, "errors": 0}
-
-    # Ensure the room has a DB row before inserting Memory rows.
-    # After a volume wipe the filesystem survives but the DB is empty;
-    # without this the FK on memories.room_name → rooms.name would fail.
-    await _ensure_room(db, room_name)
 
     entries = list_memory_files(room_dir, limit=10000)
     file_keys = set()

--- a/fastapi-backend/app/services/indexer.py
+++ b/fastapi-backend/app/services/indexer.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import CoordinationSession, Memory, Room
+from app.models import Memory, Room
 from app.services.embedding import embed_text
 from app.services.filesystem import (
     get_data_dir,
@@ -37,32 +37,23 @@ def _file_mtime(base_dir: Path, key: str) -> datetime:
 
 async def _ensure_room(db: AsyncSession, room_name: str) -> bool:
     """Ensure a Room row exists for room_name. Returns False if the directory
-    should be skipped entirely (confirmed coordination session sub-room).
+    should be skipped entirely (coordination session sub-room).
 
     After a volume wipe the filesystem survives but the DB is empty; this
     upserts the Room row so the FK on memories.room_name → rooms.name is
     satisfied.
 
-    Directories whose names contain ':session:' are validated against the
-    CoordinationSession table before skipping — a user room that happens to
-    contain ':session:' in its name is still indexed normally if no matching
-    CoordinationSession row exists.
+    Session sub-rooms ({room}:session:{short_id}) are excluded by string check
+    rather than a DB lookup. A DB lookup can't reliably distinguish them on a
+    fresh DB (CoordinationSession table is also empty after a volume wipe), and
+    ':session:' is an internal convention enforced by _spawn_coordination_session
+    — it is not reachable via normal `mycelium room create` usage.
     """
+    if ":session:" in room_name:
+        return False
     result = await db.execute(select(Room).where(Room.name == room_name))
     if result.scalar_one_or_none() is not None:
         return True
-
-    if ":session:" in room_name:
-        parent, _, short_id = room_name.partition(":session:")
-        cs_result = await db.execute(
-            select(CoordinationSession).where(
-                CoordinationSession.parent_room_name == parent,
-                CoordinationSession.short_id == short_id,
-            )
-        )
-        if cs_result.scalar_one_or_none() is not None:
-            return False
-
     db.add(Room(name=room_name, is_public=True, namespace=room_name))
     try:
         await db.flush()
@@ -87,11 +78,8 @@ async def index_room(room_name: str, db: AsyncSession, *, force: bool = False) -
     if not room_dir.exists():
         return {"indexed": 0, "skipped": 0, "pruned": 0, "errors": 0}
 
-    # Ensure the room has a DB row before inserting Memory rows, and confirm
-    # this isn't a coordination session sub-room (which has no Room row by
-    # design). _ensure_room does a DB-validated check rather than a string
-    # heuristic so rooms whose names happen to contain ':session:' are
-    # still indexed if no CoordinationSession record matches.
+    # Ensure the room has a DB row before inserting Memory rows.
+    # Returns False for session sub-rooms, which are skipped entirely.
     if not await _ensure_room(db, room_name):
         return {"indexed": 0, "skipped": 0, "pruned": 0, "errors": 0}
 

--- a/fastapi-backend/app/services/indexer.py
+++ b/fastapi-backend/app/services/indexer.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Memory
+from app.models import Memory, Room
 from app.services.embedding import embed_text
 from app.services.filesystem import (
     get_data_dir,
@@ -33,6 +33,27 @@ def _file_mtime(base_dir: Path, key: str) -> datetime:
     filename = key + ".md" if not key.endswith(".md") else key
     path = base_dir / filename
     return datetime.fromtimestamp(os.path.getmtime(path), tz=UTC)
+
+
+async def _ensure_room(db: AsyncSession, room_name: str) -> None:
+    """Create a Room row for room_name if one doesn't exist.
+
+    Called by index_room before inserting Memory rows so the FK
+    memories.room_name → rooms.name is satisfied after a volume wipe or
+    when a room directory pre-dates its DB row.  Session sub-rooms
+    ({name}:session:{id}) are skipped — they are CoordinationSession
+    records, not Room rows, and should not be indexed.
+    """
+    if ":session:" in room_name:
+        return
+    result = await db.execute(select(Room).where(Room.name == room_name))
+    if result.scalar_one_or_none() is not None:
+        return
+    db.add(Room(name=room_name, is_public=True, namespace=room_name))
+    try:
+        await db.flush()
+    except Exception:
+        await db.rollback()
 
 
 async def index_room(room_name: str, db: AsyncSession, *, force: bool = False) -> dict:
@@ -50,6 +71,16 @@ async def index_room(room_name: str, db: AsyncSession, *, force: bool = False) -
     room_dir = data_dir / "rooms" / room_name
     if not room_dir.exists():
         return {"indexed": 0, "skipped": 0, "pruned": 0, "errors": 0}
+
+    # Session sub-rooms are coordination contexts, not memory namespaces —
+    # they have no Room row and should not be indexed.
+    if ":session:" in room_name:
+        return {"indexed": 0, "skipped": 0, "pruned": 0, "errors": 0}
+
+    # Ensure the room has a DB row before inserting Memory rows.
+    # After a volume wipe the filesystem survives but the DB is empty;
+    # without this the FK on memories.room_name → rooms.name would fail.
+    await _ensure_room(db, room_name)
 
     entries = list_memory_files(room_dir, limit=10000)
     file_keys = set()

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -305,16 +305,16 @@ def delete(
 
         typer.secho(f"Room '{room_name}' deleted.", fg=typer.colors.GREEN)
 
-        # Remove from openclaw.json if it was registered there, so the gateway
-        # stops holding a LISTEN connection open for the now-deleted room.
-        # Only affects channels.mycelium-room.rooms[] — Hermes/Cursor entries
-        # are stored separately and are not touched.
+        # Unregister all agents from the room in local openclaw.json, using the
+        # same _unregister_channel path that `mycelium agent rm` uses on remote
+        # machines — keeps local and remote cleanup symmetric.
         try:
-            from mycelium.integrations.openclaw.dispatch import remove_room_from_openclaw
+            from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw
 
-            if remove_room_from_openclaw(room_name):
+            removed = unregister_room_from_openclaw(room_name)
+            if removed:
                 typer.secho(
-                    f"  Removed '{room_name}' from local openclaw.json.",
+                    f"  Unregistered {len(removed)} agent(s) from '{room_name}' in local openclaw.json.",
                     fg=typer.colors.CYAN,
                 )
         except Exception:

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -305,9 +305,8 @@ def delete(
 
         typer.secho(f"Room '{room_name}' deleted.", fg=typer.colors.GREEN)
 
-        # Unregister all agents from the room in local openclaw.json, using the
-        # same _unregister_channel path that `mycelium agent rm` uses on remote
-        # machines — keeps local and remote cleanup symmetric.
+        # Unregister all agents from the room in local adapter configs so the
+        # plugins stop reopening SSE connections to a room that no longer exists.
         try:
             from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw
 
@@ -319,6 +318,18 @@ def delete(
                 )
         except Exception:
             pass  # openclaw not installed locally — skip silently
+
+        try:
+            from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
+
+            removed = unregister_room_from_hermes(room_name)
+            if removed:
+                typer.secho(
+                    f"  Unregistered {len(removed)} agent(s) from '{room_name}' in local hermes config.yaml.",
+                    fg=typer.colors.CYAN,
+                )
+        except Exception:
+            pass  # hermes not installed locally — skip silently
 
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -305,6 +305,21 @@ def delete(
 
         typer.secho(f"Room '{room_name}' deleted.", fg=typer.colors.GREEN)
 
+        # Remove from openclaw.json if it was registered there, so the gateway
+        # stops holding a LISTEN connection open for the now-deleted room.
+        # Only affects channels.mycelium-room.rooms[] — Hermes/Cursor entries
+        # are stored separately and are not touched.
+        try:
+            from mycelium.integrations.openclaw.dispatch import remove_room_from_openclaw
+
+            if remove_room_from_openclaw(room_name):
+                typer.secho(
+                    f"  Removed '{room_name}' from local openclaw.json.",
+                    fg=typer.colors.CYAN,
+                )
+        except Exception:
+            pass  # openclaw not installed locally — skip silently
+
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False
         print_error(e, verbose=verbose)

--- a/mycelium-cli/src/mycelium/integrations/hermes/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/hermes/dispatch.py
@@ -396,5 +396,60 @@ class HermesIntegration(Integration):
         return {"ok": ok, "details": details}
 
 
+def unregister_room_from_hermes(room_name: str) -> list[str]:
+    """Remove *room_name* from the local hermes config.yaml in one shot.
+
+    Called by ``mycelium room delete`` to keep the hermes gateway from
+    re-opening an SSE connection to a room that no longer exists after the
+    next ``hermes gateway restart``.
+
+    Returns the list of agent handles that were registered in the room (may
+    be empty).  Returns [] silently if hermes config is absent or unreadable.
+    """
+    try:
+        data = _read_config_yaml()
+    except (HermesConfigError, Exception):
+        return []
+
+    platforms = data.get("platforms") or {}
+    block = platforms.get(_HERMES_PLATFORM_ID)
+    if not isinstance(block, dict):
+        return []
+    extra = block.get("extra") or {}
+    if not isinstance(extra, dict):
+        return []
+    rooms_raw = extra.get("rooms") or []
+    if not isinstance(rooms_raw, list):
+        return []
+
+    removed_agents: list[str] = []
+    kept: list[dict] = []
+    for entry in rooms_raw:
+        if not isinstance(entry, dict):
+            kept.append(entry)
+            continue
+        if entry.get("room") == room_name:
+            agents_raw = entry.get("agents") or []
+            removed_agents = [str(a) for a in agents_raw if isinstance(a, (str, int))]
+        else:
+            kept.append(entry)
+
+    if not removed_agents:
+        return []
+
+    extra["rooms"] = kept
+    try:
+        _write_config_yaml(data)
+    except Exception:
+        return []
+
+    try:
+        _restart_gateway()
+    except Exception:
+        pass
+
+    return removed_agents
+
+
 #: Back-compat alias matching the convention used by the other integrations.
 HermesAdapter = HermesIntegration

--- a/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
@@ -720,41 +720,47 @@ class OpenClawIntegration(Integration):
         return {"ok": ok, "details": details}
 
 
-def remove_room_from_openclaw(room_name: str, *, profile: str | None = None) -> bool:
-    """Remove a room entry from channels.mycelium-room.rooms[] in openclaw.json.
+def unregister_room_from_openclaw(room_name: str, *, profile: str | None = None) -> list[str]:
+    """Unregister all agents from a room in the local openclaw.json.
 
-    Called by `mycelium room delete` so stale room subscriptions don't hold
-    Postgres LISTEN connections open after the room is gone from the backend.
-    Only touches entries under channels.mycelium-room — Hermes/Cursor rooms are
+    Uses ``_unregister_channel`` per-agent — the same path the test provisioner
+    takes on remote machines via ``mycelium agent rm``.  Called by
+    ``mycelium room delete`` so local openclaw.json stays in sync after a room
+    is removed from the backend.
+
+    Only touches ``channels.mycelium-room.rooms[]`` — Hermes/Cursor entries are
     stored elsewhere and are not affected.
 
-    Returns True if the room was found and removed, False if not present or
-    if openclaw.json doesn't exist.
+    Returns the list of agent handles that were removed (empty if the room was
+    not present or openclaw.json doesn't exist).
     """
     oc_json = _openclaw_state_dir(profile) / "openclaw.json"
     if not oc_json.exists():
-        return False
+        return []
     try:
         cfg = json.loads(oc_json.read_text())
     except Exception:
-        return False
+        return []
 
     block = (cfg.get("channels") or {}).get(_CHANNEL_ID)
     if not isinstance(block, dict):
-        return False
+        return []
 
-    rooms_before = block.get("rooms") or []
-    if not isinstance(rooms_before, list):
-        return False
+    rooms = block.get("rooms") or []
+    target = next((r for r in rooms if isinstance(r, dict) and r.get("room") == room_name), None)
+    if not target:
+        return []
 
-    rooms_after = [r for r in rooms_before if r.get("room") != room_name]
-    if len(rooms_after) == len(rooms_before):
-        return False  # room wasn't in the list
+    agents = list(target.get("agents") or [])
+    if not agents:
+        return []
 
-    block["rooms"] = rooms_after
-    cfg["channels"][_CHANNEL_ID] = block
-    oc_json.write_text(json.dumps(cfg, indent=2) + "\n")
-    return True
+    integration = OpenClawIntegration(openclaw_profile=profile)
+    removed = []
+    for agent_id in agents:
+        if integration._unregister_channel(room=room_name, agent_id=agent_id):
+            removed.append(agent_id)
+    return removed
 
 
 #: Back-compat alias for the historical class name.

--- a/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/dispatch.py
@@ -720,5 +720,42 @@ class OpenClawIntegration(Integration):
         return {"ok": ok, "details": details}
 
 
+def remove_room_from_openclaw(room_name: str, *, profile: str | None = None) -> bool:
+    """Remove a room entry from channels.mycelium-room.rooms[] in openclaw.json.
+
+    Called by `mycelium room delete` so stale room subscriptions don't hold
+    Postgres LISTEN connections open after the room is gone from the backend.
+    Only touches entries under channels.mycelium-room — Hermes/Cursor rooms are
+    stored elsewhere and are not affected.
+
+    Returns True if the room was found and removed, False if not present or
+    if openclaw.json doesn't exist.
+    """
+    oc_json = _openclaw_state_dir(profile) / "openclaw.json"
+    if not oc_json.exists():
+        return False
+    try:
+        cfg = json.loads(oc_json.read_text())
+    except Exception:
+        return False
+
+    block = (cfg.get("channels") or {}).get(_CHANNEL_ID)
+    if not isinstance(block, dict):
+        return False
+
+    rooms_before = block.get("rooms") or []
+    if not isinstance(rooms_before, list):
+        return False
+
+    rooms_after = [r for r in rooms_before if r.get("room") != room_name]
+    if len(rooms_after) == len(rooms_before):
+        return False  # room wasn't in the list
+
+    block["rooms"] = rooms_after
+    cfg["channels"][_CHANNEL_ID] = block
+    oc_json.write_text(json.dumps(cfg, indent=2) + "\n")
+    return True
+
+
 #: Back-compat alias for the historical class name.
 OpenClawAdapter = OpenClawIntegration


### PR DESCRIPTION
## Summary

Fixes a PostgreSQL connection pool exhaustion issue caused by SSE streams holding dedicated `asyncpg` LISTEN connections open indefinitely after rooms are deleted or sessions end.

Three root causes, each with a targeted fix:

- **SSE 404 guard** (`routes/stream.py`): The room SSE endpoint now validates that the room (or coordination session) exists in the DB before opening a LISTEN connection. Previously any subscriber — including openclaw/hermes plugins pointing at deleted rooms — would hold a connection open forever with nothing ever arriving.

- **Openclaw room cleanup** (`commands/room.py`, `integrations/openclaw/dispatch.py`): `mycelium room delete` now calls `unregister_room_from_openclaw` which removes the room from the local `openclaw.json` via the canonical `_unregister_channel` path (same path as `mycelium agent rm`). Without this, the plugin would resubscribe to the deleted room on every gateway restart.

- **Hermes room cleanup** (`integrations/hermes/dispatch.py`): Same fix for hermes — `mycelium room delete` now calls `unregister_room_from_hermes`, removing the room entry from `~/.hermes/config.yaml` in one read-modify-write and triggering a gateway restart.

- **Indexer FK fix** (`services/indexer.py`): After a volume wipe the filesystem survives but the DB is empty. The indexer now creates missing `Room` rows via `_ensure_room()` before inserting `Memory` rows, preventing a `ForeignKeyViolationError` on startup. Session sub-room directories (`:session:`) are skipped by string check since both the `Room` and `CoordinationSession` tables are also empty after a wipe.

## Test plan

- [ ] `uv run pytest tests/ -x -q` passes in `fastapi-backend/`
- [ ] `uv run pytest tests/ -x -q` passes in `mycelium-cli/`
- [ ] Run `mycelium room delete <room>` with local openclaw installed — confirm room is removed from `openclaw.json`
- [ ] Run `mycelium room delete <room>` with local hermes installed — confirm room is removed from `config.yaml`
- [ ] Restart mycelium after a volume wipe — confirm indexer starts cleanly with no FK errors
- [ ] Monitor `pg_stat_activity` connection count across a test suite run — should stay well below 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)