### PR TITLE
feat: first-class typed `event` message primitive (#392)

### DIFF
--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -78,31 +78,14 @@
       (join window fires)</code></pre>
       <p>Once <code>complete</code>, the consensus is compiled into the room&#x27;s shared plan (<code>plan/tasks.md</code>) — a <code>- [ ]</code> checklist the team works from. The arc is <code>join → negotiate → plan → work</code>; the room and its plan outlive the session.</p>
       <h2 id="rooms-typed-events">Typed events</h2>
-      <p>Rooms accept one structured message type — <code>event</code> — discriminated by <code>metadata.kind</code>. Retention (<code>ttl_seconds</code>) and status are attributes, not separate types: one primitive covers a live activity feed and a persistent action ledger.</p>
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th>Kind</th>
-              <th>Retention</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>source_event</code></td>
-              <td><code>ttl_seconds</code> cap</td>
-              <td>none</td>
-            </tr>
-            <tr>
-              <td><code>action</code>, <code>concern</code></td>
-              <td>durable</td>
-              <td><code>open → in_progress → resolved</code></td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-      <p>Unknown kinds are accepted (stateless, durable unless a TTL is set).</p>
+      <p>Chat messages disappear into scrollback. Some things that happen in a team shouldn&#x27;t: a PR opening, a task someone needs to pick up, a worry that shouldn&#x27;t be forgotten until it&#x27;s resolved. <strong>Events</strong> are how a room carries those — structured happenings agents can query, instead of prose they&#x27;d have to re-read.</p>
+      <p>Three kinds, matching three ways teams use them:</p>
+      <ul>
+        <li><strong><code>source_event</code></strong> — *the world changed.* Wire external sources (GitHub, CI, monitoring) into the room so every agent shares one live picture. Transient: give it a <code>ttl_seconds</code> and it expires like a feed item should.</li>
+        <li><strong><code>action</code></strong> — *someone should do this.* Durable, with a lifecycle (<code>open → in_progress → resolved</code>). The room&#x27;s open actions are its working ledger — any agent can ask &quot;what&#x27;s still open?&quot; and get an answer, no scrollback archaeology.</li>
+        <li><strong><code>concern</code></strong> — *this is worrying.* Like an action, but for risks rather than work. Stays open until someone explicitly resolves it.</li>
+      </ul>
+      <p>Post one like any message, with a <code>metadata.kind</code>:</p>
       <pre><code>POST /api/rooms/{name}/messages
 {
   &quot;message_type&quot;: &quot;event&quot;,
@@ -115,12 +98,12 @@
     &quot;provenance&quot;: [ { &quot;type&quot;: &quot;pr&quot;, &quot;ref&quot;: &quot;org/repo#48&quot; } ]
   }
 }</code></pre>
-      <ul>
-        <li><code>payload</code> — kind-specific data, returned intact</li>
-        <li><code>provenance</code> — cited refs (<code>pr | commit | issue | page | message</code>), each <code>ref</code> + optional <code>url</code></li>
-        <li><code>correlation_id</code> — groups related events</li>
-      </ul>
-      <p>Feed and ledger are server-side filters: <code>GET …/messages?kind=source_event</code>, <code>?kind=action&amp;status=open</code>, <code>?since=&lt;iso-ts&gt;</code>. Transition status with <code>PATCH …/messages/{id}</code> <code>{&quot;status&quot;: &quot;resolved&quot;}</code> — broadcast over SSE. Expired events vanish from reads immediately; a background sweep reclaims them.</p>
+      <p><code>content</code> is the human-readable line (what renders if a client doesn&#x27;t know the kind); <code>payload</code> carries the structured details; <code>provenance</code> cites where it came from (<code>pr | commit | issue | page | message</code>) so agents can follow the trail back to the source.</p>
+      <p>Then query the room like a database, not a transcript:</p>
+      <pre><code>GET …/messages?kind=source_event&amp;since=&lt;ts&gt;   # the feed: what happened lately
+GET …/messages?kind=action&amp;status=open        # the ledger: what&#x27;s still open
+PATCH …/messages/{id}  {<span class="str">&quot;status&quot;</span>: <span class="str">&quot;resolved&quot;</span>}  # close it out (broadcast over SSE)</code></pre>
+      <p>The kind vocabulary is open — post your own (<code>note</code>, <code>decision</code>, <code>ci_result</code>, …) and it works today: stateless and durable unless you set a TTL. Events arrive on the room&#x27;s SSE stream like any message; clients that don&#x27;t know a kind just show the <code>content</code> line.</p>
     </section>
 
     <hr class="divider">

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -77,6 +77,52 @@
           ↑         ↓
       (join window fires)</code></pre>
       <p>Once <code>complete</code>, the consensus is compiled into the room&#x27;s shared plan (<code>plan/tasks.md</code>) — a <code>- [ ]</code> checklist the team works from. The arc is <code>join → negotiate → plan → work</code>; the room and its plan outlive the session.</p>
+      <h2 id="rooms-typed-events">Typed events</h2>
+      <p>Beyond chat (<code>broadcast</code>/<code>direct</code>/<code>announce</code>/<code>delegate</code>), rooms accept one structured message type — <code>event</code> — discriminated by <code>metadata.kind</code> with an open vocabulary. Retention and statefulness are message *attributes*, not distinct types, so a single primitive covers a live source-activity feed and a persistent action ledger.</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Kind</th>
+              <th>Persistence</th>
+              <th>Stateful?</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>source_event</code></td>
+              <td>capped by <code>ttl_seconds</code></td>
+              <td>no (status must be null)</td>
+            </tr>
+            <tr>
+              <td><code>action</code></td>
+              <td>durable</td>
+              <td>yes — defaults to <code>open</code></td>
+            </tr>
+            <tr>
+              <td><code>concern</code></td>
+              <td>durable</td>
+              <td>yes — defaults to <code>open</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>Unknown kinds are accepted (stateless, durable unless <code>ttl_seconds</code> is set), so new uses need no schema change.</p>
+      <pre><code>POST /api/rooms/{name}/messages
+{
+  &quot;message_type&quot;: &quot;event&quot;,
+  &quot;sender_handle&quot;: &quot;github-poller&quot;,
+  &quot;content&quot;: &quot;New PR: \&quot;fix recordings window\&quot; (#48)&quot;,
+  &quot;metadata&quot;: {
+    &quot;kind&quot;: &quot;source_event&quot;,
+    &quot;ttl_seconds&quot;: 1209600,
+    &quot;payload&quot;: { &quot;source&quot;: &quot;github&quot;, &quot;event&quot;: &quot;pr_opened&quot;, &quot;number&quot;: 48 },
+    &quot;provenance&quot;: [ { &quot;type&quot;: &quot;pr&quot;, &quot;ref&quot;: &quot;org/repo#48&quot;, &quot;url&quot;: &quot;https://github.com/org/repo/pull/48&quot; } ],
+    &quot;correlation_id&quot;: &quot;…&quot;
+  }
+}</code></pre>
+      <p>The metadata contract: <code>kind</code> (required), <code>ttl_seconds</code> (optional — absent means durable, never swept), <code>status</code> (<code>open | in_progress | resolved</code>, stateful kinds only), <code>payload</code> (kind-specific data), <code>provenance</code> (cited refs, each <code>type</code> ∈ <code>pr | commit | issue | page | message</code> + <code>ref</code> + optional <code>url</code>, returned intact), and <code>correlation_id</code> (groups related events).</p>
+      <p>Feed and ledger are server-side filters: <code>GET /api/rooms/{name}/messages?kind=source_event</code>, <code>?kind=action&amp;status=open</code>, <code>?since=&lt;iso-ts&gt;</code>. Expired events disappear from reads immediately and are reclaimed by a background sweep. Status transitions update the original event in place — <code>PATCH /api/rooms/{name}/messages/{id}</code> with <code>{&quot;status&quot;: &quot;resolved&quot;}</code> — so the current status is always one indexed query away, and the transition is broadcast over the room&#x27;s SSE stream. Events are excluded from knowledge ingest (they&#x27;re machine feed, not agent speech).</p>
     </section>
 
     <hr class="divider">

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -78,36 +78,31 @@
       (join window fires)</code></pre>
       <p>Once <code>complete</code>, the consensus is compiled into the room&#x27;s shared plan (<code>plan/tasks.md</code>) — a <code>- [ ]</code> checklist the team works from. The arc is <code>join → negotiate → plan → work</code>; the room and its plan outlive the session.</p>
       <h2 id="rooms-typed-events">Typed events</h2>
-      <p>Beyond chat (<code>broadcast</code>/<code>direct</code>/<code>announce</code>/<code>delegate</code>), rooms accept one structured message type — <code>event</code> — discriminated by <code>metadata.kind</code> with an open vocabulary. Retention and statefulness are message *attributes*, not distinct types, so a single primitive covers a live source-activity feed and a persistent action ledger.</p>
+      <p>Rooms accept one structured message type — <code>event</code> — discriminated by <code>metadata.kind</code>. Retention (<code>ttl_seconds</code>) and status are attributes, not separate types: one primitive covers a live activity feed and a persistent action ledger.</p>
       <div class="table-wrap">
         <table>
           <thead>
             <tr>
               <th>Kind</th>
-              <th>Persistence</th>
-              <th>Stateful?</th>
+              <th>Retention</th>
+              <th>Status</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td><code>source_event</code></td>
-              <td>capped by <code>ttl_seconds</code></td>
-              <td>no (status must be null)</td>
+              <td><code>ttl_seconds</code> cap</td>
+              <td>none</td>
             </tr>
             <tr>
-              <td><code>action</code></td>
+              <td><code>action</code>, <code>concern</code></td>
               <td>durable</td>
-              <td>yes — defaults to <code>open</code></td>
-            </tr>
-            <tr>
-              <td><code>concern</code></td>
-              <td>durable</td>
-              <td>yes — defaults to <code>open</code></td>
+              <td><code>open → in_progress → resolved</code></td>
             </tr>
           </tbody>
         </table>
       </div>
-      <p>Unknown kinds are accepted (stateless, durable unless <code>ttl_seconds</code> is set), so new uses need no schema change.</p>
+      <p>Unknown kinds are accepted (stateless, durable unless a TTL is set).</p>
       <pre><code>POST /api/rooms/{name}/messages
 {
   &quot;message_type&quot;: &quot;event&quot;,
@@ -117,12 +112,15 @@
     &quot;kind&quot;: &quot;source_event&quot;,
     &quot;ttl_seconds&quot;: 1209600,
     &quot;payload&quot;: { &quot;source&quot;: &quot;github&quot;, &quot;event&quot;: &quot;pr_opened&quot;, &quot;number&quot;: 48 },
-    &quot;provenance&quot;: [ { &quot;type&quot;: &quot;pr&quot;, &quot;ref&quot;: &quot;org/repo#48&quot;, &quot;url&quot;: &quot;https://github.com/org/repo/pull/48&quot; } ],
-    &quot;correlation_id&quot;: &quot;…&quot;
+    &quot;provenance&quot;: [ { &quot;type&quot;: &quot;pr&quot;, &quot;ref&quot;: &quot;org/repo#48&quot; } ]
   }
 }</code></pre>
-      <p>The metadata contract: <code>kind</code> (required), <code>ttl_seconds</code> (optional — absent means durable, never swept), <code>status</code> (<code>open | in_progress | resolved</code>, stateful kinds only), <code>payload</code> (kind-specific data), <code>provenance</code> (cited refs, each <code>type</code> ∈ <code>pr | commit | issue | page | message</code> + <code>ref</code> + optional <code>url</code>, returned intact), and <code>correlation_id</code> (groups related events).</p>
-      <p>Feed and ledger are server-side filters: <code>GET /api/rooms/{name}/messages?kind=source_event</code>, <code>?kind=action&amp;status=open</code>, <code>?since=&lt;iso-ts&gt;</code>. Expired events disappear from reads immediately and are reclaimed by a background sweep. Status transitions update the original event in place — <code>PATCH /api/rooms/{name}/messages/{id}</code> with <code>{&quot;status&quot;: &quot;resolved&quot;}</code> — so the current status is always one indexed query away, and the transition is broadcast over the room&#x27;s SSE stream. Events are excluded from knowledge ingest (they&#x27;re machine feed, not agent speech).</p>
+      <ul>
+        <li><code>payload</code> — kind-specific data, returned intact</li>
+        <li><code>provenance</code> — cited refs (<code>pr | commit | issue | page | message</code>), each <code>ref</code> + optional <code>url</code></li>
+        <li><code>correlation_id</code> — groups related events</li>
+      </ul>
+      <p>Feed and ledger are server-side filters: <code>GET …/messages?kind=source_event</code>, <code>?kind=action&amp;status=open</code>, <code>?since=&lt;iso-ts&gt;</code>. Transition status with <code>PATCH …/messages/{id}</code> <code>{&quot;status&quot;: &quot;resolved&quot;}</code> — broadcast over SSE. Expired events vanish from reads immediately; a background sweep reclaims them.</p>
     </section>
 
     <hr class="divider">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -249,6 +249,38 @@ Once `complete`, the consensus is compiled into the room's shared plan
 (`plan/tasks.md`) — a `- [ ]` checklist the team works from. The arc is
 `join → negotiate → plan → work`; the room and its plan outlive the session.
 
+## Typed events
+
+Beyond chat (`broadcast`/`direct`/`announce`/`delegate`), rooms accept one structured message type — `event` — discriminated by `metadata.kind` with an open vocabulary. Retention and statefulness are message *attributes*, not distinct types, so a single primitive covers a live source-activity feed and a persistent action ledger.
+
+| Kind | Persistence | Stateful? |
+|---|---|---|
+| `source_event` | capped by `ttl_seconds` | no (status must be null) |
+| `action` | durable | yes — defaults to `open` |
+| `concern` | durable | yes — defaults to `open` |
+
+Unknown kinds are accepted (stateless, durable unless `ttl_seconds` is set), so new uses need no schema change.
+
+```json
+POST /api/rooms/{name}/messages
+{
+  "message_type": "event",
+  "sender_handle": "github-poller",
+  "content": "New PR: \"fix recordings window\" (#48)",
+  "metadata": {
+    "kind": "source_event",
+    "ttl_seconds": 1209600,
+    "payload": { "source": "github", "event": "pr_opened", "number": 48 },
+    "provenance": [ { "type": "pr", "ref": "org/repo#48", "url": "https://github.com/org/repo/pull/48" } ],
+    "correlation_id": "…"
+  }
+}
+```
+
+The metadata contract: `kind` (required), `ttl_seconds` (optional — absent means durable, never swept), `status` (`open | in_progress | resolved`, stateful kinds only), `payload` (kind-specific data), `provenance` (cited refs, each `type` ∈ `pr | commit | issue | page | message` + `ref` + optional `url`, returned intact), and `correlation_id` (groups related events).
+
+Feed and ledger are server-side filters: `GET /api/rooms/{name}/messages?kind=source_event`, `?kind=action&status=open`, `?since=<iso-ts>`. Expired events disappear from reads immediately and are reclaimed by a background sweep. Status transitions update the original event in place — `PATCH /api/rooms/{name}/messages/{id}` with `{"status": "resolved"}` — so the current status is always one indexed query away, and the transition is broadcast over the room's SSE stream. Events are excluded from knowledge ingest (they're machine feed, not agent speech).
+
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -251,14 +251,15 @@ Once `complete`, the consensus is compiled into the room's shared plan
 
 ## Typed events
 
-Rooms accept one structured message type — `event` — discriminated by `metadata.kind`. Retention (`ttl_seconds`) and status are attributes, not separate types: one primitive covers a live activity feed and a persistent action ledger.
+Chat messages disappear into scrollback. Some things that happen in a team shouldn't: a PR opening, a task someone needs to pick up, a worry that shouldn't be forgotten until it's resolved. **Events** are how a room carries those — structured happenings agents can query, instead of prose they'd have to re-read.
 
-| Kind | Retention | Status |
-|---|---|---|
-| `source_event` | `ttl_seconds` cap | none |
-| `action`, `concern` | durable | `open → in_progress → resolved` |
+Three kinds, matching three ways teams use them:
 
-Unknown kinds are accepted (stateless, durable unless a TTL is set).
+- **`source_event`** — *the world changed.* Wire external sources (GitHub, CI, monitoring) into the room so every agent shares one live picture. Transient: give it a `ttl_seconds` and it expires like a feed item should.
+- **`action`** — *someone should do this.* Durable, with a lifecycle (`open → in_progress → resolved`). The room's open actions are its working ledger — any agent can ask "what's still open?" and get an answer, no scrollback archaeology.
+- **`concern`** — *this is worrying.* Like an action, but for risks rather than work. Stays open until someone explicitly resolves it.
+
+Post one like any message, with a `metadata.kind`:
 
 ```json
 POST /api/rooms/{name}/messages
@@ -275,11 +276,17 @@ POST /api/rooms/{name}/messages
 }
 ```
 
-- `payload` — kind-specific data, returned intact
-- `provenance` — cited refs (`pr | commit | issue | page | message`), each `ref` + optional `url`
-- `correlation_id` — groups related events
+`content` is the human-readable line (what renders if a client doesn't know the kind); `payload` carries the structured details; `provenance` cites where it came from (`pr | commit | issue | page | message`) so agents can follow the trail back to the source.
 
-Feed and ledger are server-side filters: `GET …/messages?kind=source_event`, `?kind=action&status=open`, `?since=<iso-ts>`. Transition status with `PATCH …/messages/{id}` `{"status": "resolved"}` — broadcast over SSE. Expired events vanish from reads immediately; a background sweep reclaims them.
+Then query the room like a database, not a transcript:
+
+```
+GET …/messages?kind=source_event&since=<ts>   # the feed: what happened lately
+GET …/messages?kind=action&status=open        # the ledger: what's still open
+PATCH …/messages/{id}  {"status": "resolved"}  # close it out (broadcast over SSE)
+```
+
+The kind vocabulary is open — post your own (`note`, `decision`, `ci_result`, …) and it works today: stateless and durable unless you set a TTL. Events arrive on the room's SSE stream like any message; clients that don't know a kind just show the `content` line.
 
 
 ---

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -251,15 +251,14 @@ Once `complete`, the consensus is compiled into the room's shared plan
 
 ## Typed events
 
-Beyond chat (`broadcast`/`direct`/`announce`/`delegate`), rooms accept one structured message type — `event` — discriminated by `metadata.kind` with an open vocabulary. Retention and statefulness are message *attributes*, not distinct types, so a single primitive covers a live source-activity feed and a persistent action ledger.
+Rooms accept one structured message type — `event` — discriminated by `metadata.kind`. Retention (`ttl_seconds`) and status are attributes, not separate types: one primitive covers a live activity feed and a persistent action ledger.
 
-| Kind | Persistence | Stateful? |
+| Kind | Retention | Status |
 |---|---|---|
-| `source_event` | capped by `ttl_seconds` | no (status must be null) |
-| `action` | durable | yes — defaults to `open` |
-| `concern` | durable | yes — defaults to `open` |
+| `source_event` | `ttl_seconds` cap | none |
+| `action`, `concern` | durable | `open → in_progress → resolved` |
 
-Unknown kinds are accepted (stateless, durable unless `ttl_seconds` is set), so new uses need no schema change.
+Unknown kinds are accepted (stateless, durable unless a TTL is set).
 
 ```json
 POST /api/rooms/{name}/messages
@@ -271,15 +270,16 @@ POST /api/rooms/{name}/messages
     "kind": "source_event",
     "ttl_seconds": 1209600,
     "payload": { "source": "github", "event": "pr_opened", "number": 48 },
-    "provenance": [ { "type": "pr", "ref": "org/repo#48", "url": "https://github.com/org/repo/pull/48" } ],
-    "correlation_id": "…"
+    "provenance": [ { "type": "pr", "ref": "org/repo#48" } ]
   }
 }
 ```
 
-The metadata contract: `kind` (required), `ttl_seconds` (optional — absent means durable, never swept), `status` (`open | in_progress | resolved`, stateful kinds only), `payload` (kind-specific data), `provenance` (cited refs, each `type` ∈ `pr | commit | issue | page | message` + `ref` + optional `url`, returned intact), and `correlation_id` (groups related events).
+- `payload` — kind-specific data, returned intact
+- `provenance` — cited refs (`pr | commit | issue | page | message`), each `ref` + optional `url`
+- `correlation_id` — groups related events
 
-Feed and ledger are server-side filters: `GET /api/rooms/{name}/messages?kind=source_event`, `?kind=action&status=open`, `?since=<iso-ts>`. Expired events disappear from reads immediately and are reclaimed by a background sweep. Status transitions update the original event in place — `PATCH /api/rooms/{name}/messages/{id}` with `{"status": "resolved"}` — so the current status is always one indexed query away, and the transition is broadcast over the room's SSE stream. Events are excluded from knowledge ingest (they're machine feed, not agent speech).
+Feed and ledger are server-side filters: `GET …/messages?kind=source_event`, `?kind=action&status=open`, `?since=<iso-ts>`. Transition status with `PATCH …/messages/{id}` `{"status": "resolved"}` — broadcast over SSE. Expired events vanish from reads immediately; a background sweep reclaims them.
 
 
 ---

--- a/fastapi-backend/alembic_migrations/versions/0018_event_message_primitive.py
+++ b/fastapi-backend/alembic_migrations/versions/0018_event_message_primitive.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Add the typed ``event`` message primitive (#392).
+
+Four new nullable columns on ``messages``:
+
+- ``metadata``          — full structured event metadata (kind, ttl_seconds,
+                          status, payload, provenance, correlation_id),
+                          returned intact to clients.
+- ``event_kind``        — promoted from metadata.kind at write time.
+- ``event_status``      — promoted from metadata.status; backs the ledger.
+- ``event_expires_at``  — created_at + ttl_seconds, precomputed for the TTL
+                          sweep. NULL = durable.
+
+Plus the two composite indexes that keep feed (?kind=) and ledger (?status=)
+queries cheap. All columns are NULL for non-event message types, so existing
+rows and writers are unaffected.
+
+Revision ID: 0018
+Revises: 0017
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("messages") as batch:
+        batch.add_column(
+            sa.Column(
+                "metadata",
+                JSONB().with_variant(sa.JSON(), "sqlite"),
+                nullable=True,
+            )
+        )
+        batch.add_column(sa.Column("event_kind", sa.String(), nullable=True))
+        batch.add_column(sa.Column("event_status", sa.String(), nullable=True))
+        batch.add_column(sa.Column("event_expires_at", sa.DateTime(timezone=True), nullable=True))
+    op.create_index("ix_messages_event_expires_at", "messages", ["event_expires_at"])
+    op.create_index(
+        "ix_messages_room_kind_created",
+        "messages",
+        ["room_name", "event_kind", "created_at"],
+    )
+    op.create_index(
+        "ix_messages_room_kind_status",
+        "messages",
+        ["room_name", "event_kind", "event_status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_messages_room_kind_status", table_name="messages")
+    op.drop_index("ix_messages_room_kind_created", table_name="messages")
+    op.drop_index("ix_messages_event_expires_at", table_name="messages")
+    with op.batch_alter_table("messages") as batch:
+        batch.drop_column("event_expires_at")
+        batch.drop_column("event_status")
+        batch.drop_column("event_kind")
+        batch.drop_column("metadata")

--- a/fastapi-backend/alembic_migrations/versions/0018_event_message_primitive.py
+++ b/fastapi-backend/alembic_migrations/versions/0018_event_message_primitive.py
@@ -43,17 +43,22 @@ def upgrade() -> None:
         batch.add_column(sa.Column("event_kind", sa.String(), nullable=True))
         batch.add_column(sa.Column("event_status", sa.String(), nullable=True))
         batch.add_column(sa.Column("event_expires_at", sa.DateTime(timezone=True), nullable=True))
-    op.create_index("ix_messages_event_expires_at", "messages", ["event_expires_at"])
-    op.create_index(
-        "ix_messages_room_kind_created",
-        "messages",
-        ["room_name", "event_kind", "created_at"],
-    )
-    op.create_index(
-        "ix_messages_room_kind_status",
-        "messages",
-        ["room_name", "event_kind", "event_status"],
-    )
+    # Plain CREATE INDEX takes an ACCESS EXCLUSIVE lock on messages for the
+    # build — on a busy deployment that blocks every room's writes. Build
+    # concurrently on postgres (needs autocommit); sqlite has no such lock
+    # semantics (or CONCURRENTLY support), so it takes the plain path.
+    indexes = [
+        ("ix_messages_event_expires_at", ["event_expires_at"]),
+        ("ix_messages_room_kind_created", ["room_name", "event_kind", "created_at"]),
+        ("ix_messages_room_kind_status", ["room_name", "event_kind", "event_status"]),
+    ]
+    if op.get_bind().dialect.name == "postgresql":
+        with op.get_context().autocommit_block():
+            for name, cols in indexes:
+                op.create_index(name, "messages", cols, postgresql_concurrently=True)
+    else:
+        for name, cols in indexes:
+            op.create_index(name, "messages", cols)
 
 
 def downgrade() -> None:

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -139,6 +139,11 @@ async def lifespan(app: FastAPI):
     await startup_scan()
     start_watcher()
 
+    # TTL sweep for transient event messages (#392)
+    from app.services.event_sweep import start_event_sweep, stop_event_sweep
+
+    start_event_sweep()
+
     # Pre-load embedding model so first request isn't slow
     from app.services.embedding import warmup as warmup_embeddings
 
@@ -149,6 +154,7 @@ async def lifespan(app: FastAPI):
 
     yield
     stop_watcher()
+    stop_event_sweep()
     logger.info("Mycelium backend shutting down")
 
 

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -155,6 +155,9 @@ async def lifespan(app: FastAPI):
     yield
     stop_watcher()
     stop_event_sweep()
+    from app.routes.messages import close_notify_connection
+
+    await close_notify_connection()
     logger.info("Mycelium backend shutting down")
 
 

--- a/fastapi-backend/app/models.py
+++ b/fastapi-backend/app/models.py
@@ -172,12 +172,38 @@ class Message(Base):
     sender_handle: Mapped[str] = mapped_column(String, nullable=False, index=True)
     recipient_handle: Mapped[str | None] = mapped_column(String, index=True)  # NULL = broadcast
 
-    # Type: announce, direct, broadcast, delegate
+    # Type: announce, direct, broadcast, delegate, event
     message_type: Mapped[str] = mapped_column(String, nullable=False, index=True)
     content: Mapped[str] = mapped_column(Text, nullable=False)
 
+    # ── event primitive (#392) ────────────────────────────────────────────
+    # Full structured metadata for message_type="event", returned intact:
+    # {kind, ttl_seconds?, status?, payload, provenance[], correlation_id?}.
+    # Attribute named event_metadata because Base.metadata is reserved by
+    # SQLAlchemy; the column itself is "metadata" per the API contract.
+    event_metadata: Mapped[dict | None] = mapped_column(
+        "metadata", JSONB().with_variant(JSON(), "sqlite"), nullable=True
+    )
+    # kind/status/expiry are promoted from metadata at write time so the
+    # feed (?kind=) and ledger (?status=) filters and the TTL sweep hit
+    # plain indexed columns instead of JSON path expressions (which differ
+    # between the AgensGraph and SQLite test backends).
+    event_kind: Mapped[str | None] = mapped_column(String, nullable=True)
+    event_status: Mapped[str | None] = mapped_column(String, nullable=True)
+    # created_at + ttl_seconds, precomputed. NULL = durable (never swept).
+    event_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+
+    __table_args__ = (
+        # Feed: newest events of a kind in a room.
+        Index("ix_messages_room_kind_created", "room_name", "event_kind", "created_at"),
+        # Ledger: open actions/concerns in a room.
+        Index("ix_messages_room_kind_status", "room_name", "event_kind", "event_status"),
     )
 
 

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -17,7 +17,7 @@ from uuid import UUID
 
 import asyncpg
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.bus import notify, room_channel
@@ -36,6 +36,56 @@ from app.schemas import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/rooms/{room_name}/messages", tags=["messages"])
+
+# Long-lived NOTIFY connection, lazily opened and reused across requests.
+# Human chat was low-volume enough to tolerate a connect-per-message, but
+# source_event pollers emit bursts — connection churn on every message is a
+# hot path. One retry with a fresh connection covers server-side drops.
+_notify_conn: asyncpg.Connection | None = None
+_notify_lock = asyncio.Lock()
+
+
+async def _notify_room(channel: str, payload: dict) -> None:
+    """Fire a Postgres NOTIFY on ``channel``. Never raises — SSE delivery is
+    best-effort and must not fail the write that triggered it."""
+    global _notify_conn
+    from urllib.parse import urlparse
+
+    async with _notify_lock:
+        for attempt in (1, 2):
+            try:
+                if _notify_conn is None or _notify_conn.is_closed():
+                    parsed = urlparse(settings.DATABASE_URL)
+                    _notify_conn = await asyncpg.connect(
+                        host=parsed.hostname,
+                        port=parsed.port or 5432,
+                        user=parsed.username,
+                        password=parsed.password,
+                        database=parsed.path.lstrip("/"),
+                    )
+                await notify(_notify_conn, channel, payload)
+                return
+            except Exception as e:
+                if _notify_conn is not None:
+                    try:
+                        await _notify_conn.close()
+                    except Exception:
+                        pass
+                    _notify_conn = None
+                if attempt == 2:
+                    logger.warning("NOTIFY failed for %s: %s", channel, e)
+
+
+async def close_notify_connection() -> None:
+    """Close the shared NOTIFY connection. Called from app lifespan shutdown."""
+    global _notify_conn
+    async with _notify_lock:
+        if _notify_conn is not None:
+            try:
+                await _notify_conn.close()
+            except Exception:
+                pass
+            _notify_conn = None
 
 
 async def _resolve_target(
@@ -124,23 +174,7 @@ async def send_message(
         notify_payload["room_name"] = coord.display_name  # legacy compat
     else:
         raise HTTPException(status_code=500, detail="resolver returned (None, None)")
-    try:
-        from urllib.parse import urlparse
-
-        parsed = urlparse(settings.DATABASE_URL)
-        conn: asyncpg.Connection = await asyncpg.connect(
-            host=parsed.hostname,
-            port=parsed.port or 5432,
-            user=parsed.username,
-            password=parsed.password,
-            database=parsed.path.lstrip("/"),
-        )
-        try:
-            await notify(conn, notify_channel, notify_payload)
-        finally:
-            await conn.close()
-    except Exception as e:
-        logger.warning("NOTIFY failed for %s: %s", notify_channel, e)
+    await _notify_room(notify_channel, notify_payload)
 
     # Events are machine feed, not negotiation replies — never let one be
     # parsed as an agent's round response.
@@ -221,13 +255,18 @@ async def list_messages(
         (Message.event_expires_at.is_(None)) | (Message.event_expires_at > datetime.now(UTC))
     )
 
+    # Real total across the same filters (page length is not a total —
+    # reverse infinite-scroll clients paginate against this).
+    count_query = select(func.count()).select_from(query.subquery())
+    total = (await session.execute(count_query)).scalar_one()
+
     query = query.order_by(Message.created_at.desc()).offset(offset).limit(limit)
     result = await session.execute(query)
     messages: list[Message] = list(result.scalars().all())
 
     return MessageListResponse(
         messages=[MessageRead.model_validate(m) for m in messages],
-        total=len(messages),
+        total=total,
     )
 
 
@@ -285,22 +324,6 @@ async def update_event_status(
     }
     channel_name = room.name if room is not None else coord.display_name  # type: ignore[union-attr]
     notify_payload["room_name"] = channel_name
-    try:
-        from urllib.parse import urlparse
-
-        parsed = urlparse(settings.DATABASE_URL)
-        conn: asyncpg.Connection = await asyncpg.connect(
-            host=parsed.hostname,
-            port=parsed.port or 5432,
-            user=parsed.username,
-            password=parsed.password,
-            database=parsed.path.lstrip("/"),
-        )
-        try:
-            await notify(conn, room_channel(channel_name), notify_payload)
-        finally:
-            await conn.close()
-    except Exception as e:
-        logger.warning("NOTIFY failed for %s: %s", channel_name, e)
+    await _notify_room(room_channel(channel_name), notify_payload)
 
     return msg

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -12,6 +12,8 @@ Also hooks into the coordination service when the room is in 'negotiating' state
 
 import asyncio
 import logging
+from datetime import UTC, datetime, timedelta
+from uuid import UUID
 
 import asyncpg
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -22,7 +24,14 @@ from app.bus import notify, room_channel
 from app.config import settings
 from app.database import get_async_session
 from app.models import CoordinationSession, Message, Room
-from app.schemas import MessageCreate, MessageListResponse, MessageRead
+from app.schemas import (
+    STATEFUL_EVENT_KINDS,
+    EventStatusUpdate,
+    MessageCreate,
+    MessageListResponse,
+    MessageRead,
+    MessageType,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +89,17 @@ async def send_message(
         message_type=payload.message_type,
         content=payload.content,
     )
+    if payload.metadata is not None:
+        # Promote kind/status to indexed columns and precompute expiry so the
+        # feed/ledger filters and the TTL sweep never touch JSON paths.
+        meta = payload.metadata.model_dump(exclude_none=True)
+        msg.event_metadata = meta
+        msg.event_kind = payload.metadata.kind
+        msg.event_status = payload.metadata.status
+        if payload.metadata.ttl_seconds:
+            msg.event_expires_at = datetime.now(UTC) + timedelta(
+                seconds=payload.metadata.ttl_seconds
+            )
     session.add(msg)
     await session.commit()
     await session.refresh(msg)
@@ -93,6 +113,8 @@ async def send_message(
         "content": msg.content,
         "created_at": msg.created_at.isoformat(),
     }
+    if msg.event_metadata is not None:
+        notify_payload["metadata"] = msg.event_metadata
     if room is not None:
         notify_channel = room_channel(room.name)
         notify_payload["room_name"] = room.name
@@ -130,7 +152,11 @@ async def send_message(
     # Fan in to KXP. Skip system-emitted coordination chatter (those are
     # CognitiveEngine-authored; ingesting them would loop the KG on its own
     # mediator output). Only deliberate agent speech reaches CFN.
-    if not msg.message_type.startswith("coordination_") and msg.sender_handle != "CognitiveEngine":
+    if (
+        not msg.message_type.startswith("coordination_")
+        and msg.message_type != MessageType.EVENT
+        and msg.sender_handle != "CognitiveEngine"
+    ):
         from app.services.knowledge_fanin import fan_in
 
         target_room = room.name if room is not None else (coord.display_name if coord else None)
@@ -155,8 +181,17 @@ async def list_messages(
     offset: int = 0,
     sender: str | None = None,
     message_type: str | None = None,
+    kind: str | None = Query(None, description="Filter events by metadata.kind"),
+    status: str | None = Query(None, description="Filter events by ledger status"),
+    since: datetime | None = Query(None, description="Only messages created at/after this time"),
 ):
-    """List messages in a room (or coordination session), newest first."""
+    """List messages in a room (or coordination session), newest first.
+
+    ``kind``/``status``/``since`` make the source-activity feed and the
+    action/concern ledger server-side filters over the room (#392). Expired
+    events (past their ``ttl_seconds``) are excluded even if the sweep
+    hasn't collected them yet.
+    """
     room, coord = await _resolve_target(room_name, session)
 
     if room is not None:
@@ -173,6 +208,16 @@ async def list_messages(
         query = query.where(Message.sender_handle == sender)
     if message_type:
         query = query.where(Message.message_type == message_type)
+    if kind:
+        query = query.where(Message.event_kind == kind)
+    if status:
+        query = query.where(Message.event_status == status)
+    if since:
+        query = query.where(Message.created_at >= since)
+    # Hide expired-but-unswept events.
+    query = query.where(
+        (Message.event_expires_at.is_(None)) | (Message.event_expires_at > datetime.now(UTC))
+    )
 
     query = query.order_by(Message.created_at.desc()).offset(offset).limit(limit)
     result = await session.execute(query)
@@ -182,3 +227,78 @@ async def list_messages(
         messages=[MessageRead.model_validate(m) for m in messages],
         total=len(messages),
     )
+
+
+@router.patch("/{message_id}", response_model=MessageRead)
+async def update_event_status(
+    room_name: str,
+    message_id: UUID,
+    payload: EventStatusUpdate,
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Transition a stateful event's status (open -> in_progress -> resolved).
+
+    Design choice (#392 left it open): the status lives on the original event
+    row and is updated in place, rather than appending follow-up events —
+    the current status must be cheaply queryable, and a follow-up-event model
+    forces a latest-per-correlation aggregation on every ledger query. The
+    transition is broadcast over SSE so subscribers see the change live.
+    """
+    room, coord = await _resolve_target(room_name, session)
+
+    result = await session.execute(select(Message).where(Message.id == message_id))
+    msg = result.scalar_one_or_none()
+    in_target = msg is not None and (
+        (room is not None and msg.room_name == room.name)
+        or (coord is not None and msg.coordination_session_id == coord.id)
+    )
+    if msg is None or not in_target:
+        raise HTTPException(status_code=404, detail="Message not found in this room")
+    if msg.message_type != MessageType.EVENT or not msg.event_kind:
+        raise HTTPException(status_code=409, detail="Not an event message")
+    if msg.event_kind not in STATEFUL_EVENT_KINDS and msg.event_status is None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Event kind {msg.event_kind!r} is stateless — no status to transition",
+        )
+
+    msg.event_status = payload.status
+    # Keep the returned metadata consistent with the promoted column.
+    meta = dict(msg.event_metadata or {})
+    meta["status"] = payload.status
+    meta["status_updated_at"] = datetime.now(UTC).isoformat()
+    msg.event_metadata = meta
+    await session.commit()
+    await session.refresh(msg)
+
+    notify_payload = {
+        "id": str(msg.id),
+        "sender_handle": msg.sender_handle,
+        "recipient_handle": msg.recipient_handle,
+        "message_type": msg.message_type,
+        "content": msg.content,
+        "metadata": msg.event_metadata,
+        "created_at": msg.created_at.isoformat(),
+        "status_transition": payload.status,
+    }
+    channel_name = room.name if room is not None else coord.display_name  # type: ignore[union-attr]
+    notify_payload["room_name"] = channel_name
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(settings.DATABASE_URL)
+        conn: asyncpg.Connection = await asyncpg.connect(
+            host=parsed.hostname,
+            port=parsed.port or 5432,
+            user=parsed.username,
+            password=parsed.password,
+            database=parsed.path.lstrip("/"),
+        )
+        try:
+            await notify(conn, room_channel(channel_name), notify_payload)
+        finally:
+            await conn.close()
+    except Exception as e:
+        logger.warning("NOTIFY failed for %s: %s", channel_name, e)
+
+    return msg

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -142,7 +142,9 @@ async def send_message(
     except Exception as e:
         logger.warning("NOTIFY failed for %s: %s", notify_channel, e)
 
-    if coord and coord.state == "negotiating":
+    # Events are machine feed, not negotiation replies — never let one be
+    # parsed as an agent's round response.
+    if coord and coord.state == "negotiating" and msg.message_type != MessageType.EVENT:
         from app.services import coordination
 
         asyncio.ensure_future(

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -6,9 +6,10 @@ Minimal schemas for Mycelium's core models.
 """
 
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # ── Room ──────────────────────────────────────────────────────────────────────
 
@@ -42,11 +43,70 @@ class MessageType:
     DIRECT = "direct"
     BROADCAST = "broadcast"
     DELEGATE = "delegate"
+    # Typed structured event (#392): source_event / action / concern / ...
+    EVENT = "event"
     # Coordination system messages (posted directly by coordination service, not via HTTP API)
     COORDINATION_JOIN = "coordination_join"
     COORDINATION_START = "coordination_start"
     COORDINATION_TICK = "coordination_tick"
     COORDINATION_CONSENSUS = "coordination_consensus"
+
+
+# ── event primitive (#392) ────────────────────────────────────────────────────
+
+# Kinds with documented semantics. The vocabulary is deliberately open —
+# unknown kinds are accepted (stateless, durable unless a TTL is given) so new
+# uses don't need a schema change; these names just get defaults applied.
+EVENT_KIND_SOURCE_EVENT = "source_event"
+STATEFUL_EVENT_KINDS = frozenset({"action", "concern"})
+
+EventStatus = Literal["open", "in_progress", "resolved"]
+
+
+class EventProvenanceRef(BaseModel):
+    """A cited reference backing an event."""
+
+    type: Literal["pr", "commit", "issue", "page", "message"]
+    ref: str = Field(..., min_length=1, description="e.g. 'org/repo#48' or a message id")
+    url: str | None = None
+
+
+class EventMetadata(BaseModel):
+    """Structured metadata for ``message_type="event"``.
+
+    Retention (``ttl_seconds``) and statefulness (``status``) are independent
+    attributes, not distinct message types — one primitive covers a transient
+    source-activity feed and a durable status-bearing ledger.
+    """
+
+    kind: str = Field(..., min_length=1, description="Event kind (open vocabulary)")
+    ttl_seconds: int | None = Field(
+        None, gt=0, description="Retention cap for transient kinds; absent = durable"
+    )
+    status: EventStatus | None = Field(
+        None, description="Ledger status for stateful kinds; null for stateless"
+    )
+    payload: dict = Field(default_factory=dict, description="Kind-specific structured data")
+    provenance: list[EventProvenanceRef] = Field(default_factory=list)
+    correlation_id: str | None = Field(
+        None, description="Groups related events / links updates to their origin"
+    )
+
+    @model_validator(mode="after")
+    def _apply_kind_defaults(self) -> "EventMetadata":
+        # Stateful kinds open by default; the ledger needs a queryable status.
+        if self.kind in STATEFUL_EVENT_KINDS and self.status is None:
+            self.status = "open"
+        # source_event is stateless by definition.
+        if self.kind == EVENT_KIND_SOURCE_EVENT and self.status is not None:
+            raise ValueError("source_event is stateless — status must be null")
+        return self
+
+
+class EventStatusUpdate(BaseModel):
+    """Body for PATCH /rooms/{name}/messages/{id} — transition an event's status."""
+
+    status: EventStatus
 
 
 class MessageCreate(BaseModel):
@@ -56,10 +116,21 @@ class MessageCreate(BaseModel):
     )
     message_type: str = Field(
         ...,
-        description="Type: announce, direct, broadcast, or delegate",
-        pattern="^(announce|direct|broadcast|delegate)$",
+        description="Type: announce, direct, broadcast, delegate, or event",
+        pattern="^(announce|direct|broadcast|delegate|event)$",
     )
     content: str = Field(..., min_length=1)
+    metadata: EventMetadata | None = Field(
+        None, description='Structured event metadata; required when message_type="event"'
+    )
+
+    @model_validator(mode="after")
+    def _metadata_matches_type(self) -> "MessageCreate":
+        if self.message_type == MessageType.EVENT and self.metadata is None:
+            raise ValueError('message_type "event" requires metadata with a kind')
+        if self.message_type != MessageType.EVENT and self.metadata is not None:
+            raise ValueError('metadata is only valid on message_type "event"')
+        return self
 
 
 class MessageRead(BaseModel):
@@ -71,9 +142,10 @@ class MessageRead(BaseModel):
     recipient_handle: str | None = None
     message_type: str
     content: str
+    metadata: dict | None = Field(None, validation_alias="event_metadata")
     created_at: datetime
 
-    model_config = {"from_attributes": True}
+    model_config = {"from_attributes": True, "populate_by_name": True}
 
 
 class MessageListResponse(BaseModel):

--- a/fastapi-backend/app/services/event_sweep.py
+++ b/fastapi-backend/app/services/event_sweep.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""TTL sweep for transient event messages (#392).
+
+Events carrying ``metadata.ttl_seconds`` get an ``event_expires_at`` stamp at
+write time; this background loop deletes rows past that stamp. Durable kinds
+(no TTL) have ``event_expires_at = NULL`` and are never touched. The GET
+endpoint independently filters expired rows, so sweep latency is invisible to
+readers — this loop just reclaims storage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+from sqlalchemy import delete
+
+from app.database import async_session_maker
+from app.models import Message
+
+logger = logging.getLogger(__name__)
+
+SWEEP_INTERVAL_SECONDS = 300
+
+_sweep_task: asyncio.Task | None = None
+
+
+async def sweep_expired_events() -> int:
+    """Delete expired event rows. Returns the number of rows removed."""
+    async with async_session_maker() as session:
+        result = await session.execute(
+            delete(Message).where(
+                Message.event_expires_at.is_not(None),
+                Message.event_expires_at < datetime.now(UTC),
+            )
+        )
+        await session.commit()
+        removed = getattr(result, "rowcount", 0) or 0
+    if removed:
+        logger.info("event sweep removed %d expired event(s)", removed)
+    return removed
+
+
+async def _sweep_loop() -> None:
+    while True:
+        try:
+            await sweep_expired_events()
+        except Exception:  # keep the loop alive across transient DB errors
+            logger.exception("event sweep iteration failed")
+        await asyncio.sleep(SWEEP_INTERVAL_SECONDS)
+
+
+def start_event_sweep() -> None:
+    global _sweep_task
+    if _sweep_task is None or _sweep_task.done():
+        _sweep_task = asyncio.get_running_loop().create_task(_sweep_loop())
+
+
+def stop_event_sweep() -> None:
+    global _sweep_task
+    if _sweep_task is not None and not _sweep_task.done():
+        _sweep_task.cancel()
+    _sweep_task = None

--- a/fastapi-backend/tests/test_events.py
+++ b/fastapi-backend/tests/test_events.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Tests for the typed ``event`` message primitive (#392)."""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+
+from app.models import Message, Room
+from app.services.event_sweep import sweep_expired_events
+
+
+@pytest_asyncio.fixture()
+async def room(db_session):
+    r = Room(name="platform-eng")
+    db_session.add(r)
+    await db_session.commit()
+    return r
+
+
+def _event_body(**meta_overrides):
+    metadata = {
+        "kind": "source_event",
+        "payload": {"source": "github", "event": "pr_opened", "number": 48},
+        "provenance": [
+            {"type": "pr", "ref": "org/repo#48", "url": "https://github.com/org/repo/pull/48"}
+        ],
+        **meta_overrides,
+    }
+    return {
+        "sender_handle": "github-poller",
+        "message_type": "event",
+        "content": 'New PR: "fix recordings window" (#48)',
+        "metadata": metadata,
+    }
+
+
+# ── POST ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_event_stores_and_returns_metadata(client, room):
+    resp = await client.post("/api/rooms/platform-eng/messages", json=_event_body())
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["message_type"] == "event"
+    assert body["metadata"]["kind"] == "source_event"
+    assert body["metadata"]["provenance"][0]["ref"] == "org/repo#48"
+    assert body["metadata"]["payload"]["number"] == 48
+
+
+@pytest.mark.asyncio
+async def test_post_event_requires_metadata(client, room):
+    body = _event_body()
+    del body["metadata"]
+    resp = await client.post("/api/rooms/platform-eng/messages", json=body)
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_post_non_event_rejects_metadata(client, room):
+    body = _event_body()
+    body["message_type"] = "broadcast"
+    resp = await client.post("/api/rooms/platform-eng/messages", json=body)
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_source_event_rejects_status(client, room):
+    resp = await client.post("/api/rooms/platform-eng/messages", json=_event_body(status="open"))
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_action_defaults_to_open(client, room):
+    resp = await client.post(
+        "/api/rooms/platform-eng/messages",
+        json=_event_body(kind="action", payload={"task": "rotate creds"}),
+    )
+    assert resp.status_code == 201
+    assert resp.json()["metadata"]["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_ttl_sets_expiry_column(client, room, db_session):
+    resp = await client.post("/api/rooms/platform-eng/messages", json=_event_body(ttl_seconds=3600))
+    assert resp.status_code == 201
+    msg = (await db_session.execute(select(Message))).scalars().one()
+    assert msg.event_expires_at is not None
+    assert msg.event_kind == "source_event"
+
+
+@pytest.mark.asyncio
+async def test_durable_event_has_no_expiry(client, room, db_session):
+    resp = await client.post("/api/rooms/platform-eng/messages", json=_event_body(kind="concern"))
+    assert resp.status_code == 201
+    msg = (await db_session.execute(select(Message))).scalars().one()
+    assert msg.event_expires_at is None
+    assert msg.event_status == "open"
+
+
+@pytest.mark.asyncio
+async def test_legacy_message_types_unchanged(client, room, db_session):
+    resp = await client.post(
+        "/api/rooms/platform-eng/messages",
+        json={"sender_handle": "a1", "message_type": "broadcast", "content": "hello"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["metadata"] is None
+    msg = (await db_session.execute(select(Message))).scalars().one()
+    assert msg.event_kind is None and msg.event_status is None
+
+
+# ── GET filters ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_kind_and_status_filters(client, room):
+    await client.post("/api/rooms/platform-eng/messages", json=_event_body())
+    await client.post(
+        "/api/rooms/platform-eng/messages", json=_event_body(kind="action", payload={})
+    )
+    await client.post(
+        "/api/rooms/platform-eng/messages",
+        json={"sender_handle": "a1", "message_type": "broadcast", "content": "chat"},
+    )
+
+    resp = await client.get("/api/rooms/platform-eng/messages?kind=source_event")
+    assert [m["metadata"]["kind"] for m in resp.json()["messages"]] == ["source_event"]
+
+    resp = await client.get("/api/rooms/platform-eng/messages?kind=action&status=open")
+    assert len(resp.json()["messages"]) == 1
+
+    resp = await client.get("/api/rooms/platform-eng/messages?status=resolved")
+    assert resp.json()["messages"] == []
+
+
+@pytest.mark.asyncio
+async def test_since_filter(client, room):
+    await client.post("/api/rooms/platform-eng/messages", json=_event_body())
+    from urllib.parse import quote
+
+    future = quote((datetime.now(UTC) + timedelta(hours=1)).isoformat())
+    resp = await client.get(f"/api/rooms/platform-eng/messages?since={future}")
+    assert resp.json()["messages"] == []
+
+
+@pytest.mark.asyncio
+async def test_expired_events_hidden_from_get(client, room, db_session):
+    await client.post("/api/rooms/platform-eng/messages", json=_event_body(ttl_seconds=3600))
+    msg = (await db_session.execute(select(Message))).scalars().one()
+    msg.event_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    await db_session.commit()
+
+    resp = await client.get("/api/rooms/platform-eng/messages")
+    assert resp.json()["messages"] == []
+
+
+# ── status transitions ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_status_transition(client, room):
+    resp = await client.post(
+        "/api/rooms/platform-eng/messages", json=_event_body(kind="action", payload={})
+    )
+    msg_id = resp.json()["id"]
+
+    resp = await client.patch(
+        f"/api/rooms/platform-eng/messages/{msg_id}", json={"status": "resolved"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["metadata"]["status"] == "resolved"
+    assert "status_updated_at" in body["metadata"]
+
+    # Queryable via the ledger filter.
+    resp = await client.get("/api/rooms/platform-eng/messages?kind=action&status=resolved")
+    assert len(resp.json()["messages"]) == 1
+    resp = await client.get("/api/rooms/platform-eng/messages?kind=action&status=open")
+    assert resp.json()["messages"] == []
+
+
+@pytest.mark.asyncio
+async def test_status_transition_rejected_for_stateless(client, room):
+    resp = await client.post("/api/rooms/platform-eng/messages", json=_event_body())
+    msg_id = resp.json()["id"]
+    resp = await client.patch(
+        f"/api/rooms/platform-eng/messages/{msg_id}", json={"status": "resolved"}
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_status_transition_rejected_for_non_event(client, room):
+    resp = await client.post(
+        "/api/rooms/platform-eng/messages",
+        json={"sender_handle": "a1", "message_type": "broadcast", "content": "chat"},
+    )
+    msg_id = resp.json()["id"]
+    resp = await client.patch(
+        f"/api/rooms/platform-eng/messages/{msg_id}", json={"status": "resolved"}
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_status_transition_404_for_wrong_room(client, room, db_session):
+    other = Room(name="other-room")
+    db_session.add(other)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/rooms/platform-eng/messages", json=_event_body(kind="action", payload={})
+    )
+    msg_id = resp.json()["id"]
+    resp = await client.patch(
+        f"/api/rooms/other-room/messages/{msg_id}", json={"status": "resolved"}
+    )
+    assert resp.status_code == 404
+
+
+# ── TTL sweep ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sweep_deletes_only_expired(client, room, db_session, monkeypatch):
+    from app.services import event_sweep
+
+    await client.post("/api/rooms/platform-eng/messages", json=_event_body(ttl_seconds=3600))
+    await client.post(
+        "/api/rooms/platform-eng/messages", json=_event_body(kind="action", payload={})
+    )
+    msgs = (await db_session.execute(select(Message))).scalars().all()
+    for m in msgs:
+        if m.event_expires_at is not None:
+            m.event_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    await db_session.commit()
+
+    # Point the sweep's session maker at the test database.
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    monkeypatch.setattr(
+        event_sweep,
+        "async_session_maker",
+        async_sessionmaker(db_session.bind, expire_on_commit=False),
+    )
+    removed = await sweep_expired_events()
+    assert removed == 1
+
+    remaining = (await db_session.execute(select(Message))).scalars().all()
+    assert len(remaining) == 1
+    assert remaining[0].event_kind == "action"

--- a/fastapi-backend/tests/test_events.py
+++ b/fastapi-backend/tests/test_events.py
@@ -254,3 +254,22 @@ async def test_sweep_deletes_only_expired(client, room, db_session, monkeypatch)
     remaining = (await db_session.execute(select(Message))).scalars().all()
     assert len(remaining) == 1
     assert remaining[0].event_kind == "action"
+
+
+@pytest.mark.asyncio
+async def test_total_is_filtered_count_not_page_length(client, room):
+    for _ in range(3):
+        await client.post("/api/rooms/platform-eng/messages", json=_event_body())
+    await client.post(
+        "/api/rooms/platform-eng/messages",
+        json={"sender_handle": "a1", "message_type": "broadcast", "content": "chat"},
+    )
+
+    # total reflects the full filtered set, not the returned page.
+    resp = await client.get("/api/rooms/platform-eng/messages?kind=source_event&limit=1")
+    body = resp.json()
+    assert len(body["messages"]) == 1
+    assert body["total"] == 3
+
+    resp = await client.get("/api/rooms/platform-eng/messages?limit=2")
+    assert resp.json()["total"] == 4

--- a/mycelium-cli/src/mycelium/docs/rooms.md
+++ b/mycelium-cli/src/mycelium/docs/rooms.md
@@ -44,14 +44,15 @@ Once `complete`, the consensus is compiled into the room's shared plan
 
 ## Typed events
 
-Rooms accept one structured message type — `event` — discriminated by `metadata.kind`. Retention (`ttl_seconds`) and status are attributes, not separate types: one primitive covers a live activity feed and a persistent action ledger.
+Chat messages disappear into scrollback. Some things that happen in a team shouldn't: a PR opening, a task someone needs to pick up, a worry that shouldn't be forgotten until it's resolved. **Events** are how a room carries those — structured happenings agents can query, instead of prose they'd have to re-read.
 
-| Kind | Retention | Status |
-|---|---|---|
-| `source_event` | `ttl_seconds` cap | none |
-| `action`, `concern` | durable | `open → in_progress → resolved` |
+Three kinds, matching three ways teams use them:
 
-Unknown kinds are accepted (stateless, durable unless a TTL is set).
+- **`source_event`** — *the world changed.* Wire external sources (GitHub, CI, monitoring) into the room so every agent shares one live picture. Transient: give it a `ttl_seconds` and it expires like a feed item should.
+- **`action`** — *someone should do this.* Durable, with a lifecycle (`open → in_progress → resolved`). The room's open actions are its working ledger — any agent can ask "what's still open?" and get an answer, no scrollback archaeology.
+- **`concern`** — *this is worrying.* Like an action, but for risks rather than work. Stays open until someone explicitly resolves it.
+
+Post one like any message, with a `metadata.kind`:
 
 ```json
 POST /api/rooms/{name}/messages
@@ -68,8 +69,14 @@ POST /api/rooms/{name}/messages
 }
 ```
 
-- `payload` — kind-specific data, returned intact
-- `provenance` — cited refs (`pr | commit | issue | page | message`), each `ref` + optional `url`
-- `correlation_id` — groups related events
+`content` is the human-readable line (what renders if a client doesn't know the kind); `payload` carries the structured details; `provenance` cites where it came from (`pr | commit | issue | page | message`) so agents can follow the trail back to the source.
 
-Feed and ledger are server-side filters: `GET …/messages?kind=source_event`, `?kind=action&status=open`, `?since=<iso-ts>`. Transition status with `PATCH …/messages/{id}` `{"status": "resolved"}` — broadcast over SSE. Expired events vanish from reads immediately; a background sweep reclaims them.
+Then query the room like a database, not a transcript:
+
+```
+GET …/messages?kind=source_event&since=<ts>   # the feed: what happened lately
+GET …/messages?kind=action&status=open        # the ledger: what's still open
+PATCH …/messages/{id}  {"status": "resolved"}  # close it out (broadcast over SSE)
+```
+
+The kind vocabulary is open — post your own (`note`, `decision`, `ci_result`, …) and it works today: stateless and durable unless you set a TTL. Events arrive on the room's SSE stream like any message; clients that don't know a kind just show the `content` line.

--- a/mycelium-cli/src/mycelium/docs/rooms.md
+++ b/mycelium-cli/src/mycelium/docs/rooms.md
@@ -41,3 +41,35 @@ idle → waiting → negotiating → complete
 Once `complete`, the consensus is compiled into the room's shared plan
 (`plan/tasks.md`) — a `- [ ]` checklist the team works from. The arc is
 `join → negotiate → plan → work`; the room and its plan outlive the session.
+
+## Typed events
+
+Beyond chat (`broadcast`/`direct`/`announce`/`delegate`), rooms accept one structured message type — `event` — discriminated by `metadata.kind` with an open vocabulary. Retention and statefulness are message *attributes*, not distinct types, so a single primitive covers a live source-activity feed and a persistent action ledger.
+
+| Kind | Persistence | Stateful? |
+|---|---|---|
+| `source_event` | capped by `ttl_seconds` | no (status must be null) |
+| `action` | durable | yes — defaults to `open` |
+| `concern` | durable | yes — defaults to `open` |
+
+Unknown kinds are accepted (stateless, durable unless `ttl_seconds` is set), so new uses need no schema change.
+
+```json
+POST /api/rooms/{name}/messages
+{
+  "message_type": "event",
+  "sender_handle": "github-poller",
+  "content": "New PR: \"fix recordings window\" (#48)",
+  "metadata": {
+    "kind": "source_event",
+    "ttl_seconds": 1209600,
+    "payload": { "source": "github", "event": "pr_opened", "number": 48 },
+    "provenance": [ { "type": "pr", "ref": "org/repo#48", "url": "https://github.com/org/repo/pull/48" } ],
+    "correlation_id": "…"
+  }
+}
+```
+
+The metadata contract: `kind` (required), `ttl_seconds` (optional — absent means durable, never swept), `status` (`open | in_progress | resolved`, stateful kinds only), `payload` (kind-specific data), `provenance` (cited refs, each `type` ∈ `pr | commit | issue | page | message` + `ref` + optional `url`, returned intact), and `correlation_id` (groups related events).
+
+Feed and ledger are server-side filters: `GET /api/rooms/{name}/messages?kind=source_event`, `?kind=action&status=open`, `?since=<iso-ts>`. Expired events disappear from reads immediately and are reclaimed by a background sweep. Status transitions update the original event in place — `PATCH /api/rooms/{name}/messages/{id}` with `{"status": "resolved"}` — so the current status is always one indexed query away, and the transition is broadcast over the room's SSE stream. Events are excluded from knowledge ingest (they're machine feed, not agent speech).

--- a/mycelium-cli/src/mycelium/docs/rooms.md
+++ b/mycelium-cli/src/mycelium/docs/rooms.md
@@ -44,15 +44,14 @@ Once `complete`, the consensus is compiled into the room's shared plan
 
 ## Typed events
 
-Beyond chat (`broadcast`/`direct`/`announce`/`delegate`), rooms accept one structured message type — `event` — discriminated by `metadata.kind` with an open vocabulary. Retention and statefulness are message *attributes*, not distinct types, so a single primitive covers a live source-activity feed and a persistent action ledger.
+Rooms accept one structured message type — `event` — discriminated by `metadata.kind`. Retention (`ttl_seconds`) and status are attributes, not separate types: one primitive covers a live activity feed and a persistent action ledger.
 
-| Kind | Persistence | Stateful? |
+| Kind | Retention | Status |
 |---|---|---|
-| `source_event` | capped by `ttl_seconds` | no (status must be null) |
-| `action` | durable | yes — defaults to `open` |
-| `concern` | durable | yes — defaults to `open` |
+| `source_event` | `ttl_seconds` cap | none |
+| `action`, `concern` | durable | `open → in_progress → resolved` |
 
-Unknown kinds are accepted (stateless, durable unless `ttl_seconds` is set), so new uses need no schema change.
+Unknown kinds are accepted (stateless, durable unless a TTL is set).
 
 ```json
 POST /api/rooms/{name}/messages
@@ -64,12 +63,13 @@ POST /api/rooms/{name}/messages
     "kind": "source_event",
     "ttl_seconds": 1209600,
     "payload": { "source": "github", "event": "pr_opened", "number": 48 },
-    "provenance": [ { "type": "pr", "ref": "org/repo#48", "url": "https://github.com/org/repo/pull/48" } ],
-    "correlation_id": "…"
+    "provenance": [ { "type": "pr", "ref": "org/repo#48" } ]
   }
 }
 ```
 
-The metadata contract: `kind` (required), `ttl_seconds` (optional — absent means durable, never swept), `status` (`open | in_progress | resolved`, stateful kinds only), `payload` (kind-specific data), `provenance` (cited refs, each `type` ∈ `pr | commit | issue | page | message` + `ref` + optional `url`, returned intact), and `correlation_id` (groups related events).
+- `payload` — kind-specific data, returned intact
+- `provenance` — cited refs (`pr | commit | issue | page | message`), each `ref` + optional `url`
+- `correlation_id` — groups related events
 
-Feed and ledger are server-side filters: `GET /api/rooms/{name}/messages?kind=source_event`, `?kind=action&status=open`, `?since=<iso-ts>`. Expired events disappear from reads immediately and are reclaimed by a background sweep. Status transitions update the original event in place — `PATCH /api/rooms/{name}/messages/{id}` with `{"status": "resolved"}` — so the current status is always one indexed query away, and the transition is broadcast over the room's SSE stream. Events are excluded from knowledge ingest (they're machine feed, not agent speech).
+Feed and ledger are server-side filters: `GET …/messages?kind=source_event`, `?kind=action&status=open`, `?since=<iso-ts>`. Transition status with `PATCH …/messages/{id}` `{"status": "resolved"}` — broadcast over SSE. Expired events vanish from reads immediately; a background sweep reclaims them.

--- a/mycelium-cli/src/mycelium_backend_client/api/messages/list_messages_api_rooms_room_name_messages_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/messages/list_messages_api_rooms_room_name_messages_get.py
@@ -1,3 +1,4 @@
+import datetime
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
@@ -18,6 +19,9 @@ def _get_kwargs(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
@@ -39,6 +43,29 @@ def _get_kwargs(
     else:
         json_message_type = message_type
     params["message_type"] = json_message_type
+
+    json_kind: None | str | Unset
+    if isinstance(kind, Unset):
+        json_kind = UNSET
+    else:
+        json_kind = kind
+    params["kind"] = json_kind
+
+    json_status: None | str | Unset
+    if isinstance(status, Unset):
+        json_status = UNSET
+    else:
+        json_status = status
+    params["status"] = json_status
+
+    json_since: None | str | Unset
+    if isinstance(since, Unset):
+        json_since = UNSET
+    elif isinstance(since, datetime.datetime):
+        json_since = since.isoformat()
+    else:
+        json_since = since
+    params["since"] = json_since
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -91,10 +118,18 @@ def sync_detailed(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | MessageListResponse]:
     """List Messages
 
      List messages in a room (or coordination session), newest first.
+
+    ``kind``/``status``/``since`` make the source-activity feed and the
+    action/concern ledger server-side filters over the room (#392). Expired
+    events (past their ``ttl_seconds``) are excluded even if the sweep
+    hasn't collected them yet.
 
     Args:
         room_name (str):
@@ -102,6 +137,9 @@ def sync_detailed(
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
         message_type (None | str | Unset):
+        kind (None | str | Unset): Filter events by metadata.kind
+        status (None | str | Unset): Filter events by ledger status
+        since (datetime.datetime | None | Unset): Only messages created at/after this time
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -117,6 +155,9 @@ def sync_detailed(
         offset=offset,
         sender=sender,
         message_type=message_type,
+        kind=kind,
+        status=status,
+        since=since,
     )
 
     response = client.get_httpx_client().request(
@@ -134,10 +175,18 @@ def sync(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> HTTPValidationError | MessageListResponse | None:
     """List Messages
 
      List messages in a room (or coordination session), newest first.
+
+    ``kind``/``status``/``since`` make the source-activity feed and the
+    action/concern ledger server-side filters over the room (#392). Expired
+    events (past their ``ttl_seconds``) are excluded even if the sweep
+    hasn't collected them yet.
 
     Args:
         room_name (str):
@@ -145,6 +194,9 @@ def sync(
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
         message_type (None | str | Unset):
+        kind (None | str | Unset): Filter events by metadata.kind
+        status (None | str | Unset): Filter events by ledger status
+        since (datetime.datetime | None | Unset): Only messages created at/after this time
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -161,6 +213,9 @@ def sync(
         offset=offset,
         sender=sender,
         message_type=message_type,
+        kind=kind,
+        status=status,
+        since=since,
     ).parsed
 
 
@@ -172,10 +227,18 @@ async def asyncio_detailed(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | MessageListResponse]:
     """List Messages
 
      List messages in a room (or coordination session), newest first.
+
+    ``kind``/``status``/``since`` make the source-activity feed and the
+    action/concern ledger server-side filters over the room (#392). Expired
+    events (past their ``ttl_seconds``) are excluded even if the sweep
+    hasn't collected them yet.
 
     Args:
         room_name (str):
@@ -183,6 +246,9 @@ async def asyncio_detailed(
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
         message_type (None | str | Unset):
+        kind (None | str | Unset): Filter events by metadata.kind
+        status (None | str | Unset): Filter events by ledger status
+        since (datetime.datetime | None | Unset): Only messages created at/after this time
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -198,6 +264,9 @@ async def asyncio_detailed(
         offset=offset,
         sender=sender,
         message_type=message_type,
+        kind=kind,
+        status=status,
+        since=since,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -213,10 +282,18 @@ async def asyncio(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> HTTPValidationError | MessageListResponse | None:
     """List Messages
 
      List messages in a room (or coordination session), newest first.
+
+    ``kind``/``status``/``since`` make the source-activity feed and the
+    action/concern ledger server-side filters over the room (#392). Expired
+    events (past their ``ttl_seconds``) are excluded even if the sweep
+    hasn't collected them yet.
 
     Args:
         room_name (str):
@@ -224,6 +301,9 @@ async def asyncio(
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
         message_type (None | str | Unset):
+        kind (None | str | Unset): Filter events by metadata.kind
+        status (None | str | Unset): Filter events by ledger status
+        since (datetime.datetime | None | Unset): Only messages created at/after this time
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -241,5 +321,8 @@ async def asyncio(
             offset=offset,
             sender=sender,
             message_type=message_type,
+            kind=kind,
+            status=status,
+            since=since,
         )
     ).parsed

--- a/mycelium-cli/src/mycelium_backend_client/api/messages/update_event_status_api_rooms_room_name_messages_message_id_patch.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/messages/update_event_status_api_rooms_room_name_messages_message_id_patch.py
@@ -1,0 +1,233 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.event_status_update import EventStatusUpdate
+from ...models.http_validation_error import HTTPValidationError
+from ...models.message_read import MessageRead
+from ...types import Response
+
+
+def _get_kwargs(
+    room_name: str,
+    message_id: UUID,
+    *,
+    body: EventStatusUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/api/rooms/{room_name}/messages/{message_id}".format(
+            room_name=quote(str(room_name), safe=""),
+            message_id=quote(str(message_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MessageRead | None:
+    if response.status_code == 200:
+        response_200 = MessageRead.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MessageRead]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    room_name: str,
+    message_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EventStatusUpdate,
+) -> Response[HTTPValidationError | MessageRead]:
+    """Update Event Status
+
+     Transition a stateful event's status (open -> in_progress -> resolved).
+
+    Design choice (#392 left it open): the status lives on the original event
+    row and is updated in place, rather than appending follow-up events —
+    the current status must be cheaply queryable, and a follow-up-event model
+    forces a latest-per-correlation aggregation on every ledger query. The
+    transition is broadcast over SSE so subscribers see the change live.
+
+    Args:
+        room_name (str):
+        message_id (UUID):
+        body (EventStatusUpdate): Body for PATCH /rooms/{name}/messages/{id} — transition an
+            event's status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MessageRead]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+        message_id=message_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    room_name: str,
+    message_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EventStatusUpdate,
+) -> HTTPValidationError | MessageRead | None:
+    """Update Event Status
+
+     Transition a stateful event's status (open -> in_progress -> resolved).
+
+    Design choice (#392 left it open): the status lives on the original event
+    row and is updated in place, rather than appending follow-up events —
+    the current status must be cheaply queryable, and a follow-up-event model
+    forces a latest-per-correlation aggregation on every ledger query. The
+    transition is broadcast over SSE so subscribers see the change live.
+
+    Args:
+        room_name (str):
+        message_id (UUID):
+        body (EventStatusUpdate): Body for PATCH /rooms/{name}/messages/{id} — transition an
+            event's status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MessageRead
+    """
+
+    return sync_detailed(
+        room_name=room_name,
+        message_id=message_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    room_name: str,
+    message_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EventStatusUpdate,
+) -> Response[HTTPValidationError | MessageRead]:
+    """Update Event Status
+
+     Transition a stateful event's status (open -> in_progress -> resolved).
+
+    Design choice (#392 left it open): the status lives on the original event
+    row and is updated in place, rather than appending follow-up events —
+    the current status must be cheaply queryable, and a follow-up-event model
+    forces a latest-per-correlation aggregation on every ledger query. The
+    transition is broadcast over SSE so subscribers see the change live.
+
+    Args:
+        room_name (str):
+        message_id (UUID):
+        body (EventStatusUpdate): Body for PATCH /rooms/{name}/messages/{id} — transition an
+            event's status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MessageRead]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+        message_id=message_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    room_name: str,
+    message_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EventStatusUpdate,
+) -> HTTPValidationError | MessageRead | None:
+    """Update Event Status
+
+     Transition a stateful event's status (open -> in_progress -> resolved).
+
+    Design choice (#392 left it open): the status lives on the original event
+    row and is updated in place, rather than appending follow-up events —
+    the current status must be cheaply queryable, and a follow-up-event model
+    forces a latest-per-correlation aggregation on every ledger query. The
+    transition is broadcast over SSE so subscribers see the change live.
+
+    Args:
+        room_name (str):
+        message_id (UUID):
+        body (EventStatusUpdate): Body for PATCH /rooms/{name}/messages/{id} — transition an
+            event's status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MessageRead
+    """
+
+    return (
+        await asyncio_detailed(
+            room_name=room_name,
+            message_id=message_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/mycelium-cli/src/mycelium_backend_client/models/__init__.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/__init__.py
@@ -24,6 +24,13 @@ from .concepts_by_ids_request import ConceptsByIdsRequest
 from .context_file import ContextFile
 from .context_file_read import ContextFileRead
 from .coordination_session_read import CoordinationSessionRead
+from .event_metadata import EventMetadata
+from .event_metadata_payload import EventMetadataPayload
+from .event_metadata_status_type_0 import EventMetadataStatusType0
+from .event_provenance_ref import EventProvenanceRef
+from .event_provenance_ref_type import EventProvenanceRefType
+from .event_status_update import EventStatusUpdate
+from .event_status_update_status import EventStatusUpdateStatus
 from .get_negotiation_status_response_get_negotiation_status import (
     GetNegotiationStatusResponseGetNegotiationStatus,
 )
@@ -57,6 +64,7 @@ from .memory_search_result import MemorySearchResult
 from .message_create import MessageCreate
 from .message_list_response import MessageListResponse
 from .message_read import MessageRead
+from .message_read_metadata_type_0 import MessageReadMetadataType0
 from .participant_create import ParticipantCreate
 from .participant_list_response import ParticipantListResponse
 from .participant_read import ParticipantRead
@@ -95,6 +103,13 @@ __all__ = (
     "ContextFile",
     "ContextFileRead",
     "CoordinationSessionRead",
+    "EventMetadata",
+    "EventMetadataPayload",
+    "EventMetadataStatusType0",
+    "EventProvenanceRef",
+    "EventProvenanceRefType",
+    "EventStatusUpdate",
+    "EventStatusUpdateStatus",
     "GetNegotiationStatusResponseGetNegotiationStatus",
     "GraphPathsRequest",
     "HTTPValidationError",
@@ -122,6 +137,7 @@ __all__ = (
     "MessageCreate",
     "MessageListResponse",
     "MessageRead",
+    "MessageReadMetadataType0",
     "ParticipantCreate",
     "ParticipantListResponse",
     "ParticipantRead",

--- a/mycelium-cli/src/mycelium_backend_client/models/event_metadata.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/event_metadata.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.event_metadata_status_type_0 import EventMetadataStatusType0
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.event_metadata_payload import EventMetadataPayload
+    from ..models.event_provenance_ref import EventProvenanceRef
+
+
+T = TypeVar("T", bound="EventMetadata")
+
+
+@_attrs_define
+class EventMetadata:
+    """Structured metadata for ``message_type="event"``.
+
+    Retention (``ttl_seconds``) and statefulness (``status``) are independent
+    attributes, not distinct message types — one primitive covers a transient
+    source-activity feed and a durable status-bearing ledger.
+
+        Attributes:
+            kind (str): Event kind (open vocabulary)
+            ttl_seconds (int | None | Unset): Retention cap for transient kinds; absent = durable
+            status (EventMetadataStatusType0 | None | Unset): Ledger status for stateful kinds; null for stateless
+            payload (EventMetadataPayload | Unset): Kind-specific structured data
+            provenance (list[EventProvenanceRef] | Unset):
+            correlation_id (None | str | Unset): Groups related events / links updates to their origin
+    """
+
+    kind: str
+    ttl_seconds: int | None | Unset = UNSET
+    status: EventMetadataStatusType0 | None | Unset = UNSET
+    payload: EventMetadataPayload | Unset = UNSET
+    provenance: list[EventProvenanceRef] | Unset = UNSET
+    correlation_id: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        kind = self.kind
+
+        ttl_seconds: int | None | Unset
+        if isinstance(self.ttl_seconds, Unset):
+            ttl_seconds = UNSET
+        else:
+            ttl_seconds = self.ttl_seconds
+
+        status: None | str | Unset
+        if isinstance(self.status, Unset):
+            status = UNSET
+        elif isinstance(self.status, EventMetadataStatusType0):
+            status = self.status.value
+        else:
+            status = self.status
+
+        payload: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.payload, Unset):
+            payload = self.payload.to_dict()
+
+        provenance: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.provenance, Unset):
+            provenance = []
+            for provenance_item_data in self.provenance:
+                provenance_item = provenance_item_data.to_dict()
+                provenance.append(provenance_item)
+
+        correlation_id: None | str | Unset
+        if isinstance(self.correlation_id, Unset):
+            correlation_id = UNSET
+        else:
+            correlation_id = self.correlation_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "kind": kind,
+            }
+        )
+        if ttl_seconds is not UNSET:
+            field_dict["ttl_seconds"] = ttl_seconds
+        if status is not UNSET:
+            field_dict["status"] = status
+        if payload is not UNSET:
+            field_dict["payload"] = payload
+        if provenance is not UNSET:
+            field_dict["provenance"] = provenance
+        if correlation_id is not UNSET:
+            field_dict["correlation_id"] = correlation_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.event_metadata_payload import EventMetadataPayload
+        from ..models.event_provenance_ref import EventProvenanceRef
+
+        d = dict(src_dict)
+        kind = d.pop("kind")
+
+        def _parse_ttl_seconds(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        ttl_seconds = _parse_ttl_seconds(d.pop("ttl_seconds", UNSET))
+
+        def _parse_status(data: object) -> EventMetadataStatusType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                status_type_0 = EventMetadataStatusType0(data)
+
+                return status_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(EventMetadataStatusType0 | None | Unset, data)
+
+        status = _parse_status(d.pop("status", UNSET))
+
+        _payload = d.pop("payload", UNSET)
+        payload: EventMetadataPayload | Unset
+        if isinstance(_payload, Unset):
+            payload = UNSET
+        else:
+            payload = EventMetadataPayload.from_dict(_payload)
+
+        _provenance = d.pop("provenance", UNSET)
+        provenance: list[EventProvenanceRef] | Unset = UNSET
+        if _provenance is not UNSET:
+            provenance = []
+            for provenance_item_data in _provenance:
+                provenance_item = EventProvenanceRef.from_dict(provenance_item_data)
+
+                provenance.append(provenance_item)
+
+        def _parse_correlation_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        correlation_id = _parse_correlation_id(d.pop("correlation_id", UNSET))
+
+        event_metadata = cls(
+            kind=kind,
+            ttl_seconds=ttl_seconds,
+            status=status,
+            payload=payload,
+            provenance=provenance,
+            correlation_id=correlation_id,
+        )
+
+        event_metadata.additional_properties = d
+        return event_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-cli/src/mycelium_backend_client/models/event_metadata_payload.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/event_metadata_payload.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="EventMetadataPayload")
+
+
+@_attrs_define
+class EventMetadataPayload:
+    """Kind-specific structured data"""
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        event_metadata_payload = cls()
+
+        event_metadata_payload.additional_properties = d
+        return event_metadata_payload
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-cli/src/mycelium_backend_client/models/event_metadata_status_type_0.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/event_metadata_status_type_0.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class EventMetadataStatusType0(str, Enum):
+    IN_PROGRESS = "in_progress"
+    OPEN = "open"
+    RESOLVED = "resolved"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/mycelium-cli/src/mycelium_backend_client/models/event_provenance_ref.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/event_provenance_ref.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.event_provenance_ref_type import EventProvenanceRefType
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="EventProvenanceRef")
+
+
+@_attrs_define
+class EventProvenanceRef:
+    """A cited reference backing an event.
+
+    Attributes:
+        type_ (EventProvenanceRefType):
+        ref (str): e.g. 'org/repo#48' or a message id
+        url (None | str | Unset):
+    """
+
+    type_: EventProvenanceRefType
+    ref: str
+    url: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_.value
+
+        ref = self.ref
+
+        url: None | str | Unset
+        if isinstance(self.url, Unset):
+            url = UNSET
+        else:
+            url = self.url
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+                "ref": ref,
+            }
+        )
+        if url is not UNSET:
+            field_dict["url"] = url
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = EventProvenanceRefType(d.pop("type"))
+
+        ref = d.pop("ref")
+
+        def _parse_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        url = _parse_url(d.pop("url", UNSET))
+
+        event_provenance_ref = cls(
+            type_=type_,
+            ref=ref,
+            url=url,
+        )
+
+        event_provenance_ref.additional_properties = d
+        return event_provenance_ref
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-cli/src/mycelium_backend_client/models/event_provenance_ref_type.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/event_provenance_ref_type.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class EventProvenanceRefType(str, Enum):
+    COMMIT = "commit"
+    ISSUE = "issue"
+    MESSAGE = "message"
+    PAGE = "page"
+    PR = "pr"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/mycelium-cli/src/mycelium_backend_client/models/event_status_update.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/event_status_update.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.event_status_update_status import EventStatusUpdateStatus
+
+T = TypeVar("T", bound="EventStatusUpdate")
+
+
+@_attrs_define
+class EventStatusUpdate:
+    """Body for PATCH /rooms/{name}/messages/{id} — transition an event's status.
+
+    Attributes:
+        status (EventStatusUpdateStatus):
+    """
+
+    status: EventStatusUpdateStatus
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        status = self.status.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "status": status,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        status = EventStatusUpdateStatus(d.pop("status"))
+
+        event_status_update = cls(
+            status=status,
+        )
+
+        event_status_update.additional_properties = d
+        return event_status_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-cli/src/mycelium_backend_client/models/event_status_update_status.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/event_status_update_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class EventStatusUpdateStatus(str, Enum):
+    IN_PROGRESS = "in_progress"
+    OPEN = "open"
+    RESOLVED = "resolved"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/mycelium-cli/src/mycelium_backend_client/models/message_create.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/message_create.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.event_metadata import EventMetadata
+
 
 T = TypeVar("T", bound="MessageCreate")
 
@@ -16,18 +20,22 @@ class MessageCreate:
     """
     Attributes:
         sender_handle (str): Sender handle (e.g., 'alpha#a8f3')
-        message_type (str): Type: announce, direct, broadcast, or delegate
+        message_type (str): Type: announce, direct, broadcast, delegate, or event
         content (str):
         recipient_handle (None | str | Unset): Recipient handle for direct messages; omit for broadcast
+        metadata (EventMetadata | None | Unset): Structured event metadata; required when message_type="event"
     """
 
     sender_handle: str
     message_type: str
     content: str
     recipient_handle: None | str | Unset = UNSET
+    metadata: EventMetadata | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.event_metadata import EventMetadata
+
         sender_handle = self.sender_handle
 
         message_type = self.message_type
@@ -40,6 +48,14 @@ class MessageCreate:
         else:
             recipient_handle = self.recipient_handle
 
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, EventMetadata):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -51,11 +67,15 @@ class MessageCreate:
         )
         if recipient_handle is not UNSET:
             field_dict["recipient_handle"] = recipient_handle
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.event_metadata import EventMetadata
+
         d = dict(src_dict)
         sender_handle = d.pop("sender_handle")
 
@@ -72,11 +92,29 @@ class MessageCreate:
 
         recipient_handle = _parse_recipient_handle(d.pop("recipient_handle", UNSET))
 
+        def _parse_metadata(data: object) -> EventMetadata | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = EventMetadata.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(EventMetadata | None | Unset, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
         message_create = cls(
             sender_handle=sender_handle,
             message_type=message_type,
             content=content,
             recipient_handle=recipient_handle,
+            metadata=metadata,
         )
 
         message_create.additional_properties = d

--- a/mycelium-cli/src/mycelium_backend_client/models/message_read.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/message_read.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from uuid import UUID
 
 from attrs import define as _attrs_define
@@ -10,6 +10,10 @@ from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.message_read_metadata_type_0 import MessageReadMetadataType0
+
 
 T = TypeVar("T", bound="MessageRead")
 
@@ -26,6 +30,7 @@ class MessageRead:
         room_name (None | str | Unset):
         coordination_session_id (None | Unset | UUID):
         recipient_handle (None | str | Unset):
+        metadata (MessageReadMetadataType0 | None | Unset):
     """
 
     id: UUID
@@ -36,9 +41,12 @@ class MessageRead:
     room_name: None | str | Unset = UNSET
     coordination_session_id: None | Unset | UUID = UNSET
     recipient_handle: None | str | Unset = UNSET
+    metadata: MessageReadMetadataType0 | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.message_read_metadata_type_0 import MessageReadMetadataType0
+
         id = str(self.id)
 
         sender_handle = self.sender_handle
@@ -69,6 +77,14 @@ class MessageRead:
         else:
             recipient_handle = self.recipient_handle
 
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, MessageReadMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -86,11 +102,15 @@ class MessageRead:
             field_dict["coordination_session_id"] = coordination_session_id
         if recipient_handle is not UNSET:
             field_dict["recipient_handle"] = recipient_handle
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.message_read_metadata_type_0 import MessageReadMetadataType0
+
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
@@ -139,6 +159,23 @@ class MessageRead:
 
         recipient_handle = _parse_recipient_handle(d.pop("recipient_handle", UNSET))
 
+        def _parse_metadata(data: object) -> MessageReadMetadataType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = MessageReadMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MessageReadMetadataType0 | None | Unset, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
         message_read = cls(
             id=id,
             sender_handle=sender_handle,
@@ -148,6 +185,7 @@ class MessageRead:
             room_name=room_name,
             coordination_session_id=coordination_session_id,
             recipient_handle=recipient_handle,
+            metadata=metadata,
         )
 
         message_read.additional_properties = d

--- a/mycelium-cli/src/mycelium_backend_client/models/message_read_metadata_type_0.py
+++ b/mycelium-cli/src/mycelium_backend_client/models/message_read_metadata_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MessageReadMetadataType0")
+
+
+@_attrs_define
+class MessageReadMetadataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        message_read_metadata_type_0 = cls()
+
+        message_read_metadata_type_0.additional_properties = d
+        return message_read_metadata_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-client/mycelium_backend_client/api/messages/list_messages_api_rooms_room_name_messages_get.py
+++ b/mycelium-client/mycelium_backend_client/api/messages/list_messages_api_rooms_room_name_messages_get.py
@@ -1,3 +1,4 @@
+import datetime
 from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
@@ -18,6 +19,9 @@ def _get_kwargs(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> dict[str, Any]:
 
     params: dict[str, Any] = {}
@@ -39,6 +43,29 @@ def _get_kwargs(
     else:
         json_message_type = message_type
     params["message_type"] = json_message_type
+
+    json_kind: None | str | Unset
+    if isinstance(kind, Unset):
+        json_kind = UNSET
+    else:
+        json_kind = kind
+    params["kind"] = json_kind
+
+    json_status: None | str | Unset
+    if isinstance(status, Unset):
+        json_status = UNSET
+    else:
+        json_status = status
+    params["status"] = json_status
+
+    json_since: None | str | Unset
+    if isinstance(since, Unset):
+        json_since = UNSET
+    elif isinstance(since, datetime.datetime):
+        json_since = since.isoformat()
+    else:
+        json_since = since
+    params["since"] = json_since
 
     params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
@@ -91,10 +118,18 @@ def sync_detailed(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | MessageListResponse]:
     """List Messages
 
      List messages in a room (or coordination session), newest first.
+
+    ``kind``/``status``/``since`` make the source-activity feed and the
+    action/concern ledger server-side filters over the room (#392). Expired
+    events (past their ``ttl_seconds``) are excluded even if the sweep
+    hasn't collected them yet.
 
     Args:
         room_name (str):
@@ -102,6 +137,9 @@ def sync_detailed(
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
         message_type (None | str | Unset):
+        kind (None | str | Unset): Filter events by metadata.kind
+        status (None | str | Unset): Filter events by ledger status
+        since (datetime.datetime | None | Unset): Only messages created at/after this time
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -117,6 +155,9 @@ def sync_detailed(
         offset=offset,
         sender=sender,
         message_type=message_type,
+        kind=kind,
+        status=status,
+        since=since,
     )
 
     response = client.get_httpx_client().request(
@@ -134,10 +175,18 @@ def sync(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> HTTPValidationError | MessageListResponse | None:
     """List Messages
 
      List messages in a room (or coordination session), newest first.
+
+    ``kind``/``status``/``since`` make the source-activity feed and the
+    action/concern ledger server-side filters over the room (#392). Expired
+    events (past their ``ttl_seconds``) are excluded even if the sweep
+    hasn't collected them yet.
 
     Args:
         room_name (str):
@@ -145,6 +194,9 @@ def sync(
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
         message_type (None | str | Unset):
+        kind (None | str | Unset): Filter events by metadata.kind
+        status (None | str | Unset): Filter events by ledger status
+        since (datetime.datetime | None | Unset): Only messages created at/after this time
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -161,6 +213,9 @@ def sync(
         offset=offset,
         sender=sender,
         message_type=message_type,
+        kind=kind,
+        status=status,
+        since=since,
     ).parsed
 
 
@@ -172,10 +227,18 @@ async def asyncio_detailed(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> Response[HTTPValidationError | MessageListResponse]:
     """List Messages
 
      List messages in a room (or coordination session), newest first.
+
+    ``kind``/``status``/``since`` make the source-activity feed and the
+    action/concern ledger server-side filters over the room (#392). Expired
+    events (past their ``ttl_seconds``) are excluded even if the sweep
+    hasn't collected them yet.
 
     Args:
         room_name (str):
@@ -183,6 +246,9 @@ async def asyncio_detailed(
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
         message_type (None | str | Unset):
+        kind (None | str | Unset): Filter events by metadata.kind
+        status (None | str | Unset): Filter events by ledger status
+        since (datetime.datetime | None | Unset): Only messages created at/after this time
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -198,6 +264,9 @@ async def asyncio_detailed(
         offset=offset,
         sender=sender,
         message_type=message_type,
+        kind=kind,
+        status=status,
+        since=since,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -213,10 +282,18 @@ async def asyncio(
     offset: int | Unset = 0,
     sender: None | str | Unset = UNSET,
     message_type: None | str | Unset = UNSET,
+    kind: None | str | Unset = UNSET,
+    status: None | str | Unset = UNSET,
+    since: datetime.datetime | None | Unset = UNSET,
 ) -> HTTPValidationError | MessageListResponse | None:
     """List Messages
 
      List messages in a room (or coordination session), newest first.
+
+    ``kind``/``status``/``since`` make the source-activity feed and the
+    action/concern ledger server-side filters over the room (#392). Expired
+    events (past their ``ttl_seconds``) are excluded even if the sweep
+    hasn't collected them yet.
 
     Args:
         room_name (str):
@@ -224,6 +301,9 @@ async def asyncio(
         offset (int | Unset):  Default: 0.
         sender (None | str | Unset):
         message_type (None | str | Unset):
+        kind (None | str | Unset): Filter events by metadata.kind
+        status (None | str | Unset): Filter events by ledger status
+        since (datetime.datetime | None | Unset): Only messages created at/after this time
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -241,5 +321,8 @@ async def asyncio(
             offset=offset,
             sender=sender,
             message_type=message_type,
+            kind=kind,
+            status=status,
+            since=since,
         )
     ).parsed

--- a/mycelium-client/mycelium_backend_client/api/messages/update_event_status_api_rooms_room_name_messages_message_id_patch.py
+++ b/mycelium-client/mycelium_backend_client/api/messages/update_event_status_api_rooms_room_name_messages_message_id_patch.py
@@ -1,0 +1,233 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.event_status_update import EventStatusUpdate
+from ...models.http_validation_error import HTTPValidationError
+from ...models.message_read import MessageRead
+from ...types import Response
+
+
+def _get_kwargs(
+    room_name: str,
+    message_id: UUID,
+    *,
+    body: EventStatusUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "patch",
+        "url": "/api/rooms/{room_name}/messages/{message_id}".format(
+            room_name=quote(str(room_name), safe=""),
+            message_id=quote(str(message_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> HTTPValidationError | MessageRead | None:
+    if response.status_code == 200:
+        response_200 = MessageRead.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[HTTPValidationError | MessageRead]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    room_name: str,
+    message_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EventStatusUpdate,
+) -> Response[HTTPValidationError | MessageRead]:
+    """Update Event Status
+
+     Transition a stateful event's status (open -> in_progress -> resolved).
+
+    Design choice (#392 left it open): the status lives on the original event
+    row and is updated in place, rather than appending follow-up events —
+    the current status must be cheaply queryable, and a follow-up-event model
+    forces a latest-per-correlation aggregation on every ledger query. The
+    transition is broadcast over SSE so subscribers see the change live.
+
+    Args:
+        room_name (str):
+        message_id (UUID):
+        body (EventStatusUpdate): Body for PATCH /rooms/{name}/messages/{id} — transition an
+            event's status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MessageRead]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+        message_id=message_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    room_name: str,
+    message_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EventStatusUpdate,
+) -> HTTPValidationError | MessageRead | None:
+    """Update Event Status
+
+     Transition a stateful event's status (open -> in_progress -> resolved).
+
+    Design choice (#392 left it open): the status lives on the original event
+    row and is updated in place, rather than appending follow-up events —
+    the current status must be cheaply queryable, and a follow-up-event model
+    forces a latest-per-correlation aggregation on every ledger query. The
+    transition is broadcast over SSE so subscribers see the change live.
+
+    Args:
+        room_name (str):
+        message_id (UUID):
+        body (EventStatusUpdate): Body for PATCH /rooms/{name}/messages/{id} — transition an
+            event's status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MessageRead
+    """
+
+    return sync_detailed(
+        room_name=room_name,
+        message_id=message_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    room_name: str,
+    message_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EventStatusUpdate,
+) -> Response[HTTPValidationError | MessageRead]:
+    """Update Event Status
+
+     Transition a stateful event's status (open -> in_progress -> resolved).
+
+    Design choice (#392 left it open): the status lives on the original event
+    row and is updated in place, rather than appending follow-up events —
+    the current status must be cheaply queryable, and a follow-up-event model
+    forces a latest-per-correlation aggregation on every ledger query. The
+    transition is broadcast over SSE so subscribers see the change live.
+
+    Args:
+        room_name (str):
+        message_id (UUID):
+        body (EventStatusUpdate): Body for PATCH /rooms/{name}/messages/{id} — transition an
+            event's status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[HTTPValidationError | MessageRead]
+    """
+
+    kwargs = _get_kwargs(
+        room_name=room_name,
+        message_id=message_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    room_name: str,
+    message_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: EventStatusUpdate,
+) -> HTTPValidationError | MessageRead | None:
+    """Update Event Status
+
+     Transition a stateful event's status (open -> in_progress -> resolved).
+
+    Design choice (#392 left it open): the status lives on the original event
+    row and is updated in place, rather than appending follow-up events —
+    the current status must be cheaply queryable, and a follow-up-event model
+    forces a latest-per-correlation aggregation on every ledger query. The
+    transition is broadcast over SSE so subscribers see the change live.
+
+    Args:
+        room_name (str):
+        message_id (UUID):
+        body (EventStatusUpdate): Body for PATCH /rooms/{name}/messages/{id} — transition an
+            event's status.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        HTTPValidationError | MessageRead
+    """
+
+    return (
+        await asyncio_detailed(
+            room_name=room_name,
+            message_id=message_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/mycelium-client/mycelium_backend_client/models/__init__.py
+++ b/mycelium-client/mycelium_backend_client/models/__init__.py
@@ -24,6 +24,13 @@ from .concepts_by_ids_request import ConceptsByIdsRequest
 from .context_file import ContextFile
 from .context_file_read import ContextFileRead
 from .coordination_session_read import CoordinationSessionRead
+from .event_metadata import EventMetadata
+from .event_metadata_payload import EventMetadataPayload
+from .event_metadata_status_type_0 import EventMetadataStatusType0
+from .event_provenance_ref import EventProvenanceRef
+from .event_provenance_ref_type import EventProvenanceRefType
+from .event_status_update import EventStatusUpdate
+from .event_status_update_status import EventStatusUpdateStatus
 from .get_negotiation_status_response_get_negotiation_status import GetNegotiationStatusResponseGetNegotiationStatus
 from .graph_paths_request import GraphPathsRequest
 from .http_validation_error import HTTPValidationError
@@ -55,6 +62,7 @@ from .memory_search_result import MemorySearchResult
 from .message_create import MessageCreate
 from .message_list_response import MessageListResponse
 from .message_read import MessageRead
+from .message_read_metadata_type_0 import MessageReadMetadataType0
 from .participant_create import ParticipantCreate
 from .participant_list_response import ParticipantListResponse
 from .participant_read import ParticipantRead
@@ -93,6 +101,13 @@ __all__ = (
     "ContextFile",
     "ContextFileRead",
     "CoordinationSessionRead",
+    "EventMetadata",
+    "EventMetadataPayload",
+    "EventMetadataStatusType0",
+    "EventProvenanceRef",
+    "EventProvenanceRefType",
+    "EventStatusUpdate",
+    "EventStatusUpdateStatus",
     "GetNegotiationStatusResponseGetNegotiationStatus",
     "GraphPathsRequest",
     "HTTPValidationError",
@@ -120,6 +135,7 @@ __all__ = (
     "MessageCreate",
     "MessageListResponse",
     "MessageRead",
+    "MessageReadMetadataType0",
     "ParticipantCreate",
     "ParticipantListResponse",
     "ParticipantRead",

--- a/mycelium-client/mycelium_backend_client/models/event_metadata.py
+++ b/mycelium-client/mycelium_backend_client/models/event_metadata.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.event_metadata_status_type_0 import EventMetadataStatusType0
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.event_metadata_payload import EventMetadataPayload
+    from ..models.event_provenance_ref import EventProvenanceRef
+
+
+T = TypeVar("T", bound="EventMetadata")
+
+
+@_attrs_define
+class EventMetadata:
+    """Structured metadata for ``message_type="event"``.
+
+    Retention (``ttl_seconds``) and statefulness (``status``) are independent
+    attributes, not distinct message types — one primitive covers a transient
+    source-activity feed and a durable status-bearing ledger.
+
+        Attributes:
+            kind (str): Event kind (open vocabulary)
+            ttl_seconds (int | None | Unset): Retention cap for transient kinds; absent = durable
+            status (EventMetadataStatusType0 | None | Unset): Ledger status for stateful kinds; null for stateless
+            payload (EventMetadataPayload | Unset): Kind-specific structured data
+            provenance (list[EventProvenanceRef] | Unset):
+            correlation_id (None | str | Unset): Groups related events / links updates to their origin
+    """
+
+    kind: str
+    ttl_seconds: int | None | Unset = UNSET
+    status: EventMetadataStatusType0 | None | Unset = UNSET
+    payload: EventMetadataPayload | Unset = UNSET
+    provenance: list[EventProvenanceRef] | Unset = UNSET
+    correlation_id: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        kind = self.kind
+
+        ttl_seconds: int | None | Unset
+        if isinstance(self.ttl_seconds, Unset):
+            ttl_seconds = UNSET
+        else:
+            ttl_seconds = self.ttl_seconds
+
+        status: None | str | Unset
+        if isinstance(self.status, Unset):
+            status = UNSET
+        elif isinstance(self.status, EventMetadataStatusType0):
+            status = self.status.value
+        else:
+            status = self.status
+
+        payload: dict[str, Any] | Unset = UNSET
+        if not isinstance(self.payload, Unset):
+            payload = self.payload.to_dict()
+
+        provenance: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.provenance, Unset):
+            provenance = []
+            for provenance_item_data in self.provenance:
+                provenance_item = provenance_item_data.to_dict()
+                provenance.append(provenance_item)
+
+        correlation_id: None | str | Unset
+        if isinstance(self.correlation_id, Unset):
+            correlation_id = UNSET
+        else:
+            correlation_id = self.correlation_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "kind": kind,
+            }
+        )
+        if ttl_seconds is not UNSET:
+            field_dict["ttl_seconds"] = ttl_seconds
+        if status is not UNSET:
+            field_dict["status"] = status
+        if payload is not UNSET:
+            field_dict["payload"] = payload
+        if provenance is not UNSET:
+            field_dict["provenance"] = provenance
+        if correlation_id is not UNSET:
+            field_dict["correlation_id"] = correlation_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.event_metadata_payload import EventMetadataPayload
+        from ..models.event_provenance_ref import EventProvenanceRef
+
+        d = dict(src_dict)
+        kind = d.pop("kind")
+
+        def _parse_ttl_seconds(data: object) -> int | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(int | None | Unset, data)
+
+        ttl_seconds = _parse_ttl_seconds(d.pop("ttl_seconds", UNSET))
+
+        def _parse_status(data: object) -> EventMetadataStatusType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                status_type_0 = EventMetadataStatusType0(data)
+
+                return status_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(EventMetadataStatusType0 | None | Unset, data)
+
+        status = _parse_status(d.pop("status", UNSET))
+
+        _payload = d.pop("payload", UNSET)
+        payload: EventMetadataPayload | Unset
+        if isinstance(_payload, Unset):
+            payload = UNSET
+        else:
+            payload = EventMetadataPayload.from_dict(_payload)
+
+        _provenance = d.pop("provenance", UNSET)
+        provenance: list[EventProvenanceRef] | Unset = UNSET
+        if _provenance is not UNSET:
+            provenance = []
+            for provenance_item_data in _provenance:
+                provenance_item = EventProvenanceRef.from_dict(provenance_item_data)
+
+                provenance.append(provenance_item)
+
+        def _parse_correlation_id(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        correlation_id = _parse_correlation_id(d.pop("correlation_id", UNSET))
+
+        event_metadata = cls(
+            kind=kind,
+            ttl_seconds=ttl_seconds,
+            status=status,
+            payload=payload,
+            provenance=provenance,
+            correlation_id=correlation_id,
+        )
+
+        event_metadata.additional_properties = d
+        return event_metadata
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-client/mycelium_backend_client/models/event_metadata_payload.py
+++ b/mycelium-client/mycelium_backend_client/models/event_metadata_payload.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="EventMetadataPayload")
+
+
+@_attrs_define
+class EventMetadataPayload:
+    """Kind-specific structured data"""
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        event_metadata_payload = cls()
+
+        event_metadata_payload.additional_properties = d
+        return event_metadata_payload
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-client/mycelium_backend_client/models/event_metadata_status_type_0.py
+++ b/mycelium-client/mycelium_backend_client/models/event_metadata_status_type_0.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class EventMetadataStatusType0(str, Enum):
+    IN_PROGRESS = "in_progress"
+    OPEN = "open"
+    RESOLVED = "resolved"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/mycelium-client/mycelium_backend_client/models/event_provenance_ref.py
+++ b/mycelium-client/mycelium_backend_client/models/event_provenance_ref.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.event_provenance_ref_type import EventProvenanceRefType
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="EventProvenanceRef")
+
+
+@_attrs_define
+class EventProvenanceRef:
+    """A cited reference backing an event.
+
+    Attributes:
+        type_ (EventProvenanceRefType):
+        ref (str): e.g. 'org/repo#48' or a message id
+        url (None | str | Unset):
+    """
+
+    type_: EventProvenanceRefType
+    ref: str
+    url: None | str | Unset = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_.value
+
+        ref = self.ref
+
+        url: None | str | Unset
+        if isinstance(self.url, Unset):
+            url = UNSET
+        else:
+            url = self.url
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "type": type_,
+                "ref": ref,
+            }
+        )
+        if url is not UNSET:
+            field_dict["url"] = url
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = EventProvenanceRefType(d.pop("type"))
+
+        ref = d.pop("ref")
+
+        def _parse_url(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        url = _parse_url(d.pop("url", UNSET))
+
+        event_provenance_ref = cls(
+            type_=type_,
+            ref=ref,
+            url=url,
+        )
+
+        event_provenance_ref.additional_properties = d
+        return event_provenance_ref
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-client/mycelium_backend_client/models/event_provenance_ref_type.py
+++ b/mycelium-client/mycelium_backend_client/models/event_provenance_ref_type.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class EventProvenanceRefType(str, Enum):
+    COMMIT = "commit"
+    ISSUE = "issue"
+    MESSAGE = "message"
+    PAGE = "page"
+    PR = "pr"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/mycelium-client/mycelium_backend_client/models/event_status_update.py
+++ b/mycelium-client/mycelium_backend_client/models/event_status_update.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..models.event_status_update_status import EventStatusUpdateStatus
+
+T = TypeVar("T", bound="EventStatusUpdate")
+
+
+@_attrs_define
+class EventStatusUpdate:
+    """Body for PATCH /rooms/{name}/messages/{id} — transition an event's status.
+
+    Attributes:
+        status (EventStatusUpdateStatus):
+    """
+
+    status: EventStatusUpdateStatus
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        status = self.status.value
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "status": status,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        status = EventStatusUpdateStatus(d.pop("status"))
+
+        event_status_update = cls(
+            status=status,
+        )
+
+        event_status_update.additional_properties = d
+        return event_status_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/mycelium-client/mycelium_backend_client/models/event_status_update_status.py
+++ b/mycelium-client/mycelium_backend_client/models/event_status_update_status.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class EventStatusUpdateStatus(str, Enum):
+    IN_PROGRESS = "in_progress"
+    OPEN = "open"
+    RESOLVED = "resolved"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/mycelium-client/mycelium_backend_client/models/message_create.py
+++ b/mycelium-client/mycelium_backend_client/models/message_create.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.event_metadata import EventMetadata
+
 
 T = TypeVar("T", bound="MessageCreate")
 
@@ -16,18 +20,22 @@ class MessageCreate:
     """
     Attributes:
         sender_handle (str): Sender handle (e.g., 'alpha#a8f3')
-        message_type (str): Type: announce, direct, broadcast, or delegate
+        message_type (str): Type: announce, direct, broadcast, delegate, or event
         content (str):
         recipient_handle (None | str | Unset): Recipient handle for direct messages; omit for broadcast
+        metadata (EventMetadata | None | Unset): Structured event metadata; required when message_type="event"
     """
 
     sender_handle: str
     message_type: str
     content: str
     recipient_handle: None | str | Unset = UNSET
+    metadata: EventMetadata | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.event_metadata import EventMetadata
+
         sender_handle = self.sender_handle
 
         message_type = self.message_type
@@ -40,6 +48,14 @@ class MessageCreate:
         else:
             recipient_handle = self.recipient_handle
 
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, EventMetadata):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -51,11 +67,15 @@ class MessageCreate:
         )
         if recipient_handle is not UNSET:
             field_dict["recipient_handle"] = recipient_handle
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.event_metadata import EventMetadata
+
         d = dict(src_dict)
         sender_handle = d.pop("sender_handle")
 
@@ -72,11 +92,29 @@ class MessageCreate:
 
         recipient_handle = _parse_recipient_handle(d.pop("recipient_handle", UNSET))
 
+        def _parse_metadata(data: object) -> EventMetadata | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = EventMetadata.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(EventMetadata | None | Unset, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
         message_create = cls(
             sender_handle=sender_handle,
             message_type=message_type,
             content=content,
             recipient_handle=recipient_handle,
+            metadata=metadata,
         )
 
         message_create.additional_properties = d

--- a/mycelium-client/mycelium_backend_client/models/message_read.py
+++ b/mycelium-client/mycelium_backend_client/models/message_read.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from uuid import UUID
 
 from attrs import define as _attrs_define
@@ -10,6 +10,10 @@ from attrs import field as _attrs_field
 from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.message_read_metadata_type_0 import MessageReadMetadataType0
+
 
 T = TypeVar("T", bound="MessageRead")
 
@@ -26,6 +30,7 @@ class MessageRead:
         room_name (None | str | Unset):
         coordination_session_id (None | Unset | UUID):
         recipient_handle (None | str | Unset):
+        metadata (MessageReadMetadataType0 | None | Unset):
     """
 
     id: UUID
@@ -36,9 +41,12 @@ class MessageRead:
     room_name: None | str | Unset = UNSET
     coordination_session_id: None | Unset | UUID = UNSET
     recipient_handle: None | str | Unset = UNSET
+    metadata: MessageReadMetadataType0 | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
+        from ..models.message_read_metadata_type_0 import MessageReadMetadataType0
+
         id = str(self.id)
 
         sender_handle = self.sender_handle
@@ -69,6 +77,14 @@ class MessageRead:
         else:
             recipient_handle = self.recipient_handle
 
+        metadata: dict[str, Any] | None | Unset
+        if isinstance(self.metadata, Unset):
+            metadata = UNSET
+        elif isinstance(self.metadata, MessageReadMetadataType0):
+            metadata = self.metadata.to_dict()
+        else:
+            metadata = self.metadata
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -86,11 +102,15 @@ class MessageRead:
             field_dict["coordination_session_id"] = coordination_session_id
         if recipient_handle is not UNSET:
             field_dict["recipient_handle"] = recipient_handle
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
 
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.message_read_metadata_type_0 import MessageReadMetadataType0
+
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
@@ -137,6 +157,23 @@ class MessageRead:
 
         recipient_handle = _parse_recipient_handle(d.pop("recipient_handle", UNSET))
 
+        def _parse_metadata(data: object) -> MessageReadMetadataType0 | None | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, dict):
+                    raise TypeError()
+                metadata_type_0 = MessageReadMetadataType0.from_dict(data)
+
+                return metadata_type_0
+            except (TypeError, ValueError, AttributeError, KeyError):
+                pass
+            return cast(MessageReadMetadataType0 | None | Unset, data)
+
+        metadata = _parse_metadata(d.pop("metadata", UNSET))
+
         message_read = cls(
             id=id,
             sender_handle=sender_handle,
@@ -146,6 +183,7 @@ class MessageRead:
             room_name=room_name,
             coordination_session_id=coordination_session_id,
             recipient_handle=recipient_handle,
+            metadata=metadata,
         )
 
         message_read.additional_properties = d

--- a/mycelium-client/mycelium_backend_client/models/message_read_metadata_type_0.py
+++ b/mycelium-client/mycelium_backend_client/models/message_read_metadata_type_0.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="MessageReadMetadataType0")
+
+
+@_attrs_define
+class MessageReadMetadataType0:
+    """ """
+
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        message_read_metadata_type_0 = cls()
+
+        message_read_metadata_type_0.additional_properties = d
+        return message_read_metadata_type_0
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi.json
+++ b/openapi.json
@@ -392,7 +392,7 @@
                     "messages"
                 ],
                 "summary": "List Messages",
-                "description": "List messages in a room (or coordination session), newest first.",
+                "description": "List messages in a room (or coordination session), newest first.\n\n``kind``/``status``/``since`` make the source-activity feed and the\naction/concern ledger server-side filters over the room (#392). Expired\nevents (past their ``ttl_seconds``) are excluded even if the sweep\nhasn't collected them yet.",
                 "operationId": "list_messages_api_rooms__room_name__messages_get",
                 "parameters": [
                     {
@@ -456,6 +456,61 @@
                             ],
                             "title": "Message Type"
                         }
+                    },
+                    {
+                        "name": "kind",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter events by metadata.kind",
+                            "title": "Kind"
+                        },
+                        "description": "Filter events by metadata.kind"
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Filter events by ledger status",
+                            "title": "Status"
+                        },
+                        "description": "Filter events by ledger status"
+                    },
+                    {
+                        "name": "since",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "format": "date-time"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "Only messages created at/after this time",
+                            "title": "Since"
+                        },
+                        "description": "Only messages created at/after this time"
                     }
                 ],
                 "responses": {
@@ -465,6 +520,69 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/MessageListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/HTTPValidationError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rooms/{room_name}/messages/{message_id}": {
+            "patch": {
+                "tags": [
+                    "messages"
+                ],
+                "summary": "Update Event Status",
+                "description": "Transition a stateful event's status (open -> in_progress -> resolved).\n\nDesign choice (#392 left it open): the status lives on the original event\nrow and is updated in place, rather than appending follow-up events \u2014\nthe current status must be cheaply queryable, and a follow-up-event model\nforces a latest-per-correlation aggregation on every ledger query. The\ntransition is broadcast over SSE so subscribers see the change live.",
+                "operationId": "update_event_status_api_rooms__room_name__messages__message_id__patch",
+                "parameters": [
+                    {
+                        "name": "room_name",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "title": "Room Name"
+                        }
+                    },
+                    {
+                        "name": "message_id",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "title": "Message Id"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EventStatusUpdate"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageRead"
                                 }
                             }
                         }
@@ -3117,6 +3235,135 @@
                 ],
                 "title": "CoordinationSessionRead"
             },
+            "EventMetadata": {
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "minLength": 1,
+                        "title": "Kind",
+                        "description": "Event kind (open vocabulary)"
+                    },
+                    "ttl_seconds": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "exclusiveMinimum": 0.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Ttl Seconds",
+                        "description": "Retention cap for transient kinds; absent = durable"
+                    },
+                    "status": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "open",
+                                    "in_progress",
+                                    "resolved"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Status",
+                        "description": "Ledger status for stateful kinds; null for stateless"
+                    },
+                    "payload": {
+                        "additionalProperties": true,
+                        "type": "object",
+                        "title": "Payload",
+                        "description": "Kind-specific structured data"
+                    },
+                    "provenance": {
+                        "items": {
+                            "$ref": "#/components/schemas/EventProvenanceRef"
+                        },
+                        "type": "array",
+                        "title": "Provenance"
+                    },
+                    "correlation_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Correlation Id",
+                        "description": "Groups related events / links updates to their origin"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "kind"
+                ],
+                "title": "EventMetadata",
+                "description": "Structured metadata for ``message_type=\"event\"``.\n\nRetention (``ttl_seconds``) and statefulness (``status``) are independent\nattributes, not distinct message types \u2014 one primitive covers a transient\nsource-activity feed and a durable status-bearing ledger."
+            },
+            "EventProvenanceRef": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "pr",
+                            "commit",
+                            "issue",
+                            "page",
+                            "message"
+                        ],
+                        "title": "Type"
+                    },
+                    "ref": {
+                        "type": "string",
+                        "minLength": 1,
+                        "title": "Ref",
+                        "description": "e.g. 'org/repo#48' or a message id"
+                    },
+                    "url": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Url"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "type",
+                    "ref"
+                ],
+                "title": "EventProvenanceRef",
+                "description": "A cited reference backing an event."
+            },
+            "EventStatusUpdate": {
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "open",
+                            "in_progress",
+                            "resolved"
+                        ],
+                        "title": "Status"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "status"
+                ],
+                "title": "EventStatusUpdate",
+                "description": "Body for PATCH /rooms/{name}/messages/{id} \u2014 transition an event's status."
+            },
             "GraphPathsRequest": {
                 "properties": {
                     "source_id": {
@@ -3814,14 +4061,25 @@
                     },
                     "message_type": {
                         "type": "string",
-                        "pattern": "^(announce|direct|broadcast|delegate)$",
+                        "pattern": "^(announce|direct|broadcast|delegate|event)$",
                         "title": "Message Type",
-                        "description": "Type: announce, direct, broadcast, or delegate"
+                        "description": "Type: announce, direct, broadcast, delegate, or event"
                     },
                     "content": {
                         "type": "string",
                         "minLength": 1,
                         "title": "Content"
+                    },
+                    "metadata": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/EventMetadata"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "description": "Structured event metadata; required when message_type=\"event\""
                     }
                 },
                 "type": "object",
@@ -3905,6 +4163,18 @@
                     "content": {
                         "type": "string",
                         "title": "Content"
+                    },
+                    "metadata": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Metadata"
                     },
                     "created_at": {
                         "type": "string",


### PR DESCRIPTION
Closes #392.

One structured message type — `event` — discriminated by `metadata.kind`, with retention (`ttl_seconds`) and statefulness (`status`) as message **attributes**, per the issue's one-primitive design. Kinds in scope: `source_event` (transient, stateless), `action` / `concern` (durable, `open → in_progress → resolved`). Unknown kinds are accepted with sane defaults, so future uses need no schema change.

## Implementation notes

- **Storage**: `messages` gains `metadata` (JSONB, returned intact) plus `event_kind`/`event_status`/`event_expires_at` **promoted at write time** — feed/ledger filters and the TTL sweep hit plain indexed columns instead of JSON path expressions (which differ between AgensGraph and the SQLite test backend). Migration `0018` adds the two composite indexes from the issue. All columns NULL for non-event types; existing rows/writers untouched.
- **Status transitions** — the issue left the design open (follow-up event vs PATCH). Went with **in-place `PATCH /rooms/{name}/messages/{id}`** `{"status": "resolved"}`: the current status must be cheaply queryable, and a follow-up-event model forces a latest-per-correlation aggregation on every ledger query. The transition is broadcast over the room SSE stream (payload carries `status_transition`). 409 for stateless kinds / non-events, 404 across rooms.
- **TTL**: `event_expires_at` precomputed at write; a lifespan-managed sweep (5 min) reclaims expired rows, and GET independently excludes expired-but-unswept events so sweep latency is invisible to readers. No TTL = durable, never swept.
- **SSE**: NOTIFY payloads include `metadata` for events; `room-sse.ts` is a transparent pump so subscribers get event frames as-is and filter/render by kind or ignore. Existing message types unchanged.
- **Knowledge ingest**: events are excluded from CFN fan-in — they're machine feed, not agent speech.
- **Docs**: "Typed events" section in the Rooms concept doc (kind vocabulary + ttl/status/provenance contract); site regenerated. `openapi.json` snapshot and vendored typed clients regenerated (CI staleness check will pass).

## Acceptance criteria

- [x] `POST /rooms/{name}/messages` accepts `message_type: "event"` with `metadata.kind`
- [x] `ttl_seconds` respected (sweep + read-time exclusion); no-TTL kinds durable
- [x] `GET` supports `?kind=`, `?status=`, `?since=`
- [x] `action`/`concern` carry transitionable, queryable status
- [x] `provenance` accepted and returned intact
- [x] `room-sse.ts` emits event frames; existing types unchanged
- [x] Docs: kind vocabulary + ttl/status/provenance contract

## Testing

16 new tests (validation incl. source_event-rejects-status and metadata-only-on-event, kind defaults, ttl expiry column, filters, expired-hidden-from-GET, transitions with 409/404 paths, sweep deletes-only-expired). Backend suite 293 passed, CLI 404 passed, ruff + ty clean on both.