### PR TITLE
fix(session): scope await missed-tick scan to the handle's session (#405)

### DIFF
--- a/fastapi-backend/app/routes/coordination_sessions.py
+++ b/fastapi-backend/app/routes/coordination_sessions.py
@@ -25,7 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.bus import room_channel
 from app.config import settings
 from app.database import async_session_maker, get_async_session
-from app.models import CoordinationSession, Message
+from app.models import CoordinationSession, Message, Participant
 from app.routes.stream import _close_listen_conn, _open_listen_conn, _stream_with_disconnect_watcher
 from app.schemas import (
     CoordinationSessionRead,
@@ -50,13 +50,20 @@ async def list_coordination_sessions(
         None,
         description="Comma-separated state filter (e.g. 'waiting,negotiating')",
     ),
+    participant: str | None = Query(
+        None,
+        description="Only sessions this agent handle actually joined (via the "
+        "participants table). Used by `session await` to scope to the caller's "
+        "own session rather than guessing the newest one in the room.",
+    ),
     limit: int = Query(200, le=1000),
 ):
     """List coordination sessions, newest first.
 
-    Supports two filters used by the OpenClaw channel plugin's polling loop
-    (``state=waiting,negotiating``) and the frontend sessions rail
-    (``parent_room=<name>``).
+    Supports the OpenClaw channel plugin's polling loop
+    (``state=waiting,negotiating``), the frontend sessions rail
+    (``parent_room=<name>``), and the CLI's missed-tick scope
+    (``participant=<handle>``).
     """
     query = select(CoordinationSession).order_by(CoordinationSession.created_at.desc())
 
@@ -66,6 +73,14 @@ async def list_coordination_sessions(
         wanted = [s.strip() for s in state.split(",") if s.strip()]
         if wanted:
             query = query.where(CoordinationSession.state.in_(wanted))
+    if participant:
+        query = query.where(
+            CoordinationSession.id.in_(
+                select(Participant.coordination_session_id).where(
+                    Participant.agent_handle == participant
+                )
+            )
+        )
 
     result = await db.execute(query.limit(limit))
     return [CoordinationSessionRead.model_validate(s) for s in result.scalars().all()]

--- a/fastapi-backend/tests/test_coordination_sessions.py
+++ b/fastapi-backend/tests/test_coordination_sessions.py
@@ -113,3 +113,29 @@ async def test_sessions_are_a_subset_of_a_room(client):
     # display_name preserves the parent → session relationship for legacy URLs.
     assert alpha_only[0]["display_name"].startswith("alpha:session:")
     assert beta_only[0]["display_name"].startswith("beta:session:")
+
+
+@pytest.mark.asyncio
+async def test_participant_filter_scopes_to_joined_sessions(client):
+    """?participant=<handle> returns only sessions that handle actually joined
+    (via the participants table) — the scope `session await` uses so an older
+    or other-agent session can't shadow the caller's own (issue #405)."""
+    await client.post("/api/rooms", json={"name": "ra"})
+    await client.post("/api/rooms", json={"name": "rb"})
+    # alice joins ra; bob joins rb. alice is never a participant of rb's session.
+    joined = await client.post("/api/rooms/ra/sessions", json={"agent_handle": "alice"})
+    assert joined.status_code == 201
+    await client.post("/api/rooms/rb/sessions", json={"agent_handle": "bob"})
+
+    alice_rooms = {
+        s["parent_room_name"]
+        for s in (await client.get("/api/coordination-sessions?participant=alice")).json()
+    }
+    assert "ra" in alice_rooms
+    assert "rb" not in alice_rooms
+
+    # Scoped like the CLI does: rb + alice → empty (alice didn't join rb).
+    scoped = (
+        await client.get("/api/coordination-sessions?parent_room=rb&participant=alice")
+    ).json()
+    assert scoped == []

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -312,17 +312,28 @@ def await_tick(
         if resolved_room:
             with httpx.Client(timeout=10) as http:
                 try:
-                    # Ticks are posted to coordination sessions (legacy display
-                    # name: ``{room}:session:{short}``). Pull the active sessions
-                    # from the first-class endpoint instead of scanning rooms.
-                    rooms_to_scan = [resolved_room]
+                    # Scope the missed-tick scan to the session THIS handle is
+                    # in — the most recent session in the room. The endpoint
+                    # returns sessions newest-first and there is at most one
+                    # non-terminal session per room, so the session ``join``
+                    # placed the handle in is the newest. Scanning older,
+                    # already-concluded sessions would replay their stale
+                    # ``coordination_consensus`` over the current session's live
+                    # ticks — the consensus branch below returns on the first
+                    # consensus it sees, unscoped (issue #405).
+                    rooms_to_scan: list[str] = []
                     coord_resp = http.get(
                         f"{config.server.api_url}/api/coordination-sessions",
-                        params={"parent_room": resolved_room, "limit": 200},
+                        params={"parent_room": resolved_room, "limit": 1},
                     )
                     if coord_resp.status_code == 200:
-                        for c in coord_resp.json():
-                            rooms_to_scan.append(c["display_name"])
+                        sessions = coord_resp.json()
+                        if sessions:
+                            rooms_to_scan.append(sessions[0]["display_name"])
+                    # Inline / non-CFN mode has no coordination-session row and
+                    # posts ticks to the room itself — fall back to the room.
+                    if not rooms_to_scan:
+                        rooms_to_scan = [resolved_room]
 
                     for scan_room in rooms_to_scan:
                         resp = http.get(

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -312,20 +312,23 @@ def await_tick(
         if resolved_room:
             with httpx.Client(timeout=10) as http:
                 try:
-                    # Scope the missed-tick scan to the session THIS handle is
-                    # in: the most recent session in the room (the endpoint
-                    # returns newest-first, and there is at most one non-terminal
-                    # session per room, so ``join`` placed the handle in the
-                    # newest). Ticks and consensus are session-scoped; consensus
-                    # is *also* mirrored to the parent room for the chat log, so
-                    # scanning the parent room — or any older session — would
-                    # replay a stale consensus over the current session's live
-                    # ticks (issue #405). No session yet → nothing has been
-                    # ticked, so skip straight to the SSE stream below.
+                    # Scope the missed-tick scan to the session THIS handle
+                    # actually joined — filter by ``participant`` (the backend
+                    # knows from the participants table) and take the newest.
+                    # Ticks and consensus are session-scoped; consensus is *also*
+                    # mirrored to the parent room for the chat log, so scanning
+                    # the parent room, an older session, or another agent's
+                    # session would replay a stale consensus over this handle's
+                    # live ticks (issue #405). No joined session yet → nothing
+                    # has been ticked, so skip straight to the SSE stream below.
                     rooms_to_scan: list[str] = []
                     coord_resp = http.get(
                         f"{config.server.api_url}/api/coordination-sessions",
-                        params={"parent_room": resolved_room, "limit": 1},
+                        params={
+                            "parent_room": resolved_room,
+                            "participant": handle,
+                            "limit": 1,
+                        },
                     )
                     if coord_resp.status_code == 200:
                         sessions = coord_resp.json()

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -313,14 +313,15 @@ def await_tick(
             with httpx.Client(timeout=10) as http:
                 try:
                     # Scope the missed-tick scan to the session THIS handle is
-                    # in — the most recent session in the room. The endpoint
-                    # returns sessions newest-first and there is at most one
-                    # non-terminal session per room, so the session ``join``
-                    # placed the handle in is the newest. Scanning older,
-                    # already-concluded sessions would replay their stale
-                    # ``coordination_consensus`` over the current session's live
-                    # ticks — the consensus branch below returns on the first
-                    # consensus it sees, unscoped (issue #405).
+                    # in: the most recent session in the room (the endpoint
+                    # returns newest-first, and there is at most one non-terminal
+                    # session per room, so ``join`` placed the handle in the
+                    # newest). Ticks and consensus are session-scoped; consensus
+                    # is *also* mirrored to the parent room for the chat log, so
+                    # scanning the parent room — or any older session — would
+                    # replay a stale consensus over the current session's live
+                    # ticks (issue #405). No session yet → nothing has been
+                    # ticked, so skip straight to the SSE stream below.
                     rooms_to_scan: list[str] = []
                     coord_resp = http.get(
                         f"{config.server.api_url}/api/coordination-sessions",
@@ -330,10 +331,6 @@ def await_tick(
                         sessions = coord_resp.json()
                         if sessions:
                             rooms_to_scan.append(sessions[0]["display_name"])
-                    # Inline / non-CFN mode has no coordination-session row and
-                    # posts ticks to the room itself — fall back to the room.
-                    if not rooms_to_scan:
-                        rooms_to_scan = [resolved_room]
 
                     for scan_room in rooms_to_scan:
                         resp = http.get(

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -122,8 +122,8 @@ class ProposeReply(BaseModel):
 class RespondReply(BaseModel):
     """Agent → Server reply to a 'respond' coordination tick.
 
-    CFN mode: action is "accept" or "reject".
-    Inline NegMAS mode: "end" is also accepted (mapped to "reject" by backend).
+    Valid actions: "accept", "reject", "counter_offer". "end" is accepted as an
+    alias for "reject" (mapped by the backend).
 
     Epistemic fields (confidence, supporting/against_evidence, addresses,
     revision_cause, deferred_to, reasoning) are optional; ``offer`` is only

--- a/mycelium-cli/tests/test_session_await.py
+++ b/mycelium-cli/tests/test_session_await.py
@@ -140,15 +140,18 @@ def test_await_returns_live_tick_for_this_handle(monkeypatch):
     assert out.get("action") == "respond"
 
 
-def test_await_falls_back_to_room_when_no_sessions(monkeypatch):
-    """Inline / non-CFN mode (no session rows) still scans the room itself."""
+def test_await_no_sessions_skips_prescan_and_streams(monkeypatch):
+    """No coordination session yet → nothing has been ticked, so the pre-check
+    scans no room's message history and goes straight to the SSE stream. (It
+    must NOT scan the parent room, where a prior session's consensus is
+    mirrored — that would re-introduce #405.)"""
     requested: list[str] = []
-    messages = {"R": [_tick_msg("R", "julia-agent")]}
-    _patch(monkeypatch, requested, [], messages)
+    _patch(monkeypatch, requested, [], {})
 
     result = CliRunner().invoke(
         session_cmd.app, ["await", "-H", "julia-agent", "-r", "R", "-t", "1"]
     )
 
     assert result.exit_code == 0, result.output
-    assert any(u.endswith("/api/rooms/R/messages") for u in requested)
+    assert not any("/messages" in u for u in requested)  # no message-history scan
+    assert any("/api/agents/julia-agent/stream" in u for u in requested)  # went to SSE

--- a/mycelium-cli/tests/test_session_await.py
+++ b/mycelium-cli/tests/test_session_await.py
@@ -46,10 +46,13 @@ class _EmptyStream:
 class _FakeClient:
     """Fake httpx.Client that records requested URLs and serves canned data."""
 
-    def __init__(self, requested: list[str], sessions: list[dict], messages: dict) -> None:
+    def __init__(
+        self, requested: list[str], sessions: list[dict], messages: dict, captured: dict
+    ) -> None:
         self._requested = requested
         self._sessions = sessions
         self._messages = messages
+        self._captured = captured
 
     def __enter__(self) -> _FakeClient:
         return self
@@ -60,6 +63,7 @@ class _FakeClient:
     def get(self, url: str, params=None):
         self._requested.append(url)
         if url.endswith("/coordination-sessions"):
+            self._captured["sessions_params"] = params or {}
             # Honor the newest-first + limit contract the endpoint provides.
             limit = (params or {}).get("limit", 200)
             return _Resp(200, self._sessions[:limit])
@@ -71,13 +75,16 @@ class _FakeClient:
         return _EmptyStream()
 
 
-def _patch(monkeypatch, requested, sessions, messages):
+def _patch(monkeypatch, requested, sessions, messages) -> dict:
+    """Patch config/room/httpx. Returns a dict that captures request params."""
+    captured: dict = {}
     cfg = SimpleNamespace(server=SimpleNamespace(api_url="http://localhost:8000"))
     monkeypatch.setattr(session_cmd.MyceliumConfig, "load", classmethod(lambda _c: cfg))
     monkeypatch.setattr(session_cmd, "_resolve_room", lambda _c, _r: "R")
     monkeypatch.setattr(
-        httpx, "Client", lambda *_a, **_k: _FakeClient(requested, sessions, messages)
+        httpx, "Client", lambda *_a, **_k: _FakeClient(requested, sessions, messages, captured)
     )
+    return captured
 
 
 def _tick_msg(room: str, participant: str) -> dict:
@@ -111,7 +118,7 @@ def test_await_ignores_stale_consensus_from_older_session(monkeypatch):
         "R:session:new": [_tick_msg("R:session:new", "other-agent")],  # not our handle
         "R:session:old": [_consensus_msg()],
     }
-    _patch(monkeypatch, requested, sessions, messages)
+    captured = _patch(monkeypatch, requested, sessions, messages)
 
     result = CliRunner().invoke(
         session_cmd.app, ["await", "-H", "julia-agent", "-r", "R", "-t", "1"]
@@ -121,6 +128,8 @@ def test_await_ignores_stale_consensus_from_older_session(monkeypatch):
     assert "stale plan" not in result.output
     # The old, completed session must never have been scanned.
     assert not any("R:session:old" in u for u in requested)
+    # The scope was the handle's own sessions, not "newest in the room".
+    assert captured["sessions_params"].get("participant") == "julia-agent"
 
 
 def test_await_returns_live_tick_for_this_handle(monkeypatch):

--- a/mycelium-cli/tests/test_session_await.py
+++ b/mycelium-cli/tests/test_session_await.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Regression tests for `mycelium session await`'s missed-tick pre-check.
+
+Issue #405: the pre-check scanned every session under the room and returned on
+the first `coordination_consensus` it found (unscoped), so an older completed
+session's consensus permanently shadowed the current session's live ticks. The
+scan must be scoped to the handle's session — the newest one in the room.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import httpx
+from typer.testing import CliRunner
+
+from mycelium.commands import session as session_cmd
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class _EmptyStream:
+    def __enter__(self) -> _EmptyStream:
+        return self
+
+    def __exit__(self, *_a) -> bool:
+        return False
+
+    def iter_lines(self):
+        return iter(())  # no live events → await falls through and returns
+
+
+class _FakeClient:
+    """Fake httpx.Client that records requested URLs and serves canned data."""
+
+    def __init__(self, requested: list[str], sessions: list[dict], messages: dict) -> None:
+        self._requested = requested
+        self._sessions = sessions
+        self._messages = messages
+
+    def __enter__(self) -> _FakeClient:
+        return self
+
+    def __exit__(self, *_a) -> bool:
+        return False
+
+    def get(self, url: str, params=None):
+        self._requested.append(url)
+        if url.endswith("/coordination-sessions"):
+            # Honor the newest-first + limit contract the endpoint provides.
+            limit = (params or {}).get("limit", 200)
+            return _Resp(200, self._sessions[:limit])
+        room = url.split("/api/rooms/", 1)[1].rsplit("/messages", 1)[0]
+        return _Resp(200, {"messages": self._messages.get(room, [])})
+
+    def stream(self, _method: str, url: str, **_kw):
+        self._requested.append(url)
+        return _EmptyStream()
+
+
+def _patch(monkeypatch, requested, sessions, messages):
+    cfg = SimpleNamespace(server=SimpleNamespace(api_url="http://localhost:8000"))
+    monkeypatch.setattr(session_cmd.MyceliumConfig, "load", classmethod(lambda _c: cfg))
+    monkeypatch.setattr(session_cmd, "_resolve_room", lambda _c, _r: "R")
+    monkeypatch.setattr(
+        httpx, "Client", lambda *_a, **_k: _FakeClient(requested, sessions, messages)
+    )
+
+
+def _tick_msg(room: str, participant: str) -> dict:
+    return {
+        "message_type": "coordination_tick",
+        "room_name": room,
+        "content": json.dumps(
+            {"kind": "negotiate", "payload": {"action": "respond", "participant_id": participant}}
+        ),
+    }
+
+
+def _consensus_msg() -> dict:
+    return {
+        "message_type": "coordination_consensus",
+        "room_name": "R:session:old",
+        "content": json.dumps({"plan": "stale plan from a previous negotiation", "broken": False}),
+    }
+
+
+def test_await_ignores_stale_consensus_from_older_session(monkeypatch):
+    """The bug (#405): newest session is live but its latest tick is for another
+    agent, and an older session has a consensus. The pre-check must NOT return
+    that stale consensus, and must never even scan the old session."""
+    requested: list[str] = []
+    sessions = [
+        {"display_name": "R:session:new", "state": "negotiating"},  # newest first
+        {"display_name": "R:session:old", "state": "complete"},
+    ]
+    messages = {
+        "R:session:new": [_tick_msg("R:session:new", "other-agent")],  # not our handle
+        "R:session:old": [_consensus_msg()],
+    }
+    _patch(monkeypatch, requested, sessions, messages)
+
+    result = CliRunner().invoke(
+        session_cmd.app, ["await", "-H", "julia-agent", "-r", "R", "-t", "1"]
+    )
+
+    # No stale consensus replayed (falls through to the live SSE stream instead).
+    assert "stale plan" not in result.output
+    # The old, completed session must never have been scanned.
+    assert not any("R:session:old" in u for u in requested)
+
+
+def test_await_returns_live_tick_for_this_handle(monkeypatch):
+    """A missed tick addressed to this handle in the current session is replayed."""
+    requested: list[str] = []
+    sessions = [{"display_name": "R:session:new", "state": "negotiating"}]
+    messages = {"R:session:new": [_tick_msg("R:session:new", "julia-agent")]}
+    _patch(monkeypatch, requested, sessions, messages)
+
+    result = CliRunner().invoke(
+        session_cmd.app, ["await", "-H", "julia-agent", "-r", "R", "-t", "1"]
+    )
+
+    assert result.exit_code == 0, result.output
+    out = json.loads(result.output.strip().splitlines()[-1])
+    assert out.get("replayed") is True
+    assert out.get("action") == "respond"
+
+
+def test_await_falls_back_to_room_when_no_sessions(monkeypatch):
+    """Inline / non-CFN mode (no session rows) still scans the room itself."""
+    requested: list[str] = []
+    messages = {"R": [_tick_msg("R", "julia-agent")]}
+    _patch(monkeypatch, requested, [], messages)
+
+    result = CliRunner().invoke(
+        session_cmd.app, ["await", "-H", "julia-agent", "-r", "R", "-t", "1"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert any(u.endswith("/api/rooms/R/messages") for u in requested)


### PR DESCRIPTION
Fixes #405.

## Root cause

`await_tick`'s missed-tick pre-check (`session.py`) built `rooms_to_scan = [parent_room, *every session under the room]` and the inner `coordination_consensus` branch `return`ed on the **first consensus in any scanned room, with no session- or handle-scoping** (the tick branch *is* handle-filtered; the consensus branch isn't). So once any session reached `complete`, its consensus permanently shadowed later sessions' live ticks.

Two verified leak vectors:

- **The parent room carries the consensus.** `_finish_cfn` posts the consensus session-scoped *and* mirrors it to the parent room for the chat channel. The parent room is scanned first, so an older session's mirrored consensus is returned before the current session is looked at.
- **Older sessions leak too.** Newest-first ordering doesn't save it: each round the CE addresses one agent, so the current session's latest tick is often for the *other* handle, fails the tick branch's handle filter, and the loop falls through to the older session's unconditional consensus branch.

## Fix

Scope the pre-check to the session **the handle actually joined** — filtered, not guessed.

The backend already records participation (the `participants` table, written by `join_room`), so this adds a `participant` filter to `GET /api/coordination-sessions` and has `session await` query `?parent_room=<room>&participant=<handle>&limit=1`. That deterministically returns the caller's own most-recent session; ticks/consensus are session-scoped, so scanning only that session's messages is complete (catches a missed tick for the handle, or its own session's consensus if it concluded between join and await). It **drops the parent-room scan entirely** — the parent room only ever holds the mirrored consensus, never ticks.

(An earlier revision of this branch scoped to "the newest session in the room." That was a heuristic, not a filter — it leaned on the one-active-session-per-room invariant and could point at a session the handle never joined once a room has multiple agents opening different sessions. Replaced with the participant filter above.)

## Tests

- Backend: `?participant=<handle>` returns only sessions the handle joined (cross-room discriminating case).
- CLI: `tests/test_session_await.py` reproduces the exact `"replayed": true` stale-consensus symptom (verified it **fails pre-fix**), asserts await sends `participant=<handle>`, never scans the old session, and that no joined-session → straight-to-SSE. Full gates green (backend 347, CLI 442, ruff/ty clean).

## Known limitation (pre-existing, not addressed here)

The pre-check has no notion of *which tick the handle has already consumed* — it returns the newest matching tick in the session. So if the agent responds to round N and calls `await` again before round N+1 fires, the pre-check can replay round N's (already-handled) tick. This fix removes the cross-session/other-agent shadowing but not that within-session replay window. A proper follow-up would give `await` a watermark — e.g. pass `since=<handle's last reply time>` (the messages endpoint already supports `since`) or a client-side cursor across `await` invocations — so it only returns ticks newer than the handle's last action. Happy to do that as a separate PR.

## Cleanup

Removed a stale `protocol.py` docstring referencing the long-removed "inline NegMAS mode" — the phantom-mode drift that seeded the bad first-draft comment in this fix.
