### PR TITLE
fix(metrics): capture CFN knowledge-query cost and fix dead pipeline breakdown

### DIFF
--- a/fastapi-backend/app/services/cfn_knowledge.py
+++ b/fastapi-backend/app/services/cfn_knowledge.py
@@ -46,7 +46,7 @@ import httpx
 import tiktoken
 
 from app.config import settings
-from app.services.metrics import record_cfn_call, record_knowledge_query
+from app.services.metrics import record_cfn_call, record_cfn_llm_usage, record_knowledge_query
 
 logger = logging.getLogger(__name__)
 
@@ -135,8 +135,15 @@ async def query_shared_memories(
     """POST to CFN's ``shared-memories/query`` endpoint.
 
     Returns CFN's query response dict: ``{"response_id": str, "message": str,
-    ...}``. Note that ``message`` is a natural-language answer synthesized by
-    CFN's evidence agent, NOT a structured list of records.
+    "meta": {...}, ...}``. Note that ``message`` is a natural-language answer
+    synthesized by CFN's evidence agent, NOT a structured list of records.
+
+    Unlike ``create_or_update_shared_memories`` (fire-and-forget, no usage data
+    ever returned), this call is synchronous and its response schema declares
+    an optional ``meta`` field ("LLM token usage and performance metrics...
+    present when LLM calls are made") — the evidence agent's own LLM call.
+    Recorded under operation ``knowledge_query`` alongside negotiation's
+    ``cfn_llm`` counters so the CLI's cost report stops missing it.
     """
     body: dict[str, Any] = {
         "header": {"agent_id": agent_id} if agent_id else {},
@@ -162,7 +169,40 @@ async def query_shared_memories(
         results_returned=1 if resp.get("message") else 0,
         duration_ms=(time.monotonic() - t0) * 1000,
     )
+    _record_query_meta_usage(resp.get("meta"))
     return resp
+
+
+def _record_query_meta_usage(meta: dict[str, Any] | None) -> None:
+    """Record token usage from a knowledge-query response's ``meta`` dict.
+
+    Untyped (plain dict, not the generated client's model) — this module
+    stays on raw httpx by design (see module docstring), so extraction mirrors
+    ``cfn_negotiation.py:_record_meta_usage`` but reads dict keys directly.
+    """
+    if not isinstance(meta, dict):
+        return
+    tokens = meta.get("tokens") or {}
+    prompt = int(tokens.get("prompt") or 0)
+    completion = int(tokens.get("completion") or 0)
+    total = int(tokens.get("total") or 0)
+    if not (prompt or completion or total):
+        return
+    record_cfn_llm_usage(
+        operation="knowledge_query",
+        prompt_tokens=prompt,
+        completion_tokens=completion,
+        total_tokens=total,
+        llm_calls=1,
+        latency_ms=float(meta.get("latency_ms") or 0.0),
+        by_operation={
+            "knowledge_query": {
+                "calls": 1,
+                "prompt_tokens": prompt,
+                "completion_tokens": completion,
+            }
+        },
+    )
 
 
 # ── Raw HTTP helpers ─────────────────────────────────────────────────────────

--- a/fastapi-backend/app/services/cfn_knowledge.py
+++ b/fastapi-backend/app/services/cfn_knowledge.py
@@ -46,7 +46,12 @@ import httpx
 import tiktoken
 
 from app.config import settings
-from app.services.metrics import record_cfn_call, record_cfn_llm_usage, record_knowledge_query
+from app.services.metrics import (
+    record_cfn_call,
+    record_cfn_llm_usage,
+    record_knowledge_query,
+    resolve_room_for_mas,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -169,16 +174,22 @@ async def query_shared_memories(
         results_returned=1 if resp.get("message") else 0,
         duration_ms=(time.monotonic() - t0) * 1000,
     )
-    _record_query_meta_usage(resp.get("meta"))
+    _record_query_meta_usage(resp.get("meta"), mas_id=mas_id)
     return resp
 
 
-def _record_query_meta_usage(meta: dict[str, Any] | None) -> None:
+def _record_query_meta_usage(meta: dict[str, Any] | None, *, mas_id: str = "") -> None:
     """Record token usage from a knowledge-query response's ``meta`` dict.
 
     Untyped (plain dict, not the generated client's model) — this module
     stays on raw httpx by design (see module docstring), so extraction mirrors
     ``cfn_negotiation.py:_record_meta_usage`` but reads dict keys directly.
+
+    ``query_shared_memories`` is keyed by mas_id, not room name, so the
+    by-room breakdown reuses ``resolve_room_for_mas`` — the same mas_id ->
+    room registry negotiation calls already populate via
+    ``record_room_identity`` — rather than requiring every caller to thread a
+    room name through just for metrics attribution.
     """
     if not isinstance(meta, dict):
         return
@@ -190,6 +201,7 @@ def _record_query_meta_usage(meta: dict[str, Any] | None) -> None:
         return
     record_cfn_llm_usage(
         operation="knowledge_query",
+        room=resolve_room_for_mas(mas_id) or "",
         prompt_tokens=prompt,
         completion_tokens=completion,
         total_tokens=total,

--- a/fastapi-backend/app/services/cfn_negotiation.py
+++ b/fastapi-backend/app/services/cfn_negotiation.py
@@ -153,9 +153,15 @@ def _record_meta_usage(meta: Any, operation: str, *, room: str, mas_id: str) -> 
         completion_tokens=int(completion),
         cached_tokens=0,
         total_tokens=int(total),
-        llm_calls=0,
+        llm_calls=1,
         latency_ms=_num(getattr(meta, "latency_ms", 0.0)),
-        by_operation=None,
+        by_operation={
+            operation: {
+                "calls": 1,
+                "prompt_tokens": int(prompt),
+                "completion_tokens": int(completion),
+            }
+        },
     )
 
 

--- a/fastapi-backend/app/services/metrics.py
+++ b/fastapi-backend/app/services/metrics.py
@@ -476,6 +476,21 @@ def record_room_identity(*, mas_id: str, room_name: str) -> None:
         _room_identities.setdefault(str(mas_id), str(room_name))
 
 
+@_safe
+def resolve_room_for_mas(mas_id: str) -> str:
+    """Look up the room name previously recorded for *mas_id*, or "" if unknown.
+
+    Read-side counterpart to ``record_room_identity``, for call sites that
+    have a mas_id but not the room name in scope (e.g. ``cfn_knowledge.py``'s
+    query path, which is keyed by mas_id, not room). Returns "" rather than
+    raising so callers can pass it straight through to a ``room=`` kwarg.
+    """
+    if not mas_id:
+        return ""
+    with _lock:
+        return _room_identities.get(str(mas_id), "")
+
+
 def snapshot() -> dict:
     """Return a JSON-serializable snapshot of all metrics."""
     with _lock:

--- a/fastapi-backend/app/services/metrics.py
+++ b/fastapi-backend/app/services/metrics.py
@@ -408,11 +408,16 @@ def record_cfn_llm_usage(
     latency_ms: float = 0.0,
     by_operation: dict[str, dict] | None = None,
 ) -> None:
-    """Record LLM token usage returned by CFN in ``_usage`` response fields.
+    """Record LLM token usage returned by CFN in ``meta.tokens`` response fields.
 
-    Captures token counts from the cognition engines (via the litellm callback)
-    for ``start_negotiation`` responses.  The ``decide`` path makes no LLM calls
-    directly (background ingestion is tracked via Prometheus on the CFN node).
+    Captures token counts from the cognition engines for both
+    ``start_negotiation`` (round-1 options generation) and
+    ``decide_negotiation`` responses. The decide path DOES make LLM calls on
+    its terminal step — the semantic-alignment validation evaluator (retry
+    decision) runs its own LLM call via ``get_llm_provider``, whose usage the
+    CE folds into the same ``meta.tokens`` it returns; ordinary continuing
+    rounds make no new LLM call (NegMAS advances deterministically over
+    options already generated at round 1) and correctly report nothing.
 
     Parameter names (``prompt_tokens`` / ``completion_tokens``) match the CFN
     ``_usage`` snapshot produced by litellm, but metric keys are normalised to

--- a/fastapi-backend/tests/test_cfn_knowledge_metrics.py
+++ b/fastapi-backend/tests/test_cfn_knowledge_metrics.py
@@ -14,12 +14,13 @@ from __future__ import annotations
 import pytest
 
 from app.services.cfn_knowledge import _record_query_meta_usage
-from app.services.metrics import _counters, _lock, snapshot
+from app.services.metrics import _counters, _lock, _room_identities, record_room_identity, snapshot
 
 
 def _reset_metrics() -> None:
     with _lock:
         _counters.clear()
+        _room_identities.clear()
 
 
 def test_query_meta_usage_recorded() -> None:
@@ -47,6 +48,33 @@ def test_query_meta_usage_absent_is_a_noop() -> None:
     _record_query_meta_usage({})
     _record_query_meta_usage({"tokens": {"prompt": 0, "completion": 0, "total": 0}})
     assert "cfn_llm" not in snapshot()["counters"]
+
+
+def test_query_meta_usage_resolves_room_via_mas_id() -> None:
+    """When the mas_id -> room mapping was already learned (e.g. via an
+    earlier negotiation call), the knowledge-query breakdown should reuse it
+    rather than requiring every caller to thread a room name through."""
+    _reset_metrics()
+    record_room_identity(mas_id="mas-42", room_name="my-room")
+    _record_query_meta_usage(
+        {"tokens": {"prompt": 100, "completion": 20, "total": 120}},
+        mas_id="mas-42",
+    )
+    cfn_llm = snapshot()["counters"]["cfn_llm"]
+    assert cfn_llm["by_room.my-room.input_tokens"] == 100
+    assert cfn_llm["by_room.my-room.output_tokens"] == 20
+
+
+def test_query_meta_usage_unknown_mas_id_skips_room_breakdown() -> None:
+    """No mapping learned yet — must not raise, and must not fabricate a room."""
+    _reset_metrics()
+    _record_query_meta_usage(
+        {"tokens": {"prompt": 100, "completion": 20, "total": 120}},
+        mas_id="never-seen",
+    )
+    cfn_llm = snapshot()["counters"]["cfn_llm"]
+    assert cfn_llm["input_tokens"] == 100
+    assert not any(k.startswith("by_room.") for k in cfn_llm)
 
 
 @pytest.mark.asyncio

--- a/fastapi-backend/tests/test_cfn_knowledge_metrics.py
+++ b/fastapi-backend/tests/test_cfn_knowledge_metrics.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Tests for CFN knowledge-query cost tracking.
+
+``shared-memories/query``'s response schema declares an optional ``meta``
+field ("LLM token usage... present when LLM calls are made") that was
+previously read nowhere — its evidence-agent LLM cost was invisible to
+``mycelium metrics show cost`` even though the data was on the wire.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.cfn_knowledge import _record_query_meta_usage
+from app.services.metrics import _counters, _lock, snapshot
+
+
+def _reset_metrics() -> None:
+    with _lock:
+        _counters.clear()
+
+
+def test_query_meta_usage_recorded() -> None:
+    _reset_metrics()
+    _record_query_meta_usage(
+        {
+            "tokens": {"prompt": 500, "completion": 120, "total": 620},
+            "latency_ms": 340.0,
+        }
+    )
+    cfn_llm = snapshot()["counters"]["cfn_llm"]
+    assert cfn_llm["input_tokens"] == 500
+    assert cfn_llm["output_tokens"] == 120
+    assert cfn_llm["total_tokens"] == 620
+    assert cfn_llm["calls"] == 1
+    assert cfn_llm["by_pipeline.knowledge_query.input_tokens"] == 500
+    assert cfn_llm["by_pipeline.knowledge_query.output_tokens"] == 120
+
+
+def test_query_meta_usage_absent_is_a_noop() -> None:
+    """CFN's meta is optional (only present when the evidence agent makes an
+    LLM call) — no meta, or an all-zero one, must not fabricate a counter."""
+    _reset_metrics()
+    _record_query_meta_usage(None)
+    _record_query_meta_usage({})
+    _record_query_meta_usage({"tokens": {"prompt": 0, "completion": 0, "total": 0}})
+    assert "cfn_llm" not in snapshot()["counters"]
+
+
+@pytest.mark.asyncio
+async def test_query_shared_memories_records_meta(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The full query_shared_memories call records the response's meta."""
+    from app.services import cfn_knowledge
+
+    _reset_metrics()
+
+    async def _fake_cfn_post(url, body, *, operation):
+        return {
+            "response_id": "r-1",
+            "message": "answer",
+            "meta": {"tokens": {"prompt": 10, "completion": 5, "total": 15}},
+        }
+
+    monkeypatch.setattr(cfn_knowledge, "_cfn_post", _fake_cfn_post)
+
+    await cfn_knowledge.query_shared_memories(
+        workspace_id="ws-1", mas_id="mas-1", intent="what changed?"
+    )
+
+    cfn_llm = snapshot()["counters"]["cfn_llm"]
+    assert cfn_llm["input_tokens"] == 10
+    assert cfn_llm["output_tokens"] == 5

--- a/mycelium-cli/src/mycelium/commands/metrics.py
+++ b/mycelium-cli/src/mycelium/commands/metrics.py
@@ -3606,7 +3606,7 @@ def _render_cost_estimates(
                         f"    [dim]{label}[/dim]",
                         f"[dim]{_fmt_num(p_total)}[/dim]",
                         f"[dim]{_fmt_cost(p_cost)}[/dim]",
-                        "",
+                        "[dim]est. (engine pricing)[/dim]",
                     )
 
         # Per-room breakdown under CFN (#297). Sessions of the same parent

--- a/mycelium-cli/src/mycelium/data/pricing.json
+++ b/mycelium-cli/src/mycelium/data/pricing.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-04T13:36:04.223482+00:00",
-  "litellm_version": "unknown",
+  "generated_at": "2026-07-22T14:22:27.637575+00:00",
+  "source": "litellm_catalog_api",
   "models": [
     {
       "pattern": "claude-sonnet-4",


### PR DESCRIPTION
## Summary

Fixes two confirmed gaps in `mycelium metrics show cost`'s CFN accounting where real LLM cost data was silently dropped, even though it was present on the wire.

- **Knowledge-query cost was never captured.** CFN's `shared-memories/query` response schema declares an optional `meta` field ("LLM token usage... present when LLM calls are made") for the evidence agent's own LLM call, but `query_shared_memories()` never read it. Added `_record_query_meta_usage()` to extract and record it under a new `knowledge_query` operation. (The separate knowledge-*write* path, `create_or_update_shared_memories`, is genuinely fire-and-forget by CFN's own design — 202 ack only, no usage data ever returned — not fixable here without a CFN-side API change.)
- **The CLI's "By pipeline" cost breakdown was permanently empty.** `_record_meta_usage()` passed `by_operation=None` and `llm_calls=0` unconditionally, so `cfn_llm.by_pipeline.*` / `by_llm_operation.*` never populated for `start_negotiation` or `decide_negotiation` either, and `cfn_llm.calls` never incremented — even though the aggregate token/cost totals were correct. Now passes a real `by_operation` dict.
- **Room attribution for knowledge-query costs.** `query_shared_memories` is keyed by `mas_id`, not room name, so the new knowledge-query recording had nowhere to attribute spend in the CLI's "By room" breakdown. Added `resolve_room_for_mas()`, the read-side counterpart to the existing `record_room_identity()` registry that negotiation calls already populate — reused rather than requiring a new call-site room parameter.

## Display impact

Nothing moves to a new top-level row — knowledge-query tokens fold into the existing "CFN Engines" total (same `cfn_llm` counter namespace). What's new: a "By pipeline" sub-section that has never rendered before (it was silently empty due to the `by_operation=None` bug) will now show a labeled row per operation (`Start Negotiation`, `Decide Negotiation`, `Knowledge Query`), and knowledge-query spend will show up under "By room" once that mas_id's room has been learned via any prior negotiation call.

## Testing

- 351 backend tests pass (5 new, covering the knowledge-query capture and room-resolution paths)
- `ruff check`, `ruff format --check`, `ty check` all clean
- Verified independent of `feat/insightclaw-integration` — this is a single clean cherry-pick onto `main`, the only commits on that branch that ever touched these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
