### PR TITLE
feat: enable L9_CFN_ENABLED by default

### DIFF
--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -124,8 +124,8 @@ class Settings(BaseSettings):
 
     # Post L9 knowledge envelopes to the CFN's /api/l9/messages endpoint
     # (knowledge query at session start, knowledge write after consensus).
-    # Requires a knowledge CE registered with the CFN; off until then.
-    L9_CFN_ENABLED: bool = False
+    # Requires a knowledge CE registered with the CFN.
+    L9_CFN_ENABLED: bool = True
 
     # Workspace ID in the CFN mgmt plane (set by mycelium install)
     WORKSPACE_ID: str = ""

--- a/mycelium-cli/src/mycelium/docker/compose-dev.yml
+++ b/mycelium-cli/src/mycelium/docker/compose-dev.yml
@@ -41,7 +41,7 @@ services:
     environment:
       CFN_MGMT_URL: http://ioc-cfn-mgmt-plane-svc:9000
       CFN_SVC_URL: http://ioc-cfn-svc:9002
-      L9_CFN_ENABLED: ${L9_CFN_ENABLED:-false}
+      L9_CFN_ENABLED: ${L9_CFN_ENABLED:-true}
       MYCELIUM_STUB_EMBEDDINGS: "1"
 
   mycelium-collector:

--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -68,7 +68,7 @@ services:
       COORDINATION_TICK_TIMEOUT_SECONDS: ${COORDINATION_TICK_TIMEOUT_SECONDS:-30}
       # Post L9 knowledge envelopes to the CFN's /api/l9/messages endpoint.
       # Requires a knowledge CE registered with the CFN; leave off otherwise.
-      L9_CFN_ENABLED: ${L9_CFN_ENABLED:-false}
+      L9_CFN_ENABLED: ${L9_CFN_ENABLED:-true}
       # IN-CONTAINER path the backend writes rooms/memory/plans to. MUST match
       # the bind-mount target below — otherwise writes land in the container's
       # overlay FS and are lost on recreate. (The host-side MYCELIUM_DATA_DIR


### PR DESCRIPTION
## Summary
- Flip `L9_CFN_ENABLED` default from `false` to `true` in `config.py`, `compose.yml`, and `compose-dev.yml`.

## Test plan
- [ ] Confirm knowledge CE is registered with CFN before merging to prod
- [ ] Verify L9 knowledge envelope posting works end-to-end with default config