### PR TITLE
Step 2: SLIM node + hello-world over a group

### DIFF
--- a/fastapi-backend/app/services/slim_client.py
+++ b/fastapi-backend/app/services/slim_client.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Thin async wrapper around ``slim-bindings`` for mycelium's SLIM fabric.
+
+**Step 2 scope only.** This module provides two things:
+
+1. **Naming / identity** — map a mycelium ``workspace/room/agent`` triple to a
+   SLIM :class:`Name` (``org/namespace/app``, with org = workspace/tenant,
+   namespace = room, app = agent id) and back, plus a dev shared-secret minter.
+2. **A small client** (:class:`SlimClient`) that stands up a SLIM app, connects
+   to a node, and creates/joins a **group** channel to exchange broadcasts.
+
+It is deliberately **isolated** from the room/coordination flow — nothing here
+is wired into routes or the bus yet. Room-becomes-a-channel and L9-over-SLIM are
+Step 3; the durable inbox/persister is Step 4. Keeping this standalone is what
+lets Step 1's green stay green.
+
+The ``slim_bindings`` import is **lazy** (native Rust wheel, availability is
+per-platform): modules that never touch SLIM import cleanly even where no wheel
+exists, and a missing wheel degrades to a clear :class:`SlimUnavailableError`
+rather than an import-time crash across every backend module.
+
+Ground truth for the binding API is the cloned examples under
+``~/Documents/GitHub/_slim-research/slim-bindings/python/examples/`` (``group.py``
++ ``common.py``); this wrapper follows their lifecycle.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import hmac
+from dataclasses import dataclass
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import slim_bindings
+
+# The node's default listen address (matches ghcr.io/agntcy/slim's default port).
+DEFAULT_NODE_ENDPOINT = "http://127.0.0.1:46357"
+
+# Minimum shared-secret length required by SLIM's dev auth (also seeds MLS).
+MIN_SECRET_LEN = 32
+
+# Default third segment for a room's group-channel Name when no explicit topic
+# is given. A channel is a Name whose app segment is the topic (bible §7b); the
+# members' own apps are their agent ids.
+DEFAULT_CHANNEL_TOPIC = "room"
+
+# Dev-only master secret from which per-channel shared secrets are
+# *deterministically* derived, so every agent on a room's channel and the
+# always-on backend independently reconstruct the same credential (which seeds
+# the group key) without a key-exchange round-trip. This is the MVP identity tier
+# per the bible (Step 2 resolve-first: shared secret); JWT/SPIRE is the production
+# path and is out of scope here. Override per deployment via the ``master_secret``
+# argument to :func:`mint_shared_secret`.
+_DEV_MASTER_SECRET = "mycelium-dev-shared-secret-v1-do-not-use-in-prod"
+
+
+class SlimError(RuntimeError):
+    """Base class for SLIM wrapper errors."""
+
+
+class SlimUnavailableError(SlimError):
+    """Raised when ``slim_bindings`` cannot be imported (no native wheel)."""
+
+
+class SlimNameError(SlimError, ValueError):
+    """Raised when a ``workspace/room/agent`` segment is not a valid Name part."""
+
+
+@dataclass(frozen=True)
+class SlimIdentity:
+    """A mycelium coordination identity: ``workspace/room/agent``.
+
+    Maps onto a SLIM :class:`Name` 3-tuple as
+    ``org=workspace, namespace=room, app=agent``.
+    """
+
+    workspace: str
+    room: str
+    agent: str
+
+    def as_tuple(self) -> tuple[str, str, str]:
+        return (self.workspace, self.room, self.agent)
+
+    def as_path(self) -> str:
+        return f"{self.workspace}/{self.room}/{self.agent}"
+
+
+def _require_bindings() -> ModuleType:
+    """Import ``slim_bindings`` lazily, or raise a clear error."""
+    try:
+        import slim_bindings
+    except ImportError as exc:  # pragma: no cover - platform dependent
+        raise SlimUnavailableError(
+            "slim-bindings is not installed for this platform. It ships as a "
+            "native wheel; install it (`uv add slim-bindings`) on a supported "
+            "platform to use the SLIM fabric."
+        ) from exc
+    return slim_bindings
+
+
+def _validate_segment(value: str, *, label: str) -> str:
+    """Reject Name segments that would corrupt the ``org/ns/app`` encoding."""
+    if not value or not value.strip():
+        raise SlimNameError(f"{label} must be non-empty")
+    if "/" in value:
+        raise SlimNameError(f"{label} must not contain '/': {value!r}")
+    return value
+
+
+def to_slim_name(workspace: str, room: str, agent: str) -> slim_bindings.Name:
+    """Map ``workspace/room/agent`` → a SLIM :class:`Name` (``org/ns/app``)."""
+    sb = _require_bindings()
+    _validate_segment(workspace, label="workspace")
+    _validate_segment(room, label="room")
+    _validate_segment(agent, label="agent")
+    return sb.Name(workspace, room, agent)
+
+
+def from_slim_name(name: slim_bindings.Name) -> SlimIdentity:
+    """Recover the ``workspace/room/agent`` identity from a SLIM :class:`Name`."""
+    org, namespace, app = name.components()
+    return SlimIdentity(workspace=org, room=namespace, agent=app)
+
+
+def to_channel_name(
+    workspace: str, room: str, topic: str = DEFAULT_CHANNEL_TOPIC
+) -> slim_bindings.Name:
+    """Map a room to its group-channel :class:`Name` (``workspace/room/topic``).
+
+    The channel is the multicast destination the moderator creates and members
+    are invited into; its third segment is the topic, distinct from each
+    member's own agent id.
+    """
+    sb = _require_bindings()
+    _validate_segment(workspace, label="workspace")
+    _validate_segment(room, label="room")
+    _validate_segment(topic, label="topic")
+    return sb.Name(workspace, room, topic)
+
+
+def mint_shared_secret(identity: SlimIdentity, *, master_secret: str = _DEV_MASTER_SECRET) -> str:
+    """Mint the dev shared secret for a channel (``workspace/room``), ≥32 chars.
+
+    The secret is **shared by every member of a room**: it seeds the group's MLS
+    key, so all agents on the same channel must derive the *same* value or they
+    can't join each other's group. It is therefore keyed on the channel scope
+    (workspace/room), **not** the agent id — the ``agent`` field of *identity* is
+    intentionally ignored. Derived via HMAC-SHA256 so any member can reconstruct
+    it offline; the 64-char hex digest comfortably exceeds :data:`MIN_SECRET_LEN`.
+    """
+    scope = f"{identity.workspace}/{identity.room}"
+    digest = hmac.new(
+        master_secret.encode("utf-8"),
+        scope.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    assert len(digest) >= MIN_SECRET_LEN
+    return digest
+
+
+def _ensure_service_initialized(sb: ModuleType) -> None:
+    """Initialize the process-global SLIM service exactly once.
+
+    ``initialize_with_defaults`` sets up tracing/runtime/service config. It is a
+    process-global, so we guard on ``is_initialized()``. Safe under asyncio:
+    there is no ``await`` between the check and the call, so no interleaving.
+    """
+    if not sb.is_initialized():
+        sb.initialize_with_defaults()
+
+
+# The global SLIM service permits only ONE dataplane connection per endpoint per
+# process ("client already connected" otherwise). Multiple apps in the same
+# process — the daemon hosting several agent connectors, or a moderator+member
+# test — must share that connection and multiplex their apps over its conn_id.
+# Cache it per endpoint. (In production the backend moderator and each agent
+# connector are separate processes, so each owns its own connection.)
+_connections: dict[str, int] = {}
+
+
+async def _shared_connection(service: slim_bindings.Service, sb: ModuleType, endpoint: str) -> int:
+    """Return the process-wide conn_id for ``endpoint``, connecting once.
+
+    Callers connect sequentially (there is no first-connect race in the
+    moderator→member handshake), so no lock is needed here.
+    """
+    conn_id = _connections.get(endpoint)
+    if conn_id is None:
+        client_config = sb.new_insecure_client_config(endpoint)
+        conn_id = await service.connect_async(client_config)
+        _connections[endpoint] = conn_id
+    return conn_id
+
+
+class SlimClient:
+    """A single SLIM app bound to one node connection.
+
+    Lifecycle (mirrors the binding examples)::
+
+        client = await SlimClient(identity).connect(endpoint)
+        # moderator:
+        session = await client.create_group(channel_name)
+        await client.invite(session, member_name)
+        # participant:
+        session = await client.listen_for_session()
+        # either side:
+        await SlimClient.publish(session, b"hello")
+        payload = await SlimClient.receive(session)
+
+    Reusable by both the backend (moderator) and the daemon (per-agent
+    connectors) in later steps.
+    """
+
+    def __init__(self, identity: SlimIdentity, *, secret: str | None = None) -> None:
+        self.identity = identity
+        self._secret = secret or mint_shared_secret(identity)
+        self._sb: ModuleType | None = None
+        self._app: slim_bindings.App | None = None
+        self._conn_id: int | None = None
+        self._local_name: slim_bindings.Name | None = None
+
+    async def connect(self, endpoint: str = DEFAULT_NODE_ENDPOINT) -> SlimClient:
+        """Connect to the node and register this app under its local Name."""
+        sb = _require_bindings()
+        _ensure_service_initialized(sb)
+        service = sb.get_global_service()
+
+        self._sb = sb
+        self._local_name = to_slim_name(*self.identity.as_tuple())
+        self._conn_id = await _shared_connection(service, sb, endpoint)
+        self._app = service.create_app_with_secret(self._local_name, self._secret)
+        await self._app.subscribe_async(self._local_name, self._conn_id)
+        return self
+
+    @property
+    def app(self) -> slim_bindings.App:
+        if self._app is None:
+            raise SlimError("SlimClient.connect() has not been called")
+        return self._app
+
+    def _group_session_config(self) -> slim_bindings.SessionConfig:
+        sb = self._sb
+        assert sb is not None
+        # MLS stays off for the Step 2 hello-world (optional in SLIM); the
+        # shared secret already gates node admission. MLS group encryption is a
+        # later hardening step.
+        return sb.SessionConfig(
+            session_type=sb.SessionType.GROUP,
+            enable_mls=False,
+            max_retries=5,
+            interval=datetime.timedelta(seconds=5),
+            metadata={},
+        )
+
+    async def create_group(self, channel: slim_bindings.Name) -> slim_bindings.Session:
+        """Create (and become moderator of) the group session for ``channel``."""
+        return await self.app.create_session_and_wait_async(self._group_session_config(), channel)
+
+    async def invite(self, session: slim_bindings.Session, member: slim_bindings.Name) -> None:
+        """Route to and invite ``member`` into the moderated group ``session``."""
+        assert self._conn_id is not None
+        await self.app.set_route_async(member, self._conn_id)
+        handle = await session.invite_async(member)
+        await handle.wait_async()
+
+    async def listen_for_session(self) -> slim_bindings.Session:
+        """Block until this app is invited into a group, then return the session."""
+        return await self.app.listen_for_session_async(None)
+
+    @staticmethod
+    async def publish(session: slim_bindings.Session, data: bytes) -> None:
+        """Broadcast ``data`` to every current member of the group ``session``.
+
+        Matches the binding example: ``publish_async`` is awaited and its
+        completion handle ignored (best-effort send; SLIM has no durable inbox).
+        """
+        await session.publish_async(data, None, None)
+
+    @staticmethod
+    async def receive(session: slim_bindings.Session, *, timeout_s: float = 30.0) -> bytes:
+        """Block for the next inbound broadcast on ``session`` and return its bytes.
+
+        This blocking pull is the wake monitor in later steps.
+        """
+        message = await session.get_message_async(timeout=datetime.timedelta(seconds=timeout_s))
+        return message.payload

--- a/fastapi-backend/pyproject.toml
+++ b/fastapi-backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "watchdog>=6.0.0",
     "tiktoken>=0.12.0",
     "rapidfuzz>=3.14.5",
+    "slim-bindings>=1.4,<2",
 ]
 
 [dependency-groups]

--- a/fastapi-backend/scripts/slim_roundtrip.py
+++ b/fastapi-backend/scripts/slim_roundtrip.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Throwaway Step 2 harness: prove a two-client group broadcast over a SLIM node.
+
+Runs a moderator and a participant in one process against a running ``slim``
+node. The moderator creates a group channel and invites the participant; the
+participant publishes one message; the moderator receives the bytes. Prints
+``OK`` and exits 0 on success.
+
+Usage (with a node on :46357, e.g. via ``mycelium hub host``)::
+
+    cd fastapi-backend
+    uv run python scripts/slim_roundtrip.py
+    # or point at another node:
+    uv run python scripts/slim_roundtrip.py http://127.0.0.1:46357
+
+This is a manual DoD aid; the guarded pytest equivalent lives in
+``tests/test_slim_roundtrip.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Allow `python scripts/slim_roundtrip.py` from the backend root: the script's
+# own dir is on sys.path by default, not the package root, so add it.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.services.slim_client import (
+    DEFAULT_NODE_ENDPOINT,
+    SlimClient,
+    SlimIdentity,
+    to_channel_name,
+    to_slim_name,
+)
+
+_WORKSPACE = "acme"
+_ROOM = "hello-room"
+_MESSAGE = b"hello over a slim group"
+
+
+async def run_roundtrip(endpoint: str = DEFAULT_NODE_ENDPOINT) -> bytes:
+    """Exchange one broadcast moderator<-participant; return what the moderator got."""
+    moderator = await SlimClient(SlimIdentity(_WORKSPACE, _ROOM, "moderator")).connect(endpoint)
+    participant = await SlimClient(SlimIdentity(_WORKSPACE, _ROOM, "participant")).connect(endpoint)
+
+    channel = to_channel_name(_WORKSPACE, _ROOM)
+    session = await moderator.create_group(channel)
+
+    participant_name = to_slim_name(_WORKSPACE, _ROOM, "participant")
+
+    async def participant_side() -> None:
+        # Blocks until the moderator's invite lands, then broadcasts once.
+        joined = await participant.listen_for_session()
+        await SlimClient.publish(joined, _MESSAGE)
+
+    participant_task = asyncio.create_task(participant_side())
+    try:
+        await moderator.invite(session, participant_name)
+        payload = await SlimClient.receive(session, timeout_s=15.0)
+    finally:
+        await participant_task
+
+    return payload
+
+
+async def _main(endpoint: str) -> int:
+    payload = await run_roundtrip(endpoint)
+    if payload == _MESSAGE:
+        print(f"OK — moderator received: {payload!r}")
+        return 0
+    print(f"MISMATCH — got {payload!r}, expected {_MESSAGE!r}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    node = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_NODE_ENDPOINT
+    raise SystemExit(asyncio.run(_main(node)))

--- a/fastapi-backend/tests/test_slim_naming.py
+++ b/fastapi-backend/tests/test_slim_naming.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Offline unit tests for the SLIM naming/identity helpers (no node required)."""
+
+import pytest
+
+# The helpers need the native binding to build a Name; skip cleanly where no
+# wheel exists so the default suite stays green (Step 2 trap: missing wheel
+# degrades gracefully).
+pytest.importorskip("slim_bindings")
+
+from app.services.slim_client import (
+    MIN_SECRET_LEN,
+    SlimIdentity,
+    SlimNameError,
+    from_slim_name,
+    mint_shared_secret,
+    to_channel_name,
+    to_slim_name,
+)
+
+
+def test_name_round_trip():
+    """workspace/room/agent → Name → workspace/room/agent is lossless."""
+    name = to_slim_name("acme", "planning", "agent-7")
+    assert name.components() == ["acme", "planning", "agent-7"]
+
+    identity = from_slim_name(name)
+    assert identity == SlimIdentity("acme", "planning", "agent-7")
+    assert identity.as_tuple() == ("acme", "planning", "agent-7")
+    assert identity.as_path() == "acme/planning/agent-7"
+
+
+def test_channel_name_uses_topic_as_app_segment():
+    """A room's channel is workspace/room/<topic>, default topic 'room'."""
+    default = to_channel_name("acme", "planning")
+    assert default.components() == ["acme", "planning", "room"]
+
+    explicit = to_channel_name("acme", "planning", "consensus")
+    assert explicit.components() == ["acme", "planning", "consensus"]
+
+
+@pytest.mark.parametrize(
+    ("workspace", "room", "agent"),
+    [
+        ("", "room", "agent"),
+        ("ws", "  ", "agent"),
+        ("ws", "room", ""),
+        ("ws/x", "room", "agent"),
+        ("ws", "ro/om", "agent"),
+        ("ws", "room", "ag/ent"),
+    ],
+)
+def test_invalid_segments_rejected(workspace, room, agent):
+    with pytest.raises(SlimNameError):
+        to_slim_name(workspace, room, agent)
+
+
+def test_mint_secret_is_deterministic_and_long_enough():
+    identity = SlimIdentity("acme", "planning", "agent-7")
+    secret = mint_shared_secret(identity)
+
+    assert len(secret) >= MIN_SECRET_LEN
+    # Deterministic so both ends derive the same credential offline.
+    assert mint_shared_secret(identity) == secret
+
+
+def test_mint_secret_is_shared_across_agents_in_a_room():
+    """The secret seeds the group key, so every agent in a room shares it."""
+    a7 = mint_shared_secret(SlimIdentity("acme", "planning", "agent-7"))
+    a8 = mint_shared_secret(SlimIdentity("acme", "planning", "agent-8"))
+    assert a7 == a8  # same channel (workspace/room) → same secret
+
+
+def test_mint_secret_differs_per_channel_and_master():
+    same_room = mint_shared_secret(SlimIdentity("acme", "planning", "agent-7"))
+    other_room = mint_shared_secret(SlimIdentity("acme", "shipping", "agent-7"))
+    other_ws = mint_shared_secret(SlimIdentity("other", "planning", "agent-7"))
+    assert same_room != other_room != other_ws and same_room != other_ws
+
+    scoped = mint_shared_secret(
+        SlimIdentity("acme", "planning", "agent-7"), master_secret="another-master"
+    )
+    assert scoped != same_room

--- a/fastapi-backend/tests/test_slim_roundtrip.py
+++ b/fastapi-backend/tests/test_slim_roundtrip.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""SLIM group round-trip integration test.
+
+Needs a running ``slim`` node. Guarded so the default unit suite stays green
+without one: if the node endpoint is unreachable, the test is skipped (mirroring
+how the old ``test_integration.py`` was gated on backend availability). Point at
+a node with ``MYCELIUM_SLIM_ENDPOINT`` (default ``http://127.0.0.1:46357``); run
+one via ``mycelium hub host``.
+"""
+
+import os
+import socket
+from urllib.parse import urlparse
+
+import pytest
+
+pytest.importorskip("slim_bindings")
+
+from app.services.slim_client import DEFAULT_NODE_ENDPOINT
+
+_ENDPOINT = os.getenv("MYCELIUM_SLIM_ENDPOINT", DEFAULT_NODE_ENDPOINT)
+
+
+def _node_reachable(endpoint: str, *, timeout: float = 1.0) -> bool:
+    parsed = urlparse(endpoint)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 46357
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _node_reachable(_ENDPOINT),
+    reason=f"no reachable SLIM node at {_ENDPOINT} (set MYCELIUM_SLIM_ENDPOINT or run `mycelium hub host`)",
+)
+
+
+@pytest.mark.asyncio
+async def test_group_broadcast_round_trip():
+    """Moderator creates + invites; participant publishes; moderator receives it."""
+    from scripts.slim_roundtrip import _MESSAGE, run_roundtrip
+
+    payload = await run_roundtrip(_ENDPOINT)
+    assert payload == _MESSAGE

--- a/fastapi-backend/uv.lock
+++ b/fastapi-backend/uv.lock
@@ -1074,6 +1074,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-multipart" },
     { name = "rapidfuzz" },
+    { name = "slim-bindings" },
     { name = "tiktoken" },
     { name = "watchdog" },
 ]
@@ -1101,6 +1102,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.5.2,<3" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rapidfuzz", specifier = ">=3.14.5" },
+    { name = "slim-bindings", specifier = ">=1.4,<2" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
@@ -1870,6 +1872,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slim-bindings"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/10/f781f076ced49a5dbd4a5eb04b1948fcd82fcd0948c2b80ecbe5c94f8ec8/slim_bindings-1.4.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:44e985aae7203d4b9173b0a824a26a8bea39a02e203ad89e0e1abec7d3b86ef5", size = 12398410, upload-time = "2026-05-23T08:57:12.545Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/11/a30899045e56b12b595683e4de194210246f6e6b95185ff520cf3d99d2be/slim_bindings-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5667a87549c4d1bf6decef34acbd8b2920b8d35451200dcf2cd55f2fb7cbc929", size = 12105663, upload-time = "2026-05-23T08:57:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/04/80/398d41159ddfa4dabd9102b23888e3bfc85a9a439403aa95814ba6de7cab/slim_bindings-1.4.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2327211828e59a0c7dc970b1210abdd4f32cc1dd3c41a68ab1e5d52f16e34664", size = 12600843, upload-time = "2026-05-23T08:57:19.022Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d3/34630486515e6236d1887aa8f49a845b1bb6b844e0773d00d5e9daa9c540/slim_bindings-1.4.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:42036cb27c7165beb7a68010aceec6a514f0de0bef164711585281d5ad0f57d1", size = 13041099, upload-time = "2026-05-23T08:57:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/ec/1ad484dcfb0f9edd87015832a4dc3eb2638a71fb3a38646b9611cee4fc35/slim_bindings-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d96b59c0108a588c55e5335a9feee74bc9b78e468a5cd4dd038e78020ce85b17", size = 12598901, upload-time = "2026-05-23T08:57:24.096Z" },
+    { url = "https://files.pythonhosted.org/packages/80/54/3c615508b65fe34d67368d67e8321becec6bc566888e261ae45fb98afa74/slim_bindings-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:618137b056627326fa55f5eeae99e800b476f1951460d5ccf58a7a0b38ef16df", size = 13031199, upload-time = "2026-05-23T08:57:26.305Z" },
+    { url = "https://files.pythonhosted.org/packages/77/41/87d47c1fd47a1681b6377419e941ba22e416490a08577242b4da1d5a89ed/slim_bindings-1.4.1-py3-none-win_amd64.whl", hash = "sha256:9c89dbdbee2ffcb92b4ffe72593556b5cc14b24226a7f617838897e44bd1f897", size = 11650639, upload-time = "2026-05-23T08:57:28.92Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/38/f6425ceb8ecbae63c17bd08af5321d399b51b459b967d7625be6375c56f8/slim_bindings-1.4.1-py3-none-win_arm64.whl", hash = "sha256:dee180e534d4b10c912190aa143dea03f2cb996f5ed58036c5257f6f028feaab", size = 10929753, upload-time = "2026-05-23T08:57:31.067Z" },
 ]
 
 [[package]]

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -19,6 +19,7 @@ from mycelium.commands import (
     demo,
     docs,
     doctor,
+    hub,
     install,
     instance,
     memory,
@@ -129,6 +130,7 @@ app.command(name="logs")(instance.logs)
 # Top-level shortcuts
 app.command(name="watch")(room.watch)
 app.command(name="sync")(memory.memory_sync)
+app.command(name="connect")(hub.connect)
 
 # Command groups
 app.add_typer(room.app, name="room")
@@ -142,6 +144,7 @@ app.add_typer(ui.app, name="ui")
 app.add_typer(agent.app, name="agent")
 app.add_typer(daemon.app, name="daemon")
 app.add_typer(demo.app, name="demo")
+app.add_typer(hub.app, name="hub")
 
 
 if __name__ == "__main__":

--- a/mycelium-cli/src/mycelium/commands/hub.py
+++ b/mycelium-cli/src/mycelium/commands/hub.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Hub commands — run and connect to a SLIM node (the messaging fabric).
+
+``mycelium hub host`` spins up the ``slim`` node container and prints the
+address peers connect to. ``mycelium connect <address>`` stores a node endpoint
+in config. The connect address is the same whether the node is self-hosted or a
+shared mycelium-hosted rendezvous — MLS makes the node a blind ciphertext
+forwarder, so there's no separate command per host.
+"""
+
+import socket
+import subprocess
+
+import typer
+
+from mycelium.commands.instance import (
+    _COMPOSE_PROJECT,
+    _get_compose_path,
+    _get_env_path,
+)
+from mycelium.config import MyceliumConfig, SlimConfig
+from mycelium.doc_ref import doc_ref
+from mycelium.error_handler import print_error
+
+app = typer.Typer(
+    help="Run and manage the SLIM node (messaging fabric).",
+    no_args_is_help=True,
+)
+
+
+def _slim_port() -> str:
+    """Resolve the node's published port from ~/.mycelium/.env (default 46357)."""
+    env_path = _get_env_path()
+    if env_path and env_path.exists():
+        from dotenv import dotenv_values
+
+        if port := dotenv_values(env_path).get("MYCELIUM_SLIM_PORT"):
+            return port
+    return "46357"
+
+
+def _lan_ip() -> str | None:
+    """Best-effort LAN IP so peers on the network can reach a self-hosted node."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(("8.8.8.8", 80))
+            return s.getsockname()[0]
+        finally:
+            s.close()
+    except OSError:
+        return None
+
+
+@doc_ref(
+    usage="mycelium hub host",
+    desc="Start the SLIM node and print the address peers connect to.",
+    group="setup",
+)
+def host(ctx: typer.Context) -> None:
+    """Spin up the SLIM node container and print the connect address.
+
+    Starts only the ``slim`` service from the compose stack and stores the local
+    endpoint in config so this machine is immediately connected. Share the
+    printed LAN address and have peers run ``mycelium connect <address>``.
+    """
+    try:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
+        compose_path = _get_compose_path()
+
+        if not compose_path.exists():
+            typer.secho(f"Compose file not found at {compose_path}", fg=typer.colors.RED)
+            typer.echo("Run 'mycelium install' first.")
+            raise typer.Exit(1)
+
+        cmd = ["docker", "compose", "-p", _COMPOSE_PROJECT, "-f", str(compose_path)]
+        env_path = _get_env_path()
+        if env_path:
+            cmd += ["--env-file", str(env_path)]
+        cmd += ["up", "-d", "slim"]
+
+        typer.echo("Starting SLIM node...")
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            if result.stdout:
+                typer.echo(result.stdout)
+            if result.stderr:
+                typer.echo(result.stderr, err=True)
+            raise typer.Exit(result.returncode)
+
+        port = _slim_port()
+        local_endpoint = f"http://127.0.0.1:{port}"
+
+        # Self-host: wire this machine up immediately.
+        config = MyceliumConfig.load()
+        config.slim = SlimConfig(node_endpoint=local_endpoint)
+        config.save()
+
+        typer.secho("SLIM node running.", fg=typer.colors.GREEN)
+        typer.echo(f"  local     → {local_endpoint}  (this machine — saved to config)")
+        lan_ip = _lan_ip()
+        if lan_ip:
+            typer.echo(f"  for peers → http://{lan_ip}:{port}")
+            typer.echo("")
+            typer.echo(f"  Peers connect with:  mycelium connect http://{lan_ip}:{port}")
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+
+
+# Register `host` on the hub group. `connect` is registered as a top-level
+# command in cli.py (`mycelium connect`), so it isn't attached here.
+app.command(name="host")(host)
+
+
+@doc_ref(
+    usage="mycelium connect <address>",
+    desc="Store the SLIM node endpoint to connect to (self- or mycelium-hosted).",
+    group="setup",
+)
+def connect(
+    ctx: typer.Context,
+    address: str = typer.Argument(
+        ...,
+        help="SLIM node address, e.g. http://hub-ip:46357 (scheme optional)",
+    ),
+) -> None:
+    """Store a SLIM node endpoint in config.
+
+    Same command whether the node is self-hosted or a shared mycelium-hosted
+    rendezvous — just point at a different address.
+    """
+    try:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
+        config = MyceliumConfig.load()
+        # Construct through SlimConfig so its validator adds the scheme and trims
+        # slashes (pydantic v2 doesn't validate plain attribute assignment).
+        config.slim = SlimConfig(node_endpoint=address)
+        config.save()
+        typer.secho(
+            f"Connected to SLIM node at {config.slim.node_endpoint}",
+            fg=typer.colors.GREEN,
+        )
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -70,6 +70,31 @@ class ServerConfig(BaseModel):
         return v.rstrip("/")
 
 
+class SlimConfig(BaseModel):
+    """SLIM messaging-fabric connection configuration.
+
+    ``node_endpoint`` is the address of the ``slim`` node this agent connects
+    to. It's the same value whether the node is self-hosted (``mycelium hub
+    host``) or a shared mycelium-hosted rendezvous — set it with ``mycelium
+    connect <address>``. MLS makes the node a blind ciphertext forwarder, so the
+    host is untrusted either way.
+    """
+
+    node_endpoint: str = Field(
+        default="http://127.0.0.1:46357",
+        description="SLIM node endpoint (host:port), e.g. http://127.0.0.1:46357",
+    )
+
+    @field_validator("node_endpoint")
+    @classmethod
+    def normalize_endpoint(cls, v: str) -> str:
+        """Ensure the endpoint carries a scheme and no trailing slash."""
+        v = v.strip().rstrip("/")
+        if v and "://" not in v:
+            v = f"http://{v}"
+        return v
+
+
 class LLMConfig(BaseModel):
     """LLM configuration (litellm format)."""
 
@@ -182,6 +207,7 @@ class MyceliumConfig(BaseModel):
 
     identity: IdentityConfig = Field(default_factory=IdentityConfig)
     server: ServerConfig = Field(default_factory=ServerConfig)
+    slim: SlimConfig = Field(default_factory=SlimConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     rooms: RoomConfig = Field(default_factory=RoomConfig)
@@ -289,6 +315,7 @@ class MyceliumConfig(BaseModel):
         """Load configuration overrides from environment variables."""
         env_config: dict[str, Any] = {
             "server": {},
+            "slim": {},
             "rooms": {},
             "llm": {},
             "runtime": {},
@@ -297,6 +324,8 @@ class MyceliumConfig(BaseModel):
 
         if api_url := os.getenv("MYCELIUM_API_URL"):
             env_config["server"]["api_url"] = api_url
+        if slim_endpoint := os.getenv("MYCELIUM_SLIM_ENDPOINT"):
+            env_config["slim"]["node_endpoint"] = slim_endpoint
         if active_room := os.getenv("MYCELIUM_ACTIVE_ROOM"):
             env_config["rooms"]["active"] = active_room
 
@@ -355,6 +384,7 @@ class MyceliumConfig(BaseModel):
         _global_sections = (
             "identity",
             "server",
+            "slim",
             "llm",
             "runtime",
             "metrics",

--- a/mycelium-cli/src/mycelium/docker/compose-dev.yml
+++ b/mycelium-cli/src/mycelium/docker/compose-dev.yml
@@ -8,6 +8,12 @@
 # Build context paths are relative to this file's location (docker/).
 # env_file paths are also relative to this file's location.
 services:
+  # The `slim` node service is defined in compose.yml with a pulled upstream
+  # image (ghcr.io/agntcy/slim) and inline node config. compose-dev.yml is an
+  # override layer always applied on top of compose.yml, so the node runs in the
+  # dev stack automatically — there is nothing dev-specific to build or override
+  # for it, so no `slim:` block is needed here.
+
   # Override env_file for all services to point at ~/.mycelium/.env so that
   # LLM_MODEL etc. are available when running compose manually from the repo
   # root (compose.yml's ../.env path resolves incorrectly then).

--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -1,4 +1,49 @@
+# Inline SLIM node config (Compose `configs.content`, no external file to ship).
+# Minimal single standalone hub: one dataplane server on :46357, TLS disabled
+# for local dev (SPIRE/mTLS is a prod concern, out of scope for the MVP).
+configs:
+  slim-node-config:
+    content: |
+      tracing:
+        log_level: info
+      runtime:
+        n_cores: 0
+        thread_name: "slim-data-plane"
+        drain_timeout: 10s
+      services:
+        slim/0:
+          node_id: mycelium-slim
+          dataplane:
+            servers:
+              - endpoint: "0.0.0.0:46357"
+                tls:
+                  insecure: true
+            clients: []
+
 services:
+
+  # ── SLIM node (always started) ───────────────────────────────────────────────
+  #
+  # The secure messaging fabric — one stateless Rust binary that routes/fans out
+  # messages by name. This is the only heavy thing in the target stack (no DB).
+  # Rooms become SLIM group channels in Step 3; for now the node just runs and
+  # nothing is wired to it. `mycelium hub host` brings up this service alone.
+
+  slim:
+    # Pinned to 1.4.x: the node's link-negotiation handshake must match the
+    # `slim-bindings` wheel the backend/daemon use (pinned to 1.4 in the backend
+    # pyproject). `:latest` tracks the 2.0 line, whose handshake rejects a 1.4
+    # client with "public key length is invalid". Bump both together.
+    image: ghcr.io/agntcy/slim:${SLIM_IMAGE_TAG:-1.4.0}
+    pull_policy: always
+    container_name: mycelium-slim
+    restart: unless-stopped
+    command: ["/slim", "--config", "/slim-config.yaml"]
+    configs:
+      - source: slim-node-config
+        target: /slim-config.yaml
+    ports:
+      - "${MYCELIUM_SLIM_PORT:-46357}:46357"
 
   # ── Mycelium Core (always started) ───────────────────────────────────────────
   #

--- a/mycelium-cli/tests/test_slim_config.py
+++ b/mycelium-cli/tests/test_slim_config.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Tests for the SLIM node-endpoint config field and `mycelium connect`."""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from mycelium.cli import app
+from mycelium.config import MyceliumConfig, SlimConfig
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("http://127.0.0.1:46357", "http://127.0.0.1:46357"),
+        ("127.0.0.1:46357", "http://127.0.0.1:46357"),  # scheme added
+        ("http://hub:46357/", "http://hub:46357"),  # trailing slash trimmed
+        ("  hub:46357  ", "http://hub:46357"),  # whitespace trimmed
+        ("https://rendezvous.example:46357", "https://rendezvous.example:46357"),
+    ],
+)
+def test_endpoint_normalization(given: str, expected: str) -> None:
+    assert SlimConfig(node_endpoint=given).node_endpoint == expected
+
+
+def test_default_endpoint() -> None:
+    assert MyceliumConfig().slim.node_endpoint == "http://127.0.0.1:46357"
+
+
+def test_connect_persists_endpoint(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`mycelium connect <addr>` writes a normalized endpoint to global config."""
+    # Isolate HOME (global config) and cwd (project config discovery) to temp.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["connect", "hub:46357"])
+    assert result.exit_code == 0, result.output
+
+    reloaded = MyceliumConfig.load()
+    assert reloaded.slim.node_endpoint == "http://hub:46357"


### PR DESCRIPTION
Implements **Part V · Step 2** of the SLIM-native rebuild ([START_HERE_STEP_2.md](docs/START_HERE_STEP_2.md)): stand up the SLIM messaging fabric and prove a two-client group broadcast. **Plumbing only** — nothing is wired into rooms/coordination (that's Step 3), so Step 1's green stays green.

## What changed

**SLIM node (Docker)**
- `compose.yml`: new `slim` core service — `ghcr.io/agntcy/slim`, port 46357, with an **inline** node config (Compose `configs.content`, no external file to ship/install). Pinned to **`1.4.0`** (see version trap below).
- `compose-dev.yml`: documented that the node is inherited from `compose.yml` (dev file is a pure override layer always applied on top — nothing dev-specific to build for a pulled image).

**Backend wrapper** — `app/services/slim_client.py` (new)
- Lazy/isolated `slim_bindings` import (missing native wheel → clear `SlimUnavailableError`, no import-time crash across backend modules).
- `workspace/room/agent` ↔ SLIM `Name` (`org/ns/app`) mapping, `to_channel_name`, channel-scoped shared-secret minter.
- `SlimClient`: connect / create_group / invite / listen / publish / receive — reusable by backend + daemon.
- Adds `slim-bindings>=1.4,<2`.

**CLI**
- `config.py`: `SlimConfig.node_endpoint` (scheme-normalizing) + `MYCELIUM_SLIM_ENDPOINT` env.
- `commands/hub.py` (new): `mycelium hub host` (start node, print connect address) and `mycelium connect <address>` (store endpoint) — same command whether self- or mycelium-hosted.

**Tests / harness**
- `tests/test_slim_naming.py` — offline name round-trip / channels / secret minting / segment validation.
- `tests/test_slim_roundtrip.py` — guarded integration test (skips if no reachable node).
- `scripts/slim_roundtrip.py` — throwaway two-client broadcast harness.
- `mycelium-cli/tests/test_slim_config.py` — endpoint normalization + `connect` persistence.

## DoD ✅
`mycelium hub host` runs a node on :46357; the harness exchanges a broadcast between two clients on one group channel:
```
OK — moderator received: b'hello over a slim group'
```
Name mapping covered by the offline unit test.

## Verification gate ✅
- Backend: ruff / format / ty clean; **203 passed, 1 skipped** (pre-existing live-LLM test). Round-trip test runs+passes with a node up.
- CLI: ruff / format / ty clean; **346 passed**.

## Two non-obvious findings
1. **Version coupling** — the node image and `slim-bindings` share a link-negotiation handshake. `:latest` (2.0 line) rejects a 1.4 client with `public key length is invalid`. Node **1.4.0** matches bindings **1.4.1**; bump both together.
2. **Single-process constraints** — one dataplane connection per endpoint per process (→ per-endpoint conn cache), and all group members must share one secret that seeds the group key (→ mint keyed on `workspace/room`, not agent). In prod the moderator and each connector are separate processes.

## Judgment call
"Add the node to both compose files" resolved by defining it fully in `compose.yml` and documenting inheritance in `compose-dev.yml` rather than duplicating the service (the dev file is only ever layered on `compose.yml`, so a duplicate would be dead weight to keep in sync).

## Deferrals (per START_HERE)
SLIM not yet wired into rooms/coordination (Step 3); no durable inbox/persister (Step 4); daemon still uses httpx SSE (Step 5); `abort`→`rejected` L9 subkind is Step 3.