### PR TITLE
Step 4: Backend as room infrastructure (persister + durable inbox + wake)

### DIFF
--- a/docs/START_HERE_STEP_5.md
+++ b/docs/START_HERE_STEP_5.md
@@ -1,0 +1,213 @@
+# START HERE — Step 5 (Claude Code connector + wake bridge — the dogfood milestone)
+
+Companion to [`START_HERE.md`](./START_HERE.md). Step 4 is **done** (this PR into
+`slim-native-rewrite`); you are picking up **Step 5**. Read `START_HERE.md`,
+[`START_HERE_STEP_1.md`](./START_HERE_STEP_1.md) → [`START_HERE_STEP_4.md`](./START_HERE_STEP_4.md)
+first if you haven't — the same rules apply. This file gives you (a) the exact state Step 4
+left behind, (b) your Step 5 marching orders, (c) the facts you must internalize, and (d) the
+traps specific to this step.
+
+**This is the step where a real agent finally rides the fabric.** Step 4 made the backend the
+always-on room infrastructure (persister + durable inbox + trigger-watcher). But no agent yet
+holds its own SLIM connection: the daemon still streams over httpx SSE. Step 5 retargets the
+Claude Code connector onto SLIM so a registered agent is **woken** by an inbound message,
+**spawned** for a turn, and its **reply lands back in the channel** — the first end-to-end
+dogfood loop.
+
+## Ground rules (unchanged from START_HERE.md)
+
+1. **The bible is authoritative:** [`slim-native-rebuild-bible.md`](./slim-native-rebuild-bible.md).
+   Your work is **Part V · Step 5**, with **§12 (wake / `@`-mention)**, **§10 (engines — not
+   yet, but the wake seam is shared)**, and **§13 (the full cycle)** as the design reference.
+2. Leave the project **runnable and green** — backend + CLI quality gates pass at the end.
+3. Code/config blocks in the bible are **reference, not paste**. The cloned `slim-bindings`
+   examples under `~/Documents/GitHub/_slim-research/` remain ground truth for the binding API
+   (the **participant** side — `listen_for_session` / `get_message` loop — is what you'll build
+   on now; the moderator side is the backend's).
+4. **Verify before you edit** — the paths below were accurate at the end of Step 4; confirm
+   shape before changing a file.
+5. Fixed decisions are not up for debate; the one open question (native-vs-CLI) has a default:
+   **keep cold-spawn** (the daemon holds the SLIM connection; the agent's contract is unchanged).
+
+## Where Step 4 left things (your starting state)
+
+Branch off `slim-native-rewrite` (Step 4 is merged). The backend is now a full room participant
+that reads the channel; the **agent side is still off-fabric**. Concretely:
+
+- **The backend consumes the channel.** `app/services/persister.py` holds `RoomPersister`: a
+  long-lived task started per room by `room_channels.py` on `provision`. It pulls
+  `L9SlimChannel.receive_with_context()`, records the transcript to `log/transcript.md`, feeds
+  the UI bus, and runs the trigger-watcher. **This is the moderator's read loop** — your
+  connector is the *member's* read loop, a different process/app.
+- **The durable inbox works and is proven on a live node.** `DeliveryLog` tracks a per-`(room,
+  handle)` cursor; on a membership add for a known handle (`RoomChannelManager.invite` →
+  `persister.note_join` → `persister.reserve`), the backend **re-serves** the missed tail
+  **point-to-point** via `L9SlimChannel.send_content_to(ctx, content)` →
+  `SlimClient.publish_to`. Re-serve needs a cached reply **context** for the handle — the
+  persister caches one per sender as messages arrive (`self._contexts`). **A handle that has
+  never sent a message has no route yet** — see the trap below, this is your concern now.
+- **Targeted send exists.** Step 4 added `SlimClient.publish_to(session, ctx, data)` and
+  `receive_message` (whole message w/ `.context`), and `L9SlimChannel.receive_with_context()` /
+  `send_content_to(ctx, content)`. Broadcast (`publish` / `L9SlimChannel.send`) is unchanged
+  from Step 3.
+- **Trigger hooks are skeletons.** `RoomChannelManager.on_summon` / `on_converged` (default:
+  log only) are handed to every persister. `@`-summon detection (`persister.find_summons`) and
+  `commit:converged` detection (`persister.is_converged`) work; the hooks fire but do nothing
+  real. **Wiring `on_summon` to an engine is Step 7; `on_converged` to `plan_compiler` is
+  Step 8.** Do not wire them here.
+- **The daemon is untouched and still on SSE.** `daemon/dispatch.py` holds an **httpx SSE**
+  stream per room and cold-spawns a turn per `@`-mention / `coordination_tick`. **Retargeting it
+  to a SLIM group subscription is your whole job.** `daemon/spawn.py`'s `spawn_claude()` stays.
+- **Presence still can't reflect a live agent connection.** Until your connector holds a SLIM
+  connection, `RoomChannelManager.members` only changes via the HTTP join's fire-and-forget
+  invite (which fails, since the agent has no connection to invite *to*). After Step 5, a joined
+  connector is actually reachable, so the moderator's invite lands and `members` becomes truly
+  authoritative — and **the durable-inbox reconnect path becomes reachable for real agents**
+  (Step 4 could only exercise it with raw `SlimClient`s in a test).
+- **Lifespan/teardown discipline is set.** `room_channels.close`/`close_all` cancels the
+  persister task; `app/main.py` calls `close_all` on shutdown. Your connector's subscription +
+  wake loop needs the same start-on-join / cancel-on-leave discipline, daemon-side.
+
+## Your Step 5 scope (from the bible, Part V · Step 5)
+
+- **Retarget the daemon to SLIM.** Replace the per-room httpx SSE stream in `daemon/dispatch.py`
+  with a **SLIM group subscription**: the connector connects as `workspace/room/<handle>`,
+  `listen_for_session` to get its group session (the backend moderator invites it), and runs a
+  `get_message` loop. On an inbound L9 message **addressed to a handle it owns** (via L9
+  `participants` recipients / an `@`-mention), **wake** that agent.
+- **Keep cold-spawn.** `spawn_claude()` (headless `claude -p ... --output-format json
+  --permission-mode bypassPermissions`) stays the turn-runner. Publish the agent's reply back to
+  the channel as an L9 `exchange` message (build it with `l9.build_envelope(..., sender=handle)`
+  and `L9SlimChannel.send`).
+- **Preserve the gates + control verbs.** Per-handle lock, budget, depth, ownership
+  (`daemon/state.py`), and `abort`/`status` must still hold — they're orthogonal to the
+  transport swap; don't lose them in the rewrite.
+- **The agent contract is unchanged.** The agent never speaks SLIM or L9; the **daemon** (the
+  connector) does. It reads the human-facing content out of the message; the `l9` key stays
+  invisible to the spawned turn.
+
+**Key files:** `daemon/dispatch.py` [rework — the seam], `daemon/spawn.py` [keep],
+`daemon/runner.py` / `daemon/state.py` / `daemon/config.py` [rework for SLIM], `integrations/
+claude_code/` [rework], and the L9-over-SLIM binding (`l9_slim.py` / `slim_client.py`) [use — the
+member side].
+
+## Facts you must internalize first
+
+- **The connector is a SLIM *member*, not the moderator.** The backend created the group and
+  invites; the connector `listen_for_session`s and waits to be invited. Do **not** have the
+  connector create the group — one moderator per room, and it's the backend. Mirror the
+  *participant* half of Step 3's `scripts/l9_slim_roundtrip.py::run_roundtrip`.
+- **One connection per endpoint per process (Step 2 constraint).** `SlimClient` shares a
+  process-wide dataplane connection per endpoint. A daemon hosting several owned handles must
+  multiplex apps over that one connection (each handle is its own `SlimClient`/app, same
+  conn_id). This already works; just don't open a second connection.
+- **The wake signal is an inbound L9 message addressed to an owned handle.** Read the envelope's
+  `participants` (recipients) — the backend/human `@`-parse compiles `@agent-x` into L9
+  recipients in Step 6, but for Step 5 you can wake on recipient-match and/or a raw `@handle`
+  token (reuse `persister.find_summons`'s idea; keep it in the connector, don't import the
+  backend). Don't wake an agent on **its own** reply (loop guard — key off sender != handle).
+- **Reply causality.** When the agent replies, parent the envelope on the message that woke it
+  (`message.parents = [woke_msg_id]`) so the backend's `CausalOrderBuffer` and transcript stay
+  causally correct — the same threading `l9_episode` does for ticks/replies.
+- **The durable inbox now covers your reconnect.** A connector that drops and rejoins is exactly
+  the Step 4 reconnect path: on re-invite the backend re-serves what it missed. For that to
+  work the connector must have **sent at least one message** (so the backend cached its reply
+  context) — otherwise the backend has no point-to-point route. If a never-spoke connector must
+  still be re-served, that's a real gap to close (see trap).
+
+## Definition of Done
+
+A registered Claude Code agent joins a room, is **woken by an inbound message**, **spawns a
+turn** (headless `claude -p`), and its **reply appears in the room** for others to see (persisted
+by the backend's transcript, visible to other members). Budget/depth/ownership gates and
+`abort`/`status` still hold.
+
+## Tests to write (end of step)
+
+Fast unit tests (the merge gate — no node, mock the `claude` binary):
+
+- **Wake path** — an inbound L9 message addressed to an owned handle invokes `spawn_claude`
+  (mocked); a message addressed elsewhere / the agent's own reply does not.
+- **Reply is valid L9** — the published reply parses as an `exchange` envelope with
+  `sender=handle` and `parents=[woke_msg_id]`.
+- **Gates still hold** — budget/depth/ownership refusals and the per-handle lock behave as before
+  the transport swap; `abort`/`status` control verbs work.
+
+Live-node **integration slice** (guarded, adds to the cumulative suite — **all prior slices must
+still pass**):
+
+- **Connector wake** — on a live node, a connector (with a **mock `claude` binary**) is invited
+  by the backend, wakes on an inbound L9 message, and its reply appears in the room. Extend
+  `scripts/l9_slim_roundtrip.py` with a `run_connector_wake(...)` scenario for the manual DoD and
+  gate the pytest on a reachable node (mirror `test_l9_over_slim_roundtrip.py`).
+
+## Verification gate (must pass before you call Step 5 done)
+
+```bash
+# Backend
+cd fastapi-backend
+uv run ruff check . && uv run ruff format --check . && uv run ty check .
+MYCELIUM_STUB_EMBEDDINGS=1 uv run pytest tests/ -x -q            # fast gate, no node
+
+# Backend integration slices (guarded) — bring a node up first (see below):
+MYCELIUM_STUB_EMBEDDINGS=1 MYCELIUM_SLIM_ENDPOINT=http://127.0.0.1:46357 \
+  uv run pytest tests/ -q                                        # all slices, node up
+
+# CLI (matches CI)
+cd ../mycelium-cli
+uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run pytest tests/ -x -q
+```
+
+Bring a standalone node up (same recipe Step 4 used):
+
+```bash
+cat > /tmp/slim-node-config.yaml <<'EOF'
+tracing: { log_level: info }
+runtime: { n_cores: 0, thread_name: "slim-data-plane", drain_timeout: 10s }
+services:
+  slim/0:
+    node_id: mycelium-slim
+    dataplane:
+      servers: [{ endpoint: "0.0.0.0:46357", tls: { insecure: true } }]
+      clients: []
+EOF
+docker run -d --rm --name mycelium-slim-test -p 46357:46357 \
+  -v /tmp/slim-node-config.yaml:/slim-config.yaml \
+  ghcr.io/agntcy/slim:1.4.0 /slim --config /slim-config.yaml
+# ... run the guarded suite ...
+docker stop mycelium-slim-test
+```
+
+## Traps specific to Step 5
+
+- **Don't make the connector a moderator.** It joins a group the backend already created. If you
+  find yourself calling `create_group` in the daemon, you've overshot — that's the backend's job,
+  and two moderators corrupt membership.
+- **Loop guard.** The connector's own reply is a broadcast it will also receive back. Key the
+  wake on `sender != owned_handle` (and don't re-summon on `coordination_*` system messages), or
+  you'll spin an agent replying to itself forever.
+- **The never-spoke re-serve gap.** Step 4's durable inbox re-serves via a **cached reply
+  context**, which only exists once a handle has sent a message. A connector that joins, stays
+  silent, drops, and rejoins has no route to be re-served on. If Step 5's flow can produce that,
+  either (a) have the connector send a lightweight presence/hello on join (seeding the route), or
+  (b) add a Name-addressed re-serve to the backend (moderator already has a route to each
+  invited member via `set_route`). Pick one, note it, and flag it — don't silently ship a hole.
+- **Don't wire the engine or the plan compiler.** `on_summon` (engine, Step 7) and `on_converged`
+  (plan_compiler, Step 8) stay skeletons. Step 5 is transport + wake only.
+- **Don't starve or double-feed the UI.** The backend persister already bridges SLIM → the UI
+  bus. The connector must **not** also POST replies to the HTTP `messages` endpoint (that would
+  double-count) — publishing to the channel is enough; the persister handles the rest.
+- **MLS on, version stays pinned.** Room channels run MLS (Step 3); the member joins the same
+  MLS group via the shared secret it derives (`mint_shared_secret`, keyed on `workspace/room`).
+  Do **not** touch the `slim:1.4.0` / `slim-bindings` 1.4.x pin — matched pair.
+- **Keep the gates.** The transport swap is not license to drop the budget/depth/ownership/lock
+  machinery in `daemon/state.py`. Re-wire it around the new wake source; don't rewrite it away.
+
+## Report when done
+
+Per `START_HERE.md`: what changed, the DoD check, and test results (fast gate + the live
+integration slice, noting all prior slices still pass). Open a PR against `slim-native-rewrite`
+(same as Steps 0–4). Deferrals to name explicitly: human-in-the-room `@`-mention + consent UX is
+**Step 6**; cognition engines (wiring `on_summon`) are **Step 7**; plan-compile firing (wiring
+`on_converged`) + memory sync are **Step 8**; cross-machine is **Step 9**; SSE/`stream.py` is
+retired in **Step 10**.

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -5,10 +5,10 @@
 Messages API — POST + list + event-status PATCH.
 
 Backed by an in-memory store (SLIM-native rebuild, Step 1); publishes to the
-in-process bus so the SSE stream sees writes live. Messages move onto the SLIM
-channel + durable persister in Steps 3-4.
-
-# TODO(step3): messages ride the SLIM channel; the persister owns the transcript.
+in-process bus so the SSE stream sees writes live. The SLIM channel's durable
+transcript is owned by the persister (``services/persister.py``, Step 4); this
+HTTP path stays the UI's post/list surface until SSE/``stream.py`` retires
+(Step 10).
 """
 
 import logging

--- a/fastapi-backend/app/services/l9_slim.py
+++ b/fastapi-backend/app/services/l9_slim.py
@@ -59,9 +59,18 @@ def serialize_envelope(envelope: L9, *, extra: dict[str, Any] | None = None) -> 
     The envelope goes under the ``l9`` key so the wire shape matches every other
     coordination message; ``extra`` carries the human-facing payload agents read.
     """
+    return json.dumps(serialize_content(envelope, extra=extra)).encode("utf-8")
+
+
+def serialize_content(envelope: L9, *, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+    """The content dict an envelope rides in (``{**extra, "l9": <envelope>}``).
+
+    :func:`serialize_envelope` is this plus a JSON encode; the persister keeps
+    the dict form to record and re-serve.
+    """
     content: dict[str, Any] = dict(extra or {})
     content[CONTENT_L9_KEY] = l9.envelope_to_dict(envelope)
-    return json.dumps(content).encode("utf-8")
+    return content
 
 
 def deserialize_envelope(data: bytes) -> tuple[L9, dict[str, Any]]:
@@ -205,6 +214,10 @@ class L9SlimChannel:
         self._client = client
         self._session = session
         self._buffer = CausalOrderBuffer()
+        # message id -> full inbound content dict, so a released envelope can be
+        # paired back with the human-facing payload it arrived with (the buffer
+        # itself only holds envelopes). Popped as envelopes release.
+        self._content_by_id: dict[str, dict[str, Any]] = {}
 
     @property
     def session(self) -> slim_bindings.Session:
@@ -216,10 +229,50 @@ class L9SlimChannel:
 
         await SlimClient.publish(self._session, serialize_envelope(envelope, extra=extra))
 
-    async def receive(self, *, timeout_s: float = 30.0) -> list[L9]:
-        """Pull one broadcast; return the envelopes it makes causally deliverable."""
+    async def send_content_to(
+        self, context: slim_bindings.MessageContext, content: dict[str, Any]
+    ) -> None:
+        """Point-to-point re-send of a whole ``content`` dict to one member.
+
+        Used by the durable-inbox persister to re-serve a missed message: the
+        stored ``content`` already carries its ``l9`` envelope, so it is
+        republished verbatim (the receiver's own :class:`CausalOrderBuffer`
+        re-orders and de-duplicates it). ``context`` targets the reconnecting
+        member (see :meth:`SlimClient.publish_to`).
+        """
         from app.services.slim_client import SlimClient
 
-        data = await SlimClient.receive(self._session, timeout_s=timeout_s)
-        envelope, _content = deserialize_envelope(data)
-        return self._buffer.add(envelope)
+        await SlimClient.publish_to(self._session, context, json.dumps(content).encode("utf-8"))
+
+    async def receive(self, *, timeout_s: float = 30.0) -> list[L9]:
+        """Pull one broadcast; return the envelopes it makes causally deliverable."""
+        released, _arrived, _ctx = await self.receive_with_context(timeout_s=timeout_s)
+        return [env for env, _content in released]
+
+    async def receive_with_context(
+        self, *, timeout_s: float = 30.0
+    ) -> tuple[list[tuple[L9, dict[str, Any]]], L9, slim_bindings.MessageContext]:
+        """Pull one message; return ``(released, arrived, context)``.
+
+        ``released`` is the list of ``(envelope, content)`` pairs the arrival
+        makes causally deliverable (each content is the full inbound dict,
+        including its ``l9`` key — what the persister records and re-serves).
+        ``arrived`` is the envelope that just arrived (whose sender the persister
+        keys the reply ``context`` by, so it can later re-serve to that member).
+        ``context`` is the raw ``MessageContext`` for point-to-point replies.
+        """
+        from app.services.slim_client import SlimClient
+
+        message = await SlimClient.receive_message(self._session, timeout_s=timeout_s)
+        arrived, content = deserialize_envelope(message.payload)
+        mid = arrived.header.message.id if arrived.header.message is not None else None
+        if mid is not None:
+            self._content_by_id[mid] = content
+        released: list[tuple[L9, dict[str, Any]]] = []
+        for env in self._buffer.add(arrived):
+            rid = env.header.message.id if env.header.message is not None else None
+            paired = self._content_by_id.pop(rid, None) if rid is not None else None
+            if paired is None:
+                paired = serialize_content(env)
+            released.append((env, paired))
+        return released, arrived, message.context

--- a/fastapi-backend/app/services/local_state.py
+++ b/fastapi-backend/app/services/local_state.py
@@ -12,9 +12,11 @@ keep the endpoints answering. They are NOT durable and NOT rich.
 Presence liveness now rides SLIM channel membership (Step 3): ``room_channels``
 is authoritative for *who is present*, while the participant rows here remain the
 metadata store (intent, context files) and the fallback when no fabric is up.
-Messages are still in-memory — the durable transcript/inbox persister is Step 4.
 
-# TODO(step4): messages move onto the SLIM channel + durable persister.
+Messages: the durable transcript for the SLIM channel is now the persister's
+markdown (``services/persister.py``, Step 4). The in-memory message list here
+still backs the HTTP post/list endpoints and the SSE feed the UI reads until
+SSE/``stream.py`` is retired (Step 10).
 """
 
 from __future__ import annotations

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -1,0 +1,453 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Backend-as-room-infrastructure: the persister / durable inbox (Step 4, bible §9).
+
+Step 3 put the backend in every room's SLIM group channel as moderator but never
+*read* the channel. Step 4 has the moderator consume it. This module is that
+consumer, and it does four things as each message flows past:
+
+1. **Persister.** Records the full transcript to the room's markdown (``log/``)
+   so it survives, is git-shareable, and is picked up by the reindex watcher —
+   memory the normal way (bible §11), a *distinct* artifact from the
+   episode-scoped ``log/episodes/*`` records ``l9_episode`` writes.
+
+2. **Durable inbox.** SLIM keeps **no** messages for an offline member (bible
+   §7d): a broadcast that happened while a member was gone is never replayed on
+   rejoin. So mycelium tracks each agent's delivery position (:class:`DeliveryLog`)
+   and, when an agent **reconnects**, **re-serves** the tail it missed — targeted
+   point-to-point (not a broadcast), so the rest of the room is untouched.
+
+3. **Trigger-watcher (skeleton).** Recognizes ``@``-summon tokens in a message
+   and calls a summon hook; the real cognition-engine wiring is Step 7. Here the
+   hook defaults to a log.
+
+4. **plan-compile hook (skeleton).** On a ``commit:converged`` envelope it fires
+   a seam Step 8 will use to run ``plan_compiler``; it does **not** compile here.
+
+The pure pieces (:class:`DeliveryLog`, the transcript read/write, the trigger
+detection) carry no SLIM dependency and are unit-tested without a node;
+:class:`RoomPersister` is the thin async loop that drives them over a live
+:class:`~app.services.l9_slim.L9SlimChannel`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from app.services import l9
+
+if TYPE_CHECKING:
+    import slim_bindings
+
+    from app.services.l9_models import L9
+    from app.services.l9_slim import L9SlimChannel
+
+logger = logging.getLogger(__name__)
+
+# The transcript memory key under a room's dir (``log/transcript.md``). One
+# jsonl-bearing markdown file per room: append-only, reindex-friendly, and
+# deliberately separate from ``log/episodes/*`` (episode-scoped) so the two
+# never clobber each other.
+TRANSCRIPT_KEY = "log/transcript"
+
+# An ``@``-summon token: ``@`` followed by a handle (letter/digit start, then
+# word chars or hyphens). Guarded so it doesn't fire mid-word (e.g. an email).
+_SUMMON_RE = re.compile(r"(?:^|(?<=[\s(<]))@([A-Za-z0-9][\w-]*)")
+
+
+# ── Envelope helpers ─────────────────────────────────────────────────────────
+
+
+def envelope_sender(envelope: L9) -> str | None:
+    """The sending handle of an envelope (first actor), or None."""
+    actors = envelope.header.participants.actors
+    return actors[0].id if actors else None
+
+
+def envelope_message_id(envelope: L9) -> str | None:
+    message = envelope.header.message
+    return message.id if message is not None else None
+
+
+def is_converged(envelope: L9) -> bool:
+    """True for a ``commit:converged`` envelope (the plan-compile trigger)."""
+    header = envelope.header
+    return header.kind.value == "commit" and header.subkind == "converged"
+
+
+def _iter_text(value: Any) -> Iterable[str]:
+    """Yield every string leaf in a nested content value."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _iter_text(v)
+    elif isinstance(value, list):
+        for v in value:
+            yield from _iter_text(v)
+
+
+def find_summons(content: dict[str, Any]) -> list[str]:
+    """Handles ``@``-summoned in a message's human-facing content.
+
+    Scans every string in ``content`` except the additive ``l9`` envelope (which
+    agents never read), de-duplicated preserving first-seen order.
+    """
+    seen: dict[str, None] = {}
+    for key, value in content.items():
+        if key == "l9":
+            continue
+        for text in _iter_text(value):
+            for match in _SUMMON_RE.findall(text):
+                seen.setdefault(match, None)
+    return list(seen)
+
+
+# ── Transcript record + delivery cursors (pure) ──────────────────────────────
+
+
+@dataclass
+class TranscriptRecord:
+    """One recorded channel message: its id, sender, kind, and full content."""
+
+    message_id: str
+    sender: str
+    kind: str
+    subkind: str | None
+    content: dict[str, Any]
+    recorded_at: str
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "message_id": self.message_id,
+            "sender": self.sender,
+            "kind": self.kind,
+            "subkind": self.subkind,
+            "content": self.content,
+            "recorded_at": self.recorded_at,
+        }
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> TranscriptRecord:
+        return cls(
+            message_id=data["message_id"],
+            sender=data.get("sender", ""),
+            kind=data.get("kind", ""),
+            subkind=data.get("subkind"),
+            content=data.get("content", {}),
+            recorded_at=data.get("recorded_at", ""),
+        )
+
+
+class DeliveryLog:
+    """A room's ordered transcript plus a per-agent delivery position.
+
+    The transcript is the ordered list of recorded messages. Each *known* handle
+    carries a cursor: the count of leading records already delivered to it. A
+    present member's cursor advances as records are recorded (SLIM delivered them
+    live); an offline member's cursor freezes, so the messages recorded while it
+    was gone become its **undelivered tail** — exactly what the durable inbox
+    re-serves on reconnect.
+    """
+
+    def __init__(self, records: list[TranscriptRecord] | None = None) -> None:
+        self._records: list[TranscriptRecord] = list(records or [])
+        self._cursors: dict[str, int] = {}
+
+    @property
+    def records(self) -> list[TranscriptRecord]:
+        return list(self._records)
+
+    def knows(self, handle: str) -> bool:
+        """True once ``handle`` has ever been tracked (join or delivery)."""
+        return handle in self._cursors
+
+    def track(self, handle: str, *, caught_up: bool = True) -> None:
+        """Register ``handle``. ``caught_up`` starts it at the transcript end
+        (a first join missed nothing that preceded it); otherwise at the start."""
+        if handle in self._cursors:
+            return
+        self._cursors[handle] = len(self._records) if caught_up else 0
+
+    def record(self, record: TranscriptRecord, *, delivered_to: Iterable[str]) -> None:
+        """Append ``record``; advance the cursor of every present member.
+
+        A present member received the broadcast live, so its cursor moves to the
+        new end. Absent members (not in ``delivered_to``) are left behind.
+        """
+        self._records.append(record)
+        end = len(self._records)
+        for handle in delivered_to:
+            self._cursors[handle] = end
+
+    def undelivered(self, handle: str) -> list[TranscriptRecord]:
+        """Records recorded but not yet delivered to ``handle`` (its missed tail)."""
+        pos = self._cursors.get(handle, len(self._records))
+        return self._records[pos:]
+
+    def mark_caught_up(self, handle: str) -> None:
+        """Advance ``handle`` to the transcript end (after a re-serve)."""
+        self._cursors[handle] = len(self._records)
+
+
+def record_from(
+    envelope: L9, content: dict[str, Any], *, now: str | None = None
+) -> TranscriptRecord:
+    """Build a :class:`TranscriptRecord` from a released envelope + its content."""
+    return TranscriptRecord(
+        message_id=envelope_message_id(envelope) or "",
+        sender=envelope_sender(envelope) or "",
+        kind=envelope.header.kind.value,
+        subkind=envelope.header.subkind,
+        content=content,
+        recorded_at=now or datetime.now(UTC).isoformat(),
+    )
+
+
+# ── Transcript persistence (markdown + jsonl block) ──────────────────────────
+
+_TRANSCRIPT_HEADER = (
+    "The live room transcript — every message recorded off the SLIM channel, "
+    "one JSON record per line (distinct from the episode records under "
+    "`log/episodes/`)."
+)
+
+
+def render_transcript(records: list[TranscriptRecord]) -> str:
+    """The markdown body for the transcript file (a jsonl block)."""
+    lines = [
+        _TRANSCRIPT_HEADER,
+        "",
+        "```jsonl",
+        *(json.dumps(r.to_json(), sort_keys=True) for r in records),
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def parse_transcript(body: str) -> list[TranscriptRecord]:
+    """Parse the jsonl block of a transcript body back into records."""
+    records: list[TranscriptRecord] = []
+    in_block = False
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped == "```jsonl":
+            in_block = True
+            continue
+        if stripped == "```":
+            in_block = False
+            continue
+        if in_block and stripped:
+            try:
+                records.append(TranscriptRecord.from_json(json.loads(stripped)))
+            except (json.JSONDecodeError, KeyError, TypeError):
+                logger.warning("skipping malformed transcript line")
+    return records
+
+
+def load_transcript(room: str) -> list[TranscriptRecord]:
+    """Read a room's persisted transcript (empty when none exists)."""
+    from app.services.filesystem import get_room_dir, read_memory_file
+
+    result = read_memory_file(get_room_dir(room), TRANSCRIPT_KEY)
+    if result is None:
+        return []
+    _meta, body = result
+    return parse_transcript(body)
+
+
+def write_transcript(room: str, records: list[TranscriptRecord]) -> None:
+    """Persist a room's transcript to ``log/transcript.md`` (best-effort)."""
+    try:
+        from app.services.filesystem import get_room_dir, write_memory_file
+
+        base = get_room_dir(room)
+        base.mkdir(parents=True, exist_ok=True)
+        write_memory_file(
+            base,
+            TRANSCRIPT_KEY,
+            render_transcript(records),
+            created_by=l9.SYSTEM_ACTOR_ID,
+            updated_by=l9.SYSTEM_ACTOR_ID,
+        )
+    except Exception:
+        logger.exception("transcript write failed for room %s", room)
+
+
+# ── The receive loop ─────────────────────────────────────────────────────────
+
+SummonHook = Callable[[str, "L9"], None]
+ConvergedHook = Callable[["L9"], None]
+
+# Consecutive immediate transport failures before the loop gives up — keeps a
+# torn-down channel from spinning a hot loop while tolerating transient hiccups.
+_MAX_CONSECUTIVE_FAILURES = 3
+
+
+def _default_summon_hook(handle: str, envelope: L9) -> None:
+    logger.info("summon hook (skeleton): @%s summoned; engine wiring is Step 7", handle)
+
+
+def _default_converged_hook(envelope: L9) -> None:
+    logger.info(
+        "plan-compile hook (skeleton): commit:converged on episode %s; "
+        "plan_compiler wiring is Step 8",
+        envelope.header.message.episode if envelope.header.message else "?",
+    )
+
+
+class RoomPersister:
+    """Consumes one room's channel: persists, re-serves, and watches triggers.
+
+    ``members_provider`` returns the handles currently on the channel (the
+    moderator's authoritative membership from
+    :class:`~app.services.room_channels.RoomChannelManager`), so the persister
+    knows who received each broadcast live. The hooks are skeletons wired to real
+    behaviour in later steps.
+    """
+
+    def __init__(
+        self,
+        room: str,
+        channel: L9SlimChannel,
+        *,
+        members_provider: Callable[[], Iterable[str]],
+        on_summon: SummonHook | None = None,
+        on_converged: ConvergedHook | None = None,
+        feed_bus: bool = True,
+    ) -> None:
+        self.room = room
+        self._channel = channel
+        self._members_provider = members_provider
+        self.on_summon = on_summon or _default_summon_hook
+        self.on_converged = on_converged or _default_converged_hook
+        self._feed_bus = feed_bus
+        # Resume from the persisted transcript so cursors/re-serve survive a
+        # backend restart (records already on disk count as history).
+        self.log = DeliveryLog(load_transcript(room))
+        # handle -> most recent inbound MessageContext, for targeted re-serve.
+        self._contexts: dict[str, slim_bindings.MessageContext] = {}
+
+    # -- membership signals (driven by RoomChannelManager) --
+
+    def note_join(self, handle: str) -> bool:
+        """Record a membership add; return True if it is a **reconnect**.
+
+        A handle the persister has never seen is a fresh join — it missed nothing
+        that preceded it, so it is tracked caught-up and this returns False. A
+        handle seen before is a reconnect: caller should :meth:`reserve` its
+        missed tail.
+        """
+        if self.log.knows(handle):
+            return True
+        self.log.track(handle, caught_up=True)
+        return False
+
+    async def reserve(self, handle: str) -> int:
+        """Re-serve ``handle`` the messages it missed while offline, in order.
+
+        Targeted (point-to-point) so the rest of the room is untouched. Requires
+        a cached reply context for ``handle`` (from an earlier message it sent);
+        without one there is no route to re-serve to, so it is a no-op until the
+        connector holds its own identity (Step 5). Returns the count re-served.
+        """
+        missed = self.log.undelivered(handle)
+        if not missed:
+            return 0
+        context = self._contexts.get(handle)
+        if context is None:
+            logger.debug("no reply context for %s; cannot re-serve %d missed", handle, len(missed))
+            return 0
+        served = 0
+        for record in missed:
+            try:
+                await self._channel.send_content_to(context, record.content)
+                served += 1
+            except Exception:
+                logger.exception("re-serve to %s failed at message %s", handle, record.message_id)
+                break
+        if served:
+            self.log.mark_caught_up(handle)
+            logger.info(
+                "re-served %d missed message(s) to %s in room %s", served, handle, self.room
+            )
+        return served
+
+    # -- the loop --
+
+    async def run(self) -> None:
+        """Pull from the channel forever, recording and dispatching each message."""
+        failures = 0
+        while True:
+            try:
+                released, arrived, context = await self._channel.receive_with_context()
+            except Exception as exc:
+                from asyncio import CancelledError
+
+                if isinstance(exc, CancelledError):
+                    raise
+                failures += 1
+                logger.debug(
+                    "persister receive error on room %s (%d): %s", self.room, failures, exc
+                )
+                if failures >= _MAX_CONSECUTIVE_FAILURES:
+                    logger.info("persister for room %s stopping after repeated errors", self.room)
+                    return
+                continue
+            failures = 0
+            # Cache the arrived sender's reply context for future re-serve.
+            sender = envelope_sender(arrived)
+            if sender is not None:
+                self._contexts[sender] = context
+            for envelope, content in released:
+                self._ingest(envelope, content)
+
+    def _ingest(self, envelope: L9, content: dict[str, Any]) -> None:
+        record = record_from(envelope, content)
+        present = set(self._members_provider())
+        self.log.record(record, delivered_to=present)
+        write_transcript(self.room, self.log.records)
+        if self._feed_bus:
+            self._publish_to_bus(record)
+        # Triggers: @-summon and commit:converged (skeleton hooks).
+        for handle in find_summons(content):
+            try:
+                self.on_summon(handle, envelope)
+            except Exception:
+                logger.exception("summon hook failed for @%s", handle)
+        if is_converged(envelope):
+            try:
+                self.on_converged(envelope)
+            except Exception:
+                logger.exception("converged hook failed")
+
+    def _publish_to_bus(self, record: TranscriptRecord) -> None:
+        """Feed the recorded message to the in-process bus so the SSE UI sees it.
+
+        The bus (``routes/stream.py``) is the frontend's live feed until Step 10;
+        agent messages arrive over SLIM, not HTTP, so the persister is what keeps
+        that feed fed. Best-effort — never fail a record over a UI push.
+        """
+        try:
+            from app.bus import bus, room_channel
+
+            payload = {
+                "id": record.message_id,
+                "sender_handle": record.sender or l9.SYSTEM_ACTOR_ID,
+                "message_type": f"l9_{record.kind}",
+                "content": json.dumps(record.content),
+                "created_at": record.recorded_at,
+                "room_name": self.room,
+            }
+            bus.publish(room_channel(self.room), payload)
+        except Exception:
+            logger.debug("bus publish from persister failed for room %s", self.room, exc_info=True)

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -16,9 +16,12 @@ installed), the calls degrade to no-ops so room CRUD and the unit suite stay
 green without a live fabric — the sole failure mode is "no SLIM channel," never
 "room create failed." A node-reachability pre-flight keeps the no-node path fast.
 
-Out of scope (Step 4): the durable inbox/persister that records the transcript
-and re-serves missed messages. This module provisions and invites; it does **not**
-run a receive loop.
+Step 4 adds the durable inbox/persister: on provision the moderator starts a
+long-lived :class:`~app.services.persister.RoomPersister` that consumes the
+channel — recording the transcript, re-serving missed messages to reconnecting
+members, and watching for ``@``-summon / ``commit:converged`` triggers. This
+module owns that task's start/stop lifecycle and surfaces the reconnect signal
+(a membership add for a handle the persister has seen before) into a re-serve.
 """
 
 from __future__ import annotations
@@ -34,6 +37,7 @@ from app.services.l9_slim import (
     L9SlimChannel,
     build_episode_abort_envelope,
 )
+from app.services.persister import ConvergedHook, RoomPersister, SummonHook
 from app.services.slim_client import (
     SlimClient,
     SlimIdentity,
@@ -60,6 +64,8 @@ class ManagedRoomChannel:
     channel: L9SlimChannel
     members: set[str] = field(default_factory=set)
     lifecycle: EpisodeLifecycle = field(default_factory=EpisodeLifecycle)
+    persister: RoomPersister | None = None
+    persister_task: asyncio.Task[None] | None = None
 
 
 class RoomChannelManager:
@@ -72,6 +78,11 @@ class RoomChannelManager:
         self._lock = asyncio.Lock()
         # Strong refs to in-flight background invites (see invite_in_background).
         self._tasks: set[asyncio.Task[bool]] = set()
+        # Trigger hooks handed to every persister. Skeletons by default (log
+        # only); Step 7 wires ``on_summon`` to the cognition-engine spawner and
+        # Step 8 wires ``on_converged`` to ``plan_compiler``.
+        self.on_summon: SummonHook | None = None
+        self.on_converged: ConvergedHook | None = None
 
     def get(self, room: str) -> ManagedRoomChannel | None:
         return self._channels.get(room)
@@ -121,8 +132,25 @@ class RoomChannelManager:
                 room=room, workspace=ws, client=client, channel=L9SlimChannel(client, session)
             )
             self._channels[room] = managed
+            self._start_persister(managed)
             logger.info("Provisioned SLIM channel for room %s (workspace=%s)", room, ws)
             return managed
+
+    def _start_persister(self, managed: ManagedRoomChannel) -> None:
+        """Attach and start the durable-inbox persister for a channel.
+
+        The consumer loop is long-lived; the task ref is held on the managed
+        channel so it isn't GC'd, and cancelled in :meth:`close`.
+        """
+        room = managed.room
+        managed.persister = RoomPersister(
+            room,
+            managed.channel,
+            members_provider=lambda: self.members(room),
+            on_summon=self.on_summon,
+            on_converged=self.on_converged,
+        )
+        managed.persister_task = asyncio.create_task(managed.persister.run())
 
     async def invite(self, room: str, agent: str) -> bool:
         """Invite ``agent`` into the room channel. Best-effort; returns success."""
@@ -139,6 +167,13 @@ class RoomChannelManager:
             logger.debug("SLIM invite skipped (room=%s agent=%s): %s", room, agent, exc)
             return False
         managed.members.add(agent)
+        # Durable inbox: a membership add for a handle the persister has already
+        # seen is a *reconnect* — re-serve its missed tail. Kept separate from the
+        # episode-abort path below: transcript continuity and episode lifecycle
+        # are orthogonal (a reconnect re-serves regardless of episode state, and a
+        # re-serve must not resurrect an aborted episode).
+        if managed.persister is not None and managed.persister.note_join(agent):
+            await managed.persister.reserve(agent)
         await self._enforce_membership_change(managed)
         return True
 
@@ -202,10 +237,19 @@ class RoomChannelManager:
             logger.warning("Failed to publish episode abort for %s: %s", episode, exc)
 
     async def close(self, room: str) -> None:
-        """Tear down the room's channel (moderator leaves; connection dropped)."""
+        """Tear down the room's channel (persister stopped; moderator leaves)."""
         managed = self._channels.pop(room, None)
         if managed is None:
             return
+        if managed.persister_task is not None:
+            managed.persister_task.cancel()
+            try:
+                await managed.persister_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:  # pragma: no cover - best-effort teardown
+                logger.debug("persister task teardown error for room %s: %s", room, exc)
+            managed.persister_task = None
         await managed.client.close()
         logger.info("Closed SLIM channel for room %s", room)
 

--- a/fastapi-backend/app/services/slim_client.py
+++ b/fastapi-backend/app/services/slim_client.py
@@ -355,6 +355,22 @@ class SlimClient:
         await session.publish_async(data, None, None)
 
     @staticmethod
+    async def publish_to(
+        session: slim_bindings.Session, context: slim_bindings.MessageContext, data: bytes
+    ) -> None:
+        """Send ``data`` to the single member that produced ``context``.
+
+        Point-to-point over the group session (``publish_to_async``): the reply
+        is routed to ``context``'s source only, not fanned out to the whole
+        group. This is the transport the durable-inbox persister uses to
+        **re-serve** missed messages to one reconnecting agent (Step 4) without
+        re-delivering to everyone. ``context`` is a ``MessageContext`` captured
+        from an earlier inbound message from that member (see
+        :meth:`receive_message`). Best-effort, like :meth:`publish`.
+        """
+        await session.publish_to_async(context, data, None, None)
+
+    @staticmethod
     async def receive(session: slim_bindings.Session, *, timeout_s: float = 30.0) -> bytes:
         """Block for the next inbound broadcast on ``session`` and return its bytes.
 
@@ -362,3 +378,16 @@ class SlimClient:
         """
         message = await session.get_message_async(timeout=datetime.timedelta(seconds=timeout_s))
         return message.payload
+
+    @staticmethod
+    async def receive_message(
+        session: slim_bindings.Session, *, timeout_s: float = 30.0
+    ) -> slim_bindings.ReceivedMessage:
+        """Block for the next inbound message and return the whole message.
+
+        Unlike :meth:`receive` (payload bytes only), this preserves the
+        ``.context`` (a ``MessageContext`` carrying the sender's routable
+        source) so the persister can later :meth:`publish_to` that sender. The
+        returned object exposes ``.payload`` (bytes) and ``.context``.
+        """
+        return await session.get_message_async(timeout=datetime.timedelta(seconds=timeout_s))

--- a/fastapi-backend/scripts/l9_slim_roundtrip.py
+++ b/fastapi-backend/scripts/l9_slim_roundtrip.py
@@ -148,6 +148,91 @@ async def run_episode_abort(endpoint: str = DEFAULT_NODE_ENDPOINT) -> L9:
         await manager.close_all()
 
 
+_INBOX_ROOM = "durable-inbox-room"
+_INBOX_EPISODE = l9.episode_urn(_INBOX_ROOM, "inbox-run")
+_HELLO_ID = "hello-from-a"
+_MISSED_ID = "missed-while-offline"
+
+
+def _agent_reply(sender: str, message_id: str) -> L9:
+    return l9.build_envelope(
+        kind=Kind.exchange,
+        episode=_INBOX_EPISODE,
+        sender=sender,
+        recipients=[l9.SYSTEM_ACTOR_ID],
+        topic=l9.topic_urn(_INBOX_ROOM),
+        message_id=message_id,
+        payload_type="reply",
+        payload_data={"action": "offer"},
+    )
+
+
+async def _wait_for(pred, *, timeout: float = 10.0) -> None:
+    """Poll ``pred`` until true (the persister processes on its own task)."""
+    waited = 0.0
+    while not pred():
+        if waited >= timeout:
+            raise TimeoutError("condition not met in time")
+        await asyncio.sleep(0.1)
+        waited += 0.1
+
+
+async def run_durable_inbox(endpoint: str = DEFAULT_NODE_ENDPOINT) -> list[L9]:
+    """Prove the durable inbox end-to-end (Step 4 DoD).
+
+    The backend provisions a channel (starting its persister). ``agent-a`` joins
+    and speaks once — so the persister has a reply route to it — then goes offline
+    (dropped from membership). ``agent-b`` broadcasts a message while ``agent-a``
+    is gone; SLIM does *not* retain it (bible §7d). ``agent-a`` reconnects
+    (re-invited): the persister recognizes the reconnect and **re-serves** the
+    missed message point-to-point. Returns what ``agent-a`` received on rejoin —
+    the message it missed while offline.
+    """
+    manager = RoomChannelManager(endpoint=endpoint, default_workspace=_WORKSPACE)
+    managed = await manager.provision(_INBOX_ROOM)
+    assert managed is not None and managed.persister is not None
+    persister = managed.persister
+
+    agent_a = await SlimClient(SlimIdentity(_WORKSPACE, _INBOX_ROOM, "agent-a")).connect(endpoint)
+    agent_b = await SlimClient(SlimIdentity(_WORKSPACE, _INBOX_ROOM, "agent-b")).connect(endpoint)
+
+    try:
+        # agent-a joins and speaks once so the persister caches its reply route.
+        a_listen = asyncio.create_task(agent_a.listen_for_session())
+        await manager.invite(_INBOX_ROOM, "agent-a")
+        a_session = await a_listen
+        await L9SlimChannel(agent_a, a_session).send(_agent_reply("agent-a", _HELLO_ID))
+        await _wait_for(lambda: "agent-a" in persister._contexts)
+
+        # agent-a goes offline: dropped from the channel membership.
+        await manager.remove(_INBOX_ROOM, "agent-a")
+
+        # agent-b joins and broadcasts while agent-a is gone.
+        b_listen = asyncio.create_task(agent_b.listen_for_session())
+        await manager.invite(_INBOX_ROOM, "agent-b")
+        b_session = await b_listen
+        await L9SlimChannel(agent_b, b_session).send(_agent_reply("agent-b", _MISSED_ID))
+        await _wait_for(
+            lambda: any(r.message_id == _MISSED_ID for r in persister.log.undelivered("agent-a"))
+        )
+
+        # agent-a reconnects (same app, new group session): the re-invite is a
+        # membership add for a known handle → the persister re-serves the tail.
+        a_relisten = asyncio.create_task(agent_a.listen_for_session())
+        await manager.invite(_INBOX_ROOM, "agent-a")
+        a_session2 = await a_relisten
+        a_channel2 = L9SlimChannel(agent_a, a_session2)
+
+        received: list[L9] = []
+        while not received:
+            received.extend(await a_channel2.receive(timeout_s=15.0))
+        return received
+    finally:
+        await agent_a.close()
+        await agent_b.close()
+        await manager.close_all()
+
+
 async def _main(endpoint: str) -> int:
     received = await run_roundtrip(endpoint)
     ids = [e.header.message.id for e in received if e.header.message is not None]
@@ -161,6 +246,16 @@ async def _main(endpoint: str) -> int:
         print(f"MISMATCH — episode abort subkind {abort.header.subkind!r}", file=sys.stderr)
         return 1
     print(f"OK — mid-episode membership change aborted with commit:{abort.header.subkind}")
+
+    inbox = await run_durable_inbox(endpoint)
+    inbox_ids = [e.header.message.id for e in inbox if e.header.message is not None]
+    if inbox_ids != [_MISSED_ID]:
+        print(
+            f"MISMATCH — durable inbox re-served {inbox_ids}, expected {[_MISSED_ID]}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK — durable inbox re-served missed message on reconnect: {inbox_ids}")
     return 0
 
 

--- a/fastapi-backend/tests/test_l9_over_slim_roundtrip.py
+++ b/fastapi-backend/tests/test_l9_over_slim_roundtrip.py
@@ -71,3 +71,22 @@ async def test_mid_episode_membership_change_aborts_over_slim():
     assert abort.header.kind.value == "commit"
     assert abort.header.subkind == "rejected"
     assert abort.payload.data.get("reason") == "membership_change"
+
+
+@pytest.mark.asyncio
+async def test_durable_inbox_reserves_missed_message_on_reconnect(tmp_path, monkeypatch):
+    """Step 4 DoD: an agent offline during a broadcast is re-served it on rejoin.
+
+    agent-a joins, goes offline, misses agent-b's broadcast (SLIM keeps nothing
+    for the absent member, §7d), reconnects, and the backend persister re-serves
+    exactly the missed message — targeted, in order.
+    """
+    # Persister writes the transcript to the data dir; isolate it to a temp path.
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    from scripts.l9_slim_roundtrip import _MISSED_ID, run_durable_inbox
+
+    received = await run_durable_inbox(_ENDPOINT)
+
+    ids = [e.header.message.id for e in received if e.header.message is not None]
+    assert ids == [_MISSED_ID]
+    assert received[0].header.kind.value == "exchange"

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the backend persister / durable inbox (app/services/persister.py).
+
+Node-free: they exercise the delivery cursor, transcript persistence, and the
+trigger detection as pure logic over built envelopes. The live durable-inbox
+round trip over a real SLIM node is in ``test_l9_over_slim_roundtrip.py``
+(guarded on a running node).
+"""
+
+import pytest
+
+from app.services import l9, persister
+from app.services.filesystem import get_room_dir, read_memory_file
+from app.services.l9_models import Kind
+
+
+def _exchange(message_id: str, *, sender: str = "agent-a", text: str | None = None):
+    """A minimal exchange envelope (optionally naming a human-facing text)."""
+    return l9.build_envelope(
+        kind=Kind.exchange,
+        episode="urn:ioc:mycelium:episode:r:s",
+        sender=sender,
+        recipients=[l9.SYSTEM_ACTOR_ID],
+        topic="urn:concept:mycelium:r",
+        message_id=message_id,
+        payload_type="reply",
+        payload_data={"action": "offer", **({"text": text} if text is not None else {})},
+    )
+
+
+def _record(
+    message_id: str, *, sender: str = "agent-a", text: str = ""
+) -> persister.TranscriptRecord:
+    env = _exchange(message_id, sender=sender, text=text or None)
+    from app.services.l9_slim import serialize_content
+
+    return persister.record_from(
+        env, serialize_content(env, extra={"text": text} if text else None)
+    )
+
+
+# ── delivery cursor ──────────────────────────────────────────────────────────
+
+
+def test_cursor_advances_for_present_members_and_stays_empty_when_caught_up():
+    log = persister.DeliveryLog()
+    log.track("agent-a", caught_up=True)
+
+    log.record(_record("m1"), delivered_to={"agent-a"})
+    assert log.undelivered("agent-a") == []  # got it live → caught up
+
+
+def test_cursor_yields_exactly_the_missed_tail_for_an_offline_agent():
+    log = persister.DeliveryLog()
+    log.track("agent-a", caught_up=True)
+
+    # agent-a present for m1, then offline for m2 and m3.
+    log.record(_record("m1"), delivered_to={"agent-a"})
+    log.record(_record("m2"), delivered_to={"agent-b"})
+    log.record(_record("m3"), delivered_to={"agent-b"})
+
+    tail = log.undelivered("agent-a")
+    assert [r.message_id for r in tail] == ["m2", "m3"]
+
+    # After re-serve it is caught up again.
+    log.mark_caught_up("agent-a")
+    assert log.undelivered("agent-a") == []
+
+
+def test_fresh_join_is_caught_up_and_misses_nothing_prior():
+    log = persister.DeliveryLog()
+    log.record(_record("m1"), delivered_to=set())  # happened before agent-a joined
+    assert not log.knows("agent-a")
+
+    log.track("agent-a", caught_up=True)  # a first join
+    assert log.undelivered("agent-a") == []  # missed nothing that preceded it
+
+    log.record(_record("m2"), delivered_to={"agent-b"})  # now offline
+    assert [r.message_id for r in log.undelivered("agent-a")] == ["m2"]
+
+
+# ── transcript persistence ───────────────────────────────────────────────────
+
+
+def test_transcript_persists_in_order_and_survives_reload():
+    room = "persist-room"
+    get_room_dir(room)  # ensure the room dir exists
+    records = [_record("m1", text="first"), _record("m2", text="second")]
+    persister.write_transcript(room, records)
+
+    reloaded = persister.load_transcript(room)
+    assert [r.message_id for r in reloaded] == ["m1", "m2"]
+    assert reloaded[0].content["text"] == "first"
+    assert reloaded[1].sender == "agent-a"
+
+
+def test_transcript_does_not_clobber_episode_records():
+    """The transcript is a distinct file from log/episodes/* (bible §11 trap)."""
+    room = "coexist-room"
+    base = get_room_dir(room)
+    # Seed an episode record where l9_episode would write one.
+    from app.services.filesystem import write_memory_file
+
+    write_memory_file(base, "log/episodes/abcd1234", "# Episode\n", created_by="x")
+
+    persister.write_transcript(room, [_record("m1")])
+
+    # Both survive independently.
+    assert read_memory_file(base, "log/episodes/abcd1234") is not None
+    assert read_memory_file(base, persister.TRANSCRIPT_KEY) is not None
+    assert (base / "log" / "transcript.md").exists()
+    assert (base / "log" / "episodes" / "abcd1234.md").exists()
+
+
+# ── trigger-watcher ──────────────────────────────────────────────────────────
+
+
+def test_summon_token_is_recognized_in_content():
+    content = {"text": "hey @aligner can you check this?", "l9": {"ignored": "@notme"}}
+    assert persister.find_summons(content) == ["aligner"]
+
+
+def test_plain_message_has_no_summons():
+    assert persister.find_summons({"text": "just chatting, no mentions"}) == []
+    # An @ inside the l9 envelope key is never treated as a summon.
+    assert persister.find_summons({"l9": {"note": "@ghost"}}) == []
+
+
+def test_multiple_summons_deduped_in_order():
+    content = {"text": "@a and @b and @a again", "extra": ["also @c"]}
+    assert persister.find_summons(content) == ["a", "b", "c"]
+
+
+# ── plan-compile hook ────────────────────────────────────────────────────────
+
+
+def test_is_converged_true_only_for_commit_converged():
+    converged = l9.build_envelope(
+        kind=Kind.commit,
+        subkind="converged",
+        episode="urn:ioc:mycelium:episode:r:s",
+        payload_type="consensus",
+        payload_data={},
+    )
+    rejected = l9.build_envelope(
+        kind=Kind.commit,
+        subkind="rejected",
+        episode="urn:ioc:mycelium:episode:r:s",
+        payload_type="consensus",
+        payload_data={},
+    )
+    assert persister.is_converged(converged) is True
+    assert persister.is_converged(rejected) is False
+    assert persister.is_converged(_exchange("m1")) is False
+
+
+# ── ingest wiring: triggers fire off recorded messages ───────────────────────
+
+
+def _persister_for(room: str, *, summoned: list, converged: list) -> persister.RoomPersister:
+    """A persister with no live channel, hooks capturing into the given lists."""
+    return persister.RoomPersister(
+        room,
+        channel=None,  # ty: ignore[invalid-argument-type]  # not exercised: we call _ingest directly
+        members_provider=lambda: set(),
+        on_summon=lambda handle, env: summoned.append(handle),
+        on_converged=lambda env: converged.append(env),
+        feed_bus=False,
+    )
+
+
+def test_ingest_fires_summon_hook_but_not_on_plain_message():
+    summoned: list[str] = []
+    converged: list = []
+    p = _persister_for("ingest-room", summoned=summoned, converged=converged)
+
+    from app.services.l9_slim import serialize_content
+
+    env = _exchange("m1", text="ping @aligner")
+    p._ingest(env, serialize_content(env, extra={"text": "ping @aligner"}))
+    assert summoned == ["aligner"]
+    assert converged == []
+
+    plain = _exchange("m2", text="no mention here")
+    p._ingest(plain, serialize_content(plain, extra={"text": "no mention here"}))
+    assert summoned == ["aligner"]  # unchanged
+
+
+def test_ingest_fires_converged_hook_for_commit_converged_only():
+    summoned: list[str] = []
+    converged: list = []
+    p = _persister_for("ingest-room-2", summoned=summoned, converged=converged)
+
+    from app.services.l9_slim import serialize_content
+
+    conv = l9.build_envelope(
+        kind=Kind.commit,
+        subkind="converged",
+        episode="urn:ioc:mycelium:episode:r:s",
+        message_id="c1",
+        payload_type="consensus",
+        payload_data={},
+    )
+    p._ingest(conv, serialize_content(conv))
+    assert len(converged) == 1
+
+    other = _exchange("m3", text="just talking")
+    p._ingest(other, serialize_content(other))
+    assert len(converged) == 1  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_reserve_without_context_is_a_noop():
+    """No cached reply context (agent never spoke) → nothing to route to."""
+    p = _persister_for("reserve-room", summoned=[], converged=[])
+    p.log.track("agent-a", caught_up=True)
+    from app.services.l9_slim import serialize_content
+
+    env = _exchange("m1")
+    p.log.record(persister.record_from(env, serialize_content(env)), delivered_to=set())
+    # agent-a missed m1 but we have no context for it → 0 re-served, no raise.
+    assert await p.reserve("agent-a") == 0


### PR DESCRIPTION
## Step 4 — Backend as room infrastructure

Picks up [`docs/START_HERE_STEP_4.md`](https://github.com/mycelium-io/mycelium/blob/step-4-persister-durable-inbox/docs/START_HERE_STEP_4.md) (Step 3 merged in #421). This is the step where the backend stops being a passive moderator and becomes the always-on room infrastructure: it **joins the channel's read loop** as the persister / durable inbox / trigger-watcher.

### What changed

**New — `app/services/persister.py`**
- **`RoomPersister`** — a long-lived task per room, started by `room_channels` on `provision`, that pulls `L9SlimChannel.receive_with_context()` and, for each message: records the transcript, feeds the UI bus, and runs the trigger-watcher.
- **Persister / transcript** — the full stream is written to the room's markdown at `log/transcript.md` (a jsonl-bearing memory file): git-shareable, reindexed the normal way, and a **distinct artifact** from the episode-scoped `log/episodes/*` (no clobber).
- **Durable inbox** — SLIM keeps nothing for an offline member (bible §7d). `DeliveryLog` tracks a per-`(room, handle)` delivery cursor; on **reconnect** (a membership add for a handle the persister has already seen) the backend **re-serves the missed tail point-to-point** via `publish_to`, so a broadcast an agent missed while offline is delivered in order on rejoin. The receiver's own `CausalOrderBuffer` re-orders/de-dupes.
- **Trigger-watcher (skeletons)** — recognizes `@`-summon tokens (`find_summons`) → summon hook (real engine is **Step 7**) and `commit:converged` (`is_converged`) → plan-compile seam (fired in **Step 8**). Both hooks log only here.

**Extended**
- `slim_client.py` — `publish_to` (targeted point-to-point send) + `receive_message` (whole message with `.context`).
- `l9_slim.py` — `receive_with_context()` / `send_content_to(ctx, content)` + a `serialize_content` helper (content dict form kept so a missed message can be re-served verbatim).
- `room_channels.py` — owns the persister start/stop lifecycle (cancel on `close`/`close_all`, strong task ref) and surfaces the reconnect → re-serve on `invite`. Reconnect re-serve is kept **orthogonal** to episode-abort (a reconnect re-serves regardless of episode state; a re-serve never resurrects an aborted episode).
- Updated the now-stale `# TODO(step4)` / `# TODO(step3)` notes in `local_state.py` / `routes/messages.py` (the UI HTTP/SSE feed stays until Step 10).

### Definition of Done ✅

An agent offline during a broadcast **receives the missed message(s) on reconnect, in order**, and the **channel transcript is persisted to markdown**. The trigger-watcher recognizes an `@`-summon and calls the (skeleton) summon hook; a `commit:converged` fires the plan-compile seam (without compiling).

### Tests

**Fast unit gate (no node)** — `tests/test_persister.py`: delivery cursor (advances for present members, yields exactly the missed tail for an offline agent, empty when caught up); transcript persistence + reload + coexists with `log/episodes/*`; `@`-summon recognition (and the `l9` key is never scanned); `commit:converged`-only plan hook; ingest wiring fires the hooks.

**Live-node integration slice (guarded)** — `test_l9_over_slim_roundtrip.py::test_durable_inbox_reserves_missed_message_on_reconnect` + a `run_durable_inbox(...)` scenario in `scripts/l9_slim_roundtrip.py`.

Verified end-to-end against a standalone `ghcr.io/agntcy/slim:1.4.0` node:

```
228 passed, 5 skipped         # backend fast gate
4 passed                       # backend live-node slices (all prior slices still pass)
346 passed                     # CLI gate (ruff + format + ty + pytest)

OK — moderator received in causal order: ['root-envelope-id', 'child-envelope-id']
OK — mid-episode membership change aborted with commit:rejected
OK — durable inbox re-served missed message on reconnect: ['missed-while-offline']
```

### Deferrals (named per the plan)

Claude Code connector + wake bridge and the daemon SLIM retarget are **Step 5** (`daemon/dispatch.py` stays on httpx SSE here); human `@`-mention + consent is **Step 6**; cognition engines (wiring `on_summon`) are **Step 7**; plan-compile firing (wiring `on_converged`) + memory sync are **Step 8**; SSE/`stream.py` retires in **Step 10**.

Handoff for the next agent: [`docs/START_HERE_STEP_5.md`](https://github.com/mycelium-io/mycelium/blob/step-4-persister-durable-inbox/docs/START_HERE_STEP_5.md).