### PR TITLE
Step 5: Claude Code connector + wake bridge (daemon on SLIM)

### DIFF
--- a/docs/START_HERE_STEP_6.md
+++ b/docs/START_HERE_STEP_6.md
@@ -1,0 +1,179 @@
+# START HERE — Step 6 (Human-in-the-room + `@`-mention + consent)
+
+Companion to [`START_HERE.md`](./START_HERE.md). Step 5 is **done** (this PR into
+`slim-native-rewrite`); you are picking up **Step 6**. Read `START_HERE.md`,
+[`START_HERE_STEP_1.md`](./START_HERE_STEP_1.md) → [`START_HERE_STEP_5.md`](./START_HERE_STEP_5.md)
+first if you haven't — the same rules apply. This file gives you (a) the exact state Step 5
+left behind, (b) your Step 6 marching orders, (c) the facts you must internalize, and (d) the
+traps specific to this step.
+
+**Step 5 put a real agent on the fabric.** A registered Claude Code agent now holds its own SLIM
+connection (via the daemon connector), is **woken** by an inbound L9 message addressed to it,
+**spawns** a headless turn, and its **reply lands back in the channel** — the first end-to-end
+dogfood loop. But the only thing that can address it today is another agent's connector or a raw
+test publisher. **Step 6 puts the human in the room:** the backend publishes the human's message
+onto the channel, `@`-parses it into L9 recipients, wakes in-room agents (via Step 5's bridge),
+and — the hero-demo differentiator — surfaces a **consent-to-be-woken** prompt when an agent is
+`@`-invited into a room it isn't in yet.
+
+## Ground rules (unchanged from START_HERE.md)
+
+1. **The bible is authoritative:** [`slim-native-rebuild-bible.md`](./slim-native-rebuild-bible.md).
+   Your work is **Part V · Step 6**, with **§12 (wake / `@`-mention / invite / consent)** and
+   **§13 (the full cycle)** as the design reference.
+2. Leave the project **runnable and green** — backend + CLI quality gates pass at the end.
+3. Code/config blocks in the bible are **reference, not paste**.
+4. **Verify before you edit** — the paths below were accurate at the end of Step 5; confirm shape
+   before changing a file.
+5. Fixed decisions are not up for debate; the one open question (human identity) has a default:
+   **the human is spoken-for by the backend** — no human connector for the MVP.
+
+## Where Step 5 left things (your starting state)
+
+Branch off `slim-native-rewrite` (Step 5 is merged). The agent side is now on the fabric; the
+**human side is still HTTP-only** and no `@`-parse maps mentions to L9 recipients. Concretely:
+
+- **The daemon is a SLIM member, not SSE.** `mycelium-cli/src/mycelium/daemon/connector.py`
+  holds `run_connector(room, handle, …)`: per owned `(room, handle)` it connects a member
+  `SlimClient`, `listen_for_session` (the backend moderator invites it), sends a presence
+  **hello** (seeding the durable-inbox reply route — Step 5 trap option (a)), then pumps a
+  `get_message` loop. `runner.py` launches one connector per owned cold-spawn handle
+  (`connector_targets`), reconciles them on SIGHUP, and cancels them on shutdown (then drops the
+  shared SLIM connection). **The old httpx SSE stream + coordination poller in `dispatch.py` are
+  no longer wired by the runner** — they remain in `dispatch.py` as legacy (their unit tests
+  still pass) and are retired with the backend SSE in **Step 10**.
+- **The wake decision lives in the connector.** `connector.should_wake(content, handle)` wakes on
+  an inbound L9 **`exchange`** that is (a) not the agent's own reply (`sender != handle` loop
+  guard) and (b) addressed to the handle — either via the L9 `participants` recipients **or** a
+  raw `@handle` token in the human text. `handle_inbound(…)` reuses `dispatch.py`'s gates
+  (`allow_from`/budget/depth), the per-handle serial lock, control verbs (`abort`/`status`), and
+  cold-spawn — **only the transport + reply sink changed** (SLIM + channel publish instead of SSE
+  + HTTP POST). The reply is an `exchange` parented on the message that woke it
+  (`parents = [woke_id]`), authored by the handle.
+- **The daemon has its own SLIM+L9 layer.** `mycelium-cli/src/mycelium/slim/` — `naming.py`
+  (identity/Name mapping + `mint_shared_secret`, a **byte-for-byte** mirror of the backend so MLS
+  matches), `client.py` (`SlimClient`: member methods + `create_group`/`invite` **for tests**),
+  `l9.py` (a lean, stdlib-only L9 helper: `build_reply_content` emits the **exact** shape the
+  backend's `l9.envelope_to_dict` produces, plus read accessors). **The CLI does not import the
+  FastAPI/ML backend** — it installs as a thin `uv tool`, so this layer is a deliberate small
+  mirror. `slim-bindings>=1.4,<2` is now a CLI dependency.
+- **Wire-shape parity is proven cross-package.** A reply built by the CLI's `l9.build_reply_content`
+  round-trips through the backend's `l9.parse_envelope` / `l9_slim.deserialize_envelope`
+  unchanged (`shape parity: True`). Keep the two L9 shapes in sync if the binding version moves —
+  the source of truth for the shape is `app.services.l9` / `app.services.l9_models`.
+- **The durable inbox now covers real reconnects.** Because the connector sends a hello on join,
+  the backend persister caches a reply route for the handle, so a connector that drops and
+  rejoins is re-served the tail it missed (Step 4's path, now reachable by a real agent).
+- **The human still speaks over HTTP.** `app/routes/messages.py` posts to the in-memory store +
+  in-process bus (the SSE UI feed). It does **not** publish onto the SLIM channel, and there is
+  **no `@`-parse → L9 participants** yet. That seam is your Step 6 job.
+
+## Your Step 6 scope (from the bible, Part V · Step 6)
+
+- **Publish the human onto the channel.** When a human posts to a room (the `messages` POST, or a
+  UI action), the backend — as the human's **spoken-for** proxy — builds an L9 `exchange`
+  envelope (`sender` = the human's handle, `l9.build_envelope`) and publishes it on the room's
+  `L9SlimChannel.send`. No human connector.
+- **`@`-parse → L9 participants.** Map `@agent-x` tokens in the human's text to L9 **recipients**
+  (everyone else = observers). The connector already wakes on recipient-match, so an in-room
+  `@`-mention wakes the agent through Step 5's bridge with no connector change.
+- **`@`-invite (not-in-room) = membership change + consent.** When a mention names an agent that
+  is **not** on the channel, the moderator treats it as an **invite**: surface an accept/decline
+  **consent** prompt on the target side; only `invite` + spawn on accept. Make it feel like
+  accepting a call (the hero-demo differentiator).
+- **`@`-invite-mid-episode policy:** queue the invite until the episode closes (default) or accept
+  a restart. The episode-abort machinery already exists (`room_channels._enforce_membership_change`).
+
+**Key files:** backend `@`-parse + participants mapping (new, near `messages.py` / a channel
+publish helper); `app/services/room_channels.py` (invite path + consent gate); the connector's
+`should_wake` (already recipient-aware — likely **no change** needed); CLI/UI consent surface
+(frontend `components/ui/dialog.tsx` for the prompt).
+
+## Facts you must internalize first
+
+- **The connector already wakes on recipients — don't re-solve waking.** Step 5's `should_wake`
+  fires on `handle in recipients_of(content)`. So the moment the backend publishes a human
+  `exchange` with the agent in L9 recipients, the in-room agent wakes. Step 6 is about **producing**
+  those recipients (the `@`-parse) and the **membership/consent** flow, not the wake itself.
+- **Two delivery formatters, one contract (CLAUDE.md).** The connector reads the human-facing text
+  from the `content` field (`l9.human_text_of`); keep the backend's published `extra` carrying the
+  body under `content` so the agent sees it. If you add fields to the published envelope, remember
+  the openclaw formatter discipline from CLAUDE.md still applies to that family.
+- **Consent is a target-side decision.** For a cold-spawn claude_code agent the "target side" is
+  the daemon that owns the handle. Decide where the accept/decline lives: a daemon-side prompt
+  (interactive) is awkward for a headless service — the UI/CLI consent surface is the natural home
+  (bible §12). Pick one, note it, flag it.
+- **Membership changes abort an open episode.** An `@`-invite that lands mid-episode will trip
+  `_enforce_membership_change` and abort it. That's why the bible's default is to **queue** the
+  invite until the episode closes. Don't invite mid-episode without honoring that policy.
+
+## Definition of Done
+
+A human `@`-mentions the Claude Code agent (in-room) and it **wakes and answers**; an `@`-invite of
+a **not-present** agent shows a **consent** prompt and only joins on accept. A declined invite does
+not join; a mid-episode invite is queued (default).
+
+## Tests to write (end of step)
+
+Fast unit tests (the merge gate — no node):
+
+- **`@`-parse → participants** — `@agent-x @agent-y do the thing` maps to recipients
+  `[agent-x, agent-y]`, others observers; a bare word `agentx@host` is not a mention.
+- **In-room mention wakes** — a published human `exchange` with the agent in recipients satisfies
+  the connector's `should_wake` (reuse the Step 5 connector tests).
+- **Not-in-room invite → consent** — an `@`-invite of an absent agent raises the consent surface
+  and does **not** join until accept; a declined invite does not join.
+- **Mid-episode invite queued** — an invite while an episode is active is deferred, not applied.
+
+Live-node **integration slice** (guarded, adds to the cumulative suite — **all prior slices must
+still pass**, backend + CLI):
+
+- **Human `@`-mention wakes the connector** — on a live node, the backend publishes a human
+  `exchange` addressed to a connected agent (mock `claude`), the connector wakes, and its reply
+  appears in the room. Model on `mycelium-cli/tests/test_connector_wake_over_slim.py`.
+- **Not-in-room `@`-invite raises consent and only joins on accept.**
+
+## Verification gate (must pass before you call Step 6 done)
+
+```bash
+# Backend
+cd fastapi-backend
+uv run ruff check . && uv run ruff format --check . && uv run ty check .
+MYCELIUM_STUB_EMBEDDINGS=1 uv run pytest tests/ -x -q            # fast gate, no node
+
+# CLI (matches CI)
+cd ../mycelium-cli
+uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run pytest tests/ -x -q
+
+# Guarded integration slices — bring a node up first (recipe in START_HERE_STEP_5.md §Verification):
+MYCELIUM_STUB_EMBEDDINGS=1 MYCELIUM_SLIM_ENDPOINT=http://127.0.0.1:46357 \
+  uv run pytest tests/ -q          # run in BOTH fastapi-backend/ and mycelium-cli/
+```
+
+Bring a standalone node up with the same docker recipe Step 5 used (see
+[`START_HERE_STEP_5.md`](./START_HERE_STEP_5.md) — the `ghcr.io/agntcy/slim:1.4.0` one-liner).
+
+## Traps specific to Step 6
+
+- **Don't double-feed the UI.** The persister already bridges SLIM → the UI bus. If the human's
+  message is now published onto the channel, make sure the backend doesn't *also* count it via the
+  legacy HTTP bus publish (that would show it twice). The persister records what flows past on the
+  channel — publish once.
+- **Don't rebuild the wake path.** The connector already wakes on recipients + `@handle`. Resist
+  adding a second mention-parser in the connector; produce L9 recipients backend-side and let the
+  existing `should_wake` do its job.
+- **Consent must actually block the join.** A consent prompt that fires *after* `invite` is
+  theater. Gate the `RoomChannelManager.invite` behind the accept, don't decorate it.
+- **Mid-episode invites.** Honor the queue-until-close default, or you'll abort live negotiations
+  every time a human name-drops a new agent.
+- **MLS on, version stays pinned.** `slim:1.4.0` / `slim-bindings` 1.4.x — matched pair; don't
+  touch it. The human's published envelope rides the same MLS group as everyone else.
+
+## Report when done
+
+Per `START_HERE.md`: what changed, the DoD check, and test results (fast gate + the live
+integration slices, noting all prior slices still pass, backend + CLI). Open a PR against
+`slim-native-rewrite` (same as Steps 0–5). Deferrals to name explicitly: cognition engines
+(wiring `on_summon`) are **Step 7**; plan-compile firing (wiring `on_converged`) + memory sync are
+**Step 8**; cross-machine is **Step 9**; SSE/`stream.py` (and the legacy SSE/poller helpers still
+sitting in the daemon's `dispatch.py`) are retired in **Step 10**.

--- a/mycelium-cli/pyproject.toml
+++ b/mycelium-cli/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "protobuf>=4.21.0",
     "rapidfuzz>=3.10.0",
     "questionary>=2.1.1",
+    "slim-bindings>=1.4,<2",
 ]
 
 [project.optional-dependencies]

--- a/mycelium-cli/src/mycelium/daemon/connector.py
+++ b/mycelium-cli/src/mycelium/daemon/connector.py
@@ -1,0 +1,473 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""SLIM connector + wake bridge — the daemon's member half (Step 5, bible §12).
+
+Step 4 made the backend the room's always-on **moderator** (persister + durable
+inbox). This module is the **member** the backend invites: per ``(room, handle)``
+it holds a SLIM group subscription and, on an inbound L9 message addressed to the
+handle, **wakes** the agent — cold-spawning a ``claude -p`` turn and publishing
+its reply back onto the channel as an L9 ``exchange`` (the backend persister
+records it, so other members see it).
+
+This replaces the daemon's old httpx SSE stream (``dispatch.py``). The dispatch
+**decision** machinery — ownership, ``allow_from``/budget/depth gates, the
+per-handle serial lock, control verbs, cold-spawn — is reused wholesale from
+``dispatch.py``; only the transport (SLIM instead of SSE) and the reply sink
+(channel publish instead of an HTTP POST) change. The agent's contract is
+unchanged: it never speaks SLIM or L9.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from mycelium.daemon.dispatch import (
+    _CONTROL_ABORT,
+    _CONTROL_STATUS,
+    _extract_body,
+    _fetch_agent_context,
+    _leading_verb,
+    _normalize_sender,
+    _post_log,
+    _render_plan_block,
+    gate_allow_from,
+    gate_budget,
+    gate_depth,
+    list_agent_handles,
+    load_manifest,
+    load_notes,
+)
+from mycelium.integrations import get_integration
+from mycelium.integrations._spawn_common import SpawnRequest
+from mycelium.slim import l9
+from mycelium.slim.client import SlimClient, SlimUnavailableError
+from mycelium.slim.naming import DEFAULT_WORKSPACE, SlimIdentity
+
+if TYPE_CHECKING:
+    from mycelium.config import MyceliumConfig
+    from mycelium.daemon.config import DaemonConfig
+    from mycelium.daemon.state import DaemonState
+    from mycelium.protocol import AgentManifest
+
+log = logging.getLogger("mycelium.daemon")
+
+# A content dict sink — the loop binds this to a channel broadcast; tests bind a
+# recorder. The connector always hands it a full ``{content, l9: <envelope>}``.
+PublishFn = Callable[[dict], Awaitable[None]]
+
+# Reconnect backoff after a dropped/failed subscription. The backend re-invites
+# a returning member and re-serves its missed tail (durable inbox, Step 4), so a
+# reconnect is cheap and safe to retry.
+_RECONNECT_BACKOFF_S = 5.0
+
+# The presence "hello" a connector broadcasts once it is in the group. It seeds
+# the backend persister's reply route for this handle (it caches a reply context
+# per *sender*), so a connector that then drops and rejoins is re-served the tail
+# it missed. Without a first message the persister has no point-to-point route to
+# a never-spoke member — this closes that gap (Step 5 trap, option (a)).
+_HELLO_TEXT = "joined the room"
+
+
+# ── Episode / topic derivation ───────────────────────────────────────────────
+# Match the backend's ``l9.episode_urn`` / ``l9.topic_urn`` forms so a reply
+# stays inside the same episode/concept the room is coordinating under.
+
+
+def _room_episode(room: str) -> str:
+    return f"urn:ioc:mycelium:episode:{room}:live"
+
+
+def _room_topic(room: str) -> str:
+    return f"urn:concept:mycelium:{room}"
+
+
+# ── Connector target discovery ───────────────────────────────────────────────
+
+
+def connector_targets(daemon_cfg: DaemonConfig) -> list[tuple[str, str]]:
+    """The ``(room, handle)`` pairs this daemon should hold a connector for.
+
+    A handle qualifies when it is (a) registered in the room's local mirror,
+    (b) owned by this daemon (``daemon.toml`` handles), and (c) a **cold_spawn**
+    family (claude_code / cursor). ``long_lived_gateway`` families (openclaw,
+    hermes) own their own delivery and are skipped, exactly as the old SSE
+    dispatch skipped them.
+    """
+    targets: list[tuple[str, str]] = []
+    for room in daemon_cfg.rooms:
+        for handle in list_agent_handles(room):
+            if handle not in daemon_cfg.handles:
+                continue
+            manifest = load_manifest(room, handle)
+            if manifest is None:
+                continue
+            try:
+                integration = get_integration(manifest.adapter)
+            except ValueError:
+                log.warning(
+                    "unknown adapter %r on @%s in %s — skipping", manifest.adapter, handle, room
+                )
+                continue
+            if integration.lifecycle != "cold_spawn":
+                continue
+            targets.append((room, handle))
+    return targets
+
+
+# ── Wake decision (pure) ─────────────────────────────────────────────────────
+
+
+def should_wake(content: dict, handle: str) -> bool:
+    """True if an inbound message should wake ``handle``.
+
+    Wakes only on an ``exchange`` (a room turn) that is **not the agent's own**
+    reply (loop guard: sender != handle) and is **addressed to the handle** —
+    either via the L9 ``participants`` recipients or a raw ``@handle`` token in
+    the human-facing text. System envelopes (``commit``/``knowledge``) are
+    observed but never spawn a turn.
+    """
+    if l9.kind_of(content) != l9.EXCHANGE_KIND:
+        return False
+    sender = l9.sender_of(content)
+    if sender is not None and _normalize_sender(sender) == _normalize_sender(handle):
+        return False
+    norm = _normalize_sender(handle)
+    if any(_normalize_sender(r) == norm for r in l9.recipients_of(content)):
+        return True
+    text = l9.human_text_of(content)
+    return _mentions(text, handle)
+
+
+def _mentions(text: str, handle: str) -> bool:
+    """True if ``text`` contains an ``@handle`` token (not mid-word)."""
+    lower = text.lower()
+    needle = f"@{handle.lower()}"
+    idx = lower.find(needle)
+    if idx == -1:
+        return False
+    end = idx + len(needle)
+    nxt = lower[end] if end < len(lower) else ""
+    return not (nxt and (nxt.isalnum() or nxt in "_-"))
+
+
+# ── Reply building ───────────────────────────────────────────────────────────
+
+
+def build_reply(
+    *, handle: str, room: str, woke: dict, text: str, message_id: str | None = None
+) -> dict:
+    """Build the L9 ``exchange`` reply content for ``handle``, parented on ``woke``.
+
+    Threads causality (``parents = [woke message id]``) and stays in the woke
+    message's episode/topic so the backend's causal buffer + transcript remain
+    correct.
+    """
+    woke_id = l9.message_id_of(woke)
+    sender = l9.sender_of(woke)
+    return l9.build_reply_content(
+        sender=handle,
+        recipients=[sender] if sender else [],
+        episode=l9.episode_of(woke) or _room_episode(room),
+        parents=[woke_id] if woke_id else [],
+        topic=l9.topic_of(woke) or _room_topic(room),
+        text=text,
+        message_id=message_id,
+    )
+
+
+# ── Per-message dispatch (transport-agnostic) ────────────────────────────────
+
+
+async def handle_inbound(
+    *,
+    config: MyceliumConfig,
+    daemon_cfg: DaemonConfig,
+    state: DaemonState,
+    room: str,
+    handle: str,
+    content: dict,
+    publish: PublishFn,
+) -> None:
+    """Wake ``handle`` for an inbound message and publish its reply.
+
+    Mirrors ``dispatch.on_message`` + ``_dispatch_one`` but SLIM-native: the
+    ownership check is implicit (this connector owns ``handle``), control verbs
+    and gates are unchanged, and the reply is published to the channel rather
+    than POSTed over HTTP.
+    """
+    if not should_wake(content, handle):
+        return
+
+    manifest = load_manifest(room, handle)
+    if manifest is None:
+        log.warning("woke @%s in %s but no manifest in local mirror — skipping", handle, room)
+        return
+
+    sender_handle = l9.sender_of(content) or "(anonymous)"
+    body = _extract_body(l9.human_text_of(content), handle)
+    verb = _leading_verb(body)
+
+    # Control verbs run OUTSIDE the per-handle lock (act on a running spawn /
+    # answer instantly) and skip the budget + depth caps — they don't spend or
+    # advance a chain.
+    if verb in _CONTROL_ABORT:
+        await _handle_abort(state, room, handle, sender_handle, content, publish)
+        return
+    if verb in _CONTROL_STATUS:
+        await _handle_status(state, room, handle, content, publish)
+        return
+
+    if not gate_allow_from(manifest, sender_handle):
+        log.info("denied @%s ← %s (allow_from)", handle, sender_handle)
+        return
+    if not gate_budget(state, manifest):
+        log.warning("denied @%s (budget exceeded)", handle)
+        return
+    if not gate_depth(state, sender_handle, daemon_cfg.depth_cap):
+        log.warning(
+            "denied @%s ← %s (depth cap %d in 60s)", handle, sender_handle, daemon_cfg.depth_cap
+        )
+        return
+
+    await _dispatch_one(
+        config=config,
+        daemon_cfg=daemon_cfg,
+        state=state,
+        room=room,
+        manifest=manifest,
+        sender_handle=sender_handle,
+        woke=content,
+        publish=publish,
+    )
+
+
+async def _dispatch_one(
+    *,
+    config: MyceliumConfig,
+    daemon_cfg: DaemonConfig,
+    state: DaemonState,
+    room: str,
+    manifest: AgentManifest,
+    sender_handle: str,
+    woke: dict,
+    publish: PublishFn,
+) -> None:
+    """Cold-spawn a turn under the per-handle serial lock; publish the reply."""
+    lock = state.lock_for(manifest.handle)
+    async with lock:
+        state.recent_dispatches[_normalize_sender(sender_handle)].append(time.monotonic())
+        notes = load_notes(room, manifest.handle)
+        prompt = l9.human_text_of(woke)
+        body = _extract_body(prompt, manifest.handle) or prompt
+        log.info("wake @%s ← %s (room=%s)", manifest.handle, sender_handle, room)
+
+        ctx, generated_at = await _fetch_agent_context(config.server.api_url, room, manifest.handle)
+        integration = get_integration(manifest.adapter)
+        request = SpawnRequest(
+            handle=manifest.handle,
+            room=room,
+            cwd=manifest.cwd or "",
+            prompt=body,
+            description=manifest.description,
+            sender=sender_handle,
+            notes=notes,
+            plan_block=_render_plan_block(ctx, generated_at),
+            binary=daemon_cfg.binary_for(manifest.adapter),
+            state=state,
+        )
+        result = await integration.spawn(request=request)
+
+        if result.aborted:
+            # The abort verb already published its own reply; just record it.
+            log.info("abort acknowledged for @%s", manifest.handle)
+            state.record_dispatch(
+                handle=manifest.handle,
+                room=room,
+                result="aborted",
+                duration_s=result.duration_s,
+                cost_usd=0.0,
+            )
+            return
+
+        ym = datetime.now(UTC).strftime("%Y-%m")
+        state.budget_used_usd[(manifest.handle, ym)] = (
+            state.budget_used_usd.get((manifest.handle, ym), 0.0) + result.cost_usd
+        )
+        state.record_dispatch(
+            handle=manifest.handle,
+            room=room,
+            result="ok" if result.ok else "error",
+            duration_s=result.duration_s,
+            cost_usd=result.cost_usd,
+        )
+
+        try:
+            await _post_log(
+                config, room, manifest, prompt=prompt, sender_handle=sender_handle, result=result
+            )
+        except Exception as exc:  # noqa: BLE001 - a log write must never sink the reply
+            state.record_error("post_log", exc)
+            log.warning("could not write log entry for @%s: %s", manifest.handle, exc)
+
+        try:
+            reply = build_reply(
+                handle=manifest.handle, room=room, woke=woke, text=result.final_message
+            )
+            await publish(reply)
+        except Exception as exc:  # noqa: BLE001 - best-effort channel publish
+            state.record_error("publish_reply", exc)
+            log.warning("could not publish reply for @%s: %s", manifest.handle, exc)
+
+
+async def _handle_abort(
+    state: DaemonState, room: str, handle: str, sender_handle: str, woke: dict, publish: PublishFn
+) -> None:
+    """``@handle abort|cancel|stop`` — SIGTERM the agent's running spawn."""
+    running = state.running.get(handle)
+    if running is None:
+        await _reply(
+            publish, handle, room, woke, f"○ nothing to abort (no run in flight) — {sender_handle}"
+        )
+        return
+    try:
+        running.process.terminate()
+    except ProcessLookupError:
+        pass
+    log.info(
+        "abort @%s ← %s (running %.1fs)",
+        handle,
+        sender_handle,
+        time.monotonic() - running.started_at,
+    )
+    await _reply(publish, handle, room, woke, f"✗ aborted by {sender_handle}")
+
+
+async def _handle_status(
+    state: DaemonState, room: str, handle: str, woke: dict, publish: PublishFn
+) -> None:
+    """``@handle status`` — describe the agent's current state."""
+    running = state.running.get(handle)
+    if running is not None:
+        elapsed = time.monotonic() - running.started_at
+        reply = (
+            f"● running for {elapsed:.0f}s (prompt: {running.prompt[:80]!r}, from {running.sender})"
+        )
+    else:
+        last = state.last_dispatch or {}
+        if last.get("agent") == handle:
+            reply = (
+                f"○ idle · last run: {last.get('result')} in "
+                f"{last.get('duration_s', 0):.1f}s (cost ${last.get('cost_usd', 0):.4f})"
+            )
+        else:
+            reply = "○ idle · no recent runs"
+    await _reply(publish, handle, room, woke, reply)
+
+
+async def _reply(publish: PublishFn, handle: str, room: str, woke: dict, text: str) -> None:
+    await publish(build_reply(handle=handle, room=room, woke=woke, text=text))
+
+
+# ── The long-lived member loop ───────────────────────────────────────────────
+
+
+async def run_connector(
+    *,
+    config: MyceliumConfig,
+    daemon_cfg: DaemonConfig,
+    state: DaemonState,
+    room: str,
+    handle: str,
+    endpoint: str | None = None,
+    workspace: str = DEFAULT_WORKSPACE,
+) -> None:
+    """Hold ``handle``'s SLIM subscription in ``room`` and wake it on inbound L9.
+
+    Connects the member app, waits to be invited by the backend moderator, sends
+    a presence hello (seeding the durable-inbox route), then pumps ``get_message``
+    forever — spawning owned turns off the loop so control verbs (abort/status)
+    stay responsive while a turn runs. Reconnects on drop; the backend re-serves
+    the missed tail.
+    """
+    node = endpoint or config.slim.node_endpoint
+    identity = SlimIdentity(workspace, room, handle)
+
+    while not state.stopping.is_set():
+        client: SlimClient | None = None
+        try:
+            client = await SlimClient(identity).connect(node)
+            session = await client.listen_for_session()
+            log.info("connector joined: %s/%s", room, handle)
+            state.rooms_connected.add(room)
+
+            async def publish(content: dict, _session=session, _client=client) -> None:
+                await SlimClient.publish(_session, l9.serialize(content))
+
+            # Seed the re-serve route so a later reconnect is re-served its tail.
+            await publish(
+                l9.build_reply_content(
+                    sender=handle,
+                    recipients=[],
+                    episode=_room_episode(room),
+                    parents=[],
+                    topic=_room_topic(room),
+                    text=_HELLO_TEXT,
+                    payload_type="presence",
+                )
+            )
+
+            while not state.stopping.is_set():
+                message = await SlimClient.receive_message(session)
+                content = l9.parse(message.payload)
+                if content is None:
+                    continue
+                asyncio.create_task(  # noqa: RUF006 - fire-and-forget; loop stays responsive
+                    _guarded_inbound(
+                        config=config,
+                        daemon_cfg=daemon_cfg,
+                        state=state,
+                        room=room,
+                        handle=handle,
+                        content=content,
+                        publish=publish,
+                    )
+                )
+        except asyncio.CancelledError:
+            raise
+        except SlimUnavailableError:  # pragma: no cover - platform dependent
+            log.warning("slim-bindings unavailable; connector for %s/%s disabled", room, handle)
+            return
+        except Exception as exc:  # noqa: BLE001 - resilient reconnect loop
+            state.record_error(f"connector[{room}/{handle}]", exc)
+            log.warning(
+                "connector %s/%s error: %s — reconnecting in %.0fs",
+                room,
+                handle,
+                exc,
+                _RECONNECT_BACKOFF_S,
+            )
+        finally:
+            state.rooms_connected.discard(room)
+            if client is not None:
+                await client.close()
+
+        if state.stopping.is_set():
+            return
+        await asyncio.sleep(_RECONNECT_BACKOFF_S)
+
+
+async def _guarded_inbound(**kwargs) -> None:
+    """Run :func:`handle_inbound`, logging (never raising) on failure."""
+    state: DaemonState = kwargs["state"]
+    room, handle = kwargs["room"], kwargs["handle"]
+    try:
+        await handle_inbound(**kwargs)
+    except Exception as exc:  # noqa: BLE001 - one bad message must not kill the loop
+        state.record_error(f"inbound[{room}/{handle}]", exc)
+        log.exception("inbound dispatch error in %s/%s: %s", room, handle, exc)

--- a/mycelium-cli/src/mycelium/daemon/runner.py
+++ b/mycelium-cli/src/mycelium/daemon/runner.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Top-level daemon orchestrator: load config, fan out SSE subscribers, serve health."""
+"""Top-level daemon orchestrator: load config, fan out SLIM connectors, serve health."""
 
 from __future__ import annotations
 
@@ -11,11 +11,17 @@ import signal
 
 from mycelium.config import MyceliumConfig
 from mycelium.daemon.config import DaemonConfig, daemon_log_path
-from mycelium.daemon.dispatch import poll_coordination_sessions, subscribe_room
+from mycelium.daemon.connector import connector_targets, run_connector
 from mycelium.daemon.health import start_health_server
 from mycelium.daemon.state import DaemonState
 
 log = logging.getLogger("mycelium.daemon")
+
+# A connector task is keyed by the (room, handle) it serves — one SLIM member
+# subscription per owned handle per room (Step 5). This supersedes the per-room
+# httpx SSE stream the daemon held through Step 4; the backend SSE endpoint
+# itself is retired in Step 10.
+ConnectorKey = tuple[str, str]
 
 
 def _setup_logging(foreground: bool) -> None:
@@ -43,51 +49,73 @@ def _setup_logging(foreground: bool) -> None:
     )
 
 
-async def _reconcile_rooms(
+def _start_connector(
+    *,
+    mycelium_cfg: MyceliumConfig,
+    daemon_cfg: DaemonConfig,
+    state: DaemonState,
+    room: str,
+    handle: str,
+) -> asyncio.Task[None]:
+    return asyncio.create_task(
+        run_connector(
+            config=mycelium_cfg,
+            daemon_cfg=daemon_cfg,
+            state=state,
+            room=room,
+            handle=handle,
+        ),
+        name=f"connector[{room}/{handle}]",
+    )
+
+
+async def _reconcile_connectors(
     *,
     mycelium_cfg: MyceliumConfig,
     state: DaemonState,
-    sse_tasks: dict[str, asyncio.Task[None]],
+    connectors: dict[ConnectorKey, asyncio.Task[None]],
 ) -> None:
-    """Add/remove SSE tasks to match the current DaemonConfig on disk.
+    """Add/remove SLIM connectors to match the current DaemonConfig on disk.
 
-    Also refreshes the handles list so newly created agents are dispatched
-    without a full daemon restart.
+    Picks up newly created agents (and dropped rooms/handles) without a full
+    daemon restart — the SIGHUP path `mycelium agent create` triggers.
     """
     daemon_cfg = DaemonConfig.load()
-    desired = set(daemon_cfg.rooms)
-    current = set(sse_tasks.keys())
 
-    # Refresh handles on the live daemon_cfg so dispatch sees new agents
+    # Refresh the live daemon_cfg so in-flight connectors see new handles.
     if state.daemon_cfg is not None:
         state.daemon_cfg.handles = daemon_cfg.handles
         state.daemon_cfg.rooms = daemon_cfg.rooms
 
-    for room in desired - current:
-        log.info("hot-reload: subscribing to %s", room)
-        sse_tasks[room] = asyncio.create_task(
-            subscribe_room(
-                config=mycelium_cfg,
-                daemon_cfg=state.daemon_cfg or daemon_cfg,
-                state=state,
-                room_name=room,
-            ),
-            name=f"sse[{room}]",
+    desired = set(connector_targets(state.daemon_cfg or daemon_cfg))
+    current = set(connectors.keys())
+
+    for room, handle in desired - current:
+        log.info("hot-reload: connecting %s/%s", room, handle)
+        connectors[room, handle] = _start_connector(
+            mycelium_cfg=mycelium_cfg,
+            daemon_cfg=state.daemon_cfg or daemon_cfg,
+            state=state,
+            room=room,
+            handle=handle,
         )
 
-    for room in current - desired:
-        log.info("hot-reload: unsubscribing from %s", room)
-        task = sse_tasks.pop(room)
+    for key in current - desired:
+        room, handle = key
+        log.info("hot-reload: disconnecting %s/%s", room, handle)
+        task = connectors.pop(key)
         task.cancel()
         try:
             await task
         except (asyncio.CancelledError, Exception):
             pass
-        state.rooms_connected.discard(room)
 
     state.rooms_configured = list(daemon_cfg.rooms)
     log.info(
-        "hot-reload complete: rooms=%d, handles=%d", len(daemon_cfg.rooms), len(daemon_cfg.handles)
+        "hot-reload complete: rooms=%d, handles=%d, connectors=%d",
+        len(daemon_cfg.rooms),
+        len(daemon_cfg.handles),
+        len(connectors),
     )
 
 
@@ -95,18 +123,18 @@ async def _reload_watcher(
     *,
     mycelium_cfg: MyceliumConfig,
     state: DaemonState,
-    sse_tasks: dict[str, asyncio.Task[None]],
+    connectors: dict[ConnectorKey, asyncio.Task[None]],
 ) -> None:
-    """Wait for reload_requested events and reconcile room subscriptions."""
+    """Wait for reload_requested events and reconcile connectors."""
     while not state.stopping.is_set():
         await state.reload_requested.wait()
         state.reload_requested.clear()
         if state.stopping.is_set():
             break
-        await _reconcile_rooms(
+        await _reconcile_connectors(
             mycelium_cfg=mycelium_cfg,
             state=state,
-            sse_tasks=sse_tasks,
+            connectors=connectors,
         )
 
 
@@ -139,35 +167,28 @@ async def _amain(foreground: bool) -> int:
         pass
 
     server = await start_health_server(state)
-    log.info("mycelium-daemon started (rooms=%d)", len(daemon_cfg.rooms))
 
-    sse_tasks: dict[str, asyncio.Task[None]] = {
-        room: asyncio.create_task(
-            subscribe_room(
-                config=mycelium_cfg,
-                daemon_cfg=daemon_cfg,
-                state=state,
-                room_name=room,
-            ),
-            name=f"sse[{room}]",
-        )
-        for room in daemon_cfg.rooms
-    }
+    targets = connector_targets(daemon_cfg)
+    log.info(
+        "mycelium-daemon started (rooms=%d, connectors=%d)", len(daemon_cfg.rooms), len(targets)
+    )
 
-    session_poller = asyncio.create_task(
-        poll_coordination_sessions(
-            config=mycelium_cfg,
+    connectors: dict[ConnectorKey, asyncio.Task[None]] = {
+        (room, handle): _start_connector(
+            mycelium_cfg=mycelium_cfg,
             daemon_cfg=daemon_cfg,
             state=state,
-        ),
-        name="coordination-session-poller",
-    )
+            room=room,
+            handle=handle,
+        )
+        for room, handle in targets
+    }
 
     reload_task = asyncio.create_task(
         _reload_watcher(
             mycelium_cfg=mycelium_cfg,
             state=state,
-            sse_tasks=sse_tasks,
+            connectors=connectors,
         ),
         name="reload-watcher",
     )
@@ -181,26 +202,19 @@ async def _amain(foreground: bool) -> int:
             await reload_task
         except (asyncio.CancelledError, Exception):
             pass
-        session_poller.cancel()
-        try:
-            await session_poller
-        except (asyncio.CancelledError, Exception):
-            pass
-        for task in sse_tasks.values():
+        for task in connectors.values():
             task.cancel()
-        for task in sse_tasks.values():
-            try:
-                await task
-            except (asyncio.CancelledError, Exception):
-                pass
-        for task in list(state.session_room_tasks.values()):
-            task.cancel()
-        for task in list(state.session_room_tasks.values()):
+        for task in connectors.values():
             try:
                 await task
             except (asyncio.CancelledError, Exception):
                 pass
         await _terminate_in_flight_spawns(state)
+        # Drop the process-wide SLIM dataplane connection (all connectors shared
+        # one conn_id per endpoint).
+        from mycelium.slim.client import close_connection
+
+        await close_connection(mycelium_cfg.slim.node_endpoint)
         server.close()
         await server.wait_closed()
 

--- a/mycelium-cli/src/mycelium/slim/__init__.py
+++ b/mycelium-cli/src/mycelium/slim/__init__.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Daemon-side SLIM fabric + L9 envelope layer.
+
+The backend (``fastapi-backend/app/services/{slim_client,l9,l9_slim}.py``) is the
+room **moderator**; this package is the **member** half a connector needs so a
+Claude Code agent can ride the same channel. It is a deliberately small,
+self-contained mirror of the backend's wrappers — the CLI installs as a thin
+``uv tool`` and must not drag in the FastAPI/ML backend just to hold a SLIM
+connection.
+
+Two invariants keep the two halves interoperable and MUST match the backend:
+
+- **Naming + shared secret** (:mod:`mycelium.slim.naming`) — the
+  ``workspace/room/agent`` → SLIM ``Name`` mapping and the MLS shared-secret
+  derivation are byte-for-byte the backend's, or a member can't join the
+  moderator's MLS group.
+- **L9 wire shape** (:mod:`mycelium.slim.l9`) — an envelope rides under the
+  additive ``l9`` key of a message's content JSON, in the exact shape the
+  backend's ``l9.envelope_to_dict`` emits, so ``l9.parse_envelope`` accepts a
+  connector's reply.
+"""
+
+from __future__ import annotations
+
+from mycelium.slim.client import SlimClient, SlimUnavailableError
+from mycelium.slim.naming import (
+    DEFAULT_NODE_ENDPOINT,
+    DEFAULT_WORKSPACE,
+    SlimIdentity,
+    mint_shared_secret,
+    node_reachable,
+    to_channel_name,
+    to_slim_name,
+)
+
+__all__ = [
+    "DEFAULT_NODE_ENDPOINT",
+    "DEFAULT_WORKSPACE",
+    "SlimClient",
+    "SlimIdentity",
+    "SlimUnavailableError",
+    "mint_shared_secret",
+    "node_reachable",
+    "to_channel_name",
+    "to_slim_name",
+]

--- a/mycelium-cli/src/mycelium/slim/client.py
+++ b/mycelium-cli/src/mycelium/slim/client.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Thin async wrapper around ``slim-bindings`` for the daemon connector.
+
+The daemon-side twin of ``fastapi-backend/app/services/slim_client.py``. A
+connector is a SLIM **member**: it registers an app, waits to be invited into
+the room's group by the always-on backend moderator, then pulls broadcasts and
+publishes its replies. The moderator methods (:meth:`create_group`,
+:meth:`invite`) are included too so tests can stand up a fake backend against a
+live node, but a connector never creates a group — one moderator per room, and
+it's the backend.
+
+``slim_bindings`` is imported **lazily** (native Rust wheel, per-platform): the
+pure L9 helpers and the daemon's dispatch logic import cleanly where no wheel
+exists, and a missing wheel degrades to a clear :class:`SlimUnavailableError`
+rather than an import-time crash.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+from mycelium.slim.naming import (
+    DEFAULT_NODE_ENDPOINT,
+    SlimIdentity,
+    mint_shared_secret,
+    to_slim_name,
+)
+
+if TYPE_CHECKING:
+    import slim_bindings
+
+
+class SlimError(RuntimeError):
+    """Base class for SLIM wrapper errors."""
+
+
+class SlimUnavailableError(SlimError):
+    """Raised when ``slim_bindings`` cannot be imported (no native wheel)."""
+
+
+def require_bindings() -> ModuleType:
+    """Import ``slim_bindings`` lazily, or raise a clear error."""
+    try:
+        import slim_bindings
+    except ImportError as exc:  # pragma: no cover - platform dependent
+        raise SlimUnavailableError(
+            "slim-bindings is not installed for this platform. It ships as a "
+            "native wheel; install it (`uv add slim-bindings`) on a supported "
+            "platform to run a SLIM connector."
+        ) from exc
+    return slim_bindings
+
+
+def _ensure_service_initialized(sb: ModuleType) -> None:
+    """Initialize the process-global SLIM service exactly once."""
+    if not sb.is_initialized():
+        sb.initialize_with_defaults()
+
+
+# The global SLIM service permits only ONE dataplane connection per endpoint per
+# process. A daemon hosting several owned handles multiplexes its per-handle apps
+# over that one connection — cache the conn_id per endpoint. (Callers connect
+# sequentially, so no lock is needed here.)
+_connections: dict[str, int] = {}
+
+
+async def _shared_connection(service: slim_bindings.Service, sb: ModuleType, endpoint: str) -> int:
+    conn_id = _connections.get(endpoint)
+    if conn_id is None:
+        client_config = sb.new_insecure_client_config(endpoint)
+        conn_id = await service.connect_async(client_config)
+        _connections[endpoint] = conn_id
+    return conn_id
+
+
+async def close_connection(endpoint: str) -> None:
+    """Drop and disconnect the cached dataplane connection for ``endpoint``.
+
+    Best-effort teardown so a node bounce doesn't leave a stale conn_id cached.
+    ``Service.disconnect`` is blocking, so it runs off-loop.
+    """
+    conn_id = _connections.pop(endpoint, None)
+    if conn_id is None:
+        return
+    try:
+        sb = require_bindings()
+    except SlimUnavailableError:  # pragma: no cover - platform dependent
+        return
+    service = sb.get_global_service()
+    await asyncio.to_thread(service.disconnect, conn_id)
+
+
+class SlimClient:
+    """A single SLIM app bound to one node connection.
+
+    Lifecycle (member side)::
+
+        client = await SlimClient(identity).connect(endpoint)
+        session = await client.listen_for_session()   # backend invites us
+        await SlimClient.publish(session, b"hello")
+        message = await SlimClient.receive_message(session)
+    """
+
+    def __init__(self, identity: SlimIdentity, *, secret: str | None = None) -> None:
+        self.identity = identity
+        self._secret = secret or mint_shared_secret(identity)
+        self._sb: ModuleType | None = None
+        self._app: slim_bindings.App | None = None
+        self._conn_id: int | None = None
+        self._local_name: slim_bindings.Name | None = None
+        self._sessions: list[slim_bindings.Session] = []
+
+    async def connect(self, endpoint: str = DEFAULT_NODE_ENDPOINT) -> SlimClient:
+        """Connect to the node and register this app under its local Name."""
+        sb = require_bindings()
+        _ensure_service_initialized(sb)
+        service = sb.get_global_service()
+
+        self._sb = sb
+        self._local_name = to_slim_name(*self.identity.as_tuple())
+        self._conn_id = await _shared_connection(service, sb, endpoint)
+        self._app = service.create_app_with_secret(self._local_name, self._secret)
+        await self._app.subscribe_async(self._local_name, self._conn_id)
+        return self
+
+    @property
+    def app(self) -> slim_bindings.App:
+        if self._app is None:
+            raise SlimError("SlimClient.connect() has not been called")
+        return self._app
+
+    def _group_session_config(self) -> slim_bindings.SessionConfig:
+        sb = self._sb
+        assert sb is not None
+        # MLS ON — the member joins the moderator's encrypted group via the
+        # shared secret it derives (create_app_with_secret). Matched pair with
+        # the backend; do not diverge.
+        return sb.SessionConfig(
+            session_type=sb.SessionType.GROUP,
+            enable_mls=True,
+            max_retries=5,
+            interval=datetime.timedelta(seconds=5),
+            metadata={},
+        )
+
+    async def create_group(self, channel: slim_bindings.Name) -> slim_bindings.Session:
+        """Create (and become moderator of) a group session — **tests only**.
+
+        A connector never calls this; the backend is the sole moderator. It
+        exists so a test can play the backend against a live node.
+        """
+        session = await self.app.create_session_and_wait_async(
+            self._group_session_config(), channel
+        )
+        self._sessions.append(session)
+        return session
+
+    async def invite(self, session: slim_bindings.Session, member: slim_bindings.Name) -> None:
+        """Route to and invite ``member`` into a moderated group — **tests only**."""
+        assert self._conn_id is not None
+        await self.app.set_route_async(member, self._conn_id)
+        handle = await session.invite_async(member)
+        await handle.wait_async()
+
+    async def listen_for_session(self) -> slim_bindings.Session:
+        """Block until this app is invited into a group, then return the session."""
+        session = await self.app.listen_for_session_async(None)
+        self._sessions.append(session)
+        return session
+
+    async def close(self) -> None:
+        """Leave every session this app holds. Best-effort; never raises.
+
+        Does **not** drop the shared dataplane connection — sibling apps (other
+        owned handles) in the process may still use it. Use
+        :func:`close_connection` for that.
+        """
+        for session in self._sessions:
+            try:
+                await self.app.delete_session_and_wait_async(session)
+            except Exception:  # noqa: BLE001 - best-effort teardown
+                pass
+        self._sessions.clear()
+
+    @staticmethod
+    async def publish(session: slim_bindings.Session, data: bytes) -> None:
+        """Broadcast ``data`` to every current member of the group ``session``."""
+        await session.publish_async(data, None, None)
+
+    @staticmethod
+    async def receive_message(
+        session: slim_bindings.Session, *, timeout_s: float = 30.0
+    ) -> slim_bindings.ReceivedMessage:
+        """Block for the next inbound message and return the whole message.
+
+        Preserves ``.payload`` (bytes) and ``.context`` (a ``MessageContext``
+        carrying the sender's routable source).
+        """
+        return await session.get_message_async(timeout=datetime.timedelta(seconds=timeout_s))

--- a/mycelium-cli/src/mycelium/slim/l9.py
+++ b/mycelium-cli/src/mycelium/slim/l9.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Lean L9 envelope helpers for the daemon connector (stdlib only).
+
+The connector only needs to do two L9 things, so this is a small, dependency-free
+counterpart to ``fastapi-backend/app/services/l9.py`` rather than a copy of its
+pydantic model tree:
+
+1. **Read** an inbound message — pull the sender, recipients, message id, kind,
+   and the human-facing text a spawned turn should see.
+2. **Build a reply** — an ``exchange`` envelope parented on the message that woke
+   the agent, wrapped in a content dict under the additive ``l9`` key.
+
+The reply is emitted in the **exact shape** the backend's
+``l9.envelope_to_dict(l9.build_envelope(kind=exchange, ...))`` produces, so the
+backend persister's ``l9.parse_envelope`` (pydantic-validating) accepts it
+unchanged. Keep this shape in sync with the backend if the L9 binding version
+moves — the source of truth for the shape is ``app.services.l9`` /
+``app.services.l9_models``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+# Mirror the backend envelope constants (``app.services.l9``). The version
+# tracks the vendored ioc-protocols-models binding.
+PROTOCOL = "SSTP"
+SUBPROTOCOL = "mycelium"
+VERSION = "0.0.6"
+
+# The additive key an L9 envelope rides under inside a message's content JSON.
+CONTENT_L9_KEY = "l9"
+
+# The content field carrying the human-facing message body (matches the HTTP
+# ``MessageCreate.content`` semantics). A connector reads it to prompt the turn
+# and writes it on the reply.
+CONTENT_TEXT_KEY = "content"
+
+# ``exchange`` is the kind for room turns (ticks/replies/human messages). The
+# connector only wakes on and only emits this kind; system envelopes
+# (``commit``/``knowledge``) are observed but never trigger a spawn.
+EXCHANGE_KIND = "exchange"
+
+
+def build_reply_content(
+    *,
+    sender: str,
+    recipients: list[str],
+    episode: str,
+    parents: list[str],
+    topic: str | None = None,
+    text: str = "",
+    message_id: str | None = None,
+    payload_type: str = "reply",
+    payload_data: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a full content dict for an agent reply: ``{content, l9: <envelope>}``.
+
+    The envelope is an ``exchange`` (no subkind — always valid), with ``sender``
+    as the first actor and ``recipients`` after it, parented on ``parents`` (the
+    message that woke the agent) so the backend's causal ordering + transcript
+    stay correct.
+    """
+    actors: list[dict[str, str]] = [{"id": sender, "role": "agent"}]
+    actors += [{"id": r, "role": "agent"} for r in recipients]
+
+    header: dict[str, Any] = {
+        "protocol": PROTOCOL,
+        "subprotocol": SUBPROTOCOL,
+        "version": VERSION,
+        "kind": EXCHANGE_KIND,
+        # ``participants.groups`` is required-but-nullable in the schema; the
+        # backend restores an explicit null after ``exclude_none``, so we mirror
+        # that here for a clean re-validation.
+        "participants": {"actors": actors, "groups": None},
+        "message": {
+            "id": message_id or str(uuid.uuid4()),
+            "parents": list(parents),
+            "episode": episode,
+        },
+    }
+    if topic:
+        header["context"] = {"topic": topic}
+
+    envelope: dict[str, Any] = {
+        "header": header,
+        "payload": {"type": payload_type, "data": payload_data or {}},
+    }
+    return {CONTENT_TEXT_KEY: text, CONTENT_L9_KEY: envelope}
+
+
+def serialize(content: dict[str, Any]) -> bytes:
+    """Encode a content dict to publishable bytes."""
+    return json.dumps(content).encode("utf-8")
+
+
+def parse(data: bytes) -> dict[str, Any] | None:
+    """Decode inbound bytes to a content dict, or ``None`` if not a JSON object."""
+    try:
+        decoded = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def envelope_of(content: dict[str, Any]) -> dict[str, Any] | None:
+    """The ``l9`` envelope embedded in a content dict, if any."""
+    env = content.get(CONTENT_L9_KEY)
+    return env if isinstance(env, dict) else None
+
+
+def _actors(content: dict[str, Any]) -> list[dict[str, Any]]:
+    env = envelope_of(content) or {}
+    participants = env.get("header", {}).get("participants", {})
+    actors = participants.get("actors")
+    return [a for a in actors if isinstance(a, dict)] if isinstance(actors, list) else []
+
+
+def sender_of(content: dict[str, Any]) -> str | None:
+    """The sending handle (first actor), by convention."""
+    actors = _actors(content)
+    if not actors:
+        return None
+    sender = actors[0].get("id")
+    return sender if isinstance(sender, str) else None
+
+
+def recipients_of(content: dict[str, Any]) -> list[str]:
+    """The recipient handles (every actor after the sender)."""
+    return [a["id"] for a in _actors(content)[1:] if isinstance(a.get("id"), str)]
+
+
+def message_id_of(content: dict[str, Any]) -> str | None:
+    """The L9 message id (used to parent a reply)."""
+    env = envelope_of(content) or {}
+    mid = env.get("header", {}).get("message", {}).get("id")
+    return mid if isinstance(mid, str) else None
+
+
+def episode_of(content: dict[str, Any]) -> str | None:
+    env = envelope_of(content) or {}
+    ep = env.get("header", {}).get("message", {}).get("episode")
+    return ep if isinstance(ep, str) else None
+
+
+def topic_of(content: dict[str, Any]) -> str | None:
+    env = envelope_of(content) or {}
+    topic = env.get("header", {}).get("context", {}).get("topic")
+    return topic if isinstance(topic, str) else None
+
+
+def kind_of(content: dict[str, Any]) -> str | None:
+    env = envelope_of(content) or {}
+    kind = env.get("header", {}).get("kind")
+    return kind if isinstance(kind, str) else None
+
+
+def _iter_text(value: Any) -> list[str]:
+    """Every string leaf in a nested value (mirrors the persister's scan)."""
+    out: list[str] = []
+    if isinstance(value, str):
+        out.append(value)
+    elif isinstance(value, dict):
+        for v in value.values():
+            out.extend(_iter_text(v))
+    elif isinstance(value, list):
+        for v in value:
+            out.extend(_iter_text(v))
+    return out
+
+
+def human_text_of(content: dict[str, Any]) -> str:
+    """The human-facing body a spawned turn should read.
+
+    Prefers the canonical ``content`` field; otherwise joins every string leaf
+    outside the ``l9`` envelope (so a message that carried its text elsewhere
+    still reaches the agent).
+    """
+    text = content.get(CONTENT_TEXT_KEY)
+    if isinstance(text, str) and text.strip():
+        return text
+    parts: list[str] = []
+    for key, value in content.items():
+        if key == CONTENT_L9_KEY:
+            continue
+        parts.extend(t for t in _iter_text(value) if t.strip())
+    return "\n".join(parts)

--- a/mycelium-cli/src/mycelium/slim/naming.py
+++ b/mycelium-cli/src/mycelium/slim/naming.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""SLIM naming / identity + shared-secret derivation (daemon side).
+
+A byte-for-byte mirror of the naming half of
+``fastapi-backend/app/services/slim_client.py``. **Keep the constants and the
+derivation in sync with the backend** — the shared secret seeds the MLS group
+key, so a connector that derives a different value cannot join the moderator's
+group. The values below are the same ones the backend defaults to
+(``SLIM_WORKSPACE = "mycelium"``, the dev master secret, the ``room`` channel
+topic).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import socket
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    import slim_bindings
+
+# The node's default listen address (matches ghcr.io/agntcy/slim's default port).
+DEFAULT_NODE_ENDPOINT = "http://127.0.0.1:46357"
+
+# Default port used when a node endpoint URL omits one (reachability probe).
+DEFAULT_NODE_PORT = 46357
+
+# The org segment (workspace/tenant) a room channel lives under. Matches the
+# backend's ``settings.SLIM_WORKSPACE`` default — a member must share it with the
+# moderator to resolve the same channel Name.
+DEFAULT_WORKSPACE = "mycelium"
+
+# Minimum shared-secret length required by SLIM's dev auth (also seeds MLS).
+MIN_SECRET_LEN = 32
+
+# Default third segment for a room's group-channel Name when no explicit topic
+# is given. Mirrors the backend's ``DEFAULT_CHANNEL_TOPIC``.
+DEFAULT_CHANNEL_TOPIC = "room"
+
+# Dev-only master secret from which per-channel shared secrets are derived. It
+# is the **same literal** as the backend's ``_DEV_MASTER_SECRET`` so both sides
+# reconstruct the identical credential offline (MVP identity tier; JWT/SPIRE is
+# the production path).
+_DEV_MASTER_SECRET = "mycelium-dev-shared-secret-v1-do-not-use-in-prod"
+
+
+class SlimNameError(ValueError):
+    """A ``workspace/room/agent`` segment is not a valid SLIM Name part."""
+
+
+@dataclass(frozen=True)
+class SlimIdentity:
+    """A mycelium coordination identity: ``workspace/room/agent``.
+
+    Maps onto a SLIM :class:`Name` 3-tuple as
+    ``org=workspace, namespace=room, app=agent``.
+    """
+
+    workspace: str
+    room: str
+    agent: str
+
+    def as_tuple(self) -> tuple[str, str, str]:
+        return (self.workspace, self.room, self.agent)
+
+    def as_path(self) -> str:
+        return f"{self.workspace}/{self.room}/{self.agent}"
+
+
+def node_reachable(endpoint: str, *, timeout: float = 1.0) -> bool:
+    """True if a TCP connection to the node ``endpoint`` succeeds quickly.
+
+    A cheap pre-flight so the daemon skips the full connect handshake (and the
+    unit suite stays fast) when no node is up. Mirrors the backend probe.
+    """
+    parsed = urlparse(endpoint)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or DEFAULT_NODE_PORT
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _validate_segment(value: str, *, label: str) -> str:
+    """Reject Name segments that would corrupt the ``org/ns/app`` encoding."""
+    if not value or not value.strip():
+        raise SlimNameError(f"{label} must be non-empty")
+    if "/" in value:
+        raise SlimNameError(f"{label} must not contain '/': {value!r}")
+    return value
+
+
+def to_slim_name(workspace: str, room: str, agent: str) -> slim_bindings.Name:
+    """Map ``workspace/room/agent`` → a SLIM :class:`Name` (``org/ns/app``)."""
+    from mycelium.slim.client import require_bindings
+
+    sb = require_bindings()
+    _validate_segment(workspace, label="workspace")
+    _validate_segment(room, label="room")
+    _validate_segment(agent, label="agent")
+    return sb.Name(workspace, room, agent)
+
+
+def to_channel_name(
+    workspace: str, room: str, topic: str = DEFAULT_CHANNEL_TOPIC
+) -> slim_bindings.Name:
+    """Map a room to its group-channel :class:`Name` (``workspace/room/topic``)."""
+    from mycelium.slim.client import require_bindings
+
+    sb = require_bindings()
+    _validate_segment(workspace, label="workspace")
+    _validate_segment(room, label="room")
+    _validate_segment(topic, label="topic")
+    return sb.Name(workspace, room, topic)
+
+
+def mint_shared_secret(identity: SlimIdentity, *, master_secret: str = _DEV_MASTER_SECRET) -> str:
+    """Mint the dev shared secret for a channel (``workspace/room``), ≥32 chars.
+
+    Keyed on the channel scope (``workspace/room``) — the ``agent`` field is
+    intentionally ignored — so every member of a room derives the *same* value
+    (which seeds the MLS group key). HMAC-SHA256 hex digest, matching the
+    backend so moderator and members agree offline.
+    """
+    scope = f"{identity.workspace}/{identity.room}"
+    digest = hmac.new(
+        master_secret.encode("utf-8"),
+        scope.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    assert len(digest) >= MIN_SECRET_LEN
+    return digest

--- a/mycelium-cli/tests/test_connector_wake_over_slim.py
+++ b/mycelium-cli/tests/test_connector_wake_over_slim.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Connector wake — live-node integration slice (Step 5 DoD).
+
+Needs a running ``slim`` node. Guarded so the default unit suite stays green
+without one (mirrors the backend's ``test_l9_over_slim_roundtrip.py``): point at
+a node with ``MYCELIUM_SLIM_ENDPOINT`` (default ``http://127.0.0.1:46357``); run
+one via ``mycelium hub host`` or the docker recipe in ``START_HERE_STEP_5.md``.
+
+Proves the Step 5 DoD end-to-end over a real MLS group channel: a mock
+"backend" moderator invites the connector's handle, publishes an L9 ``exchange``
+addressed to it, and the connector — spawning a **mocked** ``claude`` at the
+integration boundary — wakes and publishes its reply, which the moderator
+receives as a valid ``exchange`` authored by the handle and parented on the
+message that woke it.
+
+The connector's transport primitives (``SlimClient`` member session +
+``handle_inbound``) are driven directly here rather than through the full
+``run_connector`` reconnect loop; that loop is thin glue over these same
+primitives and is unit-covered in ``test_daemon_connector.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urlparse
+
+import pytest
+
+pytest.importorskip("slim_bindings")
+
+from mycelium.config import MyceliumConfig, ServerConfig
+from mycelium.daemon import connector
+from mycelium.daemon.config import DaemonConfig
+from mycelium.daemon.state import DaemonState
+from mycelium.integrations._spawn_common import SpawnResult
+from mycelium.protocol import AgentManifest
+from mycelium.slim import l9
+from mycelium.slim.client import SlimClient, close_connection
+from mycelium.slim.naming import DEFAULT_NODE_ENDPOINT, SlimIdentity, to_channel_name, to_slim_name
+
+_ENDPOINT = os.getenv("MYCELIUM_SLIM_ENDPOINT", DEFAULT_NODE_ENDPOINT)
+_WORKSPACE = "mycelium"
+_ROOM = "connector-wake-room"
+_HANDLE = "agent-a"
+_WOKE_ID = "woke-1"
+
+
+def _node_reachable(endpoint: str, *, timeout: float = 1.0) -> bool:
+    parsed = urlparse(endpoint)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 46357
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _node_reachable(_ENDPOINT),
+    reason=f"no reachable SLIM node at {_ENDPOINT} (set MYCELIUM_SLIM_ENDPOINT or run `mycelium hub host`)",
+)
+
+
+@pytest.mark.asyncio
+async def test_connector_wakes_and_replies_over_slim(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Mock the cold spawn — no real `claude` binary in CI.
+    spawn = AsyncMock(
+        return_value=SpawnResult(
+            ok=True, final_message="woke and replied", transcript="", cost_usd=0.0, duration_s=0.0
+        )
+    )
+    integration = MagicMock(lifecycle="cold_spawn", spawn=spawn)
+    monkeypatch.setattr(connector, "get_integration", lambda _adapter: integration)
+    monkeypatch.setattr(connector, "_fetch_agent_context", AsyncMock(return_value=(None, "")))
+    monkeypatch.setattr(connector, "_post_log", AsyncMock(return_value=None))
+    monkeypatch.setattr(connector, "load_notes", lambda _room, _handle: "")
+    monkeypatch.setattr(
+        connector,
+        "load_manifest",
+        lambda _room, _handle: AgentManifest(
+            handle=_HANDLE, adapter="claude_code", cwd="/tmp/x", description="participant"
+        ),
+    )
+
+    moderator = await SlimClient(SlimIdentity(_WORKSPACE, _ROOM, "backend")).connect(_ENDPOINT)
+    member = await SlimClient(SlimIdentity(_WORKSPACE, _ROOM, _HANDLE)).connect(_ENDPOINT)
+
+    session = await moderator.create_group(to_channel_name(_WORKSPACE, _ROOM))
+
+    async def member_side() -> None:
+        joined = await member.listen_for_session()
+
+        async def publish(content: dict) -> None:
+            await SlimClient.publish(joined, l9.serialize(content))
+
+        # Pull the moderator's inbound and run the real connector dispatch.
+        message = await SlimClient.receive_message(joined, timeout_s=15.0)
+        content = l9.parse(message.payload)
+        assert content is not None
+        await connector.handle_inbound(
+            config=MyceliumConfig(server=ServerConfig(api_url="http://localhost:8000")),
+            daemon_cfg=DaemonConfig(),
+            state=DaemonState(),
+            room=_ROOM,
+            handle=_HANDLE,
+            content=content,
+            publish=publish,
+        )
+
+    member_task = asyncio.create_task(member_side())
+    received: list[dict[str, Any]] = []
+    try:
+        await moderator.invite(session, to_slim_name(_WORKSPACE, _ROOM, _HANDLE))
+        # Address an exchange at the connector's handle; it should wake + reply.
+        inbound = l9.build_reply_content(
+            sender="backend",
+            recipients=[_HANDLE],
+            episode="urn:ioc:mycelium:episode:connector-wake-room:live",
+            parents=[],
+            topic="urn:concept:mycelium:connector-wake-room",
+            text=f"@{_HANDLE} please take a turn",
+            message_id=_WOKE_ID,
+            payload_type="tick",
+        )
+        await SlimClient.publish(session, l9.serialize(inbound))
+
+        while not received:
+            msg = await SlimClient.receive_message(session, timeout_s=15.0)
+            parsed = l9.parse(msg.payload)
+            # Take the connector's reply (authored by the handle); ignore the
+            # moderator's own echo of the inbound.
+            if parsed is not None and l9.sender_of(parsed) == _HANDLE:
+                received.append(parsed)
+    finally:
+        member_task.cancel()
+        try:
+            await member_task
+        except asyncio.CancelledError:
+            pass
+        await moderator.close()
+        await member.close()
+        await close_connection(_ENDPOINT)
+
+    spawn.assert_awaited_once()
+    reply = received[0]
+    assert l9.kind_of(reply) == "exchange"
+    assert l9.sender_of(reply) == _HANDLE
+    assert reply["l9"]["header"]["message"]["parents"] == [_WOKE_ID]
+    assert l9.human_text_of(reply) == "woke and replied"

--- a/mycelium-cli/tests/test_daemon_connector.py
+++ b/mycelium-cli/tests/test_daemon_connector.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Daemon SLIM connector — wake path, reply shape, gates, and control verbs.
+
+The merge gate for Step 5 (no SLIM node, ``claude`` mocked at the integration
+boundary). Pins that an inbound L9 message addressed to an owned handle wakes a
+cold spawn and its reply is published as a valid ``exchange`` parented on the
+message that woke it; that a message addressed elsewhere / the agent's own reply
+does not; and that the budget / depth / allow_from gates, the per-handle serial
+lock, and the ``abort`` / ``status`` control verbs survive the transport swap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from mycelium.config import MyceliumConfig, ServerConfig
+from mycelium.daemon import config as daemon_config
+from mycelium.daemon import connector
+from mycelium.daemon.config import DaemonConfig
+from mycelium.daemon.state import DaemonState, RunningProc
+from mycelium.integrations._spawn_common import SpawnResult
+from mycelium.protocol import AgentManifest
+from mycelium.slim import l9
+
+
+@pytest.fixture(autouse=True)
+def _tmp_daemon_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(daemon_config, "daemon_config_path", lambda: tmp_path / "daemon.toml")
+
+
+def _config() -> MyceliumConfig:
+    return MyceliumConfig(server=ServerConfig(api_url="http://localhost:8000"))
+
+
+def _manifest(handle: str = "agent-a", **kw: Any) -> AgentManifest:
+    return AgentManifest(
+        handle=handle,
+        adapter="claude_code",
+        cwd=kw.get("cwd", "/tmp/x"),
+        description="room participant",
+        allow_from=kw.get("allow_from", []),
+        budget_usd_per_month=kw.get("budget_usd_per_month", 0.0),
+    )
+
+
+def _inbound(
+    *,
+    sender: str = "human",
+    recipients: list[str] | None = None,
+    text: str = "@agent-a hello",
+    message_id: str = "woke-1",
+) -> dict:
+    return l9.build_reply_content(
+        sender=sender,
+        recipients=["agent-a"] if recipients is None else recipients,
+        episode="urn:ioc:mycelium:episode:r:live",
+        parents=[],
+        topic="urn:concept:mycelium:r",
+        text=text,
+        message_id=message_id,
+    )
+
+
+def _patch_spawn(
+    monkeypatch: pytest.MonkeyPatch, *, result: SpawnResult | None = None
+) -> MagicMock:
+    """Patch the connector's integration boundary; return the mocked ``spawn``."""
+    spawn = AsyncMock(
+        return_value=result
+        or SpawnResult(ok=True, final_message="done", transcript="", cost_usd=0.01, duration_s=0.1)
+    )
+    integration = MagicMock(lifecycle="cold_spawn", spawn=spawn)
+    monkeypatch.setattr(connector, "get_integration", lambda _adapter: integration)
+    monkeypatch.setattr(connector, "_fetch_agent_context", AsyncMock(return_value=(None, "")))
+    monkeypatch.setattr(connector, "_post_log", AsyncMock(return_value=None))
+    monkeypatch.setattr(connector, "load_notes", lambda _room, _handle: "")
+    return spawn
+
+
+async def _run(state: DaemonState, published: list[dict], content: dict, **overrides: Any) -> None:
+    async def publish(c: dict) -> None:
+        published.append(c)
+
+    kwargs: dict[str, Any] = {
+        "config": _config(),
+        "daemon_cfg": DaemonConfig(),
+        "state": state,
+        "room": "r",
+        "handle": "agent-a",
+        "content": content,
+        "publish": publish,
+    }
+    kwargs.update(overrides)
+    await connector.handle_inbound(**kwargs)
+
+
+# ── should_wake (pure) ────────────────────────────────────────────────────────
+
+
+def test_wake_on_recipient_match() -> None:
+    assert connector.should_wake(_inbound(recipients=["agent-a"], text="hi"), "agent-a")
+
+
+def test_wake_on_at_mention_even_without_recipient() -> None:
+    assert connector.should_wake(_inbound(recipients=["other"], text="@agent-a do it"), "agent-a")
+
+
+def test_no_wake_on_own_reply() -> None:
+    assert not connector.should_wake(_inbound(sender="agent-a", recipients=["human"]), "agent-a")
+
+
+def test_no_wake_when_addressed_elsewhere() -> None:
+    assert not connector.should_wake(_inbound(recipients=["agent-b"], text="hello all"), "agent-a")
+
+
+def test_no_wake_on_non_exchange_envelope() -> None:
+    content = _inbound(recipients=["agent-a"])
+    content["l9"]["header"]["kind"] = "commit"
+    assert not connector.should_wake(content, "agent-a")
+
+
+# ── Wake path + reply shape ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wake_spawns_and_publishes_valid_l9_reply(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawn = _patch_spawn(monkeypatch)
+    monkeypatch.setattr(connector, "load_manifest", lambda _room, _handle: _manifest())
+    state = DaemonState()
+    published: list[dict] = []
+
+    await _run(state, published, _inbound(message_id="woke-1"))
+
+    spawn.assert_awaited_once()
+    assert len(published) == 1
+    reply = published[0]
+    # Reply is a valid exchange authored by the handle, parented on the waker.
+    assert l9.kind_of(reply) == "exchange"
+    assert l9.sender_of(reply) == "agent-a"
+    assert l9.recipients_of(reply) == ["human"]
+    assert reply["l9"]["header"]["message"]["parents"] == ["woke-1"]
+    assert l9.human_text_of(reply) == "done"
+
+
+@pytest.mark.asyncio
+async def test_addressed_elsewhere_does_not_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawn = _patch_spawn(monkeypatch)
+    monkeypatch.setattr(connector, "load_manifest", lambda _room, _handle: _manifest())
+    state = DaemonState()
+    published: list[dict] = []
+
+    await _run(state, published, _inbound(recipients=["agent-b"], text="hello all"))
+
+    spawn.assert_not_awaited()
+    assert published == []
+
+
+@pytest.mark.asyncio
+async def test_own_reply_does_not_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawn = _patch_spawn(monkeypatch)
+    monkeypatch.setattr(connector, "load_manifest", lambda _room, _handle: _manifest())
+    state = DaemonState()
+    published: list[dict] = []
+
+    await _run(state, published, _inbound(sender="agent-a", recipients=["human"]))
+
+    spawn.assert_not_awaited()
+    assert published == []
+
+
+# ── Gates ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_budget_gate_blocks_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawn = _patch_spawn(monkeypatch)
+    monkeypatch.setattr(
+        connector, "load_manifest", lambda _room, _handle: _manifest(budget_usd_per_month=5.0)
+    )
+    state = DaemonState()
+    ym = datetime.now(UTC).strftime("%Y-%m")
+    state.budget_used_usd[("agent-a", ym)] = 10.0
+    published: list[dict] = []
+
+    await _run(state, published, _inbound())
+
+    spawn.assert_not_awaited()
+    assert published == []
+
+
+@pytest.mark.asyncio
+async def test_depth_gate_blocks_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawn = _patch_spawn(monkeypatch)
+    monkeypatch.setattr(connector, "load_manifest", lambda _room, _handle: _manifest())
+    state = DaemonState()
+    # Fill the sender's dispatch bucket to the cap so the next is refused.
+    daemon_cfg = DaemonConfig(depth_cap=1)
+    state.recent_dispatches["human"].append(time.monotonic())
+    published: list[dict] = []
+
+    await _run(state, published, _inbound(), daemon_cfg=daemon_cfg)
+
+    spawn.assert_not_awaited()
+    assert published == []
+
+
+@pytest.mark.asyncio
+async def test_allow_from_gate_blocks_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawn = _patch_spawn(monkeypatch)
+    monkeypatch.setattr(
+        connector, "load_manifest", lambda _room, _handle: _manifest(allow_from=["someone-else"])
+    )
+    state = DaemonState()
+    published: list[dict] = []
+
+    await _run(state, published, _inbound())
+
+    spawn.assert_not_awaited()
+    assert published == []
+
+
+# ── Control verbs ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_abort_terminates_running_and_replies(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawn = _patch_spawn(monkeypatch)
+    monkeypatch.setattr(connector, "load_manifest", lambda _room, _handle: _manifest())
+    state = DaemonState()
+    proc = MagicMock()
+    state.running["agent-a"] = RunningProc(
+        process=proc, started_at=time.monotonic(), prompt="p", sender="human", room="r"
+    )
+    published: list[dict] = []
+
+    await _run(state, published, _inbound(text="@agent-a abort"))
+
+    proc.terminate.assert_called_once()
+    spawn.assert_not_awaited()  # a control verb never cold-spawns
+    assert len(published) == 1
+    assert "aborted" in l9.human_text_of(published[0])
+
+
+@pytest.mark.asyncio
+async def test_status_replies_without_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawn = _patch_spawn(monkeypatch)
+    monkeypatch.setattr(connector, "load_manifest", lambda _room, _handle: _manifest())
+    state = DaemonState()
+    published: list[dict] = []
+
+    await _run(state, published, _inbound(text="@agent-a status"))
+
+    spawn.assert_not_awaited()
+    assert len(published) == 1
+    assert "idle" in l9.human_text_of(published[0])
+
+
+# ── Per-handle serial lock ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_per_handle_lock_serializes_spawns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(connector, "load_manifest", lambda _room, _handle: _manifest())
+    monkeypatch.setattr(connector, "_fetch_agent_context", AsyncMock(return_value=(None, "")))
+    monkeypatch.setattr(connector, "_post_log", AsyncMock(return_value=None))
+    monkeypatch.setattr(connector, "load_notes", lambda _room, _handle: "")
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _slow_spawn(*, request: Any) -> SpawnResult:  # noqa: ARG001
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.02)
+        in_flight -= 1
+        return SpawnResult(
+            ok=True, final_message="done", transcript="", cost_usd=0.0, duration_s=0.0
+        )
+
+    integration = MagicMock(lifecycle="cold_spawn", spawn=_slow_spawn)
+    monkeypatch.setattr(connector, "get_integration", lambda _adapter: integration)
+
+    state = DaemonState()
+    published: list[dict] = []
+    await asyncio.gather(
+        _run(state, published, _inbound(message_id="a")),
+        _run(state, published, _inbound(message_id="b")),
+    )
+
+    assert max_in_flight == 1  # the per-handle lock never lets two turns overlap
+    assert len(published) == 2

--- a/mycelium-cli/tests/test_slim_l9.py
+++ b/mycelium-cli/tests/test_slim_l9.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the daemon-side lean L9 helpers (``mycelium.slim.l9``).
+
+These pin the wire contract the connector shares with the backend moderator: an
+``exchange`` envelope under the additive ``l9`` key, sender first / recipients
+after, parents threading causality. The *shape parity* with the backend's
+``l9.envelope_to_dict`` is proven cross-package in the live integration slice;
+here we pin the accessors and the round trip.
+"""
+
+from __future__ import annotations
+
+from mycelium.slim import l9
+
+
+def _inbound(**kw):
+    return l9.build_reply_content(
+        sender=kw.get("sender", "human"),
+        recipients=kw.get("recipients", ["agent-a"]),
+        episode=kw.get("episode", "urn:ioc:mycelium:episode:r:live"),
+        parents=kw.get("parents", []),
+        topic=kw.get("topic", "urn:concept:mycelium:r"),
+        text=kw.get("text", "hello"),
+        message_id=kw.get("message_id", "m-1"),
+    )
+
+
+def test_build_reply_content_has_exchange_envelope() -> None:
+    content = _inbound(sender="agent-a", recipients=["human"], parents=["woke-1"])
+    assert l9.kind_of(content) == "exchange"
+    assert l9.sender_of(content) == "agent-a"
+    assert l9.recipients_of(content) == ["human"]
+    assert content["l9"]["header"]["message"]["parents"] == ["woke-1"]
+    # subkind is omitted (never emitted) — always-valid exchange.
+    assert "subkind" not in content["l9"]["header"]
+
+
+def test_participants_groups_is_explicit_null() -> None:
+    # The backend restores an explicit null after exclude_none; a member must
+    # emit the same or re-validation drops the key.
+    content = _inbound()
+    assert content["l9"]["header"]["participants"]["groups"] is None
+
+
+def test_accessors_read_id_episode_topic() -> None:
+    content = _inbound(message_id="m-9", episode="ep-9", topic="topic-9")
+    assert l9.message_id_of(content) == "m-9"
+    assert l9.episode_of(content) == "ep-9"
+    assert l9.topic_of(content) == "topic-9"
+
+
+def test_serialize_parse_round_trip() -> None:
+    content = _inbound(text="ping")
+    restored = l9.parse(l9.serialize(content))
+    assert restored == content
+
+
+def test_parse_rejects_non_json_and_non_object() -> None:
+    assert l9.parse(b"\xff\xfe not json") is None
+    assert l9.parse(b"[1, 2, 3]") is None
+
+
+def test_human_text_prefers_content_field() -> None:
+    content = _inbound(text="the body")
+    assert l9.human_text_of(content) == "the body"
+
+
+def test_human_text_falls_back_to_string_leaves() -> None:
+    # A message whose text landed outside the canonical field still reaches the
+    # agent (every non-``l9`` string leaf, joined).
+    content = _inbound(text="")
+    content["note"] = "surfaced anyway"
+    assert "surfaced anyway" in l9.human_text_of(content)
+
+
+def test_no_topic_omits_context() -> None:
+    content = l9.build_reply_content(
+        sender="a", recipients=[], episode="ep", parents=[], topic=None, text="x"
+    )
+    assert "context" not in content["l9"]["header"]
+    assert l9.topic_of(content) is None

--- a/mycelium-cli/uv.lock
+++ b/mycelium-cli/uv.lock
@@ -358,6 +358,7 @@ dependencies = [
     { name = "questionary" },
     { name = "rapidfuzz" },
     { name = "rich" },
+    { name = "slim-bindings" },
     { name = "toml" },
     { name = "typer" },
 ]
@@ -408,6 +409,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = ">=3.10.0" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10" },
+    { name = "slim-bindings", specifier = ">=1.4,<2" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8" },
@@ -995,6 +997,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slim-bindings"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/10/f781f076ced49a5dbd4a5eb04b1948fcd82fcd0948c2b80ecbe5c94f8ec8/slim_bindings-1.4.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:44e985aae7203d4b9173b0a824a26a8bea39a02e203ad89e0e1abec7d3b86ef5", size = 12398410, upload-time = "2026-05-23T08:57:12.545Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/11/a30899045e56b12b595683e4de194210246f6e6b95185ff520cf3d99d2be/slim_bindings-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5667a87549c4d1bf6decef34acbd8b2920b8d35451200dcf2cd55f2fb7cbc929", size = 12105663, upload-time = "2026-05-23T08:57:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/04/80/398d41159ddfa4dabd9102b23888e3bfc85a9a439403aa95814ba6de7cab/slim_bindings-1.4.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2327211828e59a0c7dc970b1210abdd4f32cc1dd3c41a68ab1e5d52f16e34664", size = 12600843, upload-time = "2026-05-23T08:57:19.022Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d3/34630486515e6236d1887aa8f49a845b1bb6b844e0773d00d5e9daa9c540/slim_bindings-1.4.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:42036cb27c7165beb7a68010aceec6a514f0de0bef164711585281d5ad0f57d1", size = 13041099, upload-time = "2026-05-23T08:57:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/ec/1ad484dcfb0f9edd87015832a4dc3eb2638a71fb3a38646b9611cee4fc35/slim_bindings-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d96b59c0108a588c55e5335a9feee74bc9b78e468a5cd4dd038e78020ce85b17", size = 12598901, upload-time = "2026-05-23T08:57:24.096Z" },
+    { url = "https://files.pythonhosted.org/packages/80/54/3c615508b65fe34d67368d67e8321becec6bc566888e261ae45fb98afa74/slim_bindings-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:618137b056627326fa55f5eeae99e800b476f1951460d5ccf58a7a0b38ef16df", size = 13031199, upload-time = "2026-05-23T08:57:26.305Z" },
+    { url = "https://files.pythonhosted.org/packages/77/41/87d47c1fd47a1681b6377419e941ba22e416490a08577242b4da1d5a89ed/slim_bindings-1.4.1-py3-none-win_amd64.whl", hash = "sha256:9c89dbdbee2ffcb92b4ffe72593556b5cc14b24226a7f617838897e44bd1f897", size = 11650639, upload-time = "2026-05-23T08:57:28.92Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/38/f6425ceb8ecbae63c17bd08af5321d399b51b459b967d7625be6375c56f8/slim_bindings-1.4.1-py3-none-win_arm64.whl", hash = "sha256:dee180e534d4b10c912190aa143dea03f2cb996f5ed58036c5257f6f028feaab", size = 10929753, upload-time = "2026-05-23T08:57:31.067Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this is

**Step 5 of the SLIM-native rebuild** (bible Part V · Step 5) — the dogfood milestone. Retargets the daemon from an httpx **SSE** stream onto a **SLIM group subscription** so a registered Claude Code agent finally rides the fabric: it is **woken** by an inbound message, **spawned** for a headless turn, and its **reply lands back in the channel**.

This is the **first CLI-side step** of the rewrite (Steps 0–4 were backend-only), so it also stands up the daemon's own SLIM+L9 layer.

## How it works

- **Connector (`daemon/connector.py`).** Per owned `(room, handle)` it connects a member `SlimClient`, `listen_for_session` (the backend moderator invites it), sends a presence **hello** (seeding the durable-inbox re-serve route — Step 5 trap option (a)), then pumps a `get_message` wake loop. Wake fires on an inbound L9 **`exchange`** addressed to the handle (via L9 `participants` recipients **or** a raw `@handle` token; `sender != handle` loop guard). The reply is an `exchange` parented on the message that woke it (`parents = [woke_id]`), published to the channel — the backend persister records it.
- **`runner.py`** launches one connector per owned cold-spawn handle (`connector_targets`), reconciles on SIGHUP, cancels on shutdown (then drops the shared SLIM connection). The legacy SSE stream + coordination poller stay in `dispatch.py` (unit tests still pass) but are **no longer wired** — they retire with the backend SSE in Step 10.
- **Daemon SLIM+L9 layer (`mycelium/slim/`).** The CLI installs as a thin `uv tool` and can't drag in the FastAPI/ML backend, so the daemon gets its own small mirror: `naming.py` (Name mapping + `mint_shared_secret`, **byte-for-byte** the backend's so MLS matches), `client.py` (`SlimClient`), and a lean stdlib-only `l9.py`. The reply shape is proven **byte-for-byte identical** to the backend's `l9.envelope_to_dict` and round-trips through `l9.parse_envelope` / `deserialize_envelope` unchanged. Adds `slim-bindings>=1.4,<2`.
- **Gates preserved.** `allow_from`/budget/depth, the per-handle serial lock, and `abort`/`status` control verbs are reused wholesale from `dispatch.py` — only the transport + reply sink change. The agent's contract is unchanged.

## DoD

✅ A registered Claude Code agent joins a room, is woken by an inbound message, spawns a turn, and its reply appears in the room. Budget/depth/ownership gates and `abort`/`status` still hold.

## Tests

- **Fast gate (merge gate, no node, `claude` mocked):** wake path, reply-is-valid-L9, budget/depth/allow_from gates, per-handle lock serialization, abort/status control verbs, L9 helper round-trip. **CLI: 368 passed.**
- **Guarded live-node slice:** `test_connector_wake_over_slim.py` — connector wakes on an inbound L9 over a real MLS group and its reply is received by the moderator. ✅ passes on a live `slim:1.4.0` node.
- **Backend untouched** — all prior slices (Steps 1–4, incl. `test_l9_over_slim_roundtrip.py`) still pass live. **Backend: 232 passed, 1 skipped.**
- Backend + CLI `ruff` / `ruff format` / `ty` all clean.

## Notable decision (flagged)

The integration slice the Step 5 doc suggested adding to the backend's `scripts/l9_slim_roundtrip.py` lives **CLI-side** instead (`tests/test_connector_wake_over_slim.py`) — the connector is in the CLI and the backend script can't import it. It drives the connector's real transport primitives against a live node with a fake backend moderator.

## Handoff

Adds `docs/START_HERE_STEP_6.md` (human-in-the-room + `@`-mention + consent).

Deferrals: cognition engines (`on_summon`) → Step 7; plan-compile (`on_converged`) + memory sync → Step 8; cross-machine → Step 9; SSE/`stream.py` (and the now-unwired daemon SSE helpers) → Step 10.