### PR TITLE
Step 6: Human-in-the-room + @-mention + consent

### DIFF
--- a/docs/START_HERE_STEP_7.md
+++ b/docs/START_HERE_STEP_7.md
@@ -1,0 +1,189 @@
+# START HERE — Step 7 (Cognition engine — base layer: observer + driver)
+
+Companion to [`START_HERE.md`](./START_HERE.md). Step 6 is **done** (this PR into
+`slim-native-rewrite`); you are picking up **Step 7**. Read `START_HERE.md`,
+[`START_HERE_STEP_1.md`](./START_HERE_STEP_1.md) → [`START_HERE_STEP_6.md`](./START_HERE_STEP_6.md)
+first if you haven't — the same rules apply. This file gives you (a) the exact state Step 6
+left behind, (b) your Step 7 marching orders, (c) the facts you must internalize, and (d) the
+traps specific to this step.
+
+**Step 6 put the human in the room.** A human posting to a room is now published onto the SLIM
+channel by the backend (the human's **spoken-for** proxy), `@`-parsed into L9 recipients so an
+in-room agent **wakes and answers** through Step 5's connector bridge — and an `@`-mention of an
+agent **not** on the channel raises a **consent-to-be-woken** prompt that only joins on accept
+(mid-episode invites are queued). **Step 7 lights up the first cognition engine:** a summoned
+**SIEP aligner** that reads the transcript, computes the convergence metrics (MPC/GAR/SCR) the
+protocol library already owns, and emits an L9 **`commit:converged`** / **`commit:rejected`**
+verdict onto the channel — in both **observer** and **driver** modes.
+
+## Ground rules (unchanged from START_HERE.md)
+
+1. **The bible is authoritative:** [`slim-native-rebuild-bible.md`](./slim-native-rebuild-bible.md).
+   Your work is **Part V · Step 7**, with **§10 (cognition engines)** and **§13 (the full cycle)**
+   as the design reference.
+2. Leave the project **runnable and green** — backend + CLI quality gates pass at the end.
+3. Code/config blocks in the bible are **reference, not paste**.
+4. **Verify before you edit** — the paths below were accurate at the end of Step 6; confirm shape
+   before changing a file.
+5. Fixed decisions are not up for debate; the one open question (aligner runtime) has a default:
+   **a cold-spawned agent turn, reusing `spawn.py`** — the same runtime the connector already
+   drives for a woken agent.
+
+## Where Step 6 left things (your starting state)
+
+Branch off `slim-native-rewrite` (Step 6 is merged). The human side is now on the fabric; what's
+still missing is anything that **judges** the exchange. Concretely:
+
+- **The human is published onto the channel.** `app/routes/messages.py`'s POST, for a real room
+  with a live channel, calls `room_channels.manager.publish_human(room, sender, text)`. That
+  builds an L9 `exchange` (sender = the human, `sender_role="human"`), maps `@agent-x` tokens to
+  L9 **recipients** via `persister.parse_mentions`, broadcasts it on `L9SlimChannel.send`, and
+  ingests it **once** through the persister (`RoomPersister.ingest_local`, de-duped by message id
+  so a SLIM loopback can't double-feed the UI bus — the CLAUDE.md "publish once" trap). No human
+  connector.
+- **`@`-parse lives in one place.** `persister.parse_mentions(text)` is the single regex-backed
+  parser (`@` must start the string or follow whitespace/`(`/`<`, so `word@host` is not a
+  mention). `persister.find_summons(content)` reuses it — **and this is the seam your summon
+  trigger rides**: `find_summons` already fires the persister's `on_summon` hook for every
+  `@`-handle in a message.
+- **Consent-gated invites are done.** `app/services/invites.py` is the pure
+  `PendingInviteRegistry` (`pending → queued → accepted/declined`). `RoomChannelManager` drives
+  it: `request_invite` (raises the prompt + pushes a `consent_request` bus event), `accept_invite`
+  (invites on accept, or **queues** mid-episode), `decline_invite`, and `close_episode` /
+  `flush_queued_invites` (drains the queue when an episode closes). Routes:
+  `app/routes/invites.py` (`GET`/`accept`/`decline`). Frontend: `components/consent-dialog.tsx`
+  wired into `event-stream.tsx`.
+- **The summon + converged hooks are still skeletons.** `RoomChannelManager.on_summon` /
+  `on_converged` are `None` by default, so the persister uses `_default_summon_hook` /
+  `_default_converged_hook` — **log only**. Nothing in `app/` sets `manager.on_summon`. That seam
+  is your Step 7 job (wire `on_summon` → the aligner spawner). `on_converged` (plan-compile) stays
+  a skeleton until **Step 8**.
+- **The protocol library is ready and unused as an engine.** `app/services/l9_episode.py` already
+  computes **MPC/GAR/SCR** (`compute_metrics`), opens/records an episode
+  (`open_episode`/`record_tick`/`record_reply`), builds the consensus envelope
+  (`build_consensus_envelope`), and writes `log/episodes/*` records (`write_episode_record`). This
+  is the deterministic tooling #2 from bible §10 — reuse it; do **not** re-derive the math in the
+  engine.
+- **The cold-spawn runtime is proven.** The connector already cold-spawns a `claude -p` turn and
+  publishes the reply as an L9 `exchange` (Step 5). The aligner's default runtime is the same
+  path (`integrations/_spawn_common.SpawnRequest` → `integration.spawn`), just prompted to *judge*
+  rather than *participate*.
+
+## Your Step 7 scope (from the bible, Part V · Step 7)
+
+- **The aligner (SIEP) engine, dormant by default, summoned.** Nothing runs (zero idle cost)
+  until an explicit `@`-summon (the floor), an agent-invoke, or an opt-in trigger-word. The
+  summon arrives through the persister's `on_summon` hook — wire `manager.on_summon` to the
+  engine spawner.
+- **Observer mode (one-shot):** read the room transcript, feed it through `l9_episode`'s
+  MPC/GAR/SCR, and emit an L9 `commit:converged` (above threshold) or `commit:rejected` (below)
+  onto the channel, then sleep.
+- **Driver mode (takes the wheel):** run **N rounds** — prompt each participant for a position,
+  collect replies, score, repeat — then emit the verdict. Reuse the connector's wake/reply
+  primitives for the per-round prompting; terminate on convergence or the round cap.
+- **Both modes at a base level** — no SAB/TFP/escalation sophistication yet (SIEP only).
+- **Key files:** `services/l9_episode.py` [L9-keep, as library]; a **new engine module**
+  (`services/cognition/` or `services/aligner.py`); the trigger-watcher seam
+  (`persister.on_summon` → wire it in `room_channels`/`main`); the spawn path
+  (`integrations/_spawn_common.py`, the connector's `_dispatch_one` as the reference runtime).
+
+## Facts you must internalize first
+
+- **"Cognition engine" is only judgment (#3 in §10).** Room infra (#1, the backend) and the
+  protocol math (#2, `l9_episode`) already exist — the engine is the LLM step that decides "is
+  this converged, and what's the agreement?" over the transcript, using #2 as tooling. Don't
+  rebuild #1 or #2 inside it.
+- **The summon seam already fires.** `persister._ingest` → `find_summons(content)` → `on_summon(handle, envelope)`
+  for every `@`-mention. In Step 6 a human `@agent-x` both wakes the agent (recipient match, the
+  connector) **and** fires `on_summon` (skeleton log). Step 7 makes `on_summon` recognize a summon
+  of the **aligner** and spawn it. Decide how the aligner's handle is distinguished from a normal
+  agent (a reserved handle / a manifest `role`); note it, flag it.
+- **Dormant-by-default is a cost contract, not a nicety.** The engine must not idle-but-bill. The
+  always-on backend listens; the LLM only runs when summoned. Keep the spawn cold.
+- **Emitting the verdict = the plan-compile trigger.** A `commit:converged` on the channel is
+  exactly what the persister's `on_converged` hook watches. You **emit** it in Step 7; **Step 8**
+  wires `on_converged` → `plan_compiler` and the `knowledge` memory sync. Don't compile the plan
+  here — just emit a correct, well-formed `commit:converged`/`commit:rejected`.
+- **Membership stays frozen during a driver run.** A driver episode is an open episode
+  (`open_episode`): a mid-run join/leave aborts it (`_enforce_membership_change`). That's also why
+  Step 6 **queues** `@`-invites mid-episode — your driver's `close_episode` is what drains that
+  queue when it finishes.
+
+## Definition of Done
+
+`@`-summoning the aligner in **observer** mode over a seeded exchange emits a correct
+`commit:converged` (with MPC/GAR/SCR matching `l9_episode.compute_metrics`); **driver** mode runs
+the configured number of rounds and emits a verdict; a below-threshold exchange yields
+`commit:rejected`.
+
+## Tests to write (end of step)
+
+Fast unit tests (the merge gate — no node):
+
+- **Observer emits a correct verdict** — a seeded transcript scores above threshold → the engine
+  emits `commit:converged` carrying the MPC/GAR/SCR `compute_metrics` returns.
+- **Below-threshold → `commit:rejected`** — a low-alignment seeded transcript yields a rejection.
+- **Driver runs the round loop and terminates** — N rounds prompt→collect→score, then a verdict;
+  it stops at convergence or the round cap (no infinite loop).
+- **Summon routing** — an `@`-summon of the aligner handle fires the engine spawner; an
+  `@`-mention of a normal agent does **not**.
+
+Live-node **integration slice** (guarded, adds to the cumulative suite — **all prior slices must
+still pass**, backend + CLI):
+
+- **`@`-summon the aligner over a live node** in a room with a seeded exchange makes it observe
+  and emit `commit:converged` on the channel. Model on
+  `fastapi-backend/tests/test_l9_over_slim_roundtrip.py` and the Step 6 connector slices.
+
+## Verification gate (must pass before you call Step 7 done)
+
+```bash
+# Backend
+cd fastapi-backend
+uv run ruff check . && uv run ruff format --check . && uv run ty check .
+MYCELIUM_STUB_EMBEDDINGS=1 uv run pytest tests/ -x -q            # fast gate, no node
+
+# CLI (matches CI)
+cd ../mycelium-cli
+uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run pytest tests/ -x -q
+
+# Guarded integration slices — bring a node up first (recipe in START_HERE_STEP_5.md §Verification):
+MYCELIUM_STUB_EMBEDDINGS=1 MYCELIUM_SLIM_ENDPOINT=http://127.0.0.1:46357 \
+  uv run pytest tests/ -q          # run in BOTH fastapi-backend/ and mycelium-cli/
+```
+
+> **Known pre-existing wrinkle (not yours to fix, but don't be surprised):** running the *whole*
+> CLI suite with `MYCELIUM_SLIM_ENDPOINT` exported trips `tests/test_slim_config.py::test_connect_persists_endpoint`,
+> which asserts a persisted endpoint the exported env var overrides. It passes in the normal gate
+> (no env var). Run the guarded connector slices by file (as Step 6 did) rather than reading a
+> whole-suite pass/fail with that env set.
+
+Bring a standalone node up with the same docker recipe Step 5 used (see
+[`START_HERE_STEP_5.md`](./START_HERE_STEP_5.md) — the `ghcr.io/agntcy/slim:1.4.0` one-liner).
+
+## Traps specific to Step 7
+
+- **Don't idle-but-bill.** The engine is dormant until summoned. If you find yourself holding an
+  LLM connection open or polling, you've broken the cost contract (§10).
+- **Don't re-implement the metrics.** MPC/GAR/SCR live in `l9_episode.compute_metrics`. The engine
+  *calls* it; it doesn't reinvent it. A second copy will drift from the `log/episodes/*` records.
+- **Emit, don't compile.** Step 7 stops at emitting `commit:converged`/`commit:rejected`. Wiring
+  `on_converged` → `plan_compiler` + the `knowledge` memory sync is **Step 8**. Resist doing it
+  early — it couples two steps and breaks the clean seam.
+- **Driver membership.** Open the driver episode (`open_episode`) so mid-run membership changes
+  abort it, and call `close_episode` when it ends so Step 6's queued `@`-invites drain. A driver
+  that never closes its episode strands queued invites forever.
+- **Distinguish the aligner from a participant.** The summon hook fires for every `@`-handle. If
+  the aligner isn't distinguished (reserved handle / manifest role), a human `@`-mentioning a
+  normal teammate would spawn an engine. Gate on identity.
+- **MLS on, version stays pinned.** `slim:1.4.0` / `slim-bindings` 1.4.x — matched pair; don't
+  touch it.
+
+## Report when done
+
+Per `START_HERE.md`: what changed, the DoD check, and test results (fast gate + the live
+integration slice, noting all prior slices still pass, backend + CLI). Open a PR against
+`slim-native-rewrite` (same as Steps 0–6). Deferrals to name explicitly: plan-compile firing
+(wiring `on_converged`) + `knowledge` memory sync are **Step 8**; cross-machine is **Step 9**;
+SSE/`stream.py` (and the legacy SSE/poller helpers still sitting in the daemon's `dispatch.py`)
+are retired in **Step 10**; SAB/TFP engines and the escalation ladder are **post-MVP**.

--- a/docs/slim-native-rebuild-bible.md
+++ b/docs/slim-native-rebuild-bible.md
@@ -488,32 +488,40 @@ Base: `/Users/juliavalenti/Documents/GitHub/mycelium`. Classifications: **[keep]
 
 ---
 
-## Known debt — the CLI/backend SLIM+L9 duplication (address before Step 7)
+## Known debt register
 
-Step 5 gave the daemon its own copy of the SLIM+L9 primitives at
-`mycelium-cli/src/mycelium/slim/` (`naming.py`, `client.py`, `l9.py`) plus the
-`_room_episode`/`_room_topic` URN helpers in `daemon/connector.py`, mirroring
-`fastapi-backend/app/services/` (`slim_client.py`, `l9.py`). This is **necessary** — the
-thin `uv tool` CLI can't import the FastAPI/ML backend — but it is a **copy**, and drift
-is silent and vicious: if `mint_shared_secret` / the master-secret literal / the
-`workspace/room` scope diverge, MLS keys mismatch and connectors **silently can't join**
-(no app-level error); envelope-shape or URN drift silently drops or misroutes messages.
+Consolidated from the step reviews (PRs #417–#423) and the design — **one authoritative
+list** (also mirrored on tracking PR #418). Scan the table; the two load-bearing items
+(D1 security, D2 duplication) have detail below. *Severity* = correctness/security impact;
+*Bites* = when it starts to hurt.
 
-Today the copies are byte-for-byte faithful and the **live integration slice** catches
-drift end-to-end — but only in the guarded suite, so a divergence can **merge green**.
+| # | Debt | Severity | Bites | Fix |
+|---|---|---|---|---|
+| **D1** | **No real auth** — a public dev shared-secret (`_DEV_MASTER_SECRET`) seeds every room's MLS key, so anyone with the repo can derive/join any channel | **High** | before anything hosted / multi-user / multi-tenant | JWT or SPIRE identity (§7). **Prerequisite for the §16 hosted-rendezvous security story.** |
+| **D2** | **CLI/backend SLIM+L9 duplication** — `mycelium/slim/` copies the backend primitives; silent drift → MLS-join / parse failures | Medium | when a copy drifts (can merge green) | (A) fast-gate golden test now; (B) shared package **before Step 7** |
+| **D3** | **Silent degradation is unobservable** — best-effort "no channel" / log-and-continue, no metrics or health surface | Medium | during the demo / ops | small counters + health surface (channels provisioned/failed, re-serves, drops) |
+| **D4** | **Unbounded growth** — transcript (full rewrite per message, no rotation), `CausalOrderBuffer._delivered`/`_pending`, JSONL search index | Low–Med | long-lived rooms / high volume | append+rotate transcript; prune buffer at episode close; ANN index past ~10k |
+| **D5** | **Durable-inbox cursors in-memory** — re-serve doesn't survive a backend restart (docstring overclaims) | Medium | backend restart while an agent is offline | persist cursors with the transcript; fix the docstring |
+| **D6** | **Broad `except Exception`** in best-effort SLIM calls hides real bugs as "no channel" | Low | a code bug silently degrades | normalize binding errors → app `SlimError` at the `slim_client.py` boundary; narrow the catches |
+| **D7** | **Fire-and-forget task not ref-held** — connector `_guarded_inbound` | Low | GC mid-spawn (rare) | strong-ref set + done-callback, as `room_channels.py` does |
+| **D8** | **Invite dedup + invite/`listen_for_session` race** | Low–Med | repeated joins / Step 6+ | dedup pending invites; reconcile invite-completion with the connector's listen |
+| **D9** | **Single-process backend** — all moderators/persisters/cursors in memory; no horizontal scaling | Low (known ceiling) | beyond single-host | out of MVP scope; documented ceiling |
 
-Fix ladder:
-- **(A) now — fast-gate golden test.** Freeze the expected secret digest + a golden envelope
-  dict as constants; *both* packages assert their output against them, so a drift goes red
-  at the merge gate (no node needed).
-- **(B) before Step 7 — extract a shared package.** A small `mycelium-slim-l9` (or fold into
-  the `mycelium-client` pattern) that backend + CLI both depend on: one source of truth for
-  naming/secret/envelope/URNs; delete the copy. Do it **before Steps 7–8**, which add
-  cognition-engine + `knowledge` envelope surface and would otherwise grow the duplication.
-- (C) a heavier protocol lib / codegen — overkill for now.
+**D1 — the security model is currently theater (the one to *not* forget).** MLS protects
+against a *node* reading traffic, but the group key is derived from a public literal, so the
+"blind hosted forwarder" de-risk in §16 only holds once members' keys are actually secret.
+Real identity (JWT/SPIRE) is therefore a **hard prerequisite before any hosted / multi-user
+use**, not a nice-to-have.
 
-Severity: medium — real debt, not a disaster (the duplication is small and well-bounded),
-but the failure mode is silent. Related watch items live on tracking PR #418.
+**D2 — the CLI/backend copy.** Step 5 gave the daemon its own SLIM+L9 primitives
+(`mycelium/slim/{naming,client,l9}.py` + the `_room_episode`/`_room_topic` URNs in
+`daemon/connector.py`) because the thin `uv tool` CLI can't import the FastAPI backend.
+Necessary, but a copy: if `mint_shared_secret` / the master-secret literal / the
+`workspace/room` scope / the envelope shape drift, connectors **silently can't join** (no
+app-level error). Today they're byte-for-byte faithful and the live slice catches drift —
+but only in the guarded suite. Fix: (A) a fast-gate golden test both packages assert against,
+then (B) extract a shared `mycelium-slim-l9` package **before Steps 7–8** grow the shared
+surface.
 
 ---
 

--- a/docs/slim-native-rebuild-bible.md
+++ b/docs/slim-native-rebuild-bible.md
@@ -506,6 +506,8 @@ list** (also mirrored on tracking PR #418). Scan the table; the two load-bearing
 | **D7** | **Fire-and-forget task not ref-held** — connector `_guarded_inbound` | Low | GC mid-spawn (rare) | strong-ref set + done-callback, as `room_channels.py` does |
 | **D8** | **Invite dedup + invite/`listen_for_session` race** | Low–Med | repeated joins / Step 6+ | dedup pending invites; reconcile invite-completion with the connector's listen |
 | **D9** | **Single-process backend** — all moderators/persisters/cursors in memory; no horizontal scaling | Low (known ceiling) | beyond single-host | out of MVP scope; documented ceiling |
+| **D10** | **Comment audit** — stale comments/docstrings left by the rewrite (removed CFN/CE/AgensGraph refs, orphaned `TODO(stepN)`, overclaiming docstrings e.g. D5) | Low | reading/maintaining the code | sweep + fix before declaring the rewrite done; pair with the CLAUDE.md/docs cleanup |
+| **D11** | **Stale agent harnesses** — openclaw/hermes plugins built on the removed CFN-tick-over-SSE model (broken SLIM-native); cursor untested over SLIM | Medium | post-MVP, when a non-claude adapter is used | per-adapter: migrate to SLIM vs. explicitly deprecate (see below) |
 
 **D1 — the security model is currently theater (the one to *not* forget).** MLS protects
 against a *node* reading traffic, but the group key is derived from a public literal, so the
@@ -522,6 +524,22 @@ app-level error). Today they're byte-for-byte faithful and the live slice catche
 but only in the guarded suite. Fix: (A) a fast-gate golden test both packages assert against,
 then (B) extract a shared `mycelium-slim-l9` package **before Steps 7–8** grow the shared
 surface.
+
+**D11 — the other harnesses will be stale.** The MVP migrates **claude_code** only.
+- **cursor** (cold_spawn) shares the daemon's SLIM connector path (`connector_targets`
+  includes it) and the family-agnostic spawn, so it *probably works over SLIM already* — but
+  it's **untested** (Step 5's slice mocks the `claude` binary). Cheapest to finish: run it
+  through a live slice.
+- **openclaw** and **hermes** (long_lived_gateway) are **broken**, not just untested: their
+  plugins subscribe to the backend's **SSE coordination-tick** stream and render ticks via
+  `route.ts` / the python gateway — a flow the rewrite **removed** in Step 0. They need their
+  delivery path rewritten to speak SLIM (embed a SLIM client or shell to the daemon) — the
+  "generalize the connector" work the plan deferred.
+
+Decision per adapter: **migrate vs. deprecate.** Given openclaw isn't dogfoodable internally
+and the vertical is coding/work agents, the honest option for openclaw/hermes may be
+**explicit deprecation until there's demand** rather than leaving them half-broken and
+looking supported. Don't ship them silently broken.
 
 ---
 

--- a/docs/slim-native-rebuild-bible.md
+++ b/docs/slim-native-rebuild-bible.md
@@ -488,6 +488,35 @@ Base: `/Users/juliavalenti/Documents/GitHub/mycelium`. Classifications: **[keep]
 
 ---
 
+## Known debt — the CLI/backend SLIM+L9 duplication (address before Step 7)
+
+Step 5 gave the daemon its own copy of the SLIM+L9 primitives at
+`mycelium-cli/src/mycelium/slim/` (`naming.py`, `client.py`, `l9.py`) plus the
+`_room_episode`/`_room_topic` URN helpers in `daemon/connector.py`, mirroring
+`fastapi-backend/app/services/` (`slim_client.py`, `l9.py`). This is **necessary** — the
+thin `uv tool` CLI can't import the FastAPI/ML backend — but it is a **copy**, and drift
+is silent and vicious: if `mint_shared_secret` / the master-secret literal / the
+`workspace/room` scope diverge, MLS keys mismatch and connectors **silently can't join**
+(no app-level error); envelope-shape or URN drift silently drops or misroutes messages.
+
+Today the copies are byte-for-byte faithful and the **live integration slice** catches
+drift end-to-end — but only in the guarded suite, so a divergence can **merge green**.
+
+Fix ladder:
+- **(A) now — fast-gate golden test.** Freeze the expected secret digest + a golden envelope
+  dict as constants; *both* packages assert their output against them, so a drift goes red
+  at the merge gate (no node needed).
+- **(B) before Step 7 — extract a shared package.** A small `mycelium-slim-l9` (or fold into
+  the `mycelium-client` pattern) that backend + CLI both depend on: one source of truth for
+  naming/secret/envelope/URNs; delete the copy. Do it **before Steps 7–8**, which add
+  cognition-engine + `knowledge` envelope surface and would otherwise grow the duplication.
+- (C) a heavier protocol lib / codegen — overkill for now.
+
+Severity: medium — real debt, not a disaster (the duplication is small and well-bounded),
+but the failure mode is silent. Related watch items live on tracking PR #418.
+
+---
+
 # PART V — THE BUILD PLAN
 
 Execute in order. This is a **build sequence**, not a phased shipping plan — it all lands as

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -28,6 +28,7 @@ os.environ.setdefault("HF_HUB_OFFLINE", "1")
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.routes.invites import router as invites_router
 from app.routes.memory import router as memory_router
 from app.routes.messages import router as messages_router
 from app.routes.plan import agent_router as agent_context_router
@@ -126,6 +127,7 @@ app.add_middleware(
 # Core routes. Health endpoints stay top-level for orchestrator probes.
 app.include_router(rooms_router, prefix="/api")
 app.include_router(messages_router, prefix="/api")
+app.include_router(invites_router, prefix="/api")
 app.include_router(sessions_router, prefix="/api")
 app.include_router(stream_router, prefix="/api")
 app.include_router(memory_router, prefix="/api")

--- a/fastapi-backend/app/routes/invites.py
+++ b/fastapi-backend/app/routes/invites.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Consent-gated invite endpoints — the human-in-the-room accept/decline surface
+(Step 6, bible §12).
+
+When a human ``@``-mentions an agent that is **not** on a room's channel, the
+backend raises a :class:`~app.services.invites.PendingInvite` instead of inviting
+straight away, and pushes a ``consent_request`` event onto the room's SSE stream.
+These endpoints back the accept/decline prompt: only on ``accept`` does the
+moderator invite (and, mid-episode, queue) the agent.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from app.services import room_channels
+from app.services.filesystem import room_exists
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/rooms/{room_name}/invites", tags=["invites"])
+
+
+def _require_room(room_name: str) -> None:
+    if not room_exists(room_name):
+        raise HTTPException(status_code=404, detail="Room not found")
+
+
+@router.get("")
+async def list_invites(room_name: str):
+    """List open (pending or queued) consent requests for a room."""
+    _require_room(room_name)
+    return {"invites": [inv.to_json() for inv in room_channels.manager.pending_invites(room_name)]}
+
+
+@router.post("/{invite_id}/accept")
+async def accept_invite(room_name: str, invite_id: str):
+    """Accept a consent prompt — invite the agent (or queue it mid-episode)."""
+    _require_room(room_name)
+    invite = await room_channels.manager.accept_invite(invite_id)
+    if invite is None:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    return invite.to_json()
+
+
+@router.post("/{invite_id}/decline")
+async def decline_invite(room_name: str, invite_id: str):
+    """Decline a consent prompt — the agent does not join."""
+    _require_room(room_name)
+    invite = room_channels.manager.decline_invite(invite_id)
+    if invite is None:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    return invite.to_json()

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -26,7 +26,7 @@ from app.schemas import (
     MessageRead,
     MessageType,
 )
-from app.services import local_state
+from app.services import local_state, room_channels
 from app.services.filesystem import room_exists
 
 logger = logging.getLogger(__name__)
@@ -87,7 +87,25 @@ async def send_message(room_name: str, payload: MessageCreate):
     if coord is not None:
         notify_payload["coordination_session_id"] = str(coord.id)
     notify_payload["room_name"] = channel
-    bus.publish(room_channel(channel), notify_payload)
+
+    # Human-in-the-room (Step 6): for a real room with a live SLIM channel, the
+    # backend publishes the human's message onto the channel as their proxy —
+    # ``@``-parsing recipients so in-room agents wake, and raising consent for
+    # absent mentions. The persister then feeds the UI bus, so we must NOT also
+    # bus.publish here (that would show the message twice — bible §12 trap).
+    # Coordination sub-rooms and the no-channel path keep the legacy bus feed.
+    published = False
+    if (
+        coord is None
+        and msg.message_type == MessageType.BROADCAST
+        and room_channels.manager.is_live(channel)
+    ):
+        result = await room_channels.manager.publish_human(
+            channel, sender=msg.sender_handle, text=msg.content
+        )
+        published = result is not None
+    if not published:
+        bus.publish(room_channel(channel), notify_payload)
 
     return MessageRead.model_validate(msg)
 

--- a/fastapi-backend/app/services/invites.py
+++ b/fastapi-backend/app/services/invites.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Consent-gated invites — the human-in-the-room membership flow (Step 6, bible §12).
+
+An ``@``-mention of an agent **already on the room channel** is a *wake* (handled
+on the fabric: the human's ``exchange`` names it as an L9 recipient and its
+connector wakes). An ``@``-mention of an agent **not on the channel** is a
+*membership change* — and a membership change is a consent decision, not a
+side effect. So instead of inviting straight away, the backend records a
+:class:`PendingInvite` and surfaces an accept/decline prompt ("someone's agent
+wants to reach yours — accept?"). The moderator only invites + spawns on accept.
+
+This registry is the pure, node-free state of that flow. The SLIM side (actually
+inviting on accept, and the mid-episode queue) lives on
+:class:`~app.services.room_channels.RoomChannelManager`, which drives this.
+
+States:
+
+- ``pending``   — consent prompt raised, awaiting a human decision.
+- ``queued``    — accepted, but an episode was live, so the membership change is
+                  deferred until the episode closes (L9's stable-membership rule,
+                  bible §12: a mid-episode join would abort the episode).
+- ``accepted``  — accepted and applied (the moderator invited the agent).
+- ``declined``  — declined (or dropped); never joins.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+PENDING = "pending"
+QUEUED = "queued"
+ACCEPTED = "accepted"
+DECLINED = "declined"
+
+# Statuses that still represent an open (not-yet-resolved) consent request.
+OPEN_STATES = frozenset({PENDING, QUEUED})
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+@dataclass
+class PendingInvite:
+    """One consent-gated invite of ``agent`` into ``room``."""
+
+    id: str
+    room: str
+    agent: str
+    requested_by: str
+    trigger_text: str = ""
+    status: str = PENDING
+    created_at: str = field(default_factory=_now)
+
+    def to_json(self) -> dict[str, str]:
+        return {
+            "id": self.id,
+            "room": self.room,
+            "agent": self.agent,
+            "requested_by": self.requested_by,
+            "trigger_text": self.trigger_text,
+            "status": self.status,
+            "created_at": self.created_at,
+        }
+
+
+class PendingInviteRegistry:
+    """In-memory registry of consent-gated invites, keyed by invite id.
+
+    :meth:`request` is idempotent per open ``(room, agent)``: a second mention of
+    the same absent agent while a consent prompt is still open returns the same
+    invite rather than stacking duplicate prompts.
+    """
+
+    def __init__(self) -> None:
+        self._invites: dict[str, PendingInvite] = {}
+
+    def request(
+        self, room: str, agent: str, *, requested_by: str, trigger_text: str = ""
+    ) -> PendingInvite:
+        """Record (or return the open) consent request for ``agent`` in ``room``."""
+        existing = self._open_for(room, agent)
+        if existing is not None:
+            return existing
+        invite = PendingInvite(
+            id=str(uuid.uuid4()),
+            room=room,
+            agent=agent,
+            requested_by=requested_by,
+            trigger_text=trigger_text,
+        )
+        self._invites[invite.id] = invite
+        return invite
+
+    def get(self, invite_id: str) -> PendingInvite | None:
+        return self._invites.get(invite_id)
+
+    def open_for_room(self, room: str) -> list[PendingInvite]:
+        """Every still-open (pending or queued) invite in ``room``."""
+        return [
+            inv for inv in self._invites.values() if inv.room == room and inv.status in OPEN_STATES
+        ]
+
+    def queued_for_room(self, room: str) -> list[PendingInvite]:
+        """Accepted-but-deferred invites in ``room`` (mid-episode queue)."""
+        return [inv for inv in self._invites.values() if inv.room == room and inv.status == QUEUED]
+
+    def mark(self, invite_id: str, status: str) -> PendingInvite | None:
+        invite = self._invites.get(invite_id)
+        if invite is None:
+            return None
+        invite.status = status
+        return invite
+
+    def _open_for(self, room: str, agent: str) -> PendingInvite | None:
+        for inv in self._invites.values():
+            if inv.room == room and inv.agent == agent and inv.status in OPEN_STATES:
+                return inv
+        return None

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -95,6 +95,20 @@ def _iter_text(value: Any) -> Iterable[str]:
             yield from _iter_text(v)
 
 
+def parse_mentions(text: str) -> list[str]:
+    """Handles ``@``-mentioned in one plain-text string.
+
+    The backend's ``@``-parse (bible §12): map ``@agent-x`` tokens in a human's
+    message to L9 recipients. De-duplicated preserving first-seen order. A bare
+    ``word@host`` is **not** a mention (the ``@`` must start the string or follow
+    whitespace / ``(`` / ``<``), so an email address never wakes an agent.
+    """
+    seen: dict[str, None] = {}
+    for match in _SUMMON_RE.findall(text):
+        seen.setdefault(match, None)
+    return list(seen)
+
+
 def find_summons(content: dict[str, Any]) -> list[str]:
     """Handles ``@``-summoned in a message's human-facing content.
 
@@ -106,7 +120,7 @@ def find_summons(content: dict[str, Any]) -> list[str]:
         if key == "l9":
             continue
         for text in _iter_text(value):
-            for match in _SUMMON_RE.findall(text):
+            for match in parse_mentions(text):
                 seen.setdefault(match, None)
     return list(seen)
 
@@ -336,6 +350,10 @@ class RoomPersister:
         self.log = DeliveryLog(load_transcript(room))
         # handle -> most recent inbound MessageContext, for targeted re-serve.
         self._contexts: dict[str, slim_bindings.MessageContext] = {}
+        # Message ids ingested this process lifetime, so a message the backend
+        # publishes itself (the human proxy, Step 6) is recorded/fed to the bus
+        # exactly once even if SLIM loops the broadcast back to the moderator.
+        self._ingested_ids: set[str] = set()
 
     # -- membership signals (driven by RoomChannelManager) --
 
@@ -411,7 +429,23 @@ class RoomPersister:
             for envelope, content in released:
                 self._ingest(envelope, content)
 
+    def ingest_local(self, envelope: L9, content: dict[str, Any]) -> None:
+        """Ingest a message the moderator published itself (the human proxy).
+
+        The backend speaks for the human on the fabric (bible §12): it publishes
+        the human's ``exchange`` on the channel *and* records it here directly, so
+        the transcript and UI bus see it regardless of whether SLIM delivers a
+        broadcast back to its own sender. :meth:`_ingest` de-dupes by message id,
+        so a loopback of the same broadcast is a no-op.
+        """
+        self._ingest(envelope, content)
+
     def _ingest(self, envelope: L9, content: dict[str, Any]) -> None:
+        mid = envelope_message_id(envelope)
+        if mid is not None:
+            if mid in self._ingested_ids:
+                return
+            self._ingested_ids.add(mid)
         record = record_from(envelope, content)
         present = set(self._members_provider())
         self.log.record(record, delivered_to=present)

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -27,17 +27,21 @@ module owns that task's start/stop lifecycle and surfaces the reconnect signal
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from dataclasses import dataclass, field
 
 from app.config import settings
 from app.services import l9
+from app.services.invites import ACCEPTED, DECLINED, QUEUED, PendingInvite, PendingInviteRegistry
+from app.services.l9_models import Kind
 from app.services.l9_slim import (
     EpisodeLifecycle,
     L9SlimChannel,
     build_episode_abort_envelope,
+    serialize_content,
 )
-from app.services.persister import ConvergedHook, RoomPersister, SummonHook
+from app.services.persister import ConvergedHook, RoomPersister, SummonHook, parse_mentions
 from app.services.slim_client import (
     SlimClient,
     SlimIdentity,
@@ -68,6 +72,20 @@ class ManagedRoomChannel:
     persister_task: asyncio.Task[None] | None = None
 
 
+@dataclass
+class HumanPublishResult:
+    """The outcome of publishing a human's message onto a room channel.
+
+    ``recipients`` are the L9 recipients the ``@``-parse resolved (present members
+    that get woken); ``invites`` are the consent-gated invites raised for mentioned
+    agents that are **not** on the channel yet.
+    """
+
+    mentioned: list[str]
+    recipients: list[str]
+    invites: list[PendingInvite]
+
+
 class RoomChannelManager:
     """Registry of backend-moderated room channels (one per room, per process)."""
 
@@ -78,6 +96,9 @@ class RoomChannelManager:
         self._lock = asyncio.Lock()
         # Strong refs to in-flight background invites (see invite_in_background).
         self._tasks: set[asyncio.Task[bool]] = set()
+        # Consent-gated invites raised by an @-mention of a not-present agent
+        # (bible §12). The moderator only invites on accept.
+        self._invites = PendingInviteRegistry()
         # Trigger hooks handed to every persister. Skeletons by default (log
         # only); Step 7 wires ``on_summon`` to the cognition-engine spawner and
         # Step 8 wires ``on_converged`` to ``plan_compiler``.
@@ -193,6 +214,138 @@ class RoomChannelManager:
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
 
+    # -- human-in-the-room (Step 6) --
+
+    async def publish_human(
+        self, room: str, *, sender: str, text: str
+    ) -> HumanPublishResult | None:
+        """Publish a human's message onto the room channel as their proxy.
+
+        The human runs no connector (bible §12): the backend builds an L9
+        ``exchange`` on their behalf, maps ``@agent-x`` tokens to L9 recipients,
+        and broadcasts it. In-room mentions wake through the connector's
+        recipient match (Step 5); mentions of agents **not** on the channel raise
+        a consent-gated invite instead. Returns ``None`` when no channel is live.
+
+        The published message is ingested locally via the persister so the
+        transcript and UI bus see it exactly once, independent of whether SLIM
+        loops a broadcast back to its own sender.
+        """
+        managed = self._channels.get(room)
+        if managed is None:
+            return None
+
+        mentioned = parse_mentions(text)
+        # Every mention is an L9 recipient (the semantic "to"); everyone else on
+        # the channel is an observer. Absent mentions stay recipients so the
+        # intent is recorded, but only present ones actually receive the broadcast.
+        envelope = l9.build_envelope(
+            kind=Kind.exchange,
+            episode=l9.episode_urn(room, "live"),
+            sender=sender,
+            sender_role="human",
+            recipients=mentioned,
+            topic=l9.topic_urn(room),
+            payload_type="message",
+        )
+        content = serialize_content(envelope, extra={"content": text})
+        try:
+            await managed.channel.send(envelope, extra={"content": text})
+        except Exception as exc:  # best-effort broadcast
+            logger.warning("failed to publish human message on room %s: %s", room, exc)
+        if managed.persister is not None:
+            managed.persister.ingest_local(envelope, content)
+
+        # Consent gate: an @-mention of an agent not on the channel is an invite.
+        invites: list[PendingInvite] = []
+        for handle in mentioned:
+            if handle in managed.members or handle == BACKEND_AGENT:
+                continue
+            invite = self.request_invite(room, handle, requested_by=sender, trigger_text=text)
+            if invite is not None:
+                invites.append(invite)
+
+        recipients = [h for h in mentioned if h != BACKEND_AGENT]
+        return HumanPublishResult(mentioned=mentioned, recipients=recipients, invites=invites)
+
+    # -- consent-gated invites (Step 6) --
+
+    def request_invite(
+        self, room: str, agent: str, *, requested_by: str, trigger_text: str = ""
+    ) -> PendingInvite | None:
+        """Raise a consent prompt to invite ``agent`` into ``room``.
+
+        Returns ``None`` when there's nothing to consent to — no live channel, or
+        the agent is already a member (that mention is a wake, not an invite).
+        Otherwise records a pending invite and surfaces the accept/decline prompt
+        on the room's UI bus. Does **not** invite; that waits for :meth:`accept_invite`.
+        """
+        managed = self._channels.get(room)
+        if managed is None or agent == BACKEND_AGENT or agent in managed.members:
+            return None
+        invite = self._invites.request(
+            room, agent, requested_by=requested_by, trigger_text=trigger_text
+        )
+        self._emit_consent_prompt(invite)
+        return invite
+
+    async def accept_invite(self, invite_id: str) -> PendingInvite | None:
+        """Accept a consent prompt: invite the agent — or queue it mid-episode.
+
+        Inviting a new member mid-episode violates L9's stable-membership rule
+        (it would abort the episode), so an accept while an episode is active is
+        **queued** and applied when the episode closes (bible §12 default).
+        Returns the updated invite, or ``None`` if the id is unknown.
+        """
+        invite = self._invites.get(invite_id)
+        if invite is None:
+            return None
+        managed = self._channels.get(invite.room)
+        if managed is None:
+            return self._invites.mark(invite_id, DECLINED)
+        if managed.lifecycle.active:
+            logger.info(
+                "invite for @%s in %s queued until episode %s closes",
+                invite.agent,
+                invite.room,
+                managed.lifecycle.episode,
+            )
+            return self._invites.mark(invite_id, QUEUED)
+        await self.invite(invite.room, invite.agent)
+        return self._invites.mark(invite_id, ACCEPTED)
+
+    def decline_invite(self, invite_id: str) -> PendingInvite | None:
+        """Decline a consent prompt: the agent does not join."""
+        return self._invites.mark(invite_id, DECLINED)
+
+    def pending_invites(self, room: str) -> list[PendingInvite]:
+        """Open (pending or queued) consent requests for ``room``."""
+        return self._invites.open_for_room(room)
+
+    async def flush_queued_invites(self, room: str) -> None:
+        """Apply invites deferred during an episode, now that it has closed."""
+        for invite in self._invites.queued_for_room(room):
+            await self.invite(room, invite.agent)
+            self._invites.mark(invite.id, ACCEPTED)
+
+    def _emit_consent_prompt(self, invite: PendingInvite) -> None:
+        """Surface a consent prompt on the room's UI bus (best-effort)."""
+        try:
+            from app.bus import bus, room_channel
+
+            bus.publish(
+                room_channel(invite.room),
+                {
+                    "room_name": invite.room,
+                    "sender_handle": l9.SYSTEM_ACTOR_ID,
+                    "message_type": "consent_request",
+                    "content": json.dumps(invite.to_json()),
+                    "created_at": invite.created_at,
+                },
+            )
+        except Exception:  # pragma: no cover - best-effort UI push
+            logger.debug("consent prompt bus publish failed for room %s", invite.room)
+
     async def remove(self, room: str, agent: str) -> bool:
         """Remove ``agent`` from the room channel. Best-effort; returns success."""
         managed = self._channels.get(room)
@@ -217,6 +370,21 @@ class RoomChannelManager:
         if managed is None:
             return False
         managed.lifecycle.open(episode, managed.members)
+        return True
+
+    async def close_episode(self, room: str) -> bool:
+        """Close the room's active episode normally and flush queued invites.
+
+        The membership-freeze that an episode holds is released here, so invites
+        an ``@``-mention deferred mid-episode (bible §12) are now safe to apply.
+        The converged/rejected wiring that calls this lands in Steps 7-8; the
+        method exists now so the mid-episode queue has a drain.
+        """
+        managed = self._channels.get(room)
+        if managed is None:
+            return False
+        managed.lifecycle.close()
+        await self.flush_queued_invites(room)
         return True
 
     async def _enforce_membership_change(self, managed: ManagedRoomChannel) -> None:

--- a/fastapi-backend/tests/test_mentions_and_invites.py
+++ b/fastapi-backend/tests/test_mentions_and_invites.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for human-in-the-room: @-parse + consent-gated invites (Step 6).
+
+Node-free. The ``@``-parse is pure; the invite/consent flow is exercised against
+a :class:`RoomChannelManager` with a faked managed channel injected directly into
+its registry, so no SLIM node (and no real invite handshake) is needed. The live
+wake-over-a-node slice lives in the CLI's
+``test_human_mention_wakes_connector.py`` (guarded).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services import invites, room_channels
+from app.services.persister import parse_mentions
+from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
+
+_ROOM = "step6-room"
+
+
+# ── @-parse → participants ────────────────────────────────────────────────────
+
+
+def test_parse_mentions_maps_tokens_and_ignores_emails():
+    assert parse_mentions("@agent-x @agent-y do the thing") == ["agent-x", "agent-y"]
+    # A bare word@host is an email, not a mention — the @ isn't at a boundary.
+    assert parse_mentions("ping agentx@host.example now") == []
+    # Deduped, first-seen order preserved.
+    assert parse_mentions("@a hi @b then @a again") == ["a", "b"]
+    # Leading and bracketed forms both count.
+    assert parse_mentions("@lead go") == ["lead"]
+    assert parse_mentions("(<@ping>)") == ["ping"]
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+def _manager_with_channel(
+    members: set[str] | None = None,
+) -> tuple[RoomChannelManager, ManagedRoomChannel]:
+    """A manager whose room has a faked, always-'live' channel + persister."""
+    manager = RoomChannelManager(endpoint="http://127.0.0.1:46357", default_workspace="mycelium")
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    persister = MagicMock()
+    managed = ManagedRoomChannel(
+        room=_ROOM,
+        workspace="mycelium",
+        client=MagicMock(),
+        channel=channel,
+        members=set(members or set()),
+    )
+    managed.persister = persister
+    manager._channels[_ROOM] = managed
+    return manager, managed
+
+
+# ── publish_human: recipients + wake vs invite ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_publish_human_maps_recipients_wakes_present_invites_absent():
+    manager, managed = _manager_with_channel(members={"agent-x"})
+
+    result = await manager.publish_human(_ROOM, sender="julia", text="@agent-x @agent-y ship it")
+
+    assert result is not None
+    # Both mentions become L9 recipients (the semantic "to").
+    assert result.recipients == ["agent-x", "agent-y"]
+
+    # The broadcast carried an exchange whose recipients are exactly the mentions.
+    channel_send = cast(MagicMock, managed.channel.send)
+    channel_send.assert_awaited_once()
+    envelope = channel_send.await_args.args[0]
+    actor_ids = [a.id for a in envelope.header.participants.actors]
+    assert actor_ids == ["julia", "agent-x", "agent-y"]
+    assert envelope.header.kind.value == "exchange"
+
+    # Persister ingests the message locally exactly once (transcript + bus feed).
+    cast(MagicMock, managed.persister).ingest_local.assert_called_once()
+
+    # agent-x is present (a wake, no invite); agent-y is absent (consent invite).
+    assert [inv.agent for inv in result.invites] == ["agent-y"]
+    assert result.invites[0].status == invites.PENDING
+
+
+@pytest.mark.asyncio
+async def test_publish_human_returns_none_without_a_live_channel():
+    manager = RoomChannelManager(endpoint="http://127.0.0.1:46357", default_workspace="mycelium")
+    assert await manager.publish_human("no-such-room", sender="julia", text="@x hi") is None
+
+
+# ── consent: accept joins, decline does not ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_absent_invite_accept_joins():
+    manager, _managed = _manager_with_channel(members=set())
+    invite_mock = AsyncMock(return_value=True)
+    manager.invite = invite_mock  # type: ignore[method-assign]
+
+    result = await manager.publish_human(_ROOM, sender="julia", text="@bob take a look")
+    assert result is not None
+    invite = result.invites[0]
+    assert manager.pending_invites(_ROOM) == [invite]
+    invite_mock.assert_not_awaited()  # consent gates the join
+
+    accepted = await manager.accept_invite(invite.id)
+    assert accepted is not None and accepted.status == invites.ACCEPTED
+    invite_mock.assert_awaited_once_with(_ROOM, "bob")
+    assert manager.pending_invites(_ROOM) == []  # no longer open
+
+
+@pytest.mark.asyncio
+async def test_absent_invite_decline_does_not_join():
+    manager, _managed = _manager_with_channel(members=set())
+    invite_mock = AsyncMock(return_value=True)
+    manager.invite = invite_mock  # type: ignore[method-assign]
+
+    result = await manager.publish_human(_ROOM, sender="julia", text="@carol ?")
+    assert result is not None
+    invite = result.invites[0]
+
+    declined = manager.decline_invite(invite.id)
+    assert declined is not None and declined.status == invites.DECLINED
+    invite_mock.assert_not_awaited()
+    assert manager.pending_invites(_ROOM) == []
+
+
+# ── mid-episode: invite queued until the episode closes ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mid_episode_invite_is_queued_then_flushed_on_close():
+    manager, _managed = _manager_with_channel(members={"agent-a"})
+    invite_mock = AsyncMock(return_value=True)
+    manager.invite = invite_mock  # type: ignore[method-assign]
+    manager.open_episode(_ROOM, "urn:ioc:mycelium:episode:step6-room:e1")
+
+    result = await manager.publish_human(_ROOM, sender="julia", text="@dave join us")
+    assert result is not None
+    invite = result.invites[0]
+
+    accepted = await manager.accept_invite(invite.id)
+    assert accepted is not None and accepted.status == invites.QUEUED
+    invite_mock.assert_not_awaited()  # deferred, not applied mid-episode
+
+    # Closing the episode drains the queue → the deferred invite is applied.
+    await manager.close_episode(_ROOM)
+    invite_mock.assert_awaited_once_with(_ROOM, "dave")
+    assert manager.pending_invites(_ROOM) == []
+
+
+# ── in-room mention already present: no invite raised ─────────────────────────
+
+
+def test_request_invite_returns_none_for_present_member():
+    manager, _managed = _manager_with_channel(members={"agent-x"})
+    assert manager.request_invite(_ROOM, "agent-x", requested_by="julia") is None
+    assert manager.request_invite(_ROOM, room_channels.BACKEND_AGENT, requested_by="julia") is None

--- a/mycelium-cli/tests/test_human_mention_wakes_connector.py
+++ b/mycelium-cli/tests/test_human_mention_wakes_connector.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Human ``@``-mention wakes the connector — live-node integration slice (Step 6 DoD).
+
+Step 5 proved an agent's connector wakes on an inbound L9 ``exchange`` addressed to
+it. Step 6 puts the human in the room: the backend, as the human's spoken-for proxy,
+publishes the human's message onto the channel with the mentioned agent as an L9
+recipient. This slice proves that a message authored by a *human* handle (not another
+agent's connector) wakes the connector and its reply lands back in the room.
+
+Needs a running ``slim`` node (guarded, like ``test_connector_wake_over_slim.py``):
+point at one with ``MYCELIUM_SLIM_ENDPOINT`` (default ``http://127.0.0.1:46357``);
+run via ``mycelium hub host`` or the docker recipe in ``START_HERE_STEP_5.md``. The
+consent (not-in-room invite) half of Step 6 is backend-side and unit-covered in
+``fastapi-backend/tests/test_mentions_and_invites.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urlparse
+
+import pytest
+
+pytest.importorskip("slim_bindings")
+
+from mycelium.config import MyceliumConfig, ServerConfig
+from mycelium.daemon import connector
+from mycelium.daemon.config import DaemonConfig
+from mycelium.daemon.state import DaemonState
+from mycelium.integrations._spawn_common import SpawnResult
+from mycelium.protocol import AgentManifest
+from mycelium.slim import l9
+from mycelium.slim.client import SlimClient, close_connection
+from mycelium.slim.naming import DEFAULT_NODE_ENDPOINT, SlimIdentity, to_channel_name, to_slim_name
+
+_ENDPOINT = os.getenv("MYCELIUM_SLIM_ENDPOINT", DEFAULT_NODE_ENDPOINT)
+_WORKSPACE = "mycelium"
+_ROOM = "human-mention-room"
+_HANDLE = "agent-a"
+_HUMAN = "julia"
+_WOKE_ID = "human-woke-1"
+
+
+def _node_reachable(endpoint: str, *, timeout: float = 1.0) -> bool:
+    parsed = urlparse(endpoint)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 46357
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _node_reachable(_ENDPOINT),
+    reason=f"no reachable SLIM node at {_ENDPOINT} (set MYCELIUM_SLIM_ENDPOINT or run `mycelium hub host`)",
+)
+
+
+@pytest.mark.asyncio
+async def test_human_mention_wakes_connector_over_slim(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Mock the cold spawn — no real `claude` binary in CI.
+    spawn = AsyncMock(
+        return_value=SpawnResult(
+            ok=True, final_message="on it", transcript="", cost_usd=0.0, duration_s=0.0
+        )
+    )
+    integration = MagicMock(lifecycle="cold_spawn", spawn=spawn)
+    monkeypatch.setattr(connector, "get_integration", lambda _adapter: integration)
+    monkeypatch.setattr(connector, "_fetch_agent_context", AsyncMock(return_value=(None, "")))
+    monkeypatch.setattr(connector, "_post_log", AsyncMock(return_value=None))
+    monkeypatch.setattr(connector, "load_notes", lambda _room, _handle: "")
+    monkeypatch.setattr(
+        connector,
+        "load_manifest",
+        lambda _room, _handle: AgentManifest(
+            handle=_HANDLE, adapter="claude_code", cwd="/tmp/x", description="participant"
+        ),
+    )
+
+    moderator = await SlimClient(SlimIdentity(_WORKSPACE, _ROOM, "backend")).connect(_ENDPOINT)
+    member = await SlimClient(SlimIdentity(_WORKSPACE, _ROOM, _HANDLE)).connect(_ENDPOINT)
+
+    session = await moderator.create_group(to_channel_name(_WORKSPACE, _ROOM))
+
+    async def member_side() -> None:
+        joined = await member.listen_for_session()
+
+        async def publish(content: dict) -> None:
+            await SlimClient.publish(joined, l9.serialize(content))
+
+        message = await SlimClient.receive_message(joined, timeout_s=15.0)
+        content = l9.parse(message.payload)
+        assert content is not None
+        await connector.handle_inbound(
+            config=MyceliumConfig(server=ServerConfig(api_url="http://localhost:8000")),
+            daemon_cfg=DaemonConfig(),
+            state=DaemonState(),
+            room=_ROOM,
+            handle=_HANDLE,
+            content=content,
+            publish=publish,
+        )
+
+    member_task = asyncio.create_task(member_side())
+    received: list[dict[str, Any]] = []
+    try:
+        await moderator.invite(session, to_slim_name(_WORKSPACE, _ROOM, _HANDLE))
+        # The backend publishes the HUMAN's message onto the channel (spoken-for
+        # proxy): sender is a human handle, the mentioned agent is an L9 recipient.
+        inbound = l9.build_reply_content(
+            sender=_HUMAN,
+            recipients=[_HANDLE],
+            episode="urn:ioc:mycelium:episode:human-mention-room:live",
+            parents=[],
+            topic="urn:concept:mycelium:human-mention-room",
+            text=f"@{_HANDLE} can you take this?",
+            message_id=_WOKE_ID,
+            payload_type="message",
+        )
+        await SlimClient.publish(session, l9.serialize(inbound))
+
+        while not received:
+            msg = await SlimClient.receive_message(session, timeout_s=15.0)
+            parsed = l9.parse(msg.payload)
+            if parsed is not None and l9.sender_of(parsed) == _HANDLE:
+                received.append(parsed)
+    finally:
+        member_task.cancel()
+        try:
+            await member_task
+        except asyncio.CancelledError:
+            pass
+        await moderator.close()
+        await member.close()
+        await close_connection(_ENDPOINT)
+
+    spawn.assert_awaited_once()
+    reply = received[0]
+    assert l9.kind_of(reply) == "exchange"
+    assert l9.sender_of(reply) == _HANDLE
+    # Reply is parented on the human's message and addressed back to the human.
+    assert reply["l9"]["header"]["message"]["parents"] == [_WOKE_ID]
+    assert l9.recipients_of(reply) == [_HUMAN]
+    assert l9.human_text_of(reply) == "on it"

--- a/mycelium-frontend/src/components/consent-dialog.tsx
+++ b/mycelium-frontend/src/components/consent-dialog.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { PendingInvite } from "@/lib/api";
+
+interface Props {
+  invite: PendingInvite | null;
+  onAccept: (invite: PendingInvite) => void;
+  onDecline: (invite: PendingInvite) => void;
+}
+
+/**
+ * Consent-to-be-woken prompt (Step 6, the hero-demo differentiator). When a
+ * human `@`-mentions an agent that isn't in the room yet, the backend raises a
+ * pending invite and pushes a `consent_request` event; this surfaces it as an
+ * accept/decline call. It should feel like accepting a phone call — nothing
+ * joins until Accept, and dismissing the prompt declines.
+ */
+export function ConsentDialog({ invite, onAccept, onDecline }: Props) {
+  return (
+    <Dialog
+      open={invite !== null}
+      onOpenChange={(next) => {
+        if (!next && invite) onDecline(invite);
+      }}
+    >
+      {invite && (
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Incoming agent request</DialogTitle>
+            <DialogDescription>
+              <span className="font-medium text-foreground">@{invite.requested_by}</span> wants to
+              bring <span className="font-medium text-foreground">@{invite.agent}</span> into this
+              room.
+              {invite.trigger_text ? (
+                <span className="mt-2 block italic">“{invite.trigger_text}”</span>
+              ) : null}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onDecline(invite)}>
+              Decline
+            </Button>
+            <Button onClick={() => onAccept(invite)}>Accept</Button>
+          </DialogFooter>
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+}

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -5,9 +5,18 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { getSSEUrl, fetchMessages, fetchRoomAgents, logFetchError } from "@/lib/api";
+import {
+  getSSEUrl,
+  fetchMessages,
+  fetchRoomAgents,
+  fetchPendingInvites,
+  respondToInvite,
+  logFetchError,
+  type PendingInvite,
+} from "@/lib/api";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomPlanHeader } from "@/components/room-plan-header";
+import { ConsentDialog } from "@/components/consent-dialog";
 
 interface Event {
   id: string;
@@ -184,6 +193,7 @@ export function EventStream({ roomName, onMemoryChanged, planRefreshTrigger = 0 
   const [connected, setConnected] = useState(false);
   const [view, setView] = useState<View>("channel");
   const [agentHandles, setAgentHandles] = useState<Set<string>>(new Set());
+  const [invites, setInvites] = useState<PendingInvite[]>([]);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Know which senders are registered agents so their replies can be badged.
@@ -212,6 +222,19 @@ export function EventStream({ roomName, onMemoryChanged, planRefreshTrigger = 0 
     }).catch(logFetchError("fetchMessages"));
   }, [roomName]);
 
+  // Load any consent prompts already open (an @-invite raised before this
+  // client connected). Live ones arrive over SSE below.
+  useEffect(() => {
+    fetchPendingInvites(roomName)
+      .then((open) => setInvites(open.filter((i) => i.status === "pending")))
+      .catch(logFetchError("fetchPendingInvites"));
+  }, [roomName]);
+
+  const respond = (invite: PendingInvite, decision: "accept" | "decline") => {
+    setInvites((prev) => prev.filter((i) => i.id !== invite.id));
+    respondToInvite(roomName, invite.id, decision).catch(logFetchError("respondToInvite"));
+  };
+
   // SSE connection
   useEffect(() => {
     const url = getSSEUrl(roomName);
@@ -224,6 +247,16 @@ export function EventStream({ roomName, onMemoryChanged, planRefreshTrigger = 0 
       es.onmessage = (e) => {
         try {
           const msg = JSON.parse(e.data);
+          // Consent prompts drive the accept/decline dialog, not the feed.
+          if (msg.message_type === "consent_request") {
+            try {
+              const invite = JSON.parse(msg.content as string) as PendingInvite;
+              setInvites((prev) =>
+                prev.some((i) => i.id === invite.id) ? prev : [...prev, invite],
+              );
+            } catch {}
+            return;
+          }
           const event = parseEvent(msg);
           setEvents(prev => [...prev, event]);
           if (event.type === "memory_changed") onMemoryChanged?.();
@@ -262,6 +295,11 @@ export function EventStream({ roomName, onMemoryChanged, planRefreshTrigger = 0 
 
   return (
     <div className="flex flex-col h-full">
+      <ConsentDialog
+        invite={invites[0] ?? null}
+        onAccept={(invite) => respond(invite, "accept")}
+        onDecline={(invite) => respond(invite, "decline")}
+      />
       <div className="flex items-stretch border-b border-border shrink-0 h-[44px] bg-paper">
         <div className="flex items-center gap-2 px-4">
           <span

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -194,6 +194,42 @@ export async function sendRoomMessage(
   return res.json();
 }
 
+/**
+ * A consent-gated invite (Step 6). Raised when a human `@`-mentions an agent
+ * that is not yet on the room's channel: the backend surfaces an accept/decline
+ * prompt ("someone's agent wants to reach yours") instead of joining directly.
+ */
+export interface PendingInvite {
+  id: string;
+  room: string;
+  agent: string;
+  requested_by: string;
+  trigger_text: string;
+  status: string;
+  created_at: string;
+}
+
+/** Open (pending or queued) consent requests for a room. */
+export async function fetchPendingInvites(roomName: string): Promise<PendingInvite[]> {
+  const res = await fetch(`/api/rooms/${roomName}/invites`, { cache: "no-store" });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return (data.invites || []) as PendingInvite[];
+}
+
+/** Accept or decline a consent prompt. Only `accept` invites (or queues) the agent. */
+export async function respondToInvite(
+  roomName: string,
+  inviteId: string,
+  decision: "accept" | "decline",
+): Promise<PendingInvite | null> {
+  const res = await fetch(`/api/rooms/${roomName}/invites/${inviteId}/${decision}`, {
+    method: "POST",
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
 export interface AgentSummary {
   handle: string;
   description: string;


### PR DESCRIPTION
Implements **Part V · Step 6** of the SLIM-native rebuild (bible §12/§13). Picks up from Step 5 (agent on the fabric) and puts the **human in the room**.

## What changed

**Publish the human onto the channel.** A human POST to a real room with a live channel now goes through `RoomChannelManager.publish_human()`: it builds an L9 `exchange` (sender = the human, `sender_role="human"`), `@`-parses the text into L9 **recipients**, broadcasts on `L9SlimChannel.send`, and ingests it **once** via the persister. No human connector — the backend is the human's spoken-for proxy.

**`@`-parse in one place.** `persister.parse_mentions(text)` is the single regex-backed parser (`word@host` is not a mention); `find_summons` reuses it. `RoomPersister` gains idempotent `_ingest` + `ingest_local`, so a SLIM loopback of the moderator's own broadcast can't double-feed the UI bus (the CLAUDE.md "publish once" trap).

**In-room mention = wake, no connector change.** `should_wake` already fires on L9 recipients, so publishing a human `exchange` with the agent in recipients wakes it through Step 5's bridge.

**`@`-invite (not-in-room) = consent.** New `app/services/invites.py` (`PendingInviteRegistry`, states `pending → queued → accepted/declined`). `RoomChannelManager` drives it: `request_invite` raises an accept/decline prompt (and a `consent_request` bus event) instead of joining; `accept_invite` invites on accept — or **queues** mid-episode (L9 stable-membership rule); `decline_invite` drops it; `close_episode`/`flush_queued_invites` drains the queue when an episode closes. Routes: `GET/accept/decline` under `rooms/{room}/invites` (`app/routes/invites.py`).

**Consent surface.** `mycelium-frontend/src/components/consent-dialog.tsx` wired into `event-stream.tsx` off the `consent_request` SSE event — "someone's agent wants to reach yours — accept?". Nothing joins until Accept; dismissing declines.

## DoD

- ✅ Human `@`-mentions an in-room Claude Code agent → it wakes and answers (live-node slice).
- ✅ `@`-invite of a not-present agent → consent prompt; only joins on accept; decline does not join; mid-episode invite is queued.

## Tests

- **Backend units** `tests/test_mentions_and_invites.py` — `@`-parse → recipients (email-safe); present = wake vs absent = consent; accept joins / decline doesn't; mid-episode queued then flushed on close.
- **In-room-mention-wakes** is already covered by the Step 5 connector units (`should_wake` on a human-sender exchange) — no connector change needed.
- **Guarded live-node slice** `mycelium-cli/tests/test_human_mention_wakes_connector.py` — backend publishes a human `exchange`; the connector wakes and its reply lands back parented + addressed to the human.

## Verification (all green)

- Backend: ruff / format / ty clean; `235 passed, 5 skipped`.
- CLI: ruff / format / ty clean; `368 passed, 2 skipped`.
- Frontend: `tsc --noEmit` clean.
- **Live `slim:1.4.0` node:** both new + all prior integration slices pass (backend roundtrip/abort/durable-inbox + both connector wake slices).

> Note: running the *whole* CLI suite with `MYCELIUM_SLIM_ENDPOINT` exported trips a **pre-existing** `test_slim_config` test that isn't env-isolated (passes in the normal gate); the guarded connector slices were run by file, as in Step 5. Flagged in the Step 7 handoff.

## Handoff

Adds `docs/START_HERE_STEP_7.md` — cognition engine base layer (observer + driver), the natural next step now that a `commit:converged` verdict has a channel to land on.

## Deferrals (per the step doc)

Cognition engines (wiring `on_summon`) = **Step 7**; plan-compile (`on_converged`) + memory sync = **Step 8**; cross-machine = **Step 9**; SSE/`stream.py` + legacy daemon `dispatch.py` retire in **Step 10**.