### PR TITLE
Debt D2: extract shared SLIM+L9 package (+ golden drift test)

### DIFF
--- a/docs/slim-native-rebuild-bible.md
+++ b/docs/slim-native-rebuild-bible.md
@@ -525,6 +525,32 @@ but only in the guarded suite. Fix: (A) a fast-gate golden test both packages as
 then (B) extract a shared `mycelium-slim-l9` package **before Steps 7–8** grow the shared
 surface.
 
+**Status (A delivered; B deferred).** The fast-gate golden test is **shipped**:
+`slim-l9-golden.json` at the repo root freezes the shared wire constants (the
+`mint_shared_secret` digest for a known `workspace/room`, the master-secret /
+workspace / channel-topic / node literals, the `episode`/`topic` URN forms, and a
+golden serialized `exchange` envelope dict). Both suites read that **one** file and
+assert their own copy against it — `fastapi-backend/tests/test_slim_l9_golden.py`
+and `mycelium-cli/tests/test_slim_l9_golden.py`. One frozen source, two asserters:
+neither copy can drift without turning a **unit** gate red (previously drift was
+caught only by the guarded live-node slice). This closes the "merges green" gap.
+
+**Why B (the shared installable package) was deferred:** both delivery paths make a
+new shared *distribution* a cross-cutting release/packaging change, not a local
+refactor. The backend `Dockerfile` installs deps by parsing `pyproject.toml`'s
+`project.dependencies` and `pip install`-ing them from **PyPI**, then `COPY . .`
+with a build context scoped to `fastapi-backend/` only — a sibling path/workspace
+dependency is unreachable there. The end-user CLI install (`install.sh`) is a
+**single self-contained wheel** from GitHub releases (or `mycelium-cli` on PyPI);
+a path dep on a sibling package would neither be bundled into that wheel nor exist
+on PyPI, so the installed CLI would fail to import. Making B green end-to-end
+therefore means publishing/bundling a new package into the release-wheel + Docker
++ `install.sh` flows — numbered-step infra explicitly out of scope for this debt
+paydown, and a live risk to green installs. The genuinely-shared code is already
+stdlib-only and byte-for-byte identical on both sides, so (A) removes the
+*correctness* risk now; (B) remains the ideal and should land alongside the
+Step 7–8 packaging pass that revisits the release/Docker flows anyway.
+
 **D11 — the other harnesses will be stale.** The MVP migrates **claude_code** only.
 - **cursor** (cold_spawn) shares the daemon's SLIM connector path (`connector_targets`
   includes it) and the family-agnostic spawn, so it *probably works over SLIM already* — but

--- a/fastapi-backend/tests/test_slim_l9_golden.py
+++ b/fastapi-backend/tests/test_slim_l9_golden.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Golden drift guard for the shared SLIM+L9 wire primitives (backend side).
+
+D2 (bible Part IV, Known debt register): the CLI daemon
+(``mycelium-cli/src/mycelium/slim/*``) carries a copy of these primitives so the
+thin ``uv tool`` CLI need not import the FastAPI/ML backend. A copy drifts
+silently — a diverging ``mint_shared_secret`` / master secret / ``workspace/room``
+scope / envelope shape / URN form means MLS group keys mismatch and connectors
+**silently can't join**, or messages get dropped/misrouted (no app-level error).
+
+This test freezes the shared wire constants in ``slim-l9-golden.json`` at the
+repo root and asserts the **backend** primitives reproduce them exactly. The CLI
+suite asserts its own copy against the *same* file
+(``mycelium-cli/tests/test_slim_l9_golden.py``). One frozen source, two
+asserters — so neither copy can move without turning this fast unit gate red
+(no live SLIM node required).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services import l9
+from app.services.l9_models import Kind
+from app.services.slim_client import (
+    _DEV_MASTER_SECRET,
+    DEFAULT_CHANNEL_TOPIC,
+    DEFAULT_NODE_ENDPOINT,
+    DEFAULT_NODE_PORT,
+    MIN_SECRET_LEN,
+    SlimIdentity,
+    mint_shared_secret,
+)
+
+_GOLDEN_PATH = Path(__file__).resolve().parent.parent.parent / "slim-l9-golden.json"
+
+
+def _golden() -> dict:
+    return json.loads(_GOLDEN_PATH.read_text(encoding="utf-8"))
+
+
+def test_golden_file_present():
+    assert _GOLDEN_PATH.is_file(), f"missing shared golden file at {_GOLDEN_PATH}"
+
+
+def test_shared_constants_match_golden():
+    """The literals the shared secret + naming derive from are frozen."""
+    g = _golden()
+    assert g["master_secret"] == _DEV_MASTER_SECRET
+    assert g["channel_topic"] == DEFAULT_CHANNEL_TOPIC
+    assert g["min_secret_len"] == MIN_SECRET_LEN
+    assert g["node_endpoint"] == DEFAULT_NODE_ENDPOINT
+    assert g["node_port"] == DEFAULT_NODE_PORT
+
+
+def test_mint_shared_secret_matches_golden_digest():
+    """The exact HMAC digest a member/moderator derive for a known room."""
+    g = _golden()["shared_secret"]
+    identity = SlimIdentity(g["workspace"], g["room"], g["agent"])
+    assert mint_shared_secret(identity) == g["expected_digest"]
+
+
+def test_episode_and_topic_urns_match_golden():
+    """The episode/topic URN forms the connector must mirror."""
+    g = _golden()["urn"]
+    assert l9.episode_urn(g["room"], g["session"]) == g["expected_episode"]
+    assert l9.topic_urn(g["room"]) == g["expected_topic"]
+
+
+def test_exchange_envelope_serializes_to_golden():
+    """The backend's serialized exchange envelope is byte-for-byte the golden."""
+    g = _golden()["envelope"]
+    i = g["inputs"]
+    envelope = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=i["episode"],
+        parents=i["parents"],
+        sender=i["sender"],
+        sender_role="agent",
+        recipients=i["recipients"],
+        recipient_role="agent",
+        topic=i["topic"],
+        payload_type=i["payload_type"],
+        payload_data={},
+        message_id=i["message_id"],
+    )
+    content = {"content": i["text"], "l9": l9.envelope_to_dict(envelope)}
+    assert content == g["expected_content"]
+
+
+def test_channel_name_topic_matches_golden():
+    """A room channel's app segment is the frozen default topic."""
+    pytest.importorskip("slim_bindings")
+    from app.services.slim_client import to_channel_name
+
+    g = _golden()
+    name = to_channel_name("acme", "planning")
+    assert name.components() == ["acme", "planning", g["channel_topic"]]

--- a/mycelium-cli/tests/test_slim_l9_golden.py
+++ b/mycelium-cli/tests/test_slim_l9_golden.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Golden drift guard for the shared SLIM+L9 wire primitives (CLI side).
+
+D2 (bible Part IV, Known debt register): this CLI daemon carries a copy of the
+backend's SLIM+L9 primitives (``mycelium.slim.{naming,client,l9}`` +
+``daemon.connector`` URN helpers) so the thin ``uv tool`` CLI need not import the
+FastAPI/ML backend. A copy drifts silently — a diverging ``mint_shared_secret`` /
+master secret / ``workspace/room`` scope / envelope shape / URN form means MLS
+group keys mismatch and this connector **silently can't join** the backend
+moderator's group, or its replies get dropped/misrouted (no app-level error).
+
+This test freezes the shared wire constants in ``slim-l9-golden.json`` at the
+repo root and asserts the **CLI** primitives reproduce them exactly. The backend
+suite asserts its own copy against the *same* file
+(``fastapi-backend/tests/test_slim_l9_golden.py``). One frozen source, two
+asserters — so neither copy can move without turning this fast unit gate red
+(no live SLIM node required).
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mycelium.daemon.connector import _room_episode, _room_topic
+from mycelium.slim import l9
+from mycelium.slim.naming import (
+    _DEV_MASTER_SECRET,
+    DEFAULT_CHANNEL_TOPIC,
+    DEFAULT_NODE_ENDPOINT,
+    DEFAULT_NODE_PORT,
+    DEFAULT_WORKSPACE,
+    MIN_SECRET_LEN,
+    SlimIdentity,
+    mint_shared_secret,
+)
+
+_GOLDEN_PATH = Path(__file__).resolve().parent.parent.parent / "slim-l9-golden.json"
+
+
+def _golden() -> dict:
+    return json.loads(_GOLDEN_PATH.read_text(encoding="utf-8"))
+
+
+def test_golden_file_present():
+    assert _GOLDEN_PATH.is_file(), f"missing shared golden file at {_GOLDEN_PATH}"
+
+
+def test_shared_constants_match_golden():
+    """The literals the shared secret + naming derive from are frozen."""
+    g = _golden()
+    assert g["master_secret"] == _DEV_MASTER_SECRET
+    assert g["workspace"] == DEFAULT_WORKSPACE
+    assert g["channel_topic"] == DEFAULT_CHANNEL_TOPIC
+    assert g["min_secret_len"] == MIN_SECRET_LEN
+    assert g["node_endpoint"] == DEFAULT_NODE_ENDPOINT
+    assert g["node_port"] == DEFAULT_NODE_PORT
+
+
+def test_mint_shared_secret_matches_golden_digest():
+    """The exact HMAC digest a connector derives for a known room."""
+    g = _golden()["shared_secret"]
+    identity = SlimIdentity(g["workspace"], g["room"], g["agent"])
+    assert mint_shared_secret(identity) == g["expected_digest"]
+
+
+def test_episode_and_topic_urns_match_golden():
+    """The connector's episode/topic URN forms match the backend's."""
+    g = _golden()["urn"]
+    assert _room_episode(g["room"]) == g["expected_episode"]
+    assert _room_topic(g["room"]) == g["expected_topic"]
+
+
+def test_exchange_reply_serializes_to_golden():
+    """The connector's serialized exchange reply is byte-for-byte the golden."""
+    g = _golden()["envelope"]
+    i = g["inputs"]
+    content = l9.build_reply_content(
+        sender=i["sender"],
+        recipients=i["recipients"],
+        episode=i["episode"],
+        parents=i["parents"],
+        topic=i["topic"],
+        text=i["text"],
+        message_id=i["message_id"],
+        payload_type=i["payload_type"],
+    )
+    assert content == g["expected_content"]
+
+
+def test_channel_name_topic_matches_golden():
+    """A room channel's app segment is the frozen default topic."""
+    pytest.importorskip("slim_bindings")
+    from mycelium.slim.naming import to_channel_name
+
+    g = _golden()
+    name = to_channel_name("acme", "planning")
+    assert name.components() == ["acme", "planning", g["channel_topic"]]

--- a/slim-l9-golden.json
+++ b/slim-l9-golden.json
@@ -1,0 +1,83 @@
+{
+  "_comment": [
+    "Frozen SLIM+L9 wire-compat golden constants — the single source of truth both",
+    "the FastAPI backend (fastapi-backend/app/services/{slim_client,l9,l9_slim}.py)",
+    "and the CLI daemon (mycelium-cli/src/mycelium/slim/{naming,client,l9}.py +",
+    "daemon/connector.py) MUST reproduce byte-for-byte. See D2 in",
+    "docs/slim-native-rebuild-bible.md (Part IV, Known debt register).",
+    "",
+    "Both test suites read THIS file and assert their own primitives against it, so",
+    "the two copies cannot silently drift apart (a drift -> MLS group-key mismatch ->",
+    "connectors silently can't join, or messages get dropped/misrouted). If a change",
+    "to the shared wire shape is genuinely intended, update this file deliberately in",
+    "the same PR and both suites will re-lock to the new value.",
+    "",
+    "Tests: fastapi-backend/tests/test_slim_l9_golden.py,",
+    "mycelium-cli/tests/test_slim_l9_golden.py"
+  ],
+
+  "master_secret": "mycelium-dev-shared-secret-v1-do-not-use-in-prod",
+  "workspace": "mycelium",
+  "channel_topic": "room",
+  "min_secret_len": 32,
+  "node_endpoint": "http://127.0.0.1:46357",
+  "node_port": 46357,
+
+  "shared_secret": {
+    "_comment": "mint_shared_secret is keyed on workspace/room only (agent ignored). HMAC-SHA256(master_secret, 'workspace/room').hexdigest().",
+    "workspace": "acme",
+    "room": "planning",
+    "agent": "agent-7",
+    "expected_digest": "cd344d4fddb429d04ec0a8ec0934e077d0bd23e72ea9ecf482528953b5a11a6c"
+  },
+
+  "urn": {
+    "_comment": "Room-scoped episode/topic URN forms. Backend: l9.episode_urn(room, session) / l9.topic_urn(room). CLI connector: _room_episode(room) / _room_topic(room) with the 'live' session literal.",
+    "room": "acme",
+    "session": "live",
+    "expected_episode": "urn:ioc:mycelium:episode:acme:live",
+    "expected_topic": "urn:concept:mycelium:acme"
+  },
+
+  "envelope": {
+    "_comment": "A golden serialized L9 'exchange' reply content dict. The backend produces this via l9.envelope_to_dict(l9.build_envelope(kind=exchange, ...)); the CLI produces the same dict via l9.build_reply_content(...). The two serializers must agree byte-for-byte or a connector's reply fails the backend persister's parse_envelope.",
+    "inputs": {
+      "sender": "alice",
+      "recipients": ["bob"],
+      "episode": "ep1",
+      "parents": ["p1"],
+      "topic": "t1",
+      "message_id": "m1",
+      "payload_type": "reply",
+      "text": "hi"
+    },
+    "expected_content": {
+      "content": "hi",
+      "l9": {
+        "header": {
+          "protocol": "SSTP",
+          "subprotocol": "mycelium",
+          "version": "0.0.6",
+          "kind": "exchange",
+          "participants": {
+            "actors": [
+              { "id": "alice", "role": "agent" },
+              { "id": "bob", "role": "agent" }
+            ],
+            "groups": null
+          },
+          "message": {
+            "id": "m1",
+            "parents": ["p1"],
+            "episode": "ep1"
+          },
+          "context": { "topic": "t1" }
+        },
+        "payload": {
+          "type": "reply",
+          "data": {}
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Pays down **D2** (bible Part IV, Known debt register): the CLI daemon carries a copy of the backend's SLIM+L9 primitives so the thin `uv tool` CLI need not import the FastAPI/ML backend. Drift between the copies is silent and vicious — a diverging `mint_shared_secret` / master-secret literal / `workspace/room` HMAC scope / L9 envelope shape / URN form means MLS group keys mismatch and connectors **silently can't join** (no app-level error), or messages get dropped/misrouted. Until now, only the guarded live-node slice caught this.

## Outcome: the (A) golden-test safety net (full extraction (B) deferred)

Per the register's fallback, this delivers **(A)** — the fast-gate golden drift test — and defers **(B)**, the shared installable package, with a documented rationale. **(A) is the register's minimum acceptable outcome** ("closing the merges-green gap"); it fully removes the *correctness* risk now.

### What shipped

- **`slim-l9-golden.json`** (repo root) — the single frozen source of truth for the shared wire constants: the `mint_shared_secret` HMAC digest for a known `workspace/room`, the master-secret / workspace / channel-topic / node literals, the `episode`/`topic` URN forms, and a **golden serialized `exchange` envelope dict**.
- **`fastapi-backend/tests/test_slim_l9_golden.py`** — the backend primitives (`app.services.slim_client` + `app.services.l9`) assert against the golden file.
- **`mycelium-cli/tests/test_slim_l9_golden.py`** — the CLI copy (`mycelium.slim.{naming,client,l9}` + `daemon.connector` URN helpers) asserts against the **same** file.

One frozen source, **two asserters**: neither copy can move without turning a **unit** gate red (previously drift was caught only by the guarded live-node slice). I verified up front that the two serializers already produce **byte-for-byte identical** output — the backend's `l9.envelope_to_dict(l9.build_envelope(kind=exchange, ...))` and the CLI's `l9.build_reply_content(...)` — and the golden freezes that exact dict.

- **`docs/slim-native-rebuild-bible.md`** — the D2 note now records **(A) delivered / (B) deferred** and why.

### What moved vs. stayed

Nothing *moved* — no code was relocated (that's (B)). The genuinely-shared code is already stdlib-only and byte-for-byte identical on both sides; the backend's richer `l9.py` (pydantic `L9` models, `VALID_SUBKINDS`, validation) stays backend-side by design. (A) locks the shared *values/shape* without touching either implementation.

### Byte-for-byte compat

Preserved and now **enforced at the unit gate**: the golden dict is the exact serialized `exchange` content both sides emit, and the digest/URN/constant assertions pin `mint_shared_secret`, the Name-mapping literals, and the URN forms.

### Why B (shared installable package) was deferred

Both delivery paths make a new shared *distribution* a cross-cutting release/packaging change, not a local refactor:
- The **backend `Dockerfile`** installs deps by parsing `pyproject.toml`'s `project.dependencies` and `pip install`-ing them **from PyPI**, then `COPY . .` with a build context scoped to `fastapi-backend/` only — a sibling path/workspace dependency is unreachable there.
- The **end-user CLI install** (`install.sh`) is a **single self-contained wheel** from GitHub releases (or `mycelium-cli` on PyPI); a path dep on a sibling package would neither be bundled into that wheel nor exist on PyPI, so the installed CLI would fail to import.

Making B green end-to-end therefore means publishing/bundling a new package into the release-wheel + Docker + `install.sh` flows — numbered-step infra explicitly out of scope for this debt paydown, and a live risk to green installs. B remains the ideal and should land alongside the Step 7–8 packaging pass that revisits those flows anyway.

## Gate results (fast unit tier — all green)

| | ruff check | ruff format --check | ty check | pytest |
|---|---|---|---|---|
| **fastapi-backend** | ✅ | ✅ | ✅ | ✅ 241 passed, 5 skipped |
| **mycelium-cli** | ✅ | ✅ | ✅ | ✅ 374 passed, 2 skipped |

The guarded **live-node integration slices** were not run here (they need a running `slim:1.4.0` node); as with prior steps they should be run separately. This PR's value is precisely that it moves drift detection *below* that guarded suite into the fast unit gate.