### PR TITLE
Step 7: SIEP aligner cognition engine (observer + driver)

### DIFF
--- a/docs/START_HERE_STEP_8.md
+++ b/docs/START_HERE_STEP_8.md
@@ -1,0 +1,202 @@
+# START HERE — Step 8 (Plan + memory sync — the full loop, same-machine)
+
+Companion to [`START_HERE.md`](./START_HERE.md). Step 7 is **done** (this PR into
+`slim-native-rewrite`); you are picking up **Step 8**. Read `START_HERE.md`,
+[`START_HERE_STEP_1.md`](./START_HERE_STEP_1.md) → [`START_HERE_STEP_7.md`](./START_HERE_STEP_7.md)
+first if you haven't — the same rules apply. This file gives you (a) the exact state Step 7
+left behind, (b) your Step 8 marching orders, (c) the facts you must internalize, and (d) the
+traps specific to this step.
+
+**Step 7 lit up the first cognition engine.** A summoned **SIEP aligner** now reads a room's
+transcript, scores it with the protocol library's MPC/GAR/SCR, and **emits an L9
+`commit:converged` / `commit:rejected` onto the channel** — in both observer and driver modes,
+dormant until an `@`-summon of its reserved handle. **Step 8 closes the loop:** the backend
+sees that `commit:converged` and fires **`plan_compiler`** → `plan/tasks.md`, and the L9
+**`knowledge`** phase carries the converged content to every participant's local store
+(markdown + JSONL reindex) — so the whole `join → exchange → converge → plan → work` cycle
+works **on one machine**.
+
+## Ground rules (unchanged from START_HERE.md)
+
+1. **The bible is authoritative:** [`slim-native-rebuild-bible.md`](./slim-native-rebuild-bible.md).
+   Your work is **Part V · Step 8**, with **§11 (memory)** and **§13 (the full cycle)** as the
+   design reference.
+2. Leave the project **runnable and green** — backend + CLI quality gates pass at the end.
+3. Code/config blocks in the bible are **reference, not paste**.
+4. **Verify before you edit** — the paths below were accurate at the end of Step 7; confirm shape
+   before changing a file.
+5. Fixed decisions are not up for debate. The conflict policy is **decided** (§11):
+   last-write-wins, order by `version`/timestamp, **no merge handler** — a stale-base write
+   **fails with details** (current content + `updated_by` + `updated_at`) and moves on.
+
+## Where Step 7 left things (your starting state)
+
+Branch off `slim-native-rewrite` (Step 7 is merged). The verdict is now on the fabric; what's
+still missing is anything that **acts** on it. Concretely:
+
+- **The aligner engine exists and emits.** `app/services/aligner.py` is the SIEP engine
+  (`AlignerEngine`), dormant until `@`-summoned. It runs **in-process in the backend**, reuses
+  `l9_episode` for the metrics (never re-derives them), and emits a well-formed
+  `commit:converged`/`commit:rejected` via the room channel + `persister.ingest_local` (recorded
+  once, deduped by message id — the "publish once" trap). It computes the verdict deterministically
+  (threshold over MPC); **no LLM of its own** at base level. Observer + driver modes both work; a
+  live-node observe slice passes.
+- **The summon seam is wired.** `RoomChannelManager.on_summon` is now a **room-aware** hook
+  (`RoomSummonHook = (room, handle, envelope)`), wired at startup in `app/main.py` to
+  `AlignerEngine.handle_summon`. `_start_persister` adapts it down to the persister's
+  `(handle, envelope)` signature by binding the room. The engine gates on a **reserved handle**
+  (`settings.ALIGNER_HANDLE`, default `"aligner"`) so an `@`-mention of a normal teammate never
+  spawns an engine. **Nothing sets `on_converged` yet** — that's you.
+- **The `on_converged` seam still fires into a skeleton.** `persister._ingest` calls
+  `on_converged(envelope)` for every `commit:converged` (deduped) — and `manager.on_converged`
+  is still `None`, so the persister uses `_default_converged_hook` (**log only**:
+  "plan_compiler wiring is Step 8"). That seam is your Step 8 job. When the aligner emits a
+  converged verdict in a room, this hook is *already firing* — you just have to make it compile.
+- **The plan compiler is intact but un-retriggered.** `app/services/plan_compiler.py` still
+  exists (an LLM stage that turns an `assignments` dict into `plan/tasks.md`). It's currently
+  called from nowhere on the SLIM path. The converged envelope's `payload.data.assignments`
+  (built by the aligner via `l9_episode.build_consensus_envelope`) is the input it wants.
+- **`knowledge` is defined in the subkind table but has no write path.** `l9.py`'s
+  `VALID_SUBKINDS[Kind.knowledge]` = `{query, distillation, extraction, feedback}`. Nothing
+  emits or consumes a `knowledge` message yet. The memory write-path-over-SLIM (bible §11) is
+  entirely yours to build.
+- **Memory primitives are ready.** `indexer.py` / `reindex.py` (JSONL search index),
+  `filesystem.py` (`write_memory_file` / `read_memory_file`, which already carries an
+  incrementing `version` in frontmatter). Local memory CRUD is plain file/JSONL ops.
+
+## Your Step 8 scope (from the bible, Part V · Step 8)
+
+- **Wire `on_converged` → `plan_compiler`.** On a `commit:converged`, the backend fires
+  `plan_compiler.py` → writes `plan/tasks.md` into the room's markdown memory. Make `on_converged`
+  room-aware the same way Step 7 made `on_summon` room-aware (the persister hook is
+  `(envelope)` only — bind the room in `_start_persister`, mirror `_summon_adapter`).
+- **Implement the L9 `knowledge` write path.** Converged content becomes `knowledge` messages
+  that **carry the content** (push-with-content, replacing today's notify-then-pull). Each
+  connector, on a `knowledge` arrival, writes the markdown locally + reindexes the JSONL. This is
+  the seam `l9.py`/`l9_slim.py` (add the `knowledge` kind to the channel) + the connector
+  (`daemon/connector.py` — it already observes non-exchange system envelopes; teach it to *act*
+  on `knowledge`).
+- **Apply the conflict policy.** Last-write-wins by `version`/timestamp; a stale-base write
+  **fails with details** and moves on. **No merge handler** (§11, decided).
+- **Key files:** `services/plan_compiler.py` [keep, re-triggered]; the L9-over-SLIM binding
+  (`l9_slim.py`, `knowledge` kind); `indexer.py`/`reindex.py` (write + reindex on knowledge
+  arrival); `persister.py` (`on_converged` seam) + `room_channels.py`/`main.py` (wire it).
+
+## Facts you must internalize first
+
+- **The trigger already fires — you're wiring the consumer.** Step 7 deliberately stopped at
+  *emitting* the verdict and left `on_converged` a skeleton so the seam stays clean. Don't touch
+  the aligner's emit path; wire the hook the persister already calls.
+- **`assignments` is the compiler's input, and it's thin at base level.** The aligner builds
+  `assignments = {handle: offer-or-action}` in `aligner._fold`. If `plan_compiler` wants richer
+  structure, either enrich what the aligner puts in `assignments` (keep it a pure dict) or have
+  the compiler read the transcript too — but **don't** couple the compiler back into the engine;
+  it's a distinct consumer stage across an explicit seam (the CLAUDE.md plan-compiler decision).
+- **Plan-first ordering matters.** In the old CFN flow the plan was compiled *before* the
+  `coordination_consensus` message was posted so `session await` returned once the plan existed.
+  On the SLIM path the verdict is already on the wire when `on_converged` fires. Decide whether a
+  UI/consumer needs a "plan ready" signal after compile, and how it learns of it (a follow-up bus
+  event, or a `knowledge`/plan message). Note your choice; flag it.
+- **`knowledge` is push-with-content, not notify-then-pull.** The whole point (§11) is that the
+  message *carries* the markdown so a running agent's working set updates mid-task — the one
+  thing git can't do. Don't reintroduce a "notify, then the connector fetches over HTTP" step.
+- **The compiler already handles the Bedrock sync-path quirk.** `plan_compiler._acompletion_compat`
+  routes Bedrock models through threaded sync `completion` (litellm's `acompletion` doesn't work
+  for Bedrock). Reuse it; don't re-solve it.
+- **Fail-soft on the compiler.** A compiler outage must not sink the converged verdict — fall
+  back to writing the raw `assignments` as the plan (the old `_finish_cfn` fail-soft behavior),
+  and keep going.
+
+## Definition of Done
+
+A converged negotiation on **one machine** produces `plan/tasks.md` and propagates the converged
+memory to all participants' local stores: `@`-summon the aligner over a seeded (or driven)
+exchange → it emits `commit:converged` → the backend compiles `plan/tasks.md` → a `knowledge`
+message writes the markdown + updates the JSONL index on a second local store. **This is the
+same-machine mini-demo of the hero flow.**
+
+## Tests to write (end of step)
+
+Fast unit tests (the merge gate — no node):
+
+- **Converged → plan file** — a `commit:converged` fired through `on_converged` compiles
+  `plan/tasks.md` with the expected tasks (mock the LLM as the plan-compiler tests already do).
+- **`knowledge` writes markdown + reindexes** — a `knowledge` message applied to a second local
+  store writes the file and updates the JSONL index.
+- **Conflict rejects a stale write with details** — a write on a stale base fails and surfaces
+  current content + `updated_by` + `updated_at`; no merge is attempted.
+- **Fail-soft compile** — a compiler outage falls back to writing the raw `assignments` and does
+  not raise into the converged path.
+
+Live-node **integration slice** (guarded, adds to the cumulative suite — **all prior slices must
+still pass**, backend + CLI):
+
+- **Same-machine acceptance:** the full flow end-to-end on one machine — join → exchange →
+  summon/converge → plan compiles → memory syncs to a second local store. Model on
+  `tests/test_l9_over_slim_roundtrip.py::test_aligner_observes_and_emits_converged_over_slim`
+  (Step 7) and extend it: after the `commit:converged`, assert `plan/tasks.md` exists and the
+  `knowledge` write landed on the second store.
+
+## Verification gate (must pass before you call Step 8 done)
+
+```bash
+# Backend
+cd fastapi-backend
+uv run ruff check . && uv run ruff format --check . && uv run ty check .
+MYCELIUM_STUB_EMBEDDINGS=1 uv run pytest tests/ -x -q            # fast gate, no node
+
+# CLI (matches CI)
+cd ../mycelium-cli
+uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run pytest tests/ -x -q
+
+# Guarded integration slices — bring a node up first (recipe in START_HERE_STEP_5.md §Verification):
+MYCELIUM_STUB_EMBEDDINGS=1 MYCELIUM_SLIM_ENDPOINT=http://127.0.0.1:46357 \
+  uv run pytest tests/test_l9_over_slim_roundtrip.py -q   # backend; run the CLI connector slices by file too
+```
+
+Bring a standalone node up with the same docker recipe Steps 5–7 used (the
+`ghcr.io/agntcy/slim:1.4.0` one-liner in [`START_HERE_STEP_5.md`](./START_HERE_STEP_5.md)).
+
+> **Known pre-existing wrinkle (not yours to fix):** running the *whole* CLI suite with
+> `MYCELIUM_SLIM_ENDPOINT` exported trips `tests/test_slim_config.py::test_connect_persists_endpoint`.
+> Run the guarded slices **by file** rather than reading a whole-suite pass/fail with that env set.
+
+## Traps specific to Step 8
+
+- **Don't compile inside the engine.** The compiler is a *consumer* across the `on_converged`
+  seam, not a CE step. Wire it in `room_channels`/`main`, not in `aligner.py`.
+- **Don't rebuild notify-then-pull.** `knowledge` carries content. If the connector ends up
+  fetching over HTTP after a notify, you've regressed §11.
+- **Mirror the room-binding seam.** `on_converged` has the same room-context gap Step 7 solved
+  for `on_summon`: the persister hook is `(envelope)` only. Add an adapter in `_start_persister`
+  next to `_summon_adapter` rather than threading room through the persister.
+- **No merge handler.** The conflict policy is decided. A stale write **fails with details**; do
+  not build reconciliation.
+- **MLS on, version stays pinned.** `slim:1.4.0` / `slim-bindings` 1.4.x — matched pair; don't
+  touch it.
+
+## What Step 7 deferred to you (explicit)
+
+- **Plan-compile firing** (wiring `on_converged` → `plan_compiler`) — **this step**.
+- **`knowledge` memory sync** — **this step**.
+- The aligner runs **no LLM of its own** at base level (its verdict is the deterministic
+  threshold over MPC). An **LLM judgment/summary layer** for the engine (reading free-text
+  positions to *extract* confidence, summarizing the agreement) is **post-MVP** — the engine reads
+  epistemic fields (`confidence`, `action`, …) straight off each exchange's L9 payload today.
+- The aligner's **wire verdict carries empty `message.parents`** (a broadcast terminal statement
+  must be releasable by every member; the full causal chain stays in the `log/episodes/*` record).
+  If you later want the plan/knowledge messages to parent on the verdict, note that the *record*
+  keeps the rich chain — read it from there, not the wire.
+
+## Later steps (unchanged)
+
+- **Cross-machine** is **Step 9**.
+- **SSE/`stream.py`** (and the legacy SSE/poller helpers still in the daemon's `dispatch.py`) are
+  retired in **Step 10**.
+- **SAB/TFP engines and the escalation ladder** are **post-MVP**.
+
+## Report when done
+
+Per `START_HERE.md`: what changed, the DoD check, and test results (fast gate + the live
+integration slice, noting all prior slices still pass, backend + CLI). Open a PR against
+`slim-native-rewrite` (same as Steps 0–7).

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -62,6 +62,24 @@ class Settings(BaseSettings):
     # Master toggle: set false to disable SLIM room provisioning outright.
     SLIM_ENABLED: bool = True
 
+    # SIEP aligner — the first cognition engine (Step 7). Dormant by default:
+    # nothing runs until the reserved handle is @-summoned on a room channel.
+    # A reserved handle is how a summon of the engine is told apart from an
+    # @-mention of a normal teammate (bible §10 / Step 7 trap).
+    ALIGNER_HANDLE: str = "aligner"
+    # "observer" (one-shot: read transcript, emit verdict) or "driver" (run
+    # rounds, prompting participants, then emit).
+    ALIGNER_MODE: str = "observer"
+    # MPC at/above this converges; below rejects (mirrors the old CFN
+    # validation-intervention default of 0.6).
+    ALIGNER_THRESHOLD: float = 0.6
+    # Driver round cap — a hard bound so the loop always terminates.
+    ALIGNER_MAX_ROUNDS: int = 3
+    # Per-round wait for participant replies before scoring what arrived.
+    ALIGNER_ROUND_TIMEOUT_S: float = 30.0
+    # How often the driver polls the transcript for round replies.
+    ALIGNER_POLL_INTERVAL_S: float = 0.2
+
     model_config = SettingsConfigDict(
         env_file=tuple(_env_files),
         env_file_encoding="utf-8",

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -77,6 +77,18 @@ async def lifespan(app: FastAPI):
     except Exception as exc:
         logger.warning("Embedding warmup failed (non-fatal): %s", exc)
 
+    # Wire the SIEP aligner (Step 7) into every room's summon seam before any
+    # channel is provisioned, so all persisters pick it up. Dormant until an
+    # @-summon of its reserved handle arrives — zero idle cost (bible §10).
+    from app.services.aligner import AlignerEngine
+    from app.services.room_channels import manager as room_channel_manager
+
+    app.state.aligner = AlignerEngine(room_channel_manager)
+    room_channel_manager.on_summon = app.state.aligner.handle_summon
+    logger.info(
+        "SIEP aligner wired (@%s, mode=%s)", app.state.aligner.handle, settings.ALIGNER_MODE
+    )
+
     yield
     stop_watcher()
     stop_event_sweep()

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -1,0 +1,463 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+The SIEP aligner — the first cognition engine (Step 7, bible §10).
+
+Bible §10 splits three things that used to be bundled as "the CE":
+
+1. **Room infrastructure** — membership + durable transcript. That is the
+   always-on backend (``room_channels`` + ``persister``); cheap, always
+   listening. *Not* cognition.
+2. **Protocol machinery** — the deterministic MPC/GAR/SCR math over the
+   transcript. That already lives in :mod:`app.services.l9_episode`; this engine
+   *calls* it and never re-derives it (a second copy would drift from the
+   ``log/episodes/*`` records).
+3. **Cognitive judgment** — "is this converged, and what is the agreement?" That
+   is *this* module, and only this module. It is a **family** (one engine per L9
+   sub-protocol); the MVP ships **SIEP** — convergence — only.
+
+**Cost is a first-class constraint.** The engine is **dormant by default (zero
+idle cost).** Nothing here runs until an explicit ``@``-summon of the reserved
+aligner handle arrives through the persister's summon seam — no polling, no held
+LLM connection. The cheap backend does the listening; the engine only wakes when
+called.
+
+**Two modes, once summoned:**
+
+- **Observer (one-shot):** read the room transcript, replay each participant's
+  exchange through :mod:`l9_episode`'s metric folding, score, and emit an L9
+  ``commit:converged`` (MPC ≥ threshold) or ``commit:rejected`` (below) onto the
+  channel — then sleep.
+- **Driver (takes the wheel):** open an episode (freezing membership), then run
+  up to *N* rounds — prompt each participant for a position on the channel (which
+  wakes their Step 5 connector), collect the replies the persister records,
+  fold + score — stopping on convergence or the round cap, then emit the verdict
+  and close the episode (which drains any invites Step 6 queued mid-episode).
+
+**Runtime note (the Step 7 open question).** The default the bible names is "a
+cold-spawned agent turn, reusing ``spawn.py``". The verdict itself — the metrics
+and the ``commit`` envelope — is inherently backend-side (it is deterministic
+math over the transcript the backend already holds, emitted onto the channel the
+backend moderates), and the CLI's ``integration.spawn`` is not reachable from the
+backend process. So this engine runs **in-process in the backend** and reuses the
+cold-spawn runtime the way the bible means it: the **driver** prompts participants
+by publishing on the channel, and their existing Step 5 connectors cold-spawn the
+turn and reply. The engine drives the participants' spawns rather than spawning a
+judge of its own. The base-level verdict needs no LLM of its own — it is the
+threshold decision over the deterministic library — which also keeps the spawn
+cold. (Flagged in the Step 8 handoff; an LLM judgment/summary layer is post-MVP.)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+from typing import TYPE_CHECKING, Any
+
+from app.config import settings
+from app.services import l9, l9_episode
+from app.services.l9_slim import serialize_content
+from app.services.room_channels import BACKEND_AGENT
+
+if TYPE_CHECKING:
+    from app.services.l9_episode import EpisodeState
+    from app.services.l9_models import L9
+    from app.services.persister import RoomPersister, TranscriptRecord
+    from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
+
+logger = logging.getLogger(__name__)
+
+MODE_OBSERVER = "observer"
+MODE_DRIVER = "driver"
+
+# Handles that are never a participant position: the engine itself, the backend
+# moderator, and the system actor the backend signs its own envelopes with.
+_NON_PARTICIPANTS = frozenset({BACKEND_AGENT, l9.SYSTEM_ACTOR_ID})
+
+# Epistemic fields the aligner reads off an exchange's L9 payload and hands to
+# ``l9_episode.record_reply`` verbatim (it validates/clamps each one).
+_EPISTEMIC_KEYS = (
+    "confidence",
+    "offer",
+    "evidence",
+    "supporting_evidence",
+    "against_evidence",
+    "addresses",
+    "revision_cause",
+    "deferred_to",
+    "reasoning",
+)
+
+
+def _norm(handle: str) -> str:
+    """Case/space-fold a handle for identity comparison (matches the connector)."""
+    return handle.strip().lower()
+
+
+def _payload(content: dict[str, Any]) -> dict[str, Any]:
+    """The L9 payload dict of a recorded message's content (empty when absent)."""
+    env = content.get("l9")
+    if not isinstance(env, dict):
+        return {}
+    payload = env.get("payload")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _payload_data(content: dict[str, Any]) -> dict[str, Any]:
+    data = _payload(content).get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def _sender_role(content: dict[str, Any]) -> str | None:
+    """Role of the first actor (the sender) on a recorded message, if any."""
+    env = content.get("l9")
+    if not isinstance(env, dict):
+        return None
+    actors = env.get("header", {}).get("participants", {}).get("actors")
+    if isinstance(actors, list) and actors and isinstance(actors[0], dict):
+        role = actors[0].get("role")
+        return role if isinstance(role, str) else None
+    return None
+
+
+def reply_from_content(content: dict[str, Any]) -> dict[str, Any]:
+    """Extract a ``record_reply``-shaped position from a recorded exchange.
+
+    The epistemic signals ride the exchange's L9 payload ``data`` (where the
+    connector and ``record_tick``/``record_reply`` put them). Only the fields
+    ``l9_episode`` understands are copied; it re-validates each, so garbage is
+    dropped there, not here. A missing ``action`` defaults to ``reject`` inside
+    ``record_reply``.
+    """
+    data = _payload_data(content)
+    reply: dict[str, Any] = {}
+    action = data.get("action")
+    if isinstance(action, str) and action:
+        reply["action"] = action
+    for key in _EPISTEMIC_KEYS:
+        if key in data:
+            reply[key] = data[key]
+    return reply
+
+
+class AlignerEngine:
+    """The dormant, summon-driven SIEP aligner (one per backend process).
+
+    Holds no state between summons beyond the set of rooms it is actively
+    judging (so a second summon can't spawn a duplicate run over the same room).
+    Reaches the channel, transcript, and episode lifecycle through the
+    :class:`RoomChannelManager` it is wired to.
+    """
+
+    def __init__(
+        self,
+        manager: RoomChannelManager,
+        *,
+        handle: str | None = None,
+        mode: str | None = None,
+        threshold: float | None = None,
+        max_rounds: int | None = None,
+        round_timeout_s: float | None = None,
+        poll_interval_s: float | None = None,
+    ) -> None:
+        self._manager = manager
+        self._handle = handle if handle is not None else settings.ALIGNER_HANDLE
+        self._mode = mode if mode is not None else settings.ALIGNER_MODE
+        self._threshold = threshold if threshold is not None else settings.ALIGNER_THRESHOLD
+        self._max_rounds = max_rounds if max_rounds is not None else settings.ALIGNER_MAX_ROUNDS
+        self._round_timeout_s = (
+            round_timeout_s if round_timeout_s is not None else settings.ALIGNER_ROUND_TIMEOUT_S
+        )
+        self._poll_interval_s = (
+            poll_interval_s if poll_interval_s is not None else settings.ALIGNER_POLL_INTERVAL_S
+        )
+        # Rooms with a run in flight — a re-summon while active is ignored.
+        self._active: set[str] = set()
+        # Strong refs to scheduled runs so they aren't GC'd mid-flight.
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    @property
+    def handle(self) -> str:
+        return self._handle
+
+    # -- the summon seam (sync; called from the persister's on_summon) --
+
+    def handle_summon(self, room: str, handle: str, envelope: L9) -> None:
+        """Fire the engine when *its* reserved handle is summoned; else ignore.
+
+        The persister fires this for every ``@``-mention in a message, so the
+        identity gate here is what keeps an ``@teammate`` from spawning an engine
+        (bible §10 / Step 7 trap). A self-authored envelope never re-summons, and
+        a room already being judged is left alone.
+        """
+        if _norm(handle) != _norm(self._handle):
+            return
+        from app.services.persister import envelope_sender
+
+        sender = envelope_sender(envelope)
+        if sender is not None and _norm(sender) == _norm(self._handle):
+            return  # never summon off our own message
+        if room in self._active:
+            logger.debug("aligner already active on room %s; ignoring re-summon", room)
+            return
+        self._active.add(room)
+        task = asyncio.create_task(self._run_and_release(room))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _run_and_release(self, room: str) -> None:
+        try:
+            if self._mode == MODE_DRIVER:
+                await self.drive(room)
+            else:
+                await self.observe(room)
+        except Exception:
+            logger.exception("aligner run failed on room %s", room)
+        finally:
+            self._active.discard(room)
+
+    # -- observer mode --
+
+    async def observe(self, room: str) -> dict[str, Any] | None:
+        """Read the transcript, score it once, and emit a verdict. One-shot."""
+        managed = self._manager.get(room)
+        if managed is None or managed.persister is None:
+            logger.info("aligner summoned for %s but no live channel/persister", room)
+            return None
+        records = managed.persister.log.records
+        ep, assignments = self._episode_from_records(managed, records)
+        converged, metrics = self._verdict(ep)
+        logger.info(
+            "aligner observed room %s → %s (%s)",
+            room,
+            "converged" if converged else "rejected",
+            metrics,
+        )
+        return await self._emit_verdict(managed, ep, assignments, converged, metrics)
+
+    # -- driver mode --
+
+    async def drive(self, room: str) -> dict[str, Any] | None:
+        """Run up to N rounds of prompt→collect→score, then emit a verdict.
+
+        Opens an episode so a mid-run membership change aborts it (frozen
+        membership, bible §9/§12); always closes it in ``finally`` so Step 6's
+        queued invites drain even when a round times out.
+        """
+        managed = self._manager.get(room)
+        if managed is None or managed.persister is None:
+            logger.info("aligner (driver) summoned for %s but no live channel/persister", room)
+            return None
+        persister = managed.persister
+        participants = [m for m in self._manager.members(room) if _norm(m) != _norm(self._handle)]
+        episode = l9.episode_urn(room, "align")
+        topic = l9.topic_urn(room)
+
+        self._manager.open_episode(room, episode)
+        ep = l9_episode.open_episode(
+            parent_room=room,
+            short_id="align",
+            workspace_id=managed.workspace,
+            mas_id="",
+            agents=participants,
+            joined_intents="aligner drive: converge on the open question",
+        )
+        assignments: dict[str, Any] = {}
+        converged = False
+        metrics: dict[str, Any] | None = None
+        try:
+            for round_n in range(1, self._max_rounds + 1):
+                before = len(persister.log.records)
+                await self._prompt_round(managed, participants, episode, topic, round_n)
+                replies = await self._collect_round(persister, participants, before)
+                for handle, record in replies.items():
+                    self._fold(ep, assignments, handle, record, round_n)
+                converged, metrics = self._verdict(ep)
+                logger.info(
+                    "aligner driver room %s round %d → %s (%s)",
+                    room,
+                    round_n,
+                    "converged" if converged else "continuing",
+                    metrics,
+                )
+                if converged:
+                    break
+            return await self._emit_verdict(managed, ep, assignments, converged, metrics)
+        finally:
+            await self._manager.close_episode(room)
+
+    async def _prompt_round(
+        self,
+        managed: ManagedRoomChannel,
+        participants: list[str],
+        episode: str,
+        topic: str,
+        round_n: int,
+    ) -> None:
+        """Publish a per-participant position prompt (wakes their connector)."""
+        for handle in participants:
+            env = l9.build_envelope(
+                kind=l9.Kind.exchange,
+                episode=episode,
+                recipients=[handle],
+                topic=topic,
+                payload_type="tick",
+                payload_data={"round": round_n, "action": "position"},
+            )
+            text = (
+                f"@{handle} — round {round_n}: state your position and confidence "
+                f"(0.0-1.0) on the open question."
+            )
+            try:
+                await managed.channel.send(env, extra={"content": text})
+            except Exception:
+                logger.warning("aligner failed to prompt @%s (round %d)", handle, round_n)
+
+    async def _collect_round(
+        self, persister: RoomPersister, participants: list[str], before: int
+    ) -> dict[str, TranscriptRecord]:
+        """Poll the transcript for each participant's latest post-prompt position.
+
+        Bounded by ``round_timeout_s`` so a silent participant can never hang the
+        loop; returns whatever arrived (possibly empty). Cheap: an async poll of
+        the in-memory transcript, no LLM held open.
+        """
+        pending = {_norm(p) for p in participants}
+        latest: dict[str, TranscriptRecord] = {}
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._round_timeout_s
+        while pending:
+            for record in persister.log.records[before:]:
+                if not self._is_position(record):
+                    continue
+                if _norm(record.sender) in pending:
+                    latest[record.sender] = record
+            pending -= {_norm(s) for s in latest}
+            if not pending or loop.time() >= deadline:
+                break
+            await asyncio.sleep(self._poll_interval_s)
+        return latest
+
+    # -- scoring (delegates the math to l9_episode) --
+
+    def _is_position(self, record: TranscriptRecord) -> bool:
+        """True when a transcript record is an agent's position (not noise).
+
+        Counts an ``exchange`` from an agent (role != human) that is not the
+        engine/backend/system and not a bare presence hello. Everything the
+        metrics fold over passes through here.
+        """
+        if record.kind != "exchange":
+            return False
+        if _payload(record.content).get("type") == "presence":
+            return False
+        if _sender_role(record.content) == "human":
+            return False
+        sender = record.sender
+        return bool(sender) and _norm(sender) not in {
+            _norm(self._handle),
+            *(_norm(h) for h in _NON_PARTICIPANTS),
+        }
+
+    def _episode_from_records(
+        self, managed: ManagedRoomChannel, records: list[TranscriptRecord]
+    ) -> tuple[EpisodeState, dict[str, Any]]:
+        """Replay the transcript's positions into a fresh episode + assignments."""
+        positions = [r for r in records if self._is_position(r)]
+        agents: list[str] = []
+        for record in positions:
+            if record.sender not in agents:
+                agents.append(record.sender)
+        ep = l9_episode.open_episode(
+            parent_room=managed.room,
+            short_id="live",
+            workspace_id=managed.workspace,
+            mas_id="",
+            agents=agents,
+            joined_intents="aligner observed exchange",
+        )
+        assignments: dict[str, Any] = {}
+        for record in positions:
+            self._fold(ep, assignments, record.sender, record, None)
+        return ep, assignments
+
+    def _fold(
+        self,
+        ep: EpisodeState,
+        assignments: dict[str, Any],
+        handle: str,
+        record: TranscriptRecord,
+        round_n: int | None,
+    ) -> None:
+        """Fold one position into the episode's metrics and the assignments map."""
+        reply = reply_from_content(record.content)
+        l9_episode.record_reply(ep, handle=handle, reply=reply, round_n=round_n)
+        assignments[handle] = reply.get("offer") or reply.get("action") or "accept"
+
+    def _verdict(self, ep: EpisodeState) -> tuple[bool, dict[str, Any] | None]:
+        """(converged, metrics). Converged ⇔ metrics exist and MPC ≥ threshold."""
+        metrics = l9_episode.compute_metrics(ep)
+        converged = metrics is not None and metrics["mpc"] >= self._threshold
+        return converged, metrics
+
+    # -- emitting the verdict --
+
+    async def _emit_verdict(
+        self,
+        managed: ManagedRoomChannel,
+        ep: EpisodeState,
+        assignments: dict[str, Any],
+        converged: bool,
+        metrics: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Broadcast the ``commit`` envelope and record it once locally.
+
+        Emitting a ``commit:converged`` here is exactly the plan-compile trigger
+        the persister watches — Step 8 wires ``on_converged`` to ``plan_compiler``.
+        Step 7 stops at emitting a correct, well-formed verdict.
+        """
+        env_dict = l9_episode.build_consensus_envelope(
+            ep, broken=not converged, assignments=assignments, metrics=metrics
+        )
+        # The verdict is a *broadcast* terminal statement. Its record-side parents
+        # (built above: the episode's synthesized reply ids) are never on the
+        # wire, and no single on-channel message is delivered to *every* member
+        # (a group broadcast is not echoed to its own sender), so any wire parent
+        # would leave some receiver's CausalOrderBuffer holding the commit
+        # forever. Emit with empty wire parents — releasable by everyone — while
+        # the full causal chain stays intact in the episode record (ep.messages).
+        wire_dict = copy.deepcopy(env_dict)
+        wire_dict["header"]["message"]["parents"] = []
+        envelope = l9.parse_envelope(wire_dict)
+        text = self._verdict_text(converged, metrics)
+        content = serialize_content(envelope, extra={"content": text})
+        try:
+            await managed.channel.send(envelope, extra={"content": text})
+        except Exception:
+            logger.warning("aligner failed to broadcast verdict on room %s", managed.room)
+        # Record + trigger locally (deduped by message id), so the transcript,
+        # UI bus, and on_converged seam fire even if SLIM never loops our own
+        # broadcast back to the moderator (mirrors the human-proxy publish).
+        if managed.persister is not None:
+            managed.persister.ingest_local(envelope, content)
+        l9_episode.write_episode_record(
+            ep,
+            outcome="converged" if converged else "rejected",
+            metrics=metrics,
+            plan_file=None,
+        )
+        return env_dict
+
+    def _verdict_text(self, converged: bool, metrics: dict[str, Any] | None) -> str:
+        """The human-facing summary agents read (must carry no ``@handle``)."""
+        if metrics is None:
+            return "✗ not converged — insufficient participation to score alignment."
+        digest = (
+            f"MPC {metrics['mpc']:.2f} · GAR {metrics['gar']:.2f} · "
+            f"SCR {metrics['scr']:.2f} over {metrics['participants']} participants"
+        )
+        if converged:
+            return f"✓ converged — {digest}."
+        return f"✗ not converged — {digest} (MPC below threshold {self._threshold:.2f})."

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -29,7 +29,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from app.config import settings
 from app.services import l9
@@ -49,6 +51,16 @@ from app.services.slim_client import (
     to_channel_name,
     to_slim_name,
 )
+
+if TYPE_CHECKING:
+    from app.services.l9_models import L9
+
+# The room-aware summon hook the manager holds: unlike the persister's
+# per-message ``SummonHook`` (which knows only the handle + envelope), this
+# carries the ``room`` so the engine wired to it (Step 7's aligner) knows which
+# channel to judge. ``_start_persister`` adapts it down to the persister's
+# signature by binding the room.
+RoomSummonHook = Callable[[str, str, "L9"], None]
 
 logger = logging.getLogger(__name__)
 
@@ -99,10 +111,11 @@ class RoomChannelManager:
         # Consent-gated invites raised by an @-mention of a not-present agent
         # (bible §12). The moderator only invites on accept.
         self._invites = PendingInviteRegistry()
-        # Trigger hooks handed to every persister. Skeletons by default (log
-        # only); Step 7 wires ``on_summon`` to the cognition-engine spawner and
-        # Step 8 wires ``on_converged`` to ``plan_compiler``.
-        self.on_summon: SummonHook | None = None
+        # Trigger hooks handed to every persister. ``on_summon`` is wired at
+        # startup (``main.py``) to the SIEP aligner's ``handle_summon`` (Step 7);
+        # ``on_converged`` stays a skeleton until Step 8 wires it to
+        # ``plan_compiler``. Unset → the persister's log-only defaults.
+        self.on_summon: RoomSummonHook | None = None
         self.on_converged: ConvergedHook | None = None
 
     def get(self, room: str) -> ManagedRoomChannel | None:
@@ -168,10 +181,26 @@ class RoomChannelManager:
             room,
             managed.channel,
             members_provider=lambda: self.members(room),
-            on_summon=self.on_summon,
+            on_summon=self._summon_adapter(room),
             on_converged=self.on_converged,
         )
         managed.persister_task = asyncio.create_task(managed.persister.run())
+
+    def _summon_adapter(self, room: str) -> SummonHook | None:
+        """Bind ``room`` onto the room-aware ``on_summon`` hook.
+
+        The persister calls its ``SummonHook`` with only ``(handle, envelope)``;
+        the engine wired to :attr:`on_summon` needs the room too. When no hook is
+        wired, return ``None`` so the persister keeps its log-only default.
+        """
+        hook = self.on_summon
+        if hook is None:
+            return None
+
+        def adapter(handle: str, envelope: L9, _room: str = room) -> None:
+            hook(_room, handle, envelope)
+
+        return adapter
 
     async def invite(self, room: str, agent: str) -> bool:
         """Invite ``agent`` into the room channel. Best-effort; returns success."""

--- a/fastapi-backend/scripts/l9_slim_roundtrip.py
+++ b/fastapi-backend/scripts/l9_slim_roundtrip.py
@@ -233,6 +233,91 @@ async def run_durable_inbox(endpoint: str = DEFAULT_NODE_ENDPOINT) -> list[L9]:
         await manager.close_all()
 
 
+_ALIGN_ROOM = "aligner-room"
+_ALIGN_EPISODE = l9.episode_urn(_ALIGN_ROOM, "live")
+
+
+def _align_position(sender: str, confidence: float, message_id: str) -> L9:
+    return l9.build_envelope(
+        kind=Kind.exchange,
+        episode=_ALIGN_EPISODE,
+        sender=sender,
+        sender_role="agent",
+        recipients=[l9.SYSTEM_ACTOR_ID],
+        topic=l9.topic_urn(_ALIGN_ROOM),
+        message_id=message_id,
+        payload_type="reply",
+        payload_data={"action": "accept", "confidence": confidence},
+    )
+
+
+def _align_summon() -> L9:
+    """A human's ``@aligner`` summon (role human → not scored as a position)."""
+    return l9.build_envelope(
+        kind=Kind.exchange,
+        episode=_ALIGN_EPISODE,
+        sender="human",
+        sender_role="human",
+        recipients=["aligner"],
+        topic=l9.topic_urn(_ALIGN_ROOM),
+        payload_type="message",
+    )
+
+
+async def run_aligner_observe(endpoint: str = DEFAULT_NODE_ENDPOINT) -> L9:
+    """Prove the Step 7 observer DoD over a live node.
+
+    The backend provisions a channel with the SIEP aligner wired to its summon
+    seam. Two agents each publish a high-confidence position; a human then
+    ``@aligner``-summons the engine. The engine (observer mode) reads the
+    transcript, scores it via ``l9_episode``, and broadcasts an L9
+    ``commit:converged`` onto the channel. Returns the commit envelope a
+    participant receives.
+    """
+    from app.services.aligner import AlignerEngine
+
+    manager = RoomChannelManager(endpoint=endpoint, default_workspace=_WORKSPACE)
+    engine = AlignerEngine(manager, handle="aligner", mode="observer", threshold=0.6)
+    manager.on_summon = engine.handle_summon  # wire BEFORE provision so the persister picks it up
+    managed = await manager.provision(_ALIGN_ROOM)
+    assert managed is not None and managed.persister is not None
+    persister = managed.persister
+
+    agent_a = await SlimClient(SlimIdentity(_WORKSPACE, _ALIGN_ROOM, "agent-a")).connect(endpoint)
+    agent_b = await SlimClient(SlimIdentity(_WORKSPACE, _ALIGN_ROOM, "agent-b")).connect(endpoint)
+
+    try:
+        a_listen = asyncio.create_task(agent_a.listen_for_session())
+        b_listen = asyncio.create_task(agent_b.listen_for_session())
+        await manager.invite(_ALIGN_ROOM, "agent-a")
+        await manager.invite(_ALIGN_ROOM, "agent-b")
+        a_channel = L9SlimChannel(agent_a, await a_listen)
+        b_channel = L9SlimChannel(agent_b, await b_listen)
+
+        # Two agents state a high-confidence position; wait until both are recorded.
+        await a_channel.send(_align_position("agent-a", 0.8, "align-a"))
+        await b_channel.send(_align_position("agent-b", 0.9, "align-b"))
+        positions = {"align-a", "align-b"}
+        await _wait_for(
+            lambda: positions <= {r.message_id for r in persister.log.records}, timeout=15.0
+        )
+
+        # The human summons the aligner → the engine observes and emits the verdict.
+        await a_channel.send(_align_summon(), extra={"content": "@aligner please converge"})
+
+        commit: L9 | None = None
+        while commit is None:
+            for env in await b_channel.receive(timeout_s=15.0):
+                if env.header.kind.value == "commit":
+                    commit = env
+                    break
+        return commit
+    finally:
+        await agent_a.close()
+        await agent_b.close()
+        await manager.close_all()
+
+
 async def _main(endpoint: str) -> int:
     received = await run_roundtrip(endpoint)
     ids = [e.header.message.id for e in received if e.header.message is not None]
@@ -256,6 +341,13 @@ async def _main(endpoint: str) -> int:
         )
         return 1
     print(f"OK — durable inbox re-served missed message on reconnect: {inbox_ids}")
+
+    commit = await run_aligner_observe(endpoint)
+    if commit.header.subkind != "converged":
+        print(f"MISMATCH — aligner verdict subkind {commit.header.subkind!r}", file=sys.stderr)
+        return 1
+    metrics = commit.payload.data.get("metrics") if commit.payload else None
+    print(f"OK — aligner observed and emitted commit:{commit.header.subkind} (metrics={metrics})")
     return 0
 
 

--- a/fastapi-backend/tests/test_aligner.py
+++ b/fastapi-backend/tests/test_aligner.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the SIEP aligner cognition engine (app/services/aligner.py).
+
+Node-free: they drive the engine over fake channels/persisters so the observer
+verdict, the below-threshold rejection, the driver round loop, and the
+reserved-handle summon gate are all exercised as pure async logic. The live-node
+observe slice is in ``test_l9_over_slim_roundtrip.py`` (guarded on a node).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from app.services import aligner, l9, l9_episode
+from app.services.l9_models import Kind
+from app.services.l9_slim import serialize_content
+from app.services.persister import DeliveryLog, TranscriptRecord, record_from
+
+_ROOM = "align-room"
+_EPISODE = l9.episode_urn(_ROOM, "live")
+_TOPIC = l9.topic_urn(_ROOM)
+
+
+def _position_record(
+    sender: str,
+    *,
+    confidence: float | None = None,
+    action: str = "accept",
+    role: str = "agent",
+    payload_type: str = "reply",
+    message_id: str | None = None,
+) -> TranscriptRecord:
+    """An agent-position transcript record carrying an epistemic payload."""
+    data: dict[str, Any] = {"action": action}
+    if confidence is not None:
+        data["confidence"] = confidence
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=_EPISODE,
+        sender=sender,
+        sender_role=role,
+        recipients=[l9.SYSTEM_ACTOR_ID],
+        topic=_TOPIC,
+        payload_type=payload_type,
+        payload_data=data,
+        message_id=message_id,
+    )
+    return record_from(env, serialize_content(env, extra={"content": f"{sender} position"}))
+
+
+# ── fakes ────────────────────────────────────────────────────────────────────
+
+
+class _FakeChannel:
+    """Records broadcasts; optionally simulates a prompted participant replying."""
+
+    def __init__(self, persister: _FakePersister | None = None, reply_conf: float | None = None):
+        self.sent: list[tuple[Any, dict[str, Any] | None]] = []
+        self._persister = persister
+        self._reply_conf = reply_conf
+        self._reply_seq = 0
+
+    async def send(self, envelope: Any, *, extra: dict[str, Any] | None = None) -> None:
+        self.sent.append((envelope, extra))
+        # Only exchange prompts trigger a simulated reply — never the commit.
+        if self._reply_conf is None or envelope.header.kind != Kind.exchange:
+            return
+        assert self._persister is not None
+        for actor in envelope.header.participants.actors[1:]:
+            self._reply_seq += 1
+            self._persister.log.record(
+                _position_record(
+                    actor.id, confidence=self._reply_conf, message_id=f"reply-{self._reply_seq}"
+                ),
+                delivered_to=set(),
+            )
+
+
+class _FakePersister:
+    def __init__(self, records: list[TranscriptRecord] | None = None):
+        self.log = DeliveryLog(records or [])
+        self.ingested: list[tuple[Any, dict[str, Any]]] = []
+
+    def ingest_local(self, envelope: Any, content: dict[str, Any]) -> None:
+        self.ingested.append((envelope, content))
+
+
+@dataclass
+class _FakeManaged:
+    room: str
+    workspace: str
+    channel: Any
+    persister: Any
+
+
+class _FakeManager:
+    def __init__(self, managed: _FakeManaged, members: list[str]):
+        self._managed = managed
+        self._members = members
+        self.opened: list[str] = []
+        self.closed: list[str] = []
+
+    def get(self, room: str) -> _FakeManaged:
+        return self._managed
+
+    def members(self, room: str) -> list[str]:
+        return list(self._members)
+
+    def open_episode(self, room: str, episode: str) -> bool:
+        self.opened.append(episode)
+        return True
+
+    async def close_episode(self, room: str) -> bool:
+        self.closed.append(room)
+        return True
+
+
+def _engine(manager: _FakeManager, **kw: Any) -> aligner.AlignerEngine:
+    kw.setdefault("handle", "aligner")
+    kw.setdefault("threshold", 0.6)
+    return aligner.AlignerEngine(manager, **kw)  # type: ignore[arg-type]
+
+
+# ── observer mode ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_observer_emits_converged_with_correct_metrics():
+    """A high-confidence seeded transcript → commit:converged with the metrics
+    l9_episode.compute_metrics returns over the same positions."""
+    records = [
+        _position_record("agent-a", confidence=0.8, message_id="a1"),
+        _position_record("agent-b", confidence=0.9, message_id="b1"),
+    ]
+    channel = _FakeChannel()
+    persister = _FakePersister(records)
+    managed = _FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = _FakeManager(managed, ["agent-a", "agent-b", "aligner"])
+
+    verdict = await _engine(manager, mode="observer").observe(_ROOM)
+
+    assert verdict is not None
+    assert verdict["header"]["kind"] == "commit"
+    assert verdict["header"]["subkind"] == "converged"
+
+    # Metrics match a fresh, independent replay of the same two positions.
+    ep = l9_episode.open_episode(
+        parent_room=_ROOM,
+        short_id="live",
+        workspace_id="mycelium",
+        mas_id="",
+        agents=["agent-a", "agent-b"],
+        joined_intents="x",
+    )
+    l9_episode.record_reply(
+        ep, handle="agent-a", reply={"action": "accept", "confidence": 0.8}, round_n=None
+    )
+    l9_episode.record_reply(
+        ep, handle="agent-b", reply={"action": "accept", "confidence": 0.9}, round_n=None
+    )
+    expected = l9_episode.compute_metrics(ep)
+    assert verdict["payload"]["data"]["metrics"] == expected
+
+    # Broadcast once, and recorded once locally (drives the on_converged seam).
+    assert len(channel.sent) == 1
+    assert len(persister.ingested) == 1
+
+
+@pytest.mark.asyncio
+async def test_observer_below_threshold_emits_rejected():
+    records = [
+        _position_record("agent-a", confidence=0.2, message_id="a1"),
+        _position_record("agent-b", confidence=0.3, message_id="b1"),
+    ]
+    channel = _FakeChannel()
+    managed = _FakeManaged(_ROOM, "mycelium", channel, _FakePersister(records))
+    manager = _FakeManager(managed, ["agent-a", "agent-b"])
+
+    verdict = await _engine(manager, mode="observer").observe(_ROOM)
+
+    assert verdict is not None
+    assert verdict["header"]["subkind"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_observer_ignores_human_and_engine_messages_when_scoring():
+    """A human proxy message and the engine's own handle never count as a
+    participant position (so they can't skew or stall the metrics)."""
+    records = [
+        _position_record("human", confidence=0.1, role="human", message_id="h1"),
+        _position_record("aligner", confidence=0.1, message_id="al1"),
+        _position_record("agent-a", confidence=0.9, message_id="a1"),
+        _position_record("agent-b", confidence=0.85, message_id="b1"),
+    ]
+    channel = _FakeChannel()
+    managed = _FakeManaged(_ROOM, "mycelium", channel, _FakePersister(records))
+    manager = _FakeManager(managed, ["agent-a", "agent-b"])
+
+    verdict = await _engine(manager, mode="observer").observe(_ROOM)
+
+    assert verdict is not None
+    assert verdict["header"]["subkind"] == "converged"
+    # Only the two agents were scored.
+    assert verdict["payload"]["data"]["metrics"]["participants"] == 2
+
+
+# ── driver mode ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_driver_converges_and_closes_episode():
+    persister = _FakePersister()
+    channel = _FakeChannel(persister, reply_conf=0.9)
+    managed = _FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = _FakeManager(managed, ["agent-a", "agent-b", "aligner"])
+
+    engine = _engine(
+        manager, mode="driver", max_rounds=3, round_timeout_s=0.2, poll_interval_s=0.01
+    )
+    verdict = await engine.drive(_ROOM)
+
+    assert verdict is not None
+    assert verdict["header"]["subkind"] == "converged"
+    # Opened an episode (frozen membership) and closed it (drains queued invites).
+    assert manager.opened == [l9.episode_urn(_ROOM, "align")]
+    assert manager.closed == [_ROOM]
+    # Converged on round 1 → prompted the two participants exactly once each.
+    prompts = [s for s, _ in channel.sent if s.header.kind == Kind.exchange]
+    assert len(prompts) == 2
+
+
+@pytest.mark.asyncio
+async def test_driver_terminates_at_round_cap_without_replies():
+    """No participant ever answers → the loop stops at the cap and rejects, never
+    hanging (bounded by round_timeout_s)."""
+    persister = _FakePersister()
+    channel = _FakeChannel(persister, reply_conf=None)  # nobody replies
+    managed = _FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = _FakeManager(managed, ["agent-a", "agent-b"])
+
+    engine = _engine(
+        manager, mode="driver", max_rounds=2, round_timeout_s=0.05, poll_interval_s=0.01
+    )
+    verdict = await asyncio.wait_for(engine.drive(_ROOM), timeout=5.0)
+
+    assert verdict is not None
+    assert verdict["header"]["subkind"] == "rejected"
+    assert manager.closed == [_ROOM]
+    # 2 rounds x 2 participants = 4 prompts before giving up.
+    prompts = [s for s, _ in channel.sent if s.header.kind == Kind.exchange]
+    assert len(prompts) == 4
+
+
+# ── summon routing ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_summon_fires_only_for_the_reserved_handle():
+    managed = _FakeManaged(_ROOM, "mycelium", _FakeChannel(), _FakePersister())
+    engine = _engine(_FakeManager(managed, []), mode="observer")
+
+    called: list[str] = []
+
+    async def fake_observe(room: str) -> None:
+        called.append(room)
+
+    engine.observe = fake_observe  # type: ignore[method-assign]
+
+    def _env(sender: str) -> Any:
+        return l9.build_envelope(
+            kind=Kind.exchange,
+            episode=_EPISODE,
+            sender=sender,
+            topic=_TOPIC,
+            payload_type="message",
+        )
+
+    # A summon of a normal teammate does not fire the engine.
+    engine.handle_summon(_ROOM, "agent-a", _env("human"))
+    await asyncio.sleep(0.02)
+    assert called == []
+
+    # A summon of the reserved handle does.
+    engine.handle_summon(_ROOM, "aligner", _env("human"))
+    await asyncio.sleep(0.02)
+    assert called == [_ROOM]
+
+    # The engine never summons off its own message (loop guard).
+    engine.handle_summon("other-room", "aligner", _env("aligner"))
+    await asyncio.sleep(0.02)
+    assert called == [_ROOM]

--- a/fastapi-backend/tests/test_l9_over_slim_roundtrip.py
+++ b/fastapi-backend/tests/test_l9_over_slim_roundtrip.py
@@ -90,3 +90,19 @@ async def test_durable_inbox_reserves_missed_message_on_reconnect(tmp_path, monk
     ids = [e.header.message.id for e in received if e.header.message is not None]
     assert ids == [_MISSED_ID]
     assert received[0].header.kind.value == "exchange"
+
+
+@pytest.mark.asyncio
+async def test_aligner_observes_and_emits_converged_over_slim(tmp_path, monkeypatch):
+    """Step 7 DoD: @-summoning the aligner over a live node makes it observe a
+    seeded high-confidence exchange and broadcast commit:converged with metrics."""
+    # The engine writes an episode record to the data dir; isolate it.
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    from scripts.l9_slim_roundtrip import run_aligner_observe
+
+    commit = await run_aligner_observe(_ENDPOINT)
+
+    assert commit.header.kind.value == "commit"
+    assert commit.header.subkind == "converged"
+    metrics = commit.payload.data.get("metrics")
+    assert metrics is not None and metrics["mpc"] >= 0.6


### PR DESCRIPTION
## Step 7 — Cognition engine, base layer (observer + driver)

Lights up the first cognition engine: a dormant, `@`-summoned **SIEP aligner** that reads a room's transcript, computes MPC/GAR/SCR via the protocol library, and emits an L9 **`commit:converged`** / **`commit:rejected`** onto the channel — in both **observer** and **driver** modes. Emit-only, per the step boundary.

### What changed
- **`app/services/aligner.py`** — the `AlignerEngine`.
  - **Dormant by default** (zero idle cost): nothing runs until an `@`-summon of its **reserved handle** (`ALIGNER_HANDLE`, default `aligner`) arrives through the persister's summon seam. Gating on identity keeps an `@`-mention of a normal teammate from spawning an engine.
  - **Reuses `l9_episode`** for MPC/GAR/SCR — never re-derives the math (no drift from `log/episodes/*`). The verdict is the deterministic threshold over MPC.
  - **Observer:** read transcript → replay positions → score → emit, then sleep.
  - **Driver:** open an episode (frozen membership), run up to N rounds prompting participants over the channel (reusing the Step 5 connector wake/reply path), score each round, stop on convergence or the round cap, then emit + `close_episode` (drains Step 6's queued invites).
  - Verdict recorded once via `persister.ingest_local` (deduped by message id) so the `on_converged` seam fires even without a SLIM loopback — the "publish once" trap.
- **`room_channels.py`** — `on_summon` is now **room-aware** (`RoomSummonHook = (room, handle, envelope)`), adapted down to the persister's `(handle, envelope)` hook by binding the room in `_start_persister`.
- **`main.py`** — wire the engine to `manager.on_summon` at startup, before any channel is provisioned.
- **`config.py`** — `ALIGNER_HANDLE/MODE/THRESHOLD/MAX_ROUNDS/ROUND_TIMEOUT_S/POLL_INTERVAL_S`.

### Design notes / flags
- **Wire verdict carries empty `message.parents`.** A broadcast terminal statement must be releasable by every member's `CausalOrderBuffer`, and no single on-channel message is delivered to its own sender — so parenting on the synthesized reply ids (or on an author's own position) would deadlock some receiver. The full causal chain stays intact in the `log/episodes/*` record.
- **Aligner runtime (the Step 7 open question).** The engine runs **in-process in the backend** rather than cold-spawning a `claude` turn of its own: the verdict (metrics + `commit` envelope) is inherently backend-side, and the CLI's `integration.spawn` is unreachable from the backend process. It reuses the cold-spawn runtime the way the bible means it — the **driver drives the participants' spawns** via the channel. The base-level verdict needs no LLM of its own, which also keeps the spawn cold. An LLM judgment/summary layer (extracting confidence from free text, summarizing the agreement) is **post-MVP**.

### DoD
`@`-summoning the aligner in **observer** mode over a seeded exchange emits a correct `commit:converged` (MPC/GAR/SCR matching `l9_episode.compute_metrics`); **driver** mode runs the configured rounds and emits a verdict; a below-threshold exchange yields `commit:rejected`. ✅

### Tests
Fast unit (`tests/test_aligner.py`): observer converged w/ correct metrics; below-threshold rejected; human/engine messages don't skew scoring; driver converges + closes episode; driver terminates at the round cap without replies; summon fires only for the reserved handle (loop-guarded).

Guarded live slice (`test_l9_over_slim_roundtrip.py::test_aligner_observes_and_emits_converged_over_slim`): `@`-summon the aligner over a real `slim:1.4.0` node → observes a seeded exchange → broadcasts `commit:converged` with metrics, received by a participant.

### Verification
- Backend: `ruff` + `ruff format --check` + `ty` clean; `pytest` **247 passed, 6 skipped** (skips = guarded live slices).
- CLI: gate clean; `pytest` **374 passed, 2 skipped**.
- Live node (`slim:1.4.0` on :46357): all **4** backend slices pass (Steps 3–6 + the new Step 7 aligner slice); CLI connector slices (Step 5/6) still pass.

### Deferrals (named)
- Plan-compile firing (`on_converged` → `plan_compiler`) + the `knowledge` memory sync are **Step 8** — handoff added at `docs/START_HERE_STEP_8.md`.
- Cross-machine is **Step 9**; SSE/`stream.py` retirement is **Step 10**; SAB/TFP engines + the escalation ladder are **post-MVP**.