### PR TITLE
Step 8: plan + memory sync (the full loop, same-machine)

### DIFF
--- a/docs/START_HERE_STEP_9.md
+++ b/docs/START_HERE_STEP_9.md
@@ -1,0 +1,205 @@
+# START HERE — Step 9 (Cross-machine — the hero flow across two hosts)
+
+Companion to [`START_HERE.md`](./START_HERE.md). Step 8 is **done** (this PR into
+`slim-native-rewrite`); you are picking up **Step 9**. Read `START_HERE.md`,
+[`START_HERE_STEP_1.md`](./START_HERE_STEP_1.md) → [`START_HERE_STEP_8.md`](./START_HERE_STEP_8.md)
+first if you haven't — the same rules apply. This file gives you (a) the exact state Step 8
+left behind, (b) your Step 9 marching orders, (c) the facts you must internalize, and (d) the
+traps specific to this step.
+
+**Step 8 closed the loop on one machine.** A summoned aligner emits `commit:converged`; the
+backend's **plan-sync consumer** (wired on `on_converged`) fires `plan_compiler` → `plan/tasks.md`
+and broadcasts the compiled plan as an L9 **`knowledge`** message that **carries the content**;
+a second local store applies it (markdown + JSONL reindex) under the last-write-wins conflict
+policy. The whole `join → exchange → converge → plan → work` cycle runs, but **both stores were
+on the same host** (the "second store" was a swapped data dir). **Step 9 makes it real across
+two machines:** the same channel, moderated by one host, carries the exchange and the `knowledge`
+stream to a **genuinely remote** store — so two people on two laptops run the hero demo.
+
+## Ground rules (unchanged from START_HERE.md)
+
+1. **The bible is authoritative:** [`slim-native-rebuild-bible.md`](./slim-native-rebuild-bible.md).
+   Your work is **Part V · Step 9**, with **§11 (memory sync)**, **§12 (consent)**, and **§13
+   (the full cycle)** as the design reference.
+2. Leave the project **runnable and green** — backend + CLI quality gates pass at the end.
+3. Code/config blocks in the bible are **reference, not paste**.
+4. **Verify before you edit** — the paths below were accurate at the end of Step 8; confirm shape
+   before changing a file.
+5. Fixed decisions are not up for debate. **LAN first, don't block on NAT** (§Step 9): get two
+   hosts on a LAN through a shared node; *document* the open-internet path (a reachable/hosted
+   node or a tunnel) but do not build NAT traversal for the MVP.
+
+## Where Step 8 left things (your starting state)
+
+Branch off `slim-native-rewrite` (Step 8 is merged). The loop works end-to-end on one host; what
+is missing is a **second host** actually on the channel. Concretely:
+
+- **The `knowledge` write path is transport-agnostic and done.** Backend
+  `app/services/memory_sync.py` builds the `knowledge:distillation` envelope (`build_knowledge_envelope`),
+  carries a `KnowledgeWrite` (key + markdown + `version`/`base_version`), and applies it locally
+  (`apply_knowledge` / `apply_knowledge_to_dir`) under the decided **last-write-wins** policy:
+  a same-version arrival is an idempotent no-op (the loopback of a write the host just made), a
+  **stale-base** write **fails with details** and moves on, no merge. `app/services/plan_sync.py`
+  (`PlanSyncEngine`) is the `on_converged` consumer that compiles the plan and emits the push.
+- **The consumer seam is wired, room-aware.** `RoomChannelManager.on_converged` is a
+  `RoomConvergedHook = (room, envelope)`, bound down to the persister's `(envelope)` signature by
+  `_converged_adapter` (mirrors Step 7's `_summon_adapter`), and set in `app/main.py` to
+  `PlanSyncEngine.handle_converged`.
+- **The connector already applies `knowledge`.** `mycelium/daemon/connector.py`
+  (`apply_knowledge_message`, called from `handle_inbound` **before** `should_wake`) writes a
+  carried memory into the local store via `mycelium/filesystem.py:apply_knowledge` (the CLI-side
+  mirror of the conflict policy). `mycelium/slim/l9.py` gained `KNOWLEDGE_KIND` + `payload_data_of`.
+  **This is exactly the receiver a second machine needs — it just isn't on a remote channel yet.**
+- **The shared-node CLI surface already exists.** `mycelium hub host` (`commands/hub.py`) spins up
+  the `slim:1.4.0` node container and prints the host's **LAN IP**; `mycelium connect <address>`
+  (top-level, registered in `cli.py`) stores a remote `slim.node_endpoint` in config — "same
+  command whether the node is self- or mycelium-hosted." The plumbing to *point at* a remote node
+  is built; what's unproven is two hosts **actually coordinating** through one.
+- **Reindex on a write is implicit.** On the host, a connector writes markdown under
+  `~/.mycelium/rooms/{room}/` and the always-on **backend's** file watcher (`reindex.py`)
+  re-embeds it. On a second machine that only runs a daemon, **there is no watcher** — the write
+  lands but the JSONL never updates. This is the sharpest gap you must close (see traps).
+
+## Your Step 9 scope (from the bible, Part V · Step 9)
+
+- **Join a remote/shared node.** Make `mycelium connect` + the daemon/backend actually coordinate
+  through a node on **another host on the LAN**: host A runs `mycelium hub host` (node + backend/
+  moderator); host B runs `mycelium connect <A-LAN-IP>` and its daemon joins A's room channel.
+  Document the open-internet path (hosted rendezvous or tunnel); do not block on NAT.
+- **Keep per-machine stores in sync by the `knowledge` stream.** The Step 8 receiver already
+  writes + (must) reindex on arrival; make sure it fires on **host B's** store when the plan push
+  crosses the shared channel. **Close the reindex gap** on a daemon-only host (decide: run a
+  backend watcher on B, or have the connector reindex explicitly after `apply_knowledge`).
+- **Consent-invite across machines (Step 6).** An `@`-invite of host B's agent must surface the
+  consent prompt to **B's** human and, on accept, invite B's connector into the channel A
+  moderates. Verify the consent → invite → join → re-serve path works when invitee and moderator
+  are on different hosts.
+- **Key files:** `commands/hub.py` / `cli.py` (`connect`); `slim/client.py` +
+  `app/services/slim_client.py` (remote endpoint, shared-secret parity); the sync path
+  (`connector.py` + `reindex.py`); the consent path (`app/routes/invites.py`,
+  `room_channels.py` invite/consent).
+
+## Facts you must internalize first
+
+- **One moderator per room, per channel.** The room is provisioned + moderated by **one** host's
+  backend (the host that "owns" the room). The other host runs a **daemon (connector) only**,
+  pointed at the shared node — it is a *member*, not a second moderator. Do **not** stand up a
+  second backend as moderator on the same room; membership/persistence would fork. (Whether host B
+  runs a full backend *at all* — just for its local watcher/UI — is the reindex decision below.)
+- **Cross-machine memory sync is the Step 8 path over a longer wire.** The `knowledge` receiver is
+  transport-agnostic — it does not care whether the node is `127.0.0.1` or a LAN peer. If two
+  hosts share a channel, the plan push already lands on B. The new work is **plumbing and proof**,
+  not a new sync mechanism. Resist rebuilding the write path.
+- **MLS is on and the channel secret is per-channel — both hosts need the same one.** `slim:1.4.0`
+  / `slim-bindings` 1.4.x is a matched pair; the shared secret is per-channel (see the SLIM
+  version-pin note). Cross-host, A and B must derive the **same** channel secret or the group
+  handshake fails. Confirm how the secret is provisioned to a joining host before you debug
+  "invite silently never lands."
+- **`knowledge` is push-with-content — still no notify-then-pull.** Cross-machine makes the "git
+  can't stream a delta into a running agent" point real (§11). Do not let host B fetch memory over
+  HTTP after a notify; the message carries the markdown.
+- **The verdict/plan record's causal chain stays in the record, not the wire.** As in Steps 7-8,
+  the `commit`/`knowledge` broadcasts carry **empty `message.parents`** so every host can release
+  them regardless of what it has seen; the rich chain lives in `log/episodes/*`.
+
+## Definition of Done
+
+Two machines on a LAN run the full hero flow: `mycelium connect` joins them through one shared
+node → an `@`-invite with a **consent prompt** brings the second host's agent in → the agents
+exchange L9 messages → a summoned aligner converges them and emits `commit:converged` → a shared
+plan compiles into markdown memory **synced to both machines** (markdown + JSONL on each) → each
+agent works its half. This is the bible's **Acceptance** hero demo, minus the UI inspector
+(Step 10).
+
+## Tests to write (end of step)
+
+Fast unit tests (the merge gate — no node):
+
+- **Remote endpoint plumbing** — `mycelium connect <addr>` persists a normalized remote
+  `node_endpoint`; the daemon/backend read it (not the `127.0.0.1` default) when constructing the
+  SLIM client.
+- **Reindex-on-arrival is explicit where there's no watcher** — whatever you choose for host B,
+  unit-cover that a `knowledge` apply updates the JSONL on a store with **no running watcher**
+  (i.e. the connector/daemon path reindexes, or the chosen watcher is exercised).
+- **Consent across a host boundary (pure pieces)** — the invite/consent state machine resolves an
+  accept into an invite for an agent whose connector is remote (no node needed for the state
+  logic).
+
+Live-node **integration slice** (guarded, adds to the cumulative suite — **all prior slices must
+still pass**, backend + CLI):
+
+- **Cross-machine acceptance:** the full flow across **two nodes / a shared node on a LAN, or two
+  containers on a docker bridge network**. Model on
+  `tests/test_l9_over_slim_roundtrip.py::test_converged_compiles_plan_and_syncs_memory_over_slim`
+  (Step 8) but make the "second store" a **genuinely separate host/container/data-dir on the
+  bridge**, not a swapped `MYCELIUM_DATA_DIR`: assert the `plan/tasks.md` markdown **and** the
+  JSONL index land on the remote store, and that a consent-invite from the moderator host brings
+  the remote member in. This is the **final acceptance test** — the whole suite green, end to end.
+
+## Verification gate (must pass before you call Step 9 done)
+
+```bash
+# Backend
+cd fastapi-backend
+uv run ruff check . && uv run ruff format --check . && uv run ty check .
+MYCELIUM_STUB_EMBEDDINGS=1 uv run pytest tests/ -x -q            # fast gate, no node
+
+# CLI (matches CI)
+cd ../mycelium-cli
+uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run pytest tests/ -x -q
+
+# Guarded integration slices — bring TWO reachable nodes (or one shared node + two data dirs on a
+# docker bridge) up first; run the cross-machine slices by file:
+MYCELIUM_STUB_EMBEDDINGS=1 MYCELIUM_SLIM_ENDPOINT=http://<shared-node>:46357 \
+  uv run pytest tests/test_l9_over_slim_roundtrip.py -q   # backend; run the CLI connector slices by file too
+```
+
+Bring nodes up with the same docker recipe Steps 5-8 used (the `ghcr.io/agntcy/slim:1.4.0`
+one-liner in [`START_HERE_STEP_5.md`](./START_HERE_STEP_5.md)); for the two-container path put
+both on a shared docker **bridge network** so they route to one node by service name.
+
+> **Known pre-existing wrinkle (not yours to fix):** running the *whole* CLI suite with
+> `MYCELIUM_SLIM_ENDPOINT` exported trips `tests/test_slim_config.py::test_connect_persists_endpoint`.
+> Run the guarded slices **by file** rather than reading a whole-suite pass/fail with that env set.
+
+## Traps specific to Step 9
+
+- **Close the reindex gap on a daemon-only host.** On the moderator host the backend watcher
+  reindexes a connector's write; a second host that runs *only* a daemon has no watcher, so the
+  `knowledge` markdown lands but search never sees it. **Decide and wire** one path (connector
+  reindexes after `apply_knowledge`, or host B runs a backend for its watcher) — don't leave the
+  remote store's JSONL silently stale.
+- **Don't fork the moderator.** One backend moderates the room; the other host is a member. Two
+  moderators = two persisters = a split transcript/membership.
+- **Shared secret parity.** If the group handshake "silently never lands" cross-host, suspect the
+  per-channel MLS secret before the network. Confirm how a joining host obtains it.
+- **Don't rebuild the sync mechanism.** The Step 8 `knowledge` path already carries content across
+  any node. Step 9 is connect + consent + reindex + proof, not a new memory protocol.
+- **LAN first; document, don't build, NAT.** A reachable/hosted node or a tunnel is the
+  open-internet story — note it; the MVP DoD is a LAN.
+- **MLS on, version stays pinned.** `slim:1.4.0` / `slim-bindings` 1.4.x on **both** hosts — a
+  version skew across machines is a new failure mode; keep the matched pair.
+
+## What Step 8 deferred to you (explicit)
+
+- **Cross-machine reindex** — the connector currently relies on the co-located backend watcher;
+  a remote-only host needs its own reindex trigger. **This step.**
+- **Consent across a host boundary** — the consent state machine + UI bus are built (Step 6); this
+  step proves them when invitee and moderator are on different hosts.
+- **Hub location** — **resolve first:** default to a **self-hosted shared node** (`mycelium hub
+  host` on the owner's machine, peers `mycelium connect` to its LAN IP); a hosted rendezvous is
+  optional and post-MVP. Note your choice; flag it.
+
+## Later steps (unchanged)
+
+- **UI: protocol inspector + room view + consent prompt** is **Step 10** (optional to land right
+  after Step 8 so the same-machine demo already looks like something).
+- **SSE/`stream.py`** (and the legacy SSE/poller helpers still in the daemon's `dispatch.py`) are
+  retired in **Step 10**.
+- **SAB/TFP engines and the escalation ladder** are **post-MVP**.
+
+## Report when done
+
+Per `START_HERE.md`: what changed, the DoD check, and test results (fast gate + the cross-machine
+integration slice, noting all prior slices still pass, backend + CLI). Open a PR against
+`slim-native-rewrite` (same as Steps 0-8).

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -81,6 +81,7 @@ async def lifespan(app: FastAPI):
     # channel is provisioned, so all persisters pick it up. Dormant until an
     # @-summon of its reserved handle arrives — zero idle cost (bible §10).
     from app.services.aligner import AlignerEngine
+    from app.services.plan_sync import PlanSyncEngine
     from app.services.room_channels import manager as room_channel_manager
 
     app.state.aligner = AlignerEngine(room_channel_manager)
@@ -88,6 +89,13 @@ async def lifespan(app: FastAPI):
     logger.info(
         "SIEP aligner wired (@%s, mode=%s)", app.state.aligner.handle, settings.ALIGNER_MODE
     )
+
+    # Wire the converged→plan→memory-sync consumer (Step 8) onto the same seam:
+    # a ``commit:converged`` the aligner emits fires plan_compiler → plan/tasks.md
+    # and a ``knowledge`` push that syncs the compiled plan to every store (§11/§13).
+    app.state.plan_sync = PlanSyncEngine(room_channel_manager)
+    room_channel_manager.on_converged = app.state.plan_sync.handle_converged
+    logger.info("plan-sync consumer wired (commit:converged → plan_compiler + knowledge)")
 
     yield
     stop_watcher()

--- a/fastapi-backend/app/services/memory_sync.py
+++ b/fastapi-backend/app/services/memory_sync.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Memory sync over SLIM — the L9 ``knowledge`` write path (Step 8, bible §11).
+
+Memory content is canonical markdown; the JSONL index is derived. Cross-machine
+sync is **not** git: an L9 ``knowledge`` message **carries the content** so a
+running agent's working set updates mid-task (the one thing git can't stream).
+This module owns both halves of that seam:
+
+1. **Emit** — :func:`build_knowledge_envelope` wraps a :class:`KnowledgeWrite`
+   (key + markdown body + version metadata) as a ``knowledge:distillation``
+   envelope broadcast on the room channel. Converged content (the compiled plan)
+   flows out this way (see :mod:`app.services.plan_sync`).
+
+2. **Apply** — :func:`apply_knowledge` writes the carried markdown into a local
+   store and reindexes the JSONL. It is the receiver half every connector runs
+   (:mod:`mycelium.daemon.connector` mirrors it CLI-side) and the backend runs
+   for knowledge authored elsewhere.
+
+**Conflict policy (bible §11, decided): last-write-wins, no merge handler.**
+Order by ``version``. An arriving write is *idempotent* when the local file is
+already at its version (the same-machine loopback of a write the backend just
+made). A write built on a **stale base** — its version is behind the local
+file — **fails with details** (current content + ``updated_by`` + ``updated_at``)
+and moves on; no reconciliation is attempted.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from app.services import l9
+from app.services.l9_models import Kind
+
+if TYPE_CHECKING:
+    from app.services.l9_models import L9
+
+logger = logging.getLogger(__name__)
+
+# The ``knowledge`` subkind a memory-sync write rides as. ``distillation`` (from
+# the SLIM-native subkind table, l9.VALID_SUBKINDS) is converged content
+# distilled to a shareable artifact — exactly the compiled plan.
+KNOWLEDGE_SUBKIND = "distillation"
+KNOWLEDGE_PAYLOAD_TYPE = "distillation"
+
+
+@dataclass
+class KnowledgeWrite:
+    """One memory write carried on a ``knowledge`` message (push-with-content).
+
+    ``version`` is this write's new version; ``base_version`` is the version the
+    writer read before editing (``None`` for a create). The receiver compares
+    ``version`` against its own file to order writes and detect a stale base.
+    """
+
+    key: str
+    content: str
+    version: int
+    created_by: str
+    updated_by: str
+    updated_at: str
+    base_version: int | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "content": self.content,
+            "version": self.version,
+            "base_version": self.base_version,
+            "created_by": self.created_by,
+            "updated_by": self.updated_by,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_payload(cls, data: dict[str, Any]) -> KnowledgeWrite | None:
+        """Parse a ``knowledge`` payload into a write, or ``None`` if malformed."""
+        key = data.get("key")
+        content = data.get("content")
+        if not isinstance(key, str) or not key or not isinstance(content, str):
+            return None
+        try:
+            version = int(data.get("version", 1))
+        except (TypeError, ValueError):
+            version = 1
+        base_version_raw = data.get("base_version")
+        base_version: int | None
+        try:
+            base_version = int(base_version_raw) if base_version_raw is not None else None
+        except (TypeError, ValueError):
+            base_version = None
+        actor = str(data.get("updated_by") or data.get("created_by") or l9.SYSTEM_ACTOR_ID)
+        return cls(
+            key=key,
+            content=content,
+            version=version,
+            created_by=str(data.get("created_by") or actor),
+            updated_by=actor,
+            updated_at=str(data.get("updated_at") or datetime.now(UTC).isoformat()),
+            base_version=base_version,
+        )
+
+
+def knowledge_write_from_envelope(envelope: L9) -> KnowledgeWrite | None:
+    """Extract the :class:`KnowledgeWrite` an envelope carries, or ``None``."""
+    payload = envelope.payload
+    if payload is None or not isinstance(payload.data, dict):
+        return None
+    return KnowledgeWrite.from_payload(payload.data)
+
+
+def is_knowledge(envelope: L9) -> bool:
+    """True for a ``knowledge`` envelope (the memory-sync write trigger)."""
+    return envelope.header.kind == Kind.knowledge
+
+
+def build_knowledge_envelope(
+    *,
+    room: str,
+    write: KnowledgeWrite,
+    recipients: list[str],
+) -> L9:
+    """Build the ``knowledge:distillation`` envelope that carries ``write``.
+
+    Broadcast on the room channel; every connector applies it locally. Emitted
+    with empty causal parents — like the aligner's terminal verdict, a broadcast
+    memory push must be releasable by every member regardless of what each has
+    seen (the rich causal chain stays in the episode record).
+    """
+    return l9.build_envelope(
+        kind=Kind.knowledge,
+        subkind=KNOWLEDGE_SUBKIND,
+        episode=l9.episode_urn(room, "knowledge"),
+        recipients=recipients,
+        topic=l9.topic_urn(room),
+        payload_type=KNOWLEDGE_PAYLOAD_TYPE,
+        payload_data=write.to_payload(),
+    )
+
+
+@dataclass
+class ApplyResult:
+    """The outcome of applying a :class:`KnowledgeWrite` to a local store."""
+
+    key: str
+    applied: bool
+    conflict: bool
+    reason: str
+    version: int
+    # On a conflict, the current local state that the stale write lost to.
+    current: dict[str, Any] | None = None
+
+    def format_conflict(self) -> str:
+        """A one-line, log-ready description of a stale-base rejection."""
+        cur = self.current or {}
+        return (
+            f"stale-base write to {self.key!r} rejected: local v{cur.get('version')} "
+            f"by {cur.get('updated_by')!r} at {cur.get('updated_at')} "
+            f"(incoming v{self.version}); {self.reason}"
+        )
+
+
+def apply_knowledge_to_dir(base_dir: Any, write: KnowledgeWrite) -> ApplyResult:
+    """Apply ``write`` to a room dir (last-write-wins). No reindex — pure file IO.
+
+    Split out from :func:`apply_knowledge` so the conflict logic is unit-testable
+    against an arbitrary directory without touching the configured data dir or
+    the (heavier) index. Returns an :class:`ApplyResult`; never raises on a
+    conflict — a stale-base write is a *result*, not an error (bible §11).
+    """
+    from app.services.filesystem import read_memory_file, write_memory_file
+
+    existing = read_memory_file(base_dir, write.key)
+    if existing is not None:
+        meta, body = existing
+        try:
+            current_version = int(meta.get("version", 1))
+        except (TypeError, ValueError):
+            current_version = 1
+        if write.version == current_version:
+            # The write we already hold looped back (same-machine emit → apply).
+            return ApplyResult(
+                key=write.key,
+                applied=False,
+                conflict=False,
+                reason="already at this version (idempotent)",
+                version=write.version,
+            )
+        if write.version < current_version:
+            # Built on a base behind the local file: last-write-wins keeps the
+            # newer local content; surface the loss with details, do not merge.
+            return ApplyResult(
+                key=write.key,
+                applied=False,
+                conflict=True,
+                reason="incoming version behind local",
+                version=write.version,
+                current={
+                    "content": body,
+                    "version": current_version,
+                    "updated_by": meta.get("updated_by") or meta.get("created_by"),
+                    "updated_at": meta.get("updated_at"),
+                },
+            )
+
+    write_memory_file(
+        base_dir,
+        write.key,
+        write.content,
+        created_by=write.created_by,
+        updated_by=write.updated_by,
+        version=write.version,
+    )
+    return ApplyResult(
+        key=write.key,
+        applied=True,
+        conflict=False,
+        reason="applied",
+        version=write.version,
+    )
+
+
+async def apply_knowledge(room: str, write: KnowledgeWrite, *, reindex: bool = True) -> ApplyResult:
+    """Apply ``write`` to the room's local store and reindex the JSONL.
+
+    The receiver half of the ``knowledge`` seam: writes the carried markdown into
+    the configured data dir (so a *second* store is simulated by pointing
+    ``MYCELIUM_DATA_DIR`` at it) and, on a real write, updates the search index
+    the normal single-file way. A stale-base rejection is logged, not raised.
+    """
+    from app.services.filesystem import get_room_dir
+
+    result = apply_knowledge_to_dir(get_room_dir(room), write)
+    if result.conflict:
+        logger.warning("%s", result.format_conflict())
+        return result
+    if result.applied and reindex:
+        try:
+            from app.services.indexer import index_single_file
+
+            await index_single_file(room, write.key)
+        except Exception:
+            logger.exception("reindex after knowledge write failed for %s/%s", room, write.key)
+    return result

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -23,8 +23,9 @@ consumer, and it does four things as each message flows past:
    and calls a summon hook; the real cognition-engine wiring is Step 7. Here the
    hook defaults to a log.
 
-4. **plan-compile hook (skeleton).** On a ``commit:converged`` envelope it fires
-   a seam Step 8 will use to run ``plan_compiler``; it does **not** compile here.
+4. **plan-compile hook.** On a ``commit:converged`` envelope it fires the
+   ``on_converged`` seam the plan-sync consumer runs ``plan_compiler`` off of
+   (Step 8); the persister itself does **not** compile — it just fires the seam.
 
 The pure pieces (:class:`DeliveryLog`, the transcript read/write, the trigger
 detection) carry no SLIM dependency and are unit-tested without a node;
@@ -312,9 +313,11 @@ def _default_summon_hook(handle: str, envelope: L9) -> None:
 
 
 def _default_converged_hook(envelope: L9) -> None:
+    # Log-only default for a persister with no plan-sync consumer wired (unit
+    # tests / a bare backend). In the running backend ``main.py`` binds this to
+    # the plan-sync consumer via the manager's ``_converged_adapter`` (Step 8).
     logger.info(
-        "plan-compile hook (skeleton): commit:converged on episode %s; "
-        "plan_compiler wiring is Step 8",
+        "converged hook (unwired): commit:converged on episode %s; no plan-sync consumer",
         envelope.header.message.episode if envelope.header.message else "?",
     )
 

--- a/fastapi-backend/app/services/plan.py
+++ b/fastapi-backend/app/services/plan.py
@@ -258,11 +258,14 @@ def write_plan_file(
     *,
     slug: str = DEFAULT_TASK_FILE,
     updated_by: str = "CognitiveEngine",
+    version: int = 1,
 ) -> Path:
     """Overwrite ``plan/{slug}.md`` with a full markdown body.
 
     Frontmatter is managed by ``write_memory_file``; ``load_plan`` strips it on
     read. Used by the plan compiler to materialize a negotiation consensus.
+    ``version`` bumps on a re-compile so the memory-sync ``knowledge`` stream
+    (bible §11) can order writes and detect a stale base.
     """
     from app.services.filesystem import write_memory_file
 
@@ -274,6 +277,7 @@ def write_plan_file(
         body.rstrip("\n") + "\n",
         created_by=updated_by,
         updated_by=updated_by,
+        version=version,
     )
 
 

--- a/fastapi-backend/app/services/plan_sync.py
+++ b/fastapi-backend/app/services/plan_sync.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Converged → plan → memory sync (Step 8, bible §13 ``[plan]``).
+
+Step 7 lit up the aligner: an ``@``-summon makes it score the transcript and
+emit an L9 ``commit:converged`` onto the channel. This module is the *consumer*
+across that seam — the backend, seeing the converged verdict, turns it into work:
+
+1. **Compile the plan.** The converged envelope carries ``assignments`` (built by
+   the aligner in ``aligner._fold``). :mod:`app.services.plan_compiler` — one LLM
+   call — turns that into a ``- [ ]`` checklist materialized at ``plan/tasks.md``.
+   Fail-soft: a compiler outage falls back to the raw ``assignments`` so the
+   verdict is never sunk (the old ``_finish_cfn`` behaviour).
+
+2. **Sync it as memory.** The compiled plan becomes a ``knowledge`` message that
+   **carries the content** (bible §11, push-with-content) so every participant's
+   local store converges — and, because the verdict was already on the wire when
+   this fires, the ``knowledge`` broadcast doubles as the **"plan ready" signal**
+   a consumer waits for (the SLIM-path replacement for the old CFN plan-first
+   ordering).
+
+Deliberately **not** a cognition-engine step (the CLAUDE.md plan-compiler
+decision): the compiler is a distinct consumer stage reached across the
+``on_converged`` seam, wired in :mod:`app.main`, never called from inside the
+aligner. Room-awareness mirrors Step 7's summon seam — the persister's hook is
+``(envelope)`` only, so :class:`~app.services.room_channels.RoomChannelManager`
+binds the room via ``_converged_adapter`` before handing it here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from app.services import l9, memory_sync, plan, plan_compiler
+from app.services.l9_slim import serialize_content
+
+if TYPE_CHECKING:
+    from app.services.l9_models import L9
+    from app.services.room_channels import RoomChannelManager
+
+logger = logging.getLogger(__name__)
+
+PLAN_TASKS_KEY = f"{plan.PLAN_DIR}/{plan.DEFAULT_TASK_FILE}"
+
+
+def _assignments_from(envelope: L9) -> dict[str, str]:
+    """The ``assignments`` map the aligner put on the converged envelope.
+
+    Coerced to ``{handle: str}`` — a value may be an ``offer`` dict, which the
+    compiler renders as an ``issue = value`` line, so a stringified form is
+    lossless enough for the prompt and keeps the compiler's typed signature.
+    """
+    payload = envelope.payload
+    data = payload.data if payload is not None and isinstance(payload.data, dict) else {}
+    raw = data.get("assignments")
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): v if isinstance(v, str) else str(v) for k, v in raw.items()}
+
+
+class PlanSyncEngine:
+    """Wires ``on_converged`` to plan compilation + memory sync (one per process).
+
+    Dormant like the aligner: nothing runs until a ``commit:converged`` flows past
+    the persister, at which point :meth:`handle_converged` schedules one compile +
+    sync run per room. A second converged verdict while a run is in flight for the
+    same room is ignored (a run re-negotiation lands as its own later verdict).
+    """
+
+    def __init__(self, manager: RoomChannelManager) -> None:
+        self._manager = manager
+        self._active: set[str] = set()
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    # -- the on_converged seam (sync; room-bound by the manager's adapter) --
+
+    def handle_converged(self, room: str, envelope: L9) -> None:
+        """Schedule the compile + sync run for a room's converged verdict."""
+        if room in self._active:
+            logger.debug("plan-sync already active on room %s; ignoring re-converge", room)
+            return
+        self._active.add(room)
+        task = asyncio.create_task(self._run_and_release(room, envelope))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _run_and_release(self, room: str, envelope: L9) -> None:
+        try:
+            await self.compile_and_sync(room, envelope)
+        except Exception:
+            logger.exception("plan-sync run failed on room %s", room)
+        finally:
+            self._active.discard(room)
+
+    # -- the run --
+
+    async def compile_and_sync(self, room: str, envelope: L9) -> memory_sync.KnowledgeWrite | None:
+        """Compile ``plan/tasks.md`` from the verdict and broadcast it as memory.
+
+        Returns the :class:`~app.services.memory_sync.KnowledgeWrite` broadcast,
+        or ``None`` when there was no channel/assignments to act on.
+        """
+        assignments = _assignments_from(envelope)
+        existing_plan = plan.read_plan_file(room)
+        base_version = _current_plan_version(room)
+        new_version = (base_version or 0) + 1
+
+        body = await self._compile_body(room, assignments, existing_plan)
+        plan.write_plan_file(room, body, updated_by=l9.SYSTEM_ACTOR_ID, version=new_version)
+        plan.set_title_from_body_if_absent(room, body, updated_by=l9.SYSTEM_ACTOR_ID)
+        logger.info("compiled plan/tasks.md for room %s (v%d)", room, new_version)
+
+        return await self._broadcast_knowledge(room, body, new_version, base_version)
+
+    async def _compile_body(
+        self, room: str, assignments: dict[str, str], existing_plan: str | None
+    ) -> str:
+        """Compile the plan body, falling back to the raw agreement on failure."""
+        try:
+            return await plan_compiler.compile_plan(
+                room_name=room,
+                assignments=assignments,
+                joined_intents="",
+                issue_options=None,
+                existing_plan=existing_plan,
+            )
+        except Exception:
+            logger.warning(
+                "plan compiler failed for room %s; writing raw agreement (fail-soft)", room
+            )
+            return plan_compiler.fallback_body(assignments)
+
+    async def _broadcast_knowledge(
+        self, room: str, body: str, version: int, base_version: int | None
+    ) -> memory_sync.KnowledgeWrite | None:
+        """Emit the compiled plan as a ``knowledge`` message carrying its content."""
+        managed = self._manager.get(room)
+        if managed is None:
+            logger.debug("no live channel for room %s; plan written but not synced", room)
+            return None
+        write = memory_sync.KnowledgeWrite(
+            key=PLAN_TASKS_KEY,
+            content=body.rstrip("\n") + "\n",
+            version=version,
+            created_by=l9.SYSTEM_ACTOR_ID,
+            updated_by=l9.SYSTEM_ACTOR_ID,
+            updated_at=_now_iso(),
+            base_version=base_version,
+        )
+        envelope = memory_sync.build_knowledge_envelope(
+            room=room, write=write, recipients=self._manager.members(room)
+        )
+        content = serialize_content(envelope, extra={"content": f"plan updated → {PLAN_TASKS_KEY}"})
+        try:
+            await managed.channel.send(envelope, extra={"content": content["content"]})
+        except Exception:
+            logger.warning("failed to broadcast plan knowledge on room %s", room)
+        # Record locally (deduped by message id) so the transcript + UI bus see
+        # the "plan ready" signal even if SLIM never loops our broadcast back.
+        if managed.persister is not None:
+            managed.persister.ingest_local(envelope, content)
+        return write
+
+
+def _current_plan_version(room: str) -> int | None:
+    """The version of the room's current ``plan/tasks.md`` frontmatter, if any."""
+    from app.services.filesystem import get_room_dir, read_memory_file
+
+    result = read_memory_file(get_room_dir(room), PLAN_TASKS_KEY)
+    if result is None:
+        return None
+    try:
+        return int(result[0].get("version", 1))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _now_iso() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -62,6 +62,12 @@ if TYPE_CHECKING:
 # signature by binding the room.
 RoomSummonHook = Callable[[str, str, "L9"], None]
 
+# The room-aware converged hook, same shape reasoning as ``RoomSummonHook``: the
+# persister's ``ConvergedHook`` is ``(envelope)`` only, but the consumer wired to
+# it (Step 8's plan-sync) needs the room to compile that room's plan + sync its
+# memory. ``_converged_adapter`` binds the room down to the persister signature.
+RoomConvergedHook = Callable[[str, "L9"], None]
+
 logger = logging.getLogger(__name__)
 
 # The moderator's app id (third Name segment) on every room channel. Distinct
@@ -111,12 +117,12 @@ class RoomChannelManager:
         # Consent-gated invites raised by an @-mention of a not-present agent
         # (bible §12). The moderator only invites on accept.
         self._invites = PendingInviteRegistry()
-        # Trigger hooks handed to every persister. ``on_summon`` is wired at
-        # startup (``main.py``) to the SIEP aligner's ``handle_summon`` (Step 7);
-        # ``on_converged`` stays a skeleton until Step 8 wires it to
-        # ``plan_compiler``. Unset → the persister's log-only defaults.
+        # Trigger hooks handed to every persister, both room-aware and wired at
+        # startup (``main.py``): ``on_summon`` → the SIEP aligner's
+        # ``handle_summon`` (Step 7); ``on_converged`` → the plan-sync consumer's
+        # ``handle_converged`` (Step 8). Unset → the persister's log-only defaults.
         self.on_summon: RoomSummonHook | None = None
-        self.on_converged: ConvergedHook | None = None
+        self.on_converged: RoomConvergedHook | None = None
 
     def get(self, room: str) -> ManagedRoomChannel | None:
         return self._channels.get(room)
@@ -182,7 +188,7 @@ class RoomChannelManager:
             managed.channel,
             members_provider=lambda: self.members(room),
             on_summon=self._summon_adapter(room),
-            on_converged=self.on_converged,
+            on_converged=self._converged_adapter(room),
         )
         managed.persister_task = asyncio.create_task(managed.persister.run())
 
@@ -199,6 +205,23 @@ class RoomChannelManager:
 
         def adapter(handle: str, envelope: L9, _room: str = room) -> None:
             hook(_room, handle, envelope)
+
+        return adapter
+
+    def _converged_adapter(self, room: str) -> ConvergedHook | None:
+        """Bind ``room`` onto the room-aware ``on_converged`` hook.
+
+        Mirrors :meth:`_summon_adapter`: the persister calls its ``ConvergedHook``
+        with only ``(envelope)``, but the plan-sync consumer needs the room too.
+        When no hook is wired, return ``None`` so the persister keeps its log-only
+        default.
+        """
+        hook = self.on_converged
+        if hook is None:
+            return None
+
+        def adapter(envelope: L9, _room: str = room) -> None:
+            hook(_room, envelope)
 
         return adapter
 

--- a/fastapi-backend/scripts/l9_slim_roundtrip.py
+++ b/fastapi-backend/scripts/l9_slim_roundtrip.py
@@ -318,6 +318,69 @@ async def run_aligner_observe(endpoint: str = DEFAULT_NODE_ENDPOINT) -> L9:
         await manager.close_all()
 
 
+async def run_aligner_converge_and_sync(
+    endpoint: str = DEFAULT_NODE_ENDPOINT,
+) -> tuple[L9, L9]:
+    """Prove the Step 8 same-machine DoD over a live node.
+
+    Extends :func:`run_aligner_observe`: after the aligner emits
+    ``commit:converged``, the backend's plan-sync consumer (wired on
+    ``on_converged``) compiles ``plan/tasks.md`` and broadcasts the compiled plan
+    as an L9 ``knowledge`` message that **carries the content**. A participant
+    receives both the ``commit`` and the ``knowledge`` push. Returns
+    ``(commit_envelope, knowledge_envelope)`` — the caller asserts the plan file
+    exists and applies the knowledge write to a *second* local store.
+    """
+    from app.services.aligner import AlignerEngine
+    from app.services.plan_sync import PlanSyncEngine
+
+    manager = RoomChannelManager(endpoint=endpoint, default_workspace=_WORKSPACE)
+    aligner = AlignerEngine(manager, handle="aligner", mode="observer", threshold=0.6)
+    plan_sync = PlanSyncEngine(manager)
+    # Wire BOTH seams before provision so the persister picks them up.
+    manager.on_summon = aligner.handle_summon
+    manager.on_converged = plan_sync.handle_converged
+    managed = await manager.provision(_ALIGN_ROOM)
+    assert managed is not None and managed.persister is not None
+    persister = managed.persister
+
+    agent_a = await SlimClient(SlimIdentity(_WORKSPACE, _ALIGN_ROOM, "agent-a")).connect(endpoint)
+    agent_b = await SlimClient(SlimIdentity(_WORKSPACE, _ALIGN_ROOM, "agent-b")).connect(endpoint)
+
+    try:
+        a_listen = asyncio.create_task(agent_a.listen_for_session())
+        b_listen = asyncio.create_task(agent_b.listen_for_session())
+        await manager.invite(_ALIGN_ROOM, "agent-a")
+        await manager.invite(_ALIGN_ROOM, "agent-b")
+        a_channel = L9SlimChannel(agent_a, await a_listen)
+        b_channel = L9SlimChannel(agent_b, await b_listen)
+
+        await a_channel.send(_align_position("agent-a", 0.8, "align-a"))
+        await b_channel.send(_align_position("agent-b", 0.9, "align-b"))
+        positions = {"align-a", "align-b"}
+        await _wait_for(
+            lambda: positions <= {r.message_id for r in persister.log.records}, timeout=15.0
+        )
+
+        await a_channel.send(_align_summon(), extra={"content": "@aligner please converge"})
+
+        # Collect until BOTH the commit verdict and the knowledge plan-push land.
+        commit: L9 | None = None
+        knowledge: L9 | None = None
+        while commit is None or knowledge is None:
+            for env in await b_channel.receive(timeout_s=15.0):
+                kind = env.header.kind.value
+                if kind == "commit" and commit is None:
+                    commit = env
+                elif kind == "knowledge" and knowledge is None:
+                    knowledge = env
+        return commit, knowledge
+    finally:
+        await agent_a.close()
+        await agent_b.close()
+        await manager.close_all()
+
+
 async def _main(endpoint: str) -> int:
     received = await run_roundtrip(endpoint)
     ids = [e.header.message.id for e in received if e.header.message is not None]

--- a/fastapi-backend/tests/test_l9_over_slim_roundtrip.py
+++ b/fastapi-backend/tests/test_l9_over_slim_roundtrip.py
@@ -106,3 +106,42 @@ async def test_aligner_observes_and_emits_converged_over_slim(tmp_path, monkeypa
     assert commit.header.subkind == "converged"
     metrics = commit.payload.data.get("metrics")
     assert metrics is not None and metrics["mpc"] >= 0.6
+
+
+@pytest.mark.asyncio
+async def test_converged_compiles_plan_and_syncs_memory_over_slim(tmp_path, monkeypatch):
+    """Step 8 DoD (same-machine): @-summon the aligner over a seeded exchange →
+    it emits commit:converged → the backend compiles plan/tasks.md → a knowledge
+    message carries the compiled plan, and applying it to a *second* local store
+    writes the markdown and updates that store's JSONL index."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.services import memory_sync, plan_compiler, search_index
+    from app.services.filesystem import get_room_dir, read_memory_file
+    from scripts.l9_slim_roundtrip import _ALIGN_ROOM, run_aligner_converge_and_sync
+
+    store1 = tmp_path / "store1"
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(store1 / ".mycelium"))
+
+    fake_plan = "# Converged Plan\n\n- [ ] ship the thing @agent-a\n- [ ] document it @agent-b"
+    with patch.object(plan_compiler, "compile_plan", AsyncMock(return_value=fake_plan)):
+        commit, knowledge = await run_aligner_converge_and_sync(_ENDPOINT)
+
+    assert commit.header.subkind == "converged"
+    assert memory_sync.is_knowledge(knowledge)
+
+    # First store: the backend compiled plan/tasks.md from the verdict.
+    plan1 = read_memory_file(get_room_dir(_ALIGN_ROOM), "plan/tasks")
+    assert plan1 is not None and "ship the thing" in plan1[1]
+
+    # Second store: the knowledge push carried the content; apply it there.
+    write = memory_sync.knowledge_write_from_envelope(knowledge)
+    assert write is not None and write.key == "plan/tasks"
+    store2 = tmp_path / "store2"
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(store2 / ".mycelium"))
+    result = await memory_sync.apply_knowledge(_ALIGN_ROOM, write)
+    assert result.applied
+
+    plan2 = read_memory_file(get_room_dir(_ALIGN_ROOM), "plan/tasks")
+    assert plan2 is not None and "ship the thing" in plan2[1]
+    assert "plan/tasks" in {r["key"] for r in search_index.load_index(_ALIGN_ROOM)}

--- a/fastapi-backend/tests/test_memory_sync.py
+++ b/fastapi-backend/tests/test_memory_sync.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Tests for the L9 ``knowledge`` memory-sync write path (Step 8, bible §11).
+
+Fast unit tests (the merge gate — no node): the ``knowledge`` envelope shape, the
+apply-to-local-store write + reindex, and the last-write-wins conflict policy
+(idempotent same-version loopback; stale-base rejection with details, no merge).
+"""
+
+import pytest
+
+from app.services import memory_sync, search_index
+from app.services.filesystem import get_room_dir, read_memory_file
+from app.services.l9_models import Kind
+
+
+def _write(
+    key: str = "plan/tasks",
+    *,
+    version: int = 1,
+    base: int | None = None,
+    content="# Plan\n\n- [ ] x",
+) -> memory_sync.KnowledgeWrite:
+    return memory_sync.KnowledgeWrite(
+        key=key,
+        content=content,
+        version=version,
+        created_by="CognitiveEngine",
+        updated_by="CognitiveEngine",
+        updated_at="2026-08-04T00:00:00+00:00",
+        base_version=base,
+    )
+
+
+class TestKnowledgeWrite:
+    def test_payload_round_trip(self):
+        w = _write(version=3, base=2)
+        back = memory_sync.KnowledgeWrite.from_payload(w.to_payload())
+        assert back is not None
+        assert (back.key, back.content, back.version, back.base_version) == (
+            w.key,
+            w.content,
+            3,
+            2,
+        )
+
+    def test_from_payload_rejects_malformed(self):
+        assert memory_sync.KnowledgeWrite.from_payload({"key": "", "content": "x"}) is None
+        assert memory_sync.KnowledgeWrite.from_payload({"content": "x"}) is None
+        assert memory_sync.KnowledgeWrite.from_payload({"key": "k"}) is None
+
+    def test_from_payload_defaults_bad_version(self):
+        back = memory_sync.KnowledgeWrite.from_payload(
+            {"key": "k", "content": "c", "version": "nope"}
+        )
+        assert back is not None and back.version == 1
+
+
+class TestKnowledgeEnvelope:
+    def test_carries_the_write_as_knowledge_distillation(self):
+        env = memory_sync.build_knowledge_envelope(room="r", write=_write(), recipients=["a", "b"])
+        assert env.header.kind == Kind.knowledge
+        assert env.header.subkind == memory_sync.KNOWLEDGE_SUBKIND
+        assert memory_sync.is_knowledge(env)
+        # Broadcast terminal push: no wire parents (releasable by everyone).
+        assert env.header.message is not None and env.header.message.parents == []
+        back = memory_sync.knowledge_write_from_envelope(env)
+        assert back is not None and back.key == "plan/tasks"
+
+
+@pytest.mark.asyncio
+class TestApplyKnowledge:
+    async def test_writes_markdown_and_reindexes_second_store(self):
+        """A knowledge write lands as markdown AND updates the JSONL index."""
+        result = await memory_sync.apply_knowledge(
+            "second-store", _write(content="# Plan\n\n- [ ] ship it")
+        )
+        assert result.applied and not result.conflict
+
+        got = read_memory_file(get_room_dir("second-store"), "plan/tasks")
+        assert got is not None
+        meta, body = got
+        assert "ship it" in body
+        assert meta["version"] == 1
+
+        # Reindexed: the JSONL search index carries the new record.
+        keys = {r["key"] for r in search_index.load_index("second-store")}
+        assert "plan/tasks" in keys
+
+    async def test_idempotent_same_version_loopback(self):
+        """Re-applying the same version (same-machine emit→apply) is a no-op."""
+        await memory_sync.apply_knowledge("r", _write(version=1))
+        again = await memory_sync.apply_knowledge("r", _write(version=1, content="# Different"))
+        assert not again.applied and not again.conflict
+        # The original content is untouched — no clobber by an equal-version write.
+        got = read_memory_file(get_room_dir("r"), "plan/tasks")
+        assert got is not None and "# Different" not in got[1]
+
+    async def test_newer_version_wins(self):
+        await memory_sync.apply_knowledge("r", _write(version=1, content="# v1"))
+        res = await memory_sync.apply_knowledge("r", _write(version=2, base=1, content="# v2 wins"))
+        assert res.applied
+        got = read_memory_file(get_room_dir("r"), "plan/tasks")
+        assert got is not None and "v2 wins" in got[1] and got[0]["version"] == 2
+
+
+class TestConflictPolicy:
+    def test_stale_base_rejected_with_details_no_merge(self, tmp_path):
+        """A write on a stale base fails with current details; nothing is merged."""
+        base_dir = tmp_path / "store"
+        base_dir.mkdir()
+        # Local is already at version 3 (someone advanced it).
+        memory_sync.apply_knowledge_to_dir(
+            base_dir,
+            memory_sync.KnowledgeWrite(
+                key="plan/tasks",
+                content="# current v3",
+                version=3,
+                created_by="alice",
+                updated_by="alice",
+                updated_at="2026-08-04T03:00:00+00:00",
+            ),
+        )
+        # An incoming write built on base v1 → version 2, behind local v3.
+        result = memory_sync.apply_knowledge_to_dir(
+            base_dir, _write(version=2, base=1, content="# stale v2")
+        )
+        assert result.conflict and not result.applied
+        assert result.current is not None
+        assert result.current["version"] == 3
+        assert result.current["updated_by"] == "alice"
+        assert "current v3" in result.current["content"]
+        # No merge: the local file still holds v3 verbatim.
+        _meta, body = read_memory_file(base_dir, "plan/tasks")  # type: ignore[misc]
+        assert body.strip() == "# current v3"
+        # The rejection formats a log-ready line.
+        assert "stale-base" in result.format_conflict()

--- a/fastapi-backend/tests/test_plan_sync.py
+++ b/fastapi-backend/tests/test_plan_sync.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Tests for the converged→plan→memory-sync consumer (Step 8, bible §13).
+
+Fast unit tests (the merge gate — no node): a ``commit:converged`` fired through
+the consumer compiles ``plan/tasks.md`` (LLM mocked, as the plan-compiler tests
+do), broadcasts it as a ``knowledge`` push, and fails soft to the raw agreement
+when the compiler is down.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import l9, memory_sync, plan, plan_sync
+from app.services.filesystem import get_room_dir, read_memory_file
+from app.services.l9_models import L9, Kind
+
+
+def _converged(assignments: dict) -> L9:
+    """A ``commit:converged`` envelope carrying ``assignments`` (aligner output)."""
+    return l9.build_envelope(
+        kind=Kind.commit,
+        subkind="converged",
+        episode=l9.episode_urn("r", "live"),
+        recipients=["a", "b"],
+        topic=l9.topic_urn("r"),
+        payload_type="consensus",
+        payload_data={"assignments": assignments, "metrics": {"mpc": 0.82}},
+    )
+
+
+class _FakeChannel:
+    def __init__(self) -> None:
+        self.sent: list = []
+
+    async def send(self, envelope, *, extra=None) -> None:
+        self.sent.append((envelope, extra))
+
+
+class _FakeManaged:
+    def __init__(self, channel) -> None:
+        self.channel = channel
+        self.persister = None
+
+
+class _FakeManager:
+    """Just enough of RoomChannelManager for the consumer: get + members."""
+
+    def __init__(self, *, live: bool = True) -> None:
+        self.channel = _FakeChannel()
+        self._managed = _FakeManaged(self.channel) if live else None
+
+    def get(self, room):
+        return self._managed
+
+    def members(self, room):
+        return ["a", "b"]
+
+
+@pytest.mark.asyncio
+class TestConvergedToPlan:
+    async def test_compiles_plan_file_with_expected_tasks(self):
+        mgr = _FakeManager()
+        engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
+        fake_plan = "# MVP Delivery\n\n- [ ] ship auth @a\n- [ ] write docs @b"
+        with patch.object(
+            plan_sync.plan_compiler, "compile_plan", AsyncMock(return_value=fake_plan)
+        ):
+            write = await engine.compile_and_sync("r", _converged({"a": "auth", "b": "docs"}))
+
+        got = read_memory_file(get_room_dir("r"), plan_sync.PLAN_TASKS_KEY)
+        assert got is not None
+        meta, body = got
+        assert "ship auth @a" in body and "write docs @b" in body
+        assert meta["version"] == 1
+        # The compiled plan also became a knowledge push carrying its content.
+        assert write is not None and write.content.startswith("# MVP Delivery")
+        assert len(mgr.channel.sent) == 1
+        env, _extra = mgr.channel.sent[0]
+        assert env.header.kind == Kind.knowledge
+        carried = memory_sync.knowledge_write_from_envelope(env)
+        assert carried is not None and carried.version == 1 and carried.base_version is None
+
+    async def test_sets_plan_title_from_heading(self):
+        mgr = _FakeManager()
+        engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
+        with patch.object(
+            plan_sync.plan_compiler,
+            "compile_plan",
+            AsyncMock(return_value="# Sprint Plan\n\n- [ ] x"),
+        ):
+            await engine.compile_and_sync("r", _converged({"a": "x"}))
+        assert plan.get_title("r") == "Sprint Plan"
+
+    async def test_recompile_bumps_version_and_threads_base(self):
+        mgr = _FakeManager()
+        engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
+        with patch.object(
+            plan_sync.plan_compiler,
+            "compile_plan",
+            AsyncMock(side_effect=["# Plan\n\n- [ ] one", "# Plan\n\n- [ ] two"]),
+        ):
+            await engine.compile_and_sync("r", _converged({"a": "one"}))
+            write2 = await engine.compile_and_sync("r", _converged({"a": "two"}))
+
+        got = read_memory_file(get_room_dir("r"), plan_sync.PLAN_TASKS_KEY)
+        assert got is not None and got[0]["version"] == 2 and "two" in got[1]
+        assert write2 is not None and write2.version == 2 and write2.base_version == 1
+
+    async def test_fail_soft_compile_falls_back_to_raw_agreement(self):
+        """A compiler outage must not sink the verdict — write the raw agreement."""
+        mgr = _FakeManager()
+        engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
+        with patch.object(
+            plan_sync.plan_compiler,
+            "compile_plan",
+            AsyncMock(side_effect=RuntimeError("LLM down")),
+        ):
+            # Must not raise.
+            write = await engine.compile_and_sync(
+                "r", _converged({"scope": "full", "timeline": "6mo"})
+            )
+
+        got = read_memory_file(get_room_dir("r"), plan_sync.PLAN_TASKS_KEY)
+        assert got is not None
+        body = got[1]
+        # fallback_body renders the raw issue=value lines.
+        assert "scope: full" in body and "timeline: 6mo" in body
+        assert write is not None
+
+    async def test_converged_adapter_binds_room_like_summon_seam(self):
+        """The manager's ``on_converged`` adapter injects the room the persister
+        can't (mirrors Step 7's summon adapter)."""
+        from app.services.room_channels import RoomChannelManager
+
+        mgr = RoomChannelManager(endpoint="http://x", default_workspace="ws")
+        seen: list = []
+        mgr.on_converged = lambda room, env: seen.append((room, env))
+        adapter = mgr._converged_adapter("room-x")
+        assert adapter is not None
+        env = _converged({"a": "x"})
+        adapter(env)  # persister calls with (envelope) only
+        assert seen == [("room-x", env)]
+        # No hook wired → no adapter (persister keeps its log-only default).
+        mgr.on_converged = None
+        assert mgr._converged_adapter("room-x") is None
+
+    async def test_no_channel_writes_plan_but_skips_broadcast(self):
+        mgr = _FakeManager(live=False)
+        engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
+        with patch.object(
+            plan_sync.plan_compiler, "compile_plan", AsyncMock(return_value="# P\n\n- [ ] a")
+        ):
+            write = await engine.compile_and_sync("r", _converged({"a": "a"}))
+        # Plan still written locally; no knowledge push (nothing to broadcast to).
+        assert read_memory_file(get_room_dir("r"), plan_sync.PLAN_TASKS_KEY) is not None
+        assert write is None

--- a/mycelium-cli/src/mycelium/daemon/connector.py
+++ b/mycelium-cli/src/mycelium/daemon/connector.py
@@ -43,6 +43,7 @@ from mycelium.daemon.dispatch import (
     load_manifest,
     load_notes,
 )
+from mycelium.filesystem import apply_knowledge, get_room_dir
 from mycelium.integrations import get_integration
 from mycelium.integrations._spawn_common import SpawnRequest
 from mycelium.slim import l9
@@ -181,6 +182,54 @@ def build_reply(
     )
 
 
+# ── Memory sync (bible §11) ──────────────────────────────────────────────────
+
+
+def apply_knowledge_message(room: str, content: dict) -> None:
+    """Write a ``knowledge`` message's carried memory into the local store.
+
+    Push-with-content (bible §11): the message *carries* the markdown, so this is
+    a pure local file write + reindex — never a fetch back over HTTP. Reindex is
+    implicit: the file lands under ``~/.mycelium/rooms/{room}/`` which the local
+    always-on backend's watcher picks up and re-embeds into the JSONL index.
+    Conflict policy is enforced in :func:`mycelium.filesystem.apply_knowledge`
+    (last-write-wins; a stale-base write is kept out, logged, and dropped).
+    """
+    data = l9.payload_data_of(content)
+    key = data.get("key")
+    body = data.get("content")
+    if not isinstance(key, str) or not key or not isinstance(body, str):
+        log.debug("knowledge message in %s carried no memory write — ignoring", room)
+        return
+    try:
+        version = int(data.get("version", 1))
+    except (TypeError, ValueError):
+        version = 1
+    created_by = str(data.get("created_by") or "CognitiveEngine")
+    updated_by = str(data.get("updated_by") or created_by)
+    result = apply_knowledge(
+        get_room_dir(room),
+        key=key,
+        content=body,
+        version=version,
+        created_by=created_by,
+        updated_by=updated_by,
+    )
+    if result.conflict:
+        cur = result.current or {}
+        log.warning(
+            "knowledge write to %s/%s rejected (stale base): local v%s by %s at %s (incoming v%s)",
+            room,
+            key,
+            cur.get("version"),
+            cur.get("updated_by"),
+            cur.get("updated_at"),
+            version,
+        )
+    elif result.applied:
+        log.info("knowledge write applied: %s/%s (v%d)", room, key, version)
+
+
 # ── Per-message dispatch (transport-agnostic) ────────────────────────────────
 
 
@@ -201,6 +250,14 @@ async def handle_inbound(
     and gates are unchanged, and the reply is published to the channel rather
     than POSTed over HTTP.
     """
+    # Memory sync (bible §11): a ``knowledge`` message carries markdown content —
+    # write it into the local store so the agent's working set updates mid-task.
+    # It never wakes a turn. Co-located connectors each apply it, but the apply is
+    # idempotent by version, so only the first actually writes; the rest skip.
+    if l9.kind_of(content) == l9.KNOWLEDGE_KIND:
+        apply_knowledge_message(room, content)
+        return
+
     if not should_wake(content, handle):
         return
 

--- a/mycelium-cli/src/mycelium/filesystem.py
+++ b/mycelium-cli/src/mycelium/filesystem.py
@@ -9,6 +9,7 @@ Mirrors the backend's filesystem service for local access.
 """
 
 import re
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -136,6 +137,85 @@ def delete_memory(base_dir: Path, key: str) -> bool:
         file_path.unlink()
         return True
     return False
+
+
+# ── Knowledge sync (bible §11) ───────────────────────────────────────────────
+# The receiver half of the L9 ``knowledge`` write path: a connector applies a
+# carried memory write into its local store. Mirrors the backend's
+# ``app.services.memory_sync.apply_knowledge_to_dir`` — kept as a tiny local copy
+# because the CLI does not import the backend package. Conflict policy (§11,
+# decided): last-write-wins by ``version``; a write on a stale base fails with
+# details, no merge.
+
+
+@dataclass
+class KnowledgeApplyResult:
+    """The outcome of applying a carried memory write to the local store."""
+
+    key: str
+    applied: bool
+    conflict: bool
+    reason: str
+    version: int
+    current: dict[str, Any] | None = None
+
+
+def apply_knowledge(
+    base_dir: Path,
+    *,
+    key: str,
+    content: str,
+    version: int,
+    created_by: str = "CognitiveEngine",
+    updated_by: str = "CognitiveEngine",
+) -> KnowledgeApplyResult:
+    """Write a carried ``knowledge`` memory locally (last-write-wins).
+
+    Idempotent when the local file is already at ``version`` (the same-machine
+    loopback of a write the backend just made). A write whose ``version`` is
+    behind the local file is a **stale base**: kept out, current state returned
+    in ``current`` — never merged (bible §11).
+    """
+    existing = read_memory(base_dir, key)
+    if existing is not None:
+        meta, body = existing
+        try:
+            current_version = int(meta.get("version", 1))
+        except (TypeError, ValueError):
+            current_version = 1
+        if version == current_version:
+            return KnowledgeApplyResult(
+                key=key,
+                applied=False,
+                conflict=False,
+                reason="already at this version (idempotent)",
+                version=version,
+            )
+        if version < current_version:
+            return KnowledgeApplyResult(
+                key=key,
+                applied=False,
+                conflict=True,
+                reason="incoming version behind local",
+                version=version,
+                current={
+                    "content": body,
+                    "version": current_version,
+                    "updated_by": meta.get("updated_by") or meta.get("created_by"),
+                    "updated_at": meta.get("updated_at"),
+                },
+            )
+    write_memory(
+        base_dir,
+        key,
+        content,
+        created_by=created_by,
+        updated_by=updated_by,
+        version=version,
+    )
+    return KnowledgeApplyResult(
+        key=key, applied=True, conflict=False, reason="applied", version=version
+    )
 
 
 def list_memories(

--- a/mycelium-cli/src/mycelium/slim/l9.py
+++ b/mycelium-cli/src/mycelium/slim/l9.py
@@ -45,6 +45,11 @@ CONTENT_TEXT_KEY = "content"
 # (``commit``/``knowledge``) are observed but never trigger a spawn.
 EXCHANGE_KIND = "exchange"
 
+# ``knowledge`` is the memory-sync kind (bible §11): a ``knowledge`` message
+# carries markdown content the connector writes into its local store + reindexes
+# (push-with-content). It never wakes a turn — it updates the working set.
+KNOWLEDGE_KIND = "knowledge"
+
 
 def build_reply_content(
     *,
@@ -157,6 +162,17 @@ def kind_of(content: dict[str, Any]) -> str | None:
     env = envelope_of(content) or {}
     kind = env.get("header", {}).get("kind")
     return kind if isinstance(kind, str) else None
+
+
+def payload_data_of(content: dict[str, Any]) -> dict[str, Any]:
+    """The L9 payload ``data`` dict of a message (empty when absent).
+
+    Used to read a ``knowledge`` message's carried memory write (key + markdown
+    content + version) so the connector can apply it locally.
+    """
+    env = envelope_of(content) or {}
+    data = env.get("payload", {}).get("data")
+    return data if isinstance(data, dict) else {}
 
 
 def _iter_text(value: Any) -> list[str]:

--- a/mycelium-cli/tests/test_connector_knowledge_sync.py
+++ b/mycelium-cli/tests/test_connector_knowledge_sync.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Connector memory-sync — the L9 ``knowledge`` write path (Step 8, bible §11).
+
+The merge gate for the CLI half of Step 8 (no SLIM node): a ``knowledge`` message
+carries markdown content, and the connector writes it into the local store
+(push-with-content) without waking a turn; the last-write-wins conflict policy
+keeps a stale-base write out with details.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mycelium import filesystem
+from mycelium.daemon import connector
+from mycelium.slim import l9
+
+
+@pytest.fixture(autouse=True)
+def _tmp_mycelium_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(filesystem, "get_mycelium_dir", lambda: tmp_path)
+
+
+def _knowledge(key: str, content: str, *, version: int = 1) -> dict:
+    """A ``knowledge`` content dict as the backend's memory_sync emits it."""
+    return {
+        "content": f"plan updated → {key}",
+        "l9": {
+            "header": {
+                "protocol": "SSTP",
+                "subprotocol": "mycelium",
+                "version": "0.0.6",
+                "kind": l9.KNOWLEDGE_KIND,
+                "subkind": "distillation",
+                "participants": {
+                    "actors": [{"id": "CognitiveEngine", "role": "coordinator"}],
+                    "groups": None,
+                },
+                "message": {"id": f"k-{version}", "parents": [], "episode": "urn:x"},
+            },
+            "payload": {
+                "type": "distillation",
+                "data": {
+                    "key": key,
+                    "content": content,
+                    "version": version,
+                    "base_version": version - 1 if version > 1 else None,
+                    "created_by": "CognitiveEngine",
+                    "updated_by": "CognitiveEngine",
+                    "updated_at": "2026-08-04T00:00:00+00:00",
+                },
+            },
+        },
+    }
+
+
+def test_knowledge_message_writes_markdown_locally(tmp_path: Path):
+    connector.apply_knowledge_message("demo", _knowledge("plan/tasks", "# Plan\n\n- [ ] ship it"))
+    got = filesystem.read_memory(filesystem.get_room_dir("demo"), "plan/tasks")
+    assert got is not None
+    meta, body = got
+    assert "ship it" in body and meta["version"] == 1
+
+
+def test_knowledge_newer_version_overwrites():
+    connector.apply_knowledge_message("demo", _knowledge("plan/tasks", "# v1", version=1))
+    connector.apply_knowledge_message("demo", _knowledge("plan/tasks", "# v2 wins", version=2))
+    got = filesystem.read_memory(filesystem.get_room_dir("demo"), "plan/tasks")
+    assert got is not None and "v2 wins" in got[1] and got[0]["version"] == 2
+
+
+def test_knowledge_stale_base_is_rejected():
+    connector.apply_knowledge_message("demo", _knowledge("plan/tasks", "# v3", version=3))
+    # An older write (v2) must not clobber the newer local v3.
+    connector.apply_knowledge_message("demo", _knowledge("plan/tasks", "# stale v2", version=2))
+    got = filesystem.read_memory(filesystem.get_room_dir("demo"), "plan/tasks")
+    assert got is not None and got[1].strip() == "# v3" and got[0]["version"] == 3
+
+
+def test_malformed_knowledge_is_ignored():
+    # Missing key/content → no write, no raise.
+    bad = _knowledge("plan/tasks", "x")
+    bad["l9"]["payload"]["data"] = {"version": 1}
+    connector.apply_knowledge_message("demo", bad)
+    assert filesystem.read_memory(filesystem.get_room_dir("demo"), "plan/tasks") is None
+
+
+@pytest.mark.asyncio
+async def test_handle_inbound_routes_knowledge_without_waking(monkeypatch):
+    """A ``knowledge`` arrival applies the write and never spawns a turn."""
+    woke = False
+
+    def _no_wake(*a, **k):  # pragma: no cover - asserts it isn't called
+        nonlocal woke
+        woke = True
+        return True
+
+    monkeypatch.setattr(connector, "should_wake", _no_wake)
+    published: list = []
+
+    async def _publish(content: dict) -> None:
+        published.append(content)
+
+    await connector.handle_inbound(
+        config=None,  # ty: ignore[invalid-argument-type]
+        daemon_cfg=None,  # ty: ignore[invalid-argument-type]
+        state=None,  # ty: ignore[invalid-argument-type]
+        room="demo",
+        handle="agent-a",
+        content=_knowledge("plan/tasks", "# Plan\n\n- [ ] a"),
+        publish=_publish,
+    )
+    assert not woke and not published
+    assert filesystem.read_memory(filesystem.get_room_dir("demo"), "plan/tasks") is not None


### PR DESCRIPTION
Picks up **Step 8** from [`START_HERE_STEP_8.md`](docs/START_HERE_STEP_8.md), on `slim-native-rewrite` (Step 7 merged). Closes the `join → exchange → converge → plan → work` loop **on one machine**: when the aligner emits `commit:converged`, the backend now compiles the plan and propagates it as memory over SLIM.

## What changed

**Backend**
- **`memory_sync.py`** — the L9 `knowledge` write path (bible §11). `build_knowledge_envelope` wraps a `KnowledgeWrite` (key + markdown + `version`/`base_version`) as a `knowledge:distillation` envelope that **carries the content** (push-with-content, not notify-then-pull). `apply_knowledge` writes it into a local store + reindexes the JSONL under the decided **last-write-wins** policy: a same-version arrival is an **idempotent** no-op (the same-machine loopback of a write the backend just made), a **stale-base** write **fails with details** (current content + `updated_by` + `updated_at`) and moves on, **no merge**.
- **`plan_sync.py`** — the `on_converged` consumer. Compiles `plan/tasks.md` via `plan_compiler` (**fail-soft** to the raw agreement on an LLM outage) and broadcasts the plan as a `knowledge` push, which doubles as the **"plan ready"** signal now that the verdict is already on the wire. A distinct consumer stage across the seam, **not** a CE step (CLAUDE.md plan-compiler decision).
- **`room_channels.py`** — `RoomConvergedHook` + `_converged_adapter`, room-aware exactly like Step 7's summon seam; wired in `main.py` to `PlanSyncEngine.handle_converged`.
- **`plan.py`** — `write_plan_file` gains a `version` param so re-compiles bump the version the `knowledge` stream orders writes by.

**CLI**
- **`daemon/connector.py`** — `apply_knowledge_message` acts on a `knowledge` arrival (before `should_wake`): writes the carried markdown into the local store; never wakes a turn. **`filesystem.apply_knowledge`** mirrors the conflict policy CLI-side.
- **`slim/l9.py`** — `KNOWLEDGE_KIND` + `payload_data_of`.

## Definition of Done ✅
`@`-summon the aligner over a seeded exchange → it emits `commit:converged` → the backend compiles `plan/tasks.md` → a `knowledge` message writes the markdown + updates the JSONL on a second local store. The same-machine mini-demo of the hero flow.

## Tests
- **Fast gate (no node):** knowledge envelope/apply + conflict policy (`test_memory_sync.py`); converged → plan file with expected tasks (LLM mocked) + fail-soft compile + room-binding adapter (`test_plan_sync.py`); CLI knowledge sync, stale-base rejection, and no-wake routing (`test_connector_knowledge_sync.py`).
- **Live-node slice:** `test_l9_over_slim_roundtrip.py` extended — after `commit:converged`, asserts `plan/tasks.md` compiled **and** the `knowledge` write (markdown + JSONL) landed on a second store. All prior Step 3-7 slices still pass.

### Verification
- Backend: `ruff` / `format` / `ty` clean; `261 passed, 7 skipped`.
- CLI: `ruff` / `format` / `ty` clean; `379 passed, 2 skipped`.
- Guarded slices against a live `slim:1.4.0` node: backend `5 passed`, CLI connector slice `1 passed`.

## Also
Adds [`docs/START_HERE_STEP_9.md`](docs/START_HERE_STEP_9.md) — the cross-machine follow-up (join a shared/remote node, keep per-machine stores in sync over the `knowledge` stream, consent-invite across hosts; LAN-first, close the reindex gap on a daemon-only host).