### PR TITLE
Debt D2: extend golden guard for the knowledge envelope

### DIFF
--- a/fastapi-backend/tests/test_slim_l9_golden.py
+++ b/fastapi-backend/tests/test_slim_l9_golden.py
@@ -25,6 +25,7 @@ import pytest
 
 from app.services import l9
 from app.services.l9_models import Kind
+from app.services.memory_sync import KnowledgeWrite, build_knowledge_envelope
 from app.services.slim_client import (
     _DEV_MASTER_SECRET,
     DEFAULT_CHANNEL_TOPIC,
@@ -89,6 +90,41 @@ def test_exchange_envelope_serializes_to_golden():
     )
     content = {"content": i["text"], "l9": l9.envelope_to_dict(envelope)}
     assert content == g["expected_content"]
+
+
+def test_knowledge_envelope_serializes_to_golden():
+    """The backend's serialized ``knowledge:distillation`` envelope is the golden.
+
+    Step 8 (bible §11) added the memory-sync wire shape: ``build_knowledge_envelope``
+    wraps a :class:`KnowledgeWrite` as a ``knowledge:distillation`` envelope the CLI
+    daemon parses and applies. ``build_knowledge_envelope`` mints a fresh random
+    ``message.id`` per call (it is not part of the shared contract), so the produced
+    id is normalized to the golden's placeholder before the byte-for-byte compare;
+    every other field must match exactly.
+    """
+    g = _golden()["knowledge"]
+    w = g["write"]
+    write = KnowledgeWrite(
+        key=w["key"],
+        content=w["content"],
+        version=w["version"],
+        base_version=w["base_version"],
+        created_by=w["created_by"],
+        updated_by=w["updated_by"],
+        updated_at=w["updated_at"],
+    )
+    envelope = build_knowledge_envelope(
+        room=g["room"],
+        write=write,
+        recipients=g["recipients"],
+    )
+    produced = l9.envelope_to_dict(envelope)
+    # The message id is a fresh UUID per build — freeze everything else, and check
+    # the id is a non-empty string separately (not a shared-contract value).
+    assert isinstance(produced["header"]["message"]["id"], str)
+    assert produced["header"]["message"]["id"]
+    produced["header"]["message"]["id"] = g["message_id_placeholder"]
+    assert produced == g["expected_envelope"]
 
 
 def test_channel_name_topic_matches_golden():

--- a/mycelium-cli/tests/test_slim_l9_golden.py
+++ b/mycelium-cli/tests/test_slim_l9_golden.py
@@ -90,6 +90,35 @@ def test_exchange_reply_serializes_to_golden():
     assert content == g["expected_content"]
 
 
+def test_knowledge_envelope_parses_to_golden_write():
+    """The connector parses the backend's ``knowledge:distillation`` envelope.
+
+    Guards the *parse* half of the memory-sync contract (Step 8, bible §11): given
+    the exact envelope the backend produces (frozen in the golden), the CLI's
+    ``l9.kind_of`` / ``l9.payload_data_of`` — the two the connector's
+    ``apply_knowledge_message`` reads through — must recover every carried write
+    field byte-for-byte. If the backend's produced shape and this parse ever drift,
+    this gate goes red instead of silently breaking cross-machine memory sync.
+    """
+    g = _golden()["knowledge"]
+    # The content dict a connector receives on the wire: the golden envelope under
+    # the additive ``l9`` key. (``content`` is empty — a knowledge push carries its
+    # payload in ``l9.payload.data``, not the human-text field.)
+    content = {"content": "", "l9": g["expected_envelope"]}
+
+    assert l9.kind_of(content) == l9.KNOWLEDGE_KIND
+
+    data = l9.payload_data_of(content)
+    w = g["write"]
+    assert data["key"] == w["key"]
+    assert data["content"] == w["content"]
+    assert data["version"] == w["version"]
+    assert data["base_version"] == w["base_version"]
+    assert data["created_by"] == w["created_by"]
+    assert data["updated_by"] == w["updated_by"]
+    assert data["updated_at"] == w["updated_at"]
+
+
 def test_channel_name_topic_matches_golden():
     """A room channel's app segment is the frozen default topic."""
     pytest.importorskip("slim_bindings")

--- a/slim-l9-golden.json
+++ b/slim-l9-golden.json
@@ -79,5 +79,55 @@
         }
       }
     }
+  },
+
+  "knowledge": {
+    "_comment": "A golden serialized L9 'knowledge:distillation' envelope — the memory-sync wire shape (Step 8, bible §11). The backend PRODUCES it via memory_sync.build_knowledge_envelope(room, write, recipients) + KnowledgeWrite.to_payload() (serialized with l9.envelope_to_dict); the CLI daemon PARSES it via slim/l9.payload_data_of and applies it in daemon/connector.apply_knowledge_message. The two must agree byte-for-byte on the payload.data write fields or cross-machine memory sync (Step 9) silently drifts. build_knowledge_envelope mints a fresh random message.id per call, so 'expected_envelope.header.message.id' is the sentinel 'MESSAGE_ID_PLACEHOLDER' — the backend test normalizes the produced id to it before comparing (the id is not part of the shared contract; every other field is).",
+    "room": "acme",
+    "recipients": ["bob"],
+    "message_id_placeholder": "MESSAGE_ID_PLACEHOLDER",
+    "write": {
+      "key": "plan/tasks.md",
+      "content": "# Plan\n\n- [ ] first task\n",
+      "version": 2,
+      "base_version": 1,
+      "created_by": "alice",
+      "updated_by": "bob",
+      "updated_at": "2026-08-04T12:00:00+00:00"
+    },
+    "expected_envelope": {
+      "header": {
+        "protocol": "SSTP",
+        "subprotocol": "mycelium",
+        "version": "0.0.6",
+        "kind": "knowledge",
+        "subkind": "distillation",
+        "participants": {
+          "actors": [
+            { "id": "CognitiveEngine", "role": "coordinator" },
+            { "id": "bob", "role": "agent" }
+          ],
+          "groups": null
+        },
+        "message": {
+          "id": "MESSAGE_ID_PLACEHOLDER",
+          "parents": [],
+          "episode": "urn:ioc:mycelium:episode:acme:knowledge"
+        },
+        "context": { "topic": "urn:concept:mycelium:acme" }
+      },
+      "payload": {
+        "type": "distillation",
+        "data": {
+          "key": "plan/tasks.md",
+          "content": "# Plan\n\n- [ ] first task\n",
+          "version": 2,
+          "base_version": 1,
+          "created_by": "alice",
+          "updated_by": "bob",
+          "updated_at": "2026-08-04T12:00:00+00:00"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## What & why

Debt **D2** (bible Part IV, Known debt register): the repo-root `slim-l9-golden.json` freezes shared SLIM+L9 wire constants that both the FastAPI backend and the CLI daemon must reproduce byte-for-byte, and two golden tests assert against it. It covered the `exchange` envelope + `mint_shared_secret` + URN forms — but **not** the new shared shape Step 8 (PR #427) added: the L9 **`knowledge:distillation`** envelope + **`KnowledgeWrite`** payload used to sync memory over SLIM.

The live integration slice guards that end-to-end, but the **fast unit gate did not** — a drift between what the backend produces and what the CLI parses could merge green. Step 9 (cross-machine) relies entirely on this knowledge stream, so a silent drift would break cross-machine memory sync. This closes that gap in the fast gate.

## What I froze

New `knowledge` section in `slim-l9-golden.json` (existing sections untouched):
- a known `KnowledgeWrite` input — `key`, `content`, `version`, `base_version`, `created_by`, `updated_by`, `updated_at`
- the golden serialized `knowledge:distillation` **envelope dict** the backend's `build_knowledge_envelope` produces for it (mirrors the existing `envelope` section)

`build_knowledge_envelope` mints a fresh random `message.id` per call (not part of the shared contract), so the golden's `message.id` is a `MESSAGE_ID_PLACEHOLDER` sentinel and the backend test normalizes the produced id to it before comparing. Every other field is frozen byte-for-byte.

## The two new assertions

The produce↔parse contract is asymmetric (backend **produces**, CLI **parses**), so both directions are guarded:

1. **Backend** (`fastapi-backend/tests/test_slim_l9_golden.py::test_knowledge_envelope_serializes_to_golden`): `build_knowledge_envelope(...)` + `KnowledgeWrite.to_payload()`, serialized via `l9.envelope_to_dict`, equals the golden envelope dict (id normalized to the placeholder; produced id separately asserted to be a non-empty string).
2. **CLI** (`mycelium-cli/tests/test_slim_l9_golden.py::test_knowledge_envelope_parses_to_golden_write`): feeding that **same** golden envelope through the CLI's actual parse path — `l9.kind_of` / `l9.payload_data_of`, the two `connector.apply_knowledge_message` reads through — recovers every carried write field. This guards that the CLI reads exactly what the backend writes.

## Contract match

**No drift found.** Verified the backend-produces and CLI-parses shapes agree: the exact envelope `build_knowledge_envelope` emits, parsed by the CLI's `payload_data_of`, yields back the same `key`/`content`/`version`/`base_version`/`created_by`/`updated_by`/`updated_at`.

## Gate results

Both new tests are fast (no SLIM node, no embedding model):
- Backend `test_slim_l9_golden.py`: **7 passed**. `ruff check` / `ruff format --check` / `ty check`: **all pass**.
- CLI `test_slim_l9_golden.py`: **7 passed**. `ruff check` / `ruff format --check` / `ty check`: **all pass**.
- Full CLI suite: **380 passed, 2 skipped**.
- Full backend suite: 261 passed, 7 skipped, **1 pre-existing environment-only failure** unrelated to this change — `test_memory_sync.py::...::test_writes_markdown_and_reindexes_second_store` fails on `PermissionError: /opt/fastembed` (the fastembed model download path is unwritable in this sandbox). It touches none of the files here and exercises the real reindex/embedding path, not the golden guard.

Production code unchanged — test/golden-data addition only.