### PR TITLE
Step 9: cross-machine — the hero flow across two hosts

### DIFF
--- a/docs/START_HERE_STEP_10.md
+++ b/docs/START_HERE_STEP_10.md
@@ -1,0 +1,188 @@
+# START HERE — Step 10 (UI: protocol inspector + room view + consent prompt; retire the legacy SSE poller)
+
+Companion to [`START_HERE.md`](./START_HERE.md). Step 9 is **done** (this PR into
+`slim-native-rewrite`); you are picking up **Step 10**, the **final** step. Read `START_HERE.md`,
+[`START_HERE_STEP_1.md`](./START_HERE_STEP_1.md) → [`START_HERE_STEP_9.md`](./START_HERE_STEP_9.md)
+first if you haven't — the same rules apply. This file gives you (a) the exact state Step 9 left
+behind, (b) your Step 10 marching orders, (c) the facts you must internalize, and (d) the traps
+specific to this step.
+
+**Step 9 made the loop real across two machines.** `mycelium connect` points a member host at a
+shared node host A runs; the connector joins A's moderated room channel; an `@`-invite raises a
+**consent prompt**, and on accept the moderator invites the remote agent **by identity**; the L9
+exchange → aligner converge → `commit:converged` → compiled `plan/tasks.md` → `knowledge` push
+all cross the wire, and the pushed markdown lands **and reindexes** on the member's own store even
+with no file watcher there (the connector reindexes explicitly). **Step 10 makes it visible and
+finishes the demotically:** a UI that shows the room, the live protocol traffic (the L9
+inspector), and surfaces the consent prompt to the human — plus the long-promised retirement of
+the legacy SSE/poller transport now that everything rides SLIM.
+
+## Ground rules (unchanged from START_HERE.md)
+
+1. **The bible is authoritative:** [`slim-native-rebuild-bible.md`](./slim-native-rebuild-bible.md).
+   Your work is **Part V · Step 10**, with **§10 (UI / inspector)**, **§12 (consent)**, and the
+   **Acceptance** hero demo as the design reference.
+2. Leave the project **runnable and green** — backend + CLI **and frontend** quality gates pass at
+   the end.
+3. Code/config blocks in the bible are **reference, not paste**.
+4. **Verify before you edit** — the paths below were accurate at the end of Step 9; confirm shape
+   before changing a file.
+5. Fixed decisions are not up for debate. Retire the legacy SSE/poller **fully** — don't leave a
+   dead endpoint or a half-wired dispatcher behind (see the retirement checklist).
+
+## Where Step 9 left things (your starting state)
+
+Branch off `slim-native-rewrite` (Step 9 is merged). The full cross-machine loop runs headless;
+what's missing is the human-facing surface and the cleanup of the retired transport. Concretely:
+
+- **The connector reindexes after a `knowledge` apply.** `mycelium/daemon/connector.py` now
+  returns the `KnowledgeApplyResult` from `apply_knowledge_message` and, on a real write, calls
+  `reindex_after_knowledge(config, room)` — a best-effort, room-scoped HTTP POST to the
+  co-located backend's `/api/rooms/{room}/reindex` (the CLI has no local embedder). This closes
+  the daemon-only reindex gap. Unit-covered in `tests/test_connector_knowledge_sync.py`
+  (reindex fires on apply, **not** on a stale-base conflict) and
+  `tests/test_daemon_connector.py` (the connector dials `config.slim.node_endpoint`).
+- **Cross-host consent is proven at the pure level.** The invite/consent state machine
+  (`app/services/invites.py`) is node-free and addresses the invitee by `workspace/room/agent`
+  identity — `tests/test_mentions_and_invites.py::test_accept_invites_remote_agent_by_identity_only`
+  pins that the moderator invites a remote agent by identity only, no host/endpoint.
+- **Remote endpoint plumbing is done.** `mycelium connect <addr>` persists a normalized
+  `slim.node_endpoint`; `run_connector` dials it (not the `127.0.0.1` default). `mycelium hub
+  host` prints the LAN address peers connect to.
+- **Guarded cross-machine slice exists.** `mycelium-cli/tests/test_connector_knowledge_sync_over_slim.py`
+  drives a real connector against a live node: a moderator broadcasts a `knowledge` push and the
+  connector writes it to a **genuinely separate data dir** (not a swapped `MYCELIUM_DATA_DIR`) and
+  triggers reindex. Runs only with a reachable node (skipped otherwise).
+- **Cross-machine ops are documented.** [`cross-machine.md`](./cross-machine.md) captures the
+  two resolved decisions (self-hosted shared node default; connector-explicit reindex) and the
+  open-internet path (hosted node / tunnel; **NAT not built**).
+- **The legacy SSE/poller is still present but unused on the hot path.** `stream.py` and the
+  daemon's `dispatch.py` still carry SSE/poller helpers (Step 5 superseded them with the SLIM
+  connector but did not delete them). `test_daemon_sse_timeout.py` still exercises the old path.
+
+## Your Step 10 scope (from the bible, Part V · Step 10)
+
+- **UI: room view.** Show a room's membership, its `plan/tasks.md` checklist, and the message
+  transcript, fed by the backend's existing UI bus (`app/bus.py`) rather than the retired SSE
+  poller. Confirm what the frontend (`mycelium-frontend/`) currently reads and move it onto the
+  live bus / whatever push the bus exposes.
+- **UI: L9 protocol inspector.** Render the live L9 traffic on a channel — `exchange` ticks/
+  replies, `commit:converged`/`rejected` verdicts (with MPC/GAR/SCR metrics), and `knowledge`
+  pushes — with their episode + causal chain. The episode records under `log/episodes/*` are the
+  source of the rich chain; the wire envelopes carry empty `message.parents` by design.
+- **UI: consent prompt.** Surface the `consent_request` bus event (raised by
+  `room_channels._emit_consent_prompt`) as an accept/decline prompt wired to
+  `POST /api/rooms/{room}/invites/{id}/accept|decline`. This is the human-in-the-room surface
+  that Steps 6/9 built the backend for — cross-host, it must reach the invitee's human.
+- **Retire the legacy SSE/poller transport.** Delete `stream.py` and the dead SSE/poller helpers
+  in the daemon's `dispatch.py`, remove their routes/wiring, and drop or rewrite
+  `test_daemon_sse_timeout.py`. Grep for `stream`, `SSE`, `poll`, `/events` and leave nothing
+  dangling. (SAB/TFP engines and the escalation ladder remain **post-MVP** — do not build them.)
+- **Key files:** `mycelium-frontend/` (room view, inspector, consent component); `app/bus.py`
+  (the push the UI reads); `app/routes/invites.py` (accept/decline, already built);
+  `app/routes/stream.py` + `daemon/dispatch.py` (deletions); `log/episodes/*` (inspector's causal
+  source).
+
+## Facts you must internalize first
+
+- **The UI reads the bus, not SLIM.** The frontend never speaks SLIM or L9. The backend moderator
+  already ingests every channel message into the persister and re-publishes onto the in-process UI
+  bus (`app/bus.py`, `room_channel(room)`); consent prompts, human messages, and plan pushes all
+  land there. Build the UI against that bus — do not add a second SLIM consumer for the browser.
+- **Consent must reach the invitee's human, cross-host.** In Step 9 the moderator (host A) raises
+  the `consent_request`. For a *remote* invitee, its human is on host B. Decide how B's human sees
+  and answers the prompt: the simplest MVP is that B's UI talks to A's backend API (the moderator
+  owns the invite registry and the accept/decline endpoints). Note your choice; don't fork the
+  registry.
+- **The inspector shows structure, not just text.** The value of the L9 layer is legibility — kind/
+  subkind, episode URN, metrics, and the causal chain. Pull the chain from `log/episodes/*`
+  (`app/services/l9_episode.py` writes them), since the broadcast envelopes deliberately carry
+  empty `message.parents`.
+- **Retirement is real deletion, not deprecation.** Everything coordinates over SLIM now (Steps
+  5–9). The SSE endpoint and the daemon's poller are dead weight; remove them so the transport
+  story is unambiguous.
+
+## Definition of Done
+
+The bible's **Acceptance** hero demo, **with the UI**: two machines on a LAN run the full flow,
+and a human watches it in the browser — the room view shows membership + the compiled plan; the L9
+inspector shows the exchange, the `commit:converged` (with metrics), and the `knowledge` push in
+their episode; an `@`-invite of a remote agent raises a **consent prompt** in the UI that, on
+accept, brings the agent in. The legacy SSE/poller transport is **gone** (no dead routes, no
+half-wired dispatcher, tests updated). Backend + CLI + frontend quality gates are green.
+
+## Tests to write (end of step)
+
+Fast unit/component tests (the merge gate — no node):
+
+- **UI bus → room view / inspector** — a component/unit test that a `consent_request` bus event
+  renders an accept/decline prompt and that a `commit`/`knowledge` bus event renders in the
+  inspector with its kind + metrics. Follow the frontend's existing test setup in
+  `mycelium-frontend/`.
+- **Accept/decline wiring** — the consent component calls the invites endpoints and reflects the
+  resulting status. (Backend accept/decline is already unit-covered; test the UI wiring.)
+- **Retirement leaves nothing dangling** — a test (or a CI grep) that the SSE route is gone and the
+  daemon no longer imports the poller; update/remove `test_daemon_sse_timeout.py`.
+
+Live-node **integration slice** (guarded, adds to the cumulative suite — **all prior slices must
+still pass**, backend + CLI):
+
+- **UI-observed acceptance** is hard to assert headlessly; at minimum keep the Step 9 cross-machine
+  slice green and add a guarded check that a `consent_request` and a `knowledge` push both reach
+  the UI bus during a live run (subscribe to `app/bus.py` in the test and assert the two events
+  arrive). The full browser demo is manual — script it in the demo doc.
+
+## Verification gate (must pass before you call Step 10 done)
+
+```bash
+# Backend
+cd fastapi-backend
+uv run ruff check . && uv run ruff format --check . && uv run ty check .
+MYCELIUM_STUB_EMBEDDINGS=1 uv run pytest tests/ -x -q            # fast gate, no node
+
+# CLI (matches CI)
+cd ../mycelium-cli
+uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run pytest tests/ -x -q
+
+# Frontend  (only `dev`/`build`/`start` scripts exist today — add `lint`/`test`
+# scripts if you introduce component tests; at minimum the production build passes)
+cd ../mycelium-frontend
+pnpm install && pnpm build
+
+# Guarded slices — bring a node up (or two containers on a docker bridge) first; run by file.
+```
+
+> **Known pre-existing wrinkle (Step 9, still applies):** running the *whole* CLI suite with
+> `MYCELIUM_SLIM_ENDPOINT` exported trips `tests/test_slim_config.py::test_connect_persists_endpoint`.
+> Run the guarded slices **by file** rather than reading a whole-suite pass/fail with that env set.
+
+## Traps specific to Step 10
+
+- **Don't add a browser SLIM consumer.** The UI reads the backend's in-process bus. A second SLIM
+  connection for the browser re-introduces the fork problem and the MLS-secret handling the backend
+  already owns.
+- **Don't half-retire the SSE path.** Delete the route, the daemon helpers, and the tests together;
+  a lingering `/events` endpoint or a dead import is a Step-10 failure.
+- **Consent UI is cross-host.** Prove (or at least document) that the invitee's human — possibly on
+  host B — can answer a prompt raised by host A's moderator. Don't build a second invite registry.
+- **Inspector chain comes from the episode records, not the wire.** Broadcasts carry empty
+  `message.parents`; read `log/episodes/*` for the causal view or you'll show a flat, parentless
+  stream.
+- **Frontend gate counts now.** Step 10 is the first step that touches `mycelium-frontend/` in
+  anger — its production build must pass, not just backend + CLI. Today the frontend has only
+  `dev`/`build`/`start` scripts; add `lint`/`test` scripts if you introduce component tests.
+
+## Later steps (post-MVP, unchanged)
+
+- **SAB/TFP engines and the escalation ladder** are **post-MVP** — not this step.
+- **JWT/SPIRE identity** (replacing the dev shared-secret tier) is the production identity path,
+  post-MVP.
+- **Hosted rendezvous / open-internet + NAT traversal** — the LAN MVP ships; a hosted node or
+  tunnel is documented in [`cross-machine.md`](./cross-machine.md) but building/operating it is
+  post-MVP.
+
+## Report when done
+
+Per `START_HERE.md`: what changed, the DoD check, and test results (fast gate + the cross-machine
+integration slice, noting all prior slices still pass, backend + CLI + frontend). Open a PR against
+`slim-native-rewrite` (same as Steps 0-9).

--- a/docs/cross-machine.md
+++ b/docs/cross-machine.md
@@ -1,0 +1,73 @@
+# Cross-machine coordination (Step 9)
+
+How two people on two laptops run the mycelium hero flow through **one shared SLIM
+node**. This is the LAN MVP; the open-internet path is documented but not built
+(bible §Step 9: *LAN first, don't block on NAT*).
+
+## Roles
+
+- **Host A — the owner / moderator.** Runs the shared SLIM node (`mycelium hub
+  host`) **and** the always-on backend that provisions and **moderates** the room
+  channel (creates the group, invites members, persists the transcript, runs the
+  aligner + plan-sync). One moderator per room — see the trap below.
+- **Host B — a member.** Runs a **daemon (connector)** pointed at host A's node
+  via `mycelium connect <A-LAN-IP>:46357`. It is a *member* of the channel, never
+  a second moderator.
+
+Membership is addressed by **identity** (`workspace/room/agent`), never by host,
+so the moderator invites host B's agent exactly as it would a local one — the
+consent → invite → join path needs no new cross-machine mechanism.
+
+## The hero flow, across two hosts
+
+```
+Host A:  mycelium hub host              # SLIM node + backend/moderator; prints the LAN address
+Host B:  mycelium connect http://<A-LAN-IP>:46357
+Host B:  mycelium agent create ...      # its daemon joins A's room channel
+Host A:  (human) @agent-b let's plan …  # consent prompt → accept → B's connector invited in
+         agents exchange L9 → @aligner converges → commit:converged
+         backend compiles plan/tasks.md → knowledge push carries the plan
+Both:    plan/tasks.md (markdown + JSONL) lands on each machine; each agent works its half
+```
+
+## Two decisions this step resolved (flagged)
+
+1. **Hub location — self-hosted shared node (default).** The owner runs the node
+   with `mycelium hub host`; peers `mycelium connect` to its LAN IP. A hosted
+   rendezvous is optional and **post-MVP**. `mycelium connect` already accepts any
+   address (incl. `https://` for a hosted node or tunnel), so no code changes are
+   needed to point at one later — only operating it.
+
+2. **Reindex on a member host — the connector reindexes explicitly.** Memory
+   content is canonical markdown; the JSONL search index is derived. On host A the
+   backend's file watcher re-embeds a write, but a member host with no watcher
+   would leave the pushed markdown **invisible to search**. So after applying a
+   `knowledge` write, the connector triggers a room-scoped reindex against its
+   co-located backend (`mycelium/daemon/connector.py:reindex_after_knowledge`,
+   best-effort, idempotent). The CLI has no local embedder — embeddings live in
+   the backend — so this is an HTTP call, exactly like `mycelium memory reindex`.
+
+## Traps
+
+- **Don't fork the moderator.** One backend moderates a room. If host B also runs
+  a backend (for its local index/UI), it must **not** provision/moderate the same
+  room, or membership and the transcript fork.
+- **Shared secret parity.** The per-channel MLS secret is derived offline from the
+  channel scope (`workspace/room`) via a shared dev master secret, so both hosts
+  reconstruct the **same** value — no key exchange. If a cross-host invite
+  "silently never lands," suspect a secret/version mismatch before the network.
+- **Version parity.** `slim:1.4.0` / `slim-bindings` 1.4.x is a matched pair on
+  **both** hosts; a skew across machines is a new failure mode.
+
+## Open-internet path (documented, not built)
+
+For hosts not on the same LAN, either:
+
+- **A reachable/hosted node** — run the `slim` node on a host with a public
+  address (or behind a load balancer) and have every peer `mycelium connect` to
+  it. MLS makes the node a blind ciphertext forwarder, so a shared/hosted node
+  never sees plaintext.
+- **A tunnel** — expose a LAN node through a tunnel (e.g. an SSH reverse tunnel or
+  a `cloudflared`/`tailscale`-style overlay) and connect to the tunnel address.
+
+NAT traversal / hole-punching is **out of scope for the MVP** — do not build it.

--- a/fastapi-backend/tests/test_mentions_and_invites.py
+++ b/fastapi-backend/tests/test_mentions_and_invites.py
@@ -164,3 +164,42 @@ def test_request_invite_returns_none_for_present_member():
     manager, _managed = _manager_with_channel(members={"agent-x"})
     assert manager.request_invite(_ROOM, "agent-x", requested_by="julia") is None
     assert manager.request_invite(_ROOM, room_channels.BACKEND_AGENT, requested_by="julia") is None
+
+
+# ── cross-host consent: the invitee is addressed by identity, not by host ──────
+
+
+@pytest.mark.asyncio
+async def test_accept_invites_remote_agent_by_identity_only(monkeypatch):
+    """Cross-host consent (Step 9): accepting resolves the invitee purely by its
+    ``workspace/room/agent`` SLIM identity — never a host or endpoint — so the
+    moderator invites the same member whether its connector runs on this machine
+    or another one on the shared node. This is why the consent → invite → join
+    path needs no new cross-machine mechanism: membership is identity-addressed.
+    """
+    manager, managed = _manager_with_channel(members=set())
+
+    # Bindings aren't installed in the unit env; record the identity the invite
+    # would resolve and hand back an opaque token in place of a SLIM Name.
+    resolved: list[tuple[str, str, str]] = []
+
+    def _fake_name(ws: str, room: str, agent: str) -> object:
+        resolved.append((ws, room, agent))
+        return object()
+
+    monkeypatch.setattr(room_channels, "to_slim_name", _fake_name)
+    cast(MagicMock, managed.client).invite = AsyncMock()  # the real manager.invite() path runs
+    cast(MagicMock, managed.persister).note_join.return_value = False  # no re-serve
+
+    result = await manager.publish_human(_ROOM, sender="julia", text="@remote-bob join us")
+    assert result is not None
+    invite = result.invites[0]
+    assert invite.agent == "remote-bob"
+
+    accepted = await manager.accept_invite(invite.id)
+    assert accepted is not None and accepted.status == invites.ACCEPTED
+
+    # Addressed by identity only (no host/endpoint) — host-independent membership.
+    assert resolved == [("mycelium", _ROOM, "remote-bob")]
+    cast(AsyncMock, managed.client.invite).assert_awaited_once()
+    assert "remote-bob" in managed.members

--- a/mycelium-cli/src/mycelium/daemon/connector.py
+++ b/mycelium-cli/src/mycelium/daemon/connector.py
@@ -27,6 +27,8 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+import httpx
+
 from mycelium.daemon.dispatch import (
     _CONTROL_ABORT,
     _CONTROL_STATUS,
@@ -43,7 +45,7 @@ from mycelium.daemon.dispatch import (
     load_manifest,
     load_notes,
 )
-from mycelium.filesystem import apply_knowledge, get_room_dir
+from mycelium.filesystem import KnowledgeApplyResult, apply_knowledge, get_room_dir
 from mycelium.integrations import get_integration
 from mycelium.integrations._spawn_common import SpawnRequest
 from mycelium.slim import l9
@@ -185,13 +187,20 @@ def build_reply(
 # ── Memory sync (bible §11) ──────────────────────────────────────────────────
 
 
-def apply_knowledge_message(room: str, content: dict) -> None:
+def apply_knowledge_message(room: str, content: dict) -> KnowledgeApplyResult | None:
     """Write a ``knowledge`` message's carried memory into the local store.
 
     Push-with-content (bible §11): the message *carries* the markdown, so this is
-    a pure local file write + reindex — never a fetch back over HTTP. Reindex is
-    implicit: the file lands under ``~/.mycelium/rooms/{room}/`` which the local
-    always-on backend's watcher picks up and re-embeds into the JSONL index.
+    a pure local file write — never a fetch back over HTTP. Returns the
+    :class:`~mycelium.filesystem.KnowledgeApplyResult` (or ``None`` when the
+    message carried no write) so the caller can trigger a reindex on a real apply.
+
+    Reindexing the JSONL is **not** done here: on the moderator host the always-on
+    backend's file watcher re-embeds a write, but a member host that runs a
+    daemon-only knows no watcher — so the connector reindexes explicitly after a
+    successful apply (see :func:`reindex_after_knowledge`). This closes the
+    "markdown lands but search never sees it" gap (Step 9, bible §11).
+
     Conflict policy is enforced in :func:`mycelium.filesystem.apply_knowledge`
     (last-write-wins; a stale-base write is kept out, logged, and dropped).
     """
@@ -200,7 +209,7 @@ def apply_knowledge_message(room: str, content: dict) -> None:
     body = data.get("content")
     if not isinstance(key, str) or not key or not isinstance(body, str):
         log.debug("knowledge message in %s carried no memory write — ignoring", room)
-        return
+        return None
     try:
         version = int(data.get("version", 1))
     except (TypeError, ValueError):
@@ -228,6 +237,33 @@ def apply_knowledge_message(room: str, content: dict) -> None:
         )
     elif result.applied:
         log.info("knowledge write applied: %s/%s (v%d)", room, key, version)
+    return result
+
+
+async def reindex_after_knowledge(config: MyceliumConfig, room: str) -> None:
+    """Re-embed a room's markdown into its JSONL index after a knowledge apply.
+
+    The receiver half of memory sync writes canonical markdown; the JSONL search
+    index is derived and must be refreshed or the member host's ``memory search``
+    never sees the new content (bible §11, Step 9). On the moderator host a file
+    watcher would do this; a member host that runs no watcher relies on the
+    connector calling its backend's reindex endpoint here.
+
+    The CLI has no local embedder (embeddings live in the backend), so — like
+    ``mycelium memory reindex`` — this is an HTTP call to the co-located backend,
+    scoped to the one room. **Best-effort:** a reindex failure must never sink the
+    write (the markdown is already durable and rebuildable), so it is logged and
+    swallowed. Reindex is idempotent, so a retry-on-reconnect re-serve is safe.
+    """
+    api_url = config.server.api_url
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(f"{api_url}/api/rooms/{room}/reindex")
+            resp.raise_for_status()
+    except Exception as exc:  # noqa: BLE001 - reindex is best-effort; markdown is canonical
+        log.warning("reindex after knowledge write failed for room %s: %s", room, exc)
+        return
+    log.debug("reindexed room %s after knowledge write", room)
 
 
 # ── Per-message dispatch (transport-agnostic) ────────────────────────────────
@@ -254,8 +290,12 @@ async def handle_inbound(
     # write it into the local store so the agent's working set updates mid-task.
     # It never wakes a turn. Co-located connectors each apply it, but the apply is
     # idempotent by version, so only the first actually writes; the rest skip.
+    # On a real write, reindex so a member host with no file watcher still surfaces
+    # the new content in search (Step 9 — close the daemon-only reindex gap).
     if l9.kind_of(content) == l9.KNOWLEDGE_KIND:
-        apply_knowledge_message(room, content)
+        result = apply_knowledge_message(room, content)
+        if result is not None and result.applied and config is not None:
+            await reindex_after_knowledge(config, room)
         return
 
     if not should_wake(content, handle):

--- a/mycelium-cli/tests/test_connector_knowledge_sync.py
+++ b/mycelium-cli/tests/test_connector_knowledge_sync.py
@@ -116,3 +116,124 @@ async def test_handle_inbound_routes_knowledge_without_waking(monkeypatch):
     )
     assert not woke and not published
     assert filesystem.read_memory(filesystem.get_room_dir("demo"), "plan/tasks") is not None
+
+
+# ── reindex-on-arrival (Step 9: close the daemon-only reindex gap) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_inbound_reindexes_after_applied_write(monkeypatch):
+    """A real knowledge apply on a member host triggers an explicit reindex.
+
+    On a daemon-only host there's no file watcher, so the connector must reindex
+    itself after writing the markdown or search never sees the new plan.
+    """
+    from mycelium.config import MyceliumConfig
+
+    monkeypatch.setattr(connector, "should_wake", lambda *a, **k: False)
+    reindexed: list[str] = []
+
+    async def _fake_reindex(config, room):
+        reindexed.append(room)
+
+    monkeypatch.setattr(connector, "reindex_after_knowledge", _fake_reindex)
+
+    async def _publish(content: dict) -> None:  # pragma: no cover - not called
+        pass
+
+    await connector.handle_inbound(
+        config=MyceliumConfig(),
+        daemon_cfg=None,  # ty: ignore[invalid-argument-type]
+        state=None,  # ty: ignore[invalid-argument-type]
+        room="demo",
+        handle="agent-a",
+        content=_knowledge("plan/tasks", "# Plan\n\n- [ ] a"),
+        publish=_publish,
+    )
+    assert reindexed == ["demo"]
+
+
+@pytest.mark.asyncio
+async def test_handle_inbound_skips_reindex_on_stale_base(monkeypatch):
+    """A stale-base (rejected) write is a no-op — it must not trigger a reindex."""
+    from mycelium.config import MyceliumConfig
+
+    monkeypatch.setattr(connector, "should_wake", lambda *a, **k: False)
+    # Seed a newer local v3 so the incoming v2 loses (last-write-wins).
+    connector.apply_knowledge_message("demo", _knowledge("plan/tasks", "# v3", version=3))
+
+    reindexed: list[str] = []
+
+    async def _fake_reindex(config, room):  # pragma: no cover - asserts not called
+        reindexed.append(room)
+
+    monkeypatch.setattr(connector, "reindex_after_knowledge", _fake_reindex)
+
+    async def _publish(content: dict) -> None:  # pragma: no cover - not called
+        pass
+
+    await connector.handle_inbound(
+        config=MyceliumConfig(),
+        daemon_cfg=None,  # ty: ignore[invalid-argument-type]
+        state=None,  # ty: ignore[invalid-argument-type]
+        room="demo",
+        handle="agent-a",
+        content=_knowledge("plan/tasks", "# stale v2", version=2),
+        publish=_publish,
+    )
+    assert reindexed == []
+
+
+@pytest.mark.asyncio
+async def test_reindex_after_knowledge_posts_to_scoped_backend_endpoint(monkeypatch):
+    """The reindex helper POSTs to the room-scoped backend reindex endpoint."""
+    from mycelium.config import MyceliumConfig, ServerConfig
+
+    calls: list[str] = []
+
+    class _FakeResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+    class _FakeClient:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a) -> None:
+            pass
+
+        async def post(self, url: str):
+            calls.append(url)
+            return _FakeResponse()
+
+    monkeypatch.setattr(connector.httpx, "AsyncClient", _FakeClient)
+    config = MyceliumConfig(server=ServerConfig(api_url="http://host-b:8000"))
+
+    await connector.reindex_after_knowledge(config, "demo")
+    assert calls == ["http://host-b:8000/api/rooms/demo/reindex"]
+
+
+@pytest.mark.asyncio
+async def test_reindex_after_knowledge_swallows_errors(monkeypatch):
+    """A reindex failure never propagates — the markdown is already canonical."""
+    from mycelium.config import MyceliumConfig
+
+    class _BoomClient:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a) -> None:
+            pass
+
+        async def post(self, url: str):
+            raise ConnectionError("backend down")
+
+    monkeypatch.setattr(connector.httpx, "AsyncClient", _BoomClient)
+    # Must not raise.
+    await connector.reindex_after_knowledge(MyceliumConfig(), "demo")

--- a/mycelium-cli/tests/test_connector_knowledge_sync_over_slim.py
+++ b/mycelium-cli/tests/test_connector_knowledge_sync_over_slim.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Cross-machine memory sync — live-node integration slice (Step 9 DoD).
+
+Needs a running ``slim`` node. Guarded so the default unit suite stays green
+without one (mirrors ``test_connector_wake_over_slim.py``): point at a node with
+``MYCELIUM_SLIM_ENDPOINT`` (default ``http://127.0.0.1:46357``); run one via
+``mycelium hub host`` or the docker recipe in ``START_HERE_STEP_5.md``. For a
+genuine two-host proof, run the node on host A and export
+``MYCELIUM_SLIM_ENDPOINT=http://<A-LAN-IP>:46357`` on host B (or put two
+containers on a shared docker **bridge network** and route by service name).
+
+Proves the Step 9 memory-sync half over a real MLS group channel: a moderator
+(host A's backend, faked here) broadcasts an L9 ``knowledge`` message that
+**carries** a compiled plan; the connector (host B) — pulling from its own member
+session — applies the carried markdown to a **genuinely separate data dir** and
+triggers a reindex on that store, with no file watcher in sight. This is the
+cross-machine realization of the same-machine Step 8 path
+(``test_l9_over_slim_roundtrip.py::test_converged_compiles_plan_and_syncs_memory_over_slim``):
+the "second store" is a distinct dir reached only through the real connector
+receiver, not a swapped ``MYCELIUM_DATA_DIR``.
+
+The connector's transport primitives are driven directly (member session +
+``handle_inbound``); the full ``run_connector`` reconnect loop is thin glue over
+them and is unit-covered in ``test_daemon_connector.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+pytest.importorskip("slim_bindings")
+
+from mycelium import filesystem
+from mycelium.config import MyceliumConfig, ServerConfig
+from mycelium.daemon import connector
+from mycelium.daemon.config import DaemonConfig
+from mycelium.daemon.state import DaemonState
+from mycelium.slim import l9
+from mycelium.slim.client import SlimClient, close_connection
+from mycelium.slim.naming import DEFAULT_NODE_ENDPOINT, SlimIdentity, to_channel_name, to_slim_name
+
+_ENDPOINT = os.getenv("MYCELIUM_SLIM_ENDPOINT", DEFAULT_NODE_ENDPOINT)
+_WORKSPACE = "mycelium"
+_ROOM = "knowledge-sync-room"
+_HANDLE = "agent-b"
+_PLAN_KEY = "plan/tasks"
+_PLAN_BODY = "# Converged Plan\n\n- [ ] ship the thing @agent-a\n- [ ] document it @agent-b\n"
+
+
+def _node_reachable(endpoint: str, *, timeout: float = 1.0) -> bool:
+    parsed = urlparse(endpoint)
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port or 46357
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _node_reachable(_ENDPOINT),
+    reason=f"no reachable SLIM node at {_ENDPOINT} (set MYCELIUM_SLIM_ENDPOINT or run `mycelium hub host`)",
+)
+
+
+def _knowledge_push() -> dict:
+    """The content dict the backend's memory_sync broadcasts for a compiled plan."""
+    return {
+        "content": f"plan updated → {_PLAN_KEY}",
+        "l9": {
+            "header": {
+                "protocol": "SSTP",
+                "subprotocol": "mycelium",
+                "version": "0.0.6",
+                "kind": l9.KNOWLEDGE_KIND,
+                "subkind": "distillation",
+                "participants": {
+                    "actors": [{"id": "CognitiveEngine", "role": "coordinator"}],
+                    "groups": None,
+                },
+                "message": {"id": "plan-push-1", "parents": [], "episode": "urn:x"},
+            },
+            "payload": {
+                "type": "distillation",
+                "data": {
+                    "key": _PLAN_KEY,
+                    "content": _PLAN_BODY,
+                    "version": 1,
+                    "base_version": None,
+                    "created_by": "CognitiveEngine",
+                    "updated_by": "CognitiveEngine",
+                    "updated_at": "2026-08-04T00:00:00+00:00",
+                },
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_knowledge_push_syncs_to_remote_store_over_slim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Host B's store is a genuinely separate data dir, reached only through the
+    # real connector receiver over the node.
+    remote_store = tmp_path / "host-b"
+    monkeypatch.setattr(filesystem, "get_mycelium_dir", lambda: remote_store)
+
+    # No backend is co-located in this slice, so record that the connector fired
+    # the explicit reindex (its markdown-lands-but-search-is-stale gap closer)
+    # rather than standing one up. The reindex → JSONL wiring itself is proven in
+    # the backend suite (Step 8 roundtrip) and by unit tests.
+    reindexed: list[str] = []
+
+    async def _record_reindex(_config: MyceliumConfig, room: str) -> None:
+        reindexed.append(room)
+
+    monkeypatch.setattr(connector, "reindex_after_knowledge", _record_reindex)
+
+    moderator = await SlimClient(SlimIdentity(_WORKSPACE, _ROOM, "backend")).connect(_ENDPOINT)
+    member = await SlimClient(SlimIdentity(_WORKSPACE, _ROOM, _HANDLE)).connect(_ENDPOINT)
+    session = await moderator.create_group(to_channel_name(_WORKSPACE, _ROOM))
+
+    applied = asyncio.Event()
+
+    async def member_side() -> None:
+        joined = await member.listen_for_session()
+
+        async def publish(_content: dict) -> None:  # pragma: no cover - knowledge never replies
+            pass
+
+        message = await SlimClient.receive_message(joined, timeout_s=15.0)
+        content = l9.parse(message.payload)
+        assert content is not None
+        await connector.handle_inbound(
+            config=MyceliumConfig(server=ServerConfig(api_url="http://localhost:8000")),
+            daemon_cfg=DaemonConfig(),
+            state=DaemonState(),
+            room=_ROOM,
+            handle=_HANDLE,
+            content=content,
+            publish=publish,
+        )
+        applied.set()
+
+    member_task = asyncio.create_task(member_side())
+    try:
+        # The member must be in the group before the moderator broadcasts, or the
+        # push lands before it is subscribed (SLIM keeps nothing for an absent
+        # member, §7d). Invite, then broadcast the knowledge push.
+        await moderator.invite(session, to_slim_name(_WORKSPACE, _ROOM, _HANDLE))
+        await SlimClient.publish(session, l9.serialize(_knowledge_push()))
+        await asyncio.wait_for(applied.wait(), timeout=20.0)
+    finally:
+        member_task.cancel()
+        try:
+            await member_task
+        except asyncio.CancelledError:
+            pass
+        await moderator.close()
+        await member.close()
+        await close_connection(_ENDPOINT)
+
+    # The carried markdown landed on host B's separate store …
+    got = filesystem.read_memory(filesystem.get_room_dir(_ROOM), _PLAN_KEY)
+    assert got is not None
+    meta, body = got
+    assert "ship the thing" in body and meta["version"] == 1
+    # … and the connector triggered a reindex there (no watcher required).
+    assert reindexed == [_ROOM]

--- a/mycelium-cli/tests/test_daemon_connector.py
+++ b/mycelium-cli/tests/test_daemon_connector.py
@@ -299,3 +299,41 @@ async def test_per_handle_lock_serializes_spawns(monkeypatch: pytest.MonkeyPatch
 
     assert max_in_flight == 1  # the per-handle lock never lets two turns overlap
     assert len(published) == 2
+
+
+# ── remote endpoint plumbing (Step 9: cross-machine) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_connector_uses_configured_remote_node_endpoint(monkeypatch):
+    """The connector dials ``config.slim.node_endpoint`` — a remote LAN node, not
+    the localhost default — so ``mycelium connect <A-LAN-IP>`` actually points a
+    member host at host A's shared node (Step 9 remote endpoint plumbing)."""
+    from mycelium.config import SlimConfig
+    from mycelium.slim.client import SlimUnavailableError
+
+    dialed: list[str] = []
+
+    class _FakeClient:
+        def __init__(self, _identity: Any) -> None:
+            pass
+
+        async def connect(self, node: str) -> Any:
+            dialed.append(node)
+            # Break out of run_connector's reconnect loop cleanly.
+            raise SlimUnavailableError("no wheel in test")
+
+    monkeypatch.setattr(connector, "SlimClient", _FakeClient)
+
+    config = MyceliumConfig(
+        server=ServerConfig(api_url="http://localhost:8000"),
+        slim=SlimConfig(node_endpoint="http://host-a.lan:46357"),
+    )
+    await connector.run_connector(
+        config=config,
+        daemon_cfg=DaemonConfig(),
+        state=DaemonState(),
+        room="demo",
+        handle="agent-a",
+    )
+    assert dialed == ["http://host-a.lan:46357"]


### PR DESCRIPTION
Picks up **Step 9** from `docs/START_HERE_STEP_9.md` (Step 8 merged). Makes the `join → exchange → converge → plan → work` loop real across **two machines on a LAN** through one shared SLIM node — moderated by host A, with host B a daemon-only member.

Per the step's mandate ("this is plumbing + proof, not a new sync mechanism"), the one genuinely new piece of code is the **reindex-on-arrival** gap closer; the rest is proving the Step 8 transport-agnostic path works over a longer wire and documenting the ops story.

## What changed

**Reindex gap (the sharp one) — `mycelium/daemon/connector.py`**
- On host A the backend's file watcher re-embeds a connector's write; a member host that runs a daemon-only has **no watcher**, so pushed markdown lands but search never sees it.
- `apply_knowledge_message` now returns the `KnowledgeApplyResult`, and on a real write `handle_inbound` calls new **`reindex_after_knowledge(config, room)`** — a best-effort, room-scoped `POST /api/rooms/{room}/reindex` to the co-located backend (the CLI has no local embedder, so reindex is HTTP, exactly like `mycelium memory reindex`). Fires only on an applied write, never on a stale-base no-op.

**Remote endpoint plumbing** — verified + unit-pinned: `run_connector` dials `config.slim.node_endpoint` (a remote LAN node), not the `127.0.0.1` default; `mycelium connect` already persists a normalized endpoint.

**Cross-host consent** — the invite/consent state machine is node-free and addresses the invitee by `workspace/room/agent` **identity only** (no host/endpoint), which is why consent → invite → join needs no new cross-machine mechanism. New test pins it.

**Docs** — `docs/cross-machine.md` (self-hosted shared node default; connector-explicit reindex; open-internet path via hosted node / tunnel — **NAT not built**) and the **Step 10 handoff** (`docs/START_HERE_STEP_10.md`).

## Decisions (flagged, per the step)
- **Hub location:** self-hosted shared node (`mycelium hub host` on the owner); hosted rendezvous is post-MVP. `connect` already accepts `https://` so no code change needed later.
- **Reindex:** connector reindexes explicitly after `apply_knowledge` (option (a) from the trap), rather than relying on a watcher — deterministic and works on a daemon-only host.

## Tests
Fast gate (no node):
- `test_connector_knowledge_sync.py` — reindex fires on apply, **not** on stale-base conflict; helper POSTs the room-scoped endpoint and swallows errors.
- `test_daemon_connector.py` — connector dials the configured remote endpoint.
- `test_mentions_and_invites.py` — moderator invites a remote agent by identity only.

Guarded live-node slice (skipped without a node):
- `test_connector_knowledge_sync_over_slim.py` — a real connector applies a `knowledge` push over the node to a **genuinely separate data dir** (not a swapped `MYCELIUM_DATA_DIR`) and triggers reindex there.

## Verification
- Backend: ruff + format + ty clean; `263 passed, 7 skipped`.
- CLI: ruff + format + ty clean; `385 passed, 3 skipped`.
- All prior guarded slices unchanged.

## DoD note
The headless two-host loop (connect → consent → exchange → converge → plan → synced-and-reindexed memory) is covered by unit + guarded slices here. The full two-laptop / two-container browser demo is the manual acceptance; the **UI inspector + room view + consent prompt** and the legacy SSE/poller retirement are **Step 10** (handoff included).