### PR TITLE
fix(sse): scope agent stream to active session rooms

### DIFF
--- a/fastapi-backend/app/routes/stream.py
+++ b/fastapi-backend/app/routes/stream.py
@@ -15,7 +15,7 @@ import logging
 from urllib.parse import urlparse
 
 import asyncpg
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 
@@ -252,13 +252,22 @@ async def stream_room_messages(room_name: str, request: Request):
 
 
 @router.get("/agents/{handle}/stream")
-async def stream_agent_events(handle: str, request: Request):
+async def stream_agent_events(
+    handle: str,
+    request: Request,
+    room: list[str] = Query(default=[]),
+):
     """
     Server-Sent Events stream for a specific agent handle.
 
     Delivers coordination_tick and coordination_consensus events addressed to
-    this agent across all rooms — no room configuration required on the client.
+    this agent. Pass one or more ``?room=<name>`` query parameters to scope
+    delivery to a specific session namespace — only events whose ``room_name``
+    starts with one of the supplied prefixes are forwarded. Without any
+    ``room`` parameter all events for the handle are delivered (legacy behaviour).
+
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
     """
     try:
         conn: asyncpg.Connection = await _open_listen_conn()
@@ -285,13 +294,17 @@ async def stream_agent_events(handle: str, request: Request):
         await _close_listen_conn(conn, channel, _on_notify if listener_added else None)
         raise HTTPException(status_code=503, detail=f"LISTEN setup failed: {e}") from e
 
-    logger.debug(f"SSE agent stream opened for: {handle}")
+    logger.debug(f"SSE agent stream opened for: {handle} (room filter: {room or 'none'})")
 
     async def _transform(payload: str) -> str | None:
         try:
-            json.loads(payload)
+            data = json.loads(payload)
         except json.JSONDecodeError:
             return None
+        if room:
+            room_name = data.get("room_name") or ""
+            if not any(room_name.startswith(r) for r in room):
+                return None
         return f"data: {payload}\n\n"
 
     async def event_generator():

--- a/fastapi-backend/app/routes/stream.py
+++ b/fastapi-backend/app/routes/stream.py
@@ -262,12 +262,12 @@ async def stream_agent_events(
 
     Delivers coordination_tick and coordination_consensus events addressed to
     this agent. Pass one or more ``?room=<name>`` query parameters to scope
-    delivery to a specific session namespace — only events whose ``room_name``
-    starts with one of the supplied prefixes are forwarded. Without any
-    ``room`` parameter all events for the handle are delivered (legacy behaviour).
+    delivery to a specific session — only events whose ``room_name`` exactly
+    matches one of the supplied values are forwarded. Without any ``room``
+    parameter all events for the handle are delivered (legacy behaviour).
 
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
-    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room:session:abc123"
     """
     try:
         conn: asyncpg.Connection = await _open_listen_conn()
@@ -296,15 +296,15 @@ async def stream_agent_events(
 
     logger.debug(f"SSE agent stream opened for: {handle} (room filter: {room or 'none'})")
 
+    room_set: frozenset[str] = frozenset(room)
+
     async def _transform(payload: str) -> str | None:
         try:
             data = json.loads(payload)
         except json.JSONDecodeError:
             return None
-        if room:
-            room_name = data.get("room_name") or ""
-            if not any(room_name.startswith(r) for r in room):
-                return None
+        if room_set and (data.get("room_name") or "") not in room_set:
+            return None
         return f"data: {payload}\n\n"
 
     async def event_generator():

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -391,7 +391,9 @@ def await_tick(
         # from prior sessions (same handle, different room) are filtered server-side.
         sse_room_scope = active_session_rooms if active_session_rooms else [resolved_room]
         url = f"{config.server.api_url}/api/agents/{handle}/stream"
-        sse_params = [("room", r) for r in sse_room_scope]
+        sse_params: list[tuple[str, str | int | float | None]] = [
+            ("room", r) for r in sse_room_scope
+        ]
         start = time.time()
 
         with (

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -315,14 +315,25 @@ def await_tick(
                     # Ticks are posted to coordination sessions (legacy display
                     # name: ``{room}:session:{short}``). Pull the active sessions
                     # from the first-class endpoint instead of scanning rooms.
-                    rooms_to_scan = [resolved_room]
                     coord_resp = http.get(
                         f"{config.server.api_url}/api/coordination-sessions",
                         params={"parent_room": resolved_room, "limit": 200},
                     )
+                    active_session_rooms: list[str] = []
                     if coord_resp.status_code == 200:
                         for c in coord_resp.json():
-                            rooms_to_scan.append(c["display_name"])
+                            if c.get("state") in ("idle", "waiting", "negotiating"):
+                                active_session_rooms.append(c["display_name"])
+
+                    # If an active session exists, scan only its room for missed ticks.
+                    # Scanning the parent room (or broken sessions) is skipped so that
+                    # a prior session's consensus is never replayed into a new session.
+                    # When NO active session exists, scan the parent room: the agent
+                    # likely missed the consensus from the session that just finished.
+                    if active_session_rooms:
+                        rooms_to_scan = active_session_rooms
+                    else:
+                        rooms_to_scan = [resolved_room]
 
                     for scan_room in rooms_to_scan:
                         resp = http.get(
@@ -376,10 +387,14 @@ def await_tick(
                 except Exception:
                     pass  # fall through to SSE
 
+        # Scope the SSE subscription to the current session's rooms so events
+        # from prior sessions (same handle, different room) are filtered server-side.
+        sse_room_scope = active_session_rooms if active_session_rooms else [resolved_room]
         url = f"{config.server.api_url}/api/agents/{handle}/stream"
+        sse_params = [("room", r) for r in sse_room_scope]
         start = time.time()
 
-        with httpx.Client(timeout=None) as http, http.stream("GET", url) as response:
+        with httpx.Client(timeout=None) as http, http.stream("GET", url, params=sse_params) as response:
             for line in response.iter_lines():
                 if timeout > 0 and (time.time() - start) >= timeout:
                     typer.echo(json_module.dumps({"type": "timeout", "seconds": timeout}))

--- a/mycelium-cli/src/mycelium/commands/session.py
+++ b/mycelium-cli/src/mycelium/commands/session.py
@@ -394,7 +394,10 @@ def await_tick(
         sse_params = [("room", r) for r in sse_room_scope]
         start = time.time()
 
-        with httpx.Client(timeout=None) as http, http.stream("GET", url, params=sse_params) as response:
+        with (
+            httpx.Client(timeout=None) as http,
+            http.stream("GET", url, params=sse_params) as response,
+        ):
             for line in response.iter_lines():
                 if timeout > 0 and (time.time() - start) >= timeout:
                     typer.echo(json_module.dumps({"type": "timeout", "seconds": timeout}))

--- a/mycelium-cli/src/mycelium_backend_client/api/stream/stream_agent_events_api_agents_handle_stream_get.py
+++ b/mycelium-cli/src/mycelium_backend_client/api/stream/stream_agent_events_api_agents_handle_stream_get.py
@@ -7,11 +7,13 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import Response, UNSET, Unset
 
 
 def _get_kwargs(
     handle: str,
+    *,
+    room: list[str] | Unset = UNSET,
 ) -> dict[str, Any]:
 
     _kwargs: dict[str, Any] = {
@@ -20,6 +22,12 @@ def _get_kwargs(
             handle=quote(str(handle), safe=""),
         ),
     }
+
+    params: dict[str, Any] = {}
+    if not isinstance(room, Unset):
+        params["room"] = room
+    if params:
+        _kwargs["params"] = params
 
     return _kwargs
 
@@ -57,17 +65,23 @@ def sync_detailed(
     handle: str,
     *,
     client: AuthenticatedClient | Client,
+    room: list[str] | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Stream Agent Events
 
      Server-Sent Events stream for a specific agent handle.
 
     Delivers coordination_tick and coordination_consensus events addressed to
-    this agent across all rooms — no room configuration required on the client.
+    this agent. Pass one or more ``room`` values to scope delivery to a
+    specific session namespace — only events whose room_name starts with one
+    of the supplied prefixes are forwarded. Without any room filter all events
+    for the handle are delivered.
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
 
     Args:
         handle (str):
+        room (list[str] | Unset): Optional room name prefix(es) to scope the stream.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -79,6 +93,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         handle=handle,
+        room=room,
     )
 
     response = client.get_httpx_client().request(
@@ -92,17 +107,23 @@ def sync(
     handle: str,
     *,
     client: AuthenticatedClient | Client,
+    room: list[str] | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Stream Agent Events
 
      Server-Sent Events stream for a specific agent handle.
 
     Delivers coordination_tick and coordination_consensus events addressed to
-    this agent across all rooms — no room configuration required on the client.
+    this agent. Pass one or more ``room`` values to scope delivery to a
+    specific session namespace — only events whose room_name starts with one
+    of the supplied prefixes are forwarded. Without any room filter all events
+    for the handle are delivered.
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
 
     Args:
         handle (str):
+        room (list[str] | Unset): Optional room name prefix(es) to scope the stream.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -115,6 +136,7 @@ def sync(
     return sync_detailed(
         handle=handle,
         client=client,
+        room=room,
     ).parsed
 
 
@@ -122,17 +144,23 @@ async def asyncio_detailed(
     handle: str,
     *,
     client: AuthenticatedClient | Client,
+    room: list[str] | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Stream Agent Events
 
      Server-Sent Events stream for a specific agent handle.
 
     Delivers coordination_tick and coordination_consensus events addressed to
-    this agent across all rooms — no room configuration required on the client.
+    this agent. Pass one or more ``room`` values to scope delivery to a
+    specific session namespace — only events whose room_name starts with one
+    of the supplied prefixes are forwarded. Without any room filter all events
+    for the handle are delivered.
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
 
     Args:
         handle (str):
+        room (list[str] | Unset): Optional room name prefix(es) to scope the stream.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -144,6 +172,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         handle=handle,
+        room=room,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -155,17 +184,23 @@ async def asyncio(
     handle: str,
     *,
     client: AuthenticatedClient | Client,
+    room: list[str] | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Stream Agent Events
 
      Server-Sent Events stream for a specific agent handle.
 
     Delivers coordination_tick and coordination_consensus events addressed to
-    this agent across all rooms — no room configuration required on the client.
+    this agent. Pass one or more ``room`` values to scope delivery to a
+    specific session namespace — only events whose room_name starts with one
+    of the supplied prefixes are forwarded. Without any room filter all events
+    for the handle are delivered.
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
 
     Args:
         handle (str):
+        room (list[str] | Unset): Optional room name prefix(es) to scope the stream.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -179,5 +214,6 @@ async def asyncio(
         await asyncio_detailed(
             handle=handle,
             client=client,
+            room=room,
         )
     ).parsed

--- a/mycelium-client/mycelium_backend_client/api/stream/stream_agent_events_api_agents_handle_stream_get.py
+++ b/mycelium-client/mycelium_backend_client/api/stream/stream_agent_events_api_agents_handle_stream_get.py
@@ -7,11 +7,13 @@ import httpx
 from ... import errors
 from ...client import AuthenticatedClient, Client
 from ...models.http_validation_error import HTTPValidationError
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     handle: str,
+    *,
+    room: list[str] | Unset = UNSET,
 ) -> dict[str, Any]:
 
     _kwargs: dict[str, Any] = {
@@ -20,6 +22,12 @@ def _get_kwargs(
             handle=quote(str(handle), safe=""),
         ),
     }
+
+    params: dict[str, Any] = {}
+    if not isinstance(room, Unset):
+        params["room"] = room
+    if params:
+        _kwargs["params"] = params
 
     return _kwargs
 
@@ -57,17 +65,23 @@ def sync_detailed(
     handle: str,
     *,
     client: AuthenticatedClient | Client,
+    room: list[str] | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Stream Agent Events
 
      Server-Sent Events stream for a specific agent handle.
 
     Delivers coordination_tick and coordination_consensus events addressed to
-    this agent across all rooms — no room configuration required on the client.
+    this agent. Pass one or more ``room`` values to scope delivery to a
+    specific session namespace — only events whose room_name starts with one
+    of the supplied prefixes are forwarded. Without any room filter all events
+    for the handle are delivered.
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
 
     Args:
         handle (str):
+        room (list[str] | Unset): Optional room name prefix(es) to scope the stream.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -79,6 +93,7 @@ def sync_detailed(
 
     kwargs = _get_kwargs(
         handle=handle,
+        room=room,
     )
 
     response = client.get_httpx_client().request(
@@ -92,17 +107,23 @@ def sync(
     handle: str,
     *,
     client: AuthenticatedClient | Client,
+    room: list[str] | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Stream Agent Events
 
      Server-Sent Events stream for a specific agent handle.
 
     Delivers coordination_tick and coordination_consensus events addressed to
-    this agent across all rooms — no room configuration required on the client.
+    this agent. Pass one or more ``room`` values to scope delivery to a
+    specific session namespace — only events whose room_name starts with one
+    of the supplied prefixes are forwarded. Without any room filter all events
+    for the handle are delivered.
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
 
     Args:
         handle (str):
+        room (list[str] | Unset): Optional room name prefix(es) to scope the stream.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -115,6 +136,7 @@ def sync(
     return sync_detailed(
         handle=handle,
         client=client,
+        room=room,
     ).parsed
 
 
@@ -122,17 +144,23 @@ async def asyncio_detailed(
     handle: str,
     *,
     client: AuthenticatedClient | Client,
+    room: list[str] | Unset = UNSET,
 ) -> Response[Any | HTTPValidationError]:
     """Stream Agent Events
 
      Server-Sent Events stream for a specific agent handle.
 
     Delivers coordination_tick and coordination_consensus events addressed to
-    this agent across all rooms — no room configuration required on the client.
+    this agent. Pass one or more ``room`` values to scope delivery to a
+    specific session namespace — only events whose room_name starts with one
+    of the supplied prefixes are forwarded. Without any room filter all events
+    for the handle are delivered.
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
 
     Args:
         handle (str):
+        room (list[str] | Unset): Optional room name prefix(es) to scope the stream.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -144,6 +172,7 @@ async def asyncio_detailed(
 
     kwargs = _get_kwargs(
         handle=handle,
+        room=room,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -155,17 +184,23 @@ async def asyncio(
     handle: str,
     *,
     client: AuthenticatedClient | Client,
+    room: list[str] | Unset = UNSET,
 ) -> Any | HTTPValidationError | None:
     """Stream Agent Events
 
      Server-Sent Events stream for a specific agent handle.
 
     Delivers coordination_tick and coordination_consensus events addressed to
-    this agent across all rooms — no room configuration required on the client.
+    this agent. Pass one or more ``room`` values to scope delivery to a
+    specific session namespace — only events whose room_name starts with one
+    of the supplied prefixes are forwarded. Without any room filter all events
+    for the handle are delivered.
     Connect with: curl -N http://localhost:8000/agents/{handle}/stream
+    Connect scoped: curl -N "http://localhost:8000/agents/{handle}/stream?room=my-room"
 
     Args:
         handle (str):
+        room (list[str] | Unset): Optional room name prefix(es) to scope the stream.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -179,5 +214,6 @@ async def asyncio(
         await asyncio_detailed(
             handle=handle,
             client=client,
+            room=room,
         )
     ).parsed

--- a/openapi.json
+++ b/openapi.json
@@ -879,7 +879,7 @@
                     "stream"
                 ],
                 "summary": "Stream Agent Events",
-                "description": "Server-Sent Events stream for a specific agent handle.\n\nDelivers coordination_tick and coordination_consensus events addressed to\nthis agent across all rooms \u2014 no room configuration required on the client.\nConnect with: curl -N http://localhost:8000/agents/{handle}/stream",
+                "description": "Server-Sent Events stream for a specific agent handle.\n\nDelivers coordination_tick and coordination_consensus events addressed to\nthis agent. Pass one or more ``?room=<name>`` query parameters to scope\ndelivery to a specific session \u2014 only events whose ``room_name`` exactly\nmatches one of the supplied values are forwarded. Without any ``room``\nparameter all events for the handle are delivered (legacy behaviour).\n\nConnect with: curl -N http://localhost:8000/agents/{handle}/stream\nConnect scoped: curl -N \"http://localhost:8000/agents/{handle}/stream?room=my-room:session:abc123\"",
                 "operationId": "stream_agent_events_api_agents__handle__stream_get",
                 "parameters": [
                     {
@@ -889,6 +889,19 @@
                         "schema": {
                             "type": "string",
                             "title": "Handle"
+                        }
+                    },
+                    {
+                        "name": "room",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [],
+                            "title": "Room"
                         }
                     }
                 ],


### PR DESCRIPTION
## Summary

- **Root cause**: `/api/agents/{handle}/stream` delivered all coordination events across every room the agent had ever participated in — no room boundary. On reconnect to a new session, `session await` could replay stale `coordination_consensus` from prior rooms before any ticks fired, producing spurious "Impasse after 0 round(s)" output.
- **Server-side filter**: Added optional `?room=<name>` query params to the agent SSE endpoint. Events are only forwarded when their `room_name` exactly matches one of the supplied values (frozenset membership). Without params, the legacy all-rooms behaviour is unchanged.
- **CLI scoping**: `session await` now queries active coordination sessions (state: `idle`, `waiting`, `negotiating`) and passes only those room names as `?room=` params. The missed-tick HTTP scan before SSE attachment is also restricted to active sessions, preventing a stale broken/failed session from replaying consensus on reconnect.
- **Generated client**: Updated the vendored `mycelium_backend_client` in both `mycelium-client/` and `mycelium-cli/` to accept the new `room: list[str] | Unset = UNSET` parameter.

## What's not changed

The global "no room filter" behaviour is still the default — callers that don't pass `?room=` get every event. Long-running multi-room subscribers are unaffected.

## Future work

**Last-Event-ID reconnection resilience** is the natural follow-on. Within a single session, a client reconnect could replay missed ticks using `Last-Event-ID` as a `created_at` cursor. Blocked today because coordination messages have `recipient_handle = NULL` (session broadcasts), so replay needs session scope — equivalent to `?room=` but more complex. Filed here for visibility; not required for this fix.

## Test plan

- [ ] `session await` in a room with a prior broken session no longer surfaces stale consensus before the new session fires
- [ ] `session await` completes normally on negotiation tick and consensus in a fresh session
- [ ] Agent with no prior sessions: stream with no `?room=` param still works (legacy path)
- [ ] `curl -N "…/agents/{handle}/stream?room=my-room:session:abc123"` — only events for that session arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)