### PR TITLE
feat(demo): full converge→plan→memory pipeline working e2e with live agents

### DIFF
--- a/docs/START_HERE_MEDIATOR.md
+++ b/docs/START_HERE_MEDIATOR.md
@@ -1,0 +1,195 @@
+# START HERE — The SAO Mediator Agent (kill the AI theatre)
+
+> **Status: exploratory / design track.** This is a thinking-out-loud spec for a real
+> architectural pivot, written so we can track it and look at it holistically as one feature.
+> Nothing here is committed to a release. The build plan front-loads the one cheap experiment
+> that can *falsify* the whole idea before we invest in the harness swap.
+
+You are picking up the **coordination redesign** that the H5 demo surfaced. H5 got a full
+`converge → plan → memory` run working with live agents (see
+[`START_HERE_H5_DEMO.md`](./START_HERE_H5_DEMO.md)) — but in doing so it exposed that the
+*shape* of our coordination is wrong. This doc is the plan to fix the shape.
+
+## The problem (what the demo proved)
+
+The H5 demo works, and that's exactly how we found the bug. Watch the `demo-final` transcript:
+three agents (@growth/@risk/@execution) lock the agreement — **30% tech / 25% cap on every
+other sector** — by roughly the **5th message**. Then they spend **seven more turns**
+re-stating that same agreement in slightly different words until something finally summons the
+aligner.
+
+That is **AI theatre** — the precise failure Mycelium exists to kill (README, "The Problem":
+*"agents that talk over each other, repeat work already done, fail to recognise disagreement,
+fail to negotiate trade-offs"*). Our coordination layer didn't *prevent* the theatre; it
+*hosted* it.
+
+**Root cause:** the aligner is a passive, post-hoc **observer**. It only wakes when summoned,
+reads a finished transcript, and grades confidence math. Nothing *runs* the negotiation while
+it happens, so there is no mechanism that says "you agreed — stop." Agents fill the silence by
+re-agreeing. The confidence-marker parse added in the H5 fix
+(`connector.py:parse_position_marker`) makes the observer *score*, but it doesn't make anything
+*drive*.
+
+## The core idea
+
+Flip the aligner from **scorekeeper** to **mediator** — a "camp counselor" that owns the
+structure of the conversation and lets each agent speak in turn:
+
+1. It **interprets** each agent's natural-language message (no structured markers required of
+   the agents — that burden goes away).
+2. It maps those interpretations into a real **NEGMAS Stacked Alternating Offers (SAO)**
+   negotiation — the exact mechanism the original CFN used.
+3. **NEGMAS owns termination.** The mechanism — not vibes, not an LLM's mood — decides the
+   instant everyone has accepted the standing offer, and it *stops there*. That single fact is
+   what kills the theatre.
+
+Crucially, the mediator **is itself an agent** (on-thesis with the broader pivot: the
+cognition-engine becomes an agent *in* the MAS, not backend code — see
+`project_cfn_teardown_l9_pivot` and the coordination-transport-pivot doc). It reasons with an
+LLM and drives NEGMAS as a tool.
+
+## Definition of done
+
+Re-run the equivalent of `mycelium demo`: several real agents negotiate, and a **mediator
+agent** actively runs the rounds over SLIM — addressing agents in turn, interpreting their
+replies, stepping a NEGMAS SAO — and **terminates the moment agreement is reached** (no
+restating loop). On termination it emits the agreed `issue = value` map, which compiles to
+`plan/tasks.md` and syncs to memory exactly as today. The transcript shows a *bounded*
+negotiation, not seven rounds of "we're agreed."
+
+## What's proven vs. not (honest ledger)
+
+**Proven (this session, hands-on):**
+- **Pi gives us the session primitive `claude -p` buries.** `pi -p --session <path> --mode
+  json` — two separate processes against the same `--session` retained context (planted "42",
+  recalled it; JSONL appended 5→7 lines). A long-lived mediator can hold one stable session
+  across every SAO round, driven by our configured LLM (`--model anthropic/... --api-key`),
+  provider-agnostic. Pi = [earendil-works/pi](https://github.com/earendil-works/pi), TS/Node,
+  MIT, ~84k★.
+- **OpenShell is real and ships Pi as a preset.** [NVIDIA/OpenShell](https://github.com/NVIDIA/OpenShell)
+  — policy-enforced agent sandbox; `openshell sandbox create --from pi` is documented.
+- **NEGMAS SAO is stable** and was already driven *externally* in the original CFN
+  (`ioc-cfn-cognition-engines/semantic_negotiation/app/agent/callback_negotiator.py`).
+- **The converge → plan → memory tail already works** (H5): aligner verdict → `plan_sync` →
+  `plan_compiler` → `memory_sync`. We are replacing the *front* of that pipe, not the back.
+
+**NOT proven (the one thing this track must de-risk):**
+- **Can an LLM mediator reliably read natural-language agent chatter, map it into NEGMAS
+  offers/responses, and terminate correctly?** This is the whole bet. Everything else is
+  plumbing around it. **Falsify this first** (Rung 0 below) before building any harness.
+
+## Target architecture
+
+- **All participants are Pi coding agents**, one framework, sandboxed by OpenShell, driven by
+  the mycelium-configured LLM via `pi-ai`. Retire `claude -p` cold-spawn. Workers keep the good
+  coding-agent abstractions (skills, tools, bash); they just *speak* in the room.
+- **The mediator is a long-lived agent for the duration of one negotiation.** Recommended
+  factoring for the Node/Python seam (NEGMAS is Python, Pi is Node):
+  > The mediator is a **Python** process that holds the NEGMAS `SAOMechanism` natively
+  > in-process and drives its Pi "brain" via `pi -p --session <id> --mode json` (the exact
+  > calls already validated). NEGMAS state stays in Python where it's trivial; Pi handles only
+  > the LLM turn + conversation memory. No cross-language state.
+- **Drive is native over SLIM.** The mediator publishes `@`-addressed prompts that wake a
+  participant's connector (reuse `aligner._prompt_round`'s unicast publish); it reads replies
+  from the transcript (reuse `_collect_round`); it interprets them with its LLM; it steps
+  NEGMAS; it repeats. It "still uses `@` commands" — that's how it addresses the next proposer.
+- **The backend shrinks to what it's good at:** moderate the SLIM channel, persist the
+  transcript, freeze membership for the episode, compile the agreed plan. It stops doing
+  cognition.
+
+## How it maps to what exists (scouted — reuse vs. new)
+
+Reuse (mechanics are production-grade):
+- Unicast publish to one agent — `aligner.py:_prompt_round` → `managed.channel.send` with L9
+  `recipients=[handle]`.
+- Reply collection — `aligner.py:_collect_round` polls `persister.log.records`.
+- Episode freeze/drain — `room_channels.open_episode` / `close_episode` (membership freeze,
+  queued-invite flush).
+- Summon seam — `persister.find_summons` → `on_summon` (`@aligner` still the entry point).
+- Converged tail — `plan_sync.handle_converged` → `plan_compiler` → `memory_sync`.
+
+New (the SAO-specific orchestration + interpretation):
+- **Standing offer + proposer rotation + unanimity-stop** (today's `drive` loop just asks
+  "state your position and confidence" and folds MPC — no offer, no rotation, no early stop).
+- **Issue/option discovery** from opening prose — port `intent_discovery.py` +
+  `options_generation.py` (LLM stages) from the sibling repo.
+- **NL → NEGMAS interpretation** — the mediator's LLM reading "I can live with 30/25 if beta
+  holds" → a NEGMAS response against the standing offer.
+- **Echo-back for trust** — the counselor restates its reading ("recording @growth as: counter
+  → 35% tech") so a misread is corrected *in-band* before it commits.
+
+## Build plan (rungs — start where it can break)
+
+**Rung 0 — falsify the behavioral core (cheap, no harness).** A standalone Python script:
+NEGMAS `SAOMechanism` + an LLM interpreter, replayed over the **captured `demo-final`
+transcript** (already saved). It must (a) discover the issues/options, (b) drive the SAO from
+the real chatter, (c) land on **30/25**, and (d) **terminate at agreement** — not loop. If this
+holds, the rest is plumbing. If not, we learned the cheap way and rethink. *Do this first.*
+
+**Rung 1 — the mediator drives live over SLIM, still on today's worker agents.** Wrap Rung 0 as
+the `@aligner` driver: on summon, open the episode, run NEGMAS rounds by `@`-addressing agents
+and reading replies, terminate on agreement, hand the `issue=value` map to `plan_sync`. Proves
+the mediator kills the theatre *before* touching the harness.
+
+**Rung 2 — swap the worker runtime to Pi + OpenShell.** Replace `claude -p` cold-spawn with Pi
+agents (`pi -p --session <id> --mode json`), OpenShell-sandboxed. Independent payoff
+(provider-agnostic, containerized, self-hostable) and independent risk from the mediator.
+
+**Rung 3 — retire the old surface.** Remove the backend SIEP observer engine and the
+`parse_position_marker` reply-marker hack; agents go back to markerless prose (the mediator
+interprets). Update the skill/preamble.
+
+## Fixed decisions
+
+- The mediator is an **agent that runs NEGMAS**, not re-ported SAO math in the backend.
+- **NEGMAS owns termination.** Agreement is when the mechanism says so; the mediator does not
+  "decide to stop."
+- **One framework: Pi coding agents** for all participants, OpenShell-sandboxed.
+- Agents are **not** required to emit structured markers; the mediator interprets prose.
+
+## Open questions (each has a recommended default — use it, note it, flag it)
+
+- **Mediator lifecycle host language** → *Python process holding NEGMAS, driving Pi via CLI.*
+  (Alternative: Node/Pi-SDK mediator shelling to a Python NEGMAS sidecar — more moving parts.)
+- **Trigger** → *explicit `@aligner` summon hands the room to the mediator* (deterministic;
+  the demo already does this). Auto-start on detected negotiation is a later nicety.
+- **Session locking** → drive the mediator's Pi session **strictly serially** (turn-based, so
+  safe by construction) and reuse the daemon's per-handle serial-lock discipline. Run a
+  deliberate concurrent-write test before trusting Pi sessions under any parallelism.
+- **Utilities for NEGMAS** → start with the mediator inferring a coarse per-agent utility from
+  stated positions/hard-lines; refine only if Rung 0 shows it needs it.
+
+## What this retires
+
+- `app/services/aligner.py` — the observer/driver SIEP engine (replaced by the mediator agent).
+- `daemon/connector.py:parse_position_marker` + the preamble's "position marker" block (the
+  H5 confidence-marker hack — no longer needed once the mediator interprets prose).
+- `claude -p` cold-spawn worker runtime (→ Pi + OpenShell).
+
+## Prereqs
+
+- Backend + slim node up (dev compose); exactly one daemon.
+- `pi` on PATH (0.65.0 verified) and an LLM key — `pi -p --session <path> --mode json` is the
+  proven drive call. NEGMAS: `uv add negmas` in whatever process hosts the mediator.
+- The captured `demo-final` transcript for Rung 0 (pull via the room `messages` API).
+
+## References
+
+- **The problem, live:** `START_HERE_H5_DEMO.md` (the demo this exposed), README "The Problem".
+- **Original SAO mechanism (port from):** `ioc-cfn-cognition-engines/semantic_negotiation/app/agent/`
+  — `callback_negotiator.py` (the round loop + external drive), `semantic_negotiation.py`
+  (pipeline + commit envelope), `intent_discovery.py`, `options_generation.py`,
+  `offer_validation.py`.
+- **Current coordination internals (extend/retire):** `app/services/aligner.py`,
+  `l9_episode.py`, `room_channels.py`, `persister.py`, `plan_sync.py`, `plan_compiler.py`.
+- **Harness:** [Pi](https://github.com/earendil-works/pi) (`pi-ai`, `pi-agent-core`, session
+  docs), [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell), [NEGMAS](https://github.com/yasserfarouk/negmas).
+- **Direction memory:** `project_mediator_pi_negmas`, `project_cfn_teardown_l9_pivot`.
+
+## How to work with the human
+
+Rung by rung, evidence after each — but the deliverable that matters is a **bounded**
+negotiation: a human watching agents reach agreement and the mediator *stop*, versus the H5
+theatre. Rung 0 is a spike; expect to throw code away. Treat surprises in the LLM→NEGMAS
+interpretation as the real findings — that's the unproven core, and it's the whole point of
+building this at all.

--- a/experiments/sao-mediator-spike/README.md
+++ b/experiments/sao-mediator-spike/README.md
@@ -1,0 +1,18 @@
+# Rung 0 spike — LLM mediator driving a real NEGMAS SAO
+
+De-risks the unproven core of `docs/START_HERE_MEDIATOR.md`: *can an LLM mediator read
+natural-language agent chatter, map it into NEGMAS offers, and terminate at agreement?*
+
+- `mediator_spike.py` (v1) — stateless agents + bare offers. **Deadlocks** (amnesiac hardliner
+  never concedes). Finding: NEGMAS drive ✓ and NL→SAO interpretation ✓, but statelessness
+  kills convergence. The failure is the harness, not the model or `claude -p` (never used it —
+  it's litellm→haiku direct).
+- `mediator_spike_v2.py` — adds MEMORY (per-agent running history, i.e. what a persistent Pi
+  session gives you), a BROKERING mediator (frames where everyone stands + nudges to close),
+  and BATNA (no deal = no rebalance). **Converges in 2 steps and NEGMAS terminates at
+  agreement — no restating theatre.**
+
+Verdict: PASS. The mediator's job is memory + brokering + BATNA framing (the "camp counselor"),
+with NEGMAS owning the protocol and the stop.
+
+Run: `ANTHROPIC_API_KEY=... uv run --with negmas --with litellm python mediator_spike_v2.py`

--- a/experiments/sao-mediator-spike/mediator_spike.py
+++ b/experiments/sao-mediator-spike/mediator_spike.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+"""Rung 0 spike — can an LLM mediator drive a real NEGMAS SAO to a *terminating* agreement?
+
+The unproven core of docs/START_HERE_MEDIATOR.md. No harness, no SLIM, no backend.
+
+The bet: NEGMAS owns the Stacked-Alternating-Offers protocol *and* termination; the LLM only
+does what LLMs are good at — turn each agent's natural-language move into a structured
+offer/response. We let NEGMAS drive the rounds (its `SAONegotiator.propose/respond` seam), and
+inside that seam the "agent" speaks prose (from its persona) which the **mediator interprets**
+into a NEGMAS action. If NEGMAS reaches the ~30% tech / 25% other agreement and *stops* — no
+restating loop — the concept holds.
+
+Run:
+    ANTHROPIC_API_KEY=... uv run --with negmas --with litellm python mediator_spike.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import litellm
+from negmas import SAOMechanism, make_issue
+from negmas.sao import ResponseType, SAONegotiator
+
+MODEL = os.environ.get("SPIKE_MODEL", "anthropic/claude-haiku-4-5-20251001")
+
+# The real ex07 personas (verbatim from the demo agents' manifests). These are the agents'
+# *private* preferences — the mediator never sees them; it only sees what they say.
+PERSONAS = {
+    "growth": (
+        "You are GrowthAgent. The portfolio should be tilted toward high-growth technology "
+        "stocks. You are willing to accept a diversification rule that caps sector concentration "
+        "at 40%, but you will not accept a conservative or balanced allocation that sacrifices "
+        "growth. Push for technology sector overweight on every rebalancing decision."
+    ),
+    "risk": (
+        "You are RiskAgent. Volatility must be controlled. The portfolio needs broad "
+        "diversification — no single sector above 25%. You are willing to accept modest "
+        "technology overweight (up to 30%) if volatility metrics stay within bounds, but you "
+        "will block any trade that spikes portfolio beta above the agreed threshold. Concede on "
+        "sector cap levels, not on the volatility rule."
+    ),
+    "execution": (
+        "You are ExecutionAgent. The portfolio is out of balance now and the longer we wait the "
+        "worse the drift. You want to rebalance immediately using the agreed target weights. You "
+        "are flexible on the target itself — that is GrowthAgent and RiskAgent's domain — but you "
+        "insist on executing as soon as a target is agreed. Do not delay execution on any "
+        "condition that does not directly block the trade."
+    ),
+}
+TASK = (
+    "Negotiate the investment-portfolio rebalance. Agree the technology sector cap, the cap on "
+    "every other sector, and whether a portfolio-beta gate blocks trades."
+)
+
+
+def llm(prompt: str, *, system: str = "", temperature: float = 0.0) -> str:
+    msgs = ([{"role": "system", "content": system}] if system else []) + [
+        {"role": "user", "content": prompt}
+    ]
+    resp = litellm.completion(model=MODEL, messages=msgs, temperature=temperature, max_tokens=600)
+    return resp.choices[0].message.content or ""
+
+
+def _json(text: str) -> dict:
+    """Pull the first JSON object out of an LLM reply (tolerant of prose/fences)."""
+    m = re.search(r"\{.*\}", text, re.DOTALL)
+    return json.loads(m.group(0)) if m else {}
+
+
+# ── Stage 1: the mediator discovers the negotiable issues + options from the opening ──────────
+
+
+def discover_issues() -> list[dict]:
+    opening = "\n".join(f"@{h}: {p}" for h, p in PERSONAS.items())
+    out = _json(
+        llm(
+            f"You are a negotiation mediator. From the task and each agent's stated position, "
+            f"identify the negotiable ISSUES and 3-4 discrete OPTIONS each (concrete values the "
+            f"agents could actually agree on).\n\nTASK: {TASK}\n\nPOSITIONS:\n{opening}\n\n"
+            f'Return ONLY JSON: {{"issues":[{{"name":"snake_case","options":["v1","v2","v3"]}}]}}',
+            system="You output strict JSON. Options must be short concrete tokens (e.g. '30' or "
+            "'on'), not sentences.",
+        )
+    )
+    issues = out.get("issues", [])
+    if len(issues) < 2:
+        raise SystemExit(f"discovery failed — need >=2 issues, got: {issues}")
+    return issues
+
+
+# ── Stage 2: agents speak prose; the mediator interprets it into a NEGMAS action ──────────────
+
+
+def agent_move(handle: str, issues: list[dict], offer: tuple | None, proposing: bool) -> str:
+    """One agent's natural-language move (its real Pi turn would produce this)."""
+    space = "; ".join(f"{i['name']} ∈ {{{', '.join(i['options'])}}}" for i in issues)
+    order = ", ".join(i["name"] for i in issues)
+    if proposing:
+        ask = (
+            f"It's your turn to PROPOSE the offer on the table. The current standing offer is "
+            f"{offer}. State the offer you propose (you may keep it or change it) and one line of "
+            f"why. Keep it to 2 sentences."
+        )
+    else:
+        ask = (
+            f"The offer on the table is {offer} (order: {order}). Say whether you ACCEPT it or "
+            f"REJECT it, and one line of why. Keep it to 2 sentences."
+        )
+    return llm(
+        f"You are @{handle} in a live negotiation. Issue space: {space}.\n{ask}",
+        system=PERSONAS[handle],
+        temperature=0.3,
+    )
+
+
+def interpret(handle: str, prose: str, issues: list[dict], proposing: bool) -> dict:
+    """THE unproven core: natural language -> structured NEGMAS action."""
+    order = ", ".join(i["name"] for i in issues)
+    schema = (
+        '{"action":"counter","offer":{"<issue>":"<option>", ...}}'
+        if proposing
+        else '{"action":"accept"}  OR  {"action":"reject"}'
+    )
+    out = _json(
+        llm(
+            f"You are the mediator interpreting @{handle}'s move into a structured action.\n"
+            f"Issues (order: {order}): "
+            + "; ".join(f"{i['name']}={i['options']}" for i in issues)
+            + f"\n\n@{handle} said:\n\"\"\"{prose}\"\"\"\n\n"
+            f"Return ONLY JSON: {schema}. Every offer value MUST be one of that issue's options.",
+            system="You output strict JSON mapping a negotiator's words to an SAO action.",
+        )
+    )
+    return out
+
+
+# ── Stage 3: NEGMAS drives the protocol; each negotiator's move is LLM prose, interpreted ─────
+
+
+class MediatedAgent(SAONegotiator):
+    def __init__(self, handle: str, issues: list[dict], trace: list, **kw):
+        super().__init__(name=handle, **kw)
+        self.handle = handle
+        self.issues = issues
+        self.trace = trace
+        self._names = [i["name"] for i in issues]
+        self._opts = {i["name"]: i["options"] for i in issues}
+
+    def _to_outcome(self, offer: dict) -> tuple | None:
+        try:
+            vals = tuple(str(offer[n]) for n in self._names)
+        except (KeyError, TypeError):
+            return None
+        if any(vals[k] not in self._opts[n] for k, n in enumerate(self._names)):
+            return None  # invalid option -> not a legal outcome (offer_validation analog)
+        return vals
+
+    def propose(self, state, dest=None):
+        prose = agent_move(self.handle, self.issues, state.current_offer, proposing=True)
+        act = interpret(self.handle, prose, self.issues, proposing=True)
+        outcome = self._to_outcome(act.get("offer", {})) or state.current_offer or self._fallback()
+        self.trace.append((state.step, self.handle, "PROPOSE", outcome, prose.strip()))
+        return outcome
+
+    def respond(self, state, source=None):
+        prose = agent_move(self.handle, self.issues, state.current_offer, proposing=False)
+        act = interpret(self.handle, prose, self.issues, proposing=False)
+        resp = ResponseType.ACCEPT_OFFER if act.get("action") == "accept" else ResponseType.REJECT_OFFER
+        self.trace.append((state.step, self.handle, resp.name, state.current_offer, prose.strip()))
+        return resp
+
+    def _fallback(self) -> tuple:
+        return tuple(self._opts[n][0] for n in self._names)
+
+
+def main() -> None:
+    print("=== Stage 1: mediator discovers issues/options ===")
+    issues = discover_issues()
+    for i in issues:
+        print(f"  • {i['name']}: {i['options']}")
+
+    negmas_issues = [make_issue(values=[str(v) for v in i["options"]], name=i["name"]) for i in issues]
+    trace: list = []
+    mech = SAOMechanism(issues=negmas_issues, n_steps=15)
+    for handle in PERSONAS:
+        mech.add(MediatedAgent(handle, issues, trace))
+
+    print("\n=== Stage 2-3: NEGMAS drives the SAO; agents speak, mediator interprets ===")
+    mech.run()
+
+    order = [i["name"] for i in issues]
+    for step, who, act, offer, prose in trace:
+        first = prose.splitlines()[0][:88] if prose else ""
+        print(f"  r{step:<2} @{who:<10} {act:<14} offer={offer}  “{first}”")
+
+    print("\n=== Verdict ===")
+    if mech.agreement is not None:
+        agreed = dict(zip(order, mech.agreement, strict=True))
+        print(f"  AGREEMENT reached in {mech.current_step} steps (n_steps cap = 15): {agreed}")
+        print(f"  Terminated at agreement — {len(trace)} agent moves total, no restating loop.")
+    else:
+        print(f"  NO AGREEMENT after {mech.current_step} steps — mediator/interpret needs work.")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/sao-mediator-spike/mediator_spike_v2.py
+++ b/experiments/sao-mediator-spike/mediator_spike_v2.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+"""Rung 0 spike v2 — put back the two things v1 stripped: memory + a brokering mediator.
+
+v1 finding: NEGMAS-drives-and-terminates ✓ and LLM-interprets-prose ✓, but the agents were
+amnesiac (fresh isolated call each round, bare offer, no cost-of-no-deal) so the hardliner
+never conceded. That's a harness bug, not the model. v2 restores what a real persistent Pi
+session + an active mediator would provide:
+
+  1. MEMORY — each agent carries the full running negotiation history (its persistent session).
+  2. BROKER — the mediator frames each round: where everyone stands, who hit a hard limit,
+     what's actually on offer vs the baseline (the "camp counselor lets everyone speak" *and*
+     nudges toward the deal). Not a bare offer relay.
+  3. BATNA — no agreement = no rebalance at all, worse for everyone. A deal beats no deal.
+
+Run:
+    ANTHROPIC_API_KEY=... uv run --with negmas --with litellm python mediator_spike_v2.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import litellm
+from negmas import SAOMechanism, make_issue
+from negmas.sao import ResponseType, SAONegotiator
+
+MODEL = os.environ.get("SPIKE_MODEL", "anthropic/claude-haiku-4-5-20251001")
+
+PERSONAS = {
+    "growth": (
+        "You are GrowthAgent. The portfolio should be tilted toward high-growth technology "
+        "stocks. You are willing to accept a diversification rule that caps sector concentration "
+        "at 40%, but you will not accept a conservative or balanced allocation that sacrifices "
+        "growth. Push for technology sector overweight on every rebalancing decision."
+    ),
+    "risk": (
+        "You are RiskAgent. Volatility must be controlled. The portfolio needs broad "
+        "diversification — no single sector above 25%. You are willing to accept modest "
+        "technology overweight (up to 30%) if volatility metrics stay within bounds, but you "
+        "will block any trade that spikes portfolio beta above the agreed threshold. Concede on "
+        "sector cap levels, not on the volatility rule."
+    ),
+    "execution": (
+        "You are ExecutionAgent. The portfolio is out of balance now and the longer we wait the "
+        "worse the drift. You want to rebalance immediately using the agreed target weights. You "
+        "are flexible on the target itself — that is GrowthAgent and RiskAgent's domain — but you "
+        "insist on executing as soon as a target is agreed. Do not delay execution on any "
+        "condition that does not directly block the trade."
+    ),
+}
+TASK = (
+    "Negotiate the investment-portfolio rebalance. Agree the technology sector cap, the cap on "
+    "every other sector, and whether a portfolio-beta gate blocks trades."
+)
+# The cost of no deal — what v1 lacked. This is what turns a hardliner into a negotiator.
+BATNA = (
+    "\n\nIMPORTANT: if the team reaches NO agreement, there is NO rebalance at all — the "
+    "portfolio stays mis-weighted, the worst outcome for everyone, you included. A compromise "
+    "you can live with beats no deal. Protect your ONE hard line; concede everything secondary."
+)
+
+HISTORY: list[str] = []
+
+
+def llm(prompt: str, *, system: str = "", temperature: float = 0.3) -> str:
+    msgs = ([{"role": "system", "content": system}] if system else []) + [
+        {"role": "user", "content": prompt}
+    ]
+    resp = litellm.completion(model=MODEL, messages=msgs, temperature=temperature, max_tokens=500)
+    return resp.choices[0].message.content or ""
+
+
+def _json(text: str) -> dict:
+    m = re.search(r"\{.*\}", text, re.DOTALL)
+    return json.loads(m.group(0)) if m else {}
+
+
+def discover_issues() -> list[dict]:
+    opening = "\n".join(f"@{h}: {p}" for h, p in PERSONAS.items())
+    out = _json(
+        llm(
+            f"You are a negotiation mediator. From the task and each agent's position, identify "
+            f"the negotiable ISSUES and 3-4 discrete OPTIONS each.\n\nTASK: {TASK}\n\n"
+            f"POSITIONS:\n{opening}\n\n"
+            f'Return ONLY JSON: {{"issues":[{{"name":"snake_case","options":["v1","v2"]}}]}}',
+            system="Strict JSON. Options are short concrete tokens (e.g. '30' or 'on').",
+            temperature=0.0,
+        )
+    )
+    issues = out.get("issues", [])
+    if len(issues) < 2:
+        raise SystemExit(f"discovery failed: {issues}")
+    return issues
+
+
+def _hist_block() -> str:
+    if not HISTORY:
+        return "(negotiation just started)"
+    return "\n".join(HISTORY[-12:])
+
+
+def broker(issues: list[dict], offer: tuple | None, round_n: int, cap: int) -> str:
+    """The mediator's framing for this round — where everyone stands + a nudge to close."""
+    order = ", ".join(i["name"] for i in issues)
+    return llm(
+        f"You are the negotiation mediator (a neutral camp counselor). It is round {round_n} of "
+        f"{cap}. Issue order: {order}. Offer on the table: {offer}.\n\nHistory so far:\n"
+        f"{_hist_block()}\n\nWrite 2 sentences to the group: summarize where each agent stands, "
+        f"name who has hit a genuine hard limit, and nudge the holdout toward closing — remind "
+        f"them a near-deal beats no rebalance. Be concrete and fair, not preachy.",
+        system="You are a fair mediator who wants a durable agreement, not to favor anyone.",
+    )
+
+
+def agent_move(
+    handle: str, issues: list[dict], offer: tuple | None, proposing: bool, broker_note: str
+) -> str:
+    space = "; ".join(f"{i['name']} ∈ {{{', '.join(i['options'])}}}" for i in issues)
+    order = ", ".join(i["name"] for i in issues)
+    role = (
+        f"It's your turn to PROPOSE the offer. Current standing offer: {offer}. Propose the offer "
+        f"you want (keep or change it) with one line of why."
+        if proposing
+        else f"The offer on the table is {offer} (order: {order}). ACCEPT or REJECT it, one line why."
+    )
+    return llm(
+        f"You are @{handle} in a live, multi-round negotiation. Issue space: {space}.\n\n"
+        f"MEDIATOR: {broker_note}\n\nNegotiation history:\n{_hist_block()}\n\n{role} "
+        f"(2 sentences max.)",
+        system=PERSONAS[handle] + BATNA,
+    )
+
+
+def interpret(handle: str, prose: str, issues: list[dict], proposing: bool) -> dict:
+    order = ", ".join(i["name"] for i in issues)
+    schema = (
+        '{"action":"counter","offer":{"<issue>":"<option>", ...}}'
+        if proposing
+        else '{"action":"accept"} OR {"action":"reject"}'
+    )
+    return _json(
+        llm(
+            f"Interpret @{handle}'s move into a structured SAO action.\nIssues (order {order}): "
+            + "; ".join(f"{i['name']}={i['options']}" for i in issues)
+            + f'\n\n@{handle} said:\n"""{prose}"""\n\nReturn ONLY JSON: {schema}. '
+            f"Every offer value MUST be one of that issue's options.",
+            system="Strict JSON mapping a negotiator's words to an SAO action.",
+            temperature=0.0,
+        )
+    )
+
+
+class MediatedAgent(SAONegotiator):
+    def __init__(self, handle: str, issues: list[dict], cap: int, **kw):
+        super().__init__(name=handle, **kw)
+        self.handle, self.issues, self.cap = handle, issues, cap
+        self._names = [i["name"] for i in issues]
+        self._opts = {i["name"]: i["options"] for i in issues}
+
+    def _to_outcome(self, offer: dict) -> tuple | None:
+        try:
+            vals = tuple(str(offer[n]) for n in self._names)
+        except (KeyError, TypeError):
+            return None
+        return vals if all(vals[k] in self._opts[n] for k, n in enumerate(self._names)) else None
+
+    def propose(self, state, dest=None):
+        note = broker(self.issues, state.current_offer, state.step, self.cap)
+        prose = agent_move(self.handle, self.issues, state.current_offer, True, note)
+        outcome = self._to_outcome(interpret(self.handle, prose, self.issues, True).get("offer", {}))
+        outcome = outcome or state.current_offer or tuple(self._opts[n][0] for n in self._names)
+        HISTORY.append(f"r{state.step}: @{self.handle} proposed {outcome}")
+        print(f"  r{state.step:<2} @{self.handle:<10} PROPOSE      {outcome}")
+        return outcome
+
+    def respond(self, state, source=None):
+        note = broker(self.issues, state.current_offer, state.step, self.cap)
+        prose = agent_move(self.handle, self.issues, state.current_offer, False, note)
+        act = interpret(self.handle, prose, self.issues, False).get("action")
+        resp = ResponseType.ACCEPT_OFFER if act == "accept" else ResponseType.REJECT_OFFER
+        HISTORY.append(f"r{state.step}: @{self.handle} {resp.name} on {state.current_offer}")
+        print(f"  r{state.step:<2} @{self.handle:<10} {resp.name:<12} on {state.current_offer}")
+        return resp
+
+
+def main() -> None:
+    cap = 20
+    print("=== Stage 1: mediator discovers issues/options ===")
+    issues = discover_issues()
+    for i in issues:
+        print(f"  • {i['name']}: {i['options']}")
+    negmas_issues = [make_issue(values=[str(v) for v in i["options"]], name=i["name"]) for i in issues]
+    mech = SAOMechanism(issues=negmas_issues, n_steps=cap)
+    for h in PERSONAS:
+        mech.add(MediatedAgent(h, issues, cap))
+
+    print("\n=== v2: memory + brokering mediator + BATNA ===")
+    mech.run()
+
+    order = [i["name"] for i in issues]
+    print("\n=== Verdict ===")
+    if mech.agreement is not None:
+        print(f"  AGREEMENT in {mech.current_step} steps: {dict(zip(order, mech.agreement, strict=True))}")
+        print("  Terminated at agreement — NEGMAS stopped the moment it was unanimous.")
+    else:
+        print(f"  NO AGREEMENT after {mech.current_step} steps.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mycelium-cli/src/mycelium/commands/demo.py
+++ b/mycelium-cli/src/mycelium/commands/demo.py
@@ -47,6 +47,11 @@ _TREE_URL = f"https://api.github.com/repos/{_REPO}/git/trees/{_REF}?recursive=1"
 # Sensible default; any scenario discovered in the dataset is selectable.
 DEFAULT_SCENARIO = "ex07_investment_portfolio"
 
+# The reserved handle that summons the SIEP aligner (backend ALIGNER_HANDLE
+# default). Summoning it scores the room's positions into a converged/rejected
+# verdict and, on converge, compiles plan/tasks.md + syncs a knowledge memory.
+ALIGNER_HANDLE = "aligner"
+
 # Adapters that can host a demo agent. Mirrors AGENT_ADAPTERS (underscore form).
 _KNOWN_ADAPTERS = ("openclaw", "claude_code", "cursor", "hermes")
 
@@ -425,6 +430,82 @@ def _provision(
     console.print("[green]✓[/green] Seeded the room — agents are negotiating")
 
 
+def _room_senders(api: str, room: str) -> set[str]:
+    """The set of handles that have posted a message to ``room`` (lowercased)."""
+    import httpx
+
+    try:
+        resp = httpx.get(f"{api}/api/rooms/{room}/messages", timeout=5.0)
+        resp.raise_for_status()
+    except httpx.HTTPError:
+        return set()
+    return {
+        str(m["sender_handle"]).lower()
+        for m in resp.json().get("messages", [])
+        if m.get("sender_handle")
+    }
+
+
+def _drive_consensus(
+    config: Any,
+    room: str,
+    handles: list[str],
+    *,
+    timeout: float = 180.0,
+    settle: float = 15.0,
+) -> None:
+    """Wait for the agents to state positions, then summon the aligner.
+
+    Cold-spawn turns land asynchronously (each is a live ``claude -p``), so poll
+    the room until every agent has spoken — then let a short settle window catch
+    their final positions — and post ``@aligner``. That summon is what the backend
+    scores into a ``commit:converged``/``rejected`` verdict and, on convergence,
+    compiles into ``plan/tasks.md`` + syncs as a ``knowledge`` memory. Driving it
+    here makes the payoff deterministic instead of hoping an agent remembers to.
+    """
+    api = config.server.api_url.rstrip("/")
+    want = {h.lower() for h in handles}
+    console.print("[dim]Waiting for agents to state their positions…[/dim]")
+    deadline = time.monotonic() + timeout
+    seen: set[str] = set()
+    while time.monotonic() < deadline:
+        seen = _room_senders(api, room)
+        if want <= seen:
+            time.sleep(settle)  # let final-round positions land before scoring
+            seen = _room_senders(api, room)
+            break
+        time.sleep(3.0)
+
+    posted = sorted(want & seen)
+    if posted:
+        console.print(f"[green]✓[/green] Positions in from {', '.join('@' + h for h in posted)}")
+    else:
+        console.print(
+            "[yellow]⚠ No agent positions yet[/yellow] — summoning the aligner anyway; "
+            "it will report no convergence."
+        )
+
+    console.print(f"[dim]Summoning [cyan]@{ALIGNER_HANDLE}[/cyan] to assess convergence…[/dim]")
+    r = _run(
+        [
+            "room",
+            "send",
+            f"@{ALIGNER_HANDLE} assess whether the team has converged and compile the plan.",
+            "--room",
+            room,
+            "--handle",
+            "demo",
+        ]  # fmt: skip
+    )
+    if r.returncode != 0:
+        console.print(f"[yellow]⚠ could not summon the aligner:[/yellow]\n{r.stderr or r.stdout}")
+        return
+    console.print(
+        f"[green]✓[/green] Summoned [bold]@{ALIGNER_HANDLE}[/bold] — on convergence the backend "
+        "compiles [cyan]plan/tasks.md[/cyan] and syncs it as a knowledge memory."
+    )
+
+
 def _print_intro(scenario: dict[str, Any], adapter: str, room: str) -> None:
     body = (
         f"[dim]Adapter:[/dim] [bold]{adapter}[/bold]    "
@@ -573,6 +654,12 @@ def demo(
             raise typer.Exit(0)
 
     _provision(chosen, adapter, model, room_name, auth_from)
+
+    # The payoff: once positions are in, summon the aligner so the negotiation
+    # actually converges → compiles plan/tasks.md → syncs a knowledge memory.
+    handles = [a["handle"] for a in chosen["agents"]]
+    _drive_consensus(_config, room_name, handles)
+
     _print_outro(chosen, adapter, room_name)
 
     if not no_watch:

--- a/mycelium-cli/src/mycelium/commands/demo.py
+++ b/mycelium-cli/src/mycelium/commands/demo.py
@@ -50,6 +50,11 @@ DEFAULT_SCENARIO = "ex07_investment_portfolio"
 # Adapters that can host a demo agent. Mirrors AGENT_ADAPTERS (underscore form).
 _KNOWN_ADAPTERS = ("openclaw", "claude_code", "cursor", "hermes")
 
+# Cold-spawn families: the daemon launches a fresh CLI process per @-mention.
+# They require a non-empty `cwd` per agent (protocol.py) and only get a SLIM
+# connector for a room the daemon is subscribed to.
+_COLD_SPAWN_ADAPTERS = ("claude_code", "cursor")
+
 
 def _cli_prefix() -> list[str]:
     """How to invoke the mycelium CLI as a subprocess (installed script or module)."""
@@ -168,6 +173,28 @@ def _resolve_scenario(scenario_id: str) -> dict[str, Any]:
 # --------------------------------------------------------------------------- #
 
 
+def _demo_workdir(room: str, handle: str) -> Path:
+    """Per-agent working dir for cold-spawn adapters (claude_code/cursor).
+
+    Cold-spawn agents require a non-empty ``cwd`` — the daemon launches the
+    agent's CLI there per @-mention (Claude treats it as the project root, cursor
+    as the workspace root). Give each demo agent its own stable dir under
+    ``~/.mycelium/demo/`` so it survives the run and is inspectable afterward.
+    """
+    from mycelium.config import MyceliumConfig
+
+    d = MyceliumConfig.get_global_config_dir() / "demo" / room / handle
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _daemon_running() -> bool:
+    """Whether the mycelium daemon is answering its health socket."""
+    from mycelium.daemon.health import read_health_blocking
+
+    return read_health_blocking(timeout=2.0) is not None
+
+
 def _adapter_installed(config: Any, adapter: str) -> bool:
     keys = {str(k).replace("-", "_") for k in (config.adapters or {})}
     return adapter in keys
@@ -205,6 +232,15 @@ def _check_prereqs(adapter: str) -> tuple[Any, list[str]]:
         httpx.get(f"{api}/api/rooms", timeout=5.0).raise_for_status()
     except httpx.HTTPError:
         problems.append(f"Backend not reachable at {api}. Is the stack up? Try: mycelium status")
+
+    # Cold-spawn agents wake only through a running daemon subscribed to the
+    # room; without it they're created but never invoked. Fail fast with the fix.
+    if adapter in _COLD_SPAWN_ADAPTERS and not _daemon_running():
+        problems.append(
+            f"The mycelium daemon isn't running — {adapter} agents cold-spawn through it. "
+            "Start it with: mycelium daemon run --foreground "
+            "(or install the service: mycelium adapter add claude-code --step=daemon)."
+        )
 
     return config, problems
 
@@ -331,6 +367,20 @@ def _provision(
         raise typer.Exit(1)
     console.print(f"[green]✓[/green] Room [cyan]{room}[/cyan]")
 
+    # 2b. Cold-spawn adapters (claude_code/cursor) only get a SLIM connector for
+    #     a room the daemon is subscribed to. Subscribe now — before the agents
+    #     are seeded — so they actually wake on the mention.
+    if adapter in _COLD_SPAWN_ADAPTERS:
+        r = _run(["daemon", "subscribe", room])
+        if r.returncode != 0:
+            console.print(f"[red]daemon subscribe {room} failed:[/red]\n{r.stderr or r.stdout}")
+            console.print(
+                "[dim]Cold-spawn agents wake only through the daemon. "
+                "Check it with: mycelium daemon status[/dim]"
+            )
+            raise typer.Exit(1)
+        console.print(f"[green]✓[/green] Daemon subscribed to [cyan]{room}[/cyan]")
+
     # 3. Agents — one `mycelium agent create` per persona, on the chosen adapter.
     for a in scenario["agents"]:
         handle = a["handle"]
@@ -340,6 +390,9 @@ def _provision(
             "--room", room,
             "--description", personas[handle],
         ]  # fmt: skip
+        # Cold-spawn families require a per-agent working dir (protocol.py).
+        if adapter in _COLD_SPAWN_ADAPTERS:
+            args += ["--cwd", str(_demo_workdir(room, handle))]
         if model and adapter == "openclaw":
             args += ["--model", model]
         if auth_source:
@@ -393,11 +446,15 @@ def _print_intro(scenario: dict[str, Any], adapter: str, room: str) -> None:
 
 def _print_outro(scenario: dict[str, Any], adapter: str, room: str) -> None:
     handles = [a["handle"] for a in scenario["agents"]]
+    cold = adapter in _COLD_SPAWN_ADAPTERS
+    cwd_flag = " --cwd <dir>" if cold else ""
     repro = "\n".join(
         [
             f"mycelium room create {room}",
+            # Cold-spawn agents wake only through a daemon subscribed to the room.
+            *([f"mycelium daemon subscribe {room}"] if cold else []),
             *[
-                f'mycelium agent create {h} --adapter {adapter} --room {room} -d "<persona>"'
+                f'mycelium agent create {h} --adapter {adapter} --room {room}{cwd_flag} -d "<persona>"'
                 for h in handles
             ],
             f'mycelium agent invoke {handles[0]} "@... <task>" -r {room}',

--- a/mycelium-cli/src/mycelium/daemon/connector.py
+++ b/mycelium-cli/src/mycelium/daemon/connector.py
@@ -22,10 +22,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import time
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import httpx
 
@@ -162,6 +163,50 @@ def _mentions(text: str, handle: str) -> bool:
 # ── Reply building ───────────────────────────────────────────────────────────
 
 
+# An agent volunteers a negotiation position by ending its reply with a marker
+# like ``[[mycelium: confidence=0.85 stance=accept]]``. The connector lifts those
+# fields onto the exchange's L9 payload so the aligner can score convergence
+# (without them every position folds to a reject — MPC is undefined). The marker
+# is stripped before the reply is posted, so the room shows clean prose.
+_POSITION_MARKER_RE = re.compile(r"\[\[\s*mycelium\s*:(.*?)\]\]", re.IGNORECASE | re.DOTALL)
+_STANCE_TO_ACTION = {
+    "accept": "accept",
+    "agree": "accept",
+    "yes": "accept",
+    "reject": "reject",
+    "block": "reject",
+    "no": "reject",
+}
+
+
+def parse_position_marker(text: str) -> tuple[dict[str, Any], str]:
+    """Split an agent reply into (epistemic payload, human-facing text).
+
+    Lifts ``confidence`` (a 0–1 float) and ``stance`` (→ L9 ``action``) out of any
+    ``[[mycelium: …]]`` markers and strips every marker from the text. Forgiving
+    by design — a malformed value is dropped, not raised, mirroring the backend's
+    ``l9_episode.sanitize_epistemic_fields``. No marker → ``({}, text)`` (a plain
+    reply, unchanged behaviour).
+    """
+    payload: dict[str, Any] = {}
+    for match in _POSITION_MARKER_RE.finditer(text):
+        for key, raw in re.findall(r"(\w+)\s*=\s*(\S+)", match.group(1)):
+            k = key.lower()
+            if k == "confidence":
+                try:
+                    val = float(raw)
+                except ValueError:
+                    continue
+                if 0.0 <= val <= 1.0:
+                    payload["confidence"] = val
+            elif k in ("stance", "action"):
+                action = _STANCE_TO_ACTION.get(raw.lower())
+                if action:
+                    payload["action"] = action
+    clean = _POSITION_MARKER_RE.sub("", text).strip() or text.strip()
+    return payload, clean
+
+
 def build_reply(
     *, handle: str, room: str, woke: dict, text: str, message_id: str | None = None
 ) -> dict:
@@ -169,8 +214,10 @@ def build_reply(
 
     Threads causality (``parents = [woke message id]``) and stays in the woke
     message's episode/topic so the backend's causal buffer + transcript remain
-    correct.
+    correct. Any volunteered position marker in ``text`` is lifted into the L9
+    payload (so the aligner can score it) and stripped from the posted prose.
     """
+    payload_data, clean_text = parse_position_marker(text)
     woke_id = l9.message_id_of(woke)
     sender = l9.sender_of(woke)
     return l9.build_reply_content(
@@ -179,7 +226,8 @@ def build_reply(
         episode=l9.episode_of(woke) or _room_episode(room),
         parents=[woke_id] if woke_id else [],
         topic=l9.topic_of(woke) or _room_topic(room),
-        text=text,
+        text=clean_text,
+        payload_data=payload_data or None,
         message_id=message_id,
     )
 

--- a/mycelium-cli/src/mycelium/daemon/install.py
+++ b/mycelium-cli/src/mycelium/daemon/install.py
@@ -388,7 +388,35 @@ def _get_daemon_pid() -> int | None:
                         if part.isdigit():
                             return int(part)
 
-    return None
+    # Fall back to the singleton lock file, which every daemon writes its PID
+    # into on startup regardless of how it was launched. This is the only way to
+    # find a *foreground* daemon (`mycelium daemon run --foreground`) — it isn't
+    # registered with launchd/systemd, so the service lookups above miss it, and
+    # without this `daemon subscribe` / the demo can't SIGHUP-reload it.
+    return _pid_from_lock()
+
+
+def _pid_from_lock() -> int | None:
+    """Read the daemon PID from the singleton lock file, if one is running.
+
+    ``_acquire_singleton_lock`` writes ``os.getpid()`` into ``daemon.lock`` for
+    every daemon (service-managed or foreground). Verify the PID is actually
+    alive before returning it so a stale lock (daemon crashed without cleanup)
+    doesn't send us signalling a dead or recycled PID.
+    """
+    from mycelium.daemon.config import daemon_lock_path
+
+    try:
+        pid = int(daemon_lock_path().read_text().strip())
+    except (OSError, ValueError):
+        return None
+    if pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)  # liveness probe — signal 0 doesn't touch the process
+    except OSError:
+        return None
+    return pid
 
 
 def uninstall_daemon_service(verbose: bool = False) -> None:  # noqa: ARG001

--- a/mycelium-cli/src/mycelium/daemon/preamble.py
+++ b/mycelium-cli/src/mycelium/daemon/preamble.py
@@ -62,6 +62,23 @@ prompt below. Your reply will be posted to that room *as @{handle}*, so:
   persist between runs goes in your notes (`mycelium memory set
   agents/{handle}/notes "..."` from your cwd).
 {desc_block}{notes_block}{plan_block}
+## Stating a position (negotiation)
+
+If this room is a negotiation — several agents converging on a shared decision —
+end your reply with a one-line position marker so the aligner can score whether
+the team has converged:
+
+    [[mycelium: confidence=0.85 stance=accept]]
+
+- `confidence` (0.0–1.0): how sure you are of the position you just argued.
+- `stance`: `accept` if you can live with the offer on the table, `reject` if
+  you cannot. Drop `stance` if you're only making an opening offer.
+
+State it honestly — it's how the team distinguishes a real agreement from
+polite yielding. The marker is stripped from your posted message; only the
+epistemic signal is kept. Omit it entirely for ordinary chat that isn't a
+negotiation position.
+
 ## Control verbs
 
 If the prompt is exactly one of `abort`, `cancel`, `stop`, or `status`,

--- a/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
@@ -6,138 +6,77 @@ description: Multi-agent coordination layer with persistent memory. Use when coo
 # Mycelium Coordination
 
 Mycelium provides persistent shared memory and real-time coordination between AI agents.
-All interaction flows through **rooms** (shared namespaces) and **CognitiveEngine** (the mediator).
-Agents never communicate directly with each other.
+All interaction flows through **rooms** (shared namespaces) carried over a secure
+messaging fabric. Agents coordinate by posting to the room, never by calling each other directly.
 
-Your core loop is the **negotiation protocol** below (join, await, respond, consensus, plan, work). Memory is the shared substrate underneath it.
+Your core loop is the **negotiation protocol** below (argue, converge, plan, work). Memory is the shared substrate underneath it.
 
 ## Core Concepts
 
-- **Rooms** are persistent namespaces. They hold memory that accumulates across sessions. Spawn sessions within rooms for real-time negotiation when needed.
-- **CognitiveEngine** mediates all coordination. It drives negotiation rounds and compiles consensus into the room's shared plan.
+- **Rooms** are persistent namespaces. They hold memory that accumulates across sessions, and they're the channel where agents negotiate in real time.
+- **The aligner** is a dormant judge, summoned with `@aligner`, that scores whether a negotiation has converged and — on convergence — compiles the agreement into the room's shared plan.
 - **Memory** is filesystem-native. Each memory is a markdown file at `~/.mycelium/rooms/{room}/{key}.md` with YAML frontmatter. The database is a search index that auto-syncs via file watcher.
 
 ## Semantic negotiation
 
-When two or more agents need to agree on a multi-issue trade-off — REST vs GraphQL, who owns what task, what budget/timeline/scope to ship — Mycelium runs a **structured negotiation** mediated by CognitiveEngine. It's a multi-round bargaining loop with a clear outcome: either consensus on every issue, or a clean "no agreement" timeout. Both are valid endings.
+When two or more agents need to agree on a multi-issue trade-off — REST vs GraphQL, who owns what task, what budget/timeline/scope to ship — Mycelium runs a **structured negotiation**. Agents argue their positions in the room; a dormant judge called the **aligner** scores whether the team has genuinely converged. It's a chat-native bargaining loop with a clear outcome: either consensus (a compiled plan) or a clean "no agreement". Both are valid endings.
 
-On consensus, Mycelium compiles the agreement into the room's **shared plan** — a `- [ ]` checklist at `plan/tasks.md` the whole team executes against. The full arc is: join → negotiate → plan → work. The negotiation decides *what*; the plan is *how the team carries it out*. See **After consensus — work the plan** below.
+On consensus, Mycelium compiles the agreement into the room's **shared plan** — a `- [ ]` checklist at `plan/tasks.md` the whole team executes against. The full arc is: argue → converge → plan → work. The negotiation decides *what*; the plan is *how the team carries it out*. See **After consensus — work the plan** below.
 
 Use it when "let's just chat about it" would spiral. Skip it for one-issue questions or quick coordination — `mycelium room send` (next section) is the right tool there.
 
 ### The lifecycle
 
-Everything is CLI-driven. You declare your position, then respond when CognitiveEngine asks.
+Negotiation is chat, not a separate command set. You're woken by the daemon when a teammate `@`-mentions you (see **Agent Mode** below); you reply in the room, arguing your position. There is no `session join` / `session await` / `negotiate propose` loop — those were retired. The whole flow is ordinary room messages plus one convention and one summon.
 
-```bash
-# 1. Join the negotiation with your one-sentence opening position.
-mycelium session join --handle claude-agent --room <room-name> \
-  -m "I want GraphQL with a 6-month timeline; REST is fine for public uploads only."
+**1 — State your position, and mark your confidence.** Reply normally, making your case. When you're taking a *negotiation position*, end your reply with a one-line marker so the aligner can score convergence:
 
-# 2. Block until it's your turn. `session await` returns when CognitiveEngine
-#    addresses you, prints a structured JSON payload, and exits.
-mycelium session await --handle claude-agent
+```
+I can accept a 30% tech cap if we keep portfolio beta under 1.1 — that's my
+hard line, everything else is negotiable.
 
-# Tick payload tells you:
-#   - current_offer       the proposal on the table
-#   - can_counter_offer   true ⇒ it's your turn to propose
-#                         false ⇒ you can only accept or reject
-#   - issues / issue_options
-#                         the canonical issue keys and their valid values
-#   - round / n_steps_total
-#                         where you are in the round budget
-#   - your_last_action    accept | reject | counter_offer | timeout | null
-#   - prior_round_outcome first_round | proposer_countered |
-#                         rejected_by_<id> | agreed | no_consensus
-#   - team_prior          (optional) the team's earned confidence on this
-#                         topic from previous negotiations, with a
-#                         provenance weight and episode count
-
-# 3a. Counter-propose (only when can_counter_offer is true). State your
-#     confidence and what your position rests on. Evidence is split into what
-#     argues FOR your position and what argues against it:
-mycelium negotiate propose ISSUE=VALUE ISSUE=VALUE ... \
-  --room <room-name> --handle claude-agent \
-  --confidence 0.8 \
-  --supporting-evidence "failed/memcached" --supporting-evidence "staging p99 data" \
-  --against-evidence "decisions/graphql-spike" \
-  --reasoning "REST held up in staging; GraphQL adds resolver complexity we can't staff"
-
-# 3b. Accept or reject the current offer (same epistemic flags apply). When your
-#     position changed, --addresses names the prior evidence you engaged and
-#     --revision-cause says WHY it moved (grounded_argument | new_evidence |
-#     semantic_memory | repair_resolution | social_compliance):
-mycelium negotiate respond accept --room <room-name> --handle claude-agent \
-  --confidence 0.9 --addresses "staging p99 data" --revision-cause grounded_argument
-mycelium negotiate respond reject --room <room-name> --handle claude-agent
-
-# Accepting only to move things along, without being persuaded? Say so
-# (--defer-to implies revision-cause social_compliance):
-mycelium negotiate respond accept --room <room-name> --handle claude-agent \
-  --confidence 0.4 --defer-to julia-agent
-
-# 4. await again for the next tick (or for the final consensus).
-mycelium session await --handle claude-agent
-# → {"type": "consensus", "plan": "...", "plan_file": "plan/tasks.md", "assignments": {...}}
-# → or {"type": "consensus", "broken": true, "plan": "Negotiation ended: timeout"}
+[[mycelium: confidence=0.85 stance=accept]]
 ```
 
-`session await` outputs structured JSON, parseable per turn:
+- `confidence` (0.0–1.0): how sure you are of the position you just argued.
+- `stance`: `accept` if you can live with the offer on the table, `reject` if you can't. Omit `stance` when you're only making an opening offer.
 
-- `{"type": "tick", ...}` — your turn; act and `await` again.
-- `{"type": "consensus", ...}` — negotiation complete. `broken: true` means timeout/no-agreement (still a valid outcome). On agreement, `plan_file` points at the room's shared plan — see **After consensus** below.
-- `{"type": "timeout"}` — no tick within the await window (default 120s); call `await` again to keep waiting, or check status.
+The marker is **stripped from your posted message** — the room sees clean prose; only the epistemic signal is kept. State it honestly: it's how the team distinguishes a real agreement from polite yielding. A reply with no marker is just a plain reply (an observation, not a scored position).
 
-### Counter-offer rules
+**2 — Converge.** Argue across as many turns as it takes. When the team believes it has agreement (or has clearly stalled), summon the judge:
 
-Mycelium validates counter-offers before they reach CognitiveEngine:
+```bash
+mycelium room send "@aligner assess whether we've converged" --room <room-name> --handle <your-handle>
+```
 
-1. **Use the exact issue keys from `issue_options`.** Case-sensitive. Made-up keys are rejected immediately and you'll get a corrective tick with the valid set.
-2. **Partial offers are fine.** You only need to include the issues you want to change. Omitted issues stay at the current standing offer's value.
-3. **Pick each value from that issue's option list.** Free-text outside the list isn't blocked locally but CFN may reject it.
-4. **Only counter when `can_counter_offer: true`.** A counter from the wrong agent gets silently downgraded to a reject — wasted turn.
+The aligner reads the transcript, folds each agent's *latest* position, and emits a verdict onto the channel:
 
-### Reading `prior_round_outcome`
+- **Converged** — mean confidence cleared the bar. The backend compiles the agreement into `plan/tasks.md` and syncs it as a shared `knowledge` memory. See **After consensus** below.
+- **Rejected** — confidence too low or too few agents took a scored position. That's a clean "no agreement", not a failure.
 
-It tells you what just happened so you don't have to infer:
-
-- `rejected_by_<id>` — that agent rejected last round; the standing offer carries forward unchanged.
-- `proposer_countered` — last round's designated proposer overrode the standing offer with a new one. Look at `current_offer` for the change.
-- `first_round` — round 1, no prior context.
-- `agreed` / `no_consensus` — terminal states; `await` returns a `consensus` envelope.
+The aligner is dormant until summoned (zero idle cost), so nothing scores until an `@aligner` mention arrives.
 
 ### Behavior
 
-- **Narrate before each command.** Say *why* you're rejecting or what you're trying to push on. "Rejecting because the timeline is too tight — countering with 6 months." This makes the negotiation legible to the user watching your terminal.
-- **Walking away is legitimate.** Each session has a fixed `n_steps_total`. If you and another agent are flip-flopping the same issue, you're not converging — keep rejecting until timeout. That's a clean "couldn't agree" signal, not a failure.
-- **Strong opening positions matter.** Be specific in `-m "..."`: stake, top concession, hard limit. "I want GraphQL" is weak. "GraphQL primary for authenticated APIs; REST is fine for uploads/webhooks; hard limit: no public-facing GraphQL without persisted queries" is strong.
-- **State your confidence and cite your sources.** Every propose/respond takes `--confidence <0-1>`, `--reasoning`, and evidence split into repeatable `--supporting-evidence` (what argues for your position) and `--against-evidence` (counter-evidence you're aware of). Use them: they're how the team distinguishes an informed position from a guess. All optional — a reply with none is exactly the plain reply.
-- **When you move, say why.** If your position shifts, `--addresses` names the prior evidence you engaged and `--revision-cause` records the reason (`grounded_argument`, `new_evidence`, `semantic_memory`, `repair_resolution`, or `social_compliance`). If you move but engage no prior evidence, you get the benefit of the doubt (counted as genuine) — the metric only flags compliance on a real signal.
-- **Defer honestly.** If you accept an offer you weren't actually persuaded by (yielding to move things along), say so with `--defer-to <handle-you-are-yielding-to>` (shorthand for `--revision-cause social_compliance`). Deference is measured as social compliance in the consensus quality metrics, not punished. Dishonest agreement corrupts the team's shared memory.
-- **Weigh the team prior; don't adopt it.** When a tick carries a `team_prior`, that's the team's earned confidence on this topic from previous negotiations, weighted by provenance. Form your own view first, then factor the prior in. Don't simply echo it.
+- **Narrate your reasoning in the reply itself.** The room is the record — say *why* you accept or reject ("beta guardrail holds, so I can concede the sector cap"). This makes the negotiation legible to the user watching, and it's what the aligner and future agents read back.
+- **Walking away is legitimate.** If you and another agent keep flip-flopping the same issue, you're not converging — hold your `reject` and low confidence. A rejected verdict is a clean "couldn't agree" signal, not a failure.
+- **Strong opening positions matter.** Be specific: stake, top concession, hard limit. "I want GraphQL" is weak. "GraphQL primary for authenticated APIs; REST fine for uploads/webhooks; hard limit: no public GraphQL without persisted queries" is strong.
+- **Mark confidence honestly.** `confidence` is how the team distinguishes an informed position from a guess, and it drives the convergence metrics (mean confidence must clear the threshold to converge). Don't inflate it to force a plan; don't deflate it to stall.
+- **Yield honestly.** If you `stance=accept` an offer you weren't actually persuaded by (just to move things along), keep your `confidence` low to reflect that. Genuine agreement (high confidence that moved toward the outcome) reads differently from social compliance (accepting while unconvinced) in the quality metrics — and dishonest agreement corrupts the team's shared memory.
 
 ### Checking status
 
-If the user asks "what's happening with the negotiation?" or "did it finish?", don't try to infer from the room's broadcast log — that's free-form narration, not the structured outcome.
+If the user asks "did it converge?", don't infer from the room's free-form narration — read the outcome the aligner recorded:
 
 ```bash
-# Current round, valid issue keys, per-agent reply status, active or concluded.
-# Also shows interim L9 quality metrics once enough agents report confidence:
-mycelium negotiate status --room <room-name>
+# The episode record with the verdict + quality metrics (MPC/GAR/SCR):
+mycelium memory get log/episodes/live --room <room-name>
 
-# In a script/CI gate: exit 2 when the agreement is weakly-supported
-# (provenance_weight < 0.60) so you can avoid acting on a contested outcome:
-mycelium negotiate status --room <room-name> --contested
+# The compiled plan, once converged:
+mycelium plan tasks --room <room-name>
 ```
 
-When `await` returns `{"type": "consensus", ...}`:
-
-- **Agreement** → consensus payload includes per-agent `assignments` and a `plan_file`.
-- **No agreement** → `broken: true` with `plan: "Negotiation ended: timeout"`. Report it as "no agreement" — it's not a system failure.
-
-Consensus payloads may also carry quality `metrics`: **MPC** (mean final confidence across agents), **GAR** (genuine agreement ratio: fraction of agents whose confidence moved toward the outcome), and **SCR** (social compliance ratio: fraction of belief revisions that were compliance — deferring, or moving without engaging the evidence — rather than genuine argument). High MPC + high GAR is a strong consensus; high SCR means agents yielded rather than agreed; report that nuance to the user. `provenance_weight = (1 − SCR) × GAR` is the single trust number: below ~0.60 the agreement is contested.
-
-The structured outcome lives in a session sub-room (`<room-name>:session:<id>`). `mycelium negotiate status` reads it automatically; don't go grepping the parent room.
+The verdict carries quality **metrics**: **MPC** (mean final confidence across agents), **GAR** (genuine agreement ratio: fraction of agents whose confidence moved toward the outcome), and **SCR** (social compliance ratio: fraction of belief revisions that were yielding rather than genuine argument). High MPC + high GAR is a strong consensus; high SCR means agents caved rather than agreed. `provenance_weight = (1 − SCR) × GAR` is the single trust number: below ~0.60 the agreement is contested — report that nuance to the user.
 
 ### After consensus — work the plan
 
@@ -190,9 +129,9 @@ Memories are markdown files under `~/.mycelium/rooms/<room>/`. Any agent who joi
 
 ### A few things to remember
 
-- **Auto-wake for mentions and ticks.** The `mycelium-daemon` listens to rooms you're registered in. It cold-spawns you for `@handle` mentions **and** negotiation ticks (CognitiveEngine rounds). You don't need to poll or watch — the daemon wakes you. For one-shot questions like "did anyone reply?", check with `mycelium watch --room X` or `mycelium room messages`.
+- **Auto-wake for mentions.** The `mycelium-daemon` listens to rooms you're registered in and cold-spawns you when a teammate `@`-mentions you — including an `@aligner` summon you should observe. You don't need to poll or watch; the daemon wakes you. For one-shot questions like "did anyone reply?", check with `mycelium watch --room X` or `mycelium room messages`.
 - **Write self-contained messages.** "What about the thing we discussed?" is useless to a recipient who doesn't share your history. Spell out the context.
-- **`session await` is for interactive (user-initiated) negotiations only.** When *you* start a negotiation in your terminal (the user asks "go negotiate in room X"), use the `session await` loop documented above — it blocks until your turn, you act, and loop. But when the **daemon spawns you for a tick**, your prompt already contains the full tick payload (round, current offer, valid commands). In that case do NOT call `session await` — just run the appropriate `mycelium negotiate` command and exit.
+- **One turn per wake.** When the daemon spawns you for a mention, your prompt already contains the message that woke you. Do your work, post your reply (with a position marker if you're negotiating), and exit — the daemon wakes you again for the next turn. Don't try to block waiting for other agents.
 
 ## Memory as Files
 

--- a/mycelium-cli/tests/test_daemon_connector.py
+++ b/mycelium-cli/tests/test_daemon_connector.py
@@ -103,6 +103,61 @@ async def _run(state: DaemonState, published: list[dict], content: dict, **overr
     await connector.handle_inbound(**kwargs)
 
 
+# ── position marker parsing (pure) ────────────────────────────────────────────
+
+
+def test_parse_marker_lifts_confidence_and_stance_and_strips() -> None:
+    payload, clean = connector.parse_position_marker(
+        "I can accept 30% tech.\n\n[[mycelium: confidence=0.85 stance=accept]]"
+    )
+    assert payload == {"confidence": 0.85, "action": "accept"}
+    assert clean == "I can accept 30% tech."
+    assert "mycelium" not in clean
+
+
+def test_parse_marker_absent_is_plain_reply() -> None:
+    payload, clean = connector.parse_position_marker("just a normal reply, no marker")
+    assert payload == {}
+    assert clean == "just a normal reply, no marker"
+
+
+def test_parse_marker_drops_out_of_range_confidence() -> None:
+    payload, _clean = connector.parse_position_marker("x [[mycelium: confidence=1.5 stance=block]]")
+    # 1.5 is out of [0,1] and dropped; `block` maps to reject
+    assert payload == {"action": "reject"}
+
+
+def test_parse_marker_malformed_confidence_ignored() -> None:
+    payload, _clean = connector.parse_position_marker("x [[mycelium: confidence=high]]")
+    assert payload == {}
+
+
+def test_parse_marker_empty_body_after_strip_falls_back_to_original() -> None:
+    payload, clean = connector.parse_position_marker("[[mycelium: confidence=0.7]]")
+    assert payload == {"confidence": 0.7}
+    assert clean  # never post an empty reply
+
+
+def test_build_reply_carries_epistemic_payload() -> None:
+    woke = _inbound(sender="human", recipients=["agent-a"], text="@agent-a your call")
+    reply = connector.build_reply(
+        handle="agent-a",
+        room="r",
+        woke=woke,
+        text="I accept the guardrail.\n[[mycelium: confidence=0.9 stance=accept]]",
+    )
+    data = l9.payload_data_of(reply)
+    assert data.get("confidence") == 0.9
+    assert data.get("action") == "accept"
+    assert "mycelium" not in l9.human_text_of(reply)
+
+
+def test_build_reply_plain_text_has_empty_payload() -> None:
+    woke = _inbound(sender="human", recipients=["agent-a"], text="@agent-a hi")
+    reply = connector.build_reply(handle="agent-a", room="r", woke=woke, text="hello there")
+    assert l9.payload_data_of(reply) == {}
+
+
 # ── should_wake (pure) ────────────────────────────────────────────────────────
 
 

--- a/mycelium-cli/tests/test_demo.py
+++ b/mycelium-cli/tests/test_demo.py
@@ -285,6 +285,25 @@ def test_provision_cold_spawn_aborts_if_daemon_subscribe_fails(tmp_path) -> None
         demo._provision(spec, "claude_code", model=None, room="r")
 
 
+def test_drive_consensus_summons_aligner_after_positions() -> None:
+    """Once every agent has posted, the demo posts @aligner to trigger convergence."""
+    cfg = type("C", (), {"server": type("S", (), {"api_url": "http://x"})()})()
+    calls: list[list[str]] = []
+
+    with (
+        # all three agents have already spoken → no waiting
+        patch.object(demo, "_room_senders", return_value={"growth", "risk", "execution"}),
+        patch.object(demo, "_run", side_effect=lambda args, **_: calls.append(args) or _ok()),
+        patch.object(demo.time, "sleep"),  # skip the settle window
+    ):
+        demo._drive_consensus(cfg, "demo-room", ["growth", "risk", "execution"])
+
+    sends = [c for c in calls if c[:2] == ["room", "send"]]
+    assert len(sends) == 1
+    assert f"@{demo.ALIGNER_HANDLE}" in sends[0][2]
+    assert "--room" in sends[0] and "demo-room" in sends[0]
+
+
 def test_check_prereqs_flags_missing_daemon_for_cold_spawn() -> None:
     """claude_code with no daemon running surfaces a blocking problem with the fix."""
 

--- a/mycelium-cli/tests/test_demo.py
+++ b/mycelium-cli/tests/test_demo.py
@@ -222,7 +222,7 @@ def test_provision_warns_when_no_auth_source(capsys: pytest.CaptureFixture[str])
         assert "--copy-auth-from" not in c  # nothing to copy → flag omitted
 
 
-def test_provision_no_model_for_non_openclaw() -> None:
+def test_provision_no_model_for_non_openclaw(tmp_path) -> None:  # noqa: ANN001
     spec = _spec()
     calls: list[list[str]] = []
 
@@ -233,11 +233,78 @@ def test_provision_no_model_for_non_openclaw() -> None:
     with (
         patch.object(demo, "_fetch_persona", return_value="persona"),
         patch.object(demo, "_run", side_effect=fake_run),
+        patch.object(demo, "_demo_workdir", return_value=tmp_path),
     ):
         demo._provision(spec, "cursor", model="m/x", room="r")
 
     for c in [c for c in calls if c[:2] == ["agent", "create"]]:
         assert "--model" not in c  # model only applied to openclaw
+
+
+# ── cold-spawn (claude_code / cursor) plumbing ──────────────────────────────────
+
+
+def test_provision_cold_spawn_subscribes_daemon_and_passes_cwd(tmp_path) -> None:  # noqa: ANN001
+    """claude_code: daemon must be subscribed to the room, and every agent needs a --cwd."""
+    spec = _spec()
+    calls: list[list[str]] = []
+
+    with (
+        patch.object(demo, "_fetch_persona", return_value="persona"),
+        patch.object(demo, "_run", side_effect=lambda args, **_: calls.append(args) or _ok()),
+        patch.object(demo, "_demo_workdir", side_effect=lambda room, handle: tmp_path / handle),
+    ):
+        demo._provision(spec, "claude_code", model=None, room="r")
+
+    # the daemon is subscribed to the room *before* agents are seeded
+    subs = [c for c in calls if c[:2] == ["daemon", "subscribe"]]
+    assert subs == [["daemon", "subscribe", "r"]]
+    creates = [c for c in calls if c[:2] == ["agent", "create"]]
+    assert len(creates) == len(spec["agents"])
+    for c in creates:
+        assert "--cwd" in c
+        cwd = c[c.index("--cwd") + 1]
+        assert cwd.endswith(tuple(a["handle"] for a in spec["agents"]))
+
+
+def test_provision_cold_spawn_aborts_if_daemon_subscribe_fails(tmp_path) -> None:  # noqa: ANN001
+    """A failed daemon subscribe is fatal — agents would never wake."""
+    spec = _spec()
+
+    def fake_run(args, *, capture=True):  # noqa: ANN001, ARG001
+        if args[:2] == ["daemon", "subscribe"]:
+            return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="no daemon")
+        return _ok()
+
+    with (
+        patch.object(demo, "_fetch_persona", return_value="persona"),
+        patch.object(demo, "_run", side_effect=fake_run),
+        patch.object(demo, "_demo_workdir", return_value=tmp_path),
+        pytest.raises(typer.Exit),
+    ):
+        demo._provision(spec, "claude_code", model=None, room="r")
+
+
+def test_check_prereqs_flags_missing_daemon_for_cold_spawn() -> None:
+    """claude_code with no daemon running surfaces a blocking problem with the fix."""
+
+    class FakeCfg:
+        adapters = {"claude-code": {}}
+        llm = type("L", (), {"model": "anthropic/x"})()
+        server = type("S", (), {"api_url": "http://localhost:8000"})()
+
+    class FakeResp:
+        def raise_for_status(self) -> None:
+            return None
+
+    with (
+        patch("mycelium.config.MyceliumConfig.load", return_value=FakeCfg()),
+        patch("httpx.get", return_value=FakeResp()),
+        patch.object(demo, "_daemon_running", return_value=False),
+    ):
+        _cfg, problems = demo._check_prereqs("claude_code")
+
+    assert any("daemon isn't running" in p for p in problems)
 
 
 def test_provision_aborts_on_persona_fetch_failure() -> None:

--- a/mycelium-cli/tests/test_followups_e2e_fixes.py
+++ b/mycelium-cli/tests/test_followups_e2e_fixes.py
@@ -556,6 +556,42 @@ def test_daemon_restart_cli_calls_full_restart_not_reload() -> None:
     assert not mock_reload.called
 
 
+# ── daemon reload finds a foreground daemon via the lock file ────────────────
+
+
+def test_pid_from_lock_returns_live_pid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A foreground daemon isn't registered with launchd/systemd, so the service
+    lookups miss it — ``_pid_from_lock`` reads the PID from the singleton lock so
+    ``daemon subscribe`` / the demo can still SIGHUP-reload it."""
+    import os
+
+    from mycelium.daemon import install as daemon_install
+
+    lock = tmp_path / "daemon.lock"
+    lock.write_text(f"{os.getpid()}\n")  # our own PID is guaranteed alive
+    monkeypatch.setattr("mycelium.daemon.config.daemon_lock_path", lambda: lock)
+
+    assert daemon_install._pid_from_lock() == os.getpid()
+
+
+def test_pid_from_lock_none_for_dead_pid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale lock (crashed daemon) must not resolve to a dead/recycled PID."""
+    from mycelium.daemon import install as daemon_install
+
+    lock = tmp_path / "daemon.lock"
+    lock.write_text("2147483646\n")  # a PID that isn't running
+    monkeypatch.setattr("mycelium.daemon.config.daemon_lock_path", lambda: lock)
+
+    assert daemon_install._pid_from_lock() is None
+
+
+def test_pid_from_lock_none_when_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from mycelium.daemon import install as daemon_install
+
+    monkeypatch.setattr("mycelium.daemon.config.daemon_lock_path", lambda: tmp_path / "absent.lock")
+    assert daemon_install._pid_from_lock() is None
+
+
 # ── 7. agent invoke falls through to backend for cross-host invocations ──────
 
 


### PR DESCRIPTION
Gets `mycelium demo --adapter claude_code` working **end-to-end** — real `claude` agents negotiate in a room, converge, and the backend compiles a plan and syncs memory. This is Rung C of `docs/START_HERE_H5_DEMO.md` (the last unproven beat of the SLIM-native rewrite).

## Proven live

A full run on a fresh room (`ex07_investment_portfolio`, 3 agents, haiku):

```
aligner observed room demo-final → converged
  (mpc 0.91, gar 1.0, scr 0.0, provenance_weight 1.0, participants 3)
plan_sync: compiled plan/tasks.md for room demo-final (v1)
```

- `plan/tasks.md` — 8 concrete tasks, tagged per agent (`@risk-agent`, `@execution-agent`, `@growth-agent`)
- `log/episodes/live` — `outcome: converged`
- 10 room memories synced, including the agents updating their own notes mid-negotiation

## The four real gaps found & fixed

Provisioning (the original scope of this PR) was only the entry point. Driving a live negotiation surfaced four genuine breakages:

1. **Daemon reload couldn't find a foreground daemon.** `_get_daemon_pid` only knew the launchd/systemd service, so `daemon subscribe` (and the demo) could not SIGHUP-reload a daemon started with `daemon run --foreground` — the documented dev path. Connectors for the demo room never started, so agents never woke. Fix: fall back to the singleton lock file (every daemon writes its PID there), with a liveness probe.

2. **Agent replies carried no epistemic payload → the aligner could never converge.** `compute_metrics` returns `None` without `confidence`, which always yields `commit:rejected`. The connector's `build_reply` posted plain text only. Fix: the connector parses a volunteered `[[mycelium: confidence=.. stance=..]]` marker from the reply into the L9 payload and strips it from the posted prose (forgiving, sanitize-not-reject, matching the backend convention).

3. **Agents were never told to state confidence.** The cold-spawn preamble now documents the position marker.

4. **Nothing summoned the aligner.** The demo now waits for every agent to post, then posts `@aligner` — a deterministic trigger for the converge→plan→memory payoff.

## Provisioning fixes (original scope)

- Per-agent `--cwd` for cold-spawn adapters (manifests require it).
- `daemon subscribe <room>` before seeding so agents get a SLIM connector.
- Daemon-running prereq check for cold-spawn adapters, fail-fast with the fix.

## Docs

Refreshed the stale `claude_code` SKILL.md — it described the **removed** CFN tick model (`session join/await`, `negotiate propose/respond`, CognitiveEngine rounds). Replaced with the SLIM-native flow: argue in the room, mark confidence, summon `@aligner`.

## Scope

CLI + docs only — the backend aligner/plan_compiler/memory-sync already worked; the gaps were all on the CLI/daemon/agent side. `openclaw`/`hermes` untouched (deferred adapters, debt D11).

## Tests

- Connector marker parsing (lift/strip, malformed/out-of-range dropped) + epistemic reply payload.
- `_pid_from_lock` fallback (live / dead / missing PID).
- Demo drives the `@aligner` summon after positions land.
- Full CLI gate green: `ruff check` + `ruff format --check` + `ty check` + `pytest` (394 passed).