### PR TITLE
Rung 1: @aligner drives a live NEGMAS SAO over SLIM (kill the AI theatre)

### DIFF
--- a/docs/SMOKE_TEST_HANDOFF.md
+++ b/docs/SMOKE_TEST_HANDOFF.md
@@ -1,0 +1,121 @@
+# Smoke-Test Handoff — help Julia see the SLIM-native rewrite actually work
+
+> **You are a fresh Claude Code session.** Your job: get the just-completed SLIM-native
+> rewrite **running end-to-end on Julia's machine** so she can *see* it work — bring the
+> stack up, drive one full `room → agent → converge → plan → memory → UI` flow, and debug
+> whatever breaks **with her, in small visible steps.** This is a hands-on validation, not
+> a code review.
+
+## Read this honestly first: what's proven vs. not
+
+The rewrite replaced a 4-service closed-source "CFN" cluster + a Postgres/AgensGraph fork
+with **one `slim` messaging node + a thin FastAPI backend + local markdown/JSONL files — no
+database.** It shipped in 10 reviewed steps (all merged into the `slim-native-rewrite`
+branch). See `docs/slim-native-rebuild-bible.md` (the authoritative spec; Part III = repo
+map, Part V = what each step did, Part VI = SLIM quickstart) and `docs/START_HERE.md`.
+
+**Proven:** each step's fast unit tests, and a cumulative *live-node integration suite* that
+was run by hand against a bare `slim:1.4.0` node during development (L9 exchange, causal
+ordering, episode abort, durable inbox, connector wake, human mention, aligner converge,
+plan+memory sync, cross-machine reindex).
+
+**NOT proven (your job):** the **full product stack via docker compose** (slim node +
+backend + frontend together), a **real `claude` agent** cold-spawned by the daemon actually
+waking and replying over SLIM, and the **UI** showing it. The CI job that would run the live
+suite (`integration-slim`) has **never executed**. So: **expect rough edges. Finding and
+fixing them is the point.** Move in small steps; confirm each green light with Julia before
+the next.
+
+## Orient (do this first)
+
+1. `cd /Users/juliavalenti/Documents/GitHub/mycelium`
+2. Make sure you're on the integrated branch: `git checkout slim-native-rewrite && git pull`.
+   (Everything below assumes this branch — `main` does NOT have the rewrite.)
+3. Skim `docs/START_HERE.md`, then `docs/cross-machine.md` — it has a **"Watching it in the
+   browser"** section that is essentially the manual acceptance script; lean on it.
+4. **Trust the code, not old docs for exact commands.** `CLAUDE.md` is stale on architecture
+   (it still describes CFN/AgensGraph). Verify CLI flags with `mycelium --help` /
+   `mycelium <cmd> --help`, and read the *current* compose at
+   `mycelium-cli/src/mycelium/docker/compose.yml` + `compose-dev.yml`.
+
+## Prereqs to confirm with Julia
+
+- **Docker** running.
+- **The `claude` CLI installed and authenticated** on this machine with **API credits** —
+  the daemon cold-spawns `claude -p` for a Claude Code agent's turn, so a real agent reply
+  **costs tokens**. (Check `which claude`.)
+- **LLM config** for the backend: the plan compiler (and any LLM stage) needs a model +
+  key. Set via `mycelium config set llm.model/llm.api_key/llm.base_url` then
+  `mycelium config apply`. (The aligner's *base* verdict is deterministic math and needs no
+  LLM, but plan compilation does.)
+- **`mas_id` / `workspace_id` are gone** — removed in the rewrite. Don't chase old config
+  errors about them. Identity is now a dev shared secret over SLIM (fine for single-host).
+
+## The smoke-test ladder (climb it; stop and debug where it breaks)
+
+**Rung 1 — Stack comes up.** Bring up the dev stack (builds backend from source):
+```
+docker compose -f mycelium-cli/src/mycelium/docker/compose.yml \
+  -f mycelium-cli/src/mycelium/docker/compose-dev.yml up -d --build
+```
+Confirm: the **`slim` node** container is healthy (listening on `:46357`), the **backend**
+answers `GET /health`, and (if you start the `ui` profile) the **frontend** serves on `:3000`.
+The one non-obvious trap: the slim **node image `1.4.0` must match `slim-bindings 1.4.x`** or
+you'll see `public key length is invalid` — do not bump one without the other. *If this rung
+fails, that alone is a valuable finding (the compose/install post-rewrite is untested).*
+
+**Rung 2 — Memory works with no database.** The foundation:
+```
+mycelium room create smoke
+mycelium memory set smoke status/hello "it works" && mycelium memory get smoke status/hello
+mycelium memory ls smoke && mycelium memory search smoke "works"
+```
+Confirm files under `~/.mycelium/rooms/smoke/` (markdown) + a `.search-index.jsonl`, and that
+search returns the hit. No DB anywhere.
+
+**Rung 3 — One Claude Code agent rides the fabric (the dogfood).** Register an agent, run the
+daemon, and wake it:
+- `mycelium agent create/add …` (check `--help`) to register a `claude_code` agent in `smoke`
+  with a `cwd`.
+- Start the daemon (`mycelium daemon …` — check `--help`; it must be running for cold-spawn).
+- Confirm the daemon's **connector joins the room's SLIM channel** (logs: "connector joined").
+- Post a message that `@`-mentions the agent into the room; confirm it **wakes, a `claude -p`
+  turn spawns, and its reply lands back in the room.** This is Step 5 — the core proof that an
+  agent coordinates over SLIM. Watch daemon logs closely; this is the most likely place to hit
+  a real bug.
+
+**Rung 4 — Converge → plan → memory.** Get positions into the room (two agents, or seed
+exchange messages), then `@`-summon the **aligner** (default handle `aligner`). Confirm it
+emits `commit:converged`/`rejected` with MPC/GAR/SCR, the backend compiles **`plan/tasks.md`**,
+and the converged content **syncs as a `knowledge` write** into the local store. (The
+`persona-before-and-after` or `demo` flows, if present/working, may help seed a realistic
+multi-agent scenario — but they may be stale; prefer a hand-driven minimal case first.)
+
+**Rung 5 — See it in the browser.** Open the frontend, open the `smoke` room, and use the
+**L9 protocol inspector** (an "L9" tab) to watch the L9 frames stream (kind/subkind, episode,
+metrics) and the episode causal chain; trigger a **consent prompt** (an `@`-invite of an agent
+not in the room) and accept/decline it. This is the AOP showcase and the visible payoff.
+
+## Known gotchas (save yourself time)
+
+- **Version pin:** slim node `1.4.0` ↔ `slim-bindings 1.4.x` (Rung 1).
+- **Daemon must be running** for `claude_code`/`cursor` (cold-spawn) agents; `openclaw`/`hermes`
+  adapters are **known-broken** post-rewrite (debt D11) — don't test them.
+- **A member host still needs a backend** for search/reindex (the CLI has no embedder).
+- **MLS is on** for room channels; the dev shared secret is consistent on one host, so
+  single-machine "just works." Cross-machine is a later exercise (`docs/cross-machine.md`).
+- **Costs tokens:** every real agent turn is a `claude -p` call.
+- **Open debts** that may bite are catalogued in the bible **Part IV (register D1–D12)** — e.g.
+  silent best-effort degradation (D3/D6): if "nothing happens," check backend + daemon logs,
+  because a lot of SLIM failures degrade quietly to "no channel."
+
+## How to work with Julia
+
+Go rung by rung. After each, **show her the concrete evidence** (the file, the log line, the
+message in the room, the frame in the inspector) so she can see it with her own eyes. When
+something breaks — and something will, this is the first real run — diagnose it together,
+fix the smallest thing, and re-run that rung. The deliverable is Julia watching a real agent
+coordinate over SLIM and a plan appear, not a passing test count.
+
+If you fix real bugs along the way, they belong on the `slim-native-rewrite` branch (or a
+small PR into it); note anything you defer against the bible's debt register.

--- a/docs/START_HERE_MEDIATOR.md
+++ b/docs/START_HERE_MEDIATOR.md
@@ -5,9 +5,13 @@
 > Nothing here is committed to a release. The build plan front-loads the one cheap experiment
 > that can *falsify* the whole idea before we invest in the harness swap.
 >
-> **⇒ CURRENT ENTRY POINT: Rung 1.** Rung 0 (the behavioral de-risk — the whole bet) **PASSED**
-> — see the ledger and the build plan below, and `experiments/sao-mediator-spike/`. Start at
-> Rung 1: wire the proven mediator loop as the live `@aligner` over SLIM against real agents.
+> **⇒ Rung 0 PASSED, Rung 1 BUILT.** Rung 0 (the behavioral de-risk — the whole bet) passed
+> (`experiments/sao-mediator-spike/`). **Rung 1's code is now merged**: the `@aligner` gained a
+> `mediator` mode that drives a real NEGMAS SAO over SLIM (`app/services/mediator.py` +
+> `aligner.py:mediate`, `tests/test_mediator.py`). It is proven node-free but **not yet run
+> against live cold-spawned agents.** ⇒ **CURRENT ENTRY POINT:
+> [`START_HERE_MEDIATOR_RUNG2.md`](./START_HERE_MEDIATOR_RUNG2.md)** — validate Rung 1 live,
+> then Rung 2 (Pi + OpenShell). The rung descriptions below remain the design reference.
 
 You are picking up the **coordination redesign** that the H5 demo surfaced. H5 got a full
 `converge → plan → memory` run working with live agents (see
@@ -141,7 +145,8 @@ proved the NEGMAS drive + NL→SAO interpretation both work; `mediator_spike_v2.
 brokering + BATNA and **converged in 2 steps, terminating at agreement**. Finding baked into the
 dir's README and `project_mediator_pi_negmas` memory. **Don't repeat this — start at Rung 1.**
 
-**Rung 1 — the mediator drives live over SLIM, still on today's worker agents. ⇐ START HERE.**
+**Rung 1 — the mediator drives live over SLIM, still on today's worker agents. ✅ CODE BUILT
+(node-free); live validation pending → see `START_HERE_MEDIATOR_RUNG2.md`.**
 Port the *proven v2 loop* (`experiments/sao-mediator-spike/mediator_spike_v2.py`: discover →
 NEGMAS rounds → interpret prose → terminate on agreement) into the `@aligner` driver: on summon,
 open the episode, run rounds by `@`-addressing agents over SLIM and reading their real replies

--- a/docs/START_HERE_MEDIATOR_RUNG2.md
+++ b/docs/START_HERE_MEDIATOR_RUNG2.md
@@ -1,0 +1,133 @@
+# START HERE — The SAO Mediator, Rung 1 validation → Rung 2 (Pi + OpenShell)
+
+> **Status: exploratory / design track**, continuing `START_HERE_MEDIATOR.md`. Read that doc
+> first for the *why* (kill the AI theatre) and the honest ledger. This doc picks up **after
+> Rung 1's code landed** and covers two things, in order: (1) **validate Rung 1 live** against
+> real cold-spawned agents — the code exists but has only been proven node-free; (2) then
+> **Rung 2**, swapping the worker runtime to Pi + OpenShell.
+
+## What Rung 1 built (already merged into `slim-native-rewrite`)
+
+The `@aligner` engine gained a third mode — **`mediator`** — that ports the proven Rung-0 v2
+loop (`experiments/sao-mediator-spike/mediator_spike_v2.py`) to run *live over SLIM*:
+
+- **`app/services/mediator.py`** (new) — the SAO orchestration: `discover_issues` (opening
+  prose → NEGMAS issues/options), a `MediatedNegotiation` run-context (running history +
+  brokering + BATNA — the "camp counselor"), the `LiveNegotiator` (a NEGMAS `SAONegotiator`
+  whose `propose`/`respond` are backed by a *real agent's* replies), and the LLM seams
+  (`llm_sync` — synchronous `litellm.completion`, which also dodges the Bedrock `acompletion`
+  breakage).
+- **`app/services/aligner.py`** — `AlignerEngine.mediate(room)`: on summon, opens the episode,
+  discovers issues from the transcript's opening positions, runs `mech.run()` on a worker
+  thread while each negotiator bridges back to the event loop (`run_coroutine_threadsafe`) to
+  `@`-address one agent over SLIM and read its real reply, then emits the agreed
+  `issue = value` map through the **same `commit:converged` seam `plan_sync` already consumes**.
+  **NEGMAS owns termination** — it stops the instant the standing offer is unanimous.
+- **`ALIGNER_MODE=mediator`** + **`ALIGNER_MEDIATOR_MAX_STEPS`** (default 20) config.
+- **`negmas`** added to `fastapi-backend` deps; **`tests/test_mediator.py`** proves the loop
+  terminates at agreement below the step cap (the anti-theatre assertion), node-free/LLM-free.
+
+**The seam that makes this safe:** the mediator is *additive*. `observer` (deterministic,
+no-LLM) is still the default mode; nothing changes for existing rooms until an operator flips
+`ALIGNER_MODE=mediator`. Rung 3 will retire the observer + the `parse_position_marker` hack.
+
+## Proven vs. NOT (updated ledger)
+
+**Proven (Rung 1, this branch):** the mediated loop drives a real NEGMAS SAO, interprets
+simulated agent prose into offers/accepts, and **terminates at agreement without a restating
+tail** — asserted in `test_mediator.py` over the same fake channel the aligner tests use.
+
+**NOT yet proven (your job, Rung 1 validation):** the loop against **real cold-spawned worker
+agents over a live SLIM node** — real replies, real latency, the daemon's cold-spawn turn
+model. This is exactly the gap `START_HERE_MEDIATOR.md`'s "Still open (Rung 1+)" flagged. The
+code is written; it has never run end-to-end against a `claude -p` agent.
+
+## Part A — Validate Rung 1 live (do this before Rung 2)
+
+Lean on `docs/SMOKE_TEST_HANDOFF.md` for bringing the stack up (it is the current, honest guide
+to the SLIM-native stack; `CLAUDE.md` is stale on architecture). Then, specifically for the
+mediator:
+
+1. **Turn the mediator on.** It needs an LLM (unlike the observer). Set the backend's
+   `ALIGNER_MODE=mediator` (env on the backend container / process) and confirm `llm.model` +
+   `llm.api_key` are configured (`mycelium config set …` → `mycelium config apply`; recreate
+   the backend container to pick up env). Optionally lower `ALIGNER_MEDIATOR_MAX_STEPS` for a
+   faster, cheaper first run.
+2. **Seed a real disagreement.** Get **two or three** real `claude_code` agents into a room
+   with genuinely conflicting opening positions (the `demo` / `persona-before-and-after` flows
+   seed the classic growth/risk/execution portfolio scenario — they may be stale, so a
+   hand-driven minimal case is fine too). Confirm each agent posts an opening position into the
+   room transcript.
+3. **Summon the mediator.** Post a message that `@`-mentions the aligner handle (default
+   `aligner`). Watch the backend logs: `discover_issues` should log the issues, then per-step
+   `mediator step N: @handle PROPOSE …` / `… ACCEPT on …` lines as it `@`-addresses agents in
+   turn and their connectors cold-spawn replies.
+4. **Watch for the payoff — a *bounded* negotiation.** The deliverable that matters (per
+   `START_HERE_MEDIATOR.md` "How to work with the human"): the transcript shows agents reaching
+   agreement and the mediator **stopping** — no seven-round restating tail. On termination it
+   emits `commit:converged` with the `issue = value` map, `plan_sync` compiles `plan/tasks.md`,
+   and it syncs to memory exactly as the observer path does today.
+
+### Where it will most likely break (debug here first)
+
+- **Interpretation drift on messy prose.** The spike's agents spoke tidy accept/reject; real
+  `claude -p` agents ramble. If `interpret` mis-maps a reply, the mediator's **echo-back** into
+  the transcript ("recording @growth as counter → …") is your window — a misread should be
+  visible and correctable in-band. If it is *not* visible enough, strengthening that echo is
+  the first fix (`mediator.py:interpret` / the `on_reading` fold in `aligner.py`).
+- **Turn timing.** `_slim_turn` waits `ALIGNER_ROUND_TIMEOUT_S` for a reply; a slow cold-spawn
+  that exceeds it yields `""` → read as a reject → NEGMAS keeps going. If real agents are
+  slower than the default 30s, raise it. A silent agent must never hang the loop (that bound is
+  the guarantee) but too-tight a bound turns real replies into spurious rejects.
+- **No opening positions.** `mediate` seeds `discover_issues` from transcript positions and
+  stubs absent agents; if nobody has spoken, discovery has nothing to structure and it rejects
+  cleanly. Make sure agents actually post before the summon (or add a real opening-position
+  prompt round — noted as a possible enhancement).
+- **Silent degradation.** As the smoke-test doc warns (debts D3/D6), SLIM failures degrade
+  quietly to "no channel." If "nothing happens," check backend + daemon logs.
+
+**Deliverable of Part A:** a human watching a real multi-agent negotiation reach agreement and
+the mediator *stop* — the direct before/after against the H5 theatre. Capture the transcript.
+
+## Part B — Rung 2: swap the worker runtime to Pi + OpenShell
+
+Only after Part A shows the theatre is dead against real agents. This is **independent payoff
+and independent risk** from the mediator (provider-agnostic, containerized, self-hostable), so
+it is its own rung.
+
+- Replace the `claude -p` cold-spawn worker runtime with **Pi** agents
+  (`pi -p --session <id> --mode json`), **OpenShell**-sandboxed. Pi = earendil-works/pi;
+  OpenShell = NVIDIA/OpenShell (`openshell sandbox create --from pi`). Both validated as real
+  in the Rung-0 session (see `START_HERE_MEDIATOR.md` "Proven, hands-on").
+- Workers keep the good coding-agent abstractions (skills, tools, bash); they just *speak* in
+  the room. The mediator's `@`-drive is unchanged — it addresses whatever agent runtime answers
+  on the channel.
+- **Session-locking discipline:** drive Pi sessions **strictly serially** (the mediator's turn
+  model is serial by construction). Reuse the daemon's per-handle serial-lock. Run a deliberate
+  concurrent-write test before trusting Pi sessions under any parallelism.
+- Touch points: the daemon dispatch/runner (`daemon/dispatch.py`, `daemon/runner.py`) and the
+  `claude_code` adapter (`integrations/claude_code/**`) are where cold-spawn lives today.
+
+## Part C — Rung 3 (retire the old surface), later
+
+Once Rung 2 is in: remove the observer engine + `daemon/connector.py:parse_position_marker`
+and the preamble's "position marker" block (agents go back to markerless prose; the mediator
+interprets). Flip the mediator to the default mode. Update the CLI skill/preamble. This is a
+deletion rung — do it last, when the mediator has earned the trust to be the only path.
+
+## Fixed decisions (unchanged from `START_HERE_MEDIATOR.md`)
+
+- The mediator is an **agent that runs NEGMAS**, not re-ported SAO math in the backend.
+- **NEGMAS owns termination.** Agreement is when the mechanism says so.
+- **One framework: Pi coding agents** for all participants, OpenShell-sandboxed (Rung 2).
+- Agents are **not** required to emit structured markers; the mediator interprets prose.
+
+## References
+
+- **Why + the ledger:** `docs/START_HERE_MEDIATOR.md`.
+- **Stack up / smoke ladder:** `docs/SMOKE_TEST_HANDOFF.md`, `docs/cross-machine.md`.
+- **The proven core:** `experiments/sao-mediator-spike/` (v1 deadlock → v2 converges).
+- **The Rung-1 code:** `app/services/mediator.py`, `app/services/aligner.py` (`mediate`),
+  `tests/test_mediator.py`.
+- **Harness (Rung 2):** Pi (earendil-works/pi), NVIDIA/OpenShell, NEGMAS (yasserfarouk/negmas).
+- **Direction memory:** `project_mediator_pi_negmas`, `project_cfn_teardown_l9_pivot`.

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -67,8 +67,10 @@ class Settings(BaseSettings):
     # A reserved handle is how a summon of the engine is told apart from an
     # @-mention of a normal teammate (bible §10 / Step 7 trap).
     ALIGNER_HANDLE: str = "aligner"
-    # "observer" (one-shot: read transcript, emit verdict) or "driver" (run
-    # rounds, prompting participants, then emit).
+    # "observer" (one-shot: read transcript, emit verdict), "driver" (run
+    # rounds, prompting participants, then emit), or "mediator" (Rung 1: run a
+    # NEGMAS SAO negotiation — @-address agents in turn, interpret their prose,
+    # and terminate the instant the mechanism reaches agreement).
     ALIGNER_MODE: str = "observer"
     # MPC at/above this converges; below rejects (mirrors the old CFN
     # validation-intervention default of 0.6).
@@ -79,6 +81,11 @@ class Settings(BaseSettings):
     ALIGNER_ROUND_TIMEOUT_S: float = 30.0
     # How often the driver polls the transcript for round replies.
     ALIGNER_POLL_INTERVAL_S: float = 0.2
+    # Mediator (Rung 1) — hard cap on NEGMAS SAO steps (one agent turn each) so
+    # the negotiation always terminates even if agreement is never reached. Set
+    # well above the participant count so several proposer rotations can happen
+    # (spike used 20).
+    ALIGNER_MEDIATOR_MAX_STEPS: int = 20
 
     model_config = SettingsConfigDict(
         env_file=tuple(_env_files),

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -71,6 +71,7 @@ logger = logging.getLogger(__name__)
 
 MODE_OBSERVER = "observer"
 MODE_DRIVER = "driver"
+MODE_MEDIATOR = "mediator"
 
 # Handles that are never a participant position: the engine itself, the backend
 # moderator, and the system actor the backend signs its own envelopes with.
@@ -161,6 +162,7 @@ class AlignerEngine:
         max_rounds: int | None = None,
         round_timeout_s: float | None = None,
         poll_interval_s: float | None = None,
+        max_steps: int | None = None,
     ) -> None:
         self._manager = manager
         self._handle = handle if handle is not None else settings.ALIGNER_HANDLE
@@ -172,6 +174,9 @@ class AlignerEngine:
         )
         self._poll_interval_s = (
             poll_interval_s if poll_interval_s is not None else settings.ALIGNER_POLL_INTERVAL_S
+        )
+        self._max_steps = (
+            max_steps if max_steps is not None else settings.ALIGNER_MEDIATOR_MAX_STEPS
         )
         # Rooms with a run in flight — a re-summon while active is ignored.
         self._active: set[str] = set()
@@ -209,7 +214,9 @@ class AlignerEngine:
 
     async def _run_and_release(self, room: str) -> None:
         try:
-            if self._mode == MODE_DRIVER:
+            if self._mode == MODE_MEDIATOR:
+                await self.mediate(room)
+            elif self._mode == MODE_DRIVER:
                 await self.drive(room)
             else:
                 await self.observe(room)
@@ -340,6 +347,194 @@ class AlignerEngine:
             await asyncio.sleep(self._poll_interval_s)
         return latest
 
+    # -- mediator mode (Rung 1: drive a real NEGMAS SAO over SLIM) --
+
+    async def mediate(self, room: str) -> dict[str, Any] | None:
+        """Run a NEGMAS SAO negotiation live over SLIM, terminating at agreement.
+
+        The Rung-1 replacement for the passive observer: on summon, discover the
+        issues from the agents' opening prose, then let NEGMAS drive the rounds —
+        ``@``-addressing one agent at a time over the channel, interpreting the
+        real reply, and stopping the *instant* the mechanism reaches unanimity
+        (the anti-theatre property). Hands the agreed ``issue = value`` map to the
+        same ``commit:converged`` seam ``plan_sync`` already consumes.
+
+        NEGMAS is synchronous, so ``mech.run()`` executes on a worker thread; each
+        negotiator bridges back to this loop for its SLIM turn (see
+        :mod:`app.services.mediator`). Always closes the episode in ``finally`` so
+        Step 6's queued invites drain even on a mid-run failure.
+        """
+        from app.services import mediator
+
+        managed = self._manager.get(room)
+        if managed is None or managed.persister is None:
+            logger.info("aligner (mediator) summoned for %s but no live channel/persister", room)
+            return None
+        persister = managed.persister
+        participants = [m for m in self._manager.members(room) if _norm(m) != _norm(self._handle)]
+        episode = l9.episode_urn(room, "align")
+        topic = l9.topic_urn(room)
+
+        self._manager.open_episode(room, episode)
+        ep = l9_episode.open_episode(
+            parent_room=room,
+            short_id="align",
+            workspace_id=managed.workspace,
+            mas_id="",
+            agents=participants,
+            joined_intents="aligner mediate: converge on the open question via SAO",
+        )
+        try:
+            positions = self._opening_positions(persister, participants)
+            issues = await asyncio.to_thread(
+                mediator.discover_issues,
+                "Converge on the room's open question — agree one value per issue.",
+                positions,
+            )
+            if not issues:
+                logger.info("aligner (mediator) room %s: no issues discovered; rejecting", room)
+                return await self._emit_verdict(
+                    managed,
+                    ep,
+                    {},
+                    converged=False,
+                    metrics=None,
+                    text="✗ not converged — could not structure the discussion into issues.",
+                )
+
+            loop = asyncio.get_running_loop()
+            negotiation = mediator.MediatedNegotiation(
+                issues=issues,
+                cap=self._max_steps,
+                loop=loop,
+                fetch_prose=lambda handle, prompt, round_n: self._slim_turn(
+                    managed, persister, handle, episode, topic, prompt, round_n
+                ),
+                turn_timeout_s=self._round_timeout_s,
+                on_reading=lambda handle, reading, proposing: self._fold_reading(
+                    ep, handle, reading, proposing
+                ),
+            )
+            mech = mediator.build_mechanism(issues, participants, negotiation, cap=self._max_steps)
+            await asyncio.to_thread(mech.run)
+
+            assignments = mediator.agreement_assignments(mech, negotiation.names)
+            converged = assignments is not None
+            _, metrics = self._verdict(ep)
+            logger.info(
+                "aligner (mediator) room %s → %s in %d steps (%s)",
+                room,
+                "agreement" if converged else "no agreement",
+                mech.current_step,
+                assignments,
+            )
+            return await self._emit_verdict(
+                managed,
+                ep,
+                assignments or {},
+                converged=converged,
+                metrics=metrics,
+                text=self._mediator_text(converged, assignments, mech.current_step),
+            )
+        finally:
+            await self._manager.close_episode(room)
+
+    def _opening_positions(
+        self, persister: RoomPersister, participants: list[str]
+    ) -> dict[str, str]:
+        """Each participant's most recent opening prose from the transcript.
+
+        The issue-discovery seed. Falls back to a bare handle stub for any agent
+        that has not yet spoken, so discovery still sees the full roster.
+        """
+        wanted = {_norm(p): p for p in participants}
+        latest: dict[str, str] = {}
+        for record in persister.log.records:
+            if not self._is_position(record):
+                continue
+            key = _norm(record.sender)
+            if key in wanted:
+                text = record.content.get("content")
+                if isinstance(text, str) and text.strip():
+                    latest[wanted[key]] = text.strip()
+        for handle in participants:
+            latest.setdefault(handle, f"(no opening position stated by @{handle})")
+        return latest
+
+    async def _slim_turn(
+        self,
+        managed: ManagedRoomChannel,
+        persister: RoomPersister,
+        handle: str,
+        episode: str,
+        topic: str,
+        prompt: str,
+        round_n: int,
+    ) -> str:
+        """Publish one ``@handle`` prompt, wait for the reply, return its prose.
+
+        Bounded by ``round_timeout_s`` (a silent agent yields ``""``, read as a
+        reject) so the mechanism can never hang on one participant. Reuses the
+        publish shape of ``_prompt_round`` and the poll of ``_collect_round`` for
+        a single addressee.
+        """
+        before = len(persister.log.records)
+        env = l9.build_envelope(
+            kind=l9.Kind.exchange,
+            episode=episode,
+            recipients=[handle],
+            topic=topic,
+            payload_type="tick",
+            payload_data={"round": round_n, "action": "position"},
+        )
+        try:
+            await managed.channel.send(env, extra={"content": prompt})
+        except Exception:
+            logger.warning("mediator failed to prompt @%s (step %d)", handle, round_n)
+            return ""
+
+        pending = _norm(handle)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._round_timeout_s
+        while True:
+            for record in persister.log.records[before:]:
+                if self._is_position(record) and _norm(record.sender) == pending:
+                    return record.content.get("content") or ""
+            if loop.time() >= deadline:
+                return ""
+            await asyncio.sleep(self._poll_interval_s)
+
+    def _fold_reading(
+        self, ep: EpisodeState, handle: str, reading: dict[str, Any], proposing: bool
+    ) -> None:
+        """Fold one interpreted SAO move into the episode so metrics stay live.
+
+        The mediated path's replies are prose, not epistemic payloads, so we
+        synthesize a ``record_reply`` shape from the mediator's own reading — the
+        L9 episode record and the consensus envelope's MPC/GAR/SCR are then
+        computed over what the mediator actually understood.
+        """
+        if not isinstance(reading, dict):
+            return
+        reply: dict[str, Any] = {}
+        action = reading.get("action")
+        if isinstance(action, str) and action:
+            reply["action"] = "accept" if action == "accept" else "reject"
+        offer = reading.get("offer")
+        if isinstance(offer, dict):
+            reply["offer"] = offer
+            reply.setdefault("action", "accept" if proposing else "reject")
+        l9_episode.record_reply(ep, handle=handle, reply=reply, round_n=None)
+
+    def _mediator_text(
+        self, converged: bool, assignments: dict[str, str] | None, steps: int
+    ) -> str:
+        """The human-facing summary the agents read on a mediated verdict."""
+        if converged and assignments:
+            terms = " · ".join(f"{issue} = {value}" for issue, value in assignments.items())
+            return f"✓ agreement in {steps} steps — {terms}."
+        return f"✗ no agreement — the negotiation ran {steps} steps without unanimity."
+
     # -- scoring (delegates the math to l9_episode) --
 
     def _is_position(self, record: TranscriptRecord) -> bool:
@@ -411,6 +606,7 @@ class AlignerEngine:
         assignments: dict[str, Any],
         converged: bool,
         metrics: dict[str, Any] | None,
+        text: str | None = None,
     ) -> dict[str, Any]:
         """Broadcast the ``commit`` envelope and record it once locally.
 
@@ -431,7 +627,8 @@ class AlignerEngine:
         wire_dict = copy.deepcopy(env_dict)
         wire_dict["header"]["message"]["parents"] = []
         envelope = l9.parse_envelope(wire_dict)
-        text = self._verdict_text(converged, metrics)
+        if text is None:
+            text = self._verdict_text(converged, metrics)
         content = serialize_content(envelope, extra={"content": text})
         try:
             await managed.channel.send(envelope, extra={"content": text})

--- a/fastapi-backend/app/services/mediator.py
+++ b/fastapi-backend/app/services/mediator.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The SAO mediator — the aligner as a *driver* of a real negotiation (Rung 1).
+
+`docs/START_HERE_MEDIATOR.md` diagnosed the H5 demo's "AI theatre": the aligner
+was a passive **observer** that only woke to grade a finished transcript, so
+agents that had already agreed by message 5 kept re-agreeing for seven more
+turns because nothing *ran* the negotiation and said "you agreed — stop."
+
+Rung 0 (`experiments/sao-mediator-spike/mediator_spike_v2.py`) proved the fix in
+a harness with simulated personas: an LLM mediator reads natural-language agent
+chatter, maps it onto a NEGMAS **Stacked Alternating Offers** mechanism, and
+**NEGMAS owns termination** — the mechanism stops the instant everyone accepts
+the standing offer. The v1→v2 lesson: bare-offer relaying to stateless agents
+deadlocks; convergence needs **memory + a brokering mediator + BATNA** (the
+"camp counselor"). This module ports that proven v2 loop to run *live over SLIM*
+against real worker agents, still driven by the reserved ``@aligner`` handle.
+
+**The Node/Python-free seam.** NEGMAS is a synchronous Python mechanism; SLIM I/O
+is async on the backend event loop. Rather than know NEGMAS's next-actor and
+inject externally-collected moves (version-fragile), we run ``mech.run()`` on a
+worker thread and let each negotiator block for its own agent's real reply: the
+negotiator's ``propose``/``respond`` bridge back to the loop with
+``run_coroutine_threadsafe`` to publish an ``@``-addressed prompt and collect the
+reply the persister records, then interpret the prose in-thread. NEGMAS keeps
+full ownership of proposer rotation and the unanimity stop; we only supply each
+agent's move when NEGMAS asks for it. LLM calls (discover/broker/interpret) run
+synchronously in-thread via ``litellm.completion`` — which also sidesteps the
+Bedrock ``acompletion`` issue (see ``plan_compiler``).
+
+The mediator is deliberately *interpretation over the agents' prose*: agents are
+never required to emit structured markers (a Rung-3 clean-up will retire the H5
+``parse_position_marker`` hack entirely). The mediator restates its reading into
+the transcript ("recording @growth as counter → 35% tech") so a misread is
+visible and correctable in-band.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from negmas import SAOMechanism, make_issue
+from negmas.sao import ResponseType, SAONegotiator
+
+from app.config import settings
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+logger = logging.getLogger(__name__)
+
+# Bounded LLM turns keep interpretation cheap and predictable.
+_MAX_TOKENS = 500
+_DISCOVER_TEMPERATURE = 0.0
+_BROKER_TEMPERATURE = 0.3
+
+# No-deal framing — the BATNA that turns a hardliner into a negotiator (the one
+# thing the v1 spike lacked). Appended to every agent-facing prompt.
+_BATNA = (
+    "If the team reaches NO agreement there is NO change at all — the worst outcome for "
+    "everyone, you included. A compromise you can live with beats no deal. Protect your one "
+    "genuine hard line; concede everything secondary."
+)
+
+
+def _extract_json(text: str) -> dict[str, Any]:
+    """First ``{...}`` JSON object in a model response (empty dict on miss)."""
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        return {}
+    try:
+        parsed = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def llm_sync(prompt: str, *, system: str = "", temperature: float = _BROKER_TEMPERATURE) -> str:
+    """One blocking chat completion using the configured model.
+
+    Synchronous on purpose: the mediator's LLM turns run inside NEGMAS's
+    ``mech.run()`` worker thread, and ``litellm.completion`` also avoids the
+    Bedrock ``acompletion`` breakage the plan compiler documents.
+    """
+    import litellm
+
+    kwargs: dict[str, Any] = {
+        "model": settings.LLM_MODEL,
+        "max_tokens": _MAX_TOKENS,
+        "temperature": temperature,
+        "messages": (
+            ([{"role": "system", "content": system}] if system else [])
+            + [{"role": "user", "content": prompt}]
+        ),
+    }
+    if settings.LLM_API_KEY:
+        kwargs["api_key"] = settings.LLM_API_KEY
+    if settings.LLM_BASE_URL:
+        kwargs["base_url"] = settings.LLM_BASE_URL
+    response = litellm.completion(**kwargs)
+    return response.choices[0].message.content or ""
+
+
+def discover_issues(
+    task: str, positions: dict[str, str], *, llm: Callable[..., str] | None = None
+) -> list[dict[str, Any]]:
+    """Mediator stage 1 — read opening prose into negotiable issues + options.
+
+    Ported from the spike's ``discover_issues``. Returns a list of
+    ``{"name": snake_case, "options": [token, ...]}``. An empty/degenerate result
+    (fewer than one issue) is a signal to the caller to bail to a rejected
+    verdict rather than build an empty mechanism.
+    """
+    llm = llm or llm_sync
+    opening = "\n".join(f"@{handle}: {prose}" for handle, prose in positions.items())
+    out = _extract_json(
+        llm(
+            "You are a negotiation mediator. From the task and each agent's opening position, "
+            "identify the negotiable ISSUES and 3-4 discrete OPTIONS each.\n\n"
+            f"TASK: {task}\n\nPOSITIONS:\n{opening}\n\n"
+            'Return ONLY JSON: {"issues":[{"name":"snake_case","options":["v1","v2"]}]}',
+            system="Strict JSON. Options are short concrete tokens (e.g. '30' or 'on').",
+            temperature=_DISCOVER_TEMPERATURE,
+        )
+    )
+    issues = out.get("issues")
+    if not isinstance(issues, list):
+        return []
+    clean: list[dict[str, Any]] = []
+    for issue in issues:
+        if not isinstance(issue, dict):
+            continue
+        name = issue.get("name")
+        options = issue.get("options")
+        if isinstance(name, str) and name and isinstance(options, list) and len(options) >= 2:
+            clean.append({"name": name, "options": [str(o) for o in options]})
+    return clean
+
+
+class MediatedNegotiation:
+    """Run context for one SAO negotiation: history, LLM seams, SLIM bridge.
+
+    Holds the per-negotiation running history (the "memory" a persistent agent
+    session provides), the injectable ``llm`` and ``fetch_prose`` seams (so tests
+    drive the whole NEGMAS loop with no live LLM or channel), and the event loop
+    the negotiator threads bridge back to for SLIM I/O.
+    """
+
+    def __init__(
+        self,
+        *,
+        issues: list[dict[str, Any]],
+        cap: int,
+        loop: asyncio.AbstractEventLoop,
+        fetch_prose: Callable[[str, str, int], Coroutine[Any, Any, str]],
+        turn_timeout_s: float,
+        llm: Callable[..., str] | None = None,
+        on_reading: Callable[[str, dict[str, Any], bool], None] | None = None,
+    ) -> None:
+        self._issues = issues
+        self._names = [i["name"] for i in issues]
+        self._options = {i["name"]: i["options"] for i in issues}
+        self._cap = cap
+        self._loop = loop
+        self._fetch_prose = fetch_prose
+        self._turn_timeout_s = turn_timeout_s
+        self._llm = llm or llm_sync
+        self._on_reading = on_reading
+        self.history: list[str] = []
+
+    # -- mediator LLM stages (run in the negotiator thread) --
+
+    def _history_block(self) -> str:
+        return "\n".join(self.history[-12:]) if self.history else "(negotiation just started)"
+
+    def broker(self, offer: tuple[Any, ...] | None, round_n: int) -> str:
+        """The mediator's per-turn framing — where everyone stands + a nudge."""
+        order = ", ".join(self._names)
+        try:
+            return self._llm(
+                f"You are the negotiation mediator (a neutral camp counselor). It is step "
+                f"{round_n} of {self._cap}. Issue order: {order}. Offer on the table: {offer}.\n\n"
+                f"History so far:\n{self._history_block()}\n\nWrite 2 sentences to the group: "
+                "summarize where each agent stands, name who has hit a genuine hard limit, and "
+                "nudge the holdout toward closing — remind them a near-deal beats no change. Be "
+                "concrete and fair, not preachy.",
+                system="You are a fair mediator who wants a durable agreement, not to favor anyone.",
+            )
+        except Exception:
+            logger.warning("mediator broker LLM failed (step %d); continuing without note", round_n)
+            return ""
+
+    def interpret(self, handle: str, prose: str, *, proposing: bool) -> dict[str, Any]:
+        """Map an agent's natural-language move into a structured SAO action."""
+        order = ", ".join(self._names)
+        schema = (
+            '{"action":"counter","offer":{"<issue>":"<option>", ...}}'
+            if proposing
+            else '{"action":"accept"} OR {"action":"reject"}'
+        )
+        space = "; ".join(f"{n}={self._options[n]}" for n in self._names)
+        try:
+            reading = _extract_json(
+                self._llm(
+                    f"Interpret @{handle}'s move into a structured SAO action.\n"
+                    f"Issues (order {order}): {space}\n\n"
+                    f'@{handle} said:\n"""{prose}"""\n\n'
+                    f"Return ONLY JSON: {schema}. Every offer value MUST be one of that issue's "
+                    "options.",
+                    system="Strict JSON mapping a negotiator's words to an SAO action.",
+                    temperature=_DISCOVER_TEMPERATURE,
+                )
+            )
+        except Exception:
+            logger.warning("mediator interpret LLM failed for @%s; treating as reject", handle)
+            reading = {}
+        if self._on_reading is not None:
+            self._on_reading(handle, reading, proposing)
+        return reading
+
+    # -- the SLIM bridge (blocks the negotiator thread on the real agent reply) --
+
+    def _prompt_for(
+        self, handle: str, offer: tuple[Any, ...] | None, proposing: bool, note: str, round_n: int
+    ) -> str:
+        space = "; ".join(f"{n} ∈ {{{', '.join(self._options[n])}}}" for n in self._names)
+        order = ", ".join(self._names)
+        role = (
+            f"It is your turn to PROPOSE. Current standing offer: {offer}. State the offer you "
+            "want (a value per issue) with one line of why."
+            if proposing
+            else f"The offer on the table is {offer} (issue order: {order}). ACCEPT it or REJECT "
+            "it, with one line of why."
+        )
+        return (
+            f"@{handle} — step {round_n}. Issue space: {space}.\n\n"
+            f"MEDIATOR: {note}\n\n{role} (2 sentences max.)\n\n{_BATNA}"
+        )
+
+    def agent_move(
+        self, handle: str, offer: tuple[Any, ...] | None, *, proposing: bool, round_n: int
+    ) -> str:
+        """Broker → prompt the real agent over SLIM → return its prose reply.
+
+        Runs in the NEGMAS worker thread; the SLIM publish/collect is bridged to
+        the backend event loop and this call blocks on the agent's real reply.
+        """
+        note = self.broker(offer, round_n)
+        prompt = self._prompt_for(handle, offer, proposing, note, round_n)
+        future = asyncio.run_coroutine_threadsafe(
+            self._fetch_prose(handle, prompt, round_n), self._loop
+        )
+        try:
+            return future.result(timeout=self._turn_timeout_s + 5.0)
+        except Exception:
+            logger.warning("mediator got no reply from @%s (step %d)", handle, round_n)
+            return ""
+
+    def to_outcome(self, offer: dict[str, Any]) -> tuple[str, ...] | None:
+        """Coerce an interpreted offer dict into a valid NEGMAS outcome tuple."""
+        try:
+            values = tuple(str(offer[name]) for name in self._names)
+        except (KeyError, TypeError):
+            return None
+        if all(values[i] in self._options[name] for i, name in enumerate(self._names)):
+            return values
+        return None
+
+    def default_outcome(self) -> tuple[str, ...]:
+        return tuple(self._options[name][0] for name in self._names)
+
+    def record(self, line: str) -> None:
+        self.history.append(line)
+
+    @property
+    def names(self) -> list[str]:
+        return list(self._names)
+
+
+class LiveNegotiator(SAONegotiator):
+    """A NEGMAS SAO negotiator backed by a real agent's replies over SLIM.
+
+    ``propose``/``respond`` mirror the proven spike's ``MediatedAgent`` — the only
+    change is the source of the prose: a real worker agent instead of a simulated
+    persona. NEGMAS calls these synchronously on the ``mech.run()`` thread.
+    """
+
+    def __init__(self, handle: str, negotiation: MediatedNegotiation, **kw: Any) -> None:
+        super().__init__(name=handle, **kw)
+        self.handle = handle
+        self._neg = negotiation
+
+    def propose(self, state: Any, dest: Any = None) -> tuple[str, ...] | None:
+        prose = self._neg.agent_move(
+            self.handle, state.current_offer, proposing=True, round_n=state.step
+        )
+        reading = self._neg.interpret(self.handle, prose, proposing=True)
+        outcome = self._neg.to_outcome(
+            reading.get("offer", {}) if isinstance(reading, dict) else {}
+        )
+        outcome = outcome or state.current_offer or self._neg.default_outcome()
+        self._neg.record(f"step {state.step}: @{self.handle} proposed {outcome}")
+        logger.info("mediator step %d: @%s PROPOSE %s", state.step, self.handle, outcome)
+        return outcome
+
+    def respond(self, state: Any, source: Any = None) -> ResponseType:
+        prose = self._neg.agent_move(
+            self.handle, state.current_offer, proposing=False, round_n=state.step
+        )
+        reading = self._neg.interpret(self.handle, prose, proposing=False)
+        action = reading.get("action") if isinstance(reading, dict) else None
+        resp = ResponseType.ACCEPT_OFFER if action == "accept" else ResponseType.REJECT_OFFER
+        self._neg.record(f"step {state.step}: @{self.handle} {resp.name} on {state.current_offer}")
+        logger.info(
+            "mediator step %d: @%s %s on %s",
+            state.step,
+            self.handle,
+            resp.name,
+            state.current_offer,
+        )
+        return resp
+
+
+def build_mechanism(
+    issues: list[dict[str, Any]], handles: list[str], negotiation: MediatedNegotiation, *, cap: int
+) -> SAOMechanism:
+    """Assemble the SAO mechanism with one live negotiator per participant."""
+    negmas_issues = [
+        make_issue(values=[str(v) for v in issue["options"]], name=issue["name"])
+        for issue in issues
+    ]
+    mech = SAOMechanism(issues=negmas_issues, n_steps=cap)
+    for handle in handles:
+        mech.add(LiveNegotiator(handle, negotiation))
+    return mech
+
+
+def agreement_assignments(mech: SAOMechanism, issue_names: list[str]) -> dict[str, str] | None:
+    """The agreed ``issue = value`` map, or ``None`` if NEGMAS never agreed."""
+    agreement = mech.agreement
+    if agreement is None:
+        return None
+    return {name: str(value) for name, value in zip(issue_names, agreement, strict=False)}

--- a/fastapi-backend/pyproject.toml
+++ b/fastapi-backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "tiktoken>=0.12.0",
     "rapidfuzz>=3.14.5",
     "slim-bindings>=1.4,<2",
+    "negmas>=0.15.7",
 ]
 
 [dependency-groups]

--- a/fastapi-backend/tests/test_mediator.py
+++ b/fastapi-backend/tests/test_mediator.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the SAO mediator (app/services/mediator.py + aligner mediate).
+
+Node-free and LLM-free: the LLM seam (``mediator.llm_sync``) is monkeypatched to
+a deterministic prompt-keyed stub and the agents are simulated by the same fake
+channel the aligner tests use. This exercises the Rung-1 property that matters —
+**NEGMAS owns termination**: once the agents accept a standing offer the
+mechanism *stops*, and the aligner emits a ``commit:converged`` carrying the
+agreed ``issue = value`` map (the anti-theatre guarantee), never looping to the
+step cap.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from app.services import aligner, l9, mediator
+from tests.test_aligner import _FakeChannel, _FakeManaged, _FakeManager, _FakePersister
+
+_ROOM = "mediate-room"
+
+
+def _fake_llm(prompt: str, *, system: str = "", temperature: float = 0.3) -> str:
+    """Deterministic stand-in for the mediator's LLM, keyed on the prompt.
+
+    - discovery → one issue ``cap`` with three options;
+    - a propose interpretation → counter to ``cap = 30``;
+    - a respond interpretation → accept;
+    - any broker framing → a short note.
+    """
+    if "identify the negotiable ISSUES" in prompt:
+        return json.dumps({"issues": [{"name": "cap", "options": ["25", "30", "35"]}]})
+    if "Interpret @" in prompt:
+        if '"action":"counter"' in prompt:  # proposing schema
+            return json.dumps({"action": "counter", "offer": {"cap": "30"}})
+        return json.dumps({"action": "accept"})  # responding schema
+    return "Everyone is close on the cap; let's lock 30 and move."
+
+
+@pytest.fixture(autouse=True)
+def _patch_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(mediator, "llm_sync", _fake_llm)
+
+
+def _engine(manager: _FakeManager, **kw: Any) -> aligner.AlignerEngine:
+    kw.setdefault("handle", "aligner")
+    kw.setdefault("mode", "mediator")
+    kw.setdefault("round_timeout_s", 0.2)
+    kw.setdefault("poll_interval_s", 0.01)
+    kw.setdefault("max_steps", 12)
+    return aligner.AlignerEngine(manager, **kw)  # type: ignore[arg-type]
+
+
+def test_discover_issues_parses_and_filters() -> None:
+    """Well-formed issues survive; a degenerate single-option issue is dropped."""
+
+    def llm(prompt: str, *, system: str = "", temperature: float = 0.0) -> str:
+        return json.dumps(
+            {
+                "issues": [
+                    {"name": "cap", "options": ["25", "30"]},
+                    {"name": "bad", "options": ["x"]},
+                ]
+            }
+        )
+
+    issues = mediator.discover_issues("task", {"a": "pos"}, llm=llm)
+    assert issues == [{"name": "cap", "options": ["25", "30"]}]
+
+
+def test_discover_issues_empty_on_garbage() -> None:
+    issues = mediator.discover_issues("task", {"a": "pos"}, llm=lambda *a, **k: "not json")
+    assert issues == []
+
+
+@pytest.mark.asyncio
+async def test_mediate_terminates_at_agreement() -> None:
+    """Agents that accept the standing offer → NEGMAS stops, verdict is converged
+    with the agreed issue=value map, and the episode is opened then closed."""
+    persister = _FakePersister()
+    channel = _FakeChannel(persister, reply_conf=0.9)  # every prompt draws a reply
+    managed = _FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = _FakeManager(managed, ["growth", "risk", "aligner"])
+
+    verdict = await _engine(manager).mediate(_ROOM)
+
+    assert verdict is not None
+    assert verdict["header"]["kind"] == "commit"
+    assert verdict["header"]["subkind"] == "converged"
+    # The agreed issue=value map rides the envelope for plan_sync to compile.
+    assert verdict["payload"]["data"]["assignments"] == {"cap": "30"}
+    # Episode lifecycle: frozen membership opened, drained on close.
+    assert manager.opened == [l9.episode_urn(_ROOM, "align")]
+    assert manager.closed == [_ROOM]
+    # The verdict was recorded locally (drives the on_converged → plan seam).
+    assert len(persister.ingested) == 1
+    # Anti-theatre: it stopped the moment agreement was reached — the number of
+    # agent turns (exchange prompts) is far below the step cap, not a full run.
+    from app.services.l9_models import Kind
+
+    prompts = [s for s, _ in channel.sent if s.header.kind == Kind.exchange]
+    assert 0 < len(prompts) < 12
+
+
+@pytest.mark.asyncio
+async def test_mediate_rejects_when_no_issues_discovered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery that yields no structurable issues → a clean rejected verdict,
+    still closing the episode (never hanging or raising)."""
+    persister = _FakePersister()
+    channel = _FakeChannel(persister, reply_conf=0.9)
+    managed = _FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = _FakeManager(managed, ["growth", "risk"])
+
+    monkeypatch.setattr(mediator, "discover_issues", lambda *a, **k: [])
+
+    verdict = await _engine(manager).mediate(_ROOM)
+
+    assert verdict is not None
+    assert verdict["header"]["subkind"] == "rejected"
+    assert manager.closed == [_ROOM]

--- a/fastapi-backend/uv.lock
+++ b/fastapi-backend/uv.lock
@@ -282,6 +282,20 @@ wheels = [
 ]
 
 [[package]]
+name = "choreographer"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "logistro" },
+    { name = "platformdirs" },
+    { name = "simplejson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/69/3058cd4f16d6b75c80e8f95e5b713d930526353ce294df9a7887453ba215/choreographer-1.3.0.tar.gz", hash = "sha256:6c44a0e48e9b37977344d40bfa5a9ed88575fe4bc0fd836771bf702bc24d6884", size = 48291, upload-time = "2026-04-28T22:57:45.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/6c/ff8bf52315064dbeb55cb5067e191120a5b2e58bb648d0d34cf7969dc2c2/choreographer-1.3.0-py3-none-any.whl", hash = "sha256:cea4cb739e4f61625e4b53888a8d3fa1d3bf73948b56753e460ab44da7d8d44f", size = 52622, upload-time = "2026-04-28T22:57:44.015Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -294,12 +308,77 @@ wheels = [
 ]
 
 [[package]]
+name = "click-config-file"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "configobj" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/09/dfee76b0d2600ae8bd65e9cc375b6de62f6ad5600616a78ee6209a9f17f3/click_config_file-0.6.0.tar.gz", hash = "sha256:ded6ec1a73c41280727ec9c06031e929cdd8a5946bf0f99c0c3db3a71793d515", size = 5800, upload-time = "2020-04-29T10:35:22.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/16/c71980d10b75cf4ee2c71bb946c3326a18585254399aac64a5e79cfba5a5/click_config_file-0.6.0-py2.py3-none-any.whl", hash = "sha256:3c5802dec437ed596f181efc988f62b1069cd48a912e280cd840ee70580f39d7", size = 5964, upload-time = "2020-04-28T07:09:14.063Z" },
+]
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/55/ba79756cb90c8d69d599d57785398ac87bba7b19c80e87f4e8a562197c93/colorlog-6.12.0.tar.gz", hash = "sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f", size = 18151, upload-time = "2026-07-23T13:40:40.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/19/0b6647bf5e331521e55d2b63bfbdc210bd9cd605189273f03614a05f702d/colorlog-6.12.0-py3-none-any.whl", hash = "sha256:30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e", size = 12239, upload-time = "2026-07-23T13:40:39.562Z" },
+]
+
+[[package]]
+name = "configobj"
+version = "5.0.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/c4/c7f9e41bc2e5f8eeae4a08a01c91b2aea3dfab40a3e14b25e87e7db8d501/configobj-5.0.9.tar.gz", hash = "sha256:03c881bbf23aa07bccf1b837005975993c4ab4427ba57f959afdd9d1a2386848", size = 101518, upload-time = "2024-09-21T12:47:46.315Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/c4/0679472c60052c27efa612b4cd3ddd2a23e885dcdc73461781d2c802d39e/configobj-5.0.9-py2.py3-none-any.whl", hash = "sha256:1ba10c5b6ee16229c79a05047aeda2b55eb4e80d7c7d8ecf17ec1ca600c79882", size = 35615, upload-time = "2024-11-26T14:03:32.972Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb", size = 293419, upload-time = "2025-07-26T12:01:21.16Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6", size = 273979, upload-time = "2025-07-26T12:01:22.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/a12359b9b2ca3a845e8f7f9ac08bdf776114eb931392fcad91743e2ea17b/contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7", size = 332653, upload-time = "2025-07-26T12:01:24.155Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/897aeebfb475b7748ea67b61e045accdfcf0d971f8a588b67108ed7f5512/contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8", size = 379536, upload-time = "2025-07-26T12:01:25.91Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8a/a8c584b82deb248930ce069e71576fc09bd7174bbd35183b7943fb1064fd/contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea", size = 384397, upload-time = "2025-07-26T12:01:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1", size = 362601, upload-time = "2025-07-26T12:01:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0a/a3fe3be3ee2dceb3e615ebb4df97ae6f3828aa915d3e10549ce016302bd1/contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7", size = 1331288, upload-time = "2025-07-26T12:01:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/acad9bd4e97f13f3e2b18a3977fe1b4a37ecf3d38d815333980c6c72e963/contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411", size = 1403386, upload-time = "2025-07-26T12:01:33.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
 ]
 
 [[package]]
@@ -351,6 +430,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
     { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
     { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -563,6 +660,23 @@ wheels = [
 ]
 
 [[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02", size = 2881131, upload-time = "2026-05-14T12:03:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/c815bea63117fa63e4e1c01f8a1110d2112fa003f838e6467094ec2432ce/fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0", size = 2426704, upload-time = "2026-05-14T12:03:15.801Z" },
+    { url = "https://files.pythonhosted.org/packages/44/04/0b91d8e916e92ad1fac9e4624760baf0fd5ff2ead614c2f68fb21373f03f/fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af", size = 5044298, upload-time = "2026-05-14T12:03:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8", size = 4999800, upload-time = "2026-05-14T12:03:20.161Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6d/67fe16c48d7ce050979b33f47e0d28a318f02da030602e944c34f7a16ef3/fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b", size = 4982666, upload-time = "2026-05-14T12:03:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/3bbab338c07c71fa56269953845e92c951a61457bbbb0f1022551ea266d9/fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78", size = 5133598, upload-time = "2026-05-14T12:03:25.168Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/aa27c7f98db5b064883dadcc5283947e81e034de42e22a33675878d98b54/fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263", size = 2292575, upload-time = "2026-05-14T12:03:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/87/36/cccb9bc2a6ab63d1b2980374f0dca72ce95ae267c9b4cfe77455bb70d0d4/fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272", size = 2343211, upload-time = "2026-05-14T12:03:30.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -594,6 +708,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+]
+
+[[package]]
+name = "gif"
+version = "23.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/36/eb714cc959b03bfc3ac66f0da62d6fea058196b378286d6c196e30d2062a/gif-23.3.0.tar.gz", hash = "sha256:9e4ef83620277dd7e81b016931684b544e5751c17d6db18b820399c7c74e04ee", size = 4564, upload-time = "2023-03-09T16:37:06.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/60/f017248efc143ce37a2a487657dd75e85db5f51d88e5e9794dad79849d21/gif-23.3.0-py3-none-any.whl", hash = "sha256:d29f5a855e55d2510748618009830cb0939f56de7eeafb0e64bd1413c57af0b8", size = 4131, upload-time = "2023-03-09T16:37:05.027Z" },
 ]
 
 [[package]]
@@ -735,6 +862,15 @@ wheels = [
 ]
 
 [[package]]
+name = "inflect"
+version = "5.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/db/cae5d8524c4b5e574c281895b212062f3b06d0e14186904ed71c538b4e90/inflect-5.6.2.tar.gz", hash = "sha256:aadc7ed73928f5e014129794bbac03058cca35d0a973a5fc4eb45c7fa26005f9", size = 69378, upload-time = "2022-07-15T15:47:42.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/d8/3e1a32d305215166f5c32652c473aa766bd7809cd10b34c544dbc31facb5/inflect-5.6.2-py3-none-any.whl", hash = "sha256:b45d91a4a28a4e617ff1821117439b06eaa86e2a4573154af0149e9be6687238", size = 33704, upload-time = "2022-07-15T15:47:40.578Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -799,6 +935,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -823,6 +968,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kaleido"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "choreographer" },
+    { name = "logistro" },
+    { name = "orjson" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/64/53eac73d31dbfc3310ee2e87bcac1ae7417427f0fbe3dd800eaf676db324/kaleido-1.3.0.tar.gz", hash = "sha256:5e0378a7475e98852773deeb6483dee91f8aa7b364dde7b5f2b3622cb468a3e6", size = 68938, upload-time = "2026-05-04T19:45:28.932Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/b9/a6d8bb7d228940f01885bd9f327ab7f9d366a9be775c4bf366bf9d9477ae/kaleido-1.3.0-py3-none-any.whl", hash = "sha256:52714dfd38e8f2a114831826200c40bb10d0ca0c11d4272f3f48ad499cd8f8ea", size = 55580, upload-time = "2026-05-04T19:45:27.483Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d9/405320f8077e8e1c5c4bd6adc45e1e6edf6d727b6da7f2e2533cf58bff71/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588", size = 66388, upload-time = "2026-03-09T13:13:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/795fedf35634f746151ca8839d05681ceb6287fbed6cc1c9bf235f7887c2/kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819", size = 64068, upload-time = "2026-03-09T13:13:25.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f", size = 1477934, upload-time = "2026-03-09T13:13:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf", size = 1278537, upload-time = "2026-03-09T13:13:28.707Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/9b782923aada3fafb1d6b84e13121954515c669b18af0c26e7d21f579855/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d", size = 1296685, upload-time = "2026-03-09T13:13:30.528Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/83241b6634b04fe44e892688d5208332bde130f38e610c0418f9ede47ded/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083", size = 1346024, upload-time = "2026-03-09T13:13:32.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/db/30ed226fb271ae1a6431fc0fe0edffb2efe23cadb01e798caeb9f2ceae8f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6", size = 987241, upload-time = "2026-03-09T13:13:34.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/c314595208e4c9587652d50959ead9e461995389664e490f4dce7ff0f782/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1", size = 2227742, upload-time = "2026-03-09T13:13:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/43/0499cec932d935229b5543d073c2b87c9c22846aab48881e9d8d6e742a2d/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0", size = 2323966, upload-time = "2026-03-09T13:13:38.204Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/79b0d760907965acfd9d61826a3d41f8f093c538f55cd2633d3f0db269f6/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15", size = 1977417, upload-time = "2026-03-09T13:13:39.966Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/01d0537c41cb75a551a438c3c7a80d0c60d60b81f694dac83dd436aec0d0/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314", size = 2491238, upload-time = "2026-03-09T13:13:41.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569, upload-time = "2026-03-09T13:13:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997, upload-time = "2026-03-09T13:13:46.878Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262, upload-time = "2026-03-09T13:15:35.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
 ]
 
 [[package]]
@@ -897,6 +1084,15 @@ wheels = [
 ]
 
 [[package]]
+name = "logistro"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/90/bfd7a6fab22bdfafe48ed3c4831713cb77b4779d18ade5e248d5dbc0ca22/logistro-2.0.1.tar.gz", hash = "sha256:8446affc82bab2577eb02bfcbcae196ae03129287557287b6a070f70c1985047", size = 8398, upload-time = "2025-11-01T02:41:18.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/6aa79ba3570bddd1bf7e951c6123f806751e58e8cce736bad77b2cf348d7/logistro-2.0.1-py3-none-any.whl", hash = "sha256:06ffa127b9fb4ac8b1972ae6b2a9d7fde57598bf5939cd708f43ec5bba2d31eb", size = 8555, upload-time = "2025-11-01T02:41:17.587Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -938,6 +1134,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
     { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
     { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/6c/7ef7ebcb2bd9739b2b66b18b076e077f44bb46fdbe28ca0506edb3c62c79/matplotlib-3.11.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e15ef41507f3d525f46154ac9e3ae785dacde9f20e593a25de8986267892ef74", size = 9453849, upload-time = "2026-07-18T03:38:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/f8/6d0c312c8d9738e7d9677f09fe5c986b3239e651a7b73a2deb38b65e4a71/matplotlib-3.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:21a67b961a6d597bca54fae826cd20695ba4a6e4d05424a08da6e13e3176fd6b", size = 9283113, upload-time = "2026-07-18T03:38:21.95Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ba8f811b8ddfac493734d6af0b2dff96919d0c28ca0d641858dab4262777c6ea", size = 10035615, upload-time = "2026-07-18T03:38:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/88/90/4e10e033d9b66589d8ed98b84c95cdbb57033d57c1f41339d7393dbd2f2e/matplotlib-3.11.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c52f7ad20ef476806ed212380b1d54d20310c8b86bdc2c9a68b51f0024a44472", size = 10842559, upload-time = "2026-07-18T03:38:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/88/eb/799612d0f8cd3e816a10fec59329fca52cd2353264df80378dfc541ae855/matplotlib-3.11.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8b14eb22961fe865efb0e4ff167e333e428908b00115a8d800ccb65ee108e481", size = 10927532, upload-time = "2026-07-18T03:38:28.532Z" },
+    { url = "https://files.pythonhosted.org/packages/88/89/56649bbaa2fd12e20f3be03dbcc135b0c8676d88bac17977599e3eb442a0/matplotlib-3.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:88a2a27dd9691ae448dfae4b26f59036be90c3c28757edd3553a29559d00859f", size = 9333886, upload-time = "2026-07-18T03:38:30.477Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/11/4d124efbbad677b7b7552f6f85a3bd432d4232f95400cea98fcd2ae36ef3/matplotlib-3.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:480194afceca4df2f137c2721227d3cba67121fbf4397b69cee7f83714b0a58a", size = 9007545, upload-time = "2026-07-18T03:38:32.833Z" },
 ]
 
 [[package]]
@@ -1070,6 +1292,7 @@ dependencies = [
     { name = "fastembed" },
     { name = "httpx" },
     { name = "litellm", extra = ["proxy"] },
+    { name = "negmas" },
     { name = "pip-system-certs" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
@@ -1098,6 +1321,7 @@ requires-dist = [
     { name = "fastembed", specifier = ">=0.8.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "litellm", extras = ["proxy"], specifier = "==1.83.14" },
+    { name = "negmas", specifier = ">=0.15.7" },
     { name = "pip-system-certs", specifier = ">=5.3" },
     { name = "pydantic-settings", specifier = ">=2.5.2,<3" },
     { name = "python-multipart", specifier = ">=0.0.9" },
@@ -1117,6 +1341,63 @@ dev = [
     { name = "ruff", specifier = ">=0.11.0,<0.16" },
     { name = "ty", specifier = ">=0.0.1a8" },
     { name = "watchdog", specifier = ">=6.0.0,<7" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
+name = "negmas"
+version = "0.15.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "click" },
+    { name = "click-config-file" },
+    { name = "cloudpickle" },
+    { name = "colorlog" },
+    { name = "dill" },
+    { name = "gif" },
+    { name = "inflect" },
+    { name = "kaleido" },
+    { name = "matplotlib" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pebble" },
+    { name = "pillow" },
+    { name = "plotly" },
+    { name = "psutil" },
+    { name = "py4j" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "setuptools" },
+    { name = "stringcase" },
+    { name = "tabulate" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/79/721f6640c9c958940fd7253e9198c2c2a8555791bc89b1fa6799711f0396/negmas-0.15.7.tar.gz", hash = "sha256:c5c3be13d2e7e17764818ab06db9beff3c65ebef123f7d2f7e0543c1e0d61a57", size = 804246, upload-time = "2026-06-16T03:32:34.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/2c/bd22a505319581e7a0dd88c1a71bcb37398959208ea198636295ae476a08/negmas-0.15.7-py3-none-any.whl", hash = "sha256:581d63eef9ba5bc516ca206d64e908fef551336282d569fe0b40963a93d3e465", size = 875459, upload-time = "2026-06-16T03:32:32.916Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -1227,22 +1508,51 @@ wheels = [
 ]
 
 [[package]]
-name = "pillow"
-version = "11.3.0"
+name = "pandas"
+version = "3.0.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069, upload-time = "2025-07-01T09:16:30.666Z" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/fe/1bc9b3ee13f68487a99ac9529968035cca2f0a51ec36892060edcc51d06a/pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4", size = 5278800, upload-time = "2025-07-01T09:14:17.648Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/32/7e2ac19b5713657384cec55f89065fb306b06af008cfd87e572035b27119/pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69", size = 4686296, upload-time = "2025-07-01T09:14:19.828Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1e/b9e12bbe6e4c2220effebc09ea0923a07a6da1e1f1bfbc8d7d29a01ce32b/pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d", size = 5871726, upload-time = "2025-07-03T13:10:04.448Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/33/e9200d2bd7ba00dc3ddb78df1198a6e80d7669cce6c2bdbeb2530a74ec58/pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6", size = 7644652, upload-time = "2025-07-03T13:10:10.391Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f1/6f2427a26fc683e00d985bc391bdd76d8dd4e92fac33d841127eb8fb2313/pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7", size = 5977787, upload-time = "2025-07-01T09:14:21.63Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024", size = 6645236, upload-time = "2025-07-01T09:14:23.321Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e7/848f69fb79843b3d91241bad658e9c14f39a32f71a301bcd1d139416d1be/pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809", size = 6086950, upload-time = "2025-07-01T09:14:25.237Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/1a/7cff92e695a2a29ac1958c2a0fe4c0b2393b60aac13b04a4fe2735cad52d/pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d", size = 6723358, upload-time = "2025-07-01T09:14:27.053Z" },
-    { url = "https://files.pythonhosted.org/packages/26/7d/73699ad77895f69edff76b0f332acc3d497f22f5d75e5360f78cbcaff248/pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149", size = 6275079, upload-time = "2025-07-01T09:14:30.104Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ce/e7dfc873bdd9828f3b6e5c2bbb74e47a98ec23cc5c74fc4e54462f0d9204/pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d", size = 6986324, upload-time = "2025-07-01T09:14:31.899Z" },
-    { url = "https://files.pythonhosted.org/packages/16/8f/b13447d1bf0b1f7467ce7d86f6e6edf66c0ad7cf44cf5c87a37f9bed9936/pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542", size = 2423067, upload-time = "2025-07-01T09:14:33.709Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/1dc810ea558d1320b597aa140a514f2fdf1d2ea09c38cf556f13ea712ec9/pandas-3.0.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fa290c16964d4963fbfbc358928239cf3bd755b20e988ce944877def2f44471d", size = 10411717, upload-time = "2026-07-22T22:18:08.307Z" },
+    { url = "https://files.pythonhosted.org/packages/68/56/fbe81c09195924d8b7b8d4461a20458fe80a6a5ed6b24f0314da684277e1/pandas-3.0.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2e26bb46934b8a2ca0c3de1d3d606fc5f6746584791b2db264d58cf370e08dc", size = 9957095, upload-time = "2026-07-22T22:18:10.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/51/fac252f4a913ed5eabf3c11b880a9e8d5a6c10f0b2129d0462212d238b4d/pandas-3.0.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73fa87b08a7ef706f8aafda39ddaccf2a99047bea62d8c88a0361bcafb2237bc", size = 10485458, upload-time = "2026-07-22T22:18:12.834Z" },
+    { url = "https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d373ce03ffd84010ed9839fa73672a9c8256990532e158440c0085db7d914b34", size = 10998091, upload-time = "2026-07-22T22:18:15.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/8c/1f29b5be8d3fc47dd7567eb167fabba2085879b31e0287ce7cba6d3d2ff4/pandas-3.0.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2a29c53d85ea98c5e792c59ef82ee9fbe6ca902c0d0adb6b23f45ef894cd7bf6", size = 11499501, upload-time = "2026-07-22T22:18:17.689Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e2/bd9c98ad2df7b38bde002adde4cdf353519da51881634323b126c55997f9/pandas-3.0.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a5ad3b02ed6bc7d7ae9b70804b2c6aa31827489d150f8e623ce82491b82085d7", size = 12060559, upload-time = "2026-07-22T22:18:20.147Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9a/ffbd852d58bd74a617fe2f8ee6a58a96982271ce41cf981eab22190b4a4b/pandas-3.0.5-cp312-cp312-pyemscripten_2024_0_wasm32.whl", hash = "sha256:b2acb4650527eec6822c3dadb2b771277b65e7dae7a267d4bccf65fd1bb3fbce", size = 7197652, upload-time = "2026-07-22T22:18:22.502Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b5/d2d3e9ae73362ba4229651b0ee1455cf78073a1ce585f6ff693782ce263e/pandas-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:80a611068e8a3ac23f7398c6c14eb46dc974e5cc9997f653e2dcfd1da74edd41", size = 9831691, upload-time = "2026-07-22T22:18:24.534Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/dea1e89d6a6796b9c43f85a09b484ee03edb8a4c4842e73e200a8c11301c/pandas-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:25ff585b972a18ef1fe9ffa3ac6544d9950508aa76832e5147640b6022821e49", size = 9105796, upload-time = "2026-07-22T22:18:27.064Z" },
+]
+
+[[package]]
+name = "pebble"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/6b/fba8cb6ca12e6bbcfac48da790b6a9d262d5beb6f34dc1b63fccc32a9ff8/pebble-5.2.1.tar.gz", hash = "sha256:9743537aa0e40751a1cbf297928e141bd2202a24624a7c0f9fc14818a7f227b1", size = 40496, upload-time = "2026-07-19T20:18:17.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/cf/f838e54b229bb202575daf7542d39da3c38434959d7a9252d4be66cb7d9a/pebble-5.2.1-py3-none-any.whl", hash = "sha256:154feb48f187ffff842cbc2fe0768ed1524d6fa72e90577a78bcea21a2f929f9", size = 34984, upload-time = "2026-07-19T20:18:15.692Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
 ]
 
 [[package]]
@@ -1273,6 +1583,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/07/795c79dbce40c39bece88e69d049babbd23ffa95b5d117f248db8ea03abb/plotly-6.9.0.tar.gz", hash = "sha256:967ad33e8c704fed051800d11d985eb206a9c795c14206b30a6f463ed9c67d0d", size = 6919903, upload-time = "2026-07-09T14:55:59.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/18/d8544811ab076f876c4892b3714f5b0dad335e1dc33aef826df431b8325d/plotly-6.9.0-py3-none-any.whl", hash = "sha256:36bebe2f1bb13884774fe61689c329071446f6ce4a8927fb1f0d6fb24f581236", size = 9909646, upload-time = "2026-07-09T14:55:55.421Z" },
 ]
 
 [[package]]
@@ -1368,6 +1691,22 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "py-rust-stemmers"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1383,6 +1722,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/ed/7d9bed02f78d85527501f86a867cd5002d97deb791b9a6b1b45b00100010/py_rust_stemmers-0.1.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:541d4b5aa911381e3d37ec483abb6a2cf2351b4f16d5e8d77f9aa2722956662a", size = 575582, upload-time = "2025-02-19T13:55:34.005Z" },
     { url = "https://files.pythonhosted.org/packages/93/40/eafd1b33688e8e8ae946d1ef25c4dc93f5b685bd104b9c5573405d7e1d30/py_rust_stemmers-0.1.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ffd946a36e9ac17ca96821963663012e04bc0ee94d21e8b5ae034721070b436c", size = 493267, upload-time = "2025-02-19T13:55:35.294Z" },
     { url = "https://files.pythonhosted.org/packages/2f/6a/15135b69e4fd28369433eb03264d201b1b0040ba534b05eddeb02a276684/py_rust_stemmers-0.1.5-cp312-none-win_amd64.whl", hash = "sha256:6ed61e1207f3b7428e99b5d00c055645c6415bb75033bff2d06394cbe035fd8e", size = 209395, upload-time = "2025-02-19T13:55:36.519Z" },
+]
+
+[[package]]
+name = "py4j"
+version = "0.10.9.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/31/0b210511177070c8d5d3059556194352e5753602fa64b85b7ab81ec1a009/py4j-0.10.9.9.tar.gz", hash = "sha256:f694cad19efa5bd1dee4f3e5270eb406613c974394035e5bfc4ec1aba870b879", size = 761089, upload-time = "2025-01-15T03:53:18.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/db/ea0203e495be491c85af87b66e37acfd3bf756fd985f87e46fc5e3bf022c/py4j-0.10.9.9-py2.py3-none-any.whl", hash = "sha256:c7c26e4158defb37b0bb124933163641a2ff6e3a3913f7811b0ddbe07ed61533", size = 203008, upload-time = "2025-01-15T03:53:15.648Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/44/fdd3a4377807b7dcabe2d4b5aa99dbbc98e2e5df3f1ca4e7f0aec492d987/pyarrow-25.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:149730a3d1f0fb59d663a0b8aa210adfd9c17c27cd94a0d143e60daea8320d4e", size = 35850884, upload-time = "2026-07-10T08:26:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/71/9f053177a7709b8c90abb00a2375b916286f9f0d6cfb21a5cadd4ef811e8/pyarrow-25.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:0721332c30fdd453fdd1fc203b2ac1f4c9db5aea28fa38d41f2574c4b068b9ec", size = 37616197, upload-time = "2026-07-10T08:26:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1a/22bfb6597dcdc861fa83c39c06e1457cb56f698940eff42fbb25de30e8e5/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fa1482b3da10cac2d4db6e26b81da543e237616af2ef6d466018b31ca586496f", size = 46841966, upload-time = "2026-07-10T08:27:07.685Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0e/cd705c042bc4fe7022478db577fcab4abdcfabb9bc37ab7a75556b3fcb2b/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5d1dbf24e151042f2fa3c129563f65d66674128868496fb008c4272b16bdf778", size = 50088993, upload-time = "2026-07-10T08:27:14.268Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ee/d822e1ee31fe31ec5d057210e0605c950b975dcd8d9a332976cc859a9df8/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:20887a762dd61dcc530f93a140840ab1f6aa7836b33270e42d627ab3cf11e537", size = 49941005, upload-time = "2026-07-10T08:27:21.274Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1b/207a90cc64619a095eb75a263ae069735f2810056d43c667befd573ec083/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58d1ab556b0cea1c93fdb799b24ad58adb2f2a2788dbce782a94f64ae1a5cc9b", size = 53112355, upload-time = "2026-07-10T08:27:27.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/fe/81d1e5f8beed15c01e98649d5c6e2167b67fd395884a2488f18bf1cf0dba/pyarrow-25.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f356afe61186395c861d5cd63dc21ff7d5fa335012a4668d979257df7fea0f5", size = 27945954, upload-time = "2026-07-10T08:27:32.903Z" },
 ]
 
 [[package]]
@@ -1501,6 +1864,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
     { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
     { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -1844,6 +2216,48 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.54.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1857,12 +2271,41 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "simplejson"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/2a/54837395a3487c725669428d513293612a48d82b95a0642c936932e5d898/simplejson-4.1.1.tar.gz", hash = "sha256:c08eb9f7a90f77ae470e19a07472e9a79ebc0d1c2315d86a72767665bd5ba79f", size = 118860, upload-time = "2026-04-24T19:24:59.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/25/e90998fe8e480eb43b966c09e835379887d427567ebd496563d3b1e16b19/simplejson-4.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:19040a17154dc03d289bab68d73ce0a6a0be01de30c584bbdd93490bead14b22", size = 112414, upload-time = "2026-04-24T19:23:06.084Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a0/abd4785f36c3400f1fbb21f517be39295a750a714f04b7ee175adf6ef580/simplejson-4.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a94ebaecdbaa80d9551a3ec6bf0c9302fc8b53ab6c1b2bfd498a1df4cb28158d", size = 91120, upload-time = "2026-04-24T19:23:07.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/78/fc060d2e3b13c6ec59288574b8efac64075e316b2afba4396a56b2422f78/simplejson-4.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:67341c95c0a168ab4a6d1e807e50463f1c8da932c3286d81e201266c427061fa", size = 91055, upload-time = "2026-04-24T19:23:09.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b6/156a8de1e1b47694f0e7de6675866936608d45dc68388fd017d36f8693be/simplejson-4.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45ec18e337fec538b7e902d489505c450b2454653d1290f3f50385e6fd8aa607", size = 190297, upload-time = "2026-04-24T19:23:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/86/1c/e4d0eab695be3eb21d0f46bce820752031f03e7113f9c80a9b3c73ee7157/simplejson-4.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:820c69a4710400e9b248d5670647d60be58824369282d3925e516b3ff1a7cd82", size = 187002, upload-time = "2026-04-24T19:23:12.982Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0e/7f5a59d29426b062d5928fb88b403c3f797129d53be7102f955dbe51aa44/simplejson-4.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e708d373a10e4378ef2d59f8361850c7150fd907ed49efe49bc5492160476d1", size = 195146, upload-time = "2026-04-24T19:23:14.517Z" },
+    { url = "https://files.pythonhosted.org/packages/78/18/9943db224dd4d5fa3c090c3e56a94c37b254338c83995ec5680285111c40/simplejson-4.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:980fc33353f81fd12d8c49d44f8c2760d1dc8192285e627c5180d141035b228a", size = 183931, upload-time = "2026-04-24T19:23:16.742Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/08/9a690da9a766161c06c627d805362cf159f1abe480969372b2897649b955/simplejson-4.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:de2ed102fff88dacf543699f53ee3a533cc11539a39baa176b7e09dd783069d6", size = 192228, upload-time = "2026-04-24T19:23:18.33Z" },
+    { url = "https://files.pythonhosted.org/packages/05/88/bd8aad36b451ffb0e0a3f721d695a88befa6d1ac7d1e02ae788ca7ff4029/simplejson-4.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2785ff8edc0e28bf773a32543a6bbed46351453c997b3f6709c744e3c2f7eabb", size = 187808, upload-time = "2026-04-24T19:23:21.165Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ee/14f91db0d1f481533b651dafbf8cd0da088d9817f7af30c68f7f19f9c847/simplejson-4.1.1-cp312-cp312-win32.whl", hash = "sha256:2e0d5ead6d14610467ec356ec1f6b5d8a56aa216abaad8d41c8b873b16cf313f", size = 88512, upload-time = "2026-04-24T19:23:22.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c4/90de06b2d8737c68c05ff9274113f854dbf6a5f28b7a955212111672cb57/simplejson-4.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:63a5451f557d6be48a231bae932458655c620902b868170b2f1c8afed496f6b4", size = 90748, upload-time = "2026-04-24T19:23:24.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/6a/8b74c52ffd33dbbde00fe7251fee6a0acdc8cea33f7a43805aed258fb79b/simplejson-4.1.1-py3-none-any.whl", hash = "sha256:2ce92b3748f02423e26d2bfb636fb9d7a8f67c8f5854dcae69d350d123b2eee2", size = 69195, upload-time = "2026-04-24T19:24:57.962Z" },
 ]
 
 [[package]]
@@ -1943,6 +2386,12 @@ wheels = [
 ]
 
 [[package]]
+name = "stringcase"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/1f/1241aa3d66e8dc1612427b17885f5fcd9c9ee3079fc0d28e9a3aeeb36fa3/stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008", size = 2958, upload-time = "2017-08-06T01:40:57.021Z" }
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1952,6 +2401,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What & why

Rung 1 of the SAO-mediator track (`docs/START_HERE_MEDIATOR.md`). The H5 demo exposed **AI theatre**: agents lock an agreement by ~message 5, then re-state it for seven more turns because the aligner is a *passive observer* — nothing *runs* the negotiation and says "you agreed, stop."

This wires the **proven Rung-0 v2 loop** (`experiments/sao-mediator-spike/mediator_spike_v2.py`) into the backend as a third `@aligner` mode, **`mediator`**, that drives a real **NEGMAS Stacked Alternating Offers** negotiation *live over SLIM* against today's worker agents. **NEGMAS owns termination** — the mechanism stops the instant the standing offer is unanimous. That single fact is what kills the theatre.

## How

- **`app/services/mediator.py`** (new) — the SAO orchestration: `discover_issues` (opening prose → NEGMAS issues/options), `MediatedNegotiation` (running history + brokering + BATNA — the "camp counselor" the v1→v2 delta proved is required), `LiveNegotiator` (a NEGMAS `SAONegotiator` whose `propose`/`respond` are backed by a *real agent's* replies), and the LLM seams (synchronous `litellm.completion`, which also dodges the Bedrock `acompletion` breakage).
- **`app/services/aligner.py`** — `AlignerEngine.mediate(room)`: opens the episode, discovers issues from the transcript's opening positions, runs `mech.run()` on a worker thread while each negotiator bridges back to the event loop (`run_coroutine_threadsafe`) to `@`-address one agent over SLIM and read its real reply, then emits the agreed `issue = value` map through the **same `commit:converged` seam `plan_sync` already consumes** → `plan/tasks.md` + memory sync, unchanged.
- **The Node/Python seam stays inside the backend** — NEGMAS state is native Python; only SLIM I/O crosses to the async loop. No cross-language state.

## Safety / blast radius

Purely **additive**. `observer` (deterministic, no-LLM) remains the default mode; nothing changes for existing rooms until an operator sets **`ALIGNER_MODE=mediator`** (+ `ALIGNER_MEDIATOR_MAX_STEPS`, default 20). Rung 3 will retire the observer and the `parse_position_marker` hack.

`negmas` added to `fastapi-backend` deps (pulls matplotlib/pandas/scipy — heavy but sanctioned by the START_HERE prereqs).

## Tests

- **`tests/test_mediator.py`** (new) — drives the full loop node-free/LLM-free (monkeypatched `llm_sync` + the aligner's fake channel) and asserts the loop **terminates at agreement below the step cap** (the anti-theatre property), emits `commit:converged` carrying the `issue=value` map, and opens/closes the episode.
- Full backend suite green (`288 passed`); the one failure (`test_l9_over_slim_roundtrip`) is a **pre-existing** `/opt/fastembed` permission/live-node env issue, identical on `slim-native-rewrite`.
- `ruff check` / `ruff format --check` / `ty check` all clean.

## NOT yet proven (follow-up)

The loop against **live cold-spawned agents over a real SLIM node** — real prose, latency, interpretation drift. Live validation + Rung 2 (Pi + OpenShell) are handed off in **`docs/START_HERE_MEDIATOR_RUNG2.md`**.