### PR TITLE
enhancement(room): delete multiple rooms in one command

### DIFF
--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -271,17 +271,17 @@ def use(
 
 
 @doc_ref(
-    usage="mycelium room delete <name> [--force]",
-    desc="Delete a room and all its data (memories, sessions, messages).",
+    usage="mycelium room delete <name> [<name> ...] [--force]",
+    desc="Delete one or more rooms and all their data (memories, sessions, messages).",
     group="room",
 )
 @app.command()
 def delete(
     ctx: typer.Context,
-    room_name: str = typer.Argument(..., help="Room name to delete"),
+    room_names: list[str] = typer.Argument(..., help="Room name(s) to delete"),
     force: bool = typer.Option(False, "--force", "-f"),
 ) -> None:
-    """Delete a room."""
+    """Delete one or more rooms."""
     try:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
         config_path = MyceliumConfig.get_config_path()
@@ -291,8 +291,12 @@ def delete(
         config = MyceliumConfig.load()
 
         if not force:
-            confirm = typer.confirm(f"Delete room '{room_name}'? This cannot be undone.")
-            if not confirm:
+            if len(room_names) == 1:
+                prompt = f"Delete room '{room_names[0]}'? This cannot be undone."
+            else:
+                names_list = ", ".join(f"'{n}'" for n in room_names)
+                prompt = f"Delete {len(room_names)} rooms ({names_list})? This cannot be undone."
+            if not typer.confirm(prompt):
                 typer.echo("Cancelled.")
                 raise typer.Exit(0)
 
@@ -300,36 +304,37 @@ def delete(
             delete_room_api_rooms_room_name_delete as delete_api,
         )
 
-        with _typed_client(config) as client:
-            delete_api.sync_detailed(room_name=room_name, client=client)
+        for room_name in room_names:
+            with _typed_client(config) as client:
+                delete_api.sync_detailed(room_name=room_name, client=client)
 
-        typer.secho(f"Room '{room_name}' deleted.", fg=typer.colors.GREEN)
+            typer.secho(f"Room '{room_name}' deleted.", fg=typer.colors.GREEN)
 
-        # Unregister all agents from the room in local adapter configs so the
-        # plugins stop reopening SSE connections to a room that no longer exists.
-        try:
-            from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw
+            # Unregister all agents from the room in local adapter configs so the
+            # plugins stop reopening SSE connections to a room that no longer exists.
+            try:
+                from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw
 
-            removed = unregister_room_from_openclaw(room_name)
-            if removed:
-                typer.secho(
-                    f"  Unregistered {len(removed)} agent(s) from '{room_name}' in local openclaw.json.",
-                    fg=typer.colors.CYAN,
-                )
-        except Exception:
-            pass  # openclaw not installed locally — skip silently
+                removed = unregister_room_from_openclaw(room_name)
+                if removed:
+                    typer.secho(
+                        f"  Unregistered {len(removed)} agent(s) from '{room_name}' in local openclaw.json.",
+                        fg=typer.colors.CYAN,
+                    )
+            except Exception:
+                pass  # openclaw not installed locally — skip silently
 
-        try:
-            from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
+            try:
+                from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
 
-            removed = unregister_room_from_hermes(room_name)
-            if removed:
-                typer.secho(
-                    f"  Unregistered {len(removed)} agent(s) from '{room_name}' in local hermes config.yaml.",
-                    fg=typer.colors.CYAN,
-                )
-        except Exception:
-            pass  # hermes not installed locally — skip silently
+                removed = unregister_room_from_hermes(room_name)
+                if removed:
+                    typer.secho(
+                        f"  Unregistered {len(removed)} agent(s) from '{room_name}' in local hermes config.yaml.",
+                        fg=typer.colors.CYAN,
+                    )
+            except Exception:
+                pass  # hermes not installed locally — skip silently
 
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False

--- a/mycelium-frontend/.dockerignore
+++ b/mycelium-frontend/.dockerignore
@@ -1,0 +1,29 @@
+node_modules
+
+# Next.js build artifacts
+.next
+out
+
+# Dev/local env files (URLs injected at runtime, not build time)
+.env
+.env.*
+!.env.example
+
+# TypeScript incremental build info
+tsconfig.tsbuildinfo
+
+# Test and coverage
+**/*.test.ts
+**/*.test.tsx
+**/*.spec.ts
+coverage
+
+# Editor/OS
+.DS_Store
+*.log
+.vscode
+.idea
+
+# Git
+.git
+.gitignore


### PR DESCRIPTION
## Summary

- `mycelium room delete` now accepts variadic room names, so `mycelium room delete foo bar baz` works in one shot
- Confirmation prompt lists all rooms when more than one is given: `Delete 3 rooms ('foo', 'bar', 'baz')? This cannot be undone.`
- Adapter cleanup (openclaw.json, hermes config) runs per-room as before
- Adds `.dockerignore` for `mycelium-frontend` (was missing entirely)

## Test plan

- [ ] `mycelium room delete room-a` — single room, prompt unchanged
- [ ] `mycelium room delete room-a room-b room-c` — multi-room prompt lists all names, each deleted in sequence
- [ ] `mycelium room delete room-a room-b --force` — skips prompt, deletes both
- [ ] Verify openclaw.json and hermes config are cleaned up for each deleted room

Made with [Cursor](https://cursor.com)