### PR TITLE
feat(spoke): propagate room deletion to spoke nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ pnpm-lock.yaml
 
 # Claude Code harness state (per-session worktrees, transcripts)
 .claude/worktrees/
+*.swp

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -79,9 +79,7 @@ async def _notify_room(channel: str, payload: dict) -> None:
 async def fire_room_notify(room_name: str, payload: dict) -> None:
     """Fire a Postgres NOTIFY on ``room:{room_name}`` without persisting a DB row.
 
-    Used by routes that need to push a synthetic event (e.g. ``room_deleted``)
-    before the room row is torn down.  Non-fatal: the SSE delivery is
-    best-effort and must never block the delete path.
+    Non-fatal: the SSE delivery is best-effort and must never block the caller.
     """
     await _notify_room(room_channel(room_name), payload)
 

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -76,6 +76,16 @@ async def _notify_room(channel: str, payload: dict) -> None:
                     logger.warning("NOTIFY failed for %s: %s", channel, e)
 
 
+async def fire_room_notify(room_name: str, payload: dict) -> None:
+    """Fire a Postgres NOTIFY on ``room:{room_name}`` without persisting a DB row.
+
+    Used by routes that need to push a synthetic event (e.g. ``room_deleted``)
+    before the room row is torn down.  Non-fatal: the SSE delivery is
+    best-effort and must never block the delete path.
+    """
+    await _notify_room(room_channel(room_name), payload)
+
+
 async def close_notify_connection() -> None:
     """Close the shared NOTIFY connection. Called from app lifespan shutdown."""
     global _notify_conn

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -305,12 +305,11 @@ async def sync_room_mas(
 
 
 async def _notify_room_deleted(room_name: str) -> None:
-    """Fire a ``room_deleted`` tombstone NOTIFY before the room row is removed.
+    """Fire a ``room_deleted`` tombstone NOTIFY after the room row is committed.
 
-    Must be called while the room row still exists in the DB so SSE consumers
-    (daemons on spoke nodes) can receive the event and clean up their local
-    state before the stream closes.  Non-fatal — a NOTIFY failure must never
-    block the delete path.
+    Non-fatal — a NOTIFY failure must never block the delete path.  Missed
+    NOTIFYs (SSE connection dropped between commit and NOTIFY) are recovered
+    by reconcile_local_rooms on the spoke's next startup.
     """
     try:
         await fire_room_notify(room_name, {"message_type": "room_deleted", "room": room_name})
@@ -329,13 +328,15 @@ async def delete_room(
     Cleanup order:
 
       1. Resolve all coordination sessions for this room (display names + IDs).
-      2. Fire a ``room_deleted`` tombstone NOTIFY while the room still exists
-         so online spoke daemons can clean up their local state immediately.
-      3. Tear down in-memory CFN coordination state. Doing this before DB
+      2. Tear down in-memory CFN coordination state. Doing this before DB
          deletes prevents in-flight ticks from firing against half-deleted
          state.
-      4. Delete the room row — coordination_sessions, participants, and
+      3. Delete the room row — coordination_sessions, participants, and
          messages cascade automatically via FK ON DELETE CASCADE.
+      4. Fire a ``room_deleted`` tombstone NOTIFY after commit — post-commit
+         ordering ensures a rollback never propagates a false tombstone to
+         spoke daemons.  Missed NOTIFYs are recovered by
+         reconcile_local_rooms on the spoke's next startup.
       5. Remove the filesystem directory.
       6. Delete the MAS in the CFN mgmt plane (non-fatal, last).
     """
@@ -355,9 +356,6 @@ async def delete_room(
     coord_sessions = list(coord_result.scalars().all())
     child_display_names = [c.display_name for c in coord_sessions]
 
-    # Tombstone NOTIFY first — room row still alive so SSE can route it.
-    await _notify_room_deleted(room_name)
-
     try:
         await coordination.teardown_for_namespace(room_name, child_display_names)
     except Exception as exc:
@@ -365,6 +363,13 @@ async def delete_room(
 
     await session.delete(room)
     await session.commit()
+
+    # Tombstone NOTIFY after commit — a pre-commit NOTIFY would be a false
+    # tombstone if the commit later rolls back, causing spokes to permanently
+    # delete local data for a room that still exists on the hub.  A NOTIFY
+    # missed due to an SSE drop after commit is recoverable via
+    # reconcile_local_rooms on the spoke's next startup.
+    await _notify_room_deleted(room_name)
 
     remove_room_dir(room_name)
     logger.info(

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.database import get_async_session
 from app.models import Room
+from app.routes.messages import fire_room_notify
 from app.schemas import RoomCreate, RoomRead
 from app.services import coordination
 from app.services.filesystem import ensure_room_structure, get_room_dir, remove_room_dir
@@ -303,6 +304,21 @@ async def sync_room_mas(
     return room
 
 
+async def _notify_room_deleted(room_name: str) -> None:
+    """Fire a ``room_deleted`` tombstone NOTIFY before the room row is removed.
+
+    Must be called while the room row still exists in the DB so SSE consumers
+    (daemons on spoke nodes) can receive the event and clean up their local
+    state before the stream closes.  Non-fatal — a NOTIFY failure must never
+    block the delete path.
+    """
+    try:
+        await fire_room_notify(room_name, {"message_type": "room_deleted", "room": room_name})
+        logger.info("Fired room_deleted NOTIFY for %s", room_name)
+    except Exception as exc:
+        logger.warning("room_deleted NOTIFY failed for %s (non-fatal): %s", room_name, exc)
+
+
 @router.delete("/{room_name}", status_code=204)
 async def delete_room(
     room_name: str,
@@ -313,13 +329,15 @@ async def delete_room(
     Cleanup order:
 
       1. Resolve all coordination sessions for this room (display names + IDs).
-      2. Tear down in-memory CFN coordination state. Doing this before DB
+      2. Fire a ``room_deleted`` tombstone NOTIFY while the room still exists
+         so online spoke daemons can clean up their local state immediately.
+      3. Tear down in-memory CFN coordination state. Doing this before DB
          deletes prevents in-flight ticks from firing against half-deleted
          state.
-      3. Delete the room row — coordination_sessions, participants, and
+      4. Delete the room row — coordination_sessions, participants, and
          messages cascade automatically via FK ON DELETE CASCADE.
-      4. Remove the filesystem directory.
-      5. Delete the MAS in the CFN mgmt plane (non-fatal, last).
+      5. Remove the filesystem directory.
+      6. Delete the MAS in the CFN mgmt plane (non-fatal, last).
     """
     if room_name in RESERVED_ROOMS:
         raise HTTPException(status_code=400, detail=f"'{room_name}' is a reserved system room")
@@ -336,6 +354,9 @@ async def delete_room(
     )
     coord_sessions = list(coord_result.scalars().all())
     child_display_names = [c.display_name for c in coord_sessions]
+
+    # Tombstone NOTIFY first — room row still alive so SSE can route it.
+    await _notify_room_deleted(room_name)
 
     try:
         await coordination.teardown_for_namespace(room_name, child_display_names)

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1940,17 +1940,17 @@ def _check_daemon_running() -> CheckResult:
 
 
 def _check_orphaned_rooms() -> CheckResult:
-    """Detect local room directories that no longer exist on the hub.
+    """Detect local room directories that are not registered in the backend.
 
-    A spoke node that was offline when a room was deleted on the hub will have
-    missed the ``room_deleted`` SSE event and the daemon's startup reconcile
-    (if the daemon wasn't running).  This check surfaces those orphans so the
+    A node that was offline when a room was deleted will have missed the
+    ``room_deleted`` SSE event and the daemon's startup reconcile (if the
+    daemon wasn't running).  This check surfaces those orphans so the
     operator can review and clean up.
 
-    This check is intentionally read-only — it queries the hub's ``/api/rooms``
-    endpoint and compares the response against the local ``~/.mycelium/rooms/``
-    directory.  It never modifies the filesystem; use ``mycelium room gc
-    --prune-orphans`` for that.
+    This check is intentionally read-only — it queries ``/api/rooms`` on the
+    configured backend and compares the response against the local
+    ``~/.mycelium/rooms/`` directory.  It never modifies the filesystem;
+    use ``mycelium room gc --prune-orphans`` for that.
     """
     from mycelium.config import MyceliumConfig
 
@@ -2019,13 +2019,13 @@ def _check_orphaned_rooms() -> CheckResult:
         return CheckResult(
             name="Orphaned rooms",
             status="ok",
-            message=f"All {len(local_rooms)} local room(s) exist on hub",
+            message=f"All {len(local_rooms)} local room(s) registered in the backend",
         )
 
     return CheckResult(
         name="Orphaned rooms",
         status="warning",
-        message=f"{len(orphans)} local room director{'y' if len(orphans) == 1 else 'ies'} not found on hub",
+        message=f"{len(orphans)} local room director{'y' if len(orphans) == 1 else 'ies'} not registered in the backend",
         details=[
             *[f"  ~/.mycelium/rooms/{r}/" for r in orphans],
             "Fix: mycelium room gc --prune-orphans",

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1964,7 +1964,9 @@ def _check_orphaned_rooms() -> CheckResult:
             message="Skipped (cannot load config)",
         )
 
-    rooms_root = Path.home() / ".mycelium" / "rooms"
+    from mycelium.filesystem import get_mycelium_dir
+
+    rooms_root = get_mycelium_dir() / "rooms"
     if not rooms_root.exists():
         return CheckResult(name="Orphaned rooms", status="ok", message="No local rooms directory")
 

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1939,6 +1939,83 @@ def _check_daemon_running() -> CheckResult:
     )
 
 
+def _check_orphaned_rooms() -> CheckResult:
+    """Detect local room directories that no longer exist on the hub.
+
+    A spoke node that was offline when a room was deleted on the hub will have
+    missed the ``room_deleted`` SSE event and the daemon's startup reconcile
+    (if the daemon wasn't running).  This check surfaces those orphans so the
+    operator can review and clean up.
+
+    This check is intentionally read-only — it queries the hub's ``/api/rooms``
+    endpoint and compares the response against the local ``~/.mycelium/rooms/``
+    directory.  It never modifies the filesystem; use ``mycelium room gc
+    --prune-orphans`` for that.
+    """
+    from mycelium.config import MyceliumConfig
+
+    try:
+        cfg = MyceliumConfig.load()
+        api_url = cfg.server.api_url
+    except Exception:
+        return CheckResult(
+            name="Orphaned rooms",
+            status="ok",
+            message="Skipped (cannot load config)",
+        )
+
+    rooms_root = Path.home() / ".mycelium" / "rooms"
+    if not rooms_root.exists():
+        return CheckResult(name="Orphaned rooms", status="ok", message="No local rooms directory")
+
+    local_rooms = sorted(d.name for d in rooms_root.iterdir() if d.is_dir())
+    if not local_rooms:
+        return CheckResult(name="Orphaned rooms", status="ok", message="No local room directories")
+
+    orphans: list[str] = []
+    try:
+        import httpx
+
+        with httpx.Client(base_url=api_url, timeout=5) as client:
+            for room_name in local_rooms:
+                try:
+                    resp = client.get(f"/api/rooms/{room_name}")
+                    if resp.status_code == 404:
+                        orphans.append(room_name)
+                except httpx.ConnectError:
+                    return CheckResult(
+                        name="Orphaned rooms",
+                        status="ok",
+                        message="Skipped (hub unreachable)",
+                    )
+                except Exception:
+                    continue
+    except Exception as exc:
+        return CheckResult(
+            name="Orphaned rooms",
+            status="ok",
+            message=f"Skipped (scan failed: {exc})",
+        )
+
+    if not orphans:
+        return CheckResult(
+            name="Orphaned rooms",
+            status="ok",
+            message=f"All {len(local_rooms)} local room(s) exist on hub",
+        )
+
+    return CheckResult(
+        name="Orphaned rooms",
+        status="warning",
+        message=f"{len(orphans)} local room director{'y' if len(orphans) == 1 else 'ies'} not found on hub",
+        details=[
+            *[f"  ~/.mycelium/rooms/{r}/" for r in orphans],
+            "Fix: mycelium room gc --prune-orphans",
+            "  or: set daemon.auto_gc_orphaned_rooms = true in config.toml",
+        ],
+    )
+
+
 def _check_cfn_pgvector() -> CheckResult:
     """Check the pgvector extension is installed in the ioc-graph-db database.
 
@@ -2069,6 +2146,7 @@ def doctor(
             _check_config_files(),
             _check_mycelium_dir_ownership(),
             _check_config_file_drift(local_backend=local),
+            _check_orphaned_rooms(),
         ]
         if local:
             config_checks.append(_check_runtime_config_drift())

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1973,6 +1973,7 @@ def _check_orphaned_rooms() -> CheckResult:
         return CheckResult(name="Orphaned rooms", status="ok", message="No local room directories")
 
     orphans: list[str] = []
+    failed: list[str] = []
     try:
         import httpx
 
@@ -1988,7 +1989,14 @@ def _check_orphaned_rooms() -> CheckResult:
                         status="ok",
                         message="Skipped (hub unreachable)",
                     )
-                except Exception:
+                except Exception as exc:
+                    failed.append(room_name)
+                    # Log but keep going so a single flaky room doesn't hide others.
+                    import logging as _logging
+
+                    _logging.getLogger(__name__).debug(
+                        "Orphaned-rooms check: could not verify '%s': %s", room_name, exc
+                    )
                     continue
     except Exception as exc:
         return CheckResult(
@@ -1998,6 +2006,16 @@ def _check_orphaned_rooms() -> CheckResult:
         )
 
     if not orphans:
+        if failed:
+            return CheckResult(
+                name="Orphaned rooms",
+                status="warning",
+                message=(
+                    f"Verified {len(local_rooms) - len(failed)}/{len(local_rooms)} room(s) — "
+                    f"{len(failed)} check(s) could not be confirmed"
+                ),
+                details=[f"  could not verify: {r}" for r in failed],
+            )
         return CheckResult(
             name="Orphaned rooms",
             status="ok",

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1968,7 +1968,9 @@ def _check_orphaned_rooms() -> CheckResult:
     if not rooms_root.exists():
         return CheckResult(name="Orphaned rooms", status="ok", message="No local rooms directory")
 
-    local_rooms = sorted(d.name for d in rooms_root.iterdir() if d.is_dir())
+    local_rooms = sorted(
+        d.name for d in rooms_root.iterdir() if d.is_dir() and not d.name.startswith(".")
+    )
     if not local_rooms:
         return CheckResult(name="Orphaned rooms", status="ok", message="No local room directories")
 
@@ -1979,25 +1981,19 @@ def _check_orphaned_rooms() -> CheckResult:
         import httpx
 
         with httpx.Client(base_url=api_url, timeout=5) as client:
-            for room_name in local_rooms:
-                try:
-                    resp = client.get(f"/api/rooms/{room_name}")
-                    if resp.status_code == 404:
-                        orphans.append(room_name)
-                except (httpx.ConnectError, httpx.ConnectTimeout):
-                    # Break rather than return: orphans already detected in
-                    # earlier iterations must not be silently discarded.
-                    hub_unreachable = True
-                    break
-                except Exception as exc:
-                    failed.append(room_name)
-                    # Log but keep going so a single flaky room doesn't hide others.
-                    import logging as _logging
-
-                    _logging.getLogger(__name__).debug(
-                        "Orphaned-rooms check: could not verify '%s': %s", room_name, exc
-                    )
-                    continue
+            try:
+                resp = client.get("/api/rooms")
+                resp.raise_for_status()
+                hub_rooms = {r["name"] for r in resp.json()}
+                orphans = [r for r in local_rooms if r not in hub_rooms]
+            except (httpx.ConnectError, httpx.ConnectTimeout):
+                hub_unreachable = True
+            except Exception as exc:
+                return CheckResult(
+                    name="Orphaned rooms",
+                    status="ok",
+                    message=f"Skipped (scan failed: {exc})",
+                )
     except Exception as exc:
         return CheckResult(
             name="Orphaned rooms",

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1975,16 +1975,25 @@ def _check_orphaned_rooms() -> CheckResult:
         return CheckResult(name="Orphaned rooms", status="ok", message="No local room directories")
 
     orphans: list[str] = []
-    failed: list[str] = []
     hub_unreachable = False
     try:
         import httpx
 
         with httpx.Client(base_url=api_url, timeout=5) as client:
             try:
-                resp = client.get("/api/rooms")
-                resp.raise_for_status()
-                hub_rooms = {r["name"] for r in resp.json()}
+                # Paginate in batches of 1000 so a deployment with >1000 rooms
+                # doesn't silently miss orphans beyond the default limit.
+                hub_rooms: set[str] = set()
+                skip = 0
+                limit = 1000
+                while True:
+                    resp = client.get("/api/rooms", params={"skip": skip, "limit": limit})
+                    resp.raise_for_status()
+                    page = resp.json()
+                    hub_rooms.update(r["name"] for r in page)
+                    if len(page) < limit:
+                        break
+                    skip += limit
                 orphans = [r for r in local_rooms if r not in hub_rooms]
             except (httpx.ConnectError, httpx.ConnectTimeout):
                 hub_unreachable = True
@@ -2002,22 +2011,6 @@ def _check_orphaned_rooms() -> CheckResult:
         )
 
     if hub_unreachable:
-        if orphans:
-            noun = "directory" if len(orphans) == 1 else "directories"
-            return CheckResult(
-                name="Orphaned rooms",
-                status="warning",
-                message=(
-                    f"{len(orphans)} local room {noun} not registered in the backend "
-                    f"(scan incomplete — backend unreachable)"
-                ),
-                details=[
-                    *[f"  ~/.mycelium/rooms/{r}/" for r in orphans],
-                    *([f"  could not verify: {r}" for r in failed] if failed else []),
-                    "Note: scan was interrupted; there may be additional orphans.",
-                    "Fix: mycelium room gc --prune-orphans",
-                ],
-            )
         return CheckResult(
             name="Orphaned rooms",
             status="ok",
@@ -2025,16 +2018,6 @@ def _check_orphaned_rooms() -> CheckResult:
         )
 
     if not orphans:
-        if failed:
-            return CheckResult(
-                name="Orphaned rooms",
-                status="warning",
-                message=(
-                    f"Verified {len(local_rooms) - len(failed)}/{len(local_rooms)} room(s) — "
-                    f"{len(failed)} check(s) could not be confirmed"
-                ),
-                details=[f"  could not verify: {r}" for r in failed],
-            )
         return CheckResult(
             name="Orphaned rooms",
             status="ok",
@@ -2042,16 +2025,12 @@ def _check_orphaned_rooms() -> CheckResult:
         )
 
     noun = "directory" if len(orphans) == 1 else "directories"
-    msg = f"{len(orphans)} local room {noun} not registered in the backend"
-    if failed:
-        msg += f"; {len(failed)} check(s) could not be confirmed"
     return CheckResult(
         name="Orphaned rooms",
         status="warning",
-        message=msg,
+        message=f"{len(orphans)} local room {noun} not registered in the backend",
         details=[
             *[f"  ~/.mycelium/rooms/{r}/" for r in orphans],
-            *([f"  could not verify: {r}" for r in failed] if failed else []),
             "Fix: mycelium room gc --prune-orphans",
             "  or: set daemon.auto_gc_orphaned_rooms = true in config.toml",
         ],

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -1974,6 +1974,7 @@ def _check_orphaned_rooms() -> CheckResult:
 
     orphans: list[str] = []
     failed: list[str] = []
+    hub_unreachable = False
     try:
         import httpx
 
@@ -1983,12 +1984,11 @@ def _check_orphaned_rooms() -> CheckResult:
                     resp = client.get(f"/api/rooms/{room_name}")
                     if resp.status_code == 404:
                         orphans.append(room_name)
-                except httpx.ConnectError:
-                    return CheckResult(
-                        name="Orphaned rooms",
-                        status="ok",
-                        message="Skipped (hub unreachable)",
-                    )
+                except (httpx.ConnectError, httpx.ConnectTimeout):
+                    # Break rather than return: orphans already detected in
+                    # earlier iterations must not be silently discarded.
+                    hub_unreachable = True
+                    break
                 except Exception as exc:
                     failed.append(room_name)
                     # Log but keep going so a single flaky room doesn't hide others.
@@ -2003,6 +2003,29 @@ def _check_orphaned_rooms() -> CheckResult:
             name="Orphaned rooms",
             status="ok",
             message=f"Skipped (scan failed: {exc})",
+        )
+
+    if hub_unreachable:
+        if orphans:
+            noun = "directory" if len(orphans) == 1 else "directories"
+            return CheckResult(
+                name="Orphaned rooms",
+                status="warning",
+                message=(
+                    f"{len(orphans)} local room {noun} not registered in the backend "
+                    f"(scan incomplete — backend unreachable)"
+                ),
+                details=[
+                    *[f"  ~/.mycelium/rooms/{r}/" for r in orphans],
+                    *([f"  could not verify: {r}" for r in failed] if failed else []),
+                    "Note: scan was interrupted; there may be additional orphans.",
+                    "Fix: mycelium room gc --prune-orphans",
+                ],
+            )
+        return CheckResult(
+            name="Orphaned rooms",
+            status="ok",
+            message="Skipped (backend unreachable)",
         )
 
     if not orphans:
@@ -2022,12 +2045,17 @@ def _check_orphaned_rooms() -> CheckResult:
             message=f"All {len(local_rooms)} local room(s) registered in the backend",
         )
 
+    noun = "directory" if len(orphans) == 1 else "directories"
+    msg = f"{len(orphans)} local room {noun} not registered in the backend"
+    if failed:
+        msg += f"; {len(failed)} check(s) could not be confirmed"
     return CheckResult(
         name="Orphaned rooms",
         status="warning",
-        message=f"{len(orphans)} local room director{'y' if len(orphans) == 1 else 'ies'} not registered in the backend",
+        message=msg,
         details=[
             *[f"  ~/.mycelium/rooms/{r}/" for r in orphans],
+            *([f"  could not verify: {r}" for r in failed] if failed else []),
             "Fix: mycelium room gc --prune-orphans",
             "  or: set daemon.auto_gc_orphaned_rooms = true in config.toml",
         ],

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -1147,6 +1147,166 @@ def delegate(
 
 
 @doc_ref(
+    usage="mycelium room gc [--prune-orphans] [--dry-run]",
+    desc="Find and optionally remove local room directories that no longer exist on the hub.",
+    group="room",
+)
+@app.command("gc")
+def gc(
+    ctx: typer.Context,
+    prune_orphans: bool = typer.Option(
+        False,
+        "--prune-orphans",
+        help="Delete orphaned local room directories (default: report only)",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Show what would be removed without actually deleting anything",
+    ),
+) -> None:
+    """Reconcile local room directories against the hub.
+
+    Compares every directory under ``~/.mycelium/rooms/`` with the hub's
+    room list.  A directory whose room no longer exists on the hub is
+    **orphaned** — typically left behind after ``mycelium room delete`` ran
+    on a remote spoke or while this node was offline.
+
+    By default the command reports orphans without touching them.
+    Pass ``--prune-orphans`` to delete them (and unregister their adapter
+    configs from openclaw/hermes).  Add ``--dry-run`` to preview the
+    deletion without writing anything.
+
+    Examples:
+        mycelium room gc                          # audit only
+        mycelium room gc --prune-orphans          # delete orphans
+        mycelium room gc --prune-orphans --dry-run  # preview deletions
+    """
+    import shutil
+
+    import httpx
+
+    from mycelium.filesystem import get_mycelium_dir
+
+    try:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
+        json_output = ctx.obj.get("json", False) if ctx.obj else False
+
+        config = MyceliumConfig.load()
+        rooms_root = get_mycelium_dir() / "rooms"
+
+        if not rooms_root.exists():
+            if json_output:
+                typer.echo('{"orphans": []}')
+            else:
+                typer.echo("No local rooms directory found.")
+            return
+
+        local_rooms = sorted(d.name for d in rooms_root.iterdir() if d.is_dir())
+        if not local_rooms:
+            if json_output:
+                typer.echo('{"orphans": []}')
+            else:
+                typer.echo("No local room directories found.")
+            return
+
+        orphans: list[str] = []
+        with httpx.Client(base_url=config.server.api_url, timeout=10) as client:
+            for room_name in local_rooms:
+                try:
+                    resp = client.get(f"/api/rooms/{room_name}")
+                    if resp.status_code == 404:
+                        orphans.append(room_name)
+                except httpx.ConnectError:
+                    typer.secho(
+                        f"Cannot reach hub at {config.server.api_url} — aborting scan.",
+                        fg=typer.colors.RED,
+                    )
+                    raise typer.Exit(1)
+                except Exception as exc:
+                    typer.secho(
+                        f"  Warning: check failed for '{room_name}': {exc}", fg=typer.colors.YELLOW
+                    )
+
+        if json_output:
+            import json as json_module
+
+            typer.echo(json_module.dumps({"orphans": orphans}))
+            return
+
+        if not orphans:
+            typer.secho(
+                f"All {len(local_rooms)} local room(s) exist on hub — nothing to clean up.",
+                fg=typer.colors.GREEN,
+            )
+            return
+
+        typer.secho(
+            f"Found {len(orphans)} orphaned room director{'y' if len(orphans) == 1 else 'ies'}:",
+            fg=typer.colors.YELLOW,
+        )
+        for name in orphans:
+            typer.echo(f"  {rooms_root / name}")
+
+        if not prune_orphans:
+            typer.echo("")
+            typer.echo("Run with --prune-orphans to delete them.")
+            return
+
+        verb = "Would remove" if dry_run else "Removing"
+        for room_name in orphans:
+            room_dir = rooms_root / room_name
+            typer.echo(f"  {verb}: {room_dir}")
+            if not dry_run:
+                try:
+                    shutil.rmtree(room_dir)
+                except Exception as exc:
+                    typer.secho(f"    Error: {exc}", fg=typer.colors.RED)
+                    continue
+
+                try:
+                    from mycelium.integrations.openclaw.dispatch import (
+                        unregister_room_from_openclaw,
+                    )
+
+                    removed = unregister_room_from_openclaw(room_name)
+                    if removed:
+                        typer.secho(
+                            f"    Unregistered {len(removed)} openclaw agent(s)",
+                            fg=typer.colors.CYAN,
+                        )
+                except Exception:
+                    pass
+
+                try:
+                    from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
+
+                    removed = unregister_room_from_hermes(room_name)
+                    if removed:
+                        typer.secho(
+                            f"    Unregistered {len(removed)} hermes agent(s)",
+                            fg=typer.colors.CYAN,
+                        )
+                except Exception:
+                    pass
+
+        if dry_run:
+            typer.echo("")
+            typer.secho("Dry run — nothing was deleted.", fg=typer.colors.YELLOW)
+        else:
+            typer.secho(
+                f"\nRemoved {len(orphans)} orphaned room director{'y' if len(orphans) == 1 else 'ies'}.",
+                fg=typer.colors.GREEN,
+            )
+
+    except (typer.Exit, typer.Abort):
+        raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+
+
+@doc_ref(
     usage="mycelium room sync-mas <name>",
     desc="Register (or re-register) a room with the CFN mgmt plane.",
     group="room",

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -1242,8 +1242,8 @@ def gc(
             return
 
         if json_output:
-            typer.echo(json_module.dumps({"orphans": orphans}))
             if not prune_orphans:
+                typer.echo(json_module.dumps({"orphans": orphans}))
                 return
         else:
             typer.secho(
@@ -1288,8 +1288,11 @@ def gc(
                             f"    Unregistered {len(oc_removed)} openclaw agent(s)",
                             fg=typer.colors.CYAN,
                         )
-                except Exception:
-                    pass
+                except Exception as exc:
+                    typer.secho(
+                        f"    Warning: could not unregister openclaw agents for '{room_name}': {exc}",
+                        fg=typer.colors.YELLOW,
+                    )
 
                 try:
                     from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
@@ -1300,8 +1303,11 @@ def gc(
                             f"    Unregistered {len(hm_removed)} hermes agent(s)",
                             fg=typer.colors.CYAN,
                         )
-                except Exception:
-                    pass
+                except Exception as exc:
+                    typer.secho(
+                        f"    Warning: could not unregister hermes agents for '{room_name}': {exc}",
+                        fg=typer.colors.YELLOW,
+                    )
 
                 if not dir_removed:
                     typer.secho(
@@ -1329,6 +1335,14 @@ def gc(
                         _changed = True
                 if _changed:
                     _dcfg.save()
+                    # Signal the running daemon to hot-reload so it drops SSE tasks
+                    # for the pruned rooms immediately rather than waiting for restart.
+                    try:
+                        from mycelium.daemon.install import reload_daemon_service
+
+                        reload_daemon_service()
+                    except Exception:
+                        pass
             except Exception as exc:
                 typer.secho(
                     f"Warning: could not update daemon config: {exc}", fg=typer.colors.YELLOW

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -1254,25 +1254,33 @@ def gc(
             return
 
         verb = "Would remove" if dry_run else "Removing"
+        removed_count = 0
+        failed_count = 0
         for room_name in orphans:
             room_dir = rooms_root / room_name
             typer.echo(f"  {verb}: {room_dir}")
             if not dry_run:
+                dir_removed = False
                 try:
                     shutil.rmtree(room_dir)
+                    dir_removed = True
+                    removed_count += 1
                 except Exception as exc:
-                    typer.secho(f"    Error: {exc}", fg=typer.colors.RED)
-                    continue
+                    typer.secho(f"    Error removing directory: {exc}", fg=typer.colors.RED)
+                    failed_count += 1
 
+                # Always unregister adapter configs regardless of whether the directory
+                # removal succeeded — the hub has already deleted the room, so plugins
+                # must stop opening SSE connections to it even if rmtree failed.
                 try:
                     from mycelium.integrations.openclaw.dispatch import (
                         unregister_room_from_openclaw,
                     )
 
-                    removed = unregister_room_from_openclaw(room_name)
-                    if removed:
+                    oc_removed = unregister_room_from_openclaw(room_name)
+                    if oc_removed:
                         typer.secho(
-                            f"    Unregistered {len(removed)} openclaw agent(s)",
+                            f"    Unregistered {len(oc_removed)} openclaw agent(s)",
                             fg=typer.colors.CYAN,
                         )
                 except Exception:
@@ -1281,23 +1289,32 @@ def gc(
                 try:
                     from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
 
-                    removed = unregister_room_from_hermes(room_name)
-                    if removed:
+                    hm_removed = unregister_room_from_hermes(room_name)
+                    if hm_removed:
                         typer.secho(
-                            f"    Unregistered {len(removed)} hermes agent(s)",
+                            f"    Unregistered {len(hm_removed)} hermes agent(s)",
                             fg=typer.colors.CYAN,
                         )
                 except Exception:
                     pass
 
+                if not dir_removed:
+                    typer.secho(
+                        "    Adapter configs unregistered; directory must be removed manually.",
+                        fg=typer.colors.YELLOW,
+                    )
+
         if dry_run:
             typer.echo("")
             typer.secho("Dry run — nothing was deleted.", fg=typer.colors.YELLOW)
         else:
-            typer.secho(
-                f"\nRemoved {len(orphans)} orphaned room director{'y' if len(orphans) == 1 else 'ies'}.",
-                fg=typer.colors.GREEN,
-            )
+            noun = "directory" if removed_count == 1 else "directories"
+            typer.secho(f"\nRemoved {removed_count} orphaned room {noun}.", fg=typer.colors.GREEN)
+            if failed_count:
+                typer.secho(
+                    f"{failed_count} director{'y' if failed_count == 1 else 'ies'} could not be removed — check permissions.",
+                    fg=typer.colors.YELLOW,
+                )
 
     except (typer.Exit, typer.Abort):
         raise

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -1189,7 +1189,6 @@ def gc(
     from mycelium.filesystem import get_mycelium_dir
 
     try:
-        verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
         json_output = ctx.obj.get("json", False) if ctx.obj else False
 
         config = MyceliumConfig.load()
@@ -1202,7 +1201,9 @@ def gc(
                 typer.echo("No local rooms directory found.")
             return
 
-        local_rooms = sorted(d.name for d in rooms_root.iterdir() if d.is_dir())
+        local_rooms = sorted(
+            d.name for d in rooms_root.iterdir() if d.is_dir() and not d.name.startswith(".")
+        )
         if not local_rooms:
             if json_output:
                 typer.echo('{"orphans": []}')
@@ -1240,27 +1241,21 @@ def gc(
                 )
             return
 
-        if not prune_orphans:
-            if json_output:
-                typer.echo(json_module.dumps({"orphans": orphans}))
-            else:
-                typer.secho(
-                    f"Found {len(orphans)} orphaned room director{'y' if len(orphans) == 1 else 'ies'}:",
-                    fg=typer.colors.YELLOW,
-                )
-                for name in orphans:
-                    typer.echo(f"  {rooms_root / name}")
-                typer.echo("")
-                typer.echo("Run with --prune-orphans to delete them.")
-            return
-
-        if not json_output:
+        if json_output:
+            typer.echo(json_module.dumps({"orphans": orphans}))
+            if not prune_orphans:
+                return
+        else:
             typer.secho(
                 f"Found {len(orphans)} orphaned room director{'y' if len(orphans) == 1 else 'ies'}:",
                 fg=typer.colors.YELLOW,
             )
             for name in orphans:
                 typer.echo(f"  {rooms_root / name}")
+            if not prune_orphans:
+                typer.echo("")
+                typer.echo("Run with --prune-orphans to delete them.")
+                return
 
         verb = "Would remove" if dry_run else "Removing"
         removed_count = 0

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -1271,7 +1271,8 @@ def gc(
                     dir_removed = True
                     removed_count += 1
                 except Exception as exc:
-                    typer.secho(f"    Error removing directory: {exc}", fg=typer.colors.RED)
+                    if not json_output:
+                        typer.secho(f"    Error removing directory: {exc}", fg=typer.colors.RED)
                     failed_count += 1
 
                 # Always unregister adapter configs regardless of whether the directory
@@ -1283,33 +1284,35 @@ def gc(
                     )
 
                     oc_removed = unregister_room_from_openclaw(room_name)
-                    if oc_removed:
+                    if oc_removed and not json_output:
                         typer.secho(
                             f"    Unregistered {len(oc_removed)} openclaw agent(s)",
                             fg=typer.colors.CYAN,
                         )
                 except Exception as exc:
-                    typer.secho(
-                        f"    Warning: could not unregister openclaw agents for '{room_name}': {exc}",
-                        fg=typer.colors.YELLOW,
-                    )
+                    if not json_output:
+                        typer.secho(
+                            f"    Warning: could not unregister openclaw agents for '{room_name}': {exc}",
+                            fg=typer.colors.YELLOW,
+                        )
 
                 try:
                     from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
 
                     hm_removed = unregister_room_from_hermes(room_name)
-                    if hm_removed:
+                    if hm_removed and not json_output:
                         typer.secho(
                             f"    Unregistered {len(hm_removed)} hermes agent(s)",
                             fg=typer.colors.CYAN,
                         )
                 except Exception as exc:
-                    typer.secho(
-                        f"    Warning: could not unregister hermes agents for '{room_name}': {exc}",
-                        fg=typer.colors.YELLOW,
-                    )
+                    if not json_output:
+                        typer.secho(
+                            f"    Warning: could not unregister hermes agents for '{room_name}': {exc}",
+                            fg=typer.colors.YELLOW,
+                        )
 
-                if not dir_removed:
+                if not dir_removed and not json_output:
                     typer.secho(
                         "    Adapter configs unregistered; directory must be removed manually.",
                         fg=typer.colors.YELLOW,

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -1217,7 +1217,7 @@ def gc(
                     resp = client.get(f"/api/rooms/{room_name}")
                     if resp.status_code == 404:
                         orphans.append(room_name)
-                except httpx.ConnectError:
+                except (httpx.ConnectError, httpx.ConnectTimeout):
                     typer.secho(
                         f"Cannot reach hub at {config.server.api_url} — aborting scan.",
                         fg=typer.colors.RED,
@@ -1228,37 +1228,47 @@ def gc(
                         f"  Warning: check failed for '{room_name}': {exc}", fg=typer.colors.YELLOW
                     )
 
-        if json_output:
-            import json as json_module
-
-            typer.echo(json_module.dumps({"orphans": orphans}))
-            return
+        import json as json_module
 
         if not orphans:
-            typer.secho(
-                f"All {len(local_rooms)} local room(s) are registered in the backend — nothing to clean up.",
-                fg=typer.colors.GREEN,
-            )
+            if json_output:
+                typer.echo(json_module.dumps({"orphans": []}))
+            else:
+                typer.secho(
+                    f"All {len(local_rooms)} local room(s) are registered in the backend — nothing to clean up.",
+                    fg=typer.colors.GREEN,
+                )
             return
-
-        typer.secho(
-            f"Found {len(orphans)} orphaned room director{'y' if len(orphans) == 1 else 'ies'}:",
-            fg=typer.colors.YELLOW,
-        )
-        for name in orphans:
-            typer.echo(f"  {rooms_root / name}")
 
         if not prune_orphans:
-            typer.echo("")
-            typer.echo("Run with --prune-orphans to delete them.")
+            if json_output:
+                typer.echo(json_module.dumps({"orphans": orphans}))
+            else:
+                typer.secho(
+                    f"Found {len(orphans)} orphaned room director{'y' if len(orphans) == 1 else 'ies'}:",
+                    fg=typer.colors.YELLOW,
+                )
+                for name in orphans:
+                    typer.echo(f"  {rooms_root / name}")
+                typer.echo("")
+                typer.echo("Run with --prune-orphans to delete them.")
             return
+
+        if not json_output:
+            typer.secho(
+                f"Found {len(orphans)} orphaned room director{'y' if len(orphans) == 1 else 'ies'}:",
+                fg=typer.colors.YELLOW,
+            )
+            for name in orphans:
+                typer.echo(f"  {rooms_root / name}")
 
         verb = "Would remove" if dry_run else "Removing"
         removed_count = 0
         failed_count = 0
         for room_name in orphans:
             room_dir = rooms_root / room_name
-            typer.echo(f"  {verb}: {room_dir}")
+            if not json_output:
+                typer.echo(f"  {verb}: {room_dir}")
             if not dry_run:
                 dir_removed = False
                 try:
@@ -1305,16 +1315,46 @@ def gc(
                     )
 
         if dry_run:
-            typer.echo("")
-            typer.secho("Dry run — nothing was deleted.", fg=typer.colors.YELLOW)
+            if json_output:
+                typer.echo(json_module.dumps({"orphans": orphans, "dry_run": True}))
+            else:
+                typer.echo("")
+                typer.secho("Dry run — nothing was deleted.", fg=typer.colors.YELLOW)
         else:
-            noun = "directory" if removed_count == 1 else "directories"
-            typer.secho(f"\nRemoved {removed_count} orphaned room {noun}.", fg=typer.colors.GREEN)
-            if failed_count:
+            # Remove pruned rooms from daemon.toml so a running daemon stops
+            # its 404 retry loop for these rooms immediately.
+            try:
+                from mycelium.daemon.config import DaemonConfig as _DC
+
+                _dcfg = _DC.load()
+                _changed = False
+                for _r in orphans:
+                    if _r in _dcfg.rooms:
+                        _dcfg.rooms.remove(_r)
+                        _changed = True
+                if _changed:
+                    _dcfg.save()
+            except Exception as exc:
                 typer.secho(
-                    f"{failed_count} director{'y' if failed_count == 1 else 'ies'} could not be removed — check permissions.",
-                    fg=typer.colors.YELLOW,
+                    f"Warning: could not update daemon config: {exc}", fg=typer.colors.YELLOW
                 )
+
+            if json_output:
+                typer.echo(
+                    json_module.dumps(
+                        {"orphans": orphans, "removed": removed_count, "failed": failed_count}
+                    )
+                )
+            else:
+                noun = "directory" if removed_count == 1 else "directories"
+                typer.secho(
+                    f"\nRemoved {removed_count} orphaned room {noun}.", fg=typer.colors.GREEN
+                )
+                if failed_count:
+                    typer.secho(
+                        f"{failed_count} director{'y' if failed_count == 1 else 'ies'} could not be removed — check permissions.",
+                        fg=typer.colors.YELLOW,
+                    )
 
     except (typer.Exit, typer.Abort):
         raise

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -1148,7 +1148,7 @@ def delegate(
 
 @doc_ref(
     usage="mycelium room gc [--prune-orphans] [--dry-run]",
-    desc="Find and optionally remove local room directories that no longer exist on the hub.",
+    desc="Find and optionally remove local room directories that are not registered in the backend.",
     group="room",
 )
 @app.command("gc")
@@ -1168,7 +1168,7 @@ def gc(
     """Reconcile local room directories against the hub.
 
     Compares every directory under ``~/.mycelium/rooms/`` with the hub's
-    room list.  A directory whose room no longer exists on the hub is
+    room list.  A directory whose room is no longer registered in the backend is
     **orphaned** — typically left behind after ``mycelium room delete`` ran
     on a remote spoke or while this node was offline.
 
@@ -1236,7 +1236,7 @@ def gc(
 
         if not orphans:
             typer.secho(
-                f"All {len(local_rooms)} local room(s) exist on hub — nothing to clean up.",
+                f"All {len(local_rooms)} local room(s) are registered in the backend — nothing to clean up.",
                 fg=typer.colors.GREEN,
             )
             return

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -170,6 +170,20 @@ class NegotiationConfig(BaseModel):
     )
 
 
+class DaemonSettings(BaseModel):
+    """Daemon behaviour tunables (hub-and-spoke cleanup, GC policy)."""
+
+    auto_gc_orphaned_rooms: bool = Field(
+        default=False,
+        description=(
+            "When True, the daemon automatically removes local room directories "
+            "that no longer exist on the hub (detected at startup and on "
+            "room_deleted SSE events).  Defaults to False so operators can review "
+            "orphans via `mycelium doctor` or `mycelium room gc` before deletion."
+        ),
+    )
+
+
 class RoomConfig(BaseModel):
     """Room management configuration."""
 
@@ -296,6 +310,7 @@ class MyceliumConfig(BaseModel):
     llm: LLMConfig = Field(default_factory=LLMConfig)
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     rooms: RoomConfig = Field(default_factory=RoomConfig)
+    daemon: DaemonSettings = Field(default_factory=DaemonSettings)
     knowledge_ingest: KnowledgeIngestConfig = Field(default_factory=KnowledgeIngestConfig)
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
     negotiation: NegotiationConfig = Field(default_factory=NegotiationConfig)

--- a/mycelium-cli/src/mycelium/daemon/dispatch.py
+++ b/mycelium-cli/src/mycelium/daemon/dispatch.py
@@ -1241,6 +1241,37 @@ async def poll_coordination_sessions(
 # ── Room-deleted handling and startup reconciliation ─────────────────────────
 
 
+def _unregister_room_from_adapters(room_name: str) -> None:
+    """Unregister *room_name* from all configured adapters (openclaw, hermes).
+
+    Non-fatal: each adapter is attempted independently.
+    """
+    try:
+        from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw
+
+        removed = unregister_room_from_openclaw(room_name)
+        if removed:
+            log.info(
+                "Unregistered %d openclaw agent(s) from deleted room '%s'",
+                len(removed),
+                room_name,
+            )
+    except Exception as exc:
+        log.debug("openclaw unregister skipped for '%s': %s", room_name, exc)
+    try:
+        from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
+
+        removed = unregister_room_from_hermes(room_name)
+        if removed:
+            log.info(
+                "Unregistered %d hermes agent(s) from deleted room '%s'",
+                len(removed),
+                room_name,
+            )
+    except Exception as exc:
+        log.debug("hermes unregister skipped for '%s': %s", room_name, exc)
+
+
 async def _handle_room_deleted(
     *,
     room_name: str,
@@ -1249,9 +1280,9 @@ async def _handle_room_deleted(
 ) -> None:
     """React to a ``room_deleted`` SSE tombstone from the hub.
 
-    Called while the SSE connection is still live (the tombstone fires before
-    the DB row is removed).  Cleans up all local spoke state immediately so
-    agents don't receive stale ticks from a room that no longer exists.
+    Called when the hub fires a ``room_deleted`` tombstone after the DB
+    commit.  Cleans up all local spoke state immediately so agents don't
+    receive stale ticks from a room that no longer exists.
 
     Actions (all non-fatal individually):
       1. Mark the room as deleted so ``subscribe_room`` exits its loop.
@@ -1310,39 +1341,18 @@ async def _handle_room_deleted(
     except Exception as exc:
         log.warning("Could not load daemon config for deleted room '%s': %s", room_name, exc)
 
-    try:
-        from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw
-
-        removed = unregister_room_from_openclaw(room_name)
-        if removed:
-            log.info(
-                "Unregistered %d openclaw agent(s) from deleted room '%s'",
-                len(removed),
-                room_name,
-            )
-    except Exception as exc:
-        log.debug("openclaw unregister skipped for '%s': %s", room_name, exc)
-
-    try:
-        from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
-
-        removed = unregister_room_from_hermes(room_name)
-        if removed:
-            log.info(
-                "Unregistered %d hermes agent(s) from deleted room '%s'",
-                len(removed),
-                room_name,
-            )
-    except Exception as exc:
-        log.debug("hermes unregister skipped for '%s': %s", room_name, exc)
+    _unregister_room_from_adapters(room_name)
 
 
-async def reconcile_local_rooms(config: MyceliumConfig) -> None:
+async def reconcile_local_rooms(config: MyceliumConfig) -> set[str]:
     """On daemon startup, verify each local room directory against the hub API.
 
     A spoke that was offline when a room was deleted on the hub will have
     missed the ``room_deleted`` SSE tombstone.  This pull-based reconciliation
     catches those orphans at next startup.
+
+    Returns the set of room names that are orphaned (deleted on hub), so the
+    caller can seed ``state.rooms_deleted`` to prevent 404-retry SSE tasks.
 
     Behaviour is gated on ``daemon.auto_gc_orphaned_rooms`` in config.toml:
       - False (default): log a warning and leave cleanup to the operator
@@ -1360,7 +1370,7 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
 
     rooms_root = get_mycelium_dir() / "rooms"
     if not rooms_root.exists():
-        return
+        return set()
 
     api_url = config.server.api_url
 
@@ -1374,11 +1384,12 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
         log.warning("Startup reconcile: could not load daemon config: %s", exc)
         _dcfg = None
     _dcfg_changed = False
+    orphaned_rooms: set[str] = set()
 
     try:
         async with httpx.AsyncClient(base_url=api_url, timeout=10) as client:
             for room_dir in sorted(rooms_root.iterdir()):
-                if not room_dir.is_dir():
+                if not room_dir.is_dir() or room_dir.name.startswith("."):
                     continue
                 room_name = room_dir.name
                 try:
@@ -1397,6 +1408,8 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
 
                 if resp.status_code != 404:
                     continue
+
+                orphaned_rooms.add(room_name)
 
                 # Room is gone on the hub.  Queue removal from daemon_cfg.rooms so
                 # the runner does not spawn a 404-retry SSE task on startup.
@@ -1424,22 +1437,7 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
 
                 # Always unregister adapter configs — the hub has deleted the room
                 # regardless of whether we removed the local directory.
-                try:
-                    from mycelium.integrations.openclaw.dispatch import (
-                        unregister_room_from_openclaw,
-                    )
-
-                    unregister_room_from_openclaw(room_name)
-                except Exception:
-                    pass
-                try:
-                    from mycelium.integrations.hermes.dispatch import (
-                        unregister_room_from_hermes,
-                    )
-
-                    unregister_room_from_hermes(room_name)
-                except Exception:
-                    pass
+                _unregister_room_from_adapters(room_name)
     except Exception as exc:
         log.warning("Startup room reconcile failed: %s", exc)
 
@@ -1448,6 +1446,8 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
             _dcfg.save()
         except Exception as exc:
             log.warning("Startup reconcile: could not save daemon config: %s", exc)
+
+    return orphaned_rooms
 
 
 # ── SSE subscription per room ────────────────────────────────────────────────
@@ -1461,10 +1461,6 @@ async def subscribe_room(
     room_name: str,
 ) -> None:
     """Stay connected to *room_name*'s SSE stream until the daemon stops."""
-    # A re-created room that was previously deleted will still appear in
-    # rooms_deleted.  Clear the tombstone so the subscription loop doesn't
-    # exit immediately on the first message.
-    state.rooms_deleted.discard(room_name)
     url = f"{config.server.api_url}/api/rooms/{room_name}/messages/stream"
 
     # No total timeout (the stream is long-lived) but a bounded read timeout
@@ -1486,11 +1482,12 @@ async def subscribe_room(
             ):
                 if resp.status_code == 404:
                     log.warning(
-                        "SSE 404 for %s — room may not exist; retry in 15s",
+                        "SSE 404 for %s — room does not exist on hub; closing subscription",
                         room_name,
                     )
-                    await asyncio.sleep(15)
-                    continue
+                    state.rooms_deleted.add(room_name)
+                    state.reload_requested.set()
+                    return
                 if resp.status_code >= 400:
                     log.warning("SSE %s for %s — retry in 5s", resp.status_code, room_name)
                     await asyncio.sleep(5)

--- a/mycelium-cli/src/mycelium/daemon/dispatch.py
+++ b/mycelium-cli/src/mycelium/daemon/dispatch.py
@@ -1474,6 +1474,13 @@ async def subscribe_room(
         pool=_SSE_CONNECT_TIMEOUT_S,
     )
 
+    # Tombstone only after this many consecutive 404s.  A single 404 can be a
+    # transient proxy blip or a subscribe-before-create race; three consecutive
+    # 404s with 15 s between them (45 s total) is a reliable signal that the
+    # room is genuinely gone.
+    _404_MAX_RETRIES = 3
+    _404_retries = 0
+
     while not state.stopping.is_set():
         try:
             async with (
@@ -1481,18 +1488,32 @@ async def subscribe_room(
                 client.stream("GET", url, headers={"Accept": "text/event-stream"}) as resp,
             ):
                 if resp.status_code == 404:
+                    _404_retries += 1
+                    if _404_retries < _404_MAX_RETRIES:
+                        log.warning(
+                            "SSE 404 for %s (attempt %d/%d) — retrying in 15s",
+                            room_name,
+                            _404_retries,
+                            _404_MAX_RETRIES,
+                        )
+                        await asyncio.sleep(15)
+                        continue
                     log.warning(
-                        "SSE 404 for %s — room does not exist on hub; closing subscription",
+                        "SSE 404 for %s after %d consecutive attempts — "
+                        "room does not exist on hub; closing subscription",
                         room_name,
+                        _404_retries,
                     )
                     state.rooms_deleted.add(room_name)
                     state.reload_requested.set()
+                    _unregister_room_from_adapters(room_name)
                     return
                 if resp.status_code >= 400:
                     log.warning("SSE %s for %s — retry in 5s", resp.status_code, room_name)
                     await asyncio.sleep(5)
                     continue
 
+                _404_retries = 0
                 log.info("SSE connected: %s", room_name)
                 state.rooms_connected.add(room_name)
 

--- a/mycelium-cli/src/mycelium/daemon/dispatch.py
+++ b/mycelium-cli/src/mycelium/daemon/dispatch.py
@@ -620,6 +620,13 @@ async def on_message(
             msg=msg,
         )
         return
+    if message_type == "room_deleted":
+        await _handle_room_deleted(
+            room_name=room_name,
+            config=config,
+            state=state,
+        )
+        return
     if message_type in {"coordination_join", "coordination_start"}:
         # Discover session sub-rooms — ticks live there, not in the parent
         # room. Mirrors the openclaw plugin's ``subscribe-session`` action.
@@ -1231,6 +1238,164 @@ async def poll_coordination_sessions(
         return
 
 
+# ── Room-deleted handling and startup reconciliation ─────────────────────────
+
+
+async def _handle_room_deleted(
+    *,
+    room_name: str,
+    config: MyceliumConfig,
+    state: DaemonState,
+) -> None:
+    """React to a ``room_deleted`` SSE tombstone from the hub.
+
+    Called while the SSE connection is still live (the tombstone fires before
+    the DB row is removed).  Cleans up all local spoke state immediately so
+    agents don't receive stale ticks from a room that no longer exists.
+
+    Actions (all non-fatal individually):
+      1. Mark the room as deleted so ``subscribe_room`` exits its loop.
+      2. Remove the local ``~/.mycelium/rooms/<room>/`` directory if
+         ``daemon.auto_gc_orphaned_rooms`` is enabled; otherwise just warn.
+      3. Unregister the room from openclaw and hermes adapter configs so
+         their plugins stop opening SSE connections to a dead room.
+    """
+    import shutil
+
+    log.info("room_deleted received for '%s' — cleaning up local state", room_name)
+    state.rooms_deleted.add(room_name)
+
+    if config.daemon.auto_gc_orphaned_rooms:
+        from mycelium.filesystem import get_room_dir
+
+        room_dir = get_room_dir(room_name)
+        if room_dir.exists():
+            try:
+                shutil.rmtree(room_dir)
+                log.info("Removed local room directory: %s", room_dir)
+            except Exception as exc:
+                log.warning("Failed to remove local room directory %s: %s", room_dir, exc)
+    else:
+        from mycelium.filesystem import get_room_dir
+
+        room_dir = get_room_dir(room_name)
+        if room_dir.exists():
+            log.warning(
+                "Room '%s' deleted on hub — local directory left at %s "
+                "(set daemon.auto_gc_orphaned_rooms=true or run 'mycelium room gc')",
+                room_name,
+                room_dir,
+            )
+
+    try:
+        from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw
+
+        removed = unregister_room_from_openclaw(room_name)
+        if removed:
+            log.info(
+                "Unregistered %d openclaw agent(s) from deleted room '%s'",
+                len(removed),
+                room_name,
+            )
+    except Exception as exc:
+        log.debug("openclaw unregister skipped for '%s': %s", room_name, exc)
+
+    try:
+        from mycelium.integrations.hermes.dispatch import unregister_room_from_hermes
+
+        removed = unregister_room_from_hermes(room_name)
+        if removed:
+            log.info(
+                "Unregistered %d hermes agent(s) from deleted room '%s'",
+                len(removed),
+                room_name,
+            )
+    except Exception as exc:
+        log.debug("hermes unregister skipped for '%s': %s", room_name, exc)
+
+
+async def reconcile_local_rooms(config: MyceliumConfig) -> None:
+    """On daemon startup, verify each local room directory against the hub API.
+
+    A spoke that was offline when a room was deleted on the hub will have
+    missed the ``room_deleted`` SSE tombstone.  This pull-based reconciliation
+    catches those orphans at next startup.
+
+    Behaviour is gated on ``daemon.auto_gc_orphaned_rooms`` in config.toml:
+      - False (default): log a warning and leave cleanup to the operator
+        (use ``mycelium doctor`` or ``mycelium room gc``).
+      - True: remove the orphaned directory and unregister adapter configs
+        automatically.
+
+    A ``ConnectError`` (hub unreachable) aborts the scan immediately — we'd
+    rather leave local state intact than delete rooms because the network was
+    down during startup.
+    """
+    import shutil
+
+    from mycelium.filesystem import get_mycelium_dir
+
+    rooms_root = get_mycelium_dir() / "rooms"
+    if not rooms_root.exists():
+        return
+
+    api_url = config.server.api_url
+
+    try:
+        async with httpx.AsyncClient(base_url=api_url, timeout=10) as client:
+            for room_dir in sorted(rooms_root.iterdir()):
+                if not room_dir.is_dir():
+                    continue
+                room_name = room_dir.name
+                try:
+                    resp = await client.get(f"/api/rooms/{room_name}")
+                except httpx.ConnectError:
+                    log.debug("Hub unreachable during startup reconcile — skipping remaining rooms")
+                    return
+                except Exception as exc:
+                    log.debug("Reconcile check failed for '%s': %s", room_name, exc)
+                    continue
+
+                if resp.status_code != 404:
+                    continue
+
+                # Room is gone on the hub.
+                if config.daemon.auto_gc_orphaned_rooms:
+                    try:
+                        shutil.rmtree(room_dir)
+                        log.info(
+                            "Startup reconcile: removed orphaned room directory '%s'", room_name
+                        )
+                    except Exception as exc:
+                        log.warning("Startup reconcile: failed to remove '%s': %s", room_dir, exc)
+                    try:
+                        from mycelium.integrations.openclaw.dispatch import (
+                            unregister_room_from_openclaw,
+                        )
+
+                        unregister_room_from_openclaw(room_name)
+                    except Exception:
+                        pass
+                    try:
+                        from mycelium.integrations.hermes.dispatch import (
+                            unregister_room_from_hermes,
+                        )
+
+                        unregister_room_from_hermes(room_name)
+                    except Exception:
+                        pass
+                else:
+                    log.warning(
+                        "Startup reconcile: room '%s' not found on hub — "
+                        "orphaned directory at %s "
+                        "(run 'mycelium room gc' or set daemon.auto_gc_orphaned_rooms=true)",
+                        room_name,
+                        room_dir,
+                    )
+    except Exception as exc:
+        log.warning("Startup room reconcile failed: %s", exc)
+
+
 # ── SSE subscription per room ────────────────────────────────────────────────
 
 
@@ -1305,6 +1470,13 @@ async def subscribe_room(
                             except Exception as exc:
                                 state.record_error(f"on_message[{room_name}]", exc)
                                 log.exception("dispatch error in %s: %s", room_name, exc)
+                            # Exit cleanly if the hub sent a room_deleted tombstone.
+                            if room_name in state.rooms_deleted:
+                                log.info(
+                                    "SSE: room '%s' deleted — closing subscription",
+                                    room_name,
+                                )
+                                return
         except asyncio.CancelledError:
             raise
         except (httpx.ReadTimeout, httpx.ConnectTimeout) as exc:

--- a/mycelium-cli/src/mycelium/daemon/dispatch.py
+++ b/mycelium-cli/src/mycelium/daemon/dispatch.py
@@ -1265,10 +1265,13 @@ async def _handle_room_deleted(
     log.info("room_deleted received for '%s' — cleaning up local state", room_name)
     state.rooms_deleted.add(room_name)
 
-    if config.daemon.auto_gc_orphaned_rooms:
-        from mycelium.filesystem import get_room_dir
+    # Build the room path directly to avoid get_room_dir()'s implicit mkdir,
+    # which would recreate the directory we're trying to report as orphaned.
+    from mycelium.filesystem import get_mycelium_dir
 
-        room_dir = get_room_dir(room_name)
+    room_dir = get_mycelium_dir() / "rooms" / room_name
+
+    if config.daemon.auto_gc_orphaned_rooms:
         if room_dir.exists():
             try:
                 shutil.rmtree(room_dir)
@@ -1276,9 +1279,6 @@ async def _handle_room_deleted(
             except Exception as exc:
                 log.warning("Failed to remove local room directory %s: %s", room_dir, exc)
     else:
-        from mycelium.filesystem import get_room_dir
-
-        room_dir = get_room_dir(room_name)
         if room_dir.exists():
             log.warning(
                 "Room '%s' deleted on hub — local directory left at %s "
@@ -1286,6 +1286,20 @@ async def _handle_room_deleted(
                 room_name,
                 room_dir,
             )
+
+    # Remove from the daemon subscription list so the room is not re-subscribed
+    # after a daemon restart, and trigger a hot-reload to cancel the SSE task.
+    try:
+        from mycelium.daemon.config import DaemonConfig
+
+        daemon_cfg = DaemonConfig.load()
+        if room_name in daemon_cfg.rooms:
+            daemon_cfg.rooms.remove(room_name)
+            daemon_cfg.save()
+            log.info("Removed '%s' from daemon subscription list", room_name)
+            state.reload_requested.set()
+    except Exception as exc:
+        log.warning("Could not update daemon config for deleted room '%s': %s", room_name, exc)
 
     try:
         from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw

--- a/mycelium-cli/src/mycelium/daemon/dispatch.py
+++ b/mycelium-cli/src/mycelium/daemon/dispatch.py
@@ -1281,7 +1281,7 @@ async def _handle_room_deleted(
     else:
         if room_dir.exists():
             log.warning(
-                "Room '%s' deleted on hub — local directory left at %s "
+                "Room '%s' deleted from the backend — local directory left at %s "
                 "(set daemon.auto_gc_orphaned_rooms=true or run 'mycelium room gc')",
                 room_name,
                 room_dir,
@@ -1289,17 +1289,27 @@ async def _handle_room_deleted(
 
     # Remove from the daemon subscription list so the room is not re-subscribed
     # after a daemon restart, and trigger a hot-reload to cancel the SSE task.
+    _room_was_subscribed = False
     try:
         from mycelium.daemon.config import DaemonConfig
 
         daemon_cfg = DaemonConfig.load()
         if room_name in daemon_cfg.rooms:
+            _room_was_subscribed = True
             daemon_cfg.rooms.remove(room_name)
-            daemon_cfg.save()
-            log.info("Removed '%s' from daemon subscription list", room_name)
-            state.reload_requested.set()
+            try:
+                daemon_cfg.save()
+                log.info("Removed '%s' from daemon subscription list", room_name)
+            except Exception as save_exc:
+                log.warning(
+                    "Could not save daemon config after removing '%s': %s", room_name, save_exc
+                )
     except Exception as exc:
-        log.warning("Could not update daemon config for deleted room '%s': %s", room_name, exc)
+        log.warning("Could not load daemon config for deleted room '%s': %s", room_name, exc)
+    # Set reload_requested outside the save() try so a disk-full error does not
+    # leave the completed subscribe_room task as a zombie in sse_tasks.
+    if _room_was_subscribed:
+        state.reload_requested.set()
 
     try:
         from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw
@@ -1399,13 +1409,13 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
                     except Exception:
                         pass
                 else:
-                    log.warning(
-                        "Startup reconcile: room '%s' not found on hub — "
-                        "orphaned directory at %s "
-                        "(run 'mycelium room gc' or set daemon.auto_gc_orphaned_rooms=true)",
-                        room_name,
-                        room_dir,
-                    )
+                        log.warning(
+                            "Startup reconcile: room '%s' not registered in the backend — "
+                            "orphaned local directory at %s "
+                            "(run 'mycelium room gc' or set daemon.auto_gc_orphaned_rooms=true)",
+                            room_name,
+                            room_dir,
+                        )
     except Exception as exc:
         log.warning("Startup room reconcile failed: %s", exc)
 
@@ -1421,6 +1431,10 @@ async def subscribe_room(
     room_name: str,
 ) -> None:
     """Stay connected to *room_name*'s SSE stream until the daemon stops."""
+    # A re-created room that was previously deleted will still appear in
+    # rooms_deleted.  Clear the tombstone so the subscription loop doesn't
+    # exit immediately on the first message.
+    state.rooms_deleted.discard(room_name)
     url = f"{config.server.api_url}/api/rooms/{room_name}/messages/stream"
 
     # No total timeout (the stream is long-lived) but a bounded read timeout

--- a/mycelium-cli/src/mycelium/daemon/dispatch.py
+++ b/mycelium-cli/src/mycelium/daemon/dispatch.py
@@ -1287,15 +1287,18 @@ async def _handle_room_deleted(
                 room_dir,
             )
 
-    # Remove from the daemon subscription list so the room is not re-subscribed
-    # after a daemon restart, and trigger a hot-reload to cancel the SSE task.
-    _room_was_subscribed = False
+    # Trigger hot-reload immediately — _reconcile_rooms filters state.rooms_deleted
+    # from desired, so the SSE task is cleaned up even if the config update below
+    # fails (e.g. disk-full on save()).
+    state.reload_requested.set()
+
+    # Best-effort: remove from daemon.toml so the room is not re-subscribed on
+    # next daemon restart.
     try:
         from mycelium.daemon.config import DaemonConfig
 
         daemon_cfg = DaemonConfig.load()
         if room_name in daemon_cfg.rooms:
-            _room_was_subscribed = True
             daemon_cfg.rooms.remove(room_name)
             try:
                 daemon_cfg.save()
@@ -1306,10 +1309,6 @@ async def _handle_room_deleted(
                 )
     except Exception as exc:
         log.warning("Could not load daemon config for deleted room '%s': %s", room_name, exc)
-    # Set reload_requested outside the save() try so a disk-full error does not
-    # leave the completed subscribe_room task as a zombie in sse_tasks.
-    if _room_was_subscribed:
-        state.reload_requested.set()
 
     try:
         from mycelium.integrations.openclaw.dispatch import unregister_room_from_openclaw
@@ -1351,9 +1350,9 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
       - True: remove the orphaned directory and unregister adapter configs
         automatically.
 
-    A ``ConnectError`` (hub unreachable) aborts the scan immediately — we'd
-    rather leave local state intact than delete rooms because the network was
-    down during startup.
+    A ``ConnectError`` or ``ConnectTimeout`` (hub unreachable) aborts the scan
+    immediately — we'd rather leave local state intact than delete rooms because
+    the network was down during startup.
     """
     import shutil
 
@@ -1365,6 +1364,17 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
 
     api_url = config.server.api_url
 
+    # Load daemon config once; patch it for each orphan found; save once at the
+    # end.  This avoids O(n) load/save cycles when many rooms are orphaned.
+    from mycelium.daemon.config import DaemonConfig as _DC
+
+    try:
+        _dcfg: _DC | None = _DC.load()
+    except Exception as exc:
+        log.warning("Startup reconcile: could not load daemon config: %s", exc)
+        _dcfg = None
+    _dcfg_changed = False
+
     try:
         async with httpx.AsyncClient(base_url=api_url, timeout=10) as client:
             for room_dir in sorted(rooms_root.iterdir()):
@@ -1373,9 +1383,14 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
                 room_name = room_dir.name
                 try:
                     resp = await client.get(f"/api/rooms/{room_name}")
-                except httpx.ConnectError:
-                    log.debug("Hub unreachable during startup reconcile — skipping remaining rooms")
-                    return
+                except (httpx.ConnectError, httpx.ConnectTimeout):
+                    # ConnectTimeout is not a subclass of ConnectError; catch both.
+                    # Break rather than return so the batched config save still runs
+                    # for any orphans already found before the hub became unreachable.
+                    log.warning(
+                        "Hub unreachable during startup reconcile — skipping remaining rooms"
+                    )
+                    break
                 except Exception as exc:
                     log.debug("Reconcile check failed for '%s': %s", room_name, exc)
                     continue
@@ -1383,7 +1398,13 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
                 if resp.status_code != 404:
                     continue
 
-                # Room is gone on the hub.
+                # Room is gone on the hub.  Queue removal from daemon_cfg.rooms so
+                # the runner does not spawn a 404-retry SSE task on startup.
+                # Saved once after this loop ends.
+                if _dcfg is not None and room_name in _dcfg.rooms:
+                    _dcfg.rooms.remove(room_name)
+                    _dcfg_changed = True
+
                 if config.daemon.auto_gc_orphaned_rooms:
                     try:
                         shutil.rmtree(room_dir)
@@ -1392,32 +1413,41 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> None:
                         )
                     except Exception as exc:
                         log.warning("Startup reconcile: failed to remove '%s': %s", room_dir, exc)
-                    try:
-                        from mycelium.integrations.openclaw.dispatch import (
-                            unregister_room_from_openclaw,
-                        )
-
-                        unregister_room_from_openclaw(room_name)
-                    except Exception:
-                        pass
-                    try:
-                        from mycelium.integrations.hermes.dispatch import (
-                            unregister_room_from_hermes,
-                        )
-
-                        unregister_room_from_hermes(room_name)
-                    except Exception:
-                        pass
                 else:
-                        log.warning(
-                            "Startup reconcile: room '%s' not registered in the backend — "
-                            "orphaned local directory at %s "
-                            "(run 'mycelium room gc' or set daemon.auto_gc_orphaned_rooms=true)",
-                            room_name,
-                            room_dir,
-                        )
+                    log.warning(
+                        "Startup reconcile: room '%s' not registered in the backend — "
+                        "orphaned local directory at %s "
+                        "(run 'mycelium room gc' or set daemon.auto_gc_orphaned_rooms=true)",
+                        room_name,
+                        room_dir,
+                    )
+
+                # Always unregister adapter configs — the hub has deleted the room
+                # regardless of whether we removed the local directory.
+                try:
+                    from mycelium.integrations.openclaw.dispatch import (
+                        unregister_room_from_openclaw,
+                    )
+
+                    unregister_room_from_openclaw(room_name)
+                except Exception:
+                    pass
+                try:
+                    from mycelium.integrations.hermes.dispatch import (
+                        unregister_room_from_hermes,
+                    )
+
+                    unregister_room_from_hermes(room_name)
+                except Exception:
+                    pass
     except Exception as exc:
         log.warning("Startup room reconcile failed: %s", exc)
+
+    if _dcfg is not None and _dcfg_changed:
+        try:
+            _dcfg.save()
+        except Exception as exc:
+            log.warning("Startup reconcile: could not save daemon config: %s", exc)
 
 
 # ── SSE subscription per room ────────────────────────────────────────────────

--- a/mycelium-cli/src/mycelium/daemon/dispatch.py
+++ b/mycelium-cli/src/mycelium/daemon/dispatch.py
@@ -1305,7 +1305,7 @@ async def _handle_room_deleted(
     if config.daemon.auto_gc_orphaned_rooms:
         if room_dir.exists():
             try:
-                shutil.rmtree(room_dir)
+                await asyncio.to_thread(shutil.rmtree, room_dir)
                 log.info("Removed local room directory: %s", room_dir)
             except Exception as exc:
                 log.warning("Failed to remove local room directory %s: %s", room_dir, exc)
@@ -1420,7 +1420,7 @@ async def reconcile_local_rooms(config: MyceliumConfig) -> set[str]:
 
                 if config.daemon.auto_gc_orphaned_rooms:
                     try:
-                        shutil.rmtree(room_dir)
+                        await asyncio.to_thread(shutil.rmtree, room_dir)
                         log.info(
                             "Startup reconcile: removed orphaned room directory '%s'", room_name
                         )
@@ -1504,11 +1504,16 @@ async def subscribe_room(
                         room_name,
                         _404_retries,
                     )
-                    state.rooms_deleted.add(room_name)
-                    state.reload_requested.set()
-                    _unregister_room_from_adapters(room_name)
+                    await _handle_room_deleted(
+                        room_name=room_name,
+                        config=config,
+                        state=state,
+                    )
                     return
                 if resp.status_code >= 400:
+                    # Non-404 error: reset the 404 counter so interleaved 5xx responses
+                    # during a rolling restart don't accumulate toward the 404 threshold.
+                    _404_retries = 0
                     log.warning("SSE %s for %s — retry in 5s", resp.status_code, room_name)
                     await asyncio.sleep(5)
                     continue

--- a/mycelium-cli/src/mycelium/daemon/runner.py
+++ b/mycelium-cli/src/mycelium/daemon/runner.py
@@ -62,20 +62,11 @@ async def _reconcile_rooms(
     desired = set(daemon_cfg.rooms)
     current = set(sse_tasks.keys())
 
-    # Clear tombstones only for rooms that are in config but do NOT have a
-    # live or done SSE task.  A room that is in both desired AND current means
-    # the config update failed (room still in daemon.toml) and the SSE task
-    # is still present (running or done) — that is not a re-add, so the
-    # tombstone must be kept to prevent a spurious re-subscription.
-    # A room in desired but NOT in current means it was removed from sse_tasks
-    # in a prior reconcile (task cleaned up) and then explicitly re-added to
-    # daemon.toml — clear the tombstone so the subscription proceeds.
-    re_added = (desired - current) & state.rooms_deleted
-    for room in re_added:
-        log.info("hot-reload: room '%s' re-added — clearing deleted tombstone", room)
-        state.rooms_deleted.discard(room)
     # Exclude tombstoned rooms from desired so their completed SSE tasks are
     # cleaned up even when _handle_room_deleted could not update the config file.
+    # Tombstones are never cleared at hot-reload time — they are set by 404,
+    # room_deleted events, or startup reconcile, and cleared only on restart
+    # (when fresh reconcile can confirm hub status with a live request).
     effective_desired = desired - state.rooms_deleted
 
     # Refresh handles on the live daemon_cfg so dispatch sees new agents
@@ -166,10 +157,15 @@ async def _amain(foreground: bool) -> int:
     # Pull-based reconciliation: verify local room dirs against the hub so
     # rooms deleted while this spoke was offline are surfaced (or auto-cleaned
     # when daemon.auto_gc_orphaned_rooms is True).
+    # The returned set of orphaned room names seeds state.rooms_deleted so
+    # _reconcile_rooms never spawns 404-retry SSE tasks for rooms that are gone.
     try:
-        await reconcile_local_rooms(mycelium_cfg)
+        orphaned_rooms = await reconcile_local_rooms(mycelium_cfg)
     except Exception as exc:
         log.warning("Startup room reconcile raised unexpectedly: %s", exc)
+        orphaned_rooms: set[str] = set()
+
+    state.rooms_deleted.update(orphaned_rooms)
 
     # Reload so the in-memory daemon_cfg reflects whatever reconcile_local_rooms
     # wrote to disk (it may have removed orphaned rooms from the subscription list).
@@ -191,6 +187,7 @@ async def _amain(foreground: bool) -> int:
             name=f"sse[{room}]",
         )
         for room in daemon_cfg.rooms
+        if room not in state.rooms_deleted
     }
 
     session_poller = asyncio.create_task(

--- a/mycelium-cli/src/mycelium/daemon/runner.py
+++ b/mycelium-cli/src/mycelium/daemon/runner.py
@@ -11,7 +11,11 @@ import signal
 
 from mycelium.config import MyceliumConfig
 from mycelium.daemon.config import DaemonConfig, daemon_log_path
-from mycelium.daemon.dispatch import poll_coordination_sessions, subscribe_room
+from mycelium.daemon.dispatch import (
+    poll_coordination_sessions,
+    reconcile_local_rooms,
+    subscribe_room,
+)
 from mycelium.daemon.health import start_health_server
 from mycelium.daemon.state import DaemonState
 
@@ -140,6 +144,14 @@ async def _amain(foreground: bool) -> int:
 
     server = await start_health_server(state)
     log.info("mycelium-daemon started (rooms=%d)", len(daemon_cfg.rooms))
+
+    # Pull-based reconciliation: verify local room dirs against the hub so
+    # rooms deleted while this spoke was offline are surfaced (or auto-cleaned
+    # when daemon.auto_gc_orphaned_rooms is True).
+    try:
+        await reconcile_local_rooms(mycelium_cfg)
+    except Exception as exc:
+        log.warning("Startup room reconcile raised unexpectedly: %s", exc)
 
     sse_tasks: dict[str, asyncio.Task[None]] = {
         room: asyncio.create_task(

--- a/mycelium-cli/src/mycelium/daemon/runner.py
+++ b/mycelium-cli/src/mycelium/daemon/runner.py
@@ -62,12 +62,28 @@ async def _reconcile_rooms(
     desired = set(daemon_cfg.rooms)
     current = set(sse_tasks.keys())
 
+    # Clear tombstones only for rooms that are in config but do NOT have a
+    # live or done SSE task.  A room that is in both desired AND current means
+    # the config update failed (room still in daemon.toml) and the SSE task
+    # is still present (running or done) — that is not a re-add, so the
+    # tombstone must be kept to prevent a spurious re-subscription.
+    # A room in desired but NOT in current means it was removed from sse_tasks
+    # in a prior reconcile (task cleaned up) and then explicitly re-added to
+    # daemon.toml — clear the tombstone so the subscription proceeds.
+    re_added = (desired - current) & state.rooms_deleted
+    for room in re_added:
+        log.info("hot-reload: room '%s' re-added — clearing deleted tombstone", room)
+        state.rooms_deleted.discard(room)
+    # Exclude tombstoned rooms from desired so their completed SSE tasks are
+    # cleaned up even when _handle_room_deleted could not update the config file.
+    effective_desired = desired - state.rooms_deleted
+
     # Refresh handles on the live daemon_cfg so dispatch sees new agents
     if state.daemon_cfg is not None:
         state.daemon_cfg.handles = daemon_cfg.handles
         state.daemon_cfg.rooms = daemon_cfg.rooms
 
-    for room in desired - current:
+    for room in effective_desired - current:
         log.info("hot-reload: subscribing to %s", room)
         sse_tasks[room] = asyncio.create_task(
             subscribe_room(
@@ -79,7 +95,7 @@ async def _reconcile_rooms(
             name=f"sse[{room}]",
         )
 
-    for room in current - desired:
+    for room in current - effective_desired:
         log.info("hot-reload: unsubscribing from %s", room)
         task = sse_tasks.pop(room)
         task.cancel()
@@ -89,9 +105,11 @@ async def _reconcile_rooms(
             pass
         state.rooms_connected.discard(room)
 
-    state.rooms_configured = list(daemon_cfg.rooms)
+    state.rooms_configured = list(effective_desired)
     log.info(
-        "hot-reload complete: rooms=%d, handles=%d", len(daemon_cfg.rooms), len(daemon_cfg.handles)
+        "hot-reload complete: rooms=%d, handles=%d",
+        len(effective_desired),
+        len(daemon_cfg.handles),
     )
 
 
@@ -152,6 +170,15 @@ async def _amain(foreground: bool) -> int:
         await reconcile_local_rooms(mycelium_cfg)
     except Exception as exc:
         log.warning("Startup room reconcile raised unexpectedly: %s", exc)
+
+    # Reload so the in-memory daemon_cfg reflects whatever reconcile_local_rooms
+    # wrote to disk (it may have removed orphaned rooms from the subscription list).
+    try:
+        daemon_cfg = DaemonConfig.load()
+        state.rooms_configured = list(daemon_cfg.rooms)
+        state.daemon_cfg = daemon_cfg
+    except Exception as exc:
+        log.warning("Could not reload daemon config after startup reconcile: %s", exc)
 
     sse_tasks: dict[str, asyncio.Task[None]] = {
         room: asyncio.create_task(

--- a/mycelium-cli/src/mycelium/daemon/runner.py
+++ b/mycelium-cli/src/mycelium/daemon/runner.py
@@ -175,6 +175,9 @@ async def _amain(foreground: bool) -> int:
         state.daemon_cfg = daemon_cfg
     except Exception as exc:
         log.warning("Could not reload daemon config after startup reconcile: %s", exc)
+        # Keep rooms_configured consistent with what sse_tasks will actually subscribe to
+        # so the health endpoint doesn't report tombstoned rooms as configured.
+        state.rooms_configured = [r for r in daemon_cfg.rooms if r not in state.rooms_deleted]
 
     sse_tasks: dict[str, asyncio.Task[None]] = {
         room: asyncio.create_task(

--- a/mycelium-cli/src/mycelium/daemon/runner.py
+++ b/mycelium-cli/src/mycelium/daemon/runner.py
@@ -171,12 +171,13 @@ async def _amain(foreground: bool) -> int:
     # wrote to disk (it may have removed orphaned rooms from the subscription list).
     try:
         daemon_cfg = DaemonConfig.load()
-        state.rooms_configured = list(daemon_cfg.rooms)
+        # Exclude tombstoned rooms so the health endpoint never reports orphaned
+        # rooms as configured — even when _dcfg.save() inside reconcile_local_rooms
+        # failed and daemon.toml still lists them.
+        state.rooms_configured = [r for r in daemon_cfg.rooms if r not in state.rooms_deleted]
         state.daemon_cfg = daemon_cfg
     except Exception as exc:
         log.warning("Could not reload daemon config after startup reconcile: %s", exc)
-        # Keep rooms_configured consistent with what sse_tasks will actually subscribe to
-        # so the health endpoint doesn't report tombstoned rooms as configured.
         state.rooms_configured = [r for r in daemon_cfg.rooms if r not in state.rooms_deleted]
 
     sse_tasks: dict[str, asyncio.Task[None]] = {

--- a/mycelium-cli/src/mycelium/daemon/state.py
+++ b/mycelium-cli/src/mycelium/daemon/state.py
@@ -51,6 +51,11 @@ class DaemonState:
     # tasks) so shutdown can cancel them and the health endpoint can surface
     # how many sub-rooms we're following.
     session_room_tasks: dict[str, Any] = field(default_factory=dict)
+    # Rooms that have been deleted on the hub (signalled via ``room_deleted``
+    # SSE events). ``subscribe_room`` checks this set after each ``on_message``
+    # call and exits the SSE loop cleanly when a room appears here, avoiding
+    # repeated 404 reconnect attempts after a hub-side deletion.
+    rooms_deleted: set[str] = field(default_factory=set)
     stopping: asyncio.Event = field(default_factory=asyncio.Event)
     reload_requested: asyncio.Event = field(default_factory=asyncio.Event)
     daemon_cfg: Any = field(default=None)  # DaemonConfig — set by runner after load

--- a/mycelium-cli/src/mycelium/docs/troubleshooting.md
+++ b/mycelium-cli/src/mycelium/docs/troubleshooting.md
@@ -293,6 +293,46 @@ In a hub-and-spoke setup, update tokens on every node that runs agents.
 
 ---
 
+### 15. Orphaned Local Room Directories
+
+**Symptom**: `mycelium doctor` reports `Orphaned rooms — X local room
+directories not registered in the backend`, or the spoke daemon logs:
+
+```
+room 'my-room' not registered in the backend — orphaned local directory
+at ~/.mycelium/rooms/my-room/ (run 'mycelium room gc' ...)
+```
+
+**Cause**: The room was deleted from the backend while the spoke daemon was
+offline and missed the `room_deleted` SSE tombstone.  The local directory and
+daemon subscription remain.
+
+**Diagnosis**:
+
+```bash
+mycelium doctor          # shows the Orphaned rooms check result
+mycelium room gc         # list orphans without removing anything
+```
+
+**Fix**:
+
+```bash
+# Remove orphaned directories and unregister adapter configs:
+mycelium room gc --prune-orphans
+
+# Or enable automatic cleanup on every daemon startup:
+mycelium config set daemon.auto_gc_orphaned_rooms true
+mycelium config apply
+mycelium daemon restart
+```
+
+The daemon reconciles on every startup: if it can reach the backend it will
+detect orphans and either warn or auto-remove them (depending on the
+`auto_gc_orphaned_rooms` setting).  No manual intervention needed once that
+setting is enabled.
+
+---
+
 ### 16. Spoke Cannot Reach Hub Backend
 
 **Symptom**: `mycelium status` or `mycelium room ls` from a spoke returns

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/dist/src/channel/room-sse.js
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/dist/src/channel/room-sse.js
@@ -12,6 +12,10 @@ import { CHANNEL_ID } from "../config.js";
 export function startRoomSSE(runtime, cfg, abort, handleMessage, log) {
     const signal = abort.signal;
     const sseUrl = `${cfg.backendUrl}/api/rooms/${encodeURIComponent(cfg.room)}/messages/stream`;
+    // Tombstone only after this many consecutive 404s — mirrors the Python daemon's
+    // _404_MAX_RETRIES logic so both delivery paths behave identically on deletion.
+    const NOT_FOUND_MAX_RETRIES = 3;
+    let notFoundRetries = 0;
     (async () => {
         while (!signal.aborted) {
             try {
@@ -20,15 +24,21 @@ export function startRoomSSE(runtime, cfg, abort, handleMessage, log) {
                     signal,
                 });
                 if (res.status === 404) {
-                    log.warn(`[${CHANNEL_ID}] room SSE 404 for ${cfg.room} — room may not exist yet, retry 15s`);
-                    await new Promise((r) => setTimeout(r, 15_000));
-                    continue;
+                    notFoundRetries++;
+                    if (notFoundRetries < NOT_FOUND_MAX_RETRIES) {
+                        log.warn(`[${CHANNEL_ID}] room SSE 404 for ${cfg.room} (attempt ${notFoundRetries}/${NOT_FOUND_MAX_RETRIES}) — retry 15s`);
+                        await new Promise((r) => setTimeout(r, 15_000));
+                        continue;
+                    }
+                    log.warn(`[${CHANNEL_ID}] room SSE 404 for ${cfg.room} after ${notFoundRetries} attempts — room deleted, stopping`);
+                    return;
                 }
                 if (!res.ok || !res.body) {
                     log.warn(`[${CHANNEL_ID}] SSE ${res.status} — retry 5s`);
                     await new Promise((r) => setTimeout(r, 5000));
                     continue;
                 }
+                notFoundRetries = 0;
                 log.info(`[${CHANNEL_ID}] SSE connected: ${cfg.room} (agents: ${cfg.agents.join(", ")})`);
                 const reader = res.body.getReader();
                 const decoder = new TextDecoder();

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/dist/src/channel/room-sse.js
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/dist/src/channel/room-sse.js
@@ -55,6 +55,12 @@ export function startRoomSSE(runtime, cfg, abort, handleMessage, log) {
                             continue;
                         }
                         handleMessage(runtime, cfg, msg, log);
+                        // Stop the subscription loop permanently on room deletion.
+                        // The room no longer exists on the hub; retrying would 404-loop.
+                        if (msg.message_type === "room_deleted") {
+                            log.info(`[${CHANNEL_ID}] room "${cfg.room}" deleted — stopping SSE subscription`);
+                            return;
+                        }
                     }
                 }
             }

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/dist/src/channel/room-sse.js
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/dist/src/channel/room-sse.js
@@ -34,6 +34,9 @@ export function startRoomSSE(runtime, cfg, abort, handleMessage, log) {
                     return;
                 }
                 if (!res.ok || !res.body) {
+                    // Non-404 error: reset the counter so interleaved 5xx responses
+                    // during a rolling restart don't accumulate toward the 404 threshold.
+                    notFoundRetries = 0;
                     log.warn(`[${CHANNEL_ID}] SSE ${res.status} — retry 5s`);
                     await new Promise((r) => setTimeout(r, 5000));
                     continue;

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/dist/src/channel/route.js
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/dist/src/channel/route.js
@@ -31,6 +31,9 @@ export function routeMessage(cfg, msg, ownMessageIds) {
         msg.message_type === "coordination_start") {
         return routeJoin(msg);
     }
+    if (msg.message_type === "room_deleted") {
+        return formatRoomDeleted(cfg, msg);
+    }
     return routeBroadcast(cfg, msg);
 }
 // ── Tick ──────────────────────────────────────────────────────────────────
@@ -370,6 +373,22 @@ export function routeBroadcast(cfg, msg) {
         agentId,
         sender,
         content,
+        messageId: msg.id,
+    }));
+}
+// ── Room deleted ───────────────────────────────────────────────────────────
+export function formatRoomDeleted(cfg, msg) {
+    const room = msg.room ?? msg.room_name ?? cfg.room;
+    const instruction = [
+        `[Room Deleted] The room "${room}" has been removed from the backend.`,
+        "Your subscription to this room is now ending — save any in-progress work",
+        "and prepare to disconnect. You will not receive further messages from this room.",
+    ].join(" ");
+    return cfg.agents.map((agentId) => ({
+        kind: "dispatch",
+        agentId,
+        sender: "Mycelium",
+        content: instruction,
         messageId: msg.id,
     }));
 }

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/room-sse.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/room-sse.ts
@@ -25,6 +25,11 @@ export function startRoomSSE(
   const signal = abort.signal;
   const sseUrl = `${cfg.backendUrl}/api/rooms/${encodeURIComponent(cfg.room)}/messages/stream`;
 
+  // Tombstone only after this many consecutive 404s — mirrors the Python daemon's
+  // _404_MAX_RETRIES logic so both delivery paths behave identically on deletion.
+  const NOT_FOUND_MAX_RETRIES = 3;
+  let notFoundRetries = 0;
+
   (async () => {
     while (!signal.aborted) {
       try {
@@ -33,9 +38,18 @@ export function startRoomSSE(
           signal,
         });
         if (res.status === 404) {
-          log.warn(`[${CHANNEL_ID}] room SSE 404 for ${cfg.room} — room may not exist yet, retry 15s`);
-          await new Promise((r) => setTimeout(r, 15_000));
-          continue;
+          notFoundRetries++;
+          if (notFoundRetries < NOT_FOUND_MAX_RETRIES) {
+            log.warn(
+              `[${CHANNEL_ID}] room SSE 404 for ${cfg.room} (attempt ${notFoundRetries}/${NOT_FOUND_MAX_RETRIES}) — retry 15s`,
+            );
+            await new Promise((r) => setTimeout(r, 15_000));
+            continue;
+          }
+          log.warn(
+            `[${CHANNEL_ID}] room SSE 404 for ${cfg.room} after ${notFoundRetries} attempts — room deleted, stopping`,
+          );
+          return;
         }
         if (!res.ok || !res.body) {
           log.warn(`[${CHANNEL_ID}] SSE ${res.status} — retry 5s`);
@@ -43,6 +57,7 @@ export function startRoomSSE(
           continue;
         }
 
+        notFoundRetries = 0;
         log.info(
           `[${CHANNEL_ID}] SSE connected: ${cfg.room} (agents: ${cfg.agents.join(", ")})`,
         );

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/room-sse.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/room-sse.ts
@@ -52,6 +52,9 @@ export function startRoomSSE(
           return;
         }
         if (!res.ok || !res.body) {
+          // Non-404 error: reset the counter so interleaved 5xx responses
+          // during a rolling restart don't accumulate toward the 404 threshold.
+          notFoundRetries = 0;
           log.warn(`[${CHANNEL_ID}] SSE ${res.status} — retry 5s`);
           await new Promise((r) => setTimeout(r, 5000));
           continue;

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/room-sse.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/room-sse.ts
@@ -72,6 +72,14 @@ export function startRoomSSE(
             }
 
             handleMessage(runtime, cfg, msg, log);
+            // Stop the subscription loop permanently on room deletion.
+            // The room no longer exists on the hub; retrying would 404-loop.
+            if (msg.message_type === "room_deleted") {
+              log.info(
+                `[${CHANNEL_ID}] room "${cfg.room}" deleted — stopping SSE subscription`,
+              );
+              return;
+            }
           }
         }
       } catch (err: any) {

--- a/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/route.ts
+++ b/mycelium-cli/src/mycelium/integrations/openclaw/assets/mycelium/plugin/src/channel/route.ts
@@ -75,6 +75,10 @@ export function routeMessage(
     return routeJoin(msg);
   }
 
+  if (msg.message_type === "room_deleted") {
+    return formatRoomDeleted(cfg, msg);
+  }
+
   return routeBroadcast(cfg, msg);
 }
 
@@ -471,6 +475,24 @@ export function routeBroadcast(cfg: ChannelConfig, msg: any): RouteAction[] {
     agentId,
     sender,
     content,
+    messageId: msg.id,
+  }));
+}
+
+// ── Room deleted ───────────────────────────────────────────────────────────
+
+export function formatRoomDeleted(cfg: ChannelConfig, msg: any): RouteAction[] {
+  const room = msg.room ?? msg.room_name ?? cfg.room;
+  const instruction = [
+    `[Room Deleted] The room "${room}" has been removed from the backend.`,
+    "Your subscription to this room is now ending — save any in-progress work",
+    "and prepare to disconnect. You will not receive further messages from this room.",
+  ].join(" ");
+  return cfg.agents.map((agentId) => ({
+    kind: "dispatch" as const,
+    agentId,
+    sender: "Mycelium",
+    content: instruction,
     messageId: msg.id,
   }));
 }


### PR DESCRIPTION
## Summary

- **Hub**: fires a `room_deleted` SSE tombstone after the DB commit (`rooms.py:_notify_room_deleted`), so spoke daemons and OpenClaw agents are notified the moment deletion is committed
- **Daemon (Python path)**: `subscribe_room` handles `room_deleted` events and bounded 404 retries (3 × 15 s) via `_handle_room_deleted`, which sets the tombstone, optionally removes the local directory (when `auto_gc_orphaned_rooms = true`), updates `daemon.toml`, and unregisters adapter configs — all in one canonical place
- **OpenClaw (TS path)**: `room-sse.ts` matches the Python 404-retry logic; `route.ts` dispatches a human-readable cleanup instruction to each agent on `room_deleted`; both delivery paths behave identically
- **Startup reconcile**: `reconcile_local_rooms` catches rooms deleted while the spoke was offline, seeds `state.rooms_deleted` before any SSE tasks are created, and filters `rooms_configured` so the health endpoint never reports orphaned rooms
- **`mycelium room gc`**: new CLI command to list or prune orphaned local room directories; uses paginated bulk GET to avoid N+1 hub requests; `--json` output is clean (all human-readable `secho` calls gated on `not json_output`)
- **`mycelium doctor`**: `check_orphaned_rooms` implemented with the same paginated bulk fetch; uses `get_mycelium_dir()` so `MYCELIUM_DATA_DIR` is respected
- **Tombstone invariant**: tombstones are set by 404-after-retries, `room_deleted` events, or startup reconcile — never cleared at hot-reload, only on daemon restart when a fresh reconcile can confirm hub status with a live request
- **Rolling-restart safety**: 404 retry counter resets on any non-404 ≥ 400 response so interleaved 5xx responses don't accumulate toward the deletion threshold (both Python and TS paths)

## Test plan

- [ ] Delete a hub room while spoke daemon is running — verify daemon logs `room_deleted received`, removes dir if `auto_gc_orphaned_rooms = true`, removes room from daemon.toml, daemon SIGHUP causes health to no longer list it
- [ ] Delete a hub room while spoke is offline — restart daemon, verify `reconcile_local_rooms` detects orphan, seeds tombstone, no 404-retry SSE task spawned
- [ ] Simulate rolling restart (hub returns 500 then 404) — verify 404 counter resets on 500, daemon does not tombstone prematurely
- [ ] Run `mycelium room gc` with and without `--prune-orphans` and `--json` — verify JSON output contains no stray text
- [ ] Run `mycelium doctor` — verify `check_orphaned_rooms` lists orphans without N+1 requests
- [ ] OpenClaw: delete a room — verify agents receive the `room_deleted` instruction string, SSE loop exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)