### PR TITLE
chore: rename the SLIM+L9 golden fixture to contracts/slim-l9-wire.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,11 +156,11 @@ aligner's Pi brain and the plan compiler are the LLM consumers.
   consensus is `commit:converged|rejected`, with episode URNs and causal
   `message.parents`. The subkind table lives in `app/services/l9.py:VALID_SUBKINDS`
   and is SLIM-native (`converged|resolved|rejected`).
-- **CLI/backend SLIM+L9 duplication is guarded by a golden test.** The thin `uv
+- **CLI/backend SLIM+L9 duplication is guarded by a contract test.** The thin `uv
   tool` CLI can't import the backend, so `mycelium/slim/` copies the SLIM+L9
-  primitives. `slim-l9-golden.json` (repo root) freezes the shared wire constants;
-  both `fastapi-backend/tests/test_slim_l9_golden.py` and
-  `mycelium-cli/tests/test_slim_l9_golden.py` assert against it, so neither copy can
+  primitives. `contracts/slim-l9-wire.json` freezes the shared wire constants;
+  both `fastapi-backend/tests/test_slim_l9_wire.py` and
+  `mycelium-cli/tests/test_slim_l9_wire.py` assert against it, so neither copy can
   drift without a red unit gate.
 - **SLIM security is a shared-secret PSK today (D1).** The group key derives from
   `MYCELIUM_SLIM_MASTER_SECRET` (set the same on every host that shares rooms);

--- a/contracts/slim-l9-wire.json
+++ b/contracts/slim-l9-wire.json
@@ -1,6 +1,6 @@
 {
   "_comment": [
-    "Frozen SLIM+L9 wire-compat golden constants — the single source of truth both",
+    "Frozen SLIM+L9 wire-compat contract constants — the single source of truth both",
     "the FastAPI backend (fastapi-backend/app/services/{slim_client,l9,l9_slim}.py)",
     "and the CLI daemon (mycelium-cli/src/mycelium/slim/{naming,client,l9}.py +",
     "daemon/connector.py) MUST reproduce byte-for-byte. See D2 in",
@@ -12,8 +12,8 @@
     "to the shared wire shape is genuinely intended, update this file deliberately in",
     "the same PR and both suites will re-lock to the new value.",
     "",
-    "Tests: fastapi-backend/tests/test_slim_l9_golden.py,",
-    "mycelium-cli/tests/test_slim_l9_golden.py"
+    "Tests: fastapi-backend/tests/test_slim_l9_wire.py,",
+    "mycelium-cli/tests/test_slim_l9_wire.py"
   ],
 
   "master_secret": "mycelium-dev-shared-secret-v1-do-not-use-in-prod",
@@ -40,7 +40,7 @@
   },
 
   "envelope": {
-    "_comment": "A golden serialized L9 'exchange' reply content dict. The backend produces this via l9.envelope_to_dict(l9.build_envelope(kind=exchange, ...)); the CLI produces the same dict via l9.build_reply_content(...). The two serializers must agree byte-for-byte or a connector's reply fails the backend persister's parse_envelope.",
+    "_comment": "A frozen serialized L9 'exchange' reply content dict. The backend produces this via l9.envelope_to_dict(l9.build_envelope(kind=exchange, ...)); the CLI produces the same dict via l9.build_reply_content(...). The two serializers must agree byte-for-byte or a connector's reply fails the backend persister's parse_envelope.",
     "inputs": {
       "sender": "alice",
       "recipients": ["bob"],
@@ -82,7 +82,7 @@
   },
 
   "knowledge": {
-    "_comment": "A golden serialized L9 'knowledge:distillation' envelope — the memory-sync wire shape (Step 8, bible §11). The backend PRODUCES it via memory_sync.build_knowledge_envelope(room, write, recipients) + KnowledgeWrite.to_payload() (serialized with l9.envelope_to_dict); the CLI daemon PARSES it via slim/l9.payload_data_of and applies it in daemon/connector.apply_knowledge_message. The two must agree byte-for-byte on the payload.data write fields or cross-machine memory sync (Step 9) silently drifts. build_knowledge_envelope mints a fresh random message.id per call, so 'expected_envelope.header.message.id' is the sentinel 'MESSAGE_ID_PLACEHOLDER' — the backend test normalizes the produced id to it before comparing (the id is not part of the shared contract; every other field is).",
+    "_comment": "A frozen serialized L9 'knowledge:distillation' envelope — the memory-sync wire shape (Step 8, bible §11). The backend PRODUCES it via memory_sync.build_knowledge_envelope(room, write, recipients) + KnowledgeWrite.to_payload() (serialized with l9.envelope_to_dict); the CLI daemon PARSES it via slim/l9.payload_data_of and applies it in daemon/connector.apply_knowledge_message. The two must agree byte-for-byte on the payload.data write fields or cross-machine memory sync (Step 9) silently drifts. build_knowledge_envelope mints a fresh random message.id per call, so 'expected_envelope.header.message.id' is the sentinel 'MESSAGE_ID_PLACEHOLDER' — the backend test normalizes the produced id to it before comparing (the id is not part of the shared contract; every other field is).",
     "room": "acme",
     "recipients": ["bob"],
     "message_id_placeholder": "MESSAGE_ID_PLACEHOLDER",

--- a/fastapi-backend/tests/test_slim_l9_wire.py
+++ b/fastapi-backend/tests/test_slim_l9_wire.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Golden drift guard for the shared SLIM+L9 wire primitives (backend side).
+"""Contract drift guard for the shared SLIM+L9 wire primitives (backend side).
 
 The CLI daemon
 (``mycelium-cli/src/mycelium/slim/*``) carries a copy of these primitives so the
@@ -10,10 +10,10 @@ silently — a diverging ``mint_shared_secret`` / master secret / ``workspace/ro
 scope / envelope shape / URN form means MLS group keys mismatch and connectors
 **silently can't join**, or messages get dropped/misrouted (no app-level error).
 
-This test freezes the shared wire constants in ``slim-l9-golden.json`` at the
+This test freezes the shared wire constants in ``contracts/slim-l9-wire.json`` at the
 repo root and asserts the **backend** primitives reproduce them exactly. The CLI
 suite asserts its own copy against the *same* file
-(``mycelium-cli/tests/test_slim_l9_golden.py``). One frozen source, two
+(``mycelium-cli/tests/test_slim_l9_contract.py``). One frozen source, two
 asserters — so neither copy can move without turning this fast unit gate red
 (no live SLIM node required).
 """
@@ -36,20 +36,20 @@ from app.services.slim_client import (
     mint_shared_secret,
 )
 
-_GOLDEN_PATH = Path(__file__).resolve().parent.parent.parent / "slim-l9-golden.json"
+_CONTRACT_PATH = Path(__file__).resolve().parent.parent.parent / "contracts" / "slim-l9-wire.json"
 
 
-def _golden() -> dict:
-    return json.loads(_GOLDEN_PATH.read_text(encoding="utf-8"))
+def _contract() -> dict:
+    return json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
 
 
-def test_golden_file_present():
-    assert _GOLDEN_PATH.is_file(), f"missing shared golden file at {_GOLDEN_PATH}"
+def test_contract_file_present():
+    assert _CONTRACT_PATH.is_file(), f"missing shared contract file at {_CONTRACT_PATH}"
 
 
-def test_shared_constants_match_golden():
+def test_shared_constants_match_contract():
     """The literals the shared secret + naming derive from are frozen."""
-    g = _golden()
+    g = _contract()
     assert g["master_secret"] == _DEV_MASTER_SECRET
     assert g["channel_topic"] == DEFAULT_CHANNEL_TOPIC
     assert g["min_secret_len"] == MIN_SECRET_LEN
@@ -57,23 +57,23 @@ def test_shared_constants_match_golden():
     assert g["node_port"] == DEFAULT_NODE_PORT
 
 
-def test_mint_shared_secret_matches_golden_digest():
+def test_mint_shared_secret_matches_contract_digest():
     """The exact HMAC digest a member/moderator derive for a known room."""
-    g = _golden()["shared_secret"]
+    g = _contract()["shared_secret"]
     identity = SlimIdentity(g["workspace"], g["room"], g["agent"])
     assert mint_shared_secret(identity) == g["expected_digest"]
 
 
-def test_episode_and_topic_urns_match_golden():
+def test_episode_and_topic_urns_match_contract():
     """The episode/topic URN forms the connector must mirror."""
-    g = _golden()["urn"]
+    g = _contract()["urn"]
     assert l9.episode_urn(g["room"], g["session"]) == g["expected_episode"]
     assert l9.topic_urn(g["room"]) == g["expected_topic"]
 
 
-def test_exchange_envelope_serializes_to_golden():
-    """The backend's serialized exchange envelope is byte-for-byte the golden."""
-    g = _golden()["envelope"]
+def test_exchange_envelope_serializes_to_contract():
+    """The backend's serialized exchange envelope is byte-for-byte the contract."""
+    g = _contract()["envelope"]
     i = g["inputs"]
     envelope = l9.build_envelope(
         kind=Kind.exchange,
@@ -92,17 +92,17 @@ def test_exchange_envelope_serializes_to_golden():
     assert content == g["expected_content"]
 
 
-def test_knowledge_envelope_serializes_to_golden():
-    """The backend's serialized ``knowledge:distillation`` envelope is the golden.
+def test_knowledge_envelope_serializes_to_contract():
+    """The backend's serialized ``knowledge:distillation`` envelope is the contract.
 
     The memory-sync wire shape: ``build_knowledge_envelope``
     wraps a :class:`KnowledgeWrite` as a ``knowledge:distillation`` envelope the CLI
     daemon parses and applies. ``build_knowledge_envelope`` mints a fresh random
     ``message.id`` per call (it is not part of the shared contract), so the produced
-    id is normalized to the golden's placeholder before the byte-for-byte compare;
+    id is normalized to the contract's placeholder before the byte-for-byte compare;
     every other field must match exactly.
     """
-    g = _golden()["knowledge"]
+    g = _contract()["knowledge"]
     w = g["write"]
     write = KnowledgeWrite(
         key=w["key"],
@@ -127,11 +127,11 @@ def test_knowledge_envelope_serializes_to_golden():
     assert produced == g["expected_envelope"]
 
 
-def test_channel_name_topic_matches_golden():
+def test_channel_name_topic_matches_contract():
     """A room channel's app segment is the frozen default topic."""
     pytest.importorskip("slim_bindings")
     from app.services.slim_client import to_channel_name
 
-    g = _golden()
+    g = _contract()
     name = to_channel_name("acme", "planning")
     assert name.components() == ["acme", "planning", g["channel_topic"]]

--- a/fastapi-backend/tests/test_slim_master_secret.py
+++ b/fastapi-backend/tests/test_slim_master_secret.py
@@ -54,6 +54,6 @@ def test_require_secret_satisfied_by_real_secret(monkeypatch):
 
 
 def test_explicit_master_secret_still_honoured(monkeypatch):
-    """An explicit argument bypasses env resolution (used by the golden test)."""
+    """An explicit argument bypasses env resolution (used by the contract test)."""
     monkeypatch.setenv("MYCELIUM_SLIM_MASTER_SECRET", "ignored")
     assert mint_shared_secret(_ID, master_secret="explicit") == _expected("explicit")

--- a/mycelium-cli/tests/test_slim_l9_wire.py
+++ b/mycelium-cli/tests/test_slim_l9_wire.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Golden drift guard for the shared SLIM+L9 wire primitives (CLI side).
+"""Contract drift guard for the shared SLIM+L9 wire primitives (CLI side).
 
 The CLI daemon carries its own copy of the SLIM+L9 primitives
 (``mycelium.slim.{naming,client,l9}`` + ``daemon.connector`` URN helpers) so the
@@ -11,7 +11,7 @@ shape / URN form means MLS group keys mismatch and this connector **silently
 can't join** the backend moderator's group, or its replies get dropped/misrouted
 (no app-level error).
 
-This test freezes the shared wire constants in ``slim-l9-golden.json`` at the
+This test freezes the shared wire constants in ``contracts/slim-l9-wire.json`` at the
 repo root and asserts the **CLI** primitives reproduce them exactly, preventing
 silent wire-contract drift (no live SLIM node required).
 """
@@ -34,20 +34,20 @@ from mycelium.slim.naming import (
     mint_shared_secret,
 )
 
-_GOLDEN_PATH = Path(__file__).resolve().parent.parent.parent / "slim-l9-golden.json"
+_CONTRACT_PATH = Path(__file__).resolve().parent.parent.parent / "contracts" / "slim-l9-wire.json"
 
 
-def _golden() -> dict:
-    return json.loads(_GOLDEN_PATH.read_text(encoding="utf-8"))
+def _contract() -> dict:
+    return json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
 
 
-def test_golden_file_present():
-    assert _GOLDEN_PATH.is_file(), f"missing shared golden file at {_GOLDEN_PATH}"
+def test_contract_file_present():
+    assert _CONTRACT_PATH.is_file(), f"missing shared contract file at {_CONTRACT_PATH}"
 
 
-def test_shared_constants_match_golden():
+def test_shared_constants_match_contract():
     """The literals the shared secret + naming derive from are frozen."""
-    g = _golden()
+    g = _contract()
     assert g["master_secret"] == _DEV_MASTER_SECRET
     assert g["workspace"] == DEFAULT_WORKSPACE
     assert g["channel_topic"] == DEFAULT_CHANNEL_TOPIC
@@ -56,23 +56,23 @@ def test_shared_constants_match_golden():
     assert g["node_port"] == DEFAULT_NODE_PORT
 
 
-def test_mint_shared_secret_matches_golden_digest():
+def test_mint_shared_secret_matches_contract_digest():
     """The exact HMAC digest a connector derives for a known room."""
-    g = _golden()["shared_secret"]
+    g = _contract()["shared_secret"]
     identity = SlimIdentity(g["workspace"], g["room"], g["agent"])
     assert mint_shared_secret(identity) == g["expected_digest"]
 
 
-def test_episode_and_topic_urns_match_golden():
+def test_episode_and_topic_urns_match_contract():
     """The connector's episode/topic URN forms match the backend's."""
-    g = _golden()["urn"]
+    g = _contract()["urn"]
     assert _room_episode(g["room"]) == g["expected_episode"]
     assert _room_topic(g["room"]) == g["expected_topic"]
 
 
-def test_exchange_reply_serializes_to_golden():
-    """The connector's serialized exchange reply is byte-for-byte the golden."""
-    g = _golden()["envelope"]
+def test_exchange_reply_serializes_to_contract():
+    """The connector's serialized exchange reply is byte-for-byte the contract."""
+    g = _contract()["envelope"]
     i = g["inputs"]
     content = l9.build_reply_content(
         sender=i["sender"],
@@ -87,18 +87,18 @@ def test_exchange_reply_serializes_to_golden():
     assert content == g["expected_content"]
 
 
-def test_knowledge_envelope_parses_to_golden_write():
+def test_knowledge_envelope_parses_to_contract_write():
     """The connector parses the backend's ``knowledge:distillation`` envelope.
 
     Guards the *parse* half of the memory-sync contract: given
-    the exact envelope the backend produces (frozen in the golden), the CLI's
+    the exact envelope the backend produces (frozen in the contract), the CLI's
     ``l9.kind_of`` / ``l9.payload_data_of`` — the two the connector's
     ``apply_knowledge_message`` reads through — must recover every carried write
     field byte-for-byte. If the backend's produced shape and this parse ever drift,
     this gate goes red instead of silently breaking cross-machine memory sync.
     """
-    g = _golden()["knowledge"]
-    # The content dict a connector receives on the wire: the golden envelope under
+    g = _contract()["knowledge"]
+    # The content dict a connector receives on the wire: the contract envelope under
     # the additive ``l9`` key. (``content`` is empty — a knowledge push carries its
     # payload in ``l9.payload.data``, not the human-text field.)
     content = {"content": "", "l9": g["expected_envelope"]}
@@ -116,11 +116,11 @@ def test_knowledge_envelope_parses_to_golden_write():
     assert data["updated_at"] == w["updated_at"]
 
 
-def test_channel_name_topic_matches_golden():
+def test_channel_name_topic_matches_contract():
     """A room channel's app segment is the frozen default topic."""
     pytest.importorskip("slim_bindings")
     from mycelium.slim.naming import to_channel_name
 
-    g = _golden()
+    g = _contract()
     name = to_channel_name("acme", "planning")
     assert name.components() == ["acme", "planning", g["channel_topic"]]


### PR DESCRIPTION
`slim-l9-golden.json` sat loose in the repo root and used "golden" (standard golden-master/snapshot jargon, but noisy). Move it into a self-documenting `contracts/` dir and name it for what it is — a **cross-package wire contract** that keeps the backend's and CLI's duplicated SLIM+L9 primitives from silently drifting.

- `slim-l9-golden.json` → `contracts/slim-l9-wire.json`
- `test_slim_l9_golden.py` → `test_slim_l9_wire.py` (backend + CLI) + internal `_CONTRACT_PATH`/`_contract()`/`test_*_contract_*` renames
- path resolution, `CLAUDE.md`, the fixture's own comments, and one docstring updated

Pure rename, the guard is unchanged. Both contract suites pass (7 + 7).