### PR TITLE
Shared test-support layer: fakes/fixtures for fast in-process testing (#460)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
         working-directory: fastapi-backend
         run: uv run ty check .
 
+      # Fast gate: the core protocol (room -> engine -> await -> respond ->
+      # converge -> plan) over the fake stack — no node, no LLM. Runs first so a
+      # broken happy path fails in seconds, ahead of the full suite.
+      - name: Smoke (fake stack)
+        working-directory: fastapi-backend
+        run: uv run pytest -m smoke -q
+
       - name: Unit tests
         working-directory: fastapi-backend
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+# Mycelium test targets.
+#
+# One command to validate a change without standing up the real stack. Every
+# target here runs against local files + in-process fakes — no SLIM node, no Pi
+# binary, no live LLM, no backend server. See fastapi-backend/tests/README.md and
+# mycelium-cli/tests/README.md for how the fakes work.
+
+.PHONY: help test test-backend test-cli test-frontend smoke lint
+
+help:
+	@echo "Targets:"
+	@echo "  make test           Run the backend + CLI unit suites (node-free)"
+	@echo "  make test-backend   Backend unit tests (fastapi-backend)"
+	@echo "  make test-cli       CLI unit tests (mycelium-cli)"
+	@echo "  make test-frontend  Frontend unit tests (mycelium-frontend, vitest)"
+	@echo "  make smoke          Fast end-to-end happy-path over the fake stack"
+	@echo "  make lint           Ruff + ty gate for backend and CLI"
+
+# The fast gate an agent runs before pushing: both Python unit suites.
+test: test-backend test-cli
+
+test-backend:
+	cd fastapi-backend && uv run pytest tests/ -q
+
+test-cli:
+	cd mycelium-cli && uv run pytest tests/ -q
+
+test-frontend:
+	cd mycelium-frontend && pnpm test
+
+# room -> engine -> await -> respond -> converge -> plan, all over fakes.
+smoke:
+	cd fastapi-backend && uv run pytest -m smoke -q
+
+lint:
+	cd fastapi-backend && uv run ruff check . && uv run ruff format --check . && uv run ty check .
+	cd mycelium-cli && uv run ruff check . && uv run ruff format --check . && uv run ty check .

--- a/fastapi-backend/pytest.ini
+++ b/fastapi-backend/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 asyncio_mode = auto
 testpaths = tests
+markers =
+    smoke: fast end-to-end happy-path check over the fake stack (no node, no LLM)

--- a/fastapi-backend/tests/README.md
+++ b/fastapi-backend/tests/README.md
@@ -1,0 +1,56 @@
+# Backend tests
+
+Unit tests run against local files + temp dirs — **no SLIM node, no Pi binary, no
+live LLM, no backend server.** `conftest.py` isolates every test (a temp
+`MYCELIUM_DATA_DIR`, a reset in-memory `local_state`); `fakes.py` gives you the
+fake coordination stack.
+
+## Test a feature without a live stack
+
+Import the fakes you need from `tests.fakes` and wire them into the service under
+test. There is exactly one of each fake — don't re-declare them per file.
+
+| You're testing… | Import | It stands in for |
+| --- | --- | --- |
+| The aligner / mediator driving a negotiation | `FakeChannel`, `FakePersister`, `FakeManaged`, `FakeManager` | the SLIM channel + persister + `RoomChannelManager` |
+| The mediator's LLM decisions | `make_fake_llm` / `fake_brain_factory` | the Pi brain (`AlignerEngine`'s `brain_factory` seam) |
+| `room_channels` provisioning / membership | `FakeSlimClient`, `FakeSession` | `slim_client.SlimClient` (the `slim_bindings` transport) |
+| `PiBrain.__call__` without spawning `pi` | `patch_pi_run(monkeypatch, stdout=…)` | `subprocess.run` / `shutil.which` |
+
+### Example — drive the SAO mediator to agreement, node-free
+
+```python
+from tests.fakes import FakeChannel, FakePersister, FakeManaged, FakeManager, fake_brain_factory
+
+persister = FakePersister()
+channel = FakeChannel(persister, reply_conf=0.9)   # every prompt draws a reply
+managed = FakeManaged("room", "mycelium", channel, persister)
+manager = FakeManager(managed, ["growth", "risk", "aligner"])
+
+engine = aligner.AlignerEngine(manager, handle="aligner", brain_factory=fake_brain_factory)
+verdict = await engine.mediate("room")   # converges without a node or an LLM
+```
+
+### Example — provision a room channel against a fake node
+
+```python
+from app.services import room_channels
+from tests.fakes import FakeSlimClient
+
+monkeypatch.setattr(room_channels, "SlimClient", FakeSlimClient)
+monkeypatch.setattr(room_channels, "node_reachable", lambda _e: True)
+monkeypatch.setattr(room_channels, "to_channel_name", lambda *a: object())
+monkeypatch.setattr(room_channels, "to_slim_name", lambda *a: object())
+```
+
+## Live-node / live-LLM slices
+
+The SLIM roundtrip slices need a reachable node and **skip** without one — set
+`MYCELIUM_SLIM_ENDPOINT`. Live-LLM tests are guarded by `MYCELIUM_LLM_TESTS=1`.
+
+## Commands
+
+```bash
+uv run pytest tests/ -x -q
+uv run ruff check . && uv run ruff format . && uv run ty check .
+```

--- a/fastapi-backend/tests/fakes.py
+++ b/fastapi-backend/tests/fakes.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Shared in-process fakes for the backend test suite.
+
+One import gets you a fake coordination stack — no SLIM node, no Pi binary, no
+live LLM. These used to be re-declared per test file (``_FakeChannel`` /
+``_FakePersister`` / ``_FakeManager`` in ``test_aligner`` and ``test_plan_sync``,
+the deterministic ``_fake_llm`` in ``test_mediator``, ``_patch_run`` in
+``test_pi_brain``); this module is the single home for them.
+
+What stands in for what:
+
+* :class:`FakeSlimClient` / :class:`FakeSession` — the ``slim_bindings`` transport
+  (``app.services.slim_client.SlimClient``), so ``room_channels`` provisioning /
+  membership / channel lifecycle run without a node.
+* :class:`FakeChannel` — an ``L9SlimChannel`` (``app.services.l9_slim``): records
+  broadcasts and can simulate a prompted participant replying.
+* :class:`FakePersister` — the transcript side of ``RoomPersister``
+  (``app.services.persister``): a ``DeliveryLog`` plus ``ingest_local``.
+* :class:`FakeManaged` / :class:`FakeManager` — ``ManagedRoomChannel`` /
+  ``RoomChannelManager`` (``app.services.room_channels``).
+* :func:`make_fake_llm` / :func:`fake_brain_factory` — the mediator's Pi brain
+  seam (``brain_factory`` on ``AlignerEngine``), a deterministic prompt-keyed stub.
+* :func:`patch_pi_run` — mock ``subprocess.run`` / ``shutil.which`` so ``PiBrain``
+  never spawns a real ``pi``.
+
+See ``tests/README.md`` for the "test a feature without a live stack" recipe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from app.services import l9
+from app.services.l9_models import Kind
+from app.services.l9_slim import serialize_content
+from app.services.persister import DeliveryLog, TranscriptRecord, record_from
+
+if TYPE_CHECKING:
+    import pytest
+
+# The default room the simulated participant replies are stamped for. The
+# mediator threads replies by message parents/recipients, not by episode URN, so
+# a fake reply carrying this room's episode is read correctly even in a
+# negotiation over a differently-named room (this preserves the historical
+# behavior when these fakes lived in ``test_aligner``).
+DEFAULT_ROOM = "align-room"
+EPISODE = l9.episode_urn(DEFAULT_ROOM, "live")
+TOPIC = l9.topic_urn(DEFAULT_ROOM)
+
+
+def position_record(
+    sender: str,
+    *,
+    confidence: float | None = None,
+    action: str = "accept",
+    role: str = "agent",
+    payload_type: str = "reply",
+    message_id: str | None = None,
+    episode: str = EPISODE,
+    topic: str = TOPIC,
+) -> TranscriptRecord:
+    """An agent-position transcript record carrying an epistemic payload."""
+    data: dict[str, Any] = {"action": action}
+    if confidence is not None:
+        data["confidence"] = confidence
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=episode,
+        sender=sender,
+        sender_role=role,
+        recipients=[l9.SYSTEM_ACTOR_ID],
+        topic=topic,
+        payload_type=payload_type,
+        payload_data=data,
+        message_id=message_id,
+    )
+    return record_from(env, serialize_content(env, extra={"content": f"{sender} position"}))
+
+
+# ── L9 channel + persister (the aligner/plan-sync/mediator layer) ─────────────
+
+
+class FakeChannel:
+    """Records broadcasts; optionally simulates a prompted participant replying.
+
+    Stands in for ``app.services.l9_slim.L9SlimChannel``. With ``reply_conf`` set,
+    every ``exchange`` prompt draws a simulated reply from each addressed actor
+    into the paired persister's log — enough to drive the SAO mediator to
+    agreement node-free (see ``test_mediator``).
+    """
+
+    def __init__(
+        self, persister: FakePersister | None = None, reply_conf: float | None = None
+    ) -> None:
+        self.sent: list[tuple[Any, dict[str, Any] | None]] = []
+        self._persister = persister
+        self._reply_conf = reply_conf
+        self._reply_seq = 0
+
+    async def send(self, envelope: Any, *, extra: dict[str, Any] | None = None) -> None:
+        self.sent.append((envelope, extra))
+        # Only exchange prompts trigger a simulated reply — never the commit.
+        if self._reply_conf is None or envelope.header.kind != Kind.exchange:
+            return
+        assert self._persister is not None
+        for actor in envelope.header.participants.actors[1:]:
+            self._reply_seq += 1
+            self._persister.log.record(
+                position_record(
+                    actor.id, confidence=self._reply_conf, message_id=f"reply-{self._reply_seq}"
+                ),
+                delivered_to=set(),
+            )
+
+
+class FakePersister:
+    """The transcript side of ``RoomPersister``: a log plus ``ingest_local``."""
+
+    def __init__(self, records: list[TranscriptRecord] | None = None) -> None:
+        self.log = DeliveryLog(records or [])
+        self.ingested: list[tuple[Any, dict[str, Any]]] = []
+
+    def ingest_local(self, envelope: Any, content: dict[str, Any]) -> None:
+        self.ingested.append((envelope, content))
+
+
+@dataclass
+class FakeManaged:
+    """Stands in for ``room_channels.ManagedRoomChannel`` (room + channel state)."""
+
+    room: str = DEFAULT_ROOM
+    workspace: str = "mycelium"
+    channel: Any = None
+    persister: Any = None
+
+
+class FakeManager:
+    """Just enough of ``RoomChannelManager`` for the aligner + plan-sync consumers.
+
+    Two construction styles are supported so the one fake serves both callers:
+
+    * ``FakeManager(managed, members)`` — the aligner/mediator style, with an
+      explicit managed channel and roster.
+    * ``FakeManager(live=False)`` — the plan-sync style, which builds a default
+      managed channel wrapping a fresh :class:`FakeChannel` (or ``None`` when not
+      ``live``) and exposes it as ``.channel``.
+    """
+
+    def __init__(
+        self,
+        managed: FakeManaged | None = None,
+        members: list[str] | None = None,
+        *,
+        live: bool = True,
+    ) -> None:
+        if managed is None:
+            self.channel = FakeChannel()
+            managed = FakeManaged(channel=self.channel) if live else None
+        else:
+            self.channel = getattr(managed, "channel", None)
+        self._managed = managed
+        self._members = list(members) if members is not None else ["a", "b"]
+        self.opened: list[str] = []
+        self.closed: list[str] = []
+
+    def get(self, room: str) -> FakeManaged | None:
+        return self._managed
+
+    def members(self, room: str) -> list[str]:
+        return list(self._members)
+
+    def open_episode(self, room: str, episode: str) -> bool:
+        self.opened.append(episode)
+        return True
+
+    async def close_episode(self, room: str) -> bool:
+        self.closed.append(room)
+        return True
+
+
+# ── the SLIM transport (room_channels / slim_client layer) ────────────────────
+
+
+@dataclass
+class FakeSession:
+    """A stand-in for a ``slim_bindings`` group session.
+
+    Records what the moderator did to it (invites, removes, broadcasts) so
+    ``room_channels`` provisioning/membership can be asserted without a node.
+    """
+
+    channel: Any = None
+    published: list[bytes] = field(default_factory=list)
+    invited: list[Any] = field(default_factory=list)
+    removed: list[Any] = field(default_factory=list)
+
+    async def publish_async(self, data: bytes, *_a: Any, **_k: Any) -> None:
+        self.published.append(data)
+
+
+class FakeSlimClient:
+    """A minimal in-process stand-in for ``slim_client.SlimClient``.
+
+    Covers both roles the real client plays:
+
+    * **Moderator** (backend / ``room_channels``): ``connect`` → ``create_group`` →
+      ``invite`` / ``remove_member`` → ``close``.
+    * **Member** (a replayed inbox): ``listen_for_session`` plus the static
+      ``publish`` / ``receive_message`` the durable-inbox stream sits on.
+
+    Instance state records the lifecycle; ``inbox`` is a class-level scripted
+    queue so a test can preload messages before the client is constructed (mirror
+    of the CLI's ``FakeSlimClient``). Reset it per test with :meth:`reset`.
+    """
+
+    inbox: ClassVar[list[bytes]] = []
+    published: ClassVar[list[bytes]] = []
+
+    def __init__(self, identity: Any, *, secret: str | None = None) -> None:
+        self.identity = identity
+        self.secret = secret
+        self.endpoint: str | None = None
+        self.session: FakeSession | None = None
+        self.closed = False
+
+    @classmethod
+    def reset(cls) -> None:
+        """Clear the class-level scripted inbox/outbox (call between tests)."""
+        cls.inbox = []
+        cls.published = []
+
+    async def connect(self, endpoint: str = "") -> FakeSlimClient:
+        self.endpoint = endpoint
+        return self
+
+    async def create_group(self, channel: Any) -> FakeSession:
+        self.session = FakeSession(channel=channel)
+        return self.session
+
+    async def invite(self, session: FakeSession, member: Any) -> None:
+        session.invited.append(member)
+
+    async def remove_member(self, session: FakeSession, member: Any) -> None:
+        session.removed.append(member)
+
+    async def listen_for_session(self) -> str:
+        return "session-1"
+
+    async def close(self) -> None:
+        self.closed = True
+
+    @staticmethod
+    async def publish(session: Any, data: bytes) -> None:
+        if isinstance(session, FakeSession):
+            session.published.append(data)
+        FakeSlimClient.published.append(data)
+
+    @staticmethod
+    async def receive_message(session: Any, *, timeout_s: float = 30.0) -> Any:
+        from app.services.slim_client import SlimError
+
+        if not FakeSlimClient.inbox:
+            # Simulate a real idle window: block briefly, then report a benign
+            # timeout the reconnecting stream treats as "quiet, still connected".
+            await asyncio.sleep(0.02)
+            raise SlimError("receive timeout")
+        payload = FakeSlimClient.inbox.pop(0)
+
+        class _Msg:
+            def __init__(self, p: bytes) -> None:
+                self.payload = p
+                self.context = None
+
+        return _Msg(payload)
+
+
+# ── the Pi brain / LLM seam ───────────────────────────────────────────────────
+
+
+def make_fake_llm() -> Any:
+    """A deterministic stand-in for the mediator's Pi brain, keyed on the prompt.
+
+    * discovery → one issue ``cap`` with three options;
+    * a propose interpretation → counter to ``cap = 30``;
+    * a respond interpretation → accept;
+    * any broker framing → a short note.
+
+    This is the ``brain_factory`` payload that lets the SAO mediator run
+    node-free and LLM-free (see ``test_mediator``).
+    """
+
+    def _fake_llm(prompt: str, *, system: str = "", temperature: float = 0.3) -> str:
+        if "identify the negotiable ISSUES" in prompt:
+            return json.dumps({"issues": [{"name": "cap", "options": ["25", "30", "35"]}]})
+        if "Interpret @" in prompt:
+            if '"action":"counter"' in prompt:  # proposing schema
+                return json.dumps({"action": "counter", "offer": {"cap": "30"}})
+            return json.dumps({"action": "accept"})  # responding schema
+        return "Everyone is close on the cap; let's lock 30 and move."
+
+    return _fake_llm
+
+
+def fake_brain_factory(_episode: str) -> Any:
+    """A ``brain_factory`` that yields :func:`make_fake_llm` for any episode."""
+    return make_fake_llm()
+
+
+def patch_pi_run(
+    monkeypatch: pytest.MonkeyPatch, *, stdout: str, returncode: int = 0
+) -> list[list[str]]:
+    """Mock ``subprocess.run`` / ``shutil.which`` so ``PiBrain`` never spawns ``pi``.
+
+    Returns the list that captures each argv the brain would have executed.
+    """
+    from app.services import pi_brain
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="boom")
+
+    monkeypatch.setattr(pi_brain.shutil, "which", lambda _b: "/usr/bin/pi")
+    monkeypatch.setattr(pi_brain.subprocess, "run", fake_run)
+    return calls

--- a/fastapi-backend/tests/fakes.py
+++ b/fastapi-backend/tests/fakes.py
@@ -159,6 +159,7 @@ class FakeManager:
         *,
         live: bool = True,
     ) -> None:
+        self.channel: Any
         if managed is None:
             self.channel = FakeChannel()
             managed = FakeManaged(channel=self.channel) if live else None

--- a/fastapi-backend/tests/test_aligner.py
+++ b/fastapi-backend/tests/test_aligner.py
@@ -12,116 +12,20 @@ observe slice is in ``test_l9_over_slim_roundtrip.py`` (guarded on a node).
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 from typing import Any
 
 import pytest
 
 from app.services import aligner, l9
 from app.services.l9_models import Kind
-from app.services.l9_slim import serialize_content
-from app.services.persister import DeliveryLog, TranscriptRecord, record_from
+from tests.fakes import FakeChannel, FakeManaged, FakeManager, FakePersister
 
 _ROOM = "align-room"
 _EPISODE = l9.episode_urn(_ROOM, "live")
 _TOPIC = l9.topic_urn(_ROOM)
 
 
-def _position_record(
-    sender: str,
-    *,
-    confidence: float | None = None,
-    action: str = "accept",
-    role: str = "agent",
-    payload_type: str = "reply",
-    message_id: str | None = None,
-) -> TranscriptRecord:
-    """An agent-position transcript record carrying an epistemic payload."""
-    data: dict[str, Any] = {"action": action}
-    if confidence is not None:
-        data["confidence"] = confidence
-    env = l9.build_envelope(
-        kind=Kind.exchange,
-        episode=_EPISODE,
-        sender=sender,
-        sender_role=role,
-        recipients=[l9.SYSTEM_ACTOR_ID],
-        topic=_TOPIC,
-        payload_type=payload_type,
-        payload_data=data,
-        message_id=message_id,
-    )
-    return record_from(env, serialize_content(env, extra={"content": f"{sender} position"}))
-
-
-# ── fakes ────────────────────────────────────────────────────────────────────
-
-
-class _FakeChannel:
-    """Records broadcasts; optionally simulates a prompted participant replying."""
-
-    def __init__(self, persister: _FakePersister | None = None, reply_conf: float | None = None):
-        self.sent: list[tuple[Any, dict[str, Any] | None]] = []
-        self._persister = persister
-        self._reply_conf = reply_conf
-        self._reply_seq = 0
-
-    async def send(self, envelope: Any, *, extra: dict[str, Any] | None = None) -> None:
-        self.sent.append((envelope, extra))
-        # Only exchange prompts trigger a simulated reply — never the commit.
-        if self._reply_conf is None or envelope.header.kind != Kind.exchange:
-            return
-        assert self._persister is not None
-        for actor in envelope.header.participants.actors[1:]:
-            self._reply_seq += 1
-            self._persister.log.record(
-                _position_record(
-                    actor.id, confidence=self._reply_conf, message_id=f"reply-{self._reply_seq}"
-                ),
-                delivered_to=set(),
-            )
-
-
-class _FakePersister:
-    def __init__(self, records: list[TranscriptRecord] | None = None):
-        self.log = DeliveryLog(records or [])
-        self.ingested: list[tuple[Any, dict[str, Any]]] = []
-
-    def ingest_local(self, envelope: Any, content: dict[str, Any]) -> None:
-        self.ingested.append((envelope, content))
-
-
-@dataclass
-class _FakeManaged:
-    room: str
-    workspace: str
-    channel: Any
-    persister: Any
-
-
-class _FakeManager:
-    def __init__(self, managed: _FakeManaged, members: list[str]):
-        self._managed = managed
-        self._members = members
-        self.opened: list[str] = []
-        self.closed: list[str] = []
-
-    def get(self, room: str) -> _FakeManaged:
-        return self._managed
-
-    def members(self, room: str) -> list[str]:
-        return list(self._members)
-
-    def open_episode(self, room: str, episode: str) -> bool:
-        self.opened.append(episode)
-        return True
-
-    async def close_episode(self, room: str) -> bool:
-        self.closed.append(room)
-        return True
-
-
-def _engine(manager: _FakeManager, **kw: Any) -> aligner.AlignerEngine:
+def _engine(manager: FakeManager, **kw: Any) -> aligner.AlignerEngine:
     kw.setdefault("handle", "aligner")
     kw.setdefault("threshold", 0.6)
     return aligner.AlignerEngine(manager, **kw)  # type: ignore[arg-type]
@@ -132,8 +36,8 @@ def _engine(manager: _FakeManager, **kw: Any) -> aligner.AlignerEngine:
 
 @pytest.mark.asyncio
 async def test_summon_fires_only_for_the_reserved_handle():
-    managed = _FakeManaged(_ROOM, "mycelium", _FakeChannel(), _FakePersister())
-    engine = _engine(_FakeManager(managed, []))
+    managed = FakeManaged(_ROOM, "mycelium", FakeChannel(), FakePersister())
+    engine = _engine(FakeManager(managed, []))
 
     called: list[str] = []
 
@@ -190,8 +94,8 @@ async def test_engine_runtime_host_skips_registered_engine(
         created_by="cli-user",
     )
 
-    managed = _FakeManaged(room, "mycelium", _FakeChannel(), _FakePersister())
-    engine = _engine(_FakeManager(managed, []))
+    managed = FakeManaged(room, "mycelium", FakeChannel(), FakePersister())
+    engine = _engine(FakeManager(managed, []))
     called: list[str] = []
 
     async def fake_mediate(

--- a/fastapi-backend/tests/test_event_sweep.py
+++ b/fastapi-backend/tests/test_event_sweep.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the TTL event sweep (app/services/event_sweep.py).
+
+Node-free: the sweep is a thin loop over ``local_state``; here we drive the one
+iteration directly and pin the start/stop task lifecycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services import event_sweep
+from app.services import local_state as ls
+
+
+@pytest.mark.asyncio
+async def test_sweep_removes_expired_and_spares_durable() -> None:
+    now = datetime.now(UTC)
+    ls.add_message(
+        "room-a",
+        ls.StoredMessage(
+            sender_handle="a",
+            message_type="event",
+            content="expired",
+            event_expires_at=now - timedelta(seconds=1),
+        ),
+    )
+    ls.add_message(
+        "room-a",
+        ls.StoredMessage(sender_handle="a", message_type="broadcast", content="durable"),
+    )
+
+    removed = await event_sweep.sweep_expired_events()
+    assert removed == 1
+    assert [m.content for m in ls.list_messages("room-a")] == ["durable"]
+
+
+@pytest.mark.asyncio
+async def test_sweep_returns_zero_when_nothing_expired() -> None:
+    ls.add_message(
+        "room-a",
+        ls.StoredMessage(sender_handle="a", message_type="broadcast", content="keep"),
+    )
+    assert await event_sweep.sweep_expired_events() == 0
+
+
+@pytest.mark.asyncio
+async def test_start_is_idempotent_and_stop_cancels() -> None:
+    event_sweep.start_event_sweep()
+    task = event_sweep._sweep_task
+    assert task is not None and not task.done()
+
+    # A second start does not spawn a competing loop.
+    event_sweep.start_event_sweep()
+    assert event_sweep._sweep_task is task
+
+    event_sweep.stop_event_sweep()
+    assert event_sweep._sweep_task is None
+    await asyncio.sleep(0)  # let the cancellation propagate
+    assert task.cancelled() or task.done()

--- a/fastapi-backend/tests/test_indexer.py
+++ b/fastapi-backend/tests/test_indexer.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the filesystem→JSONL indexer (app/services/indexer.py).
+
+Node-free and model-free: ``embed_text`` is stubbed with a deterministic vector
+so these run without downloading the ONNX embedding model, and the markdown lives
+under the temp ``MYCELIUM_DATA_DIR`` ``conftest`` provides. They pin the pieces
+the API tests only hit end-to-end: the incremental skip, the prune-by-omission,
+and the single-file index/prune the watcher drives.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services import indexer, search_index
+from app.services.filesystem import get_room_dir, write_memory_file
+
+
+@pytest.fixture(autouse=True)
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the ONNX embedder with a cheap deterministic vector."""
+    monkeypatch.setattr(indexer, "embed_text", lambda text: [float(len(text)), 1.0, 0.0])
+
+
+def _write(room: str, key: str, value: str) -> None:
+    write_memory_file(get_room_dir(room), key, value, created_by="tester")
+
+
+@pytest.mark.asyncio
+async def test_index_room_builds_records_for_every_file() -> None:
+    _write("room-a", "decisions/db", "postgres")
+    _write("room-a", "decisions/lang", "python")
+
+    stats = await indexer.index_room("room-a")
+
+    assert stats["indexed"] == 2
+    keys = sorted(r["key"] for r in search_index.load_index("room-a"))
+    assert keys == ["decisions/db", "decisions/lang"]
+
+
+@pytest.mark.asyncio
+async def test_index_room_skips_unchanged_on_second_pass() -> None:
+    import os
+
+    _write("room-a", "decisions/db", "postgres")
+    first = await indexer.index_room("room-a")
+    assert first["indexed"] == 1
+
+    # Backdate the file's mtime so it's unambiguously older than the just-written
+    # index record — the incremental path must then skip it.
+    path = get_room_dir("room-a") / "decisions" / "db.md"
+    past = path.stat().st_mtime - 3600
+    os.utime(path, (past, past))
+
+    second = await indexer.index_room("room-a")
+    assert second["indexed"] == 0 and second["skipped"] == 1
+
+
+@pytest.mark.asyncio
+async def test_index_room_force_reindexes_unchanged() -> None:
+    _write("room-a", "decisions/db", "postgres")
+    await indexer.index_room("room-a")
+
+    forced = await indexer.index_room("room-a", force=True)
+    assert forced["indexed"] == 1 and forced["skipped"] == 0
+
+
+@pytest.mark.asyncio
+async def test_index_room_prunes_vanished_files() -> None:
+    _write("room-a", "decisions/db", "postgres")
+    _write("room-a", "decisions/lang", "python")
+    await indexer.index_room("room-a")
+
+    # Delete one markdown file; its index record should be pruned by omission.
+    (get_room_dir("room-a") / "decisions" / "lang.md").unlink()
+    stats = await indexer.index_room("room-a")
+
+    assert stats["pruned"] == 1
+    assert [r["key"] for r in search_index.load_index("room-a")] == ["decisions/db"]
+
+
+@pytest.mark.asyncio
+async def test_index_room_ignores_session_scoped_names() -> None:
+    stats = await indexer.index_room("room-a:session:abcd1234")
+    assert stats == {"indexed": 0, "skipped": 0, "pruned": 0, "errors": 0}
+
+
+@pytest.mark.asyncio
+async def test_index_all_rooms_counts_rooms_and_skips_sessions() -> None:
+    _write("room-a", "k", "va")
+    _write("room-b", "k", "vb")
+    # A session-scoped directory must be excluded from the room walk.
+    _write("room-a:session:zzzz", "k", "vs")
+
+    result = await indexer.index_all_rooms()
+    assert result["rooms"] == 2
+    assert result["total_indexed"] == 2
+
+
+@pytest.mark.asyncio
+async def test_index_single_file_indexes_then_prunes() -> None:
+    _write("room-a", "decisions/db", "postgres")
+
+    assert await indexer.index_single_file("room-a", "decisions/db") is True
+    assert [r["key"] for r in search_index.load_index("room-a")] == ["decisions/db"]
+
+    (get_room_dir("room-a") / "decisions" / "db.md").unlink()
+    # File gone → the single-file path prunes the stale record (True = it acted).
+    assert await indexer.index_single_file("room-a", "decisions/db") is True
+    assert search_index.load_index("room-a") == []
+    # Nothing left to prune → a repeat is a no-op (False).
+    assert await indexer.index_single_file("room-a", "decisions/db") is False

--- a/fastapi-backend/tests/test_local_state.py
+++ b/fastapi-backend/tests/test_local_state.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the in-memory room-state shim (app/services/local_state.py).
+
+Node-free and DB-free: this is the process-memory stand-in for the removed
+``messages`` / ``participants`` / ``memory_subscriptions`` tables, so it's pure
+Python. ``conftest`` resets the module-global maps between tests.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.services import local_state as ls
+
+
+def test_deterministic_ids_are_stable_and_idempotent() -> None:
+    """A room maps to one session id; a (session, handle) pair to one participant id."""
+    sid = ls.session_id_for_room("room-a")
+    assert sid == ls.session_id_for_room("room-a")  # stable across calls
+    assert sid != ls.session_id_for_room("room-b")  # per-room
+    pid = ls.participant_id(sid, "agent-a")
+    assert pid == ls.participant_id(sid, "agent-a")
+    assert pid != ls.participant_id(sid, "agent-b")
+
+
+def test_get_or_create_session_is_idempotent() -> None:
+    first = ls.get_or_create_session("room-a")
+    assert ls.get_or_create_session("room-a") is first  # same shim, not a new one
+    assert ls.get_session("room-a") is first
+    assert ls.get_session("never") is None
+    assert first.short_id == str(first.id)[:8]
+
+
+def test_participant_add_find_list_remove() -> None:
+    sid = ls.session_id_for_room("room-a")
+    p = ls.StoredParticipant(coordination_session_id=sid, agent_handle="agent-a")
+    ls.add_participant(sid, p)
+
+    assert ls.find_participant(sid, "agent-a") is p
+    assert ls.find_participant(sid, "ghost") is None
+    assert ls.list_participants(sid) == [p]
+
+    assert ls.remove_participant(sid, p.id) is True
+    assert ls.remove_participant(sid, p.id) is False  # already gone
+    assert ls.list_participants(sid) == []
+
+
+def test_message_add_list_find() -> None:
+    msg = ls.StoredMessage(sender_handle="a", message_type="broadcast", content="hi")
+    ls.add_message("room-a", msg)
+
+    assert ls.list_messages("room-a") == [msg]
+    assert ls.list_messages("empty") == []
+    assert ls.find_message(msg.id) is msg
+    assert ls.find_message(ls.uuid.uuid4()) is None
+
+
+def test_sweep_drops_only_expired_messages() -> None:
+    now = datetime.now(UTC)
+    durable = ls.StoredMessage(sender_handle="a", message_type="broadcast", content="keep")
+    expired = ls.StoredMessage(
+        sender_handle="a",
+        message_type="event",
+        content="gone",
+        event_expires_at=now - timedelta(seconds=1),
+    )
+    future = ls.StoredMessage(
+        sender_handle="a",
+        message_type="event",
+        content="stay",
+        event_expires_at=now + timedelta(hours=1),
+    )
+    for m in (durable, expired, future):
+        ls.add_message("room-a", m)
+
+    removed = ls.sweep_expired_messages(now)
+    assert removed == 1
+    remaining = {m.content for m in ls.list_messages("room-a")}
+    assert remaining == {"keep", "stay"}  # durable (no TTL) + not-yet-expired survive
+
+
+def test_subscription_add_list_remove() -> None:
+    sub = ls.StoredSubscription(room_name="room-a", subscriber="agent-a", key_pattern="decisions/*")
+    ls.add_subscription(sub)
+
+    assert ls.list_subscriptions("room-a") == [sub]
+    assert ls.remove_subscription("room-a", sub.id) is True
+    assert ls.remove_subscription("room-a", sub.id) is False
+    assert ls.list_subscriptions("room-a") == []
+
+
+def test_clear_all_resets_every_map() -> None:
+    sid = ls.session_id_for_room("room-a")
+    ls.get_or_create_session("room-a")
+    ls.add_participant(sid, ls.StoredParticipant(coordination_session_id=sid, agent_handle="a"))
+    ls.add_message("room-a", ls.StoredMessage(sender_handle="a", message_type="b", content="c"))
+    ls.add_subscription(ls.StoredSubscription(room_name="room-a", subscriber="a", key_pattern="*"))
+
+    ls.clear_all()
+
+    assert ls.get_session("room-a") is None
+    assert ls.list_participants(sid) == []
+    assert ls.list_messages("room-a") == []
+    assert ls.list_subscriptions("room-a") == []

--- a/fastapi-backend/tests/test_mediator.py
+++ b/fastapi-backend/tests/test_mediator.py
@@ -21,36 +21,25 @@ from typing import Any
 import pytest
 
 from app.services import aligner, l9, mediator
-from tests.test_aligner import _FakeChannel, _FakeManaged, _FakeManager, _FakePersister
+from tests.fakes import (
+    FakeChannel,
+    FakeManaged,
+    FakeManager,
+    FakePersister,
+    fake_brain_factory,
+)
 
 _ROOM = "mediate-room"
 
 
-def _fake_llm(prompt: str, *, system: str = "", temperature: float = 0.3) -> str:
-    """Deterministic stand-in for the mediator's LLM, keyed on the prompt.
-
-    - discovery → one issue ``cap`` with three options;
-    - a propose interpretation → counter to ``cap = 30``;
-    - a respond interpretation → accept;
-    - any broker framing → a short note.
-    """
-    if "identify the negotiable ISSUES" in prompt:
-        return json.dumps({"issues": [{"name": "cap", "options": ["25", "30", "35"]}]})
-    if "Interpret @" in prompt:
-        if '"action":"counter"' in prompt:  # proposing schema
-            return json.dumps({"action": "counter", "offer": {"cap": "30"}})
-        return json.dumps({"action": "accept"})  # responding schema
-    return "Everyone is close on the cap; let's lock 30 and move."
-
-
-def _engine(manager: _FakeManager, **kw: Any) -> aligner.AlignerEngine:
+def _engine(manager: FakeManager, **kw: Any) -> aligner.AlignerEngine:
     kw.setdefault("handle", "aligner")
     kw.setdefault("round_timeout_s", 0.2)
     kw.setdefault("poll_interval_s", 0.01)
     kw.setdefault("max_steps", 12)
     # The mediator brain is Pi in production; inject the deterministic fake here so
     # the SAO runs node-free and LLM-free.
-    kw.setdefault("brain_factory", lambda _episode: _fake_llm)
+    kw.setdefault("brain_factory", fake_brain_factory)
     return aligner.AlignerEngine(manager, **kw)  # type: ignore[arg-type]
 
 
@@ -173,10 +162,10 @@ def test_propose_holds_own_line_not_the_table_when_unreadable() -> None:
 async def test_mediate_terminates_at_agreement() -> None:
     """Agents that accept the standing offer → NEGMAS stops, verdict is converged
     with the agreed issue=value map, and the episode is opened then closed."""
-    persister = _FakePersister()
-    channel = _FakeChannel(persister, reply_conf=0.9)  # every prompt draws a reply
-    managed = _FakeManaged(_ROOM, "mycelium", channel, persister)
-    manager = _FakeManager(managed, ["growth", "risk", "aligner"])
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)  # every prompt draws a reply
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "aligner"])
 
     verdict = await _engine(manager).mediate(_ROOM)
 
@@ -218,10 +207,10 @@ async def test_two_convenings_write_distinct_episode_records() -> None:
     ensure_room_structure(room_dir)
 
     async def _convene() -> str:
-        persister = _FakePersister()
-        channel = _FakeChannel(persister, reply_conf=0.9)
-        managed = _FakeManaged(_ROOM, "mycelium", channel, persister)
-        manager = _FakeManager(managed, ["growth", "risk", "aligner"])
+        persister = FakePersister()
+        channel = FakeChannel(persister, reply_conf=0.9)
+        managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+        manager = FakeManager(managed, ["growth", "risk", "aligner"])
         verdict = await _engine(manager).mediate(_ROOM)
         assert verdict is not None
         return manager.opened[0]
@@ -244,10 +233,10 @@ async def test_mediate_scopes_to_named_participants() -> None:
     from app.services.l9_models import Kind as _Kind
     from app.services.persister import envelope_recipients
 
-    persister = _FakePersister()
-    channel = _FakeChannel(persister, reply_conf=0.9)
-    managed = _FakeManaged(_ROOM, "mycelium", channel, persister)
-    manager = _FakeManager(managed, ["growth", "risk", "legal", "aligner"])
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "legal", "aligner"])
 
     await _engine(manager).mediate(_ROOM, scoped_participants=["growth", "risk"])
 
@@ -267,10 +256,10 @@ async def test_mediate_rejects_when_no_issues_discovered(
 ) -> None:
     """Discovery that yields no structurable issues → a clean rejected verdict,
     still closing the episode (never hanging or raising)."""
-    persister = _FakePersister()
-    channel = _FakeChannel(persister, reply_conf=0.9)
-    managed = _FakeManaged(_ROOM, "mycelium", channel, persister)
-    manager = _FakeManager(managed, ["growth", "risk"])
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk"])
 
     monkeypatch.setattr(mediator, "discover_issues", lambda *a, **k: [])
 

--- a/fastapi-backend/tests/test_pi_brain.py
+++ b/fastapi-backend/tests/test_pi_brain.py
@@ -23,6 +23,7 @@ import pytest
 
 from app.services import pi_brain
 from app.services.pi_brain import PiBrain, PiBrainError, parse_pi_json_output
+from tests.fakes import patch_pi_run
 
 
 def _stream(*events: dict[str, Any]) -> str:
@@ -261,26 +262,11 @@ def test_ensure_config_merges_existing(tmp_path: Path) -> None:
 # ── __call__ (subprocess mocked) ────────────────────────────────────────────
 
 
-def _patch_run(
-    monkeypatch: pytest.MonkeyPatch, *, stdout: str, returncode: int = 0
-) -> list[list[str]]:
-    """Capture argv and return a canned CompletedProcess from subprocess.run."""
-    calls: list[list[str]] = []
-
-    def fake_run(cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="boom")
-
-    monkeypatch.setattr(pi_brain.shutil, "which", lambda _b: "/usr/bin/pi")
-    monkeypatch.setattr(pi_brain.subprocess, "run", fake_run)
-    return calls
-
-
 def test_call_returns_parsed_text(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     stdout = _stream(
         {"type": "message_end", "message": {"role": "assistant", "content": "hello world"}}
     )
-    calls = _patch_run(monkeypatch, stdout=stdout)
+    calls = patch_pi_run(monkeypatch, stdout=stdout)
     out = _brain(tmp_path)("interpret this", system="sys")
     assert out == "hello world"
     assert calls and calls[0][-1] == "interpret this"
@@ -293,7 +279,7 @@ def test_call_raises_on_missing_binary(tmp_path: Path, monkeypatch: pytest.Monke
 
 
 def test_call_raises_on_nonzero_exit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_run(monkeypatch, stdout="", returncode=2)
+    patch_pi_run(monkeypatch, stdout="", returncode=2)
     with pytest.raises(PiBrainError, match="exited 2"):
         _brain(tmp_path)("p")
 
@@ -310,7 +296,7 @@ def test_call_raises_on_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 
 def test_call_ignores_temperature(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """temperature is accepted for brain-callable parity but never reaches the CLI."""
-    calls = _patch_run(
+    calls = patch_pi_run(
         monkeypatch,
         stdout=_stream({"type": "message_end", "message": {"role": "assistant", "content": "x"}}),
     )

--- a/fastapi-backend/tests/test_plan_sync.py
+++ b/fastapi-backend/tests/test_plan_sync.py
@@ -16,6 +16,7 @@ import pytest
 from app.services import l9, memory_sync, plan, plan_sync
 from app.services.filesystem import get_room_dir, read_memory_file
 from app.services.l9_models import L9, Kind
+from tests.fakes import FakeManager
 
 
 def _converged(assignments: dict) -> L9:
@@ -31,38 +32,10 @@ def _converged(assignments: dict) -> L9:
     )
 
 
-class _FakeChannel:
-    def __init__(self) -> None:
-        self.sent: list = []
-
-    async def send(self, envelope, *, extra=None) -> None:
-        self.sent.append((envelope, extra))
-
-
-class _FakeManaged:
-    def __init__(self, channel) -> None:
-        self.channel = channel
-        self.persister = None
-
-
-class _FakeManager:
-    """Just enough of RoomChannelManager for the consumer: get + members."""
-
-    def __init__(self, *, live: bool = True) -> None:
-        self.channel = _FakeChannel()
-        self._managed = _FakeManaged(self.channel) if live else None
-
-    def get(self, room):
-        return self._managed
-
-    def members(self, room):
-        return ["a", "b"]
-
-
 @pytest.mark.asyncio
 class TestConvergedToPlan:
     async def test_compiles_plan_file_with_expected_tasks(self):
-        mgr = _FakeManager()
+        mgr = FakeManager()
         engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
         fake_plan = "# MVP Delivery\n\n- [ ] ship auth @a\n- [ ] write docs @b"
         with patch.object(
@@ -84,7 +57,7 @@ class TestConvergedToPlan:
         assert carried is not None and carried.version == 1 and carried.base_version is None
 
     async def test_sets_plan_title_from_heading(self):
-        mgr = _FakeManager()
+        mgr = FakeManager()
         engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
         with patch.object(
             plan_sync.plan_compiler,
@@ -95,7 +68,7 @@ class TestConvergedToPlan:
         assert plan.get_title("r") == "Sprint Plan"
 
     async def test_recompile_bumps_version_and_threads_base(self):
-        mgr = _FakeManager()
+        mgr = FakeManager()
         engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
         with patch.object(
             plan_sync.plan_compiler,
@@ -111,7 +84,7 @@ class TestConvergedToPlan:
 
     async def test_fail_soft_compile_falls_back_to_raw_agreement(self):
         """A compiler outage must not sink the verdict — write the raw agreement."""
-        mgr = _FakeManager()
+        mgr = FakeManager()
         engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
         with patch.object(
             plan_sync.plan_compiler,
@@ -148,7 +121,7 @@ class TestConvergedToPlan:
         assert mgr._converged_adapter("room-x") is None
 
     async def test_no_channel_writes_plan_but_skips_broadcast(self):
-        mgr = _FakeManager(live=False)
+        mgr = FakeManager(live=False)
         engine = plan_sync.PlanSyncEngine(mgr)  # type: ignore[arg-type]
         with patch.object(
             plan_sync.plan_compiler, "compile_plan", AsyncMock(return_value="# P\n\n- [ ] a")

--- a/fastapi-backend/tests/test_reindex.py
+++ b/fastapi-backend/tests/test_reindex.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the auto-reindex startup scan + watcher glue (reindex.py).
+
+Node-free: the watchdog Observer and the indexer are stubbed, so these pin the
+control flow — the startup scan delegates to ``index_all_rooms`` and swallows its
+errors, and a watcher file event routes to ``index_single_file``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services import reindex
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_delegates_to_index_all_rooms(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[bool] = []
+
+    async def fake_index_all() -> dict:
+        called.append(True)
+        return {"rooms": 2, "total_indexed": 3, "total_skipped": 1}
+
+    monkeypatch.setattr("app.services.indexer.index_all_rooms", fake_index_all)
+    await reindex.startup_scan()
+    assert called == [True]
+
+
+@pytest.mark.asyncio
+async def test_startup_scan_swallows_indexer_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def boom() -> dict:
+        raise RuntimeError("index blew up")
+
+    monkeypatch.setattr("app.services.indexer.index_all_rooms", boom)
+    # Startup must not fail because the scan did (it's non-fatal).
+    await reindex.startup_scan()
+
+
+@pytest.mark.asyncio
+async def test_reindex_file_delegates_to_index_single_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[tuple[str, str]] = []
+
+    async def fake_single(room: str, key: str) -> bool:
+        seen.append((room, key))
+        return True
+
+    monkeypatch.setattr("app.services.indexer.index_single_file", fake_single)
+    await reindex._reindex_file("room-a", "decisions/db")
+    assert seen == [("room-a", "decisions/db")]
+
+
+@pytest.mark.asyncio
+async def test_reindex_file_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def boom(room: str, key: str) -> bool:
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr("app.services.indexer.index_single_file", boom)
+    await reindex._reindex_file("room-a", "k")  # must not raise
+
+
+def test_start_watcher_is_non_fatal_without_watchdog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing ``watchdog`` disables the watcher rather than crashing startup."""
+    import sys
+
+    # Poisoning the module entries makes the in-function ``from watchdog... import``
+    # raise ImportError, exercising the graceful-disable branch even though the
+    # package is installed in the dev env.
+    monkeypatch.setitem(sys.modules, "watchdog.events", None)
+    monkeypatch.setitem(sys.modules, "watchdog.observers", None)
+    reindex.start_watcher()  # returns cleanly, observer never created
+    assert reindex._observer is None

--- a/fastapi-backend/tests/test_room_channels.py
+++ b/fastapi-backend/tests/test_room_channels.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for backend-as-moderator channel provisioning (room_channels.py).
+
+Node-free: the SLIM transport is the shared :class:`FakeSlimClient` and the
+persister start is stubbed to a no-op, so provisioning, member tracking, the
+server-held presence lease, and the episode lifecycle are exercised as pure async
+logic. The live-node slices stay in ``test_slim_roundtrip.py`` (guarded on a node).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from app.config import settings
+from app.services import room_channels
+from tests.fakes import FakeSession, FakeSlimClient
+
+
+@pytest.fixture
+def manager(monkeypatch: pytest.MonkeyPatch) -> room_channels.RoomChannelManager:
+    """A manager wired to the fake transport, with the persister loop stubbed out."""
+    monkeypatch.setattr(settings, "SLIM_ENABLED", True)
+    monkeypatch.setattr(room_channels, "node_reachable", lambda _endpoint: True)
+    monkeypatch.setattr(room_channels, "SlimClient", FakeSlimClient)
+    # The durable-inbox persister owns a background loop we don't want in a unit
+    # test — provisioning/membership is the surface under test here.
+    monkeypatch.setattr(room_channels.RoomChannelManager, "_start_persister", lambda self, m: None)
+    return room_channels.RoomChannelManager(endpoint="http://node", default_workspace="ws")
+
+
+@pytest.mark.asyncio
+async def test_provision_creates_channel_and_counts_ok(
+    manager: room_channels.RoomChannelManager,
+) -> None:
+    managed = await manager.provision("room-a")
+
+    assert managed is not None
+    assert manager.is_live("room-a")
+    assert managed.workspace == "ws"
+    assert isinstance(managed.client, FakeSlimClient)
+    assert manager.status()["provisions_ok"] == 1
+
+
+@pytest.mark.asyncio
+async def test_provision_is_idempotent(manager: room_channels.RoomChannelManager) -> None:
+    first = await manager.provision("room-a")
+    second = await manager.provision("room-a")
+    assert first is second  # same managed channel, not a second provision
+    assert manager.status()["provisions_ok"] == 1
+
+
+@pytest.mark.asyncio
+async def test_provision_skips_when_slim_disabled(
+    manager: room_channels.RoomChannelManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(settings, "SLIM_ENABLED", False)
+    assert await manager.provision("room-a") is None
+    assert not manager.is_live("room-a")
+
+
+@pytest.mark.asyncio
+async def test_provision_skips_when_node_unreachable(
+    manager: room_channels.RoomChannelManager, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(room_channels, "node_reachable", lambda _endpoint: False)
+    assert await manager.provision("room-a") is None
+
+
+@pytest.mark.asyncio
+async def test_invite_tracks_membership_and_routes_to_session(
+    manager: room_channels.RoomChannelManager,
+) -> None:
+    managed = await manager.provision("room-a")
+    assert managed is not None
+
+    assert await manager.invite("room-a", "agent-a") is True
+    assert "agent-a" in managed.members
+    # The invite was routed onto the moderated session (fake records it).
+    session = cast("FakeSession", managed.channel.session)
+    assert len(session.invited) == 1
+    # The moderator's own id is never invited.
+    assert await manager.invite("room-a", room_channels.BACKEND_AGENT) is False
+
+
+@pytest.mark.asyncio
+async def test_remove_drops_membership(manager: room_channels.RoomChannelManager) -> None:
+    managed = await manager.provision("room-a")
+    assert managed is not None
+    await manager.invite("room-a", "agent-a")
+
+    assert await manager.remove("room-a", "agent-a") is True
+    assert "agent-a" not in managed.members
+    # Removing an absent member is a no-op failure, not a crash.
+    assert await manager.remove("room-a", "ghost") is False
+
+
+@pytest.mark.asyncio
+async def test_members_union_slim_presence_and_lease(
+    manager: room_channels.RoomChannelManager,
+) -> None:
+    await manager.provision("room-a")
+    await manager.invite("room-a", "agent-slim")  # client-connected → SLIM presence
+    manager.refresh_lease("room-a", "agent-http")  # server-held → presence lease
+
+    assert manager.members("room-a") == ["agent-http", "agent-slim"]
+
+
+def test_expired_lease_drops_from_membership(
+    manager: room_channels.RoomChannelManager,
+) -> None:
+    # A lease with a zero TTL is immediately stale and must not count as present.
+    manager.refresh_lease("room-a", "agent-http", ttl_s=-1.0)
+    assert manager.members("room-a") == []
+
+
+@pytest.mark.asyncio
+async def test_open_and_close_episode_lifecycle(
+    manager: room_channels.RoomChannelManager,
+) -> None:
+    managed = await manager.provision("room-a")
+    assert managed is not None
+
+    assert manager.open_episode("room-a", "urn:ioc:mycelium:episode:room-a:e1") is True
+    assert managed.lifecycle.active
+    assert await manager.close_episode("room-a") is True
+    assert not managed.lifecycle.active
+
+    # No channel → lifecycle ops are safe no-ops.
+    assert manager.open_episode("ghost", "e") is False
+    assert await manager.close_episode("ghost") is False
+
+
+@pytest.mark.asyncio
+async def test_status_reports_per_room_snapshot(
+    manager: room_channels.RoomChannelManager,
+) -> None:
+    await manager.provision("room-a")
+    await manager.invite("room-a", "agent-a")
+
+    status = manager.status()
+    assert status["channels_live"] == 1
+    room = next(r for r in status["rooms"] if r["room"] == "room-a")
+    assert room["provisioned"] is True
+    assert room["members"] == ["agent-a"]

--- a/fastapi-backend/tests/test_slim_client.py
+++ b/fastapi-backend/tests/test_slim_client.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the SLIM naming + shared-secret mechanics (slim_client.py).
+
+Node-free: these cover the pure pieces — the ``workspace/room/agent`` ↔ Name
+mapping, segment validation, the deterministic per-channel secret derivation, and
+the master-secret resolution policy — none of which need a live node. The connect
+/ group / publish lifecycle is the live-node slice (``test_slim_roundtrip.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services import slim_client
+from app.services.slim_client import (
+    MIN_SECRET_LEN,
+    SlimError,
+    SlimIdentity,
+    SlimNameError,
+    from_slim_name,
+    mint_shared_secret,
+    node_reachable,
+    resolve_master_secret,
+    to_slim_name,
+)
+
+
+def test_identity_roundtrips_through_a_slim_name() -> None:
+    identity = SlimIdentity("ws", "room-a", "agent-a")
+    assert identity.as_tuple() == ("ws", "room-a", "agent-a")
+    assert identity.as_path() == "ws/room-a/agent-a"
+    # workspace/room/agent → Name(org/ns/app) → back to the same identity.
+    assert from_slim_name(to_slim_name(*identity.as_tuple())) == identity
+
+
+@pytest.mark.parametrize("bad", ["", "  ", "has/slash"])
+def test_name_segments_reject_invalid_values(bad: str) -> None:
+    with pytest.raises(SlimNameError):
+        to_slim_name(bad, "room", "agent")
+
+
+def test_shared_secret_is_deterministic_and_scoped_to_the_channel() -> None:
+    a1 = SlimIdentity("ws", "room-a", "agent-a")
+    a2 = SlimIdentity("ws", "room-a", "agent-b")  # different agent, same channel
+    b = SlimIdentity("ws", "room-b", "agent-a")  # different room
+
+    secret = mint_shared_secret(a1, master_secret="master")
+    # Every member of a channel derives the SAME secret (agent id is ignored).
+    assert secret == mint_shared_secret(a2, master_secret="master")
+    # A different channel (room) derives a different secret.
+    assert secret != mint_shared_secret(b, master_secret="master")
+    # A different master derives a different secret.
+    assert secret != mint_shared_secret(a1, master_secret="other")
+    assert len(secret) >= MIN_SECRET_LEN
+
+
+def test_resolve_master_secret_prefers_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MYCELIUM_SLIM_MASTER_SECRET", "my-private-secret")
+    assert resolve_master_secret() == "my-private-secret"
+
+
+def test_resolve_master_secret_falls_back_to_dev_literal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MYCELIUM_SLIM_MASTER_SECRET", raising=False)
+    monkeypatch.delenv("MYCELIUM_SLIM_REQUIRE_SECRET", raising=False)
+    assert resolve_master_secret() == slim_client._DEV_MASTER_SECRET
+
+
+def test_resolve_master_secret_fails_closed_when_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REQUIRE_SECRET without a secret must refuse the public dev literal."""
+    monkeypatch.delenv("MYCELIUM_SLIM_MASTER_SECRET", raising=False)
+    monkeypatch.setenv("MYCELIUM_SLIM_REQUIRE_SECRET", "1")
+    with pytest.raises(SlimError, match="refusing"):
+        resolve_master_secret()
+
+
+def test_node_reachable_is_false_for_a_dead_port() -> None:
+    # Nothing is listening on this port on localhost → a fast, clean False.
+    assert node_reachable("http://127.0.0.1:1", timeout=0.2) is False

--- a/fastapi-backend/tests/test_smoke.py
+++ b/fastapi-backend/tests/test_smoke.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Non-interactive smoke: the core protocol over the fake stack.
+
+One scriptable check that the happy path still works end to end —
+**room → engine → await → respond → converge → plan** — with **no SLIM node, no
+Pi binary, and no live LLM**. The mediator runs the real NEGMAS SAO loop; only its
+brain (the deterministic ``fake_brain_factory``), the agents (the ``FakeChannel``
+reply simulation, i.e. the await/respond turns), and the plan compiler are faked.
+
+Run it alone with ``make smoke`` (or ``uv run pytest -m smoke``). If this goes red,
+the protocol itself broke — not a corner case.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import aligner, l9, plan, plan_sync
+from app.services.filesystem import ensure_room_structure, get_room_dir, read_memory_file
+from app.services.l9_models import Kind
+from tests.fakes import (
+    FakeChannel,
+    FakeManaged,
+    FakeManager,
+    FakePersister,
+    fake_brain_factory,
+)
+
+_ROOM = "smoke-room"
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_core_protocol_room_to_plan_over_fakes() -> None:
+    # ── room ── a persistent room namespace on disk.
+    ensure_room_structure(get_room_dir(_ROOM))
+
+    # ── engine + await/respond ── the aligner negotiates over a fake channel whose
+    # prompted participants always reply (the simulated await→respond turns), with a
+    # deterministic Pi brain. NEGMAS owns termination, so it stops at agreement.
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "aligner"])
+
+    engine = aligner.AlignerEngine(
+        manager,  # type: ignore[arg-type]
+        handle="aligner",
+        round_timeout_s=0.2,
+        poll_interval_s=0.01,
+        max_steps=12,
+        brain_factory=fake_brain_factory,
+    )
+
+    # ── converge ── a commit:converged verdict carrying the agreed issue=value map.
+    verdict = await engine.mediate(_ROOM)
+    assert verdict is not None
+    assert verdict["header"]["subkind"] == "converged"
+    assignments = verdict["payload"]["data"]["assignments"]
+    assert assignments  # the negotiation actually agreed on something
+
+    # ── plan ── the converged map compiles into the room's shared plan. The compiler
+    # is the one remaining LLM stage, faked here to a deterministic checklist.
+    converged = l9.build_envelope(
+        kind=Kind.commit,
+        subkind="converged",
+        episode=l9.episode_urn(_ROOM, "live"),
+        recipients=["growth", "risk"],
+        topic=l9.topic_urn(_ROOM),
+        payload_type="consensus",
+        payload_data={"assignments": assignments},
+    )
+    compiled = "# Smoke Plan\n\n- [ ] ship the agreed cap @growth\n- [ ] sign off @risk"
+    plan_engine = plan_sync.PlanSyncEngine(manager)  # type: ignore[arg-type]
+    with patch.object(plan_sync.plan_compiler, "compile_plan", AsyncMock(return_value=compiled)):
+        write = await plan_engine.compile_and_sync(_ROOM, converged)
+
+    # The plan file exists with the agreed tasks, the title is set, and the plan was
+    # broadcast as a knowledge push — the protocol's observable end state.
+    got = read_memory_file(get_room_dir(_ROOM), plan_sync.PLAN_TASKS_KEY)
+    assert got is not None
+    _meta, body = got
+    assert "ship the agreed cap @growth" in body
+    assert plan.get_title(_ROOM) == "Smoke Plan"
+    assert write is not None and write.content.startswith("# Smoke Plan")
+    assert manager.channel.sent  # a knowledge broadcast went out

--- a/mycelium-cli/tests/README.md
+++ b/mycelium-cli/tests/README.md
@@ -1,0 +1,58 @@
+# CLI tests
+
+Unit tests run **without a SLIM node, a running backend, or live HTTP.**
+`conftest.py` holds the shared fakes + fixtures; import the classes from
+`tests.conftest`, or take the fixtures by name (pytest injects them). There is
+exactly one of each fake — don't re-declare them per file.
+
+## Test a command / connector without a live stack
+
+| You're testing… | Use | It stands in for |
+| --- | --- | --- |
+| A command that calls the backend (`room`, `memory`, `plan`, …) | the `backend` fixture + patch the one generated `…​.sync` | the typed `mycelium_backend_client` plumbing |
+| Connector / daemon HTTP (`announce_presence`, `reindex_after_knowledge`, briefing fetch) | the `fake_httpx` fixture, `FakeResp` | `httpx.AsyncClient` / `httpx.Client` |
+| The member message stream / wake decision | `FakeSlimClient` (or the `fake_slim_client` fixture) | `slim.client.SlimClient` |
+| Anything that touches `~/.mycelium` | the `isolated_home` fixture | points `Path.home()` at a temp dir |
+
+### Example — a command test (typed backend client)
+
+```python
+from mycelium.commands import room as room_cmd
+
+def test_list_rooms(backend, monkeypatch):
+    backend(room_cmd, room="demo")          # stub config/_typed_client/_resolve_room
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.rooms.list_rooms_api_rooms_get.sync",
+        lambda **kw: RoomListResponse(rooms=[...]),
+    )
+    result = CliRunner().invoke(room_cmd.app, ["list"])
+    assert result.exit_code == 0
+```
+
+### Example — a connector HTTP test (`fake_httpx`)
+
+```python
+from tests.conftest import FakeHTTPX, FakeResp
+
+async def test_announce(fake_httpx: FakeHTTPX):
+    await connector.announce_presence(cfg, "myroom", "agent-a")
+    assert fake_httpx.calls == [("POST", ".../api/rooms/myroom/sessions", {"agent_handle": "agent-a"})]
+
+    fake_httpx.respond_with(lambda *_: FakeResp(boom=True))   # exercise the error branch
+```
+
+### Example — the member stream (`FakeSlimClient`)
+
+```python
+from tests.conftest import FakeSlimClient
+
+monkeypatch.setattr(member, "SlimClient", FakeSlimClient)
+FakeSlimClient.inbox = [l9.serialize(tick), ...]     # scripted inbound messages
+content = await member.await_addressed(cfg, "r", "agent-a", timeout_s=2)
+```
+
+## Commands
+
+```bash
+uv run ruff check . && uv run ruff format --check . && uv run ty check . && uv run pytest tests/ -x -q
+```

--- a/mycelium-cli/tests/conftest.py
+++ b/mycelium-cli/tests/conftest.py
@@ -13,7 +13,7 @@ What stands in for what:
 
 * :class:`FakeSlimClient` — ``mycelium.slim.client.SlimClient`` with a scripted
   inbox, for the member/daemon message-stream tests.
-* :class:`FakeResp` / :class:`FakeHTTPXClient` + the :func:`fake_httpx` fixture —
+* :class:`FakeResp` + the :func:`fake_httpx` fixture (sync + async clients) —
   ``httpx.AsyncClient`` / ``httpx.Client``, so the connector/daemon HTTP calls run
   without a backend.
 * :func:`stub_typed_client` (via the :func:`backend` fixture) — the generated
@@ -129,15 +129,11 @@ class FakeResp:
         return self._payload
 
 
-class FakeHTTPXClient:
-    """A stand-in for ``httpx.AsyncClient`` / ``httpx.Client`` (async + sync).
+class _FakeHTTPXBase:
+    """Shared recording + context-manager plumbing for the httpx fakes.
 
     Records every request as ``(method, url, json/params)`` onto the shared
-    ``calls`` list and returns a scripted :class:`FakeResp`. ``responder`` maps a
-    request to a response; by default every call yields an empty-payload 200.
-    Works as both an async and a sync context manager, so the one fake covers the
-    connector's ``async with httpx.AsyncClient()`` and a command's
-    ``with httpx.Client()``.
+    ``calls`` list and returns a scripted :class:`FakeResp` from ``responder``.
     """
 
     def __init__(
@@ -148,22 +144,19 @@ class FakeHTTPXClient:
         self._calls = calls
         self._responder = responder
 
-    # context-manager protocol (both flavors)
-    async def __aenter__(self) -> FakeHTTPXClient:
+    def _record(self, method: str, url: str, payload: dict) -> FakeResp:
+        self._calls.append((method, url, payload))
+        return self._responder(method, url, payload)
+
+
+class FakeAsyncHTTPXClient(_FakeHTTPXBase):
+    """Stand-in for ``httpx.AsyncClient`` (the connector/daemon path)."""
+
+    async def __aenter__(self) -> FakeAsyncHTTPXClient:
         return self
 
     async def __aexit__(self, *_exc: object) -> bool:
         return False
-
-    def __enter__(self) -> FakeHTTPXClient:
-        return self
-
-    def __exit__(self, *_exc: object) -> bool:
-        return False
-
-    def _record(self, method: str, url: str, payload: dict) -> FakeResp:
-        self._calls.append((method, url, payload))
-        return self._responder(method, url, payload)
 
     async def get(self, url: str, *, params: dict | None = None, **_: Any) -> FakeResp:
         return self._record("GET", url, params or {})
@@ -172,11 +165,27 @@ class FakeHTTPXClient:
         return self._record("POST", url, json or {})
 
 
+class FakeSyncHTTPXClient(_FakeHTTPXBase):
+    """Stand-in for ``httpx.Client`` (a command's ``with httpx.Client()``)."""
+
+    def __enter__(self) -> FakeSyncHTTPXClient:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+    def get(self, url: str, *, params: dict | None = None, **_: Any) -> FakeResp:
+        return self._record("GET", url, params or {})
+
+    def post(self, url: str, *, json: dict | None = None, **_: Any) -> FakeResp:
+        return self._record("POST", url, json or {})
+
+
 class FakeHTTPX:
     """Controller returned by the :func:`fake_httpx` fixture.
 
-    ``calls`` accumulates every request; ``respond_with`` swaps in a custom
-    responder (default: an empty-payload 200 for everything).
+    ``calls`` accumulates every request (across both the sync and async fakes);
+    ``respond_with`` swaps in a custom responder (default: an empty-payload 200).
     """
 
     def __init__(self) -> None:
@@ -186,13 +195,16 @@ class FakeHTTPX:
     def respond_with(self, responder: Callable[[str, str, dict], FakeResp]) -> None:
         self._responder = responder
 
-    def _factory(self, *_a: object, **_k: object) -> FakeHTTPXClient:
-        return FakeHTTPXClient(self.calls, lambda m, u, p: self._responder(m, u, p))
+    def _async_factory(self, *_a: object, **_k: object) -> FakeAsyncHTTPXClient:
+        return FakeAsyncHTTPXClient(self.calls, lambda m, u, p: self._responder(m, u, p))
+
+    def _sync_factory(self, *_a: object, **_k: object) -> FakeSyncHTTPXClient:
+        return FakeSyncHTTPXClient(self.calls, lambda m, u, p: self._responder(m, u, p))
 
 
 @pytest.fixture
 def fake_httpx(monkeypatch: pytest.MonkeyPatch) -> FakeHTTPX:
-    """Patch ``httpx.AsyncClient`` and ``httpx.Client`` with a recording fake.
+    """Patch ``httpx.AsyncClient`` and ``httpx.Client`` with recording fakes.
 
     Modules under test do ``import httpx; httpx.AsyncClient(...)``, so patching the
     attribute on the ``httpx`` module covers all of them. Returns the
@@ -200,8 +212,8 @@ def fake_httpx(monkeypatch: pytest.MonkeyPatch) -> FakeHTTPX:
     ``.respond_with``.
     """
     ctrl = FakeHTTPX()
-    monkeypatch.setattr(httpx, "AsyncClient", ctrl._factory)
-    monkeypatch.setattr(httpx, "Client", ctrl._factory)
+    monkeypatch.setattr(httpx, "AsyncClient", ctrl._async_factory)
+    monkeypatch.setattr(httpx, "Client", ctrl._sync_factory)
     return ctrl
 
 
@@ -214,12 +226,14 @@ def stub_typed_client(
     *,
     api_url: str = "http://localhost:8000",
     room: str | None = None,
+    active_room: str | None = None,
 ) -> None:
     """Neutralize a command module's backend plumbing for a unit test.
 
     Patches, on ``module``:
 
-    * ``MyceliumConfig.load`` → a config pointing at ``api_url`` (no config file);
+    * ``MyceliumConfig.load`` → a config pointing at ``api_url`` (no config file),
+      whose ``get_active_room()`` returns ``active_room``;
     * ``_typed_client`` → a no-op context manager yielding a dummy client;
     * ``_resolve_room`` → ``room`` (when the module has one and ``room`` is given).
 
@@ -227,7 +241,10 @@ def stub_typed_client(
     (``monkeypatch.setattr("mycelium_backend_client.api.<...>.sync", fake)``), the
     same shape the pre-existing ``test_room_messages`` used.
     """
-    fake_config = SimpleNamespace(server=SimpleNamespace(api_url=api_url))
+    fake_config = SimpleNamespace(
+        server=SimpleNamespace(api_url=api_url),
+        get_active_room=lambda: active_room,
+    )
     if hasattr(module, "MyceliumConfig"):
         monkeypatch.setattr(module.MyceliumConfig, "load", classmethod(lambda _cls: fake_config))
     if hasattr(module, "_typed_client"):
@@ -248,8 +265,14 @@ def backend(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
     ``monkeypatch``.
     """
 
-    def _install(module: Any, *, api_url: str = "http://localhost:8000", room: str | None = None):
-        stub_typed_client(monkeypatch, module, api_url=api_url, room=room)
+    def _install(
+        module: Any,
+        *,
+        api_url: str = "http://localhost:8000",
+        room: str | None = None,
+        active_room: str | None = None,
+    ) -> None:
+        stub_typed_client(monkeypatch, module, api_url=api_url, room=room, active_room=active_room)
 
     return _install
 

--- a/mycelium-cli/tests/conftest.py
+++ b/mycelium-cli/tests/conftest.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Shared fixtures + in-process fakes for the CLI test suite.
+
+One import gets you a fake backend/transport stack — no SLIM node, no running
+backend server, no live HTTP. Before this module every file re-declared its own
+``_FakeResp`` / ``_FakeClient`` (six near-identical copies across the connector
+and daemon tests) and the membership tests each ported ``_FakeSlimClient`` by
+hand. This is the single home for them.
+
+What stands in for what:
+
+* :class:`FakeSlimClient` — ``mycelium.slim.client.SlimClient`` with a scripted
+  inbox, for the member/daemon message-stream tests.
+* :class:`FakeResp` / :class:`FakeHTTPXClient` + the :func:`fake_httpx` fixture —
+  ``httpx.AsyncClient`` / ``httpx.Client``, so the connector/daemon HTTP calls run
+  without a backend.
+* :func:`stub_typed_client` (via the :func:`backend` fixture) — the generated
+  ``mycelium_backend_client`` typed-client plumbing a command goes through
+  (``MyceliumConfig.load`` / ``_typed_client`` / ``_resolve_room``), so a command
+  test only has to script the one API ``.sync`` it exercises.
+* :func:`isolated_home` — points ``Path.home()`` (hence ``get_mycelium_dir``) at a
+  temp dir so no test reads or writes the real ``~/.mycelium``.
+
+See ``tests/README.md`` for the "test a command without a live stack" recipe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, Mock
+
+import httpx
+import pytest
+
+from mycelium.slim.client import SlimReceiveTimeout
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+
+# ── SLIM transport ────────────────────────────────────────────────────────────
+
+
+class FakeSlimClient:
+    """A minimal stand-in for ``SlimClient`` that replays a scripted inbox.
+
+    ``inbox`` / ``published`` are class-level so a test can preload messages
+    before the client is constructed (the member core builds its own client). An
+    empty inbox blocks briefly then raises :class:`SlimReceiveTimeout`, which the
+    reconnecting stream reads as "quiet, still connected". Reset per test with
+    :meth:`reset`.
+    """
+
+    inbox: list[bytes] = []  # noqa: RUF012 — intentionally class-level scripted queue
+    published: list[bytes] = []  # noqa: RUF012
+
+    def __init__(self, _identity: Any, *, secret: str | None = None) -> None:
+        pass
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.inbox = []
+        cls.published = []
+
+    async def connect(self, _endpoint: str) -> FakeSlimClient:
+        return self
+
+    async def listen_for_session(self) -> str:
+        return "session-1"
+
+    async def close(self) -> None:
+        pass
+
+    @staticmethod
+    async def publish(_session: Any, data: bytes) -> None:
+        FakeSlimClient.published.append(data)
+
+    @staticmethod
+    async def receive_message(_session: Any, *, timeout_s: float = 30.0):  # noqa: ARG004
+        if not FakeSlimClient.inbox:
+            await asyncio.sleep(0.02)
+            raise SlimReceiveTimeout("receive timeout")
+        payload = FakeSlimClient.inbox.pop(0)
+
+        class _Msg:
+            def __init__(self, p: bytes) -> None:
+                self.payload = p
+
+        return _Msg(payload)
+
+
+@pytest.fixture
+def fake_slim_client() -> type[FakeSlimClient]:
+    """The :class:`FakeSlimClient` class, reset to a clean inbox/outbox.
+
+    Monkeypatch it in where the code under test imports ``SlimClient``, e.g.
+    ``monkeypatch.setattr(member, "SlimClient", fake_slim_client)``.
+    """
+    FakeSlimClient.reset()
+    return FakeSlimClient
+
+
+# ── HTTP transport (httpx) ────────────────────────────────────────────────────
+
+
+class FakeResp:
+    """A stand-in for ``httpx.Response``.
+
+    ``json()`` returns the scripted ``payload``; ``raise_for_status()`` raises
+    when ``boom`` is set (to exercise the error branch). This unifies the six
+    ``_FakeResp`` variants that used to live in the connector/daemon tests.
+    """
+
+    def __init__(self, payload: Any = None, *, boom: bool = False, status_code: int = 200) -> None:
+        self._payload = payload
+        self._boom = boom
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self._boom:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class FakeHTTPXClient:
+    """A stand-in for ``httpx.AsyncClient`` / ``httpx.Client`` (async + sync).
+
+    Records every request as ``(method, url, json/params)`` onto the shared
+    ``calls`` list and returns a scripted :class:`FakeResp`. ``responder`` maps a
+    request to a response; by default every call yields an empty-payload 200.
+    Works as both an async and a sync context manager, so the one fake covers the
+    connector's ``async with httpx.AsyncClient()`` and a command's
+    ``with httpx.Client()``.
+    """
+
+    def __init__(
+        self,
+        calls: list[tuple[str, str, dict]],
+        responder: Callable[[str, str, dict], FakeResp],
+    ) -> None:
+        self._calls = calls
+        self._responder = responder
+
+    # context-manager protocol (both flavors)
+    async def __aenter__(self) -> FakeHTTPXClient:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    def __enter__(self) -> FakeHTTPXClient:
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+    def _record(self, method: str, url: str, payload: dict) -> FakeResp:
+        self._calls.append((method, url, payload))
+        return self._responder(method, url, payload)
+
+    async def get(self, url: str, *, params: dict | None = None, **_: Any) -> FakeResp:
+        return self._record("GET", url, params or {})
+
+    async def post(self, url: str, *, json: dict | None = None, **_: Any) -> FakeResp:
+        return self._record("POST", url, json or {})
+
+
+class FakeHTTPX:
+    """Controller returned by the :func:`fake_httpx` fixture.
+
+    ``calls`` accumulates every request; ``respond_with`` swaps in a custom
+    responder (default: an empty-payload 200 for everything).
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+        self._responder: Callable[[str, str, dict], FakeResp] = lambda *_a: FakeResp({})
+
+    def respond_with(self, responder: Callable[[str, str, dict], FakeResp]) -> None:
+        self._responder = responder
+
+    def _factory(self, *_a: object, **_k: object) -> FakeHTTPXClient:
+        return FakeHTTPXClient(self.calls, lambda m, u, p: self._responder(m, u, p))
+
+
+@pytest.fixture
+def fake_httpx(monkeypatch: pytest.MonkeyPatch) -> FakeHTTPX:
+    """Patch ``httpx.AsyncClient`` and ``httpx.Client`` with a recording fake.
+
+    Modules under test do ``import httpx; httpx.AsyncClient(...)``, so patching the
+    attribute on the ``httpx`` module covers all of them. Returns the
+    :class:`FakeHTTPX` controller — read ``.calls``, script responses via
+    ``.respond_with``.
+    """
+    ctrl = FakeHTTPX()
+    monkeypatch.setattr(httpx, "AsyncClient", ctrl._factory)
+    monkeypatch.setattr(httpx, "Client", ctrl._factory)
+    return ctrl
+
+
+# ── the generated typed backend client (command plumbing) ─────────────────────
+
+
+def stub_typed_client(
+    monkeypatch: pytest.MonkeyPatch,
+    module: Any,
+    *,
+    api_url: str = "http://localhost:8000",
+    room: str | None = None,
+) -> None:
+    """Neutralize a command module's backend plumbing for a unit test.
+
+    Patches, on ``module``:
+
+    * ``MyceliumConfig.load`` → a config pointing at ``api_url`` (no config file);
+    * ``_typed_client`` → a no-op context manager yielding a dummy client;
+    * ``_resolve_room`` → ``room`` (when the module has one and ``room`` is given).
+
+    After this the test only scripts the one generated API ``.sync`` it exercises
+    (``monkeypatch.setattr("mycelium_backend_client.api.<...>.sync", fake)``), the
+    same shape the pre-existing ``test_room_messages`` used.
+    """
+    fake_config = SimpleNamespace(server=SimpleNamespace(api_url=api_url))
+    if hasattr(module, "MyceliumConfig"):
+        monkeypatch.setattr(module.MyceliumConfig, "load", classmethod(lambda _cls: fake_config))
+    if hasattr(module, "_typed_client"):
+        fake_cm = MagicMock()
+        fake_cm.__enter__.return_value = Mock(name="client")
+        fake_cm.__exit__.return_value = None
+        monkeypatch.setattr(module, "_typed_client", lambda _c: fake_cm)
+    if room is not None and hasattr(module, "_resolve_room"):
+        monkeypatch.setattr(module, "_resolve_room", lambda *_a, **_k: room)
+
+
+@pytest.fixture
+def backend(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
+    """A helper that stubs a command module's typed-client plumbing.
+
+    Usage: ``backend(room_cmd, room="demo")`` then patch the specific API
+    ``.sync``. Thin wrapper over :func:`stub_typed_client` bound to this test's
+    ``monkeypatch``.
+    """
+
+    def _install(module: Any, *, api_url: str = "http://localhost:8000", room: str | None = None):
+        stub_typed_client(monkeypatch, module, api_url=api_url, room=room)
+
+    return _install
+
+
+# ── environment isolation ─────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``Path.home()`` (and thus ``get_mycelium_dir``) at a temp dir.
+
+    ``filesystem.get_mycelium_dir`` resolves to ``~/.mycelium``; setting ``HOME``
+    keeps a test from ever touching the developer's real data dir. Returns the
+    temp home so a test can seed ``.mycelium`` under it.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path

--- a/mycelium-cli/tests/test_connector_keepalive.py
+++ b/mycelium-cli/tests/test_connector_keepalive.py
@@ -21,6 +21,7 @@ import pytest
 from mycelium.daemon import connector
 from mycelium.engine.runtime import EngineDrive
 from mycelium.slim import l9, member
+from tests.conftest import FakeHTTPX, FakeResp
 
 
 def _keepalive(sender: str = "growth") -> dict:
@@ -139,50 +140,23 @@ async def test_drive_ignores_keepalive_then_reads_reply() -> None:
 # ── self-rejoin announce ─────────────────────────────────────────────────────
 
 
-class _FakeResp:
-    def __init__(self, boom: bool = False) -> None:
-        self._boom = boom
-
-    def raise_for_status(self) -> None:
-        if self._boom:
-            raise RuntimeError("500")
-
-
-class _FakeClient:
-    def __init__(self, calls: list[tuple[str, dict]], boom: bool = False) -> None:
-        self._calls = calls
-        self._boom = boom
-
-    async def __aenter__(self) -> _FakeClient:
-        return self
-
-    async def __aexit__(self, *_a: object) -> bool:
-        return False
-
-    async def post(self, url: str, json: dict | None = None) -> _FakeResp:
-        self._calls.append((url, json or {}))
-        return _FakeResp(self._boom)
-
-
 @pytest.mark.asyncio
-async def test_announce_presence_posts_join(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_announce_presence_posts_join(fake_httpx: FakeHTTPX) -> None:
     from mycelium.config import MyceliumConfig, ServerConfig
 
-    calls: list[tuple[str, dict]] = []
-    monkeypatch.setattr(connector.httpx, "AsyncClient", lambda **_k: _FakeClient(calls))
     cfg = MyceliumConfig(server=ServerConfig(api_url="http://localhost:8000"))
 
     await connector.announce_presence(cfg, "myroom", "agent-a")
 
-    assert calls == [
-        ("http://localhost:8000/api/rooms/myroom/sessions", {"agent_handle": "agent-a"})
+    assert fake_httpx.calls == [
+        ("POST", "http://localhost:8000/api/rooms/myroom/sessions", {"agent_handle": "agent-a"})
     ]
 
 
 @pytest.mark.asyncio
-async def test_announce_presence_is_best_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_announce_presence_is_best_effort(fake_httpx: FakeHTTPX) -> None:
     from mycelium.config import MyceliumConfig
 
-    monkeypatch.setattr(connector.httpx, "AsyncClient", lambda **_k: _FakeClient([], boom=True))
+    fake_httpx.respond_with(lambda *_a: FakeResp(boom=True))
     # A backend error must not raise — the connector still falls back to waiting.
     await connector.announce_presence(MyceliumConfig(), "r", "a")

--- a/mycelium-cli/tests/test_connector_knowledge_sync.py
+++ b/mycelium-cli/tests/test_connector_knowledge_sync.py
@@ -18,6 +18,7 @@ import pytest
 from mycelium import filesystem
 from mycelium.daemon import connector
 from mycelium.slim import l9
+from tests.conftest import FakeResp
 
 
 @pytest.fixture(autouse=True)
@@ -185,55 +186,23 @@ async def test_handle_inbound_skips_reindex_on_stale_base(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_reindex_after_knowledge_posts_to_scoped_backend_endpoint(monkeypatch):
+async def test_reindex_after_knowledge_posts_to_scoped_backend_endpoint(fake_httpx):
     """The reindex helper POSTs to the room-scoped backend reindex endpoint."""
     from mycelium.config import MyceliumConfig, ServerConfig
 
-    calls: list[str] = []
-
-    class _FakeResponse:
-        def raise_for_status(self) -> None:
-            pass
-
-    class _FakeClient:
-        def __init__(self, *a, **k) -> None:
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a) -> None:
-            pass
-
-        async def post(self, url: str):
-            calls.append(url)
-            return _FakeResponse()
-
-    monkeypatch.setattr(connector.httpx, "AsyncClient", _FakeClient)
     config = MyceliumConfig(server=ServerConfig(api_url="http://host-b:8000"))
 
     await connector.reindex_after_knowledge(config, "demo")
-    assert calls == ["http://host-b:8000/api/rooms/demo/reindex"]
+    assert [url for _method, url, _p in fake_httpx.calls] == [
+        "http://host-b:8000/api/rooms/demo/reindex"
+    ]
 
 
 @pytest.mark.asyncio
-async def test_reindex_after_knowledge_swallows_errors(monkeypatch):
+async def test_reindex_after_knowledge_swallows_errors(fake_httpx):
     """A reindex failure never propagates — the markdown is already canonical."""
     from mycelium.config import MyceliumConfig
 
-    class _BoomClient:
-        def __init__(self, *a, **k) -> None:
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a) -> None:
-            pass
-
-        async def post(self, url: str):
-            raise ConnectionError("backend down")
-
-    monkeypatch.setattr(connector.httpx, "AsyncClient", _BoomClient)
+    fake_httpx.respond_with(lambda *_a: FakeResp(boom=True))
     # Must not raise.
     await connector.reindex_after_knowledge(MyceliumConfig(), "demo")

--- a/mycelium-cli/tests/test_daemon_agent_context.py
+++ b/mycelium-cli/tests/test_daemon_agent_context.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from mycelium.daemon import dispatch
+from tests.conftest import FakeHTTPX, FakeResp
 
 
 @pytest.fixture(autouse=True)
@@ -57,39 +58,11 @@ def test_humanize_age_minutes() -> None:
 # ── _fetch_agent_context cache ───────────────────────────────────────────────
 
 
-class _FakeResp:
-    def __init__(self, payload: dict) -> None:
-        self._payload = payload
-
-    def raise_for_status(self) -> None:
-        return None
-
-    def json(self) -> dict:
-        return self._payload
+_CTX = {"context": "ctx", "generated_at": "2026-05-21T18:00:00+00:00"}
 
 
-class _FakeClient:
-    """Stand-in for httpx.AsyncClient that counts GETs."""
-
-    calls = 0
-
-    def __init__(self, *_a, **_kw) -> None:
-        pass
-
-    async def __aenter__(self) -> _FakeClient:
-        return self
-
-    async def __aexit__(self, *_exc) -> None:
-        return None
-
-    async def get(self, _url: str, *, params: dict) -> _FakeResp:  # noqa: ARG002
-        type(self).calls += 1
-        return _FakeResp({"context": "ctx", "generated_at": "2026-05-21T18:00:00+00:00"})
-
-
-def test_fetch_agent_context_caches_within_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
-    _FakeClient.calls = 0
-    monkeypatch.setattr(dispatch.httpx, "AsyncClient", _FakeClient)
+def test_fetch_agent_context_caches_within_ttl(fake_httpx: FakeHTTPX) -> None:
+    fake_httpx.respond_with(lambda *_a: FakeResp(_CTX))
 
     async def run() -> None:
         a = await dispatch._fetch_agent_context("http://hub", "room-a", "alpha")
@@ -98,27 +71,22 @@ def test_fetch_agent_context_caches_within_ttl(monkeypatch: pytest.MonkeyPatch) 
         assert b == a
 
     asyncio.run(run())
-    assert _FakeClient.calls == 1  # second call served from cache
+    assert len(fake_httpx.calls) == 1  # second call served from cache
 
 
-def test_fetch_agent_context_separate_per_room(monkeypatch: pytest.MonkeyPatch) -> None:
-    _FakeClient.calls = 0
-    monkeypatch.setattr(dispatch.httpx, "AsyncClient", _FakeClient)
+def test_fetch_agent_context_separate_per_room(fake_httpx: FakeHTTPX) -> None:
+    fake_httpx.respond_with(lambda *_a: FakeResp(_CTX))
 
     async def run() -> None:
         await dispatch._fetch_agent_context("http://hub", "room-a", "alpha")
         await dispatch._fetch_agent_context("http://hub", "room-b", "alpha")
 
     asyncio.run(run())
-    assert _FakeClient.calls == 2
+    assert len(fake_httpx.calls) == 2
 
 
-def test_fetch_agent_context_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
-    class _BoomClient(_FakeClient):
-        async def get(self, _url: str, *, params: dict) -> _FakeResp:  # noqa: ARG002
-            raise RuntimeError("network down")
-
-    monkeypatch.setattr(dispatch.httpx, "AsyncClient", _BoomClient)
+def test_fetch_agent_context_swallows_errors(fake_httpx: FakeHTTPX) -> None:
+    fake_httpx.respond_with(lambda *_a: FakeResp(boom=True))
 
     async def run() -> None:
         result = await dispatch._fetch_agent_context("http://hub", "room-x", "alpha")

--- a/mycelium-cli/tests/test_doctor_checks.py
+++ b/mycelium-cli/tests/test_doctor_checks.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for ``mycelium doctor`` checks beyond the mediator-Pi one.
+
+Node-free: the checks are stubbed at their filesystem / subprocess seams, so the
+local-backend classifier and the config-files check run without a live stack.
+The mediator-Pi check has its own file (``test_doctor_mediator_pi``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mycelium.commands import doctor
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("http://localhost:8000", True),
+        ("http://127.0.0.1:8000", True),
+        ("http://0.0.0.0:8000", True),
+        ("http://host-a.lan:8000", False),
+        ("https://mycelium.example.com", False),
+    ],
+)
+def test_is_local_backend_classifies_host(url: str, expected: bool) -> None:
+    assert doctor._is_local_backend(url) is expected
+
+
+def test_check_config_files_ok_when_present(isolated_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    myc = isolated_home / ".mycelium"
+    myc.mkdir(parents=True, exist_ok=True)
+    (myc / ".env").write_text("X=1")
+    (myc / "config.toml").write_text("")
+
+    result = doctor._check_config_files()
+    assert result.status == "ok"
+
+
+def test_check_config_files_errors_when_missing(
+    isolated_home, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # isolated_home is an empty temp home → both files absent.
+    result = doctor._check_config_files()
+    assert result.status == "error"
+    assert ".env" in result.message and "config.toml" in result.message
+    assert any("mycelium install" in d for d in result.details)

--- a/mycelium-cli/tests/test_memory_commands.py
+++ b/mycelium-cli/tests/test_memory_commands.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for ``mycelium memory`` (get / ls / search).
+
+Node-free: ``get`` and ``ls`` read the local markdown under a temp home
+(``isolated_home``); ``search`` goes through the backend, whose API ``.sync`` is
+stubbed. No live stack.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from mycelium.commands import memory as memory_cmd
+from mycelium.filesystem import get_room_dir, write_memory
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _home(isolated_home) -> None:
+    """Every memory test reads/writes under the temp ``~/.mycelium``."""
+
+
+def _seed(room: str, key: str, value: str) -> None:
+    write_memory(get_room_dir(room), key, value, created_by="tester")
+
+
+def test_memory_get_prints_key_and_content() -> None:
+    _seed("demo", "decisions/db", "we chose postgres")
+    result = runner.invoke(memory_cmd.app, ["get", "decisions/db", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "decisions/db" in result.output
+    assert "we chose postgres" in result.output
+
+
+def test_memory_get_missing_key_exits_nonzero() -> None:
+    result = runner.invoke(memory_cmd.app, ["get", "nope", "--room", "demo"])
+    assert result.exit_code == 1
+    assert "Not found" in result.output
+
+
+def test_memory_ls_lists_and_filters_by_prefix() -> None:
+    _seed("demo", "decisions/db", "postgres")
+    _seed("demo", "decisions/lang", "python")
+    _seed("demo", "status/sprint", "green")
+
+    listed = runner.invoke(memory_cmd.app, ["ls", "--room", "demo"])
+    assert listed.exit_code == 0, listed.output
+    assert "3 memories" in listed.output
+
+    filtered = runner.invoke(memory_cmd.app, ["ls", "decisions/", "--room", "demo"])
+    assert filtered.exit_code == 0, filtered.output
+    assert "2 memories" in filtered.output
+    assert "status/sprint" not in filtered.output
+
+
+def test_memory_ls_empty_prints_hint() -> None:
+    result = runner.invoke(memory_cmd.app, ["ls", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "No memories found" in result.output
+
+
+def test_memory_search_renders_backend_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    import datetime
+    import uuid
+
+    from mycelium_backend_client.models import (
+        MemoryRead,
+        MemorySearchResponse,
+        MemorySearchResult,
+    )
+
+    monkeypatch.setattr(memory_cmd, "_get_active_room", lambda _room: "demo")
+
+    stamp = datetime.datetime(2026, 6, 1)  # noqa: DTZ001
+
+    class _Client:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, *_a):
+            return False
+
+    monkeypatch.setattr(memory_cmd, "_get_client", lambda: _Client())
+
+    mem = MemoryRead(
+        id=uuid.uuid4(),
+        key="decisions/db",
+        value="postgres",
+        content_text="we chose postgres for durability",
+        version=1,
+        created_by="tester",
+        room_name="demo",
+        created_at=stamp,
+        updated_at=stamp,
+    )
+    resp = MemorySearchResponse(results=[MemorySearchResult(memory=mem, similarity=0.91)], total=1)
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.memory."
+        "search_memories_api_rooms_room_name_memory_search_post.sync",
+        lambda **_kw: resp,
+    )
+
+    result = runner.invoke(memory_cmd.app, ["search", "database choice", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "decisions/db" in result.output
+    assert "0.910" in result.output
+    assert "we chose postgres" in result.output
+
+
+def test_memory_search_no_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mycelium_backend_client.models import MemorySearchResponse
+
+    monkeypatch.setattr(memory_cmd, "_get_active_room", lambda _room: "demo")
+
+    class _Client:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, *_a):
+            return False
+
+    monkeypatch.setattr(memory_cmd, "_get_client", lambda: _Client())
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.memory."
+        "search_memories_api_rooms_room_name_memory_search_post.sync",
+        lambda **_kw: MemorySearchResponse(results=[], total=0),
+    )
+
+    result = runner.invoke(memory_cmd.app, ["search", "nothing", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "No matching memories found" in result.output

--- a/mycelium-cli/tests/test_metrics_commands.py
+++ b/mycelium-cli/tests/test_metrics_commands.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for ``mycelium metrics`` helpers.
+
+Node-free: ``metrics status`` aggregates docker/prometheus/collector state (its
+own integration surface), so these pin the pure, deterministic helpers — the
+add-pricing spec parser, the MAS-id formatter, and the collector-PID reader — that
+back the command without a live stack.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mycelium.commands import metrics as metrics_cmd
+
+
+def test_parse_add_spec_pattern_and_key() -> None:
+    assert metrics_cmd._parse_add_spec("gpt-4o:openai/gpt-4o") == {
+        "pattern": "gpt-4o",
+        "provider": "",
+        "litellm_key": "openai/gpt-4o",
+    }
+
+
+def test_parse_add_spec_bare_key_doubles_as_pattern() -> None:
+    assert metrics_cmd._parse_add_spec("claude-sonnet-4-6") == {
+        "pattern": "claude-sonnet-4-6",
+        "provider": "",
+        "litellm_key": "claude-sonnet-4-6",
+    }
+
+
+def test_format_mas_shortens_by_default_and_full_on_detail() -> None:
+    mas = "0123456789abcdef0123456789abcdef"
+    assert metrics_cmd._format_mas(mas) == "01234567"  # narrow column
+    assert metrics_cmd._format_mas(mas, detail=True) == mas
+    assert metrics_cmd._format_mas("") == ""
+
+
+def test_read_collector_pid_returns_running_pid(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    import os
+
+    pid_file = tmp_path / "collector.pid"
+    pid_file.write_text(str(os.getpid()))
+    monkeypatch.setattr(metrics_cmd, "_collector_pid_file", lambda: pid_file)
+    # Our own pid is alive, so it's returned as-is.
+    assert metrics_cmd._read_collector_pid() == os.getpid()
+
+
+def test_read_collector_pid_none_when_missing(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setattr(metrics_cmd, "_collector_pid_file", lambda: tmp_path / "absent.pid")
+    assert metrics_cmd._read_collector_pid() is None
+
+
+def test_read_collector_pid_prunes_dead_pid(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    pid_file = tmp_path / "collector.pid"
+    pid_file.write_text("999999999")  # a pid that isn't running
+    monkeypatch.setattr(metrics_cmd, "_collector_pid_file", lambda: pid_file)
+    assert metrics_cmd._read_collector_pid() is None
+    assert not pid_file.exists()  # a stale pid file is cleaned up

--- a/mycelium-cli/tests/test_participate_cli.py
+++ b/mycelium-cli/tests/test_participate_cli.py
@@ -19,6 +19,7 @@ from typer.testing import CliRunner
 
 from mycelium.cli import app
 from mycelium.commands import participate
+from tests.conftest import FakeResp
 
 runner = CliRunner()
 
@@ -29,22 +30,11 @@ def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MYCELIUM_ROOM_ID", "demo")
 
 
-class _FakeResp:
-    def __init__(self, data: dict) -> None:
-        self._data = data
-
-    def raise_for_status(self) -> None:
-        pass
-
-    def json(self) -> dict:
-        return self._data
-
-
 def test_await_prints_addressed_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_get(url: str, params: dict | None = None, timeout: float | None = None) -> _FakeResp:
+    def fake_get(url: str, params: dict | None = None, timeout: float | None = None) -> FakeResp:
         assert url.endswith("/api/rooms/demo/await")
         assert params is not None and params["handle"] == "me"
-        return _FakeResp(
+        return FakeResp(
             {
                 "room": "demo",
                 "handle": "me",
@@ -68,7 +58,7 @@ def test_await_prints_addressed_message(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_await_timeout_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_get(url, params=None, timeout=None):
-        return _FakeResp({"room": "demo", "handle": "me", "message": None})
+        return FakeResp({"room": "demo", "handle": "me", "message": None})
 
     monkeypatch.setattr(participate.httpx, "get", fake_get)
     result = runner.invoke(app, ["await", "--handle", "me", "--timeout", "1", "--json"])
@@ -82,7 +72,7 @@ def test_respond_posts_reply(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_post(url, json=None, timeout=None):
         captured["url"] = url
         captured["body"] = json
-        return _FakeResp({"room": "demo", "handle": "me", "message_id": "r-1"})
+        return FakeResp({"room": "demo", "handle": "me", "message_id": "r-1"})
 
     monkeypatch.setattr(participate.httpx, "post", fake_post)
 

--- a/mycelium-cli/tests/test_plan_commands.py
+++ b/mycelium-cli/tests/test_plan_commands.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for ``mycelium plan`` (ls / show / tasks) + the fetch wiring.
+
+Node-free: the rendering commands run against a stubbed ``_fetch_plan`` payload,
+and one test drives the real ``_fetch_plan`` through the ``fake_httpx`` transport
+to pin the HTTP wiring. No backend server.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from mycelium.commands import plan as plan_cmd
+from tests.conftest import FakeHTTPX, FakeResp
+
+runner = CliRunner()
+
+_PLAN = {
+    "room": "demo",
+    "files": [
+        {
+            "slug": "tasks",
+            "title": "MVP",
+            "updated_at": "2026-06-01T10:00:00",
+            "content": "# MVP\n\n- [ ] ship auth @a",
+            "tasks": [
+                {"id": "t1", "text": "ship auth @a", "done": False, "slug": "tasks"},
+                {"id": "t2", "text": "write docs @b", "done": True, "slug": "tasks"},
+            ],
+        }
+    ],
+    "tasks": [
+        {"id": "t1", "text": "ship auth @a", "done": False, "slug": "tasks"},
+        {"id": "t2", "text": "write docs @b", "done": True, "slug": "tasks"},
+    ],
+}
+
+
+def test_plan_ls_renders_file_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plan_cmd, "_fetch_plan", lambda room=None: _PLAN)
+    result = runner.invoke(plan_cmd.app, ["ls"])
+    assert result.exit_code == 0, result.output
+    assert "demo plan" in result.output
+    assert "tasks" in result.output
+
+
+def test_plan_ls_empty_prints_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plan_cmd, "_fetch_plan", lambda room=None: {"room": "demo", "files": []})
+    result = runner.invoke(plan_cmd.app, ["ls"])
+    assert result.exit_code == 0, result.output
+    assert "No plan files yet." in result.output
+
+
+def test_plan_show_prints_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plan_cmd, "_fetch_plan", lambda room=None: _PLAN)
+    result = runner.invoke(plan_cmd.app, ["show", "tasks"])
+    assert result.exit_code == 0, result.output
+    assert "ship auth @a" in result.output
+
+
+def test_plan_show_unknown_slug_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plan_cmd, "_fetch_plan", lambda room=None: _PLAN)
+    result = runner.invoke(plan_cmd.app, ["show", "ghost"])
+    assert result.exit_code == 1
+    assert "Plan file not found" in result.output
+
+
+def test_plan_tasks_lists_open_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plan_cmd, "_fetch_plan", lambda room=None: _PLAN)
+    result = runner.invoke(plan_cmd.app, ["tasks"])
+    assert result.exit_code == 0, result.output
+    assert "1 open" in result.output and "1 done" in result.output
+    assert "ship auth @a" in result.output
+    assert "write docs @b" not in result.output  # done tasks hidden without --all
+
+
+def test_plan_tasks_all_includes_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(plan_cmd, "_fetch_plan", lambda room=None: _PLAN)
+    result = runner.invoke(plan_cmd.app, ["tasks", "--all"])
+    assert result.exit_code == 0, result.output
+    assert "write docs @b" in result.output
+
+
+def test_fetch_plan_hits_room_scoped_endpoint(
+    fake_httpx: FakeHTTPX, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real ``_fetch_plan`` GETs the room-scoped plan endpoint."""
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        plan_cmd.MyceliumConfig,
+        "load",
+        classmethod(lambda _cls: SimpleNamespace(server=SimpleNamespace(api_url="http://bk:8000"))),
+    )
+    monkeypatch.setattr(plan_cmd, "_resolve_room", lambda _cfg, _room: "demo")
+    fake_httpx.respond_with(lambda *_a: FakeResp(_PLAN))
+
+    data = plan_cmd._fetch_plan("demo")
+    assert data["room"] == "demo"
+    # base_url rides the client constructor; the recorded url is the request path.
+    assert fake_httpx.calls == [("GET", "/api/rooms/demo/plan", {})]

--- a/mycelium-cli/tests/test_room_commands.py
+++ b/mycelium-cli/tests/test_room_commands.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for ``mycelium room`` (list / create / use) on a fake backend.
+
+Node-free: the generated ``rooms`` API ``.sync`` calls are stubbed and the typed
+client is a no-op context manager, so these exercise the command plumbing —
+rendering, the active-room switch, and the empty case — without a backend server.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from typer.testing import CliRunner
+
+from mycelium.commands import room as room_cmd
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate(isolated_home, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real (empty) config on a temp home, plus a no-op typed client.
+
+    ``room`` reads ``config.get_active_room()`` and requires a config file to
+    exist, so it needs the real ``MyceliumConfig`` (not the SimpleNamespace the
+    shared ``backend`` fixture installs) — only the typed client is stubbed.
+    """
+    from unittest.mock import MagicMock, Mock
+
+    from mycelium.config import MyceliumConfig
+
+    cfg_path = isolated_home / ".mycelium" / "config.toml"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text("")
+    monkeypatch.setattr(
+        room_cmd.MyceliumConfig, "get_config_path", classmethod(lambda _cls: cfg_path)
+    )
+    monkeypatch.setattr(
+        room_cmd.MyceliumConfig, "load", classmethod(lambda _cls, *a, **k: MyceliumConfig())
+    )
+    fake_cm = MagicMock()
+    fake_cm.__enter__.return_value = Mock(name="client")
+    fake_cm.__exit__.return_value = None
+    monkeypatch.setattr(room_cmd, "_typed_client", lambda _c: fake_cm)
+
+
+_ids = iter(range(1, 1000))
+
+
+def _room(name: str) -> object:
+    from mycelium_backend_client.models import RoomRead
+
+    return RoomRead(
+        id=next(_ids),
+        name=name,
+        is_public=True,
+        created_at=datetime.datetime(2026, 6, 1),  # noqa: DTZ001
+    )
+
+
+def test_room_list_renders_rooms(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.rooms.list_rooms_api_rooms_get.sync",
+        lambda **_kw: [_room("alpha"), _room("beta")],
+    )
+    result = runner.invoke(room_cmd.app, ["ls"])
+    assert result.exit_code == 0, result.output
+    assert "Rooms (2)" in result.output
+    assert "alpha" in result.output and "beta" in result.output
+
+
+def test_room_list_empty_prints_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.rooms.list_rooms_api_rooms_get.sync",
+        lambda **_kw: [],
+    )
+    result = runner.invoke(room_cmd.app, ["ls"])
+    assert result.exit_code == 0, result.output
+    assert "No rooms found." in result.output
+
+
+def test_room_list_passes_limit_and_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def fake_sync(**kwargs):
+        captured.update(kwargs)
+        return [_room("alpha")]
+
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.rooms.list_rooms_api_rooms_get.sync", fake_sync
+    )
+    result = runner.invoke(room_cmd.app, ["ls", "--limit", "7", "--name", "alpha"])
+    assert result.exit_code == 0, result.output
+    assert captured["limit"] == 7
+    assert captured["name"] == "alpha"
+
+
+def test_room_create_writes_local_dir_and_reports(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.rooms.create_room_api_rooms_post.sync",
+        lambda **_kw: _room("gamma"),
+    )
+    result = runner.invoke(room_cmd.app, ["create", "gamma"])
+    assert result.exit_code == 0, result.output
+    assert "Created room: gamma" in result.output
+    # The command also materializes the room dir locally (cross-machine safety).
+    from mycelium.filesystem import get_room_dir
+
+    assert get_room_dir("gamma").exists()

--- a/mycelium-cli/tests/test_slim_member.py
+++ b/mycelium-cli/tests/test_slim_member.py
@@ -11,14 +11,13 @@ implementation so they can't drift.
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any
 
 import pytest
 
 from mycelium.config import MyceliumConfig, ServerConfig
 from mycelium.slim import l9, member
-from mycelium.slim.client import SlimReceiveTimeout
+from tests.conftest import FakeSlimClient
 
 
 def _exchange(sender: str, recipients: list[str], text: str, *, mid: str = "m1") -> dict:
@@ -95,44 +94,6 @@ def test_build_reply_lifts_position_marker() -> None:
 # ── the message stream (fake transport) ───────────────────────────────────────
 
 
-class _FakeSlimClient:
-    """A minimal stand-in for SlimClient that replays a scripted inbox."""
-
-    inbox: list[bytes] = []
-    published: list[bytes] = []
-
-    def __init__(self, _identity: Any, *, secret: str | None = None) -> None:
-        pass
-
-    async def connect(self, _endpoint: str) -> _FakeSlimClient:
-        return self
-
-    async def listen_for_session(self) -> str:
-        return "session-1"
-
-    async def close(self) -> None:
-        pass
-
-    @staticmethod
-    async def publish(_session: Any, data: bytes) -> None:
-        _FakeSlimClient.published.append(data)
-
-    @staticmethod
-    async def receive_message(_session: Any, *, timeout_s: float = 30.0):  # noqa: ARG004
-        if not _FakeSlimClient.inbox:
-            # Simulate a real idle window: block briefly, then report a benign
-            # timeout (which the stream treats as "still connected, just quiet").
-            await asyncio.sleep(0.02)
-            raise SlimReceiveTimeout("receive timeout")
-        payload = _FakeSlimClient.inbox.pop(0)
-
-        class _Msg:
-            def __init__(self, p: bytes) -> None:
-                self.payload = p
-
-        return _Msg(payload)
-
-
 def _cfg() -> MyceliumConfig:
     return MyceliumConfig(server=ServerConfig(api_url="http://localhost:8000"))
 
@@ -140,11 +101,11 @@ def _cfg() -> MyceliumConfig:
 @pytest.mark.asyncio
 async def test_await_addressed_returns_first_addressed(monkeypatch: pytest.MonkeyPatch) -> None:
     # No node: stub SlimClient and the presence announce (best-effort HTTP).
-    monkeypatch.setattr(member, "SlimClient", _FakeSlimClient)
+    monkeypatch.setattr(member, "SlimClient", FakeSlimClient)
     monkeypatch.setattr(member, "announce_presence", _noop_announce)
     monkeypatch.setattr(member, "KEEPALIVE_INTERVAL_S", 3600)  # keep it out of the way
-    _FakeSlimClient.published = []
-    _FakeSlimClient.inbox = [
+    FakeSlimClient.published = []
+    FakeSlimClient.inbox = [
         l9.serialize(_keepalive("other")),  # dropped
         l9.serialize(_exchange("backend", ["other"], "not me")),  # not addressed
         l9.serialize(_exchange("backend", ["agent-a"], "@agent-a your turn", mid="hit")),
@@ -157,7 +118,7 @@ async def test_await_addressed_returns_first_addressed(monkeypatch: pytest.Monke
 
 @pytest.mark.asyncio
 async def test_stream_applies_knowledge_and_swallows_it(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(member, "SlimClient", _FakeSlimClient)
+    monkeypatch.setattr(member, "SlimClient", FakeSlimClient)
     monkeypatch.setattr(member, "announce_presence", _noop_announce)
     monkeypatch.setattr(member, "KEEPALIVE_INTERVAL_S", 3600)
     applied: list[dict] = []
@@ -175,8 +136,8 @@ async def test_stream_applies_knowledge_and_swallows_it(monkeypatch: pytest.Monk
 
     knowledge = _exchange("backend", [], "plan updated")
     knowledge["l9"]["header"]["kind"] = l9.KNOWLEDGE_KIND
-    _FakeSlimClient.published = []
-    _FakeSlimClient.inbox = [
+    FakeSlimClient.published = []
+    FakeSlimClient.inbox = [
         l9.serialize(knowledge),
         l9.serialize(_exchange("backend", ["agent-a"], "@agent-a go", mid="hit")),
     ]
@@ -189,11 +150,11 @@ async def test_stream_applies_knowledge_and_swallows_it(monkeypatch: pytest.Monk
 
 @pytest.mark.asyncio
 async def test_await_addressed_times_out(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(member, "SlimClient", _FakeSlimClient)
+    monkeypatch.setattr(member, "SlimClient", FakeSlimClient)
     monkeypatch.setattr(member, "announce_presence", _noop_announce)
     monkeypatch.setattr(member, "KEEPALIVE_INTERVAL_S", 3600)
-    _FakeSlimClient.published = []
-    _FakeSlimClient.inbox = [l9.serialize(_exchange("backend", ["other"], "not me"))]
+    FakeSlimClient.published = []
+    FakeSlimClient.inbox = [l9.serialize(_exchange("backend", ["other"], "not me"))]
 
     # The one non-addressed message is consumed, then the stream idles — await
     # returns None once the (short) timeout elapses.


### PR DESCRIPTION
## Epic: shared test-support layer (#460 + #461, #462, #463)

Closes #460, #461, #462, #463.

One import gets you an in-process fake stack — **no SLIM node, no Pi binary, no live LLM, no backend server** — plus node-free tests for the services/commands that had none, and a one-command smoke of the whole protocol.

### Why this matters day to day

- **Testing a feature stops being a reverse-engineering exercise.** Before, touching the aligner or a connector meant hand-copying a fake channel/persister/manager or fake HTTP client from some other test file first. Now it's `from tests.fakes import ...` (backend) or the `fake_httpx` / `backend` fixtures (CLI), with a `tests/README.md` in each package saying which fake stands in for which real thing. That "how do I even test this" tax — the biggest drag on feature work — is gone.
- **Validate a change in ~5 seconds without standing anything up.** `make smoke` runs the full protocol (room → engine → await → respond → converge → plan) over the fake stack. No `docker compose up`, no API key, no clicking through `mycelium demo`. Red = the happy path itself broke.
- **One obvious way to run tests:** `make test` / `test-backend` / `test-cli` / `test-frontend` / `smoke` / `lint`.
- **A real safety net where there was none.** Six backend services (`room_channels`, `slim_client`, `local_state`, `event_sweep`, `indexer`, `reindex`) had *zero* unit tests and could only run against a live node; five CLI commands (`room`, `memory`, `plan`, `metrics`, `doctor`) had no dedicated tests. Now a break in room provisioning or `memory search` fails a fast local test instead of surfacing mid-session.
- **CI fails faster:** the smoke gate runs first, so a broken protocol fails in seconds ahead of the full suite.

The compounding win is that the next feature builds on these fakes instead of reinventing them — provided the shared modules stay the single home.

> Note: this is **test infrastructure only** — no runtime/product behavior changes. The payoff is entirely in how quickly and safely the code can be changed.

### What's in it

**#460 — keystone (one import → fake stack)**
- `fastapi-backend/tests/fakes.py`: `FakeChannel` / `FakePersister` / `FakeManaged` / `FakeManager`, `make_fake_llm` / `fake_brain_factory`, `patch_pi_run`, and a new `FakeSlimClient` / `FakeSession`. Migrated `test_aligner` / `test_mediator` / `test_plan_sync` / `test_pi_brain` onto it.
- `mycelium-cli/tests/conftest.py` (new; `tests/__init__.py` added so it's importable): `FakeSlimClient`, `FakeResp` + the `fake_httpx` fixture (sync **and** async clients), `stub_typed_client` / `backend` fixture, `isolated_home`. Migrated 5 files — collapses the 6× `_FakeResp` duplication to one.
- A `tests/README.md` recipe in each package.

**#461 — backend node-free tests (+41):** `room_channels` (provisioning / membership / presence leases / episode lifecycle via `FakeSlimClient`), `slim_client` (name mapping, secret derivation, reachability), `local_state`, `event_sweep`, `indexer`, `reindex`.

**#462 — CLI command tests (+30):** dedicated `test_room_commands`, `test_memory_commands`, `test_plan_commands`, `test_metrics_commands`, `test_doctor_checks` on the shared fakes.

**#463 — smoke + Makefile + CI:** `test_smoke.py` runs room → engine → await → respond → converge → plan over fakes (marked `smoke`); root `Makefile` with `test` / `test-backend` / `test-cli` / `test-frontend` / `smoke` / `lint`; a fail-first smoke gate in CI.

### Verification (CI-matching gate)

- Backend: ruff ✓ · format ✓ · ty ✓ · **370 passed, 1 skipped** (was 328 → +42)
- CLI: ruff ✓ · format ✓ · ty ✓ · **416 passed** (was 386 → +30)
- The keystone migrations changed no behavior (pass counts held before/after); net **−365 lines of duplicated fakes**.
