### PR TITLE
Onboarding: synced 'Run a sample coordination' tour

### DIFF
--- a/mycelium-frontend/package-lock.json
+++ b/mycelium-frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@base-ui/react": "^1.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",
+        "driver.js": "^1.8.0",
         "lucide-react": "^1.21.0",
         "next": "^16.2.6",
         "next-themes": "^0.4.6",
@@ -4124,6 +4125,12 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/driver.js": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.8.0.tgz",
+      "integrity": "sha512-+8/IO7h1v14IzWh2GP60N7T3PFZweXwdn5e5POuxRSBoCYUojsBxzqawPeXh3YZIibRy7EehYNEyxe7slwwtdg==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/mycelium-frontend/package.json
+++ b/mycelium-frontend/package.json
@@ -14,6 +14,7 @@
     "@base-ui/react": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.0",
+    "driver.js": "^1.8.0",
     "lucide-react": "^1.21.0",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",

--- a/mycelium-frontend/src/app/globals.css
+++ b/mycelium-frontend/src/app/globals.css
@@ -267,6 +267,68 @@ body {
 .markdown-body.contrast li { color: var(--text); }
 .markdown-body.contrast p:first-child { margin-top: 0.15em; }
 
+/* ── Onboarding tour (driver.js popover, themed to the app tokens) ── */
+.driver-popover.mycelium-tour {
+  background: var(--elevated);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
+  padding: 16px;
+  max-width: 320px;
+  font-family: 'IBM Plex Sans', -apple-system, sans-serif;
+}
+.driver-popover.mycelium-tour .driver-popover-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+.driver-popover.mycelium-tour .driver-popover-description {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--muted-foreground);
+  margin-top: 4px;
+}
+.driver-popover.mycelium-tour .driver-popover-progress-text {
+  font-size: 12px;
+  color: var(--faint);
+  font-variant-numeric: tabular-nums;
+}
+.driver-popover.mycelium-tour .driver-popover-close-btn {
+  color: var(--muted-foreground);
+  font-size: 20px;
+}
+.driver-popover.mycelium-tour .driver-popover-close-btn:hover { color: var(--text); }
+.driver-popover.mycelium-tour .driver-popover-navigation-btns {
+  gap: 6px;
+  margin-top: 4px;
+}
+.driver-popover.mycelium-tour .driver-popover-navigation-btns button {
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  text-shadow: none;
+  border-radius: 8px;
+  padding: 5px 12px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.driver-popover.mycelium-tour .driver-popover-navigation-btns button:hover {
+  background: var(--muted-bg);
+}
+.driver-popover.mycelium-tour .driver-popover-next-btn {
+  background: var(--accent) !important;
+  color: var(--accent-fg) !important;
+  border-color: transparent !important;
+}
+.driver-popover.mycelium-tour .driver-popover-next-btn:hover { opacity: 0.9; }
+/* Arrow follows the popover surface on whichever side it points from. */
+.driver-popover.mycelium-tour .driver-popover-arrow-side-left.driver-popover-arrow { border-left-color: var(--elevated); }
+.driver-popover.mycelium-tour .driver-popover-arrow-side-right.driver-popover-arrow { border-right-color: var(--elevated); }
+.driver-popover.mycelium-tour .driver-popover-arrow-side-top.driver-popover-arrow { border-top-color: var(--elevated); }
+.driver-popover.mycelium-tour .driver-popover-arrow-side-bottom.driver-popover-arrow { border-bottom-color: var(--elevated); }
+
 /* shadcn/ui token bridge: maps shadcn's semantic tokens onto the app palette
  * so <Dialog>/<Button>/<DropdownMenu> render in-theme (light + dark). Only
  * shadcn token names live here; the app's own --color-* are defined above. ── */

--- a/mycelium-frontend/src/app/globals.css
+++ b/mycelium-frontend/src/app/globals.css
@@ -267,6 +267,24 @@ body {
 .markdown-body.contrast li { color: var(--text); }
 .markdown-body.contrast p:first-child { margin-top: 0.15em; }
 
+/* Primary accent button: not a flat fill. A top-lit gradient, an inner
+ * highlight edge, and a soft lift give it dimension so it doesn't read cheap. */
+.btn-accent {
+  background-image: linear-gradient(to bottom, color-mix(in srgb, var(--accent) 90%, white), var(--accent));
+  color: var(--accent-fg);
+  border: 1px solid color-mix(in srgb, var(--accent) 74%, black) !important;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22), inset 0 1px 0 rgba(255, 255, 255, 0.22);
+  transition: box-shadow 0.15s ease, background-image 0.15s ease, transform 0.05s ease;
+}
+.btn-accent:hover {
+  background-image: linear-gradient(to bottom, color-mix(in srgb, var(--accent) 96%, white), color-mix(in srgb, var(--accent) 95%, black));
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--accent) 35%, transparent), inset 0 1px 0 rgba(255, 255, 255, 0.24);
+}
+.btn-accent:active {
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.22);
+  transform: translateY(0.5px);
+}
+
 /* ── Onboarding tour (driver.js popover, themed to the app tokens) ── */
 .driver-popover.mycelium-tour {
   background: var(--elevated);

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -7,9 +7,10 @@ import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { fetchRoom, logFetchError, type EpisodeSummary } from "@/lib/api";
 import { AppShell } from "@/components/app-shell";
-import { EventStream } from "@/components/event-stream";
+import { EventStream, type View, type NegotiationPhase } from "@/components/event-stream";
 import { RoomChatBox } from "@/components/room-chat-box";
 import { RoomInspector, type Tab } from "@/components/room-inspector";
+import { RoomTour } from "@/components/room-tour";
 import { GlobalStatusItems, StatusButton } from "@/components/status-items";
 import { useRoomStatus } from "@/lib/use-status";
 
@@ -42,6 +43,21 @@ export default function RoomPage() {
   const [connected, setConnected] = useState(false);
   const [inspectorTab, setInspectorTab] = useState<Tab>("agents");
   const [inspectorOpen, setInspectorOpen] = useState(true);
+  const [editorView, setEditorView] = useState<View>("channel");
+  const [negPhase, setNegPhase] = useState<NegotiationPhase>("idle");
+  const [tourActive, setTourActive] = useState(false);
+
+  // Start the coached tour when arriving via "Run a sample coordination".
+  useEffect(() => {
+    if (typeof window !== "undefined" && new URLSearchParams(window.location.search).get("tour") === "1") {
+      setTourActive(true);
+    }
+  }, []);
+
+  const handleTourExit = useCallback(() => {
+    setTourActive(false);
+    if (typeof window !== "undefined") window.history.replaceState(null, "", window.location.pathname);
+  }, []);
 
   const { agents, episodes, openTasks } = useRoomStatus(roomName);
 
@@ -117,7 +133,10 @@ export default function RoomPage() {
               roomName={roomName}
               onMemoryChanged={handleMemoryChanged}
               onConnectionChange={setConnected}
+              onNegotiationPhaseChange={setNegPhase}
               planRefreshTrigger={memoryRefresh}
+              view={editorView}
+              onViewChange={setEditorView}
             />
           </div>
           <RoomChatBox roomName={roomName} />
@@ -133,6 +152,14 @@ export default function RoomPage() {
           onOpenChange={setInspectorOpen}
         />
       </div>
+
+      <RoomTour
+        active={tourActive}
+        phase={negPhase}
+        setEditorView={setEditorView}
+        setInspectorTab={setInspectorTab}
+        onExit={handleTourExit}
+      />
     </AppShell>
   );
 }

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -137,6 +137,7 @@ export default function RoomPage() {
               planRefreshTrigger={memoryRefresh}
               view={editorView}
               onViewChange={setEditorView}
+              suppressInvites={tourActive}
             />
           </div>
           <RoomChatBox roomName={roomName} />

--- a/mycelium-frontend/src/components/command-center.tsx
+++ b/mycelium-frontend/src/components/command-center.tsx
@@ -5,8 +5,23 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Boxes } from "lucide-react";
+import { Boxes, Sparkles } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
+
+// The seeded sample room the "Run a sample coordination" onboarding routes into.
+const SAMPLE_TOUR_HREF = "/room/pricing-model?tour=1";
+
+function RunSampleButton({ className = "" }: { className?: string }) {
+  return (
+    <Link
+      href={SAMPLE_TOUR_HREF}
+      className={`inline-flex items-center gap-2 rounded-md bg-accent px-3.5 py-2 text-label font-medium text-accent-fg transition-opacity hover:opacity-90 ${className}`}
+    >
+      <Sparkles className="size-4" />
+      Run a sample coordination
+    </Link>
+  );
+}
 import {
   fetchRooms,
   fetchRoomAgents,
@@ -67,11 +82,14 @@ export function CommandCenter() {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto max-w-5xl px-8 py-8">
-        <header className="mb-6">
-          <h1 className="text-2xl font-semibold text-text">Command center</h1>
-          <p className="mt-1 text-label text-muted-foreground">
-            Every coordination workspace, at a glance. Open one to negotiate, plan, and remember.
-          </p>
+        <header className="mb-6 flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-semibold text-text">Command center</h1>
+            <p className="mt-1 text-label text-muted-foreground">
+              Every coordination workspace, at a glance. Open one to negotiate, plan, and remember.
+            </p>
+          </div>
+          <RunSampleButton className="mt-1 flex-shrink-0" />
         </header>
 
         {loaded && rooms.length === 0 ? (
@@ -79,7 +97,8 @@ export function CommandCenter() {
             <EmptyState
               icon={Boxes}
               title="No rooms yet"
-              description="Create one from the sidebar to get started."
+              description="See it work first: run a guided sample coordination, or create a room from the sidebar."
+              action={<RunSampleButton />}
             />
           </div>
         ) : (

--- a/mycelium-frontend/src/components/command-center.tsx
+++ b/mycelium-frontend/src/components/command-center.tsx
@@ -3,25 +3,12 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { Boxes, Sparkles } from "lucide-react";
+import { Boxes, Plus, Sparkles } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
-
-// The seeded sample room the "Run a sample coordination" onboarding routes into.
-const SAMPLE_TOUR_HREF = "/room/pricing-model?tour=1";
-
-function RunSampleButton({ className = "" }: { className?: string }) {
-  return (
-    <Link
-      href={SAMPLE_TOUR_HREF}
-      className={`inline-flex items-center gap-2 rounded-md bg-accent px-3.5 py-2 text-label font-medium text-accent-fg transition-opacity hover:opacity-90 ${className}`}
-    >
-      <Sparkles className="size-4" />
-      Run a sample coordination
-    </Link>
-  );
-}
+import { Button } from "@/components/ui/button";
+import { CreateRoomDialog } from "@/components/create-room-dialog";
 import {
   fetchRooms,
   fetchRoomAgents,
@@ -29,6 +16,22 @@ import {
   logFetchError,
   type EpisodeSummary,
 } from "@/lib/api";
+
+// The seeded sample room the "Run a sample coordination" onboarding routes into.
+const SAMPLE_TOUR_HREF = "/room/pricing-model?tour=1";
+
+/** Secondary onboarding CTA: see it work before building anything. */
+function RunSampleLink({ className = "" }: { className?: string }) {
+  return (
+    <Link
+      href={SAMPLE_TOUR_HREF}
+      className={`inline-flex h-8 items-center gap-2 rounded-md border border-border px-3.5 text-label font-medium text-text transition-colors hover:border-border2 hover:bg-surface ${className}`}
+    >
+      <Sparkles className="size-4 text-accent" />
+      Run a sample
+    </Link>
+  );
+}
 
 interface Room {
   name: string;
@@ -67,21 +70,25 @@ function episodeState(ep: EpisodeSummary): { label: string; color: string; live:
 export function CommandCenter() {
   const [rooms, setRooms] = useState<Room[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const load = useCallback(
+    () =>
+      fetchRooms()
+        .then((data: Room[]) => { setRooms(data); setLoaded(true); })
+        .catch((e) => { logFetchError("fetchRooms")(e); setLoaded(true); }),
+    [],
+  );
 
   useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetchRooms()
-        .then((data: Room[]) => { if (!cancelled) { setRooms(data); setLoaded(true); } })
-        .catch((e) => { logFetchError("fetchRooms")(e); if (!cancelled) setLoaded(true); });
     load();
     const t = setInterval(load, 10_000);
-    return () => { cancelled = true; clearInterval(t); };
-  }, []);
+    return () => clearInterval(t);
+  }, [load]);
 
   return (
     <div className="flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-5xl px-8 py-8">
+      <div className="px-8 py-8">
         <header className="mb-6 flex items-start justify-between gap-4">
           <div className="min-w-0">
             <h1 className="text-2xl font-semibold text-text">Command center</h1>
@@ -89,7 +96,13 @@ export function CommandCenter() {
               Every coordination workspace, at a glance. Open one to negotiate, plan, and remember.
             </p>
           </div>
-          <RunSampleButton className="mt-1 flex-shrink-0" />
+          <div className="mt-1 flex flex-shrink-0 items-center gap-2">
+            <RunSampleLink />
+            <Button onClick={() => setShowCreate(true)}>
+              <Plus className="size-4" />
+              New room
+            </Button>
+          </div>
         </header>
 
         {loaded && rooms.length === 0 ? (
@@ -97,18 +110,28 @@ export function CommandCenter() {
             <EmptyState
               icon={Boxes}
               title="No rooms yet"
-              description="See it work first: run a guided sample coordination, or create a room from the sidebar."
-              action={<RunSampleButton />}
+              description="Create your first coordination room, or run a guided sample to see it work."
+              action={
+                <div className="flex items-center gap-2">
+                  <Button onClick={() => setShowCreate(true)}>
+                    <Plus className="size-4" />
+                    New room
+                  </Button>
+                  <RunSampleLink />
+                </div>
+              }
             />
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {rooms.map(room => (
               <RoomCard key={room.name} room={room} />
             ))}
           </div>
         )}
       </div>
+
+      <CreateRoomDialog open={showCreate} onClose={() => setShowCreate(false)} onCreated={load} />
     </div>
   );
 }

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -246,9 +246,12 @@ interface Props {
   /** Optional controlled tab (e.g. driven by the onboarding tour). */
   view?: View;
   onViewChange?: (view: View) => void;
+  /** Hold back the consent-request modal (e.g. during the onboarding tour, so
+   *  its backdrop doesn't cover the coached highlights). */
+  suppressInvites?: boolean;
 }
 
-export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onNegotiationPhaseChange, planRefreshTrigger = 0, view: viewProp, onViewChange }: Props) {
+export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onNegotiationPhaseChange, planRefreshTrigger = 0, view: viewProp, onViewChange, suppressInvites = false }: Props) {
   const [events, setEvents] = useState<Event[]>([]);
   const [connected, setConnected] = useState(false);
 
@@ -387,7 +390,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   return (
     <div className="flex flex-col h-full">
       <ConsentDialog
-        invite={invites[0] ?? null}
+        invite={suppressInvites ? null : (invites[0] ?? null)}
         onAccept={(invite) => respond(invite, "accept")}
         onDecline={(invite) => respond(invite, "decline")}
       />

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -234,16 +234,21 @@ function renderWithMentions(text: string): React.ReactNode {
   );
 }
 
-type View = "channel" | "negotiate" | "plan" | "l9";
+export type View = "channel" | "negotiate" | "plan" | "l9";
+export type NegotiationPhase = "idle" | "negotiating" | "converged" | "rejected";
 
 interface Props {
   roomName: string;
   onMemoryChanged?: () => void;
   onConnectionChange?: (connected: boolean) => void;
+  onNegotiationPhaseChange?: (phase: NegotiationPhase) => void;
   planRefreshTrigger?: number;
+  /** Optional controlled tab (e.g. driven by the onboarding tour). */
+  view?: View;
+  onViewChange?: (view: View) => void;
 }
 
-export function EventStream({ roomName, onMemoryChanged, onConnectionChange, planRefreshTrigger = 0 }: Props) {
+export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onNegotiationPhaseChange, planRefreshTrigger = 0, view: viewProp, onViewChange }: Props) {
   const [events, setEvents] = useState<Event[]>([]);
   const [connected, setConnected] = useState(false);
 
@@ -252,7 +257,9 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, pla
   useEffect(() => {
     onConnectionChange?.(connected);
   }, [connected, onConnectionChange]);
-  const [view, setView] = useState<View>("channel");
+  const [viewInternal, setViewInternal] = useState<View>("channel");
+  const view = viewProp ?? viewInternal;
+  const setView = (v: View) => { if (viewProp === undefined) setViewInternal(v); onViewChange?.(v); };
   const [agentHandles, setAgentHandles] = useState<Set<string>>(new Set());
   const [invites, setInvites] = useState<PendingInvite[]>([]);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -354,16 +361,28 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, pla
     [events],
   );
 
-  // A negotiation is "live" while ticks have arrived with no consensus after.
-  const negotiating = useMemo(() => {
+  // Negotiation phase, derived from the coordination stream. Drives the live
+  // tab dot and (via the callback) the onboarding tour's convergence sync.
+  const phase = useMemo<NegotiationPhase>(() => {
     let lastTick = -1;
     let lastConsensus = -1;
+    let consensusBroken = false;
     events.forEach((e, i) => {
       if (e.type === "coordination_tick") lastTick = i;
-      if (e.type === "coordination_consensus") lastConsensus = i;
+      if (e.type === "coordination_consensus") {
+        lastConsensus = i;
+        consensusBroken = e.raw.broken === true;
+      }
     });
-    return lastTick > -1 && lastTick > lastConsensus;
+    if (lastConsensus > -1 && lastConsensus > lastTick) return consensusBroken ? "rejected" : "converged";
+    if (lastTick > -1) return "negotiating";
+    return "idle";
   }, [events]);
+  const negotiating = phase === "negotiating";
+
+  useEffect(() => {
+    onNegotiationPhaseChange?.(phase);
+  }, [phase, onNegotiationPhaseChange]);
 
   return (
     <div className="flex flex-col h-full">
@@ -385,6 +404,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, pla
             return (
               <button
                 key={t.id}
+                data-tour={`tab-${t.id}`}
                 onClick={() => setView(t.id)}
                 className={`flex items-center gap-1.5 rounded-md px-3 py-1 text-label font-medium transition-colors ${
                   active

--- a/mycelium-frontend/src/components/negotiation-view.tsx
+++ b/mycelium-frontend/src/components/negotiation-view.tsx
@@ -179,6 +179,7 @@ export function NegotiationView({ events }: { events: readonly NegEvent[] }) {
           <span className="text-label text-faint">Round</span>
           <span className="font-mono text-label tabular text-text">{neg.currentRound || "-"}</span>
           <span
+            data-tour="consensus"
             className="ml-auto rounded px-2 py-0.5 text-micro font-semibold capitalize"
             style={{ color: STATE_TONE[neg.state], background: `color-mix(in srgb, ${STATE_TONE[neg.state]} 14%, transparent)` }}
           >
@@ -188,7 +189,7 @@ export function NegotiationView({ events }: { events: readonly NegEvent[] }) {
         </div>
 
         {/* Current Offer board */}
-        <div className="mt-5">
+        <div data-tour="offer-board" className="mt-5">
           <div className="mb-2 text-micro uppercase tracking-wide text-faint">
             Current offer · {neg.issues.length} issue{neg.issues.length === 1 ? "" : "s"}
           </div>
@@ -224,7 +225,7 @@ export function NegotiationView({ events }: { events: readonly NegEvent[] }) {
 
         {/* Agent × Round swim lanes */}
         {neg.agents.length > 0 && (
-          <div className="mt-6">
+          <div data-tour="swimlanes" className="mt-6">
             <div className="mb-2 flex items-center gap-4 text-micro uppercase tracking-wide text-faint">
               <span>Agent × round · aligner brokers</span>
               <span className="ml-auto flex items-center gap-3 normal-case tracking-normal">

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -144,7 +144,7 @@ export function RoomChatBox({ roomName, defaultSender, onSent }: Props) {
   };
 
   return (
-    <div className="border-t border-border bg-bg px-4 py-3 flex-shrink-0">
+    <div data-tour="composer" className="border-t border-border bg-bg px-4 py-3 flex-shrink-0">
       <div className="relative">
         {mention !== null && candidates.length > 0 && (
           <div className="absolute bottom-full left-0 mb-2 z-20 w-full max-w-md bg-elevated border border-border rounded-xl shadow-xl overflow-hidden p-1">

--- a/mycelium-frontend/src/components/room-inspector.tsx
+++ b/mycelium-frontend/src/components/room-inspector.tsx
@@ -84,6 +84,7 @@ export function RoomInspector({
             return (
               <button
                 key={id}
+                data-tour={`inspector-${id}`}
                 onClick={() => setTab(id)}
                 className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-label font-medium transition-colors ${
                   active ? "bg-elevated text-text shadow-sm ring-1 ring-border" : "text-muted-foreground hover:text-text"

--- a/mycelium-frontend/src/components/room-tour.tsx
+++ b/mycelium-frontend/src/components/room-tour.tsx
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import { startRoomTour, type NegotiationPhase, type TourDeps, type TourHandle } from "@/lib/tour";
+
+interface Props extends TourDeps {
+  /** Start the tour when this flips true (e.g. `?tour=1`). */
+  active: boolean;
+  /** Live negotiation phase, fed to the controller for convergence sync. */
+  phase: NegotiationPhase;
+}
+
+/** Thin seam: starts the imperative tour controller and forwards the phase. */
+export function RoomTour({ active, phase, setEditorView, setInspectorTab, onExit }: Props) {
+  const handleRef = useRef<TourHandle | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    handleRef.current = startRoomTour({ setEditorView, setInspectorTab, onExit });
+    return () => {
+      handleRef.current?.destroy();
+      handleRef.current = null;
+    };
+    // Start once per activation; deps are read fresh via the closure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+
+  useEffect(() => {
+    handleRef.current?.notifyPhase(phase);
+  }, [phase]);
+
+  return null;
+}

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -50,7 +50,7 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   }, [rooms, query]);
 
   return (
-    <aside className="flex w-[236px] flex-shrink-0 flex-col border-r border-border bg-surface/50">
+    <aside data-tour="rooms" className="flex w-[236px] flex-shrink-0 flex-col border-r border-border bg-surface/50">
       {/* Brand */}
       <Link
         href="/"

--- a/mycelium-frontend/src/components/ui/button.tsx
+++ b/mycelium-frontend/src/components/ui/button.tsx
@@ -11,8 +11,7 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-accent text-accent-fg hover:opacity-90",
+        default: "btn-accent",
         outline:
           "border-border text-text hover:bg-surface hover:border-border2",
         secondary:

--- a/mycelium-frontend/src/lib/tour.ts
+++ b/mycelium-frontend/src/lib/tour.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+// The onboarding tour is a plain imperative controller, not a hook: driver.js
+// owns its own overlay/DOM/lifecycle, so wrapping it in React state adds
+// ceremony without benefit. `startRoomTour` holds all the logic (steps,
+// theming, convergence sync); a thin <RoomTour> seam wires it to `?tour=1`.
+
+import { driver, type Driver } from "driver.js";
+import "driver.js/dist/driver.css";
+import type { View } from "@/components/event-stream";
+import type { Tab as InspectorTab } from "@/components/room-inspector";
+
+export type NegotiationPhase = "idle" | "negotiating" | "converged" | "rejected";
+
+export interface TourDeps {
+  setEditorView: (v: View) => void;
+  setInspectorTab: (t: InspectorTab) => void;
+  /** Called when the tour finishes or is dismissed. */
+  onExit: () => void;
+}
+
+export interface TourHandle {
+  destroy: () => void;
+  /** Feed the live negotiation phase so the tour can pace itself to it. */
+  notifyPhase: (phase: NegotiationPhase) => void;
+}
+
+// Step indices that live inside the Negotiate view — when the sample
+// negotiation converges while the user is parked on the offer board or swim
+// lanes, we jump them straight to the consensus reveal (the synced payoff).
+const OFFER_BOARD_STEP = 3;
+const SWIMLANES_STEP = 4;
+const CONSENSUS_STEP = 5;
+
+export function startRoomTour(deps: TourDeps): TourHandle {
+  const d: Driver = driver({
+    showProgress: true,
+    allowClose: true,
+    overlayColor: "#05070a",
+    overlayOpacity: 0.6,
+    stagePadding: 6,
+    stageRadius: 10,
+    popoverClass: "mycelium-tour",
+    nextBtnText: "Next",
+    prevBtnText: "Back",
+    doneBtnText: "Done",
+    progressText: "{{current}} of {{total}}",
+    onDestroyed: () => deps.onExit(),
+    steps: [
+      {
+        element: '[data-tour="rooms"]',
+        popover: {
+          title: "Your workspaces",
+          description:
+            "Every room is an end-to-end-encrypted coordination space with its own agents, plan, and memory. This sample was seeded for you.",
+          side: "right",
+          align: "start",
+        },
+      },
+      {
+        element: '[data-tour="composer"]',
+        popover: {
+          title: "Post a position",
+          description:
+            "Agents (and you) speak in plain language here. No protocol to learn: you state a goal, others respond.",
+          side: "top",
+          align: "start",
+        },
+      },
+      {
+        element: '[data-tour="tab-negotiate"]',
+        popover: {
+          title: "Summon the aligner",
+          description:
+            "When a room needs to decide something, the aligner brokers a real NEGMAS negotiation. Open it and watch this sample resolve.",
+          side: "bottom",
+          align: "end",
+        },
+        onHighlightStarted: () => deps.setEditorView("negotiate"),
+      },
+      {
+        element: '[data-tour="offer-board"]',
+        popover: {
+          title: "Offers, interpreted live",
+          description:
+            "Each natural-language reply is snapped to a move on the negotiation grid. The standing offer updates every round.",
+          side: "left",
+          align: "start",
+        },
+      },
+      {
+        element: '[data-tour="swimlanes"]',
+        popover: {
+          title: "Round by round",
+          description:
+            "Agents propose, counter, and accept. The aligner addresses one at a time until they converge — or it stops without agreement.",
+          side: "left",
+          align: "start",
+        },
+      },
+      {
+        element: '[data-tour="consensus"]',
+        popover: {
+          title: "Unanimity, not theatre",
+          description:
+            "The mechanism stops the instant they agree. GAR scores how genuinely each agent moved toward the outcome.",
+          side: "bottom",
+          align: "end",
+        },
+      },
+      {
+        element: '[data-tour="tab-plan"]',
+        popover: {
+          title: "Consensus becomes a plan",
+          description:
+            "The agreement compiles into a shared checklist with per-agent owners, before it is even announced.",
+          side: "bottom",
+          align: "end",
+        },
+        onHighlightStarted: () => deps.setEditorView("plan"),
+      },
+      {
+        element: '[data-tour="inspector-memory"]',
+        popover: {
+          title: "And it persists",
+          description:
+            "Decisions, context, and the plan sync to the room's memory — durable, searchable, and shared across sessions.",
+          side: "left",
+          align: "start",
+        },
+        onHighlightStarted: () => deps.setInspectorTab("memory"),
+      },
+    ],
+  });
+
+  d.drive();
+
+  return {
+    destroy: () => {
+      if (d.isActive()) d.destroy();
+    },
+    notifyPhase: (phase) => {
+      if (!d.isActive()) return;
+      const i = d.getActiveIndex();
+      if (phase === "converged" && (i === OFFER_BOARD_STEP || i === SWIMLANES_STEP)) {
+        d.moveTo(CONSENSUS_STEP);
+      }
+    },
+  };
+}


### PR DESCRIPTION
A coached first-run experience for a fresh install (relates to #444). A new **"Run a sample coordination"** entry point drops you into a seeded sample room where a guided tour steps you through the app *in sync with a live negotiation* — the payoff being the Negotiate instrument doing its thing while the tour points at it.

Frontend-first: it drives the mock sample room today. Real backend provisioning of a seeded sample room is the #444 follow-up; this PR builds the full UX + the enabling seams.

## What's here

- **`lib/tour.ts`** — a plain imperative tour controller (driver.js). All the substance lives here: step sequence, token-themed popover, and the convergence sync. Deliberately *not* a hook — driver.js owns its own DOM/lifecycle, so a hook would just add ceremony.
- **`components/room-tour.tsx`** — a thin React seam that starts the controller on `?tour=1` and forwards the live negotiation phase.
- **Synced pacing** — the tour drives app state as it steps (opens the Negotiate tab, the Memory panel) and **auto-advances to the consensus reveal the moment the sample negotiation converges**.
- **Entry point** — command-center "Run a sample coordination" routes into the seeded room and starts the tour.
- **`data-tour` anchors** on the sidebar, composer, editor tabs, offer board, swim lanes, consensus badge, and inspector tabs.

## Enabling seams

- `EventStream` gains a controllable `view` and a negotiation-phase callback; the consent-request modal can be suppressed (so its backdrop doesn't cover the tour highlights).

## Also in this PR (polish spotted along the way)

- **Primary button** no longer reads flat: a top-lit gradient + inner highlight + soft lift (`.btn-accent`), applied to the Button `default` variant app-wide.
- **Command center** is full-width, with **New room** as the primary CTA and **Run a sample** as a secondary action (header + empty state); wired the create-room dialog.

## Verification

- `pnpm build` (production) passes; `tsc --noEmit` clean; `package-lock.json` synced for `driver.js`.
- Try it: open `/`, click **Run a sample coordination**, and watch the tour walk the live negotiation to consensus.