### PR TITLE
Purge stale CFN branding + dead package-data from CLI pyproject

### DIFF
--- a/mycelium-cli/pyproject.toml
+++ b/mycelium-cli/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mycelium-cli"
 version = "0.1.0"
-description = "Command-line interface for Mycelium IoC/CFN coordination layer"
+description = "Command-line interface for the Mycelium coordination layer"
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 authors = [
     { name = "Cisco ETI", email = "eti@cisco.com" }
 ]
-keywords = ["mycelium", "cli", "cfn", "ioc", "coordination"]
+keywords = ["mycelium", "cli", "coordination"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -91,23 +91,9 @@ mycelium = [
     "docs/**/*.md",
     "integrations/claude_code/assets/**/*",
     "integrations/cursor/assets/**/*",
-    "integrations/openclaw/assets/mycelium/**/*",
-    "integrations/hermes/assets/**/*",
     "daemon/service/*",
     "docker/*",
-    "docker/initdb/*",
     "docker/env.defaults",
-]
-
-[tool.setuptools.exclude-package-data]
-# Dev-only files inside the openclaw plugin source tree. node_modules ships
-# test deps (vitest) that pyinstaller/setuptools would otherwise sweep into
-# the wheel, bloating it by tens of MB. test/ is unit test source that has
-# no runtime purpose on an end user's machine.
-mycelium = [
-    "integrations/openclaw/assets/mycelium/plugin/node_modules/**/*",
-    "integrations/openclaw/assets/mycelium/plugin/test/**/*",
-    "integrations/openclaw/assets/mycelium/plugin/package-lock.json",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Cleans up residue in `mycelium-cli/pyproject.toml` from before the SLIM-native rewrite / CFN teardown.

- **`description`** — drop CFN wording.
- **`keywords`** — retire `"cfn"` and `"ioc"`, keep `["mycelium", "cli", "coordination"]`.
- **`package-data`** — remove globs pointing at deleted dirs: `integrations/openclaw/assets/mycelium/**/*`, `integrations/hermes/assets/**/*`, `docker/initdb/*`.
- **`exclude-package-data`** — remove the dead openclaw block (target tree no longer exists).

Verified on disk that `integrations/openclaw/`, `integrations/hermes/`, and `docker/initdb/` are all gone. `ruff check` passes; no `cfn`/`ioc`/`openclaw`/`hermes`/`initdb` references remain in the file.

OpenClaw revival is tracked separately in #448; the asset dirs were already deleted, so these globs are just cruft.

Closes #457