### PR TITLE
feat(engine): synthesizer engine kind (#471)

### DIFF
--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -311,8 +311,6 @@
 
     <hr class="divider">
 
-
-
 <section class="doc-section" id="adapter-api">
       <!-- keep -->
       <h1>REST API</h1>

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Concepts · mycelium</title>
-<meta name="description" content="The core concepts behind Mycelium: rooms, episodes, memory, plan, the aligner, and the L9 protocol.">
+<meta name="description" content="The core concepts behind Mycelium: rooms, episodes, memory, plan, engines (the aligner and synthesizer), and the L9 protocol.">
 <meta property="og:title" content="Concepts · mycelium">
-<meta property="og:description" content="The core concepts behind Mycelium: rooms, episodes, memory, plan, the aligner, and the L9 protocol.">
+<meta property="og:description" content="The core concepts behind Mycelium: rooms, episodes, memory, plan, engines (the aligner and synthesizer), and the L9 protocol.">
 <meta property="og:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <meta property="og:url" content="https://mycelium-io.github.io/mycelium/concepts.html">
 <meta property="og:type" content="website">
@@ -52,6 +52,7 @@
       <a href="#episodes" class="nav-link sub">Episodes</a>
       <a href="#memory" class="nav-link sub">Memory</a>
       <a href="#plan" class="nav-link sub">Plan</a>
+      <a href="#engines" class="nav-link sub">Engines</a>
       <a href="#aligner" class="nav-link sub">Aligner</a>
       <a href="#l9-protocol" class="nav-link sub">L9 Protocol</a>
     </div>
@@ -63,7 +64,7 @@
     <section class="doc-section" id="rooms">
       <h1>Rooms</h1>
       <p>A room is a persistent coordination namespace. All memories, messages, and <a href="#episodes">episodes</a> are scoped to a room. A room IS its namespace; there&#x27;s no separation between the two.</p>
-      <p>Under the hood a room is an <a href="https://github.com/agntcy/slim"><strong>AGNTCY SLIM</strong></a> group channel: agents (and the human, by proxy) are members of one MLS-encrypted channel per room, and the backend is its always-on moderator. There&#x27;s no database: a room&#x27;s durable state is the files on disk, and sharing is git.</p>
+      <p>Under the hood a room is a <strong>SLIM group channel</strong>: agents (and the human, by proxy) are members of one MLS-encrypted channel per room, and the backend is its always-on moderator. There&#x27;s no database: a room&#x27;s durable state is the files on disk, and sharing is git.</p>
       <h2 id="rooms-rooms-are-directories">Rooms are Directories</h2>
       <p>Each room maps to a directory at <code>~/.mycelium/rooms/{room_name}/</code>. Standard subdirectories are created automatically:</p>
       <pre><code>~/.mycelium/rooms/design-review/
@@ -312,10 +313,75 @@ cd ~/.mycelium/rooms/design-review &amp;&amp; git init</code></pre>
 
     <hr class="divider">
 
+    <section class="doc-section" id="engines">
+      <h1>Engines</h1>
+      <p>An <strong>engine</strong> is a first-party unit of cognition that lives inside a room. Where your agents are the participants, engines are the room&#x27;s <em>reasoning citizens</em> — they read what the room knows and act on it: mediate a decision, distill the memory, and (in time) more.</p>
+      <p>Engines exist because some work isn&#x27;t any single agent&#x27;s job. Deciding <em>whose offer wins</em> shouldn&#x27;t fall to one of the negotiating parties; summarizing the whole room shouldn&#x27;t depend on one agent remembering everything. An engine is a neutral, first-party actor the room owns.</p>
+      <p>Two properties define every engine:</p>
+      <ul>
+        <li><strong>Summoned, never automatic.</strong> An engine is dormant until you register it in a</li>
+      </ul>
+      <p>room and <code>@</code>-summon it. There is no join window, no polling, no held LLM connection — zero idle cost. Cognition runs <em>because you asked for it</em>.</p>
+      <ul>
+        <li><strong>A room citizen with a handle.</strong> A registered engine is an agent whose</li>
+      </ul>
+      <p>manifest says <code>adapter: engine</code> and carries a <code>kind</code>. It runs <em>as that handle</em>, so it can be <code>@</code>-addressed and its output is attributed like any member&#x27;s.</p>
+      <h2 id="engines-kinds">Kinds</h2>
+      <p>The engine layer is one seam with a growing set of kinds — you pick the kind at registration time. No new adapter per engine; the same <code>mycelium engine</code> commands host all of them.</p>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Kind</th>
+              <th>What it does</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>aligner</code></td>
+              <td>Mediates a real NEGMAS negotiation to consensus, then compiles the agreement into the room&#x27;s plan. See <a href="#aligner">Aligner</a>.</td>
+            </tr>
+            <tr>
+              <td><code>synthesizer</code></td>
+              <td>Reads the room&#x27;s memory and writes back a single structured briefing at <code>context/synthesis</code>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>More kinds (bargaining, team-formation, drift evaluation) plug into the same seam over time.</p>
+      <h2 id="engines-the-lifecycle">The lifecycle</h2>
+      <p>Every engine, whatever its kind, follows the same three steps.</p>
+      <pre><code><span class="comment"># 1. Register it once per room (pick the kind)</span>
+<span class="cmd">mycelium engine create</span> summarizer <span class="flag">--kind</span> synthesizer <span class="flag">--room</span> sprint-plan
+
+<span class="comment"># 2. Summon it — this is what makes cognition run</span>
+<span class="cmd">mycelium engine invoke</span> summarizer <span class="str">&quot;brief the room on where we stand&quot;</span> <span class="flag">-r</span> sprint-plan
+
+<span class="comment"># 3. It runs as that handle and writes its result back into the room</span>
+<span class="cmd">mycelium memory get</span> context/synthesis <span class="flag">-r</span> sprint-plan</code></pre>
+      <p><code>mycelium engine ls</code> shows the engines registered in a room and their kinds.</p>
+      <h2 id="engines-the-synthesizer">The synthesizer</h2>
+      <p>The <code>synthesizer</code> distills a room. On summon it reads every memory namespace — decisions, status, context, work, the plan — and runs one <strong>Pi</strong> turn to compile them into a single markdown briefing: the room&#x27;s goal, key decisions, current status, and open work. It upserts that briefing as a <code>knowledge</code> memory at <code>context/synthesis</code>, so it&#x27;s versioned, searchable, and shared like any other memory.</p>
+      <p>It is deliberately faithful — the briefing reflects only what&#x27;s in the room&#x27;s memory; it never invents facts. If a Pi turn fails it writes nothing rather than a half-formed summary. Run it again after a burst of activity and the summary upserts (version increments) in place.</p>
+      <h2 id="engines-where-an-engine-runs">Where an engine runs</h2>
+      <p>An engine&#x27;s cognition runs in one of two places, selected by the <code>engine.runtime</code> config (the backend and the host daemon are a pair — set both the same):</p>
+      <ul>
+        <li><strong><code>backend</code></strong> (default): the always-on backend runs the engine through its</li>
+      </ul>
+      <p>summon seam. Nothing extra to install.</p>
+      <ul>
+        <li><strong><code>host</code></strong>: the local daemon holds the engine and runs it on the host, where</li>
+      </ul>
+      <p><code>pi</code> lives. Use this when the engine&#x27;s brain needs host tools or credentials.</p>
+      <p>Every engine&#x27;s brain is <strong>Pi</strong>, Mycelium&#x27;s own cognition runtime (it ships in the backend image). Pi is never imposed on your participant agents — they run however they like (Claude Code, Cursor, a plain HTTP client) and only ever answer in prose.</p>
+    </section>
+
+    <hr class="divider">
+
     <section class="doc-section" id="aligner">
       <h1>Aligner</h1>
-      <p>The aligner is Mycelium&#x27;s first-party mediator. Agents never talk to each other directly; all coordination flows through it. It reads everyone&#x27;s opening positions, brokers the negotiation one agent at a time, and stops the moment the team agrees.</p>
-      <p>Unlike a passive relay, the aligner is <em>summoned</em>: nothing runs until you register it in a <a href="#rooms">room</a> and invoke it. There is no join window and no auto-start.</p>
+      <p>The aligner is the negotiation <a href="#engines">engine</a> — the <code>kind</code> that mediates a decision to consensus. Agents never talk to each other directly; all coordination flows through it. It reads everyone&#x27;s opening positions, brokers the negotiation one agent at a time, and stops the moment the team agrees.</p>
+      <p>Like every engine, the aligner is <em>summoned</em>: nothing runs until you register it in a <a href="#rooms">room</a> and invoke it. There is no join window and no auto-start.</p>
       <pre><code><span class="comment"># Register the mediator once per room</span>
 <span class="cmd">mycelium engine create</span> aligner <span class="flag">--kind</span> aligner <span class="flag">--room</span> sprint-plan
 

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -34,7 +34,7 @@ PAGES: list[tuple[str, str, str, str, str, str, str]] = [
      "Coordination layer for multi-agent systems. Install and run your first multi-agent coordination flow: room, agents, negotiation, plan."),
     ("concepts", "concepts.html", "Concepts · mycelium", "Concepts",
      "CON-001", "CONCEPTS · ROOMS · EPISODES · MEMORY · PLAN",
-     "The core concepts behind Mycelium: rooms, episodes, memory, plan, the aligner, and the L9 protocol."),
+     "The core concepts behind Mycelium: rooms, episodes, memory, plan, engines (the aligner and synthesizer), and the L9 protocol."),
     ("adapters", "adapters.html", "Adapters · mycelium", "Adapters",
      "ADP-001", "ADAPTERS · CLAUDE CODE · CURSOR · REST API",
      "Connect Claude Code, Cursor, or any HTTP client to the Mycelium coordination layer."),
@@ -56,6 +56,7 @@ SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
     ("episodes.md",                 "episodes",           "concepts",    "Concepts",     "Episodes"),
     ("memory.md",                   "memory",             "concepts",    "Concepts",     "Memory"),
     ("plan.md",                     "plan",               "concepts",    "Concepts",     "Plan"),
+    ("engines.md",                  "engines",            "concepts",    "Concepts",     "Engines"),
     ("aligner.md",                  "aligner",            "concepts",    "Concepts",     "Aligner"),
     ("l9-protocol.md",              "l9-protocol",        "concepts",    "Concepts",     "L9 Protocol"),
     # ── adapters (adapters.html) — all hand-coded ──

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -23,7 +23,9 @@ aren't an optional add-on, they're half the system.
 
 **Rooms** are persistent coordination spaces. Agents join a room to share context,
 and when they need to agree on something they open an [episode](#episodes): a
-scoped, recorded negotiation on the room's channel.
+scoped, recorded negotiation on the room's channel. Each room is one secure
+[AGNTCY SLIM](https://github.com/agntcy/slim) group channel, the encrypted fabric
+agents coordinate over.
 
 **Persistent Memory** means markdown files on your filesystem are the shared source
 of truth, greppable and editable by any agent, and a local semantic index makes
@@ -579,16 +581,99 @@ with the room's committed work in view.
 
 ---
 
+# Engines
+
+An **engine** is a first-party unit of cognition that lives inside a room. Where
+your agents are the participants, engines are the room's *reasoning citizens* —
+they read what the room knows and act on it: mediate a decision, distill the
+memory, and (in time) more.
+
+Engines exist because some work isn't any single agent's job. Deciding *whose
+offer wins* shouldn't fall to one of the negotiating parties; summarizing the
+whole room shouldn't depend on one agent remembering everything. An engine is a
+neutral, first-party actor the room owns.
+
+Two properties define every engine:
+
+- **Summoned, never automatic.** An engine is dormant until you register it in a
+  room and `@`-summon it. There is no join window, no polling, no held LLM
+  connection — zero idle cost. Cognition runs *because you asked for it*.
+- **A room citizen with a handle.** A registered engine is an agent whose
+  manifest says `adapter: engine` and carries a `kind`. It runs *as that handle*,
+  so it can be `@`-addressed and its output is attributed like any member's.
+
+## Kinds
+
+The engine layer is one seam with a growing set of kinds — you pick the kind at
+registration time. No new adapter per engine; the same `mycelium engine`
+commands host all of them.
+
+| Kind | What it does |
+|---|---|
+| `aligner` | Mediates a real NEGMAS negotiation to consensus, then compiles the agreement into the room's plan. See [Aligner](#aligner). |
+| `synthesizer` | Reads the room's memory and writes back a single structured briefing at `context/synthesis`. |
+
+More kinds (bargaining, team-formation, drift evaluation) plug into the same
+seam over time.
+
+## The lifecycle
+
+Every engine, whatever its kind, follows the same three steps.
+
+```bash
+# 1. Register it once per room (pick the kind)
+mycelium engine create summarizer --kind synthesizer --room sprint-plan
+
+# 2. Summon it — this is what makes cognition run
+mycelium engine invoke summarizer "brief the room on where we stand" -r sprint-plan
+
+# 3. It runs as that handle and writes its result back into the room
+mycelium memory get context/synthesis -r sprint-plan
+```
+
+`mycelium engine ls` shows the engines registered in a room and their kinds.
+
+## The synthesizer
+
+The `synthesizer` distills a room. On summon it reads every memory namespace —
+decisions, status, context, work, the plan — and runs one **Pi** turn to compile
+them into a single markdown briefing: the room's goal, key decisions, current
+status, and open work. It upserts that briefing as a `knowledge` memory at
+`context/synthesis`, so it's versioned, searchable, and shared like any other
+memory.
+
+It is deliberately faithful — the briefing reflects only what's in the room's
+memory; it never invents facts. If a Pi turn fails it writes nothing rather than
+a half-formed summary. Run it again after a burst of activity and the summary
+upserts (version increments) in place.
+
+## Where an engine runs
+
+An engine's cognition runs in one of two places, selected by the `engine.runtime`
+config (the backend and the host daemon are a pair — set both the same):
+
+- **`backend`** (default): the always-on backend runs the engine through its
+  summon seam. Nothing extra to install.
+- **`host`**: the local daemon holds the engine and runs it on the host, where
+  `pi` lives. Use this when the engine's brain needs host tools or credentials.
+
+Every engine's brain is **Pi**, Mycelium's own cognition runtime (it ships in the
+backend image). Pi is never imposed on your participant agents — they run however
+they like (Claude Code, Cursor, a plain HTTP client) and only ever answer in
+prose.
+
+
+---
+
 # Aligner
 
-The aligner is Mycelium's first-party mediator. Agents never talk to each other
-directly; all coordination flows through it. It reads everyone's opening
-positions, brokers the negotiation one agent at a time, and stops the moment the
-team agrees.
+The aligner is the negotiation [engine](#engines) — the `kind` that mediates a
+decision to consensus. Agents never talk to each other directly; all
+coordination flows through it. It reads everyone's opening positions, brokers the
+negotiation one agent at a time, and stops the moment the team agrees.
 
-Unlike a passive relay, the aligner is *summoned*: nothing runs until you
-register it in a [room](#rooms) and invoke it. There is no join window and no
-auto-start.
+Like every engine, the aligner is *summoned*: nothing runs until you register it
+in a [room](#rooms) and invoke it. There is no join window and no auto-start.
 
 ```bash
 # Register the mediator once per room
@@ -851,7 +936,7 @@ local embedding index. Coordination messages ride SLIM as additive
 | Protocol | L9 envelopes over SLIM | `exchange` ticks/replies, `commit:*`, `knowledge` |
 | Cognition | the aligner (Pi + NEGMAS) | drives the negotiation (see [aligner](#aligner)) |
 | Embeddings | local ONNX model | 384-dim embeddings, no API key |
-| LLM | litellm | plan compilation (100+ providers) |
+| LLM | Pi | plan compilation + health probe |
 | Backend | FastAPI (room moderator) | membership, transcript, moderation API |
 | Waker | optional daemon | cold-spawns runtimes that can't wake themselves |
 | CLI | Typer + Rich | agent interface |
@@ -875,11 +960,13 @@ mycelium respond --room my-project --handle me "moving toward 30% …"
 `claude -p` on a mention. It's built on the same membership core; agents never
 speak SLIM or L9 directly.
 
-**The aligner is the cognition engine.** Negotiation is driven by a first-party
-mediator, the aligner, registered in a room and summoned by `@`-mention. Its
-brain is a persistent Pi coding-agent session running a NEGMAS Stacked
-Alternating Offers negotiation; NEGMAS owns termination, stopping the instant
-the agents agree. See [aligner](#aligner) and [episodes](#episodes).
+**Cognition rides on engines.** First-party [engines](#engines) are registered in
+a room and summoned by `@`-mention; each `kind` is a distinct unit of reasoning.
+The `aligner` drives negotiation — its brain is a persistent Pi coding-agent
+session running a NEGMAS Stacked Alternating Offers mechanism that owns
+termination, stopping the instant the agents agree. The `synthesizer` distills
+the room's memory into a shared briefing. See [engines](#engines),
+[aligner](#aligner), and [episodes](#episodes).
 
 ## Adapters
 
@@ -890,7 +977,6 @@ the same regardless of adapter: join, await, respond.
 |---------|--------|
 | **claude_code** | proven; the supported path today |
 | **cursor** | untested / unverified |
-| **openclaw, hermes** | deprecated |
 
 ### Claude Code
 
@@ -924,11 +1010,6 @@ cursor-agent login                          # one-time, interactive
 mycelium agent create design-agent --adapter cursor \
     --cwd ~/repos/my-frontend --room my-project
 ```
-
-### OpenClaw / Hermes (deprecated)
-
-The OpenClaw and Hermes adapters are deprecated and no longer supported. Use
-the Claude Code adapter.
 
 ### Backend API
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -180,8 +180,8 @@
             </tr>
             <tr>
               <td>LLM</td>
-              <td>litellm</td>
-              <td>plan compilation (100+ providers)</td>
+              <td>Pi</td>
+              <td>plan compilation + health probe</td>
             </tr>
             <tr>
               <td>Backend</td>
@@ -213,7 +213,7 @@
 <span class="comment"># Post a reply or opening position</span>
 <span class="cmd">mycelium respond</span> <span class="flag">--room</span> my-project <span class="flag">--handle</span> me <span class="str">&quot;moving toward 30% …&quot;</span></code></pre>
       <p><strong>The daemon is an optional waker.</strong> For runtimes that can&#x27;t wake themselves (e.g. Claude Code), the daemon subscribes on their behalf and cold-spawns <code>claude -p</code> on a mention. It&#x27;s built on the same membership core; agents never speak SLIM or L9 directly.</p>
-      <p><strong>The aligner is the cognition engine.</strong> Negotiation is driven by a first-party mediator, the aligner, registered in a room and summoned by <code>@</code>-mention. Its brain is a persistent Pi coding-agent session running a NEGMAS Stacked Alternating Offers negotiation; NEGMAS owns termination, stopping the instant the agents agree. See <a href="#aligner">aligner</a> and <a href="#episodes">episodes</a>.</p>
+      <p><strong>Cognition rides on engines.</strong> First-party <a href="#engines">engines</a> are registered in a room and summoned by <code>@</code>-mention; each <code>kind</code> is a distinct unit of reasoning. The <code>aligner</code> drives negotiation — its brain is a persistent Pi coding-agent session running a NEGMAS Stacked Alternating Offers mechanism that owns termination, stopping the instant the agents agree. The <code>synthesizer</code> distills the room&#x27;s memory into a shared briefing. See <a href="#engines">engines</a>, <a href="#aligner">aligner</a>, and <a href="#episodes">episodes</a>.</p>
       <h2 id="architecture-adapters">Adapters</h2>
       <p>Mycelium integrates with AI coding agents via adapters. The coordination model is the same regardless of adapter: join, await, respond.</p>
       <div class="table-wrap">
@@ -378,9 +378,9 @@ cursor-agent login                          # one-time, interactive
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium room delete</span> <span class="arg">&lt;name&gt;</span> [<span class="flag">--force</span>]</code>
+          <code><span class="cmd">mycelium room delete</span> <span class="arg">&lt;name&gt;</span> [<span class="arg">&lt;name&gt;</span> ...] [<span class="flag">--force</span>]</code>
         </div>
-        <div class="cmd-ref-body">Delete a room and all its data (memories, sessions, messages).</div>
+        <div class="cmd-ref-body">Delete one or more rooms and all their data (memories, sessions, messages).</div>
       </div>
 
       <div class="cmd-ref">
@@ -394,7 +394,7 @@ cursor-agent login                          # one-time, interactive
         <div class="cmd-ref-header">
           <code><span class="cmd">mycelium room send</span> &quot;<span class="arg">&lt;content&gt;</span>&quot; [<span class="flag">--room</span> <span class="arg">&lt;room&gt;</span>] [<span class="flag">--handle</span> <span class="arg">&lt;handle&gt;</span>]</code>
         </div>
-        <div class="cmd-ref-body">Send an addressed chat message into a room. Use <code>@handle</code> mentions to direct it to specific agents bound via the OpenClaw channel plugin.</div>
+        <div class="cmd-ref-body">Send an addressed chat message into a room. Use <code>@handle</code> mentions to direct it to specific agents.</div>
       </div>
 
       <div class="cmd-ref">
@@ -566,9 +566,9 @@ cursor-agent login                          # one-time, interactive
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium adapter add</span> <span class="arg">&lt;type&gt;</span> [<span class="flag">--openclaw-profile</span> <span class="arg">NAME</span>] [<span class="flag">--openclaw-container</span> <span class="arg">NAME</span>] [<span class="flag">--dry-run</span>] [<span class="flag">--force</span>]</code>
+          <code><span class="cmd">mycelium adapter add</span> <span class="arg">&lt;type&gt;</span> [<span class="flag">--dry-run</span>]</code>
         </div>
-        <div class="cmd-ref-body">Install an agent framework adapter (openclaw, claude-code, cursor).</div>
+        <div class="cmd-ref-body">Install an agent framework adapter (claude-code, cursor).</div>
       </div>
 
       <div class="cmd-ref">
@@ -676,10 +676,10 @@ cursor-agent login                          # one-time, interactive
 <span class="comment"># Mycelium backend API URL</span>
 <span class="arg">api_url</span> = <span class="str">&quot;http://localhost:8000&quot;</span>
 
-<span class="comment"># LLM configuration (litellm format).</span>
+<span class="comment"># LLM configuration (&quot;provider/model&quot; format).</span>
 <span class="cmd" id="config-llm">[llm]</span>
 
-<span class="comment"># LLM model in litellm format (e.g. anthropic/claude-sonnet-4-6)</span>
+<span class="comment"># LLM model in provider/model format (e.g. anthropic/claude-sonnet-4-6)</span>
 <span class="arg">model</span> = <span class="str">&quot;&quot;</span>
 
 <span class="comment"># API key for the LLM provider</span>

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -100,6 +100,15 @@ class Settings(BaseSettings):
     ALIGNER_PI_OPENSHELL: bool = False
     # Per-turn wall-clock bound (seconds) on one pi brain call before it is killed.
     ALIGNER_PI_TIMEOUT_S: float = 120.0
+    # Synthesizer engine (kind ``synthesizer``) — reads a room's memory and
+    # compiles a structured summary as a ``knowledge`` memory. Dormant by
+    # default like the aligner: nothing runs until a registered synthesizer
+    # engine is @-summoned. Reuses the shared LLM_* + ALIGNER_PI_* Pi runtime
+    # settings; only its own handle default and per-turn timeout live here.
+    SYNTHESIZER_HANDLE: str = "synthesizer"
+    # Per-turn wall-clock bound (seconds) on the synthesizer's one-shot pi call.
+    SYNTHESIZER_PI_TIMEOUT_S: float = 120.0
+
     # Where a registered `engine` (kind aligner) runs its NEGMAS drive — selects
     # the engine runtime. "backend" (default):
     # this backend owns the run via its summon seam. "host": the host daemon owns

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -19,6 +19,7 @@ import sys
 import tomllib
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 # Must be set before sentence-transformers / huggingface_hub are imported.
 # Prevents network calls when the model is already cached locally.
@@ -85,12 +86,33 @@ async def lifespan(app: FastAPI):
     from app.services.aligner import AlignerEngine
     from app.services.plan_sync import PlanSyncEngine
     from app.services.room_channels import manager as room_channel_manager
+    from app.services.synthesizer import SynthesizerEngine
 
+    # Two engine kinds share the one summon seam. Each engine self-selects by the
+    # summoned handle's manifest kind (and the aligner's reserved-handle
+    # fallback), so a fan-out dispatcher is enough — no central kind table. Only
+    # one engine ever acts per summon since a handle maps to a single kind.
     app.state.aligner = AlignerEngine(room_channel_manager)
-    room_channel_manager.on_summon = app.state.aligner.handle_summon
+    app.state.synthesizer = SynthesizerEngine(room_channel_manager)
+    _engine_handlers = (
+        app.state.aligner.handle_summon,
+        app.state.synthesizer.handle_summon,
+    )
+
+    def _dispatch_summon(
+        room: str, handle: str, envelope: Any, co_summons: list[str] | None = None
+    ) -> None:
+        for fire in _engine_handlers:
+            try:
+                fire(room, handle, envelope, co_summons)
+            except Exception:
+                logger.exception("engine summon handler failed for @%s in %s", handle, room)
+
+    room_channel_manager.on_summon = _dispatch_summon
     logger.info(
-        "SIEP aligner wired (@%s, mediator brain=pi via %s)",
+        "engines wired (aligner @%s, synthesizer @%s; brain=pi via %s)",
         app.state.aligner.handle,
+        app.state.synthesizer.handle,
         settings.ALIGNER_PI_BINARY,
     )
 

--- a/fastapi-backend/app/services/synthesizer.py
+++ b/fastapi-backend/app/services/synthesizer.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The synthesizer — a cognition engine that summarizes a room's memory.
+
+A second engine ``kind`` alongside the aligner. Where the aligner *converges* a
+negotiation, the synthesizer *distills*: on an ``@``-summon it reads the room's
+memory namespaces and compiles a single structured markdown summary, then writes
+it back as a ``knowledge`` memory (``context/synthesis``) so every agent — and
+``memory search`` — can pick it up.
+
+It shares the aligner's design constraints:
+
+* **Dormant by default (zero idle cost).** Nothing runs until a registered
+  ``engine`` of kind ``synthesizer`` is summoned through the persister's summon
+  seam — no polling, no held LLM connection.
+* **One-shot Pi cognition.** The summary is one throwaway ``pi`` turn off the
+  event loop (:func:`_pi_complete`), the same pattern as
+  :mod:`app.services.plan_compiler`. Fail-soft: a Pi outage logs and writes
+  nothing rather than a half-baked summary.
+* **Writes through the canonical memory path.** The summary is upserted via the
+  same versioned + indexed write every ``memory set`` uses, so it is searchable
+  and version-tracked like any other memory.
+
+Unlike the aligner it holds no episode and drives no negotiation — it is a pure
+read → summarize → write consumer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from app.config import settings
+
+# The manifest-kind gate and handle-fold are the shared summon-gate primitives;
+# reuse the aligner's single copy rather than re-deriving the manifest read.
+from app.services.aligner import _norm, _registered_engine_kind
+
+if TYPE_CHECKING:
+    from app.services.l9_models import L9
+    from app.services.room_channels import RoomChannelManager
+
+logger = logging.getLogger(__name__)
+
+# The engine kind this class owns. A summon whose manifest kind differs is
+# ignored, so the aligner and the synthesizer can share one summon seam.
+ENGINE_KIND = "synthesizer"
+
+# Where the compiled summary lands. ``context/`` is the room's background surface
+# (an existing namespace — no new storage concept), and ``synthesis`` is a stable
+# slug so each run upserts (version increments) rather than accreting files.
+SYNTHESIS_KEY = "context/synthesis"
+
+# Manifest storage — never a knowledge surface to summarize.
+_SKIP_PREFIXES = ("agents/",)
+
+
+def _read_room_memory(room: str) -> list[tuple[str, dict[str, Any], str]]:
+    """Every knowledge memory in the room (all namespaces bar ``agents/``).
+
+    Returns ``(key, meta, content)`` newest-first, minus agent manifests and the
+    prior synthesis itself (so a re-run summarizes source memory, not its own
+    output).
+    """
+    from app.services.filesystem import get_room_dir, list_memory_files
+
+    entries = list_memory_files(get_room_dir(room))
+    return [
+        (key, meta, content)
+        for key, meta, content in entries
+        if not key.startswith(_SKIP_PREFIXES) and key != SYNTHESIS_KEY
+    ]
+
+
+def _build_prompt(room: str, entries: list[tuple[str, dict[str, Any], str]]) -> str:
+    """Assemble the synthesizer prompt. Pure — no I/O, directly unit-testable."""
+    blocks = [f"## {key}\n{content.strip()}" for key, _meta, content in entries]
+    corpus = "\n\n".join(blocks)
+    return (
+        f"You are the synthesizer for the Mycelium coordination room '{room}'.\n"
+        "Below are the room's memories, each under its namespace key. Produce a "
+        "single concise, well-structured markdown briefing that captures the "
+        "room's current state: key decisions, current status, open work, and any "
+        "notable context. Group related points; do not just list the memories "
+        "back. Preserve @handle owners where they matter. Be faithful — never "
+        "invent facts not present below.\n\n"
+        "Output ONLY the markdown briefing — no preamble, no code fences.\n\n"
+        f"--- ROOM MEMORY ---\n{corpus}\n--- END ROOM MEMORY ---"
+    )
+
+
+def _strip_fences(text: str) -> str:
+    """Drop a wrapping ``` fence if the model added one despite instructions."""
+    t = text.strip()
+    if not t.startswith("```"):
+        return t
+    lines = t.splitlines()[1:]
+    if lines and lines[-1].strip().startswith("```"):
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def _pi_complete(prompt: str, timeout_s: float) -> str:
+    """One blocking Pi turn producing the raw summary markdown.
+
+    A throwaway ``--session`` file keeps it a true one-shot with no memory to
+    carry — the same pattern as :func:`app.services.plan_compiler._pi_complete`.
+    Isolated so tests can patch it without a live Pi.
+    """
+    from app.services.pi_brain import PiBrain
+
+    session_dir = Path(tempfile.gettempdir()) / "mycelium-pi-sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    brain = PiBrain(
+        session_path=session_dir / f"synthesize-{uuid.uuid4().hex}.jsonl",
+        model=settings.LLM_MODEL,
+        api_key=settings.LLM_API_KEY,
+        base_url=settings.LLM_BASE_URL,
+        binary=settings.ALIGNER_PI_BINARY,
+        timeout_s=timeout_s,
+        openshell=settings.ALIGNER_PI_OPENSHELL,
+    )
+    return brain(prompt)
+
+
+class SynthesizerEngine:
+    """Read a room's memory on summon and write back a structured summary.
+
+    Holds no state between summons beyond the set of rooms it is actively
+    summarizing (so a second summon can't spawn a duplicate run over the same
+    room). Reaches the channel/membership through the
+    :class:`RoomChannelManager` it is wired to, and the memory store through the
+    filesystem services.
+    """
+
+    def __init__(
+        self,
+        manager: RoomChannelManager,
+        *,
+        handle: str | None = None,
+        timeout_s: float | None = None,
+    ) -> None:
+        self._manager = manager
+        self._handle = handle if handle is not None else settings.SYNTHESIZER_HANDLE
+        self._timeout_s = timeout_s if timeout_s is not None else settings.SYNTHESIZER_PI_TIMEOUT_S
+        # Rooms with a run in flight — a re-summon while active is ignored.
+        self._active: set[str] = set()
+        # Strong refs to scheduled runs so they aren't GC'd mid-flight.
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    @property
+    def handle(self) -> str:
+        return self._handle
+
+    # -- the summon seam (sync; called from the persister's on_summon) --
+
+    def handle_summon(
+        self, room: str, handle: str, envelope: L9, co_summons: list[str] | None = None
+    ) -> None:
+        """Fire the synthesizer when a registered ``engine`` (kind
+        ``synthesizer``) is summoned; else ignore.
+
+        The persister fires this for every ``@``-mention, so the manifest-kind
+        gate is what keeps an ``@teammate`` (or the aligner's summon) from
+        spawning a synthesis. There is no reserved-handle fallback: the
+        synthesizer is only ever a registered engine.
+        """
+        if _registered_engine_kind(room, handle) != ENGINE_KIND:
+            return
+        # When ENGINE_RUNTIME=host the host daemon owns a registered engine's run.
+        if settings.ENGINE_RUNTIME == "host":
+            logger.info(
+                "engine @%s summoned in %s but ENGINE_RUNTIME=host — host daemon owns the run",
+                handle,
+                room,
+            )
+            return
+        from app.services.persister import envelope_sender
+
+        sender = envelope_sender(envelope)
+        if sender is not None and _norm(sender) in {_norm(self._handle), _norm(handle)}:
+            return  # never summon off our own message
+        if room in self._active:
+            logger.debug("synthesizer already active on room %s; ignoring re-summon", room)
+            return
+        self._active.add(room)
+        task = asyncio.create_task(self._run_and_release(room, handle))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _run_and_release(self, room: str, engine_handle: str) -> None:
+        try:
+            await self.synthesize(room, engine_handle=engine_handle)
+        except Exception:
+            logger.exception("synthesizer run failed on room %s", room)
+        finally:
+            self._active.discard(room)
+
+    # -- the one path: read → summarize → write --
+
+    async def synthesize(self, room: str, engine_handle: str | None = None) -> str | None:
+        """Compile the room's memory into a ``knowledge`` summary; return it.
+
+        Returns the summary markdown on success, or ``None`` when there is
+        nothing to summarize or the Pi turn fails (fail-soft — no partial
+        summary is written).
+        """
+        me = engine_handle or self._handle
+        entries = _read_room_memory(room)
+        if not entries:
+            logger.info("synthesizer: room %s has no memory to summarize", room)
+            return None
+
+        prompt = _build_prompt(room, entries)
+        try:
+            raw = await asyncio.wait_for(
+                asyncio.to_thread(_pi_complete, prompt, self._timeout_s),
+                timeout=self._timeout_s + 5.0,
+            )
+        except Exception:
+            logger.exception("synthesizer: Pi turn failed for room %s", room)
+            return None
+
+        summary = _strip_fences(raw or "")
+        if not summary.strip():
+            logger.warning("synthesizer: Pi returned empty summary for room %s", room)
+            return None
+
+        await self._write_summary(room, summary, me)
+        logger.info(
+            "synthesizer: wrote %s for room %s (%d memories)", SYNTHESIS_KEY, room, len(entries)
+        )
+        return summary
+
+    async def _write_summary(self, room: str, summary: str, created_by: str) -> None:
+        """Upsert the summary through the canonical versioned + indexed path."""
+        # Lazy import: the route module imports services heavily, so importing it
+        # at module load would risk a cycle. ``create_memories`` is the single
+        # source of truth for a correct (versioned, indexed, NOTIFY-ing) write —
+        # reused here rather than re-implementing the upsert.
+        from app.routes.memory import create_memories
+        from app.schemas import MemoryBatchCreate, MemoryCreate
+
+        await create_memories(
+            room,
+            MemoryBatchCreate(
+                items=[
+                    MemoryCreate(
+                        key=SYNTHESIS_KEY,
+                        value=summary.rstrip("\n") + "\n",
+                        created_by=created_by,
+                        embed=True,
+                        tags=["synthesis"],
+                    )
+                ]
+            ),
+        )

--- a/fastapi-backend/tests/test_synthesizer.py
+++ b/fastapi-backend/tests/test_synthesizer.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the synthesizer cognition engine (app/services/synthesizer.py).
+
+Node-free: the Pi turn is patched, so these exercise the summon gate, the
+read → summarize → write path, the fail-soft behavior, and the exclusion of
+manifests / the prior summary from the corpus — all as pure async logic against
+a temp ``.mycelium`` dir.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+import yaml
+
+from app.services import l9, synthesizer
+from app.services.filesystem import get_room_dir, read_memory_file, write_memory_file
+from app.services.l9_models import Kind
+from tests.fakes import FakeChannel, FakeManaged, FakeManager, FakePersister
+
+_ROOM = "synth-room"
+_EPISODE = l9.episode_urn(_ROOM, "live")
+_TOPIC = l9.topic_urn(_ROOM)
+
+
+def _engine() -> synthesizer.SynthesizerEngine:
+    managed = FakeManaged(_ROOM, "mycelium", FakeChannel(), FakePersister())
+    return synthesizer.SynthesizerEngine(FakeManager(managed, []))  # type: ignore[arg-type]
+
+
+def _env(sender: str) -> Any:
+    return l9.build_envelope(
+        kind=Kind.exchange,
+        episode=_EPISODE,
+        sender=sender,
+        topic=_TOPIC,
+        payload_type="message",
+    )
+
+
+def _seed_memories(room: str) -> None:
+    write_memory_file(
+        get_room_dir(room),
+        "decisions/db",
+        "PostgreSQL chosen for graph+SQL+vector support.",
+        created_by="agent-a",
+    )
+    write_memory_file(
+        get_room_dir(room),
+        "status/current",
+        "Backend scaffolding underway; API not yet wired.",
+        created_by="agent-b",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _fast_embed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Skip the ONNX embedding model — the write path is what we're testing."""
+    monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+
+
+# ── the read → summarize → write path ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_synthesize_writes_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_memories(_ROOM)
+    seen_prompt: list[str] = []
+
+    def fake_pi(prompt: str, _timeout: float) -> str:
+        seen_prompt.append(prompt)
+        return "# Room briefing\n\n- DB: PostgreSQL\n- Status: scaffolding"
+
+    monkeypatch.setattr(synthesizer, "_pi_complete", fake_pi)
+
+    result = await _engine().synthesize(_ROOM)
+
+    assert result is not None
+    assert "Room briefing" in result
+    written = read_memory_file(get_room_dir(_ROOM), synthesizer.SYNTHESIS_KEY)
+    assert written is not None
+    _meta, body = written
+    assert "Room briefing" in body
+    # The corpus fed to Pi carried the source memories.
+    assert "PostgreSQL" in seen_prompt[0]
+    assert "scaffolding" in seen_prompt[0]
+
+
+@pytest.mark.asyncio
+async def test_synthesize_excludes_manifests_and_prior_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _seed_memories(_ROOM)
+    # A manifest and a prior synthesis must never feed the next summary.
+    write_memory_file(
+        get_room_dir(_ROOM),
+        "agents/synth-1",
+        yaml.safe_dump({"adapter": "engine", "kind": "synthesizer"}),
+        created_by="cli-user",
+    )
+    write_memory_file(
+        get_room_dir(_ROOM),
+        synthesizer.SYNTHESIS_KEY,
+        "STALE PRIOR SUMMARY",
+        created_by="synthesizer",
+    )
+    seen_prompt: list[str] = []
+    monkeypatch.setattr(synthesizer, "_pi_complete", lambda p, _t: seen_prompt.append(p) or "ok")
+
+    await _engine().synthesize(_ROOM)
+
+    assert "adapter: engine" not in seen_prompt[0]
+    assert "STALE PRIOR SUMMARY" not in seen_prompt[0]
+
+
+@pytest.mark.asyncio
+async def test_synthesize_noop_on_empty_room(monkeypatch: pytest.MonkeyPatch) -> None:
+    get_room_dir(_ROOM).mkdir(parents=True, exist_ok=True)  # exists but no memory
+
+    def boom(_p: str, _t: float) -> str:
+        raise AssertionError("Pi must not run for an empty room")
+
+    monkeypatch.setattr(synthesizer, "_pi_complete", boom)
+
+    assert await _engine().synthesize(_ROOM) is None
+    assert read_memory_file(get_room_dir(_ROOM), synthesizer.SYNTHESIS_KEY) is None
+
+
+@pytest.mark.asyncio
+async def test_synthesize_failsoft_on_pi_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed_memories(_ROOM)
+
+    def boom(_p: str, _t: float) -> str:
+        raise RuntimeError("pi exploded")
+
+    monkeypatch.setattr(synthesizer, "_pi_complete", boom)
+
+    # No exception escapes, no partial summary is written.
+    assert await _engine().synthesize(_ROOM) is None
+    assert read_memory_file(get_room_dir(_ROOM), synthesizer.SYNTHESIS_KEY) is None
+
+
+# ── the summon gate ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_summon_fires_only_for_a_registered_synthesizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Pin backend runtime — the host path is covered separately, and the local
+    # ``~/.mycelium/.env`` may default this to ``host``.
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "ENGINE_RUNTIME", "backend")
+    write_memory_file(
+        get_room_dir(_ROOM),
+        "agents/synth-1",
+        yaml.safe_dump({"adapter": "engine", "kind": "synthesizer"}),
+        created_by="cli-user",
+    )
+    write_memory_file(
+        get_room_dir(_ROOM),
+        "agents/mediator-1",
+        yaml.safe_dump({"adapter": "engine", "kind": "aligner"}),
+        created_by="cli-user",
+    )
+    engine = _engine()
+    called: list[str] = []
+
+    async def fake_synthesize(room: str, engine_handle: str | None = None) -> None:
+        called.append(engine_handle or "?")
+
+    engine.synthesize = fake_synthesize  # type: ignore[method-assign]
+
+    # A normal teammate: no fire.
+    engine.handle_summon(_ROOM, "agent-a", _env("human"))
+    # The aligner engine: not ours — no fire.
+    engine.handle_summon(_ROOM, "mediator-1", _env("human"))
+    await asyncio.sleep(0.02)
+    assert called == []
+
+    # A registered synthesizer: fires as that handle.
+    engine.handle_summon(_ROOM, "synth-1", _env("human"))
+    await asyncio.sleep(0.02)
+    assert called == ["synth-1"]
+
+
+@pytest.mark.asyncio
+async def test_summon_skipped_when_engine_runtime_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.config import settings
+
+    write_memory_file(
+        get_room_dir(_ROOM),
+        "agents/synth-1",
+        yaml.safe_dump({"adapter": "engine", "kind": "synthesizer"}),
+        created_by="cli-user",
+    )
+    monkeypatch.setattr(settings, "ENGINE_RUNTIME", "host")
+    engine = _engine()
+    called: list[str] = []
+
+    async def fake_synthesize(room: str, engine_handle: str | None = None) -> None:
+        called.append(engine_handle or "?")
+
+    engine.synthesize = fake_synthesize  # type: ignore[method-assign]
+
+    engine.handle_summon(_ROOM, "synth-1", _env("human"))
+    await asyncio.sleep(0.02)
+    assert called == []  # the host daemon owns the run

--- a/fastapi-backend/tests/test_synthesizer_live.py
+++ b/fastapi-backend/tests/test_synthesizer_live.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Live-LLM slice for the synthesizer engine.
+
+Guarded by ``MYCELIUM_LLM_TESTS=1`` (costs tokens). Exercises the real path end
+to end: real room memories on disk → a real ``pi`` turn against the configured
+model → a real ``context/synthesis`` memory written through the canonical
+(versioned + indexed) write. Only the embedding vector is stubbed — it is
+orthogonal to the synthesis and would otherwise load the ONNX model.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.services import synthesizer
+from app.services.filesystem import get_room_dir, read_memory_file, write_memory_file
+from tests.fakes import FakeChannel, FakeManaged, FakeManager, FakePersister
+
+_ROOM = "synth-live"
+
+
+@pytest.mark.skipif(
+    os.getenv("MYCELIUM_LLM_TESTS") != "1",
+    reason="live LLM test — set MYCELIUM_LLM_TESTS=1 to run",
+)
+@pytest.mark.asyncio
+async def test_synthesize_live(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+
+    write_memory_file(
+        get_room_dir(_ROOM),
+        "context/goal",
+        "Move the Atlas catalog off the legacy store with zero downtime.",
+        created_by="operator",
+    )
+    write_memory_file(
+        get_room_dir(_ROOM),
+        "decisions/cutover",
+        "Phased cutover over a 48h window; dual-write then flip reads.",
+        created_by="aligner",
+    )
+    write_memory_file(
+        get_room_dir(_ROOM),
+        "status/sprint",
+        "Cutover rehearsal green; production flip scheduled Thursday.",
+        created_by="growth",
+    )
+
+    managed = FakeManaged(_ROOM, "mycelium", FakeChannel(), FakePersister())
+    engine = synthesizer.SynthesizerEngine(FakeManager(managed, []))  # type: ignore[arg-type]
+
+    summary = await engine.synthesize(_ROOM)
+
+    assert summary is not None and summary.strip()
+    written = read_memory_file(get_room_dir(_ROOM), synthesizer.SYNTHESIS_KEY)
+    assert written is not None
+    _meta, body = written
+    # The real briefing should reflect the seeded facts, not fabricate.
+    assert "cutover" in body.lower() or "atlas" in body.lower()
+    print(f"\n--- live synthesis ({len(body)} chars) ---\n{body}\n")

--- a/mycelium-cli/src/mycelium/docs/aligner.md
+++ b/mycelium-cli/src/mycelium/docs/aligner.md
@@ -1,13 +1,12 @@
 # Aligner
 
-The aligner is Mycelium's first-party mediator. Agents never talk to each other
-directly; all coordination flows through it. It reads everyone's opening
-positions, brokers the negotiation one agent at a time, and stops the moment the
-team agrees.
+The aligner is the negotiation [engine](#engines) — the `kind` that mediates a
+decision to consensus. Agents never talk to each other directly; all
+coordination flows through it. It reads everyone's opening positions, brokers the
+negotiation one agent at a time, and stops the moment the team agrees.
 
-Unlike a passive relay, the aligner is *summoned*: nothing runs until you
-register it in a [room](#rooms) and invoke it. There is no join window and no
-auto-start.
+Like every engine, the aligner is *summoned*: nothing runs until you register it
+in a [room](#rooms) and invoke it. There is no join window and no auto-start.
 
 ```bash
 # Register the mediator once per room

--- a/mycelium-cli/src/mycelium/docs/architecture.md
+++ b/mycelium-cli/src/mycelium/docs/architecture.md
@@ -109,11 +109,13 @@ mycelium respond --room my-project --handle me "moving toward 30% …"
 `claude -p` on a mention. It's built on the same membership core; agents never
 speak SLIM or L9 directly.
 
-**The aligner is the cognition engine.** Negotiation is driven by a first-party
-mediator, the aligner, registered in a room and summoned by `@`-mention. Its
-brain is a persistent Pi coding-agent session running a NEGMAS Stacked
-Alternating Offers negotiation; NEGMAS owns termination, stopping the instant
-the agents agree. See [aligner](#aligner) and [episodes](#episodes).
+**Cognition rides on engines.** First-party [engines](#engines) are registered in
+a room and summoned by `@`-mention; each `kind` is a distinct unit of reasoning.
+The `aligner` drives negotiation — its brain is a persistent Pi coding-agent
+session running a NEGMAS Stacked Alternating Offers mechanism that owns
+termination, stopping the instant the agents agree. The `synthesizer` distills
+the room's memory into a shared briefing. See [engines](#engines),
+[aligner](#aligner), and [episodes](#episodes).
 
 ## Adapters
 

--- a/mycelium-cli/src/mycelium/docs/engines.md
+++ b/mycelium-cli/src/mycelium/docs/engines.md
@@ -1,0 +1,80 @@
+# Engines
+
+An **engine** is a first-party unit of cognition that lives inside a room. Where
+your agents are the participants, engines are the room's *reasoning citizens* —
+they read what the room knows and act on it: mediate a decision, distill the
+memory, and (in time) more.
+
+Engines exist because some work isn't any single agent's job. Deciding *whose
+offer wins* shouldn't fall to one of the negotiating parties; summarizing the
+whole room shouldn't depend on one agent remembering everything. An engine is a
+neutral, first-party actor the room owns.
+
+Two properties define every engine:
+
+- **Summoned, never automatic.** An engine is dormant until you register it in a
+  room and `@`-summon it. There is no join window, no polling, no held LLM
+  connection — zero idle cost. Cognition runs *because you asked for it*.
+- **A room citizen with a handle.** A registered engine is an agent whose
+  manifest says `adapter: engine` and carries a `kind`. It runs *as that handle*,
+  so it can be `@`-addressed and its output is attributed like any member's.
+
+## Kinds
+
+The engine layer is one seam with a growing set of kinds — you pick the kind at
+registration time. No new adapter per engine; the same `mycelium engine`
+commands host all of them.
+
+| Kind | What it does |
+|---|---|
+| `aligner` | Mediates a real NEGMAS negotiation to consensus, then compiles the agreement into the room's plan. See [Aligner](#aligner). |
+| `synthesizer` | Reads the room's memory and writes back a single structured briefing at `context/synthesis`. |
+
+More kinds (bargaining, team-formation, drift evaluation) plug into the same
+seam over time.
+
+## The lifecycle
+
+Every engine, whatever its kind, follows the same three steps.
+
+```bash
+# 1. Register it once per room (pick the kind)
+mycelium engine create summarizer --kind synthesizer --room sprint-plan
+
+# 2. Summon it — this is what makes cognition run
+mycelium engine invoke summarizer "brief the room on where we stand" -r sprint-plan
+
+# 3. It runs as that handle and writes its result back into the room
+mycelium memory get context/synthesis -r sprint-plan
+```
+
+`mycelium engine ls` shows the engines registered in a room and their kinds.
+
+## The synthesizer
+
+The `synthesizer` distills a room. On summon it reads every memory namespace —
+decisions, status, context, work, the plan — and runs one **Pi** turn to compile
+them into a single markdown briefing: the room's goal, key decisions, current
+status, and open work. It upserts that briefing as a `knowledge` memory at
+`context/synthesis`, so it's versioned, searchable, and shared like any other
+memory.
+
+It is deliberately faithful — the briefing reflects only what's in the room's
+memory; it never invents facts. If a Pi turn fails it writes nothing rather than
+a half-formed summary. Run it again after a burst of activity and the summary
+upserts (version increments) in place.
+
+## Where an engine runs
+
+An engine's cognition runs in one of two places, selected by the `engine.runtime`
+config (the backend and the host daemon are a pair — set both the same):
+
+- **`backend`** (default): the always-on backend runs the engine through its
+  summon seam. Nothing extra to install.
+- **`host`**: the local daemon holds the engine and runs it on the host, where
+  `pi` lives. Use this when the engine's brain needs host tools or credentials.
+
+Every engine's brain is **Pi**, Mycelium's own cognition runtime (it ships in the
+backend image). Pi is never imposed on your participant agents — they run however
+they like (Claude Code, Cursor, a plain HTTP client) and only ever answer in
+prose.

--- a/mycelium-cli/src/mycelium/docs/index.md
+++ b/mycelium-cli/src/mycelium/docs/index.md
@@ -10,7 +10,8 @@ Built-in reference for the Mycelium multi-agent coordination system.
 - **episodes**: A negotiation as a scoped, recorded round on a room's channel
 - **memory**: Persistent markdown store with local semantic search
 - **plan**: Title + markdown files + checklist tasks surfaced to every agent
-- **aligner**: The mediator that drives a negotiation to consensus
+- **engines**: First-party cognition citizens summoned into a room (the aligner, the synthesizer, and more)
+- **aligner**: The negotiation engine kind — drives a negotiation to consensus
 - **l9-protocol**: The epistemic envelope layer negotiation rides on
 - **cli-reference**: All CLI commands (generated from source)
 - **architecture**: Stack, adapters, and integrations

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -294,9 +294,10 @@ class MemoryLogEntry(BaseModel):
 AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "engine"})
 
 #: Cognition-engine kinds hosted by the first-party ``engine`` runtime family.
-#: The extensibility axis: ``aligner`` (SIEP converge) today; ``bargainer`` (SAB),
-#: ``team_former`` (TFP), a drift evaluator, etc. later — no new adapter per CE.
-ENGINE_KINDS: frozenset[str] = frozenset({"aligner"})
+#: The extensibility axis: ``aligner`` (SIEP converge) and ``synthesizer`` (room
+#: memory → structured summary) today; ``bargainer`` (SAB), ``team_former`` (TFP),
+#: a drift evaluator, etc. later — no new adapter per CE.
+ENGINE_KINDS: frozenset[str] = frozenset({"aligner", "synthesizer"})
 
 
 class AgentManifest(BaseModel):

--- a/mycelium-cli/tests/test_engine.py
+++ b/mycelium-cli/tests/test_engine.py
@@ -22,6 +22,13 @@ from mycelium.protocol import AGENT_ADAPTERS, ENGINE_KINDS, AgentManifest
 def test_engine_is_a_registered_family() -> None:
     assert "engine" in AGENT_ADAPTERS
     assert "aligner" in ENGINE_KINDS
+    assert "synthesizer" in ENGINE_KINDS
+
+
+def test_manifest_accepts_synthesizer() -> None:
+    m = AgentManifest(handle="synth-1", adapter="engine", kind="synthesizer")
+    assert m.adapter == "engine"
+    assert m.kind == "synthesizer"
 
 
 def test_manifest_requires_a_kind() -> None:

--- a/mycelium-frontend/src/lib/tour.ts
+++ b/mycelium-frontend/src/lib/tour.ts
@@ -125,6 +125,17 @@ export function startRoomTour(deps: TourDeps): TourHandle {
       {
         element: '[data-tour="inspector-memory"]',
         popover: {
+          title: "Summon the synthesizer",
+          description:
+            "A second engine. On @-summon, the synthesizer distills the whole room — goal, the new decision, the plan — into one shared briefing at context/synthesis.",
+          side: "left",
+          align: "start",
+        },
+        onHighlightStarted: () => deps.setInspectorTab("memory"),
+      },
+      {
+        element: '[data-tour="inspector-memory"]',
+        popover: {
           title: "And it persists",
           description:
             "Decisions, context, and the plan sync to the room's memory — durable, searchable, and shared across sessions.",

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -173,6 +173,13 @@ const atlas: RoomFixture = {
       updated_at: iso(60 * 20),
     },
     {
+      key: "agents/synthesizer",
+      value: agentManifest("Distills room memory into a shared briefing.", "engine"),
+      created_by: "operator",
+      version: 1,
+      updated_at: iso(60 * 20),
+    },
+    {
       key: "decisions/cutover",
       value: "Phased cutover over a 48h window; dual-write then flip reads.",
       content_text: "Phased cutover over a 48h window; dual-write then flip reads.",
@@ -195,6 +202,20 @@ const atlas: RoomFixture = {
       created_by: "growth",
       version: 2,
       updated_at: iso(120),
+    },
+    {
+      key: "context/synthesis",
+      value:
+        "# Atlas migration — room briefing\n\n" +
+        "**Decision.** Phased cutover over a 48h window; dual-write then flip reads.\n\n" +
+        "**Status.** Cutover rehearsal green; production flip scheduled Thursday.\n\n" +
+        "**Goal.** Move the Atlas catalog off the legacy store with zero downtime.\n\n" +
+        "_Owners:_ @growth drives delivery; @risk guards reliability.",
+      content_text:
+        "Atlas migration briefing: phased 48h cutover (dual-write then flip); rehearsal green, flip Thursday; zero-downtime goal.",
+      created_by: "synthesizer",
+      version: 1,
+      updated_at: iso(38),
     },
   ],
   plan: {
@@ -256,6 +277,8 @@ const pricing: RoomFixture = {
   memories: [
     { key: "agents/finance", value: agentManifest("Protects margin; models unit economics."), created_by: "operator", version: 1, updated_at: iso(160) },
     { key: "agents/growth", value: agentManifest("Wants adoption; favors a low entry price."), created_by: "operator", version: 1, updated_at: iso(160) },
+    { key: "agents/aligner", value: agentManifest("First-party mediator (NEGMAS SAO).", "engine"), created_by: "operator", version: 1, updated_at: iso(160) },
+    { key: "agents/synthesizer", value: agentManifest("Distills room memory into a shared briefing.", "engine"), created_by: "operator", version: 1, updated_at: iso(160) },
     { key: "context/goal", value: "Pick a launch price for the Pro tier.", content_text: "Pick a launch price for the Pro tier.", created_by: "operator", version: 1, updated_at: iso(175) },
   ],
   plan: { room: "pricing-model", title: null, files: [], tasks: [], open_count: 0, done_count: 0 },
@@ -340,6 +363,7 @@ export const COLLECTOR_METRICS = {
         growth: { input: 82_000, output: 21_000, cache_read: 40_000, cache_write: 5_000, total: 148_000 },
         risk: { input: 61_000, output: 18_000, cache_read: 30_000, cache_write: 4_000, total: 113_000 },
         aligner: { input: 41_300, output: 13_100, cache_read: 20_400, cache_write: 3_800, total: 78_600 },
+        synthesizer: { input: 12_600, output: 3_400, cache_read: 6_000, cache_write: 900, total: 22_900 },
       },
       by_model: {
         "anthropic/claude-sonnet-4-6": { input: 143_000, output: 39_000, cache_read: 70_000, cache_write: 9_000, total: 261_000 },
@@ -348,7 +372,7 @@ export const COLLECTOR_METRICS = {
     },
     cost_usd: {
       total: 4.82,
-      by_agent: { growth: 2.1, risk: 1.6, aligner: 1.12 },
+      by_agent: { growth: 2.1, risk: 1.6, aligner: 1.12, synthesizer: 0.28 },
       by_model: { "anthropic/claude-sonnet-4-6": 3.9, "anthropic/claude-haiku-4-5": 0.92 },
     },
     messages: { processed: 214 },
@@ -358,6 +382,7 @@ export const COLLECTOR_METRICS = {
       growth: { calls: 46, last: iso(28) },
       risk: { calls: 38, last: iso(31) },
       aligner: { calls: 22, last: iso(42) },
+      synthesizer: { calls: 6, last: iso(38) },
     },
   },
 };

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -280,6 +280,19 @@ const pricing: RoomFixture = {
     { key: "agents/aligner", value: agentManifest("First-party mediator (NEGMAS SAO).", "engine"), created_by: "operator", version: 1, updated_at: iso(160) },
     { key: "agents/synthesizer", value: agentManifest("Distills room memory into a shared briefing.", "engine"), created_by: "operator", version: 1, updated_at: iso(160) },
     { key: "context/goal", value: "Pick a launch price for the Pro tier.", content_text: "Pick a launch price for the Pro tier.", created_by: "operator", version: 1, updated_at: iso(175) },
+    {
+      key: "context/synthesis",
+      value:
+        "# Pricing model — room briefing\n\n" +
+        "**Goal.** Pick a launch price for the Pro tier.\n\n" +
+        "**Outcome.** Pro launches at **$39/seat**, 75 seats, annual term — margin held above 60%.\n\n" +
+        "_Owners:_ @finance guards margin; @growth drives adoption.",
+      content_text:
+        "Pricing briefing: Pro tier launches at $39/seat, 75 seats, annual; margin held above 60%.",
+      created_by: "synthesizer",
+      version: 1,
+      updated_at: iso(6),
+    },
   ],
   plan: { room: "pricing-model", title: null, files: [], tasks: [], open_count: 0, done_count: 0 },
   messages: [

--- a/mycelium-frontend/src/mocks/stream.ts
+++ b/mycelium-frontend/src/mocks/stream.ts
@@ -51,6 +51,10 @@ const pricingTimeline: StreamStep[] = [
   { delayMs: 1500, message: tick("s10", 3, "growth", "accept", { price: "39", seats: "75", term: "annual" }) },
   { delayMs: 1400, message: tick("s11", 3, "finance", "accept", { price: "39", seats: "75", term: "annual" }) },
   { delayMs: 1800, message: { id: "s12", sender_handle: "backend", message_type: "coordination_consensus", content: JSON.stringify({ plan: "pricing agreed", assignments: { price: "39", seats: "75", term: "annual" }, plan_file: "plan/tasks.md", episode: PRICING_EPISODE, metrics: { gar: 0.86 } }), episode: PRICING_EPISODE } },
+  // After the plan lands, summon the synthesizer: it distills the room's memory
+  // (goal, the new decision, the plan) into a shared briefing at context/synthesis.
+  { delayMs: 2000, message: say("s13", "operator", "@synthesizer brief the room on where we landed.") },
+  { delayMs: 1800, message: say("s14", "synthesizer", "Distilled the outcome → context/synthesis: Pro launches at $39/seat, 75 seats, annual — margin held above 60%.") },
 ];
 
 const TIMELINES: Record<string, StreamStep[]> = {


### PR DESCRIPTION
**Draft for review.** Implements #471 — synthesis as an *invocable engine* (not the removed auto-triggered system).

A second cognition-engine `kind` alongside the aligner. On `@`-summon it reads the room's memory namespaces, compiles a structured markdown briefing via one throwaway `pi` turn, and upserts it as a `knowledge` memory at `context/synthesis` — searchable + version-tracked like any memory.

### What's here
- **`protocol.py`** — register `synthesizer` in `ENGINE_KINDS`. CLI `engine create --kind synthesizer` / `engine invoke` validation is already data-driven off this set, so no command changes needed.
- **`app/services/synthesizer.py`** — `SynthesizerEngine`:
  - dormant-by-default summon gate (reuses the aligner's `_registered_engine_kind` / `_norm` primitives — one source of truth for the manifest read),
  - one-shot Pi cognition mirroring `plan_compiler._pi_complete`,
  - **fail-soft**: a Pi outage logs and writes nothing (no half-baked summary),
  - writes through the canonical `create_memories` path (versioned, indexed, NOTIFY),
  - excludes `agents/` manifests and the prior summary from its own corpus.
- **`app/config.py`** — `SYNTHESIZER_HANDLE` + `SYNTHESIZER_PI_TIMEOUT_S`; reuses the shared `LLM_*` / `ALIGNER_PI_*` Pi runtime.
- **`app/main.py`** — a fan-out summon dispatcher so the aligner and synthesizer share the single `on_summon` seam; each self-selects by manifest kind (only one ever acts per summon).

### Tests
- CLI: `synthesizer` accepted as a kind.
- Backend: summon gate (fires only for a registered synthesizer, not a teammate or the aligner), host-runtime skip, and the read → summarize → write path incl. fail-soft + corpus exclusions.
- Full suites green: backend 376 passed / 1 skipped, CLI 417 passed. ruff + ty clean.

### Design notes / open questions for review
- **Output surface**: I chose `context/synthesis` (existing namespace, stable slug so it upserts). The issue floated `plan/`-adjacent vs `context/` — easy to change.
- **No SLIM broadcast yet**: the write goes through `create_memories` which already fires a NOTIFY; I did not add a `knowledge`-envelope broadcast like `plan_sync` does. Can add if we want live push to members.
- **Corpus scope**: currently all namespaces except `agents/` (includes `log/`). Could trim `log/episodes/` if summaries get noisy.

Still to add (per follow-up): seed the synthesizer into the UI mock data + the "Run a sample coordination" demo. Docs concept work is tracked in #472.

Closes #471