### PR TITLE
fix(config): emit ENGINE_RUNTIME in generated .env

### DIFF
--- a/mycelium-cli/src/mycelium/docker_utils.py
+++ b/mycelium-cli/src/mycelium/docker_utils.py
@@ -114,6 +114,13 @@ def generate_env_file(
         if config.llm.base_url
         else "# LLM_BASE_URL not set — using provider default",
         "",
+        "# ── Engine ───────────────────────────────────────────────────────────────",
+        # Where a registered `engine` runs its NEGMAS/Pi drive. The backend and
+        # the host daemon are a pair (see EngineConfig): emitted explicitly so
+        # `config apply` can't silently revert a `host` deployment to
+        # backend-run engines (which would double-run the engine).
+        f"ENGINE_RUNTIME={config.engine.runtime}",
+        "",
     ]
 
     # ── Operator-managed pins (preserved across `mycelium config apply`) ─────

--- a/mycelium-cli/tests/test_docker_env_materialization.py
+++ b/mycelium-cli/tests/test_docker_env_materialization.py
@@ -55,3 +55,26 @@ def test_env_metrics_port_defaults_to_4318() -> None:
     cfg = MyceliumConfig()
     env = _parse_env(generate_env_file(cfg))
     assert env["MYCELIUM_METRICS_PORT"] == "4318"
+
+
+# ── engine runtime materialisation ───────────────────────────────────────────
+
+
+def test_env_materialises_engine_runtime_default() -> None:
+    """Default config writes ENGINE_RUNTIME=backend."""
+    env = _parse_env(generate_env_file(MyceliumConfig()))
+    assert env["ENGINE_RUNTIME"] == "backend"
+
+
+def test_env_materialises_engine_runtime_host() -> None:
+    """A ``host`` deployment must survive ``config apply``.
+
+    Regression: the generator previously omitted ENGINE_RUNTIME entirely, so
+    ``config apply`` silently reverted a host deployment to backend-run engines
+    (double-running the engine). The backend and daemon are a pair — the .env
+    must carry the host setting.
+    """
+    cfg = MyceliumConfig()
+    cfg.engine.runtime = "host"
+    env = _parse_env(generate_env_file(cfg))
+    assert env["ENGINE_RUNTIME"] == "host"


### PR DESCRIPTION
### The bug
`generate_env_file` (the `mycelium config apply` / `mycelium install` env writer in `docker_utils.py`) rendered `MYCELIUM_*` and `LLM_*` keys but **never emitted `ENGINE_RUNTIME`** — even though `config.engine.runtime` exists and defaults are documented as a backend/host *pair*.

Effect: on a deployment with `engine.runtime = host` (daemon drives the engine on the host where `pi` lives), running `mycelium config apply` silently dropped `ENGINE_RUNTIME=host` from `~/.mycelium/.env`. The backend then came up in its default `backend` mode and **also** ran the registered engine — the exact double-run the pairing exists to prevent (CLAUDE.md: "flip both together — they're a pair").

Found while testing the synthesizer engine (#471): a `host` config kept reverting to backend across `config apply`.

### The fix
Emit `ENGINE_RUNTIME={config.engine.runtime}` in the generated `.env`, in its own Engine section. Adds two regression tests: default → `backend`, and a `host` config survives `config apply`.

### Verified live
Reproduced on my running stack (config kept losing `host`), applied the fix, re-ran `config apply` → `.env` now carries `ENGINE_RUNTIME=host`, and the recreated backend container reports `host`. CLI env-materialization tests: 15 passed.