### PR TITLE
promo: refresh HyperFrames to the new UI shell + add synthesizer beat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,9 @@ docs/               Docs site (generated from mycelium-cli/src/mycelium/docs/),
                     demo script, design notes
 mycelium-promo/     HyperFrames promo video, a code-defined HTML→MP4 walkthrough
                     (CLI install → app install → room → adapter → post positions →
-                    summon the aligner → await/respond → consensus → plan → work).
+                    summon the aligner → await/respond → consensus → plan → work →
+                    distill the room to memory via the synthesizer). The app-screen
+                    mockups mirror the frontend's workspace shell + dark design tokens.
                     Renders 1920x1080 H.264. `cd mycelium-promo && npm run dev` to
                     preview, `npm run render` to export to renders/*.mp4.
                     The README + docs/index.html embed the rendered MP4 via a

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 <div align="center">
 
-https://github.com/user-attachments/assets/e357bc45-87d5-46d9-b533-750ca39150d5
+https://github.com/user-attachments/assets/5e7b41c8-f98a-4cf3-bb85-fe17d855de7a
 
 <em>install → coordinate → plan → work.</em>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,7 @@
 
       <div class="hero-video" style="margin: 0 0 32px; text-align: center;">
         <video
-          src="https://github.com/user-attachments/assets/e357bc45-87d5-46d9-b533-750ca39150d5"
+          src="https://github.com/user-attachments/assets/5e7b41c8-f98a-4cf3-bb85-fe17d855de7a"
           controls
           playsinline
           preload="metadata"

--- a/mycelium-promo/.gitignore
+++ b/mycelium-promo/.gitignore
@@ -13,3 +13,5 @@ skills/
 
 # Rendered MP4s are uploaded to GitHub (user-attachments), not committed
 renders/
+
+renders/_*.mp4

--- a/mycelium-promo/index.html
+++ b/mycelium-promo/index.html
@@ -14,16 +14,23 @@
       * { margin: 0; padding: 0; box-sizing: border-box; }
       html, body {
         margin: 0; width: 1920px; height: 1080px;
-        overflow: hidden; background: #0c0d10;
+        overflow: hidden; background: #0c0e11;
         font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-        color: #eaeaea;
+        color: #e8ebee;
       }
+      /* Tokens mirror the frontend's post-redesign dark theme
+         (mycelium-frontend/src/app/globals.css .dark). */
       :root {
-        --bg: #0c0d10; --surface: #111216; --paper: #14161b;
-        --border: rgba(234, 234, 234, 0.10); --border2: rgba(234, 234, 234, 0.22);
-        --accent: #5dd4e0; --accent2: #7dd3fc;
-        --green: #34d399; --purple: #c084fc; --yellow: #fbbf24;
-        --text: #eaeaea; --text2: #a8a6a0; --muted: #b8b5ae; --dim: #46443e;
+        --bg: #0c0e11; --surface: #14171c; --paper: #191d22; --elevated: #21262d;
+        --border: rgba(255, 255, 255, 0.08); --border2: rgba(255, 255, 255, 0.16);
+        --hairline: rgba(255, 255, 255, 0.035);
+        --accent: #5cc7d2; --accent-fg: #06181b; --accent-soft: rgba(92, 199, 210, 0.13);
+        --accent2: #8fd6de;
+        --green: #4fc296; --yellow: #d9a94e; --red: #e6746f;
+        /* Purple retired — the redesign is single-accent; kept as a neutral so
+           any lingering reference reads as muted, not off-brand violet. */
+        --purple: #a7adb5;
+        --text: #e8ebee; --text2: #a7adb5; --muted: #a7adb5; --dim: #565d65;
       }
 
       /* ── Background canvas ────────────────────────────── */
@@ -156,7 +163,7 @@
       }
       .ui-rail .label { color: var(--muted); letter-spacing: 0.18em; text-transform: uppercase; font-size: 16px; margin-bottom: 18px; }
       .ui-rail .item { padding: 12px 14px; color: var(--text2); border-left: 2px solid transparent; }
-      .ui-rail .item.active { color: var(--text); border-left-color: var(--accent); background: rgba(93, 212, 224, 0.04); }
+      .ui-rail .item.active { color: var(--text); border-left-color: var(--accent); background: rgba(92, 199, 210, 0.04); }
       .ui-pane { flex: 1; display: flex; flex-direction: column; min-width: 0; }
       .pane-header {
         height: 60px; padding: 0 32px;
@@ -187,8 +194,8 @@
         display: inline-block;
         padding: 3px 10px; margin-right: 8px;
         font-family: 'Geist Mono', monospace; font-size: 16px;
-        background: rgba(93, 212, 224, 0.08);
-        border: 1px solid rgba(93, 212, 224, 0.3);
+        background: rgba(92, 199, 210, 0.08);
+        border: 1px solid rgba(92, 199, 210, 0.3);
         color: var(--accent);
         border-radius: 3px;
       }
@@ -213,6 +220,105 @@
         color: var(--text2);
       }
       .mem-item .key { color: var(--accent); }
+
+      /* ── New workspace shell (mirrors the frontend redesign: full-height
+         rooms sidebar · room header · view tabs · tabbed inspector · status
+         bar). Kept alongside the older .ui-* chrome so scenes migrate one at a
+         time without breaking the timeline hooks. ── */
+      .ui-shell { flex: 1; display: flex; min-height: 0; }
+      .ui-sidebar {
+        width: 360px; flex-shrink: 0;
+        border-right: 1px solid var(--border);
+        background: color-mix(in srgb, var(--surface) 55%, transparent);
+        display: flex; flex-direction: column;
+      }
+      .ui-sidebar .brand {
+        height: 88px; display: flex; align-items: center; padding: 0 28px;
+        border-bottom: 1px solid var(--border);
+        font-family: 'Cormorant Garamond', serif; font-style: italic; font-weight: 600;
+        font-size: 42px; color: var(--text);
+      }
+      .ui-sidebar .side-head {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 24px 28px 14px;
+        font-family: 'Geist Mono', monospace; font-size: 16px; font-weight: 600;
+        letter-spacing: 0.18em; text-transform: uppercase; color: var(--muted);
+      }
+      .ui-sidebar .side-head .count { color: var(--dim); }
+      .ui-search {
+        margin: 0 22px 16px; padding: 13px 16px;
+        border: 1px solid var(--border); border-radius: 10px; background: var(--bg);
+        font-family: 'Geist Mono', monospace; font-size: 18px; color: var(--dim);
+      }
+      .ui-rooms { flex: 1; padding: 0 14px; display: flex; flex-direction: column; gap: 4px; }
+      .ui-room {
+        display: flex; align-items: center; gap: 15px;
+        padding: 12px 12px; border-radius: 10px;
+        font-family: 'Geist Mono', monospace; font-size: 23px; color: var(--text2);
+      }
+      .ui-room.active { background: var(--elevated); box-shadow: inset 0 0 0 1px var(--border); color: var(--text); }
+      .ui-room .ravatar {
+        width: 42px; height: 42px; border-radius: 9px; flex-shrink: 0;
+        display: flex; align-items: center; justify-content: center;
+        font-size: 17px; font-weight: 600; letter-spacing: 0.03em;
+        background: var(--surface); color: var(--muted);
+      }
+      .ui-room.active .ravatar { background: var(--accent); color: var(--accent-fg); }
+      .ui-sidebar .side-foot {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 18px 28px; border-top: 1px solid var(--border);
+        font-family: 'Geist Mono', monospace; font-size: 16px; color: var(--muted);
+      }
+      .ui-main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+      .ui-header {
+        height: 88px; flex-shrink: 0; display: flex; align-items: center; gap: 18px; padding: 0 34px;
+        border-bottom: 1px solid var(--border);
+        background: color-mix(in srgb, var(--surface) 50%, transparent);
+      }
+      .ui-header .rm-name { font-size: 31px; font-weight: 600; color: var(--text); }
+      .ui-header .rm-mas { font-family: 'Geist Mono', monospace; font-size: 18px; color: var(--dim); }
+      .ui-viewtabs {
+        display: flex; align-items: center; gap: 6px;
+        padding: 14px 26px; border-bottom: 1px solid var(--border);
+      }
+      .ui-viewtabs .vt {
+        padding: 8px 18px; border-radius: 8px;
+        font-family: 'Geist Mono', monospace; font-size: 18px; font-weight: 600;
+        letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+      }
+      .ui-viewtabs .vt.active { background: var(--elevated); color: var(--text); box-shadow: inset 0 0 0 1px var(--border); }
+      .ui-composer {
+        margin: 8px 34px 30px; padding: 22px 26px;
+        border: 1px solid var(--border); border-radius: 18px; background: var(--surface);
+        font-family: 'IBM Plex Sans', sans-serif; font-size: 23px; color: var(--muted);
+      }
+      .ui-inspector {
+        width: 460px; flex-shrink: 0;
+        border-left: 1px solid var(--border);
+        background: color-mix(in srgb, var(--surface) 42%, transparent);
+        display: flex; flex-direction: column;
+      }
+      .insp-tabs {
+        height: 70px; flex-shrink: 0; display: flex; align-items: center; gap: 6px; padding: 0 18px;
+        border-bottom: 1px solid var(--border); background: var(--paper);
+      }
+      .insp-tabs .it {
+        display: flex; align-items: center; gap: 9px;
+        padding: 9px 16px; border-radius: 8px;
+        font-family: 'Geist Mono', monospace; font-size: 17px; font-weight: 600;
+        letter-spacing: 0.06em; color: var(--muted);
+      }
+      .insp-tabs .it.active { background: var(--elevated); color: var(--text); box-shadow: inset 0 0 0 1px var(--border); }
+      .insp-tabs .it .ic { width: 14px; height: 14px; border: 1.5px solid currentColor; border-radius: 3px; }
+      .ui-statusbar {
+        height: 42px; flex-shrink: 0; display: flex; align-items: center; gap: 24px;
+        padding: 0 26px; border-top: 1px solid var(--border);
+        background: var(--surface);
+        font-family: 'Geist Mono', monospace; font-size: 15px; letter-spacing: 0.04em; color: var(--muted);
+      }
+      .ui-statusbar .sb-accent { color: var(--accent); }
+      .ui-statusbar .sb-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--green); display: inline-block; margin-right: 8px; vertical-align: middle; }
+      .ui-statusbar .spacer { flex: 1; }
 
       /* ── Session view ────────────────────────────────── */
       .session-main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
@@ -295,8 +401,8 @@
         color: var(--dim); font-weight: 400;
       }
       .sess-table .cell.head.past { color: var(--accent); font-weight: 600; }
-      .sess-table .cell.head.cur  { color: var(--text); font-weight: 600; background: rgba(93,212,224,0.06); }
-      .sess-table .cell.cur { background: rgba(93,212,224,0.06); }
+      .sess-table .cell.head.cur  { color: var(--text); font-weight: 600; background: rgba(92, 199, 210,0.06); }
+      .sess-table .cell.cur { background: rgba(92, 199, 210,0.06); }
 
       /* Action glyphs */
       .glyph { display: inline-block; flex-shrink: 0; }
@@ -361,7 +467,7 @@
       .consensus-banner {
         margin: 16px 28px 0;
         border: 1px solid var(--green);
-        background: rgba(52,211,153,0.04);
+        background: rgba(79, 194, 150,0.04);
         padding: 16px 18px;
       }
       .consensus-banner .head {
@@ -491,8 +597,8 @@
         border: 1.5px solid var(--border2);
         color: var(--text);
       }
-      .chat-avatar.julia  { background: linear-gradient(135deg, #5dd4e0 0%, #7dd3fc 100%); color: #0c0d10; }
-      .chat-avatar.selina  { background: linear-gradient(135deg, #c084fc 0%, #a855f7 100%); }
+      .chat-avatar.julia  { background: linear-gradient(135deg, #5cc7d2 0%, #8fd6de 100%); color: #06181b; }
+      .chat-avatar.selina  { background: linear-gradient(135deg, #7f8a94 0%, #5b666f 100%); color: #e8ebee; }
       .chat-msg .body { flex: 1; min-width: 0; }
       .chat-msg .meta {
         display: flex; align-items: baseline; gap: 14px; margin-bottom: 6px;
@@ -506,9 +612,9 @@
         font-size: 12px; font-weight: 600;
         letter-spacing: 0.16em;
         padding: 2px 7px; border-radius: 3px;
-        background: rgba(93, 212, 224, 0.12);
+        background: rgba(92, 199, 210, 0.12);
         color: var(--accent);
-        border: 1px solid rgba(93, 212, 224, 0.4);
+        border: 1px solid rgba(92, 199, 210, 0.4);
       }
       .chat-msg .time {
         font-family: 'IBM Plex Sans', sans-serif;
@@ -519,13 +625,13 @@
         font-size: 22px; line-height: 1.45; color: #dbdbdf;
       }
       .chat-msg .text .mention {
-        background: rgba(93, 212, 224, 0.14);
+        background: rgba(92, 199, 210, 0.14);
         color: var(--accent);
         padding: 2px 6px; border-radius: 3px;
       }
       /* Typewriter: words start invisible, GSAP fades them in one by one */
       .word { opacity: 0; }
-      .chat-msg .text .mention.julia { background: rgba(93,212,224,0.16); color: var(--accent); }
+      .chat-msg .text .mention.julia { background: rgba(92, 199, 210,0.16); color: var(--accent); }
       .chat-msg .text .mention.selina { background: rgba(192,132,252,0.18); color: var(--purple); }
       .chat-typing {
         display: inline-flex; gap: 7px; align-items: center;
@@ -718,32 +824,52 @@
           </div>
         </div>
         <div id="s4-ui" class="ui-window" style="position: absolute; left: 60px; right: 60px; top: 200px;">
-          <div class="ui-topbar">
-            <span class="brand">mycelium</span>
-            <span class="tab active">rooms</span>
-            <span class="tab">episodes</span>
-            <span class="tab">settings</span>
-          </div>
-          <div class="ui-subnav">
-            <span><span class="sigil">rm:</span>design-review</span>
-          </div>
-          <div class="ui-body">
-            <div class="ui-rail">
-              <div class="label">Episodes</div>
-              <div class="item active">none yet</div>
+          <div class="ui-shell">
+            <div class="ui-sidebar">
+              <div class="brand">mycelium</div>
+              <div class="side-head"><span>Rooms</span><span class="count">3</span></div>
+              <div class="ui-search">Search rooms…</div>
+              <div class="ui-rooms">
+                <div class="ui-room active"><span class="ravatar">DR</span>design-review</div>
+                <div class="ui-room"><span class="ravatar">PM</span>pricing-model</div>
+                <div class="ui-room"><span class="ravatar">AT</span>atlas-migration</div>
+              </div>
+              <div class="side-foot"><span>metrics</span><span>◐ theme</span></div>
             </div>
-            <div class="ui-pane">
-              <div class="pane-header">Room activity</div>
-              <div class="event-stream">
-                <div class="event-row"><span class="ts">12:04:17</span><span class="who">julia</span><span class="body"><span class="pill">memory.set</span>decisions/scope → "Ship the reduced-scope Q3 spec first"</span></div>
+            <div class="ui-main">
+              <div class="ui-header">
+                <span class="rm-name">design-review</span>
+                <span class="rm-mas">mas_31ab77c0</span>
+              </div>
+              <div class="ui-viewtabs">
+                <span class="vt active">Channel</span>
+                <span class="vt">Negotiate</span>
+                <span class="vt">Plan</span>
+              </div>
+              <div class="ui-pane">
+                <div class="event-stream">
+                  <div class="event-row"><span class="ts">12:04:17</span><span class="who">julia</span><span class="body"><span class="pill">memory.set</span>decisions/scope → "Ship the reduced-scope Q3 spec first"</span></div>
+                </div>
+                <div class="ui-composer">message design-review · start with @handle to invoke an agent</div>
               </div>
             </div>
-            <div class="ui-memory">
-              <div class="mem-header">Memory</div>
+            <div class="ui-inspector">
+              <div class="insp-tabs">
+                <span class="it"><span class="ic"></span>Agents</span>
+                <span class="it"><span class="ic"></span>Episodes</span>
+                <span class="it active"><span class="ic"></span>Memory</span>
+              </div>
               <div class="mem-list">
                 <div class="mem-item"><span class="key">decisions/scope</span><div>Ship the reduced-scope Q3 spec first</div></div>
               </div>
             </div>
+          </div>
+          <div class="ui-statusbar">
+            <span><span class="sb-dot"></span>connected</span>
+            <span class="sb-accent">rm:design-review</span>
+            <span class="spacer"></span>
+            <span>SLIM · 127.0.0.1:46357</span>
+            <span>1 memory</span>
           </div>
         </div>
       </div>
@@ -1216,11 +1342,14 @@
       // UI window slides up over the terminal
       // ~2s pause after memory set so the viewer can read the terminal output
       tl.from('#s4-ui', { y: 800, opacity: 0, duration: 1.0, ease: 'power3.out' }, 35.0);
-      tl.from('#s4-ui .ui-topbar', { y: -10, opacity: 0, duration: 0.5 }, 36.0);
-      tl.from('#s4-ui .ui-subnav', { y: -10, opacity: 0, duration: 0.5 }, 36.2);
-      tl.from('#s4-ui .ui-rail .item', { x: -20, opacity: 0, duration: 0.4, stagger: 0.1 }, 36.4);
+      tl.from('#s4-ui .ui-sidebar', { x: -30, opacity: 0, duration: 0.5 }, 36.0);
+      tl.from('#s4-ui .ui-room', { x: -20, opacity: 0, duration: 0.4, stagger: 0.09 }, 36.3);
+      tl.from('#s4-ui .ui-header', { y: -10, opacity: 0, duration: 0.5 }, 36.2);
+      tl.from('#s4-ui .ui-viewtabs .vt', { y: -8, opacity: 0, duration: 0.35, stagger: 0.06 }, 36.5);
       tl.from('#s4-ui .event-row', { x: 30, opacity: 0, duration: 0.5 }, 36.8);
-      tl.from('#s4-ui .mem-item', { x: -20, opacity: 0, duration: 0.5 }, 37.0);
+      tl.from('#s4-ui .ui-inspector', { x: 30, opacity: 0, duration: 0.5 }, 36.9);
+      tl.from('#s4-ui .mem-item', { x: -20, opacity: 0, duration: 0.5 }, 37.2);
+      tl.from('#s4-ui .ui-statusbar', { y: 12, opacity: 0, duration: 0.45 }, 37.2);
 
       // ── Scene 5: Adapter add (41.4–52.4s) ──
       tl.from('#s5 .scene-title', { x: -40, opacity: 0, duration: 0.6, ease: 'expo.out' }, 41.6);
@@ -1467,7 +1596,7 @@
       // Offer table border + bg shift to green (locked)
       tl.to('#s6-offer .offer-table', {
         borderColor: 'var(--green)',
-        backgroundColor: 'rgba(52,211,153,0.06)',
+        backgroundColor: 'rgba(79, 194, 150,0.06)',
         duration: 0.6,
       }, 81.4);
       // Offer values lock in green, staggered

--- a/mycelium-promo/index.html
+++ b/mycelium-promo/index.html
@@ -745,12 +745,12 @@
       id="root"
       data-composition-id="main"
       data-start="0"
-      data-duration="100"
+      data-duration="107"
       data-width="1920"
       data-height="1080"
     >
       <!-- Background canvas runs the entire duration -->
-      <div id="bg-wrap" class="clip" data-start="0" data-duration="100" data-track-index="0">
+      <div id="bg-wrap" class="clip" data-start="0" data-duration="107" data-track-index="0">
         <canvas id="mycelium-bg"></canvas>
       </div>
 
@@ -898,28 +898,29 @@
       <div id="s5b" class="clip scene" data-start="52.2" data-duration="9.8" data-track-index="6">
         <div class="scene-title"><span class="num">05</span><span class="label">@-mention from the room</span></div>
         <div id="s5b-win" class="ui-window" style="position: absolute; left: 60px; right: 60px; top: 200px; bottom: 60px; height: auto;">
-          <div class="ui-topbar">
-            <span class="brand">mycelium</span>
-            <span class="tab active">rooms</span>
-            <span class="tab">episodes</span>
-            <span class="tab">settings</span>
-          </div>
-          <div class="ui-subnav">
-            <span>rooms</span>
-            <span class="crumb-sep">/</span>
-            <span><span class="sigil">rm:</span>design-review</span>
-          </div>
-          <div class="ui-body">
-            <div class="ui-rail">
-              <div class="label">Agents · 3</div>
-              <div class="item"><span class="sigil">@</span>julia-agent</div>
-              <div class="item"><span class="sigil">@</span>selina-agent</div>
-              <div class="item"><span class="sigil">@</span>aligner</div>
-              <div class="label" style="margin-top: 32px;">Episodes</div>
-              <div class="item dim">none yet</div>
+          <div class="ui-shell">
+            <div class="ui-sidebar">
+              <div class="brand">mycelium</div>
+              <div class="side-head"><span>Rooms</span><span class="count">3</span></div>
+              <div class="ui-search">Search rooms…</div>
+              <div class="ui-rooms">
+                <div class="ui-room active"><span class="ravatar">DR</span>design-review</div>
+                <div class="ui-room"><span class="ravatar">PM</span>pricing-model</div>
+                <div class="ui-room"><span class="ravatar">AT</span>atlas-migration</div>
+              </div>
+              <div class="side-foot"><span>metrics</span><span>◐ theme</span></div>
             </div>
-          <div class="ui-pane">
-            <div class="pane-header">Room activity</div>
+            <div class="ui-main">
+              <div class="ui-header">
+                <span class="rm-name">design-review</span>
+                <span class="rm-mas">mas_31ab77c0</span>
+              </div>
+              <div class="ui-viewtabs">
+                <span class="vt active">Channel</span>
+                <span class="vt">Negotiate</span>
+                <span class="vt">Plan</span>
+              </div>
+              <div class="ui-pane">
             <div class="event-stream chat-events">
               <div id="s5b-m1" class="chat-msg">
                 <div class="chat-avatar user">AL</div>
@@ -963,10 +964,28 @@
                 </div>
               </div>
             </div>
-            <div class="chat-input">
-              <span class="placeholder">message rm:design-review · start with @handle to invoke an agent</span>
+                <div class="ui-composer">message design-review · start with @handle to invoke an agent</div>
+              </div>
+            </div>
+            <div class="ui-inspector">
+              <div class="insp-tabs">
+                <span class="it active"><span class="ic"></span>Agents</span>
+                <span class="it"><span class="ic"></span>Episodes</span>
+                <span class="it"><span class="ic"></span>Memory</span>
+              </div>
+              <div class="mem-list">
+                <div class="mem-item"><span class="key">@julia-agent</span><div>claude_code</div></div>
+                <div class="mem-item"><span class="key">@selina-agent</span><div>claude_code</div></div>
+                <div class="mem-item"><span class="key">@aligner</span><div>engine · aligner</div></div>
+                <div class="mem-item"><span class="key">@synthesizer</span><div>engine · synthesizer</div></div>
+              </div>
             </div>
           </div>
+          <div class="ui-statusbar">
+            <span><span class="sb-dot"></span>connected</span>
+            <span class="sb-accent">rm:design-review</span>
+            <span class="spacer"></span>
+            <span>4 agents</span>
           </div>
         </div>
       </div>
@@ -975,21 +994,28 @@
       <div id="s6" class="clip scene" data-start="61.6" data-duration="24" data-track-index="7">
         <div class="scene-title"><span class="num">06</span><span class="label">Agents coordinate</span></div>
         <div id="s6-ui" class="ui-window" style="position: absolute; left: 80px; right: 80px; top: 160px; bottom: 80px; height: auto;">
-          <div class="ui-topbar">
-            <span class="brand">mycelium</span>
-            <span class="tab active">rooms</span>
-          </div>
-          <div class="ui-subnav">
-            <span><span class="sigil">rm:</span>design-review</span>
-            <span class="crumb-sep">/</span>
-            <span><span class="sigil">ep:</span>q3-launch-3a8</span>
-          </div>
-          <div class="ui-body">
-            <div class="ui-rail">
-              <div class="label">Episodes</div>
-              <div class="item">archive</div>
-              <div class="item active"><span class="square-dot filled" style="color: var(--accent);"></span>q3-launch-3a8</div>
+          <div class="ui-shell">
+            <div class="ui-sidebar">
+              <div class="brand">mycelium</div>
+              <div class="side-head"><span>Rooms</span><span class="count">3</span></div>
+              <div class="ui-search">Search rooms…</div>
+              <div class="ui-rooms">
+                <div class="ui-room active"><span class="ravatar">DR</span>design-review</div>
+                <div class="ui-room"><span class="ravatar">PM</span>pricing-model</div>
+                <div class="ui-room"><span class="ravatar">AT</span>atlas-migration</div>
+              </div>
+              <div class="side-foot"><span>metrics</span><span>◐ theme</span></div>
             </div>
+            <div class="ui-main">
+              <div class="ui-header">
+                <span class="rm-name">design-review</span>
+                <span class="rm-mas">ep · q3-launch-3a8</span>
+              </div>
+              <div class="ui-viewtabs">
+                <span class="vt">Channel</span>
+                <span class="vt active">Negotiate</span>
+                <span class="vt">Plan</span>
+              </div>
 
             <!-- Main session pane -->
             <div class="session-main">
@@ -1149,9 +1175,16 @@
                 <div id="s6-consensus-plan" class="plan">NEGMAS converged. The aligner hands the agreement to the plan compiler.</div>
               </div>
             </div>
+            </div>
 
-            <!-- Event log -->
-            <div class="ui-eventlog">
+            <!-- Event log lives in the right inspector -->
+            <div class="ui-inspector">
+              <div class="insp-tabs">
+                <span class="it"><span class="ic"></span>Agents</span>
+                <span class="it active"><span class="ic"></span>Episodes</span>
+                <span class="it"><span class="ic"></span>Memory</span>
+              </div>
+              <div class="ui-eventlog">
               <div class="eventlog-header">Event Log · 11</div>
               <div class="eventlog-rows">
                 <div id="s6-ev-1" class="eventlog-row propose">
@@ -1206,6 +1239,13 @@
                 </div>
               </div>
             </div>
+            </div>
+          </div>
+          <div class="ui-statusbar">
+            <span><span class="sb-dot" style="background: var(--accent);"></span>negotiating</span>
+            <span class="sb-accent">ep:q3-launch-3a8</span>
+            <span class="spacer"></span>
+            <span>aligner · NEGMAS SAO</span>
           </div>
         </div>
       </div>
@@ -1214,18 +1254,29 @@
       <div id="s6b" class="clip scene" data-start="85.4" data-duration="9" data-track-index="8">
         <div class="scene-title"><span class="num">07</span><span class="label">Consensus becomes the plan</span></div>
         <div id="s6b-ui" class="ui-window" style="position: absolute; left: 80px; right: 80px; top: 160px; bottom: 80px; height: auto;">
-          <div class="ui-topbar">
-            <span class="brand">mycelium</span>
-            <span class="tab active">rooms</span>
-          </div>
-          <div class="ui-subnav">
-            <span><span class="sigil">rm:</span>design-review</span>
-            <span class="crumb-sep">/</span>
-            <span><span class="sigil">pl:</span>plan/tasks.md</span>
-          </div>
-          <div class="ui-body" style="display: flex; flex-direction: column;">
-            <div class="pane-header">Shared Plan · compiled from episode q3-launch-3a8</div>
-            <div style="flex: 1; display: flex; align-items: center; justify-content: center; padding: 40px 80px;">
+          <div class="ui-shell">
+            <div class="ui-sidebar">
+              <div class="brand">mycelium</div>
+              <div class="side-head"><span>Rooms</span><span class="count">3</span></div>
+              <div class="ui-search">Search rooms…</div>
+              <div class="ui-rooms">
+                <div class="ui-room active"><span class="ravatar">DR</span>design-review</div>
+                <div class="ui-room"><span class="ravatar">PM</span>pricing-model</div>
+                <div class="ui-room"><span class="ravatar">AT</span>atlas-migration</div>
+              </div>
+              <div class="side-foot"><span>metrics</span><span>◐ theme</span></div>
+            </div>
+            <div class="ui-main">
+              <div class="ui-header">
+                <span class="rm-name">design-review</span>
+                <span class="rm-mas">pl · plan/tasks.md</span>
+              </div>
+              <div class="ui-viewtabs">
+                <span class="vt">Channel</span>
+                <span class="vt">Negotiate</span>
+                <span class="vt active">Plan</span>
+              </div>
+              <div class="ui-pane" style="align-items: center; justify-content: center; padding: 36px 64px;">
               <div id="s6b-plan" class="plan-file" style="width: 100%; max-width: 1180px;">
                 <div class="file-bar">
                   <span class="glyph glyph-square"></span>
@@ -1252,13 +1303,96 @@
                   </div>
                 </div>
               </div>
+              </div>
             </div>
+            <div class="ui-inspector">
+              <div class="insp-tabs">
+                <span class="it"><span class="ic"></span>Agents</span>
+                <span class="it"><span class="ic"></span>Episodes</span>
+                <span class="it active"><span class="ic"></span>Memory</span>
+              </div>
+              <div class="mem-list">
+                <div class="mem-item"><span class="key">plan/tasks</span><div>Q3 launch plan · 4 tasks</div></div>
+                <div class="mem-item"><span class="key">decisions/scope</span><div>Ship the reduced-scope Q3 spec first</div></div>
+              </div>
+            </div>
+          </div>
+          <div class="ui-statusbar">
+            <span><span class="sb-dot"></span>plan compiled</span>
+            <span class="sb-accent">pl:plan/tasks.md</span>
+            <span class="spacer"></span>
+            <span>4 tasks · 4 owners</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Scene 6c: The synthesizer distills the room into a briefing ── -->
+      <div id="s6c" class="clip scene" data-start="94.4" data-duration="6" data-track-index="9">
+        <div class="scene-title"><span class="num">08</span><span class="label">Distill the room to memory</span></div>
+        <div id="s6c-ui" class="ui-window" style="position: absolute; left: 80px; right: 80px; top: 160px; bottom: 80px; height: auto;">
+          <div class="ui-shell">
+            <div class="ui-sidebar">
+              <div class="brand">mycelium</div>
+              <div class="side-head"><span>Rooms</span><span class="count">3</span></div>
+              <div class="ui-search">Search rooms…</div>
+              <div class="ui-rooms">
+                <div class="ui-room active"><span class="ravatar">DR</span>design-review</div>
+                <div class="ui-room"><span class="ravatar">PM</span>pricing-model</div>
+                <div class="ui-room"><span class="ravatar">AT</span>atlas-migration</div>
+              </div>
+              <div class="side-foot"><span>metrics</span><span>◐ theme</span></div>
+            </div>
+            <div class="ui-main">
+              <div class="ui-header">
+                <span class="rm-name">design-review</span>
+                <span class="rm-mas">@synthesizer · engine</span>
+              </div>
+              <div class="ui-viewtabs">
+                <span class="vt active">Channel</span>
+                <span class="vt">Negotiate</span>
+                <span class="vt">Plan</span>
+              </div>
+              <div class="ui-pane" style="align-items: center; justify-content: center; padding: 36px 64px;">
+                <div id="s6c-brief" class="plan-file" style="width: 100%; max-width: 1180px;">
+                  <div class="file-bar">
+                    <span class="glyph glyph-square"></span>
+                    <span class="path">context/synthesis</span>
+                    <span class="compiled"><span class="glyph glyph-accept"></span>synthesized by @synthesizer</span>
+                  </div>
+                  <div class="file-body">
+                    <div class="pl-head"># design-review — room briefing</div>
+                    <div id="s6c-b1" class="task"><span class="box">—</span><span class="label">Goal · lock the Q3 launch plan with the team.</span></div>
+                    <div id="s6c-b2" class="task"><span class="box">—</span><span class="label">Decision · ship the reduced-scope Q3 spec first.</span></div>
+                    <div id="s6c-b3" class="task"><span class="box">—</span><span class="label">Plan · 4 tasks compiled, owners <span class="handle">@selina-agent</span> / <span class="handle">@julia-agent</span>.</span></div>
+                    <div id="s6c-b4" class="task"><span class="box">—</span><span class="label">Status · staging + go/no-go review scheduled.</span></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="ui-inspector">
+              <div class="insp-tabs">
+                <span class="it"><span class="ic"></span>Agents</span>
+                <span class="it"><span class="ic"></span>Episodes</span>
+                <span class="it active"><span class="ic"></span>Memory</span>
+              </div>
+              <div class="mem-list">
+                <div id="s6c-mem" class="mem-item"><span class="key">context/synthesis</span><div>design-review briefing · just now</div></div>
+                <div class="mem-item"><span class="key">plan/tasks</span><div>Q3 launch plan · 4 tasks</div></div>
+                <div class="mem-item"><span class="key">decisions/scope</span><div>Ship the reduced-scope Q3 spec first</div></div>
+              </div>
+            </div>
+          </div>
+          <div class="ui-statusbar">
+            <span><span class="sb-dot"></span>synthesized</span>
+            <span class="sb-accent">context/synthesis</span>
+            <span class="spacer"></span>
+            <span>@synthesizer · pi</span>
           </div>
         </div>
       </div>
 
       <!-- ── Scene 7: Outro ────────────────────────────── -->
-      <div id="outro" class="clip scene outro" data-start="94" data-duration="6" data-track-index="9">
+      <div id="outro" class="clip scene outro" data-start="100.4" data-duration="6" data-track-index="10">
         <div class="wordmark">mycelium</div>
         <div class="ready">negotiate · plan · work · together</div>
         <div class="url">mycelium-io.github.io/mycelium</div>
@@ -1368,10 +1502,10 @@
       tl.from('#s5b .scene-title', { x: -40, opacity: 0, duration: 0.6, ease: 'expo.out' }, 52.4);
       // Mycelium room window slides in
       tl.from('#s5b-win', { y: 60, opacity: 0, duration: 0.7, ease: 'power3.out' }, 52.6);
-      tl.from('#s5b-win .ui-topbar',   { y: -10, opacity: 0, duration: 0.5 }, 52.9);
-      tl.from('#s5b-win .ui-subnav',   { y: -10, opacity: 0, duration: 0.5 }, 53.0);
-      tl.from('#s5b-win .ui-rail',     { x: -20, opacity: 0, duration: 0.5 }, 53.1);
-      tl.from('#s5b-win .pane-header', { y: -10, opacity: 0, duration: 0.4 }, 53.2);
+      tl.from('#s5b-win .ui-sidebar',   { x: -30, opacity: 0, duration: 0.5 }, 52.9);
+      tl.from('#s5b-win .ui-header',    { y: -10, opacity: 0, duration: 0.5 }, 53.0);
+      tl.from('#s5b-win .ui-viewtabs',  { y: -8, opacity: 0, duration: 0.4 }, 53.1);
+      tl.from('#s5b-win .ui-inspector', { x: 30, opacity: 0, duration: 0.5 }, 53.2);
       // User message appears at normal scale
       tl.from('#s5b-m1 .chat-avatar', { scale: 0, opacity: 0, duration: 0.4, ease: 'back.out(2)' }, 53.6);
       tl.from('#s5b-m1 .body',        { x: 20, opacity: 0, duration: 0.5, ease: 'power2.out' }, 53.7);
@@ -1384,11 +1518,12 @@
         boxShadow: '0 0 0 rgba(0,0,0,0)',
         duration: 0.7,
       }, 57.4);
-      tl.to('#s5b-win .ui-topbar',   { opacity: 0, duration: 0.6 }, 57.4);
-      tl.to('#s5b-win .ui-subnav',   { opacity: 0, duration: 0.6 }, 57.4);
-      tl.to('#s5b-win .ui-rail',     { opacity: 0, duration: 0.6 }, 57.4);
-      tl.to('#s5b-win .pane-header', { opacity: 0, duration: 0.6 }, 57.4);
-      tl.to('#s5b-win .chat-input',  { opacity: 0, duration: 0.6 }, 57.4);
+      tl.to('#s5b-win .ui-sidebar',   { opacity: 0, duration: 0.6 }, 57.4);
+      tl.to('#s5b-win .ui-header',    { opacity: 0, duration: 0.6 }, 57.4);
+      tl.to('#s5b-win .ui-viewtabs',  { opacity: 0, duration: 0.6 }, 57.4);
+      tl.to('#s5b-win .ui-inspector', { opacity: 0, duration: 0.6 }, 57.4);
+      tl.to('#s5b-win .ui-statusbar', { opacity: 0, duration: 0.6 }, 57.4);
+      tl.to('#s5b-win .ui-composer',  { opacity: 0, duration: 0.6 }, 57.4);
       // Give the event-stream its own panel bg + radius so the floating message stands out
       tl.to('#s5b-win .event-stream', {
         backgroundColor: 'rgba(20, 22, 27, 0.92)',
@@ -1415,9 +1550,10 @@
 
       tl.from('#s6 .scene-title', { x: -40, opacity: 0, duration: 0.6, ease: 'expo.out' }, 61.8);
       tl.from('#s6-ui', { y: 80, opacity: 0, duration: 0.8, ease: 'power3.out' }, 62.0);
-      tl.from('#s6-ui .ui-topbar', { y: -10, opacity: 0, duration: 0.5 }, 62.8);
-      tl.from('#s6-ui .ui-subnav', { y: -10, opacity: 0, duration: 0.5 }, 63.0);
-      tl.from('#s6-ui .ui-rail .item', { x: -20, opacity: 0, duration: 0.4, stagger: 0.1 }, 63.2);
+      tl.from('#s6-ui .ui-sidebar', { x: -30, opacity: 0, duration: 0.5 }, 62.8);
+      tl.from('#s6-ui .ui-header',  { y: -10, opacity: 0, duration: 0.5 }, 62.9);
+      tl.from('#s6-ui .ui-viewtabs', { y: -8, opacity: 0, duration: 0.4 }, 63.0);
+      tl.from('#s6-ui .ui-room', { x: -20, opacity: 0, duration: 0.4, stagger: 0.09 }, 63.2);
 
       tl.from('#s6-header .col-l',             { y: 16, opacity: 0, duration: 0.5 }, 63.8);
       tl.from('#s6-header > div:nth-child(2)', { y: 16, opacity: 0, duration: 0.5 }, 63.9);
@@ -1442,21 +1578,21 @@
       tl.from('#s6-offer', { y: 20, opacity: 0, duration: 0.5, ease: 'power2.out' }, 65.8);
       tl.from('#s6-offer .offer-row', { x: -10, opacity: 0, duration: 0.35, stagger: 0.08 }, 66.0);
 
-      // Set transform origin over session-main's center for the zoom-in
-      tl.set('#s6 .ui-body', { transformOrigin: '44% 50%' }, 61.6);
-      // Zoom into session-main; fade rail + eventlog AND the surrounding window chrome
-      // so only the focused panel is left floating on the canvas bg
-      tl.to('#s6 .ui-body',     { scale: 1.35, duration: 0.8, ease: 'power3.inOut' }, 66.5);
-      tl.to('#s6 .ui-rail',     { opacity: 0, duration: 0.7 }, 66.5);
-      tl.to('#s6 .ui-eventlog', { opacity: 0, duration: 0.7 }, 66.5);
+      // Zoom into session-main; fade the sidebar, inspector, and surrounding
+      // window chrome so only the focused panel is left floating on the canvas bg
+      tl.set('#s6 .session-main', { transformOrigin: '50% 46%' }, 61.6);
+      tl.to('#s6 .session-main', { scale: 1.32, duration: 0.8, ease: 'power3.inOut' }, 66.5);
+      tl.to('#s6 .ui-sidebar',   { opacity: 0, duration: 0.7 }, 66.5);
+      tl.to('#s6 .ui-inspector', { opacity: 0, duration: 0.7 }, 66.5);
+      tl.to('#s6 .ui-statusbar', { opacity: 0, duration: 0.7 }, 66.5);
       tl.to('#s6-ui', {
         backgroundColor: 'rgba(0,0,0,0)',
         borderColor: 'rgba(0,0,0,0)',
         boxShadow: '0 0 0 rgba(0,0,0,0)',
         duration: 0.7,
       }, 66.5);
-      tl.to('#s6 .ui-topbar', { backgroundColor: 'rgba(0,0,0,0)', opacity: 0, duration: 0.7 }, 66.5);
-      tl.to('#s6 .ui-subnav', { backgroundColor: 'rgba(0,0,0,0)', opacity: 0, duration: 0.7 }, 66.5);
+      tl.to('#s6 .ui-header',   { backgroundColor: 'rgba(0,0,0,0)', opacity: 0, duration: 0.7 }, 66.5);
+      tl.to('#s6 .ui-viewtabs', { opacity: 0, duration: 0.7 }, 66.5);
       // Give session-main its own panel bg + radius so it stands out from the canvas
       tl.to('#s6 .session-main', {
         backgroundColor: 'rgba(20, 22, 27, 0.92)',
@@ -1619,9 +1755,11 @@
       const planTasks = ['#s6b-t1', '#s6b-t2', '#s6b-t3', '#s6b-t4'];
       tl.from('#s6b .scene-title', { x: -40, opacity: 0, duration: 0.6, ease: 'expo.out' }, 85.6);
       tl.from('#s6b-ui', { y: 80, opacity: 0, duration: 0.8, ease: 'power3.out' }, 85.8);
-      tl.from('#s6b-ui .ui-topbar', { y: -10, opacity: 0, duration: 0.5 }, 86.5);
-      tl.from('#s6b-ui .ui-subnav', { y: -10, opacity: 0, duration: 0.5 }, 86.65);
-      tl.from('#s6b-ui .pane-header', { opacity: 0, duration: 0.4 }, 86.8);
+      tl.from('#s6b-ui .ui-sidebar', { x: -30, opacity: 0, duration: 0.5 }, 86.5);
+      tl.from('#s6b-ui .ui-header',  { y: -10, opacity: 0, duration: 0.5 }, 86.6);
+      tl.from('#s6b-ui .ui-viewtabs', { y: -8, opacity: 0, duration: 0.4 }, 86.7);
+      tl.from('#s6b-ui .ui-inspector', { x: 30, opacity: 0, duration: 0.5 }, 86.8);
+      tl.from('#s6b-ui .ui-statusbar', { y: 12, opacity: 0, duration: 0.45 }, 86.9);
       // The plan file materializes: frame first, then checklist items populate
       tl.from('#s6b-plan', { y: 24, opacity: 0, scale: 0.97, duration: 0.6, ease: 'power3.out' }, 87.1);
       tl.from('#s6b-plan .file-bar', { opacity: 0, duration: 0.35 }, 87.4);
@@ -1647,10 +1785,32 @@
         { opacity: 1, scale: 1, duration: 0.4, ease: 'back.out(2)' },
         92.48);
 
-      // ── Scene 7: Outro (94–100s) ──
-      tl.from('#outro .wordmark', { y: 50, opacity: 0, duration: 1.0, ease: 'power3.out' }, 94.2);
-      tl.from('#outro .ready',    { y: 20, opacity: 0, duration: 0.7, ease: 'power2.out' }, 94.8);
-      tl.from('#outro .url',      { opacity: 0, duration: 0.6 }, 95.4);
+      // ── Scene 6c: Synthesizer distills the room → context/synthesis (94.4–100.4s) ──
+      tl.from('#s6c .scene-title', { x: -40, opacity: 0, duration: 0.6, ease: 'expo.out' }, 94.6);
+      tl.from('#s6c-ui', { y: 80, opacity: 0, duration: 0.8, ease: 'power3.out' }, 94.8);
+      tl.from('#s6c-ui .ui-sidebar', { x: -30, opacity: 0, duration: 0.5 }, 95.4);
+      tl.from('#s6c-ui .ui-header',  { y: -10, opacity: 0, duration: 0.5 }, 95.5);
+      tl.from('#s6c-ui .ui-viewtabs', { y: -8, opacity: 0, duration: 0.4 }, 95.6);
+      tl.from('#s6c-ui .ui-inspector', { x: 30, opacity: 0, duration: 0.5 }, 95.7);
+      tl.from('#s6c-ui .ui-statusbar', { y: 12, opacity: 0, duration: 0.45 }, 95.8);
+      // The briefing materializes: frame, heading, then the distilled points
+      tl.from('#s6c-brief', { y: 24, opacity: 0, scale: 0.97, duration: 0.6, ease: 'power3.out' }, 96.0);
+      tl.from('#s6c-brief .file-bar', { opacity: 0, duration: 0.35 }, 96.3);
+      tl.from('#s6c-brief .pl-head', { x: -10, opacity: 0, duration: 0.4 }, 96.5);
+      ['#s6c-b1','#s6c-b2','#s6c-b3','#s6c-b4'].forEach((sel, i) => {
+        tl.from(sel, { x: -14, opacity: 0, duration: 0.35, ease: 'power2.out' }, 96.8 + i * 0.4);
+      });
+      // The new memory pings in the inspector
+      tl.from('#s6c-mem', { x: 16, opacity: 0, duration: 0.4 }, 98.4);
+      tl.fromTo('#s6c-mem',
+        { backgroundColor: 'var(--accent-soft)' },
+        { backgroundColor: 'rgba(0,0,0,0)', duration: 1.1 },
+        98.4);
+
+      // ── Scene 7: Outro (100.4–106.4s) ──
+      tl.from('#outro .wordmark', { y: 50, opacity: 0, duration: 1.0, ease: 'power3.out' }, 100.6);
+      tl.from('#outro .ready',    { y: 20, opacity: 0, duration: 0.7, ease: 'power2.out' }, 101.2);
+      tl.from('#outro .url',      { opacity: 0, duration: 0.6 }, 101.8);
 
       window.__timelines['main'] = tl;
     </script>


### PR DESCRIPTION
The HyperFrames promo never got updated after the UI redesign (#467), so its mocked app screens showed the old shell. This rebuilds them to match the current app and adds a synthesizer beat.

### What changed
- **Recolor** to the frontend's post-redesign dark tokens: softer teal accent `#5cc7d2`, muted green/amber, new surfaces/borders, **purple retired** (single-accent discipline).
- **All four app scenes** (room, chat, negotiate, plan) rebuilt into the new **workspace shell**: full-height rooms sidebar (serif brand + monogram room avatars), room header, `Channel · Negotiate · Plan` view tabs, composer, tabbed inspector (`Agents · Episodes · Memory`), status bar.
- Retargeted the coupled GSAP tweens — intros plus the s5b/s6 "zoom in, fade the chrome, float the panel" sequences — to the new shell elements.
- **New scene 08 · "Distill the room to memory"** — the synthesizer compiling `context/synthesis` from the room's memory, with the briefing materializing and the new memory pinging in the inspector. Outro shifted; composition extended to 107s.
- Re-rendered `renders/mycelium-promo.mp4` (1920×1080, ~107s).

### Verified
Rendered at each step and eyeballed frames for all scenes — room, chat, negotiate, plan, synthesizer, outro. `hyperframes lint`: 0 errors (warnings are pre-existing overlapping-tween / file-size advisories).

### ⚠️ Manual step still needed
The README + `docs/index.html` embed the MP4 via `user-attachments/...` URLs that **only mint when dragged into GitHub's web UI** — `gh` can't do it. After mer**: drag `mycelium-promo/renders/mycelium-promo.mp4` into a PR/issue comment, then swap the new URL into both embeds.

Refs #467, #471.