### PR TITLE
cleanup(comments): scrub temporal narration + tracker breadcrumbs

### DIFF
--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -118,8 +118,9 @@ def _new_episode_id() -> str:
     Each ``@``-summon convenes a *distinct* episode. The id flows into the episode
     URN (``l9.episode_urn``), every envelope on the wire, and the
     ``log/episodes/{id}.md`` record filename — so two convenings in the same room
-    never share a URN or clobber each other's record. Was a hardcoded constant
-    (``"align"``); every negotiation then overwrote the one ``align.md``.
+    never share a URN or clobber each other's record. Each ``@``-summon convenes a
+    distinct episode with its own tag, so negotiations don't collide on one
+    ``align.md``.
     """
     return uuid.uuid4().hex[:8]
 

--- a/fastapi-backend/app/services/embedding.py
+++ b/fastapi-backend/app/services/embedding.py
@@ -6,9 +6,6 @@ Local embedding service using fastembed (ONNX-based).
 
 Provides semantic vector embeddings for persistent memory search.
 Uses BAAI/bge-small-en-v1.5 (384 dimensions, runs locally, no PyTorch).
-
-Drop-in replacement for the previous sentence-transformers implementation.
-Aligned with cisco-eti/ioc-cfn-cognitive-agents embedding stack.
 """
 
 import logging

--- a/fastapi-backend/app/services/event_sweep.py
+++ b/fastapi-backend/app/services/event_sweep.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""TTL sweep for transient event messages (#392).
+"""TTL sweep for transient event messages.
 
 Events carrying ``metadata.ttl_seconds`` get an ``event_expires_at`` stamp at
 write time; this background loop drops messages past that stamp. Durable kinds

--- a/fastapi-backend/app/services/mediator.py
+++ b/fastapi-backend/app/services/mediator.py
@@ -3,10 +3,8 @@
 
 """The SAO mediator — the aligner as a *driver* of a real negotiation.
 
-The aligner as a passive **observer** only wakes to grade a finished transcript,
-so agents that had already agreed by message 5 kept re-agreeing for seven more
-turns because nothing *ran* the negotiation and said "you agreed — stop." This
-module fixes that by actively driving the negotiation.
+This module actively drives the NEGMAS SAO negotiation and terminates at
+unanimity, rather than only grading a finished transcript after the fact.
 
 An LLM mediator reads natural-language agent
 chatter, maps it onto a NEGMAS **Stacked Alternating Offers** mechanism, and
@@ -28,8 +26,7 @@ agent's move when NEGMAS asks for it. LLM calls (discover/broker/interpret) run
 synchronously in-thread against the injected Pi brain (see ``pi_brain``).
 
 The mediator is deliberately *interpretation over the agents' prose*: agents are
-never required to emit structured markers (a future cleanup will retire the
-``parse_position_marker`` hack entirely). The mediator restates its reading into
+never required to emit structured markers. The mediator restates its reading into
 the transcript ("recording @growth as counter → 35% tech") so a misread is
 visible and correctable in-band.
 """

--- a/fastapi-backend/app/services/pi_brain.py
+++ b/fastapi-backend/app/services/pi_brain.py
@@ -16,8 +16,7 @@ The mediator injects its brain as a callable
 long-lived ``pi -p --session <path> --mode json`` subprocess. Because one
 :class:`PiBrain` instance reuses a single ``--session`` file across every call,
 the brain accumulates **real durable memory across SAO rounds** — the natural
-home for the running state ``MediatedNegotiation`` threads by hand today (the
-v1→v2 "the camp counselor needs memory" lesson, now native).
+home for the running state ``MediatedNegotiation`` threads by hand today.
 
 **Synchronous on purpose.** The mediator's brain turns run inside NEGMAS's
 ``mech.run()`` worker thread, so this is blocking too. We shell out with a

--- a/fastapi-backend/app/services/plan_compiler.py
+++ b/fastapi-backend/app/services/plan_compiler.py
@@ -29,7 +29,7 @@ from app.services.metrics import record_llm_call
 logger = logging.getLogger(__name__)
 
 # Hard ceiling on the LLM call so a hung provider can never make a negotiation's
-# `session await` hang forever — _finish_cfn falls back to the raw agreement.
+# `session await` hang forever; on timeout we fall back to the raw agreement.
 COMPILER_TIMEOUT_SECS = 30.0
 
 
@@ -109,7 +109,7 @@ def _build_prompt(
 
 
 def fallback_body(assignments: dict[str, str]) -> str:
-    """Deterministic non-LLM plan body. Used by _finish_cfn when the compiler fails.
+    """Deterministic non-LLM plan body, used as the fail-soft fallback when the compiler fails.
 
     Pure — no I/O. Ugly (one line per raw ``issue=value``) but lossless, so a
     compiler outage never costs the negotiation outcome.
@@ -206,8 +206,8 @@ async def compile_plan(
     the agreement and the agents' opening positions. Re-negotiation: a merge
     that preserves completed ``- [x]`` tasks verbatim and revises open ones.
 
-    RAISES on LLM failure/timeout — the caller (``_finish_cfn``) owns the
-    fail-soft fallback to :func:`fallback_body`.
+    RAISES on LLM failure/timeout — the caller owns the fail-soft
+    fallback to :func:`fallback_body`.
     """
     prompt = _build_prompt(
         assignments=assignments,

--- a/fastapi-backend/app/services/plan_sync.py
+++ b/fastapi-backend/app/services/plan_sync.py
@@ -12,14 +12,13 @@ seam — the backend, seeing the converged verdict, turns it into work:
    the aligner in ``aligner._fold``). :mod:`app.services.plan_compiler` — one LLM
    call — turns that into a ``- [ ]`` checklist materialized at ``plan/tasks.md``.
    Fail-soft: a compiler outage falls back to the raw ``assignments`` so the
-   verdict is never sunk (the old ``_finish_cfn`` behaviour).
+   verdict is never sunk.
 
 2. **Sync it as memory.** The compiled plan becomes a ``knowledge`` message that
    **carries the content** (push-with-content) so every participant's
-   local store converges — and, because the verdict was already on the wire when
+   local store converges — and, because the verdict is already on the wire when
    this fires, the ``knowledge`` broadcast doubles as the **"plan ready" signal**
-   a consumer waits for (the SLIM-path replacement for the old CFN plan-first
-   ordering).
+   a consumer waits for.
 
 Deliberately **not** a cognition-engine step (the CLAUDE.md plan-compiler
 decision): the compiler is a distinct consumer stage reached across the

--- a/fastapi-backend/tests/fakes.py
+++ b/fastapi-backend/tests/fakes.py
@@ -4,10 +4,7 @@
 """Shared in-process fakes for the backend test suite.
 
 One import gets you a fake coordination stack — no SLIM node, no Pi binary, no
-live LLM. These used to be re-declared per test file (``_FakeChannel`` /
-``_FakePersister`` / ``_FakeManager`` in ``test_aligner`` and ``test_plan_sync``,
-the deterministic ``_fake_llm`` in ``test_mediator``, ``_patch_run`` in
-``test_pi_brain``); this module is the single home for them.
+live LLM. This module is the single, shared home for the backend test fakes.
 
 What stands in for what:
 

--- a/fastapi-backend/tests/test_coordination_health.py
+++ b/fastapi-backend/tests/test_coordination_health.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Tests for the coordination health surface (D3).
+"""Tests for the coordination health surface.
 
 The ``/health`` endpoint's ``coordination`` block is how "is the fabric actually
-working" becomes answerable in one GET (H1). This pins its shape and the per-room
+working" becomes answerable in one GET. This pins its shape and the per-room
 counters that make channel provisioning, missed-message re-serves, and drops
 visible — signals the persister tracks but that were previously log-only.
 """

--- a/fastapi-backend/tests/test_events.py
+++ b/fastapi-backend/tests/test_events.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Tests for the typed ``event`` message primitive (#392)."""
+"""Tests for the typed ``event`` message primitive."""
 
 from datetime import UTC, datetime, timedelta
 

--- a/fastapi-backend/tests/test_mediator.py
+++ b/fastapi-backend/tests/test_mediator.py
@@ -122,8 +122,7 @@ def test_propose_holds_own_line_not_the_table_when_unreadable() -> None:
     When an agent's proposing move can't be read onto the grid (here an off-grid
     '999'), it must be recorded as holding ITS OWN last line — never the standing
     offer on the table. Adopting the table's number silently converts a rejection
-    into a fabricated concession, which is exactly how the negotiation used to
-    'converge' on a value nobody actually offered.
+    into a fabricated concession.
     """
     import asyncio
 

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -112,9 +112,8 @@ def test_cursors_survive_a_restart_so_an_offline_tail_is_still_reserved():
     """The D5 fix: an agent offline at shutdown must still be recognised as a
     reconnect and re-served exactly its missed tail after a backend restart.
 
-    Before cursors were persisted, only the transcript reloaded; the restarted
-    log knew no cursors, so undelivered() defaulted to the transcript end and the
-    reconnecting agent silently got nothing.
+    Cursors persist alongside the transcript, so a reconnecting agent re-serves
+    its missed tail after a backend restart.
     """
     room = "cursor-restart-room"
     get_room_dir(room)

--- a/mycelium-cli/src/mycelium/commands/adapter.py
+++ b/mycelium-cli/src/mycelium/commands/adapter.py
@@ -8,7 +8,7 @@ Thin typer layer. All per-family install/uninstall/step/status behaviour
 lives behind the single ``Integration`` contract
 (``mycelium.integrations``); this module just parses arguments and dispatches
 via ``get_integration(...)`` — there is no ``if adapter_type ==`` branching
-left (that asymmetry was the disease tracked as #173).
+left.
 
 Supported families: ``claude-code``, ``cursor``.
 Every family that has an entry in ``ADAPTER_TYPES`` below is also wired

--- a/mycelium-cli/src/mycelium/daemon/connector.py
+++ b/mycelium-cli/src/mycelium/daemon/connector.py
@@ -52,8 +52,9 @@ from mycelium.integrations import get_integration
 from mycelium.integrations._spawn_common import SpawnRequest
 from mycelium.slim import l9
 
-# Historical aliases — re-exported so callers/tests that import these membership
-# helpers from ``connector`` keep working; the single implementation is the core.
+# Re-exported for import compatibility so callers/tests that import these
+# membership helpers from ``connector`` keep working; the single implementation
+# lives in ``mycelium.slim.member``.
 from mycelium.slim.member import (  # noqa: F401
     KEEPALIVE_TYPE as _KEEPALIVE_TYPE,
 )

--- a/mycelium-cli/src/mycelium/integrations/base.py
+++ b/mycelium-cli/src/mycelium/integrations/base.py
@@ -4,12 +4,9 @@
 """
 Integration — the single contract for a runtime family Mycelium integrates with.
 
-This is the source-of-truth the project tracked as #173: instead of
-per-family behaviour drifting apart across two unrelated
-code trees (an asset/installer pile in ``commands/adapter.py`` and a dispatch
-OOP layer in the old ``agent_adapters/``), every runtime family is one
-``Integration`` subclass exposing the same facets. Adding a capability to one
-family without the others now surfaces as an abstract-method gap (and a
+Every runtime family is one ``Integration`` subclass exposing the same
+facets, giving a unified dispatch/install contract. Adding a capability to one
+family without the others surfaces as an abstract-method gap (and a
 failing ``tests/test_integration_contract.py``), not a silent degradation.
 
 An integration has two facets, sliced by lifetime:

--- a/mycelium-cli/src/mycelium/integrations/claude_code/install.py
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/install.py
@@ -3,10 +3,9 @@
 
 """Claude Code install facet — skill/hooks install + daemon service core.
 
-Relocated verbatim from ``commands/adapter.py`` so the single ``Integration``
-contract (see ``integrations/base.py``) owns both the dispatch and install
-facets per runtime family — closing #173. The typer command layer is now a
-thin dispatcher over ``get_integration(...)``; nothing here changed behaviour.
+The single ``Integration`` contract (see ``integrations/base.py``) owns both
+the dispatch and install facets per runtime family. The typer command layer is
+a thin dispatcher over ``get_integration(...)``.
 """
 
 from __future__ import annotations

--- a/mycelium-cli/src/mycelium/integrations/claude_code/spawn.py
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/spawn.py
@@ -3,16 +3,9 @@
 
 """Claude Code cold-spawn — invokes ``claude -p`` for one ``@handle`` mention.
 
-Relocated from ``mycelium/daemon/dispatch.py`` (where it lived as
-``spawn_claude`` / ``_parse_claude_output``) so the daemon dispatch loop can
-call ``Integration.spawn(...)`` uniformly across cold-spawn families instead
-of branching on ``manifest.adapter``.
-
-The function body is unchanged — same shutil.which probe, same subprocess
-exec, same JSON parser. ``RunningProc`` registration also stays here in this
-commit; the next milestone (daemon-core) moves it up into the daemon loop so
-all cold-spawn families (claude_code, cursor, future) inherit abort/status
-behaviour from one place.
+A family-agnostic wrapper matching the ``Integration.spawn`` signature, so the
+daemon dispatch loop can call ``Integration.spawn(...)`` uniformly across
+cold-spawn families instead of branching on ``manifest.adapter``.
 """
 
 from __future__ import annotations

--- a/mycelium-cli/tests/test_claude_install.py
+++ b/mycelium-cli/tests/test_claude_install.py
@@ -4,16 +4,15 @@
 """Claude Code install facet — hook registration is empty + stale-cleanup
 is exhaustive.
 
-This adapter no longer ships hook scripts (the in-process knowledge
-extractor handles what those wrappers used to do, with cleaner privacy
-gates). The risk in that change is twofold:
+Hook registration is empty because knowledge extraction is handled
+in-process; stale-cleanup covers the hooks a previous release may have
+registered. Two invariants:
 
 1. If ``_CLAUDE_CODE_HOOK_EVENTS`` ever drifts back to listing a hook,
    ``_register_claude_code_hooks`` would re-add a settings.json entry
    pointing at a hook script that the package no longer ships. Claude
-   Code then aborts every spawn with ``SessionEnd hook ... not found``
-   — which is exactly the regression that broke autonomous coordination
-   for ``claude_code`` agents in 2026-05.
+   Code then aborts every spawn with ``SessionEnd hook ... not found``,
+   which breaks autonomous coordination for ``claude_code`` agents.
 
 2. ``_CLAUDE_CODE_STALE_HOOKS`` must list every hook event a previous
    release may have registered. If a stale entry isn't covered here, an
@@ -128,8 +127,7 @@ def test_stale_and_live_hook_lists_are_disjoint() -> None:
     ``_CLAUDE_CODE_HOOK_EVENTS``, ``_install_claude_code`` would
     re-introduce the entry on every reinstall: the cleanup loop strips
     it from settings.json, then the registration loop adds it right
-    back. That's the exact bug we hit in 2026-05 when claude_code
-    spawns started failing with ``SessionEnd hook ... not found``."""
+    back, and claude_code spawns fail with ``SessionEnd hook ... not found``."""
     stale_events = {event for _name, event in claude_install._CLAUDE_CODE_STALE_HOOKS}
     live_events = {event for _name, event in claude_install._CLAUDE_CODE_HOOK_EVENTS}
     assert stale_events.isdisjoint(live_events), (

--- a/mycelium-cli/tests/test_daemon_coordination.py
+++ b/mycelium-cli/tests/test_daemon_coordination.py
@@ -530,9 +530,7 @@ async def test_handle_tick_looks_up_manifest_under_parent_room_not_subroom(
     because that's the only channel the aligner NOTIFY's on. Manifests
     are mirrored under the *parent* room, so the lookup must derive the
     parent — otherwise every tick stalls with "no manifest in local mirror"
-    even though the agent is registered correctly. This was the live failure
-    mode that surfaced when the mycelium-daemon first started subscribing to
-    session sub-rooms in 2026-05.
+    even though the agent is registered correctly.
     """
     seen_rooms: list[str] = []
 

--- a/mycelium-cli/tests/test_docker_env_image_tag_pin.py
+++ b/mycelium-cli/tests/test_docker_env_image_tag_pin.py
@@ -3,11 +3,9 @@
 
 """Regression tests for the ``MYCELIUM_IMAGE_TAG`` round-trip behaviour.
 
-Before this fix, ``write_env_file`` would silently drop the pin set by
-``mycelium pull --version <X>``, causing ``mycelium config apply`` (and any
-other path that regenerated .env) to roll users back to ``:latest`` on the
-next ``mycelium up``.  We caught this only when a test environment kept
-running 1.0.13 while we thought we were on 1.0.14rc3.
+``write_env_file`` must preserve a pre-existing ``MYCELIUM_IMAGE_TAG`` pin
+across regeneration, so that ``mycelium config apply`` (and any other path
+that regenerates .env) does not roll a pinned host back to ``:latest``.
 
 The contract:
 

--- a/mycelium-cli/tests/test_followups_e2e_fixes.py
+++ b/mycelium-cli/tests/test_followups_e2e_fixes.py
@@ -114,8 +114,8 @@ def test_cursor_register_does_not_leak_handle_when_cwd_missing(tmp_path: Path) -
     ``install_workspace_assets`` raises ``NotADirectoryError`` and the
     handle must NOT have been persisted to ``daemon.toml``.
 
-    Before the fix the handle was claimed first and the asset drop ran
-    second, so the failure path left orphan ownership behind.
+    The asset drop must run before the handle is claimed, so a failure on
+    the asset path leaves no orphan ownership behind.
     """
     missing = tmp_path / "does-not-exist"
     assert not missing.exists()
@@ -275,8 +275,8 @@ def test_cursor_login_check_warns_when_no_config(
     assert result.status == "warning"
     assert "has not been run" in result.message.lower()
     assert any("cursor-agent login" in detail for detail in (result.details or []))
-    # The hint must point at the *current* config location (~/.config/cursor/auth.json),
-    # not the stale ~/.cursor/cli-config.json schema we used to read.
+    # The hint must point at the canonical config location
+    # (~/.config/cursor/auth.json), not the stale ~/.cursor/cli-config.json schema.
     assert any("/.config/cursor/auth.json" in d for d in (result.details or []))
 
 
@@ -313,16 +313,11 @@ def test_cursor_login_check_ok_with_auth_json_access_token(
 def test_cursor_login_check_warns_when_auth_json_missing_even_if_cli_config_has_authinfo(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Pins F1b. ``cli-config.json`` ``authInfo.email`` is biographical —
-    it persists across logout and lingers as a stale "user X used to be
-    logged in" breadcrumb. We do NOT treat it as a "currently
-    authenticated" signal, because doing so would let doctor green-light
-    a host where ``cursor-agent`` will fail to spawn.
-
-    Reproducer from the post-fix e2e rerun: with auth.json moved aside,
-    the daemon correctly posted a friendly "cursor-agent is not
-    authenticated" error, but doctor — using a previous version of this
-    check that included the cli-config fallback — reported "authenticated".
+    """``cli-config.json`` ``authInfo.email`` is biographical — it persists
+    across logout and is not a "currently authenticated" signal. auth.json is
+    canonical: when it is absent, doctor must warn even if cli-config.json
+    still carries ``authInfo``, otherwise doctor green-lights a host where
+    ``cursor-agent`` will fail to spawn.
     """
     import json
 
@@ -651,18 +646,14 @@ def test_load_manifest_remote_returns_none_for_missing_or_error() -> None:
 def test_agent_invoke_falls_through_to_backend_when_local_mirror_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pins F2 from the cursor-e2e walkthrough.
+    """``mycelium agent invoke <handle>`` must resolve manifests local-first
+    then fall through to the backend, so cross-host invocation works (hub
+    invoking a spoke-registered agent or vice-versa).
 
-    Before the fix, ``mycelium agent invoke <handle>`` checked the local
-    filesystem mirror for ``agents/<handle>`` and bailed with
-    ``Not found: no agent named …`` if the manifest hadn't been
-    materialised on this host. That blocked every cross-host invocation
-    (hub invoking a spoke-registered agent or vice-versa).
-
-    The fix calls ``_load_manifest`` first (cheap local read) and falls
-    through to ``_load_manifest_remote`` (backend memory API) only when
-    local returns ``None``. This test forces that fall-through path and
-    asserts the message is sent.
+    It calls ``_load_manifest`` first (cheap local read) and falls through to
+    ``_load_manifest_remote`` (backend memory API) only when local returns
+    ``None``. This test forces that fall-through path and asserts the message
+    is sent.
     """
     import importlib
 

--- a/mycelium-cli/tests/test_instance_announce_image_tag.py
+++ b/mycelium-cli/tests/test_instance_announce_image_tag.py
@@ -42,8 +42,9 @@ def test_announce_warns_when_no_env_file(
 def test_announce_warns_when_pin_missing_from_env(
     env_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """The bug we just fixed: ``mycelium config apply`` regenerates .env
-    without ``MYCELIUM_IMAGE_TAG``.  Compose silently falls back to ``:latest``.
+    """``MYCELIUM_IMAGE_TAG`` may be absent from a regenerated .env (e.g.
+    after ``mycelium config apply``); compose must not silently fall back to
+    ``:latest`` without warning.
     """
     env_path.write_text("MYCELIUM_DB_PASSWORD=password\n", encoding="utf-8")
     instance._announce_image_tag()

--- a/mycelium-cli/tests/test_metrics_math.py
+++ b/mycelium-cli/tests/test_metrics_math.py
@@ -4,12 +4,10 @@
 """
 Unit tests for the metrics display math.
 
-These guard a class of bug that was present before the
-feat/simple_metrics restructure: the cache hit-rate and savings
-calculations were mathematically inconsistent with how LLM providers
-actually bill cached prefixes, and the ``heartbeat`` channel
-(idle-loop keep-alive traffic) was silently aggregated into headline
-token totals, drowning real agent work.
+These guard regressions in token bucketing (foreground work vs
+background ``heartbeat`` keep-alive traffic) and in the cache hit-rate
+and savings math, which must match how LLM providers bill cached
+prefixes.
 
 What's covered:
   * _oc_token_totals correctly splits by-channel tokens into

--- a/mycelium-cli/tests/test_prom_scrape.py
+++ b/mycelium-cli/tests/test_prom_scrape.py
@@ -6,26 +6,18 @@ Unit tests for the minimal Prometheus text-format parser and the HTTP-RED
 roll-up used by ``mycelium metrics collect`` to scrape CFN service
 ``/metrics`` endpoints.
 
-Why this is worth its own test file (and not just an integration smoke
-test against a live mgmt-plane container):
+Covers edge cases in Prometheus exposition parsing and HTTP-RED roll-up
+math:
 
-  * The exposition format has half a dozen edge cases (blank lines,
-    HELP/TYPE comments, label-value backslash escapes, +Inf buckets,
-    missing trailing newlines) that a "happy path" sample wouldn't cover.
-    Each one of those has burned someone in production at least once.
-  * The HTTP-RED roll-up specifically *excludes* 404 from the error count
-    (health probes / scanner noise dominate it) and converts seconds →
-    milliseconds (to match every other histogram panel in
-    ``mycelium metrics show``). Both of those decisions are easy to
-    silently regress, and both are the kind of bug that doesn't surface
-    until somebody is staring at a dashboard wondering why error rate
-    flipped or why latency suddenly looks 1000× off.
-  * ``histogram_quantile`` mirrors Prometheus's PromQL semantics
-    (linear interpolation within buckets, +Inf clamped to the previous
-    finite bound). Subtle behaviours like the +Inf clamp and the
-    "all observations in one bucket" edge case are exactly the kind of
-    thing where a one-line refactor can silently start returning ``inf``
-    or zero for a healthy p99.
+  * Exposition-format edge cases: blank lines, HELP/TYPE comments,
+    label-value backslash escapes, +Inf buckets, missing trailing
+    newlines.
+  * The HTTP-RED roll-up excludes 404 from the error count (health
+    probes / scanner noise) and converts seconds → milliseconds to match
+    the histogram panels in ``mycelium metrics show``.
+  * ``histogram_quantile`` mirrors Prometheus's PromQL semantics: linear
+    interpolation within buckets, +Inf clamped to the previous finite
+    bound, and the "all observations in one bucket" edge case.
 """
 
 from __future__ import annotations

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -15,7 +15,7 @@ import {
 // The L9 protocol inspector renders the AOP layer legibly: the live L9 payloads
 // crossing a room's channel (exchange ticks/replies, commit verdicts with
 // MPC/GAR/SCR, knowledge pushes) as a wire feed, plus the persisted episode
-// records, the causal chain the broadcast envelopes deliberately omit.
+// records and their causal chain.
 
 // ── frame model ────────────────────────────────────────────────────────────────
 

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -228,9 +228,7 @@ export async function fetchRoomAgents(roomName: string): Promise<AgentSummary[]>
     if (!rest || rest.includes("/")) continue;
     // The manifest is YAML. The memory API may hand it back as a raw string,
     // a structured dict, OR (what the backend actually does) wrapped as
-    // `{text: "<yaml>"}`. Normalize to one YAML string and parse that; the
-    // old code missed the {text} shape and defaulted every agent to
-    // claude_code.
+    // `{text: "<yaml>"}`. Normalize to one YAML string and parse that.
     const value = item.value;
     let raw = "";
     let structured: Record<string, unknown> | null = null;

--- a/mycelium-frontend/src/lib/backend.ts
+++ b/mycelium-frontend/src/lib/backend.ts
@@ -9,9 +9,8 @@ import { join } from "node:path";
  * Resolve the internal backend URL: SERVER-SIDE, at REQUEST time.
  *
  * This MUST be evaluated per-request, never baked into the build: one image
- * runs in dev, Docker, and cloud against different backends. (A next.config
- * rewrite froze this at build time and ignored the runtime env, which broke the
- * Dockerized UI; see next.config.ts.) Precedence:
+ * runs in dev, Docker, and cloud against different backends. See next.config.ts
+ * for the request proxy. Precedence:
  *
  *   1. MYCELIUM_INTERNAL_API_URL (compose / runtime env)
  *   2. server.api_url from ~/.mycelium/config.toml (matches the CLI)


### PR DESCRIPTION
Closes #455.

Full-codebase comment audit (the `audit-comments` skill), run over 276 source files via a cheap-model fan-out. Findings were curated hard — load-bearing "why" is kept; only high-confidence comment smells were stripped.

## What was removed
- **Temporal / historical narration** — "used to", "no longer", "Relocated from", "Drop-in replacement for the previous…", "the old code missed…".
- **Tracker breadcrumbs** — `#392`, `#173`, and `D3`/`H1` plan-step labels.
- **Dated war-stories** — "in 2026-05", "1.0.14rc3", "feat/simple_metrics restructure".
- **Stale symbol references** — the removed `_finish_cfn` function (no longer exists in the tree).

Present-tense intent and design rationale are preserved throughout; comments now describe the code as it is, with lineage left to git.

## What was deliberately kept
Reviewed and judged load-bearing (not stripped): the SLIM keepalive/heartbeat mechanics, master-secret security guidance, the `l9_episode` architecture note, the engine `brain.py` Pi-tool rationale, and the `test_claude_spawn` threat-model docstrings.

## Scope & verification
27 files changed (−134/+85). Backend `ruff`/`ty` ✓ · CLI `ruff`/`ty` ✓ + touched tests **123 passed** · frontend `tsc` ✓. Comments/docstrings only — no code or assertions touched.