### PR TITLE
feat(frontend): server-pushed refresh for top-level state changes

### DIFF
--- a/fastapi-backend/app/bus.py
+++ b/fastapi-backend/app/bus.py
@@ -31,6 +31,18 @@ def agent_channel(handle: str) -> str:
     return f"agent:{handle}"
 
 
+APP_CHANNEL = "app"
+
+
+def app_channel() -> str:
+    """Canonical channel for global, non-room-scoped app events.
+
+    Room create/delete happen outside any single room's context, so they can't
+    ride a ``room:{name}`` channel — the UI's room list subscribes here instead.
+    """
+    return APP_CHANNEL
+
+
 class _Bus:
     """A minimal in-memory channel fan-out.
 

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 
 from fastapi import APIRouter, HTTPException
 
+from app.bus import app_channel, bus
 from app.schemas import RoomCreate, RoomRead
 from app.services import room_channels
 from app.services.filesystem import (
@@ -73,6 +74,17 @@ async def create_room(room: RoomCreate):
 
     result = _room_read(room.name)
     assert result is not None  # just created
+
+    # Push to the global app channel so every open UI's room list updates live.
+    bus.publish(
+        app_channel(),
+        {
+            "type": "room_created",
+            "room_name": room.name,
+            "mas_id": room.mas_id,
+            "created_at": datetime.now(UTC).isoformat(),
+        },
+    )
     return result
 
 
@@ -125,3 +137,5 @@ async def delete_room(room_name: str):
     await room_channels.manager.close(room_name)
     remove_room_dir(room_name)
     logger.info("Removed room %s", room_name)
+
+    bus.publish(app_channel(), {"type": "room_deleted", "room_name": room_name})

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -184,3 +184,15 @@ async def leave_room(room_name: str, session_id: UUID):
         raise HTTPException(status_code=404, detail="Participant not found")
     if handle is not None:
         await room_channels.manager.remove(room_name, handle)
+        # Mirror the join event so the room's agent roster updates live on leave.
+        bus.publish(
+            room_channel(room_name),
+            {
+                "type": "coordination_leave",
+                "room_name": room_name,
+                "agent_handle": handle,
+                "sender_handle": l9.SYSTEM_ACTOR_ID,
+                "message_type": "coordination_leave",
+                "created_at": datetime.now(UTC).isoformat(),
+            },
+        )

--- a/fastapi-backend/app/routes/stream.py
+++ b/fastapi-backend/app/routes/stream.py
@@ -10,6 +10,7 @@ invest here.
 
 GET /rooms/{room}/messages/stream — room event stream
 GET /agents/{handle}/stream       — per-agent event stream
+GET /events/stream                — global app events (room create/delete)
 """
 
 import asyncio
@@ -19,7 +20,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-from app.bus import agent_channel, bus, room_channel
+from app.bus import agent_channel, app_channel, bus, room_channel
 from app.services import local_state
 from app.services.filesystem import room_exists
 
@@ -74,6 +75,20 @@ async def stream_agent_events(handle: str, request: Request):
     """Server-Sent Events stream for a specific agent handle."""
     return StreamingResponse(
         _sse_from_channel(request, agent_channel(handle)),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.get("/events/stream")
+async def stream_app_events(request: Request):
+    """Server-Sent Events stream for global app state changes.
+
+    Carries non-room-scoped events (``room_created`` / ``room_deleted``) so the
+    UI's room list updates live without per-room polling.
+    """
+    return StreamingResponse(
+        _sse_from_channel(request, app_channel()),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/fastapi-backend/tests/test_app_events.py
+++ b/fastapi-backend/tests/test_app_events.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Server-pushed refresh events for top-level state changes.
+
+Room create/delete fan out on the global ``app`` channel; agent leave mirrors
+the existing join event on the room channel. The UI subscribes to these so its
+room list and agent roster update live instead of waiting on a poll.
+"""
+
+import pytest
+
+from app.bus import app_channel, bus, room_channel
+
+
+def _drain(queue) -> list[dict]:
+    out: list[dict] = []
+    while not queue.empty():
+        out.append(queue.get_nowait())
+    return out
+
+
+@pytest.mark.asyncio
+async def test_create_room_publishes_room_created(client):
+    q = bus.subscribe(app_channel())
+    try:
+        resp = await client.post("/api/rooms", json={"name": "platform-eng", "mas_id": "mas-1"})
+        assert resp.status_code == 201
+        events = _drain(q)
+    finally:
+        bus.unsubscribe(app_channel(), q)
+
+    assert {"type": "room_created", "room_name": "platform-eng", "mas_id": "mas-1"}.items() <= (
+        events[0].items()
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_room_publishes_room_deleted(client):
+    await client.post("/api/rooms", json={"name": "platform-eng"})
+    q = bus.subscribe(app_channel())
+    try:
+        resp = await client.delete("/api/rooms/platform-eng")
+        assert resp.status_code == 204
+        events = _drain(q)
+    finally:
+        bus.unsubscribe(app_channel(), q)
+
+    assert events == [{"type": "room_deleted", "room_name": "platform-eng"}]
+
+
+@pytest.mark.asyncio
+async def test_idempotent_recreate_does_not_publish(client):
+    await client.post("/api/rooms", json={"name": "platform-eng"})
+    q = bus.subscribe(app_channel())
+    try:
+        resp = await client.post("/api/rooms", json={"name": "platform-eng"})
+        assert resp.status_code == 201
+        events = _drain(q)
+    finally:
+        bus.unsubscribe(app_channel(), q)
+
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_leave_publishes_coordination_leave(client):
+    await client.post("/api/rooms", json={"name": "platform-eng"})
+    joined = await client.post(
+        "/api/rooms/platform-eng/sessions",
+        json={"agent_handle": "alice", "intent": "help"},
+    )
+    assert joined.status_code == 201
+    session_id = joined.json()["id"]
+
+    # Subscribe after the join so we only capture the leave event.
+    q = bus.subscribe(room_channel("platform-eng"))
+    try:
+        resp = await client.delete(f"/api/rooms/platform-eng/sessions/{session_id}")
+        assert resp.status_code == 204
+        events = _drain(q)
+    finally:
+        bus.unsubscribe(room_channel("platform-eng"), q)
+
+    leave = next(e for e in events if e.get("type") == "coordination_leave")
+    assert leave["room_name"] == "platform-eng"
+    assert leave["agent_handle"] == "alice"

--- a/mycelium-frontend/src/app/api/events/stream/route.ts
+++ b/mycelium-frontend/src/app/api/events/stream/route.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { getBackendUrl } from "@/lib/backend";
+import { isMockMode } from "@/mocks";
+
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache, no-transform",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+};
+
+export async function GET() {
+  // Fake-backend mode has no live room churn: hold an idle keep-alive stream
+  // open so the client's EventSource connects cleanly and never errors.
+  if (isMockMode()) {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("event: ping\ndata: {}\n\n"));
+      },
+    });
+    return new Response(stream, { headers: SSE_HEADERS });
+  }
+
+  const upstream = `${getBackendUrl()}/api/events/stream`;
+  const res = await fetch(upstream, {
+    headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+    cache: "no-store",
+  });
+
+  if (!res.ok || !res.body) {
+    return new Response("upstream SSE unavailable", { status: 502 });
+  }
+
+  // Pipe through a TransformStream so each chunk flushes immediately rather
+  // than waiting for Next.js to decide when to flush (mirrors the room stream).
+  const { readable, writable } = new TransformStream();
+  res.body.pipeTo(writable).catch(() => {/* client disconnect */});
+
+  return new Response(readable, { headers: SSE_HEADERS });
+}

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -59,7 +59,7 @@ export default function RoomPage() {
     if (typeof window !== "undefined") window.history.replaceState(null, "", window.location.pathname);
   }, []);
 
-  const { agents, episodes, openTasks } = useRoomStatus(roomName);
+  const { agents, episodes, openTasks } = useRoomStatus(roomName, memoryRefresh);
 
   useEffect(() => {
     let cancelled = false;

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -19,6 +19,8 @@ import {
 
 interface Props {
   roomName: string;
+  /** Bumped by the room page on pushed presence/memory events to refetch now. */
+  refreshKey?: number;
 }
 
 /** Two-letter monogram from a handle: "backend-lead" → BL, "oc-test2" → OT,
@@ -43,7 +45,7 @@ function initials(handle: string): string {
  * side effects (mycelium-daemon manifest mirror, OpenClaw gateway config + restart)
  * that the hub cannot perform. Use `mycelium agent add` / `create` / `rm`.
  */
-export function AgentsPanel({ roomName }: Props) {
+export function AgentsPanel({ roomName, refreshKey = 0 }: Props) {
   const [agents, setAgents] = useState<AgentSummary[]>([]);
   const [loaded, setLoaded] = useState(false);
 
@@ -63,7 +65,7 @@ export function AgentsPanel({ roomName }: Props) {
     refresh();
     const t = setInterval(refresh, 30_000);
     return () => clearInterval(t);
-  }, [refresh]);
+  }, [refresh, refreshKey]);
 
   return (
     <div className="flex h-full flex-col overflow-hidden">

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -194,6 +194,7 @@ const typeStyles: Record<string, { tone: "accent" | "ok" | "warn" | "muted" | "i
   announce:               { tone: "ink",    label: "ANNOUNCE" },
   delegate:               { tone: "accent", label: "DELEGATE" },
   coordination_join:      { tone: "accent", label: "JOIN" },
+  coordination_leave:     { tone: "muted",  label: "LEAVE" },
   coordination_start:     { tone: "accent", label: "START" },
   coordination_tick:      { tone: "muted",  label: "TICK" },
   coordination_consensus: { tone: "ok",     label: "CONSENSUS" },
@@ -334,6 +335,10 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
           // A consensus compiles the negotiation into plan/tasks.md, so nudge
           // the plan header to refetch so the checklist surfaces immediately.
           if (event.type === "coordination_consensus" && event.raw.broken !== true) {
+            onMemoryChanged?.();
+          }
+          // Presence changes: refresh the room's derived state (agent roster/count).
+          if (event.type === "coordination_join" || event.type === "coordination_leave") {
             onMemoryChanged?.();
           }
         } catch {}

--- a/mycelium-frontend/src/components/room-inspector.tsx
+++ b/mycelium-frontend/src/components/room-inspector.tsx
@@ -106,7 +106,7 @@ export function RoomInspector({
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">
-        {tab === "agents" && <AgentsPanel roomName={roomName} />}
+        {tab === "agents" && <AgentsPanel roomName={roomName} refreshKey={memoryRefresh} />}
         {tab === "episodes" && <EpisodesRail roomName={roomName} />}
         {tab === "memory" && (
           <MemoryPanel roomName={roomName} masId={masId ?? null} refreshTrigger={memoryRefresh} />

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { BarChart3, Boxes, Plus, Search, SearchX } from "lucide-react";
-import { fetchRooms, logFetchError } from "@/lib/api";
+import { fetchRooms, getAppEventsSSEUrl, logFetchError } from "@/lib/api";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { EmptyState } from "@/components/empty-state";
@@ -40,8 +40,25 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
 
   useEffect(() => {
     load();
-    const t = setInterval(load, 10_000);
-    return () => clearInterval(t);
+    // Push keeps the list instant; the slow poll is a fail-soft fallback for a
+    // dropped SSE connection.
+    const t = setInterval(load, 30_000);
+
+    let es: EventSource | undefined;
+    let retry: ReturnType<typeof setTimeout>;
+    function connect() {
+      es = new EventSource(getAppEventsSSEUrl());
+      es.onmessage = (e) => {
+        try {
+          const msg = JSON.parse(e.data);
+          if (msg.type === "room_created" || msg.type === "room_deleted") load();
+        } catch {}
+      };
+      es.onerror = () => { es?.close(); retry = setTimeout(connect, 5000); };
+    }
+    connect();
+
+    return () => { clearInterval(t); es?.close(); clearTimeout(retry); };
   }, []);
 
   const filtered = useMemo(() => {

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -149,6 +149,11 @@ export function getSSEUrl(roomName: string) {
   return `/api/rooms/${roomName}/messages/stream`;
 }
 
+/** SSE endpoint for global app events (room create/delete). */
+export function getAppEventsSSEUrl() {
+  return `/api/events/stream`;
+}
+
 export async function sendRoomMessage(
   roomName: string,
   data: { sender_handle: string; content: string; message_type?: string },

--- a/mycelium-frontend/src/lib/use-status.ts
+++ b/mycelium-frontend/src/lib/use-status.ts
@@ -18,8 +18,12 @@ export interface RoomStatus {
   openTasks: number | null;
 }
 
-/** Lightweight per-room counts for the status bar (polled, fail-soft). */
-export function useRoomStatus(roomName: string): RoomStatus {
+/** Lightweight per-room counts for the status bar (polled, fail-soft).
+ *
+ *  ``refreshKey`` triggers an immediate reload when it changes — the room page
+ *  bumps it on pushed presence/memory events so counts update without waiting
+ *  on the poll. */
+export function useRoomStatus(roomName: string, refreshKey = 0): RoomStatus {
   const [agents, setAgents] = useState<number | null>(null);
   const [episodes, setEpisodes] = useState<EpisodeSummary[] | null>(null);
   const [openTasks, setOpenTasks] = useState<number | null>(null);
@@ -34,7 +38,7 @@ export function useRoomStatus(roomName: string): RoomStatus {
     load();
     const t = setInterval(load, 8000);
     return () => { cancelled = true; clearInterval(t); };
-  }, [roomName]);
+  }, [roomName, refreshKey]);
 
   return { agents, episodes, openTasks };
 }


### PR DESCRIPTION
Closes #459.

Top-level app state (room list, agent presence) now updates **live** via server-pushed events instead of relying on refetch/polling. Reuses the existing in-process bus + SSE plumbing — no new realtime service, no message broker, no database.

## The gap
The bus is per-channel (`room:{name}`, `agent:{handle}`) and the frontend only opens an EventSource *per room*. Room create/delete happen **outside any room context**, so there was no channel the sidebar could listen on. This adds a global `app` channel for exactly those events; room-scoped changes (agent presence) ride the existing `room:{name}` stream.

## Backend
- `bus.py` — add a global `app` channel (`app_channel()`).
- `stream.py` — `GET /events/stream` serves it over SSE (same `_sse_from_channel` helper).
- `rooms.py` — publish `room_created` (carrying `mas_id`) and `room_deleted` on the app channel; idempotent re-create stays silent.
- `sessions.py` — publish `coordination_leave` on the room channel, mirroring the existing join event.

## Frontend
- `rooms-sidebar` subscribes to `/api/events/stream` and refetches the room list on `room_created`/`room_deleted`; the poll drops to a 30s fail-soft fallback.
- New Next SSE proxy route (`api/events/stream/route.ts`) mirrors the room-stream proxy (immediate flush via TransformStream; idle keep-alive stream in `MYCELIUM_UI_MOCK` mode).
- `event-stream` nudges the room's derived state on join/leave; the room page threads that refresh through `useRoomStatus` and `AgentsPanel`, so the agent count and roster update live.

## Checklist (from the issue)
- [x] Push server-side events for room create/delete and agent add/remove.
- [x] Reuse the SLIM-native event-stream plumbing (in-process bus + SSE), no new service.
- [x] Wire the frontend to react (refetch the affected views).
- mas_id: written only at room creation (no runtime provisioning endpoint exists), so it's carried on `room_created` for the sidebar; the room page keeps its existing meta poll.

## Verification
- Backend: `ruff`/`ty` clean; full suite **380 passed, 2 skipped**; new `test_app_events.py` covers create/delete/leave emission + idempotent-recreate silence.
- Frontend: `tsc` clean; `vitest` **10 passed**.