### PR TITLE
docs: describe Pi accurately (not Mycelium's own; drop 'never imposed')

### DIFF
--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -454,7 +454,7 @@ cd ~/.mycelium/rooms/design-review &amp;&amp; git init</code></pre>
         <li><strong><code>host</code></strong>: the local daemon holds the engine and runs it on the host, where</li>
       </ul>
       <p><code>pi</code> lives. Use this when the engine&#x27;s brain needs host tools or credentials.</p>
-      <p>Every engine&#x27;s brain is <strong>Pi</strong>, Mycelium&#x27;s own cognition runtime (it ships in the backend image). Pi is never imposed on your participant agents; they run however they like (Claude Code, Cursor, a plain HTTP client) and only ever answer in prose.</p>
+      <p>Every engine&#x27;s brain is <strong>Pi</strong>, the coding-agent runtime Mycelium uses for engine cognition (it ships in the backend image). It applies only to engines. Your participant agents run however you like (Claude Code, Cursor, a plain HTTP client) and only ever answer in prose.</p>
     </section>
 
     <hr class="divider">
@@ -488,7 +488,7 @@ cd ~/.mycelium/rooms/design-review &amp;&amp; git init</code></pre>
       <p>agreed <code>{issue: value}</code> map, and <code>plan_compiler</code> (a separate LLM stage that <em>consumes</em> the outcome, distinct from the negotiation engine) turns it into the room&#x27;s <a href="#plan">shared plan</a>, <code>plan/tasks.md</code>: a <code>- [ ]</code> checklist with <code>@handle</code> owners. This runs before the consensus is announced, so the plan exists by the time <code>await</code> returns.</p>
       <p>Walking away with no agreement is a legitimate outcome. There&#x27;s no &quot;concede gradually&quot; mechanism: if your hard constraints can&#x27;t be met, keep rejecting.</p>
       <h2 id="aligner-memory-across-rounds">Memory across rounds</h2>
-      <p>The aligner&#x27;s brain is a persistent <strong>Pi</strong> coding-agent session (<code>pi -p --session &lt;id&gt;</code>), spawned fresh per episode and kept alive across every round of that episode. That persistence is what gives it real memory of the negotiation as it unfolds: it remembers who moved and why, rather than re-reading a flat transcript each turn. Pi ships in the backend image; it is Mycelium&#x27;s own cognition runtime and is never imposed on participant agent runtimes.</p>
+      <p>The aligner&#x27;s brain is a persistent <strong>Pi</strong> coding-agent session (<code>pi -p --session &lt;id&gt;</code>), spawned fresh per episode and kept alive across every round of that episode. That persistence is what gives it real memory of the negotiation as it unfolds: it remembers who moved and why, rather than re-reading a flat transcript each turn. Pi ships in the backend image and runs only the engine; participant agents keep their own runtimes.</p>
       <h2 id="aligner-tunables">Tunables</h2>
       <p>The aligner is dormant by default and configured through <code>~/.mycelium/.env</code> (backend settings). The common knobs:</p>
       <div class="table-wrap">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -754,10 +754,10 @@ config (the backend and the host daemon are a pair; set both the same):
 - **`host`**: the local daemon holds the engine and runs it on the host, where
   `pi` lives. Use this when the engine's brain needs host tools or credentials.
 
-Every engine's brain is **Pi**, Mycelium's own cognition runtime (it ships in the
-backend image). Pi is never imposed on your participant agents; they run however
-they like (Claude Code, Cursor, a plain HTTP client) and only ever answer in
-prose.
+Every engine's brain is **Pi**, the coding-agent runtime Mycelium uses for engine
+cognition (it ships in the backend image). It applies only to engines. Your
+participant agents run however you like (Claude Code, Cursor, a plain HTTP
+client) and only ever answer in prose.
 
 
 ---
@@ -813,8 +813,8 @@ The aligner's brain is a persistent **Pi** coding-agent session (`pi -p --sessio
 <id>`), spawned fresh per episode and kept alive across every round of that
 episode. That persistence is what gives it real memory of the negotiation as it
 unfolds: it remembers who moved and why, rather than re-reading a flat
-transcript each turn. Pi ships in the backend image; it is Mycelium's own
-cognition runtime and is never imposed on participant agent runtimes.
+transcript each turn. Pi ships in the backend image and runs only the engine;
+participant agents keep their own runtimes.
 
 ## Tunables
 

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -90,8 +90,8 @@ class Settings(BaseSettings):
     # mediator, an *internal* agent — always a persistent, optionally
     # OpenShell-sandboxed `pi -p --session <id> --mode json` session that gives the
     # internal agent real memory across SAO rounds (the anti-theatre property).
-    # This is ONLY mycelium's own cognition runtime — user/participant agent
-    # runtimes (claude_code, cursor, …) are untouched; Pi is never imposed on them.
+    # This is ONLY the runtime for mycelium's own cognition engines; user/participant
+    # agent runtimes (claude_code, cursor, …) are untouched and keep their own runtime.
     # Path/name of the `pi` binary the mediator brain runs.
     ALIGNER_PI_BINARY: str = "pi"
     # Wrap each pi session in an OpenShell sandbox when true. Off by default:

--- a/mycelium-cli/src/mycelium/docs/aligner.md
+++ b/mycelium-cli/src/mycelium/docs/aligner.md
@@ -49,8 +49,8 @@ The aligner's brain is a persistent **Pi** coding-agent session (`pi -p --sessio
 <id>`), spawned fresh per episode and kept alive across every round of that
 episode. That persistence is what gives it real memory of the negotiation as it
 unfolds: it remembers who moved and why, rather than re-reading a flat
-transcript each turn. Pi ships in the backend image; it is Mycelium's own
-cognition runtime and is never imposed on participant agent runtimes.
+transcript each turn. Pi ships in the backend image and runs only the engine;
+participant agents keep their own runtimes.
 
 ## Tunables
 

--- a/mycelium-cli/src/mycelium/docs/engines.md
+++ b/mycelium-cli/src/mycelium/docs/engines.md
@@ -60,7 +60,7 @@ config (the backend and the host daemon are a pair; set both the same):
 - **`host`**: the local daemon holds the engine and runs it on the host, where
   `pi` lives. Use this when the engine's brain needs host tools or credentials.
 
-Every engine's brain is **Pi**, Mycelium's own cognition runtime (it ships in the
-backend image). Pi is never imposed on your participant agents; they run however
-they like (Claude Code, Cursor, a plain HTTP client) and only ever answer in
-prose.
+Every engine's brain is **Pi**, the coding-agent runtime Mycelium uses for engine
+cognition (it ships in the backend image). It applies only to engines. Your
+participant agents run however you like (Claude Code, Cursor, a plain HTTP
+client) and only ever answer in prose.


### PR DESCRIPTION
Pi is a third-party coding-agent runtime that Mycelium *uses* for engine cognition, not one Mycelium authored. The docs claimed it as "Mycelium's own cognition runtime" and leaned on a defensive "never imposed on participant agents" framing.

- `engines.md` / `aligner.md`: Pi is "the coding-agent runtime Mycelium uses for engine cognition"; it ships in the backend image and runs only the engines. Participant agents keep their own runtimes.
- `config.py`: the `ALIGNER_PI_BINARY` comment reworded the same way.
- Regenerated `concepts.html` (+ `llms-full.txt`).

Prose only; no behavior change.