### PR TITLE
Make agent-to-agent coordination legible: presence fixes, `mycelium network`, per-room SLIM view

### DIFF
--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -308,6 +308,21 @@ class AlignerEngine:
             scoped = {_norm(h) for h in scoped_participants}
             participants = [m for m in participants if _norm(m) in scoped]
             logger.info("aligner (mediator) room %s scoped to %s", room, participants)
+
+        # Nothing to broker: a negotiation needs at least two participants that are
+        # present with opening positions. Rather than open a throwaway episode and
+        # reject it in silence — leaving whoever summoned the aligner with no
+        # feedback at all — let the brain explain, in its own words, why it can't
+        # align and what to do next.
+        if len(participants) < 2:
+            logger.info(
+                "aligner (mediator) room %s: %d participant(s) present — nothing to align",
+                room,
+                len(participants),
+            )
+            await self._explain_stall(managed, room, me, participants)
+            return None
+
         episode_id = _new_episode_id()
         episode = l9.episode_urn(room, episode_id)
         topic = l9.topic_urn(room)
@@ -486,6 +501,59 @@ class AlignerEngine:
             if loop.time() >= deadline:
                 return ""
             await asyncio.sleep(self._poll_interval_s)
+
+    async def _explain_stall(
+        self, managed: ManagedRoomChannel, room: str, sender: str, participants: list[str]
+    ) -> None:
+        """Post the aligner's own account of why it can't align yet.
+
+        The brain writes the message so it reads naturally and in context (not a
+        canned string); a static line is the fail-soft fallback when the brain is
+        unavailable. Either way the room gets a plain, actionable reply instead of
+        silence.
+        """
+        roster = ", ".join(participants) if participants else "no other agents"
+        prompt = (
+            "You are this room's alignment mediator, just summoned to help it align, "
+            "but you cannot run a negotiation right now: it needs at least two agents "
+            "that are present in the room and holding opening positions, and the current "
+            f"roster is: {roster}. Write a short, friendly message to the room (2-3 "
+            "sentences) that explains you can't align yet and says what to do next — have "
+            "at least two agents join and post their opening positions (e.g. with "
+            "'mycelium respond'), then summon you again. Plain prose, no @-mentions."
+        )
+        text = ""
+        try:
+            brain = self._make_brain(l9.episode_urn(room, _new_episode_id()))
+            text = (await asyncio.to_thread(brain, prompt) or "").strip()
+        except Exception:
+            logger.warning("aligner brain unavailable to explain stall in %s", room, exc_info=True)
+        if not text:
+            text = (
+                "I can't align the room yet — a negotiation needs at least two agents "
+                "present with opening positions to broker between. Have the agents join "
+                "and post their positions, then summon me again."
+            )
+        await self._say(managed, room, sender, text)
+
+    async def _say(self, managed: ManagedRoomChannel, room: str, sender: str, text: str) -> None:
+        """Broadcast a plain message from the aligner (not a verdict envelope). Any
+        ``@`` tokens are stripped so the notice can't spuriously summon anyone."""
+        safe = _AT_MENTION.sub("", text)
+        env = l9.build_envelope(
+            kind=l9.Kind.exchange,
+            episode=l9.episode_urn(room, "live"),
+            sender=sender,
+            topic=l9.topic_urn(room),
+            payload_type="message",
+        )
+        content = serialize_content(env, extra={"content": safe})
+        try:
+            await managed.channel.send(env, extra={"content": safe})
+        except Exception:
+            logger.warning("aligner failed to broadcast message on room %s", room)
+        if managed.persister is not None:
+            managed.persister.ingest_local(env, content)
 
     def _fold_reading(
         self, ep: EpisodeState, handle: str, reading: dict[str, Any], proposing: bool

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -187,7 +187,10 @@ class RoomChannelManager:
                     "room": room,
                     "provisioned": True,
                     "persister_alive": task is not None and not task.done(),
-                    "members": sorted(managed.members),
+                    # Union of SLIM-connected members and live server-held `await`
+                    # leases — the same roster `members()` serves the mediator, so
+                    # a bare-CLI participant long-polling `await` is visible here.
+                    "members": self.members(room),
                     "pending_invites": len(self.pending_invites(room)),
                     "episode_active": managed.lifecycle.active,
                     "reserves": managed.persister.reserves if managed.persister else 0,
@@ -493,9 +496,14 @@ class RoomChannelManager:
         # cross-host agents (not registered here), so a CLI-only user can still
         # wake their own agent, and the consent surface is reserved for the
         # genuinely external case it's meant for.
+        # "Present" is SLIM-connected members plus live server-held `await` leases. A
+        # bare-CLI agent long-polling `await` is a first-class participant — its
+        # turn is delivered via the durable transcript cursor its poll reads, not a
+        # SLIM broadcast — so an @-mention of it is a wake, not a consent invite.
+        present = set(self.members(room))
         invites: list[PendingInvite] = []
         for handle in mentioned:
-            if handle in managed.members or handle == BACKEND_AGENT:
+            if handle in present or handle == BACKEND_AGENT:
                 continue
             if _is_own_registered_agent(room, handle):
                 if managed.lifecycle.active:
@@ -559,7 +567,12 @@ class RoomChannelManager:
                 managed.lifecycle.episode,
             )
             return self._invites.mark(invite_id, QUEUED)
-        await self.invite(invite.room, invite.agent)
+        # Schedule the SLIM invite off the request path. The group invite
+        # handshake retries against an absent member before failing, so awaiting it
+        # here would stall the HTTP accept for the whole retry budget (observed as a
+        # hung/timed-out accept). Mark accepted now; `members` updates if/when the
+        # invite lands, exactly as it does for a background join.
+        self.invite_in_background(invite.room, invite.agent)
         return self._invites.mark(invite_id, ACCEPTED)
 
     def decline_invite(self, invite_id: str) -> PendingInvite | None:

--- a/fastapi-backend/tests/test_aligner.py
+++ b/fastapi-backend/tests/test_aligner.py
@@ -76,6 +76,57 @@ async def test_summon_fires_only_for_the_reserved_handle():
 
 
 @pytest.mark.asyncio
+async def test_mediate_explains_when_too_few_participants():
+    """Summoned with fewer than two participants, the aligner posts a
+    brain-authored explanation to the room instead of silently opening and
+    rejecting a throwaway episode."""
+    channel = FakeChannel()
+    persister = FakePersister()
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["solo"])  # one participant besides the aligner
+    engine = _engine(
+        manager,
+        brain_factory=lambda _ep: (lambda _prompt, **_kw: "Post positions first, then summon me."),
+    )
+
+    result = await engine.mediate(_ROOM)
+
+    assert result is None
+    assert manager.opened == []  # no throwaway episode opened
+    # The aligner broadcast its explanation to the room ...
+    assert len(channel.sent) == 1
+    env, extra = channel.sent[0]
+    assert env.header.kind == Kind.exchange
+    assert extra is not None and extra["content"] == "Post positions first, then summon me."
+    # ... and recorded it locally so the transcript / UI see it.
+    assert persister.ingested
+    assert persister.ingested[-1][1]["content"] == "Post positions first, then summon me."
+
+
+@pytest.mark.asyncio
+async def test_mediate_stall_falls_back_when_brain_unavailable():
+    """If the brain errors, the aligner still leaves a static, actionable reply
+    rather than saying nothing."""
+    channel = FakeChannel()
+    persister = FakePersister()
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+
+    def _boom(_ep: str) -> Any:
+        def _raise(_prompt: str, **_kw: Any) -> str:
+            raise RuntimeError("no pi")
+
+        return _raise
+
+    engine = _engine(FakeManager(managed, []), brain_factory=_boom)  # zero participants
+
+    await engine.mediate(_ROOM)
+
+    assert len(channel.sent) == 1
+    _, extra = channel.sent[0]
+    assert extra is not None and "at least two agents" in extra["content"]
+
+
+@pytest.mark.asyncio
 async def test_engine_runtime_host_skips_registered_engine(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/fastapi-backend/tests/test_mentions_and_invites.py
+++ b/fastapi-backend/tests/test_mentions_and_invites.py
@@ -12,6 +12,7 @@ wake-over-a-node slice lives in the CLI's
 
 from __future__ import annotations
 
+import asyncio
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
@@ -96,6 +97,31 @@ async def test_publish_human_returns_none_without_a_live_channel():
     assert await manager.publish_human("no-such-room", sender="julia", text="@x hi") is None
 
 
+@pytest.mark.asyncio
+async def test_publish_human_treats_await_lease_holder_as_present():
+    """A bare-CLI agent long-polling ``await`` holds a presence lease but no SLIM
+    membership. An @-mention of it must be a wake (delivered via the transcript its
+    poll reads), not a consent invite."""
+    manager, _managed = _manager_with_channel(members=set())
+    manager.refresh_lease(_ROOM, "workpc")  # an active `await` long-poll
+
+    result = await manager.publish_human(_ROOM, sender="julia", text="@workpc ping")
+
+    assert result is not None
+    assert result.invites == []  # present via lease → wake, no consent prompt
+    assert manager.pending_invites(_ROOM) == []
+
+
+def test_status_members_include_await_leases():
+    """status() reports the roster the mediator sees — SLIM members plus live
+    leases — so a server-held ``await`` participant is visible on ``/health``."""
+    manager, _managed = _manager_with_channel(members={"agent-x"})
+    manager.refresh_lease(_ROOM, "workpc")
+
+    entry = next(r for r in manager.status()["rooms"] if r["room"] == _ROOM)
+    assert set(entry["members"]) == {"agent-x", "workpc"}
+
+
 # ── consent: accept joins, decline does not ───────────────────────────────────
 
 
@@ -113,6 +139,7 @@ async def test_absent_invite_accept_joins():
 
     accepted = await manager.accept_invite(invite.id)
     assert accepted is not None and accepted.status == invites.ACCEPTED
+    await asyncio.gather(*manager._tasks)  # accept schedules the SLIM invite off the request path
     invite_mock.assert_awaited_once_with(_ROOM, "bob")
     assert manager.pending_invites(_ROOM) == []  # no longer open
 
@@ -198,6 +225,7 @@ async def test_accept_invites_remote_agent_by_identity_only(monkeypatch):
 
     accepted = await manager.accept_invite(invite.id)
     assert accepted is not None and accepted.status == invites.ACCEPTED
+    await asyncio.gather(*manager._tasks)  # the invite now runs off the request path
 
     # Addressed by identity only (no host/endpoint) — host-independent membership.
     assert resolved == [("mycelium", _ROOM, "remote-bob")]

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -25,6 +25,7 @@ from mycelium.commands import (
     instance,
     memory,
     metrics,
+    network,
     openshell,
     participate,
     plan,
@@ -106,6 +107,7 @@ app.command(name="doctor")(doctor.doctor)
 app.command(name="up")(instance.start)
 app.command(name="down")(instance.stop)
 app.command(name="status")(instance.status)
+app.command(name="network")(network.network)
 app.command(name="logs")(instance.logs)
 
 # Top-level shortcuts

--- a/mycelium-cli/src/mycelium/commands/network.py
+++ b/mycelium-cli/src/mycelium/commands/network.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""``mycelium network`` — SLIM coordination fabric status.
+
+Surfaces the backend's live coordination telemetry (from ``/health``): the SLIM
+node endpoint, channel/provision counters, and, per room, who is present plus the
+durable-inbox counters. This is the read-only observability view over the fabric —
+who is on the channel and how each room's channel is doing.
+
+The backend is the authority on room membership: the SLIM node only forwards
+ciphertext and cannot report rosters, so "who is on the network" is the backend's
+union of SLIM-connected members and server-held ``await`` participants.
+"""
+
+from __future__ import annotations
+
+import json as json_module
+
+import httpx
+import typer
+
+from mycelium.config import MyceliumConfig
+from mycelium.doc_ref import doc_ref
+from mycelium.error_handler import print_error
+from mycelium.exceptions import ConfigNotFoundError
+from mycelium.http_client import MyceliumHTTPClient
+from mycelium.ui_status import print_title
+
+
+@doc_ref(
+    usage="mycelium network [room]",
+    desc="Show SLIM fabric status: node, channels, and per-room members.",
+    group="setup",
+)
+def network(
+    ctx: typer.Context,
+    room: str | None = typer.Argument(None, help="Only show this room"),
+) -> None:
+    """
+    Show the SLIM coordination fabric status.
+
+    Renders the backend's live coordination telemetry: the SLIM node endpoint,
+    live-channel and provision counters, and — per room — who is present (SLIM
+    members plus server-held ``await`` participants), open consent invites, whether
+    an episode is active, and durable-inbox counters (re-serves, receive errors).
+
+    Examples:
+        mycelium network
+        mycelium network handshake
+        mycelium network --json
+    """
+    try:
+        json_output = ctx.obj.get("json", False) if ctx.obj else False
+
+        config_path = MyceliumConfig.get_config_path()
+        if not config_path.exists():
+            raise ConfigNotFoundError(str(config_path))
+        config = MyceliumConfig.load()
+
+        with MyceliumHTTPClient(config=config) as client:
+            resp = client.get("/health")
+            health = resp.json()
+
+        coord = (health or {}).get("coordination") or {}
+        rooms = coord.get("rooms") or []
+        if room:
+            rooms = [r for r in rooms if r.get("room") == room]
+
+        if json_output:
+            typer.echo(json_module.dumps({**coord, "rooms": rooms}, indent=2, default=str))
+            return
+
+        endpoint = coord.get("endpoint") or "—"
+        enabled = bool(coord.get("slim_enabled"))
+        print_title("Mycelium Network", subtitle=f"SLIM node {endpoint}")
+
+        dot = typer.style("●", fg=typer.colors.GREEN if enabled else typer.colors.RED)
+        typer.echo(
+            f"  {dot} fabric {'enabled' if enabled else 'disabled'}   "
+            f"channels: {coord.get('channels_live', 0)} live   "
+            f"provisions: {coord.get('provisions_ok', 0)} ok / "
+            f"{coord.get('provisions_failed', 0)} failed   "
+            f"invite failures: {coord.get('invite_failures', 0)}"
+        )
+        typer.echo()
+
+        if not rooms:
+            suffix = f" matching '{room}'" if room else ""
+            typer.echo(f"  no provisioned rooms{suffix}")
+            return
+
+        # MEMBERS goes last so a long roster extends the line instead of breaking
+        # the fixed columns before it.
+        name_w = max(len("ROOM"), *(len(r.get("room", "")) for r in rooms))
+        typer.secho(
+            f"  {'ROOM':<{name_w}}  PEND  EPISODE  RESRV  RECV-ERR  MEMBERS",
+            fg=typer.colors.BRIGHT_BLACK,
+        )
+        for r in sorted(rooms, key=lambda x: x.get("room", "")):
+            members = r.get("members") or []
+            episode = "active" if r.get("episode_active") else "idle"
+            typer.echo(
+                f"  {r.get('room', ''):<{name_w}}  "
+                f"{r.get('pending_invites', 0):>4}  "
+                f"{episode:<7}  "
+                f"{r.get('reserves', 0):>5}  "
+                f"{r.get('receive_errors', 0):>8}  "
+                f"{', '.join(members) if members else '—'}"
+            )
+        typer.echo()
+
+    except (typer.Exit, typer.Abort):
+        raise
+    except ConfigNotFoundError:
+        raise
+    except httpx.HTTPError as exc:
+        cfg = MyceliumConfig.load()
+        print_error(f"Cannot reach the backend at {cfg.server.api_url}: {exc}")
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -875,9 +875,13 @@ def messages(
         typer.secho(f"({len(msgs)} {plural}, newest first)\n", fg=typer.colors.BRIGHT_BLACK)
         for m in msgs:
             stamp = m.created_at.strftime("%H:%M:%S")
-            content = m.content.replace("\n", " ")
-            preview = content[:100] + ("…" if len(content) > 100 else "")
-            typer.echo(f"  {stamp}  {m.sender_handle} [{m.message_type}]: {preview}")
+            # Show the full message — this is the read-the-transcript command, so
+            # never truncate. Keep multi-line content readable by indenting any
+            # continuation lines under the first.
+            first, *rest = (m.content or "").split("\n")
+            typer.echo(f"  {stamp}  {m.sender_handle} [{m.message_type}]: {first}")
+            for line in rest:
+                typer.echo(f"              {line}")
         typer.echo()
 
     except (typer.Exit, typer.Abort):

--- a/mycelium-cli/tests/test_network.py
+++ b/mycelium-cli/tests/test_network.py
@@ -1,0 +1,119 @@
+"""Tests for `mycelium network` — the SLIM coordination fabric status view.
+
+The command reads the backend's ``/health`` coordination block and renders the
+node, channel counters, and per-room membership/telemetry. These tests patch the
+config plumbing and the HTTP client, and assert on rendering, the room filter,
+and the JSON path.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from mycelium.commands import network as net_cmd
+
+
+def _health(rooms: list[dict]) -> dict:
+    return {
+        "status": "ok",
+        "coordination": {
+            "endpoint": "http://slim:46357",
+            "slim_enabled": True,
+            "channels_live": len(rooms),
+            "provisions_ok": len(rooms),
+            "provisions_failed": 0,
+            "invite_failures": 0,
+            "rooms": rooms,
+        },
+    }
+
+
+def _room(name: str, members: list[str] | None = None, **over: object) -> dict:
+    base = {
+        "room": name,
+        "provisioned": True,
+        "members": members or [],
+        "pending_invites": 0,
+        "episode_active": False,
+        "reserves": 0,
+        "receive_errors": 0,
+    }
+    base.update(over)
+    return base
+
+
+def _patch(monkeypatch: pytest.MonkeyPatch, tmp_path, health: dict) -> None:
+    cfg_path = tmp_path / "config.toml"
+    cfg_path.write_text("x")
+    fake_config = SimpleNamespace(server=SimpleNamespace(api_url="http://localhost:8000"))
+    monkeypatch.setattr(
+        net_cmd.MyceliumConfig, "get_config_path", classmethod(lambda _cls: cfg_path)
+    )
+    monkeypatch.setattr(net_cmd.MyceliumConfig, "load", classmethod(lambda _cls: fake_config))
+
+    client = Mock()
+    client.get.return_value = SimpleNamespace(json=lambda: health)
+    cm = MagicMock()
+    cm.__enter__.return_value = client
+    cm.__exit__.return_value = None
+    monkeypatch.setattr(net_cmd, "MyceliumHTTPClient", lambda **_kw: cm)
+
+
+def _app(json_flag: bool = False) -> typer.Typer:
+    app = typer.Typer()
+
+    @app.callback()
+    def _root(ctx: typer.Context) -> None:
+        ctx.obj = {"json": json_flag}
+
+    app.command(name="network")(net_cmd.network)
+    return app
+
+
+def test_network_renders_fabric_and_rooms(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _patch(monkeypatch, tmp_path, _health([_room("handshake", ["mac", "workpc"])]))
+
+    result = CliRunner().invoke(_app(), ["network"])
+
+    assert result.exit_code == 0, result.output
+    assert "Mycelium Network" in result.output
+    assert "http://slim:46357" in result.output
+    assert "fabric enabled" in result.output
+    assert "handshake" in result.output
+    assert "mac, workpc" in result.output  # server-held members shown in full
+
+
+def test_network_filters_to_one_room(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _patch(monkeypatch, tmp_path, _health([_room("alpha"), _room("beta")]))
+
+    result = CliRunner().invoke(_app(), ["network", "beta"])
+
+    assert result.exit_code == 0, result.output
+    assert "beta" in result.output
+    assert "alpha" not in result.output
+
+
+def test_network_empty_rooms(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _patch(monkeypatch, tmp_path, _health([]))
+
+    result = CliRunner().invoke(_app(), ["network"])
+
+    assert result.exit_code == 0, result.output
+    assert "no provisioned rooms" in result.output
+
+
+def test_network_json_output(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    _patch(monkeypatch, tmp_path, _health([_room("handshake", ["mac"])]))
+
+    result = CliRunner().invoke(_app(json_flag=True), ["network"])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["endpoint"] == "http://slim:46357"
+    assert parsed["rooms"][0]["room"] == "handshake"

--- a/mycelium-cli/tests/test_network.py
+++ b/mycelium-cli/tests/test_network.py
@@ -35,7 +35,7 @@ def _health(rooms: list[dict]) -> dict:
 
 
 def _room(name: str, members: list[str] | None = None, **over: object) -> dict:
-    base = {
+    base: dict[str, object] = {
         "room": name,
         "provisioned": True,
         "members": members or [],

--- a/mycelium-cli/tests/test_room_messages.py
+++ b/mycelium-cli/tests/test_room_messages.py
@@ -109,3 +109,46 @@ def test_room_messages_singular_count(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert result.exit_code == 0, result.output
     assert "1 message," in result.output  # singular, not "1 messages"
+
+
+def test_room_messages_shows_full_content_not_truncated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The read-the-transcript command must not clip content (regression: was cut
+    to 100 chars with an ellipsis, so long messages were unreadable)."""
+    from mycelium_backend_client.models import MessageListResponse, MessageRead
+
+    long_text = "x" * 300 + " END-MARKER"
+    msg = MessageRead(
+        id=uuid4(),
+        sender_handle="operator",
+        message_type="broadcast",
+        content=long_text,
+        created_at=datetime.datetime(2026, 6, 11, 21, 22, 56),  # noqa: DTZ001
+    )
+    _patch_common(monkeypatch, lambda **_kw: MessageListResponse(messages=[msg], total=1))
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest"])
+
+    assert result.exit_code == 0, result.output
+    assert "END-MARKER" in result.output  # full content survives
+    assert "…" not in result.output  # no truncation ellipsis
+
+
+def test_room_messages_indents_multiline_content(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Multi-line content stays readable — continuation lines indented, not
+    flattened into a single space-joined line."""
+    from mycelium_backend_client.models import MessageListResponse, MessageRead
+
+    msg = MessageRead(
+        id=uuid4(),
+        sender_handle="operator",
+        message_type="broadcast",
+        content="first line\nsecond line",
+        created_at=datetime.datetime(2026, 6, 11, 21, 22, 56),  # noqa: DTZ001
+    )
+    _patch_common(monkeypatch, lambda **_kw: MessageListResponse(messages=[msg], total=1))
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest"])
+
+    assert result.exit_code == 0, result.output
+    assert "first line" in result.output
+    assert "second line" in result.output

--- a/mycelium-frontend/src/app/api/[...path]/route.ts
+++ b/mycelium-frontend/src/app/api/[...path]/route.ts
@@ -29,7 +29,11 @@ async function proxy(req: Request): Promise<Response> {
 
   const backend = getBackendUrl();
   const { pathname, search } = new URL(req.url);
-  const target = `${backend}${pathname}${search}`;
+  // The backend serves health at the root (`/health`), while everything else it
+  // exposes is under `/api`. Map the proxied `/api/health` onto the root path so
+  // the health/fabric views can read it through the same proxy.
+  const backendPath = pathname === "/api/health" ? "/health" : pathname;
+  const target = `${backend}${backendPath}${search}`;
 
   const headers = new Headers(req.headers);
   for (const h of STRIP_REQUEST) headers.delete(h);

--- a/mycelium-frontend/src/components/event-stream.render.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.render.test.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { act } from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeEventSource } from "@/test/fake-event-source";
+
+vi.mock("@/lib/api", () => ({
+  getSSEUrl: (room: string) => `/api/rooms/${room}/messages/stream`,
+  fetchMessages: vi.fn().mockResolvedValue({ messages: [] }),
+  fetchRoomAgents: vi.fn().mockResolvedValue([]),
+  fetchPendingInvites: vi.fn().mockResolvedValue([]),
+  respondToInvite: vi.fn(),
+  logFetchError: () => () => undefined,
+}));
+
+import { EventStream } from "@/components/event-stream";
+
+const CREATED = "2026-08-04T10:00:00.000000+00:00";
+
+/** The live SSE stream wraps a human/agent message as an L9 exchange envelope —
+ *  the shape that was silently dropped before (issue #490). */
+function l9Exchange(text: string) {
+  return {
+    message_type: "l9_exchange",
+    sender_handle: "user",
+    created_at: CREATED,
+    content: JSON.stringify({
+      content: text,
+      l9: {
+        header: { kind: "exchange", participants: { actors: [{ id: "user", role: "human" }] } },
+        payload: { type: "message", data: {} },
+      },
+    }),
+  };
+}
+
+describe("<EventStream /> live message rendering", () => {
+  beforeEach(() => {
+    FakeEventSource.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+
+  it("renders an l9_exchange streamed over SSE as a chat message", async () => {
+    render(<EventStream roomName="sprint" />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(l9Exchange("hello over the live channel"));
+    });
+
+    // The prose is unwrapped from the L9 envelope and rendered like a broadcast,
+    // so the live feed matches what a refresh (REST) would show.
+    expect(await screen.findByText("hello over the live channel")).toBeInTheDocument();
+  });
+
+  it("warns loudly on an unhandled message_type instead of dropping it silently", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    render(<EventStream roomName="sprint" />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit({
+        message_type: "brand_new_type",
+        sender_handle: "x",
+        created_at: CREATED,
+        content: "{}",
+      });
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('unhandled message_type "brand_new_type"'),
+      expect.anything(),
+    );
+    warn.mockRestore();
+  });
+});

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -89,7 +89,7 @@ function SystemNotice({
 }
 
 function parseEvent(msg: Record<string, unknown>): Event {
-  const mtype = (msg.message_type as string) || (msg.type as string) || "unknown";
+  let mtype = (msg.message_type as string) || (msg.type as string) || "unknown";
   const sender = (msg.sender_handle as string) || (msg.updated_by as string) || "?";
   const recipient = (msg.recipient_handle as string) || null;
   const created = (msg.created_at as string) || new Date().toISOString();
@@ -165,7 +165,25 @@ function parseEvent(msg: Record<string, unknown>): Event {
       content = `${key} v${version} by ${by}`;
       break;
     }
+    case "l9_exchange":
+      // The live SSE stream wraps human/agent messages as an L9 exchange
+      // envelope, while the REST snapshot (loaded on mount/refresh) delivers the
+      // same message as a plain "broadcast". Unwrap the prose and normalise to
+      // the chat shape so the live feed matches a refresh instead of silently
+      // dropping the message.
+      content = (raw.content as string) || "";
+      mtype = recipient ? "direct" : "broadcast";
+      break;
     default:
+      // A message type nothing above handles would otherwise vanish from the
+      // channel view without a trace (exactly how l9_exchange hid). Surface it
+      // loudly so an unsupported/renamed type can't fail silently again.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[mycelium] EventStream: unhandled message_type "${mtype}" — ` +
+          "rendered as a raw fallback and likely hidden from the channel view",
+        msg,
+      );
       content = (msg.content as string) || JSON.stringify(msg).slice(0, 100);
   }
 

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -18,6 +18,7 @@ import { RoomPlanHeader } from "@/components/room-plan-header";
 import { ConsentDialog } from "@/components/consent-dialog";
 import { L9Inspector } from "@/components/l9-inspector";
 import { NegotiationView } from "@/components/negotiation-view";
+import { RoomSlimView } from "@/components/room-slim";
 import { EmptyState } from "@/components/empty-state";
 import { MessagesSquare } from "lucide-react";
 
@@ -235,7 +236,7 @@ function renderWithMentions(text: string): React.ReactNode {
   );
 }
 
-export type View = "channel" | "negotiate" | "plan" | "l9";
+export type View = "channel" | "negotiate" | "plan" | "l9" | "slim";
 export type NegotiationPhase = "idle" | "negotiating" | "converged" | "rejected";
 
 interface Props {
@@ -407,6 +408,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
             { id: "negotiate" as const, label: "Negotiate", count: null,                          dot: negotiating },
             { id: "l9" as const,        label: "L9",        count: null,                          dot: false },
             { id: "plan" as const,      label: "Plan",      count: null,                          dot: false },
+            { id: "slim" as const,      label: "SLIM",      count: null,                          dot: false },
           ]).map(t => {
             const active = view === t.id;
             return (
@@ -439,6 +441,10 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
       ) : view === "negotiate" ? (
         <div className="flex-1 min-h-0">
           <NegotiationView events={events} />
+        </div>
+      ) : view === "slim" ? (
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <RoomSlimView roomName={roomName} />
         </div>
       ) : (
       <div ref={scrollRef} className="flex-1 overflow-y-auto">

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -111,6 +111,9 @@ export function RoomChatBox({ roomName, defaultSender, onSent }: Props) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setSending(false);
+      // The textarea is disabled while sending; it re-enables on the next
+      // render, so refocus after that commit lands to keep the user typing.
+      requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [content, onSent, roomName, sender, sending]);
 

--- a/mycelium-frontend/src/components/room-slim.tsx
+++ b/mycelium-frontend/src/components/room-slim.tsx
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  fetchCoordination,
+  logFetchError,
+  type CoordinationRoom,
+  type CoordinationStatus,
+} from "@/lib/api";
+
+/** The "SLIM" room view: this room's SLIM channel status — the node it rides,
+ *  who is present (SLIM members plus server-held `await` participants), episode
+ *  state, and durable-inbox counters. Scoped to the current room (the fabric-wide
+ *  fleet view is the CLI's `mycelium network`). Read-only, polled, fail-soft. */
+export function RoomSlimView({ roomName }: { roomName: string }) {
+  const [coord, setCoord] = useState<CoordinationStatus | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () =>
+      fetchCoordination()
+        .then((c) => {
+          if (cancelled) return;
+          setCoord(c);
+          setLoaded(true);
+        })
+        .catch((err) => {
+          logFetchError("fetchCoordination")(err);
+          if (!cancelled) setLoaded(true);
+        });
+    load();
+    const t = setInterval(load, 20_000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  const room: CoordinationRoom | null = coord?.rooms.find((r) => r.room === roomName) ?? null;
+  const enabled = coord?.slim_enabled ?? false;
+
+  if (loaded && !coord) {
+    return <div className="p-6 text-label text-muted-foreground">Backend unreachable.</div>;
+  }
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-6 p-6">
+      {/* SLIM node — the fabric this room's channel rides. */}
+      <section className="overflow-hidden rounded-xl border border-border bg-surface/40">
+        <SectionHeader
+          title="SLIM node"
+          dot={enabled ? "var(--green)" : "var(--red)"}
+          dotLabel={coord ? (enabled ? "connected" : "disabled") : "offline"}
+        />
+        <div className="divide-y divide-border">
+          <Stat label="Endpoint">
+            <span className="font-mono text-text">{coord?.endpoint ?? "—"}</span>
+          </Stat>
+          <Stat label="Channels live">
+            <span className="tabular text-text">{coord?.channels_live ?? "—"}</span>
+          </Stat>
+          <Stat label="Provisions">
+            <span className="tabular text-text">
+              {coord ? `${coord.provisions_ok} ok / ${coord.provisions_failed} failed` : "—"}
+            </span>
+          </Stat>
+        </div>
+      </section>
+
+      {/* This room's channel. */}
+      <section className="overflow-hidden rounded-xl border border-border bg-surface/40">
+        <SectionHeader
+          title={`Channel · ${roomName}`}
+          dot={room?.provisioned ? "var(--green)" : "var(--yellow)"}
+          dotLabel={room?.provisioned ? "provisioned" : "not provisioned"}
+        />
+        {!room ? (
+          <div className="px-4 py-3 text-label text-muted-foreground">
+            {loaded ? "No live channel for this room yet." : "Loading…"}
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            <Stat label="Members present">
+              {room.members.length > 0 ? (
+                <div className="flex flex-wrap justify-end gap-1">
+                  {room.members.map((m) => (
+                    <span
+                      key={m}
+                      className="rounded-full border border-border bg-surface px-2 py-0.5 font-mono text-micro text-text"
+                    >
+                      {m}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <span className="text-muted-foreground">none</span>
+              )}
+            </Stat>
+            <Stat label="Episode">
+              <span style={{ color: room.episode_active ? "var(--accent)" : undefined }} className="text-text">
+                {room.episode_active ? "active" : "idle"}
+              </span>
+            </Stat>
+            <Stat label="Pending invites">
+              <span
+                className="tabular"
+                style={{ color: room.pending_invites > 0 ? "var(--yellow)" : "var(--text)" }}
+              >
+                {room.pending_invites}
+              </span>
+            </Stat>
+            <Stat label="Durable inbox">
+              <span className="tabular text-text">
+                {room.reserves} re-served
+                {room.receive_errors > 0 && (
+                  <span style={{ color: "var(--red)" }}> · {room.receive_errors} recv-err</span>
+                )}
+              </span>
+            </Stat>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function SectionHeader({ title, dot, dotLabel }: { title: string; dot: string; dotLabel: string }) {
+  return (
+    <div className="flex items-center gap-2 border-b border-border bg-paper px-4 py-2.5">
+      <span className="text-label font-semibold text-text">{title}</span>
+      <span className="ml-auto flex items-center gap-1.5 text-micro text-muted-foreground">
+        <span style={{ color: dot }}>●</span>
+        {dotLabel}
+      </span>
+    </div>
+  );
+}
+
+function Stat({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-4 px-4 py-2.5">
+      <span className="text-label text-muted-foreground">{label}</span>
+      <div className="text-label">{children}</div>
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -11,6 +11,7 @@ import { fetchRooms, getAppEventsSSEUrl, logFetchError } from "@/lib/api";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { EmptyState } from "@/components/empty-state";
+import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface Room {
   name: string;
@@ -108,7 +109,8 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
       </div>
 
       {/* Rooms list */}
-      <nav className="flex-1 overflow-y-auto px-2 pb-2">
+      <ScrollArea className="min-h-0 flex-1">
+        <nav className="px-2 pb-2">
         {filtered.length === 0 ? (
           rooms.length === 0 ? (
             <EmptyState size="sm" icon={Boxes} title="No rooms yet" description="Create one with the + above." />
@@ -141,7 +143,8 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
             );
           })
         )}
-      </nav>
+        </nav>
+      </ScrollArea>
 
       {/* Footer */}
       <div className="flex items-center gap-1 border-t border-border px-3 py-2">

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -366,3 +366,42 @@ export async function fetchEpisode(
   if (!res.ok) return null;
   return res.json();
 }
+
+// ── SLIM coordination fabric (the `/health` coordination block) ──────────────
+
+/** Per-room channel telemetry: present members (SLIM + server-held `await`
+ *  leases), open consent invites, episode state, and durable-inbox counters. */
+export interface CoordinationRoom {
+  room: string;
+  provisioned: boolean;
+  persister_alive: boolean;
+  members: string[];
+  pending_invites: number;
+  episode_active: boolean;
+  reserves: number;
+  reserve_failures: number;
+  reserve_skipped: number;
+  receive_errors: number;
+  transient_errors: number;
+}
+
+/** The fabric-wide view: SLIM node endpoint, live-channel + provision counters,
+ *  and one entry per provisioned room. */
+export interface CoordinationStatus {
+  endpoint: string;
+  slim_enabled: boolean;
+  channels_live: number;
+  provisions_ok: number;
+  provisions_failed: number;
+  invite_failures: number;
+  rooms: CoordinationRoom[];
+}
+
+/** Read the SLIM coordination telemetry from the backend `/health` endpoint.
+ *  Fail-soft: returns null when the backend is unreachable or has no block. */
+export async function fetchCoordination(): Promise<CoordinationStatus | null> {
+  const res = await fetch(`/api/health`, { cache: "no-store" });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return data?.coordination ?? null;
+}

--- a/mycelium-frontend/src/mocks/handlers.ts
+++ b/mycelium-frontend/src/mocks/handlers.ts
@@ -46,7 +46,47 @@ export async function handleMock(req: Request): Promise<Response | null> {
   }
 
   // ── /health ─────────────────────────────────────────────────────────────────
-  if (rest[0] === "health") return json({ status: "ok", mock: true });
+  if (rest[0] === "health")
+    return json({
+      status: "ok",
+      mock: true,
+      coordination: {
+        endpoint: "http://mycelium-slim:46357",
+        slim_enabled: true,
+        channels_live: 2,
+        provisions_ok: 2,
+        provisions_failed: 0,
+        invite_failures: 0,
+        rooms: [
+          {
+            room: "atlas-migration",
+            provisioned: true,
+            persister_alive: true,
+            members: ["planner", "julia"],
+            pending_invites: 1,
+            episode_active: true,
+            reserves: 3,
+            reserve_failures: 0,
+            reserve_skipped: 0,
+            receive_errors: 0,
+            transient_errors: 0,
+          },
+          {
+            room: "design-review",
+            provisioned: true,
+            persister_alive: true,
+            members: [],
+            pending_invites: 0,
+            episode_active: false,
+            reserves: 0,
+            reserve_failures: 0,
+            reserve_skipped: 0,
+            receive_errors: 0,
+            transient_errors: 0,
+          },
+        ],
+      },
+    });
 
   if (rest[0] !== "rooms") return null;
 


### PR DESCRIPTION
Closes #485, #486, #487, #488, #489, #490.

Driving the coordination stack end-to-end (two machines through a shared SLIM node) surfaced a cluster of issues that made agent-to-agent coordination hard to see and hard to reason about. This fixes them across the backend, CLI, and frontend.

## Backend — server-held presence (#487, #488)
`ServerHeld` `await` leases weren't counted as presence. A bare-CLI agent long-polling `await` looked absent, so an `@mention` of it was shunted into a consent invite whose accept then **hung** on a SLIM invite to a non-connected member.
- `status()` reports the SLIM-members-plus-leases roster → awaiting agents show on `/health` (#488)
- `publish_human` treats lease-holders as present → `@mention` is a wake, not an invite (#487)
- `accept_invite` schedules the SLIM invite off the request path → no HTTP hang (#487)

## Backend — aligner explains the stall (#489)
Summoned with fewer than two participants holding positions, the aligner opened a throwaway episode, rejected it, and left the summoner with **silence**. It now posts a brain-authored (fail-soft to a static line) explanation of why it can't align and what to do next, without opening an episode.

## CLI (#485, #486)
- `mycelium network [room]` — surfaces SLIM coordination telemetry from `/health` (node, channel/provision counters, per-room members + durable-inbox counters), with `--json`
- `room messages` no longer truncates content to 100 chars; multi-line messages stay readable

## Frontend (#486, #490)
- New **SLIM** per-room view (5th toggle beside Channel/Negotiate/L9/Plan): this room's channel — node it rides, present members, episode state, pending invites, durable-inbox counters
- `/api/health` proxy fix: the backend serves health at root `/health`, so `/api/health` was 404-ing — the global health indicator never actually read health
- **Live feed fix (#490):** the SSE stream delivers messages as L9 envelopes (`l9_exchange`), but `EventStream` only parsed the REST `broadcast` shape, so live messages never rendered — you had to refresh. `parseEvent` now unwraps the envelope and normalizes it; live negotiations render as they happen. Unhandled message types now `console.warn` loudly instead of vanishing silently.
- rooms sidebar uses the `ScrollArea` primitive; chat textarea refocuses after send

## Tests
Backend 384 passed, CLI 428 passed, frontend 12 passed; ruff/format/ty and tsc clean. The presence fix, SLIM view, live rendering, and aligner reply were also verified live against a running backend + node.