### PR TITLE
docs: add paste-to-your-agent onboarding via agents.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,19 @@ mycelium plan tasks   # the - [ ] checklist the team now executes against
 You'll need **Docker**, an **LLM API key** (agents can't negotiate without
 one), and **at least one agent runtime** (Claude Code).
 
+**Onboard your agent.** The fastest setup is to let an agent do it — paste
+this prompt into Claude Code (or any agent runtime with a shell):
+
+```text
+Use curl to read https://mycelium-io.github.io/mycelium/agents.md and perform the setup to install Mycelium
+```
+
+The agent follows [agents.md](https://mycelium-io.github.io/mycelium/agents.md),
+a setup runbook written for agents: it installs the CLI, brings up the stack,
+and connects its own runtime as an adapter.
+
+Or install by hand:
+
 ```bash
 # 1. Install the CLI and bring up the stack
 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,148 @@
+---
+name: mycelium-setup
+description: Set up and maintain Mycelium (install the CLI, bring up the stack, connect your agent runtime)
+user-invocable: true
+allowed-tools: Bash(command:*), Bash(curl:*), Bash(docker:*), Bash(mycelium:*), Bash(uv:*)
+metadata:
+  author: mycelium
+---
+
+# Mycelium Setup
+
+Set up or maintain Mycelium with minimal friction. If you are running this
+prompt, you are an agent: your goal is to follow the steps below and stand up
+Mycelium for the user — CLI, stack, and the adapter that connects your own
+runtime to it — so the user can put you (and other agents) in a shared room to
+coordinate.
+
+Mycelium is a coordination layer for teams of autonomous agents: persistent
+rooms, shared markdown memory, and mediated negotiation over an encrypted SLIM
+channel. Full docs: <https://mycelium-io.github.io/mycelium/> (LLM-friendly
+single file: <https://mycelium-io.github.io/mycelium/llms-full.txt>).
+
+## Step 1: Install or upgrade the CLI
+
+Check whether the CLI exists:
+
+```bash
+command -v mycelium
+```
+
+If missing, install it:
+
+```bash
+curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
+```
+
+The installer places a standalone `mycelium` binary on the PATH (it may ask
+you to open a new shell or source your shell profile; do that before
+continuing). If `mycelium` is already present, make sure it is current:
+
+```bash
+mycelium upgrade --check   # report whether a newer release exists
+mycelium upgrade           # fetch it
+```
+
+Verify with `mycelium --version`.
+
+## Step 2: Check prerequisites
+
+The stack runs as containers, so Docker with the compose plugin must be
+available:
+
+```bash
+docker info --format '{{.ServerVersion}}'
+docker compose version
+```
+
+If either fails, stop and tell the user to install or start Docker first —
+do not attempt to install Docker yourself.
+
+## Step 3: Bring up the stack
+
+First check whether Mycelium is already installed on this machine:
+
+```bash
+mycelium status
+```
+
+If it reports healthy services, skip to Step 4. If Mycelium is installed but
+services are down or misconfigured, prefer repair over reinstall:
+
+```bash
+mycelium up        # start the SLIM node + backend
+mycelium doctor    # diagnose and fix configuration issues
+```
+
+For a fresh install, you need the user's LLM configuration: negotiation is
+mediated by an LLM, so ask the user which provider/model to use and for an API
+key. Never invent or reuse a key without asking. Then run the non-interactive
+installer:
+
+```bash
+mycelium install -n \
+  --llm-model anthropic/claude-sonnet-4-6 \
+  --llm-api-key <KEY_FROM_USER>
+```
+
+- `--llm-model` takes `provider/model` format (e.g. `anthropic/claude-sonnet-4-6`,
+  `openai/gpt-4o`, `ollama/llama3`).
+- Add `--llm-base-url <url>` for Ollama or other local/custom endpoints.
+- If the user wants to defer the LLM decision, run `mycelium install -n` with
+  no LLM flags: memory and rooms work immediately, but agents cannot converge
+  in negotiation until a model is configured
+  (`mycelium config set llm.model <model>` + `mycelium config apply`).
+
+If instead you are running in a real interactive terminal alongside the user,
+plain `mycelium install` walks them through the same choices with prompts.
+
+## Step 4: Verify
+
+```bash
+mycelium status
+mycelium doctor
+```
+
+`status` checks the backend, SLIM node, LLM, and containers; `doctor`
+diagnoses and offers to fix anything misconfigured (pass `--fix` to apply
+fixes without prompting). Don't proceed until the backend is reachable.
+
+## Step 5: Connect your agent runtime
+
+Install the adapter for the runtime you are running in, so this and future
+sessions know how to participate in rooms:
+
+```bash
+mycelium adapter add claude-code   # Claude Code: installs the mycelium skill + lifecycle hooks into ~/.claude/
+mycelium adapter add cursor        # Cursor: drops workspace rules at agent-create time
+```
+
+The user may need to restart their agent session if the runtime doesn't
+hot-reload skills (Claude Code doesn't). Optionally wire up the shared daemon
+so agents can be cold-spawned when a room mentions them while no session is
+awake:
+
+```bash
+mycelium adapter add claude-code --step=daemon
+```
+
+## Step 6: Suggest a first run
+
+Setup is done. Tell the user the human surface is the UI — `mycelium ui open`
+— where they create rooms, add agents, and watch a negotiation live. Offer to
+walk the CLI equivalent right now:
+
+```bash
+mycelium room create my-project && mycelium room use my-project
+mycelium engine create aligner --kind aligner --room my-project
+
+# Post an opening position, then summon the mediator
+mycelium respond --room my-project --handle <your-handle> "…your opening position…"
+mycelium engine invoke aligner "converge on <the open question>"
+
+# Loop: wait to be addressed, then reply — until the room converges
+mycelium await   --room my-project --handle <your-handle> --json
+mycelium respond --room my-project --handle <your-handle> "…your reply…"
+
+mycelium plan tasks   # the shared checklist the consensus compiled into
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -138,6 +138,10 @@
     <section class="doc-section" id="quickstart">
       <h1>Quick Start</h1>
       <h2 id="quickstart-install">Install</h2>
+      <p><strong>Onboard your agent.</strong> Mycelium is built for agents, so the fastest setup is to let one do it: paste this prompt into your agent (Claude Code, Cursor, any runtime with a shell):</p>
+      <pre><code>Use curl to read https://mycelium-io.github.io/mycelium/agents.md and perform the setup to install Mycelium</code></pre>
+      <p>The agent fetches <a href="agents.md">agents.md</a>, a setup runbook written for agents, and walks it end to end: install the CLI, bring up the stack, connect its own runtime as an adapter, and offer a first coordination run.</p>
+      <p>Prefer to install by hand? The same flow, step by step:</p>
       <pre><code>curl <span class="flag">-fsSL</span> https://mycelium-io.github.io/mycelium/install.sh | bash</code></pre>
       <p>The installer sets up the CLI, prompts for your LLM provider, then brings up the stack via <code>docker compose</code>: a <strong>SLIM node</strong> (the encrypted messaging fabric agents coordinate over) and a thin <strong>backend</strong> that moderates each room. There is no database: rooms and memory are files on disk.</p>
       <p>Run <code>mycelium --help</code> after install to verify.</p>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -70,6 +70,20 @@ the same dead end.
 
 ## Install
 
+**Onboard your agent.** Mycelium is built for agents, so the fastest setup is
+to let one do it: paste this prompt into your agent (Claude Code, Cursor, any
+runtime with a shell):
+
+```text
+Use curl to read https://mycelium-io.github.io/mycelium/agents.md and perform the setup to install Mycelium
+```
+
+The agent fetches [agents.md](agents.md), a setup runbook written for agents,
+and walks it end to end: install the CLI, bring up the stack, connect its own
+runtime as an adapter, and offer a first coordination run.
+
+Prefer to install by hand? The same flow, step by step:
+
 ```bash
 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
 ```

--- a/mycelium-cli/src/mycelium/docs/quickstart.md
+++ b/mycelium-cli/src/mycelium/docs/quickstart.md
@@ -2,6 +2,20 @@
 
 ## Install
 
+**Onboard your agent.** Mycelium is built for agents, so the fastest setup is
+to let one do it: paste this prompt into your agent (Claude Code, Cursor, any
+runtime with a shell):
+
+```text
+Use curl to read https://mycelium-io.github.io/mycelium/agents.md and perform the setup to install Mycelium
+```
+
+The agent fetches [agents.md](agents.md), a setup runbook written for agents,
+and walks it end to end: install the CLI, bring up the stack, connect its own
+runtime as an adapter, and offer a first coordination run.
+
+Prefer to install by hand? The same flow, step by step:
+
 ```bash
 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
 ```


### PR DESCRIPTION
## Summary

Adds a paste-to-your-agent onboarding path, modeled on Parallel's `parallel.ai/agents.md` strategy: the user pastes a single prompt into their agent (Claude Code, Cursor, any runtime with a shell), and the agent fetches a setup runbook written for agents and performs the whole install itself.

## Changes

- **`docs/agents.md`** (new): an agent-facing setup runbook served at `https://mycelium-io.github.io/mycelium/agents.md` once merged (`docs/` is the Pages root and `.nojekyll` means the raw markdown is served verbatim, same as `install.sh`). Six steps, all real CLI surface:
  1. Install or upgrade the CLI (`command -v mycelium`, the curl installer, `mycelium upgrade --check`)
  2. Check Docker + compose prerequisites (stop and defer to the user rather than installing Docker)
  3. Bring up the stack — repair paths (`mycelium up` / `mycelium doctor`) if already installed, otherwise `mycelium install -n --llm-model … --llm-api-key …`, with an explicit instruction to ask the user for the key rather than invent one
  4. Verify with `mycelium status` / `mycelium doctor`
  5. Connect the agent's own runtime: `mycelium adapter add claude-code` (or `cursor`), session-restart caveat, optional `--step=daemon`
  6. Suggest a first run: room → aligner → position → invoke → await/respond → `plan tasks`, plus `mycelium ui open` for the human
- **Quick Start** (`mycelium-cli/src/mycelium/docs/quickstart.md` + regenerated `docs/index.html` / `docs/llms-full.txt`): the copyable prompt — `Use curl to read https://mycelium-io.github.io/mycelium/agents.md and perform the setup to install Mycelium` — now leads the Install section, with the manual path kept below as "or install by hand".
- **README.md**: same onboarding prompt at the top of Quick Start.

## Testing

Docs-only change; regenerated the site via `uv run python ../docs/generate_docs.py` and verified the rendered install section in `index.html`. No Python code touched.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — not applicable, no code changes
- [x] Linting passes (`uv run ruff check .`) — not applicable, no code changes
- [x] Format check passes (`uv run ruff format --check .`) — not applicable, no code changes

## Related Issues

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRiuAYLE7wCLjA5RVYBG2p

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRiuAYLE7wCLjA5RVYBG2p)_