### PR TITLE
First-class principal layer: agent owner/team + user store + attribution (#495)

### DIFF
--- a/contracts/user-store.json
+++ b/contracts/user-store.json
@@ -1,0 +1,41 @@
+{
+  "_comment": [
+    "Frozen contract for the global user store, which both the FastAPI backend",
+    "(fastapi-backend/app/services/principals.py) and the thin uv-tool CLI",
+    "(mycelium-cli/src/mycelium/protocol.py + commands/user.py) reproduce",
+    "independently — the CLI can't import the backend, so each carries its own",
+    "load_user / write_user / get_users_dir.",
+    "",
+    "Both test suites read THIS file and assert their own primitives against it,",
+    "so the two copies can't silently drift (a divergent store dir, tag, version",
+    "rule, normalization, or frontmatter body would make records one side writes",
+    "unreadable — or mis-rolled-up — by the other). If a change to the shared",
+    "shape is genuinely intended, update this file in the same change and both",
+    "suites re-lock to the new value.",
+    "",
+    "Tests: fastapi-backend/tests/test_user_store_contract.py,",
+    "mycelium-cli/tests/test_user_store_contract.py"
+  ],
+
+  "store_dirname": "users",
+  "manifest_tag": "user-manifest",
+  "initial_version": 1,
+
+  "normalize": {
+    "_comment": "handle + team slugs are @-stripped, trimmed, lower-cased; blank teams dropped.",
+    "input": {
+      "handle": "@Julia",
+      "display_name": "Julia Valenti",
+      "teams": ["@Core", "Infra", "  "],
+      "notify": null
+    },
+    "expected": {
+      "handle": "julia",
+      "display_name": "Julia Valenti",
+      "teams": ["core", "infra"],
+      "notify": null
+    }
+  },
+
+  "serialized_body": "display_name: Julia Valenti\nteams:\n- core\n- infra\nnotify: null"
+}

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -151,6 +151,9 @@ PATCH .../messages/{id}  {<span class="str">&quot;status&quot;</span>: <span cla
 <span class="cmd">mycelium agent ls</span> <span class="flag">--owner</span> julia   # <span class="str">&quot;my agents&quot;</span>
 <span class="cmd">mycelium agent ls</span> <span class="flag">--team</span> core     # <span class="str">&quot;my team&quot;</span>
 
+<span class="comment"># Declare who you are on this machine (sets identity + upserts the user record)</span>
+<span class="cmd">mycelium iam julia</span> <span class="flag">--name</span> <span class="str">&quot;Julia Valenti&quot;</span> <span class="flag">--team</span> core
+
 <span class="comment"># Who am I acting as?</span>
 <span class="cmd">mycelium whoami</span></code></pre>
       <h2 id="users-cost-roll-up">Cost roll-up</h2>

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -49,6 +49,7 @@
     <div class="nav-section">
       <div class="nav-section-label">Concepts</div>
       <a href="#rooms" class="nav-link sub">Rooms</a>
+      <a href="#users" class="nav-link sub">Users &amp; Teams</a>
       <a href="#episodes" class="nav-link sub">Episodes</a>
       <a href="#memory" class="nav-link sub">Memory</a>
       <a href="#plan" class="nav-link sub">Plan</a>
@@ -120,6 +121,42 @@
 GET .../messages?kind=action&amp;status=open        # the ledger: what&#x27;s still open
 PATCH .../messages/{id}  {<span class="str">&quot;status&quot;</span>: <span class="str">&quot;resolved&quot;</span>}  # close it out (broadcast over SSE)</code></pre>
       <p>The kind vocabulary is open. Post your own (<code>note</code>, <code>decision</code>, <code>ci_result</code>, ...) and it works today: stateless and durable unless you set a TTL. Events arrive on the room&#x27;s SSE stream like any message; clients that don&#x27;t know a kind just show the <code>content</code> line.</p>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="users">
+      <h1>Users &amp; teams</h1>
+      <p>Mycelium models <em>whom an agent belongs to</em>. Without it, every agent on the fabric is anonymous: presence says &quot;agent-y is live,&quot; never &quot;julia&#x27;s agent-y is live.&quot; Ownership gives scoping (&quot;my agents&quot; vs another team&#x27;s), attribution (whose agent edited that?), and routing (escalate back to an agent&#x27;s owner).</p>
+      <p>Two entities, symmetric on disk:</p>
+      <ul>
+        <li><strong>Agents</strong> are room-scoped (<code>rooms/{room}/agents/{handle}</code>). A manifest can name</li>
+      </ul>
+      <p>an <code>owner</code> (a user handle) and a <code>team</code> (a slug).</p>
+      <ul>
+        <li><strong>Users</strong> are global (<code>users/{handle}</code>), because a person spans rooms. A user is</li>
+      </ul>
+      <p>what an <code>owner</code> points at.</p>
+      <h2 id="users-self-asserted-for-now">Self-asserted, for now</h2>
+      <p>At this tier trust is exactly today&#x27;s handles: <strong>consistent, not cryptographic</strong>. <code>owner: julia</code> is a claim, not a verified identity; anyone can assert it. That&#x27;s deliberate: it shapes the model right so scoping, attribution, and routing have real slots to read, ahead of verified identity (per-member SLIM binding / JWT / SPIRE) filling those slots with signed claims. Don&#x27;t rely on it for access control.</p>
+      <p>Both fields default to empty, so nothing about existing agents changes: an agent with no owner is unowned.</p>
+      <h2 id="users-commands">Commands</h2>
+      <pre><code><span class="comment"># Register a human, once, globally</span>
+<span class="cmd">mycelium user create</span> julia <span class="flag">--name</span> <span class="str">&quot;Julia Valenti&quot;</span> <span class="flag">--team</span> core
+<span class="cmd">mycelium user ls</span>
+<span class="cmd">mycelium user show</span> julia          # record + the agents she owns + summed budget
+
+<span class="comment"># Bind an agent to its owner</span>
+<span class="cmd">mycelium agent create</span> release-agent <span class="flag">--cwd</span> ~/repo <span class="flag">--owner</span> julia <span class="flag">--team</span> core
+<span class="cmd">mycelium agent ls</span> <span class="flag">--owner</span> julia   # <span class="str">&quot;my agents&quot;</span>
+<span class="cmd">mycelium agent ls</span> <span class="flag">--team</span> core     # <span class="str">&quot;my team&quot;</span>
+
+<span class="comment"># Who am I acting as?</span>
+<span class="cmd">mycelium whoami</span></code></pre>
+      <h2 id="users-cost-roll-up">Cost roll-up</h2>
+      <p>Budget is a per-agent field (<code>budget_usd_per_month</code>). A user&#x27;s cost is the <strong>sum of the budgets of the agents they own</strong>: the honest figure this tier can report without a per-action cost ledger. <code>user show</code> and <code>whoami</code> roll it up per user; <code>GET /api/teams</code> rolls it up per team.</p>
+      <h2 id="users-in-the-ui">In the UI</h2>
+      <p>Agent rows show their owner and team. An <strong>acting-as</strong> picker (top of a room) selects the user the browser represents; the <strong>mine</strong> filter then scopes the agent roster to agents you own or your team fields. The acting-as choice is stored locally in the browser: the same self-asserted handle, no login.</p>
     </section>
 
     <hr class="divider">

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -53,6 +53,7 @@ SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
     ("quickstart.md",               "quickstart",         "start",       "Get Started",  "Quick Start"),
     # ── concepts (concepts.html) ──
     ("rooms.md",                    "rooms",              "concepts",    "Concepts",     "Rooms"),
+    ("principals.md",               "users",              "concepts",    "Concepts",     "Users & Teams"),
     ("episodes.md",                 "episodes",           "concepts",    "Concepts",     "Episodes"),
     ("memory.md",                   "memory",             "concepts",    "Concepts",     "Memory"),
     ("plan.md",                     "plan",               "concepts",    "Concepts",     "Plan"),

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -349,6 +349,65 @@ The kind vocabulary is open. Post your own (`note`, `decision`, `ci_result`, ...
 
 ---
 
+# Users & teams
+
+Mycelium models *whom an agent belongs to*. Without it, every agent on the fabric
+is anonymous: presence says "agent-y is live," never "julia's agent-y is live."
+Ownership gives scoping ("my agents" vs another team's), attribution (whose agent
+edited that?), and routing (escalate back to an agent's owner).
+
+Two entities, symmetric on disk:
+
+- **Agents** are room-scoped (`rooms/{room}/agents/{handle}`). A manifest can name
+  an `owner` (a user handle) and a `team` (a slug).
+- **Users** are global (`users/{handle}`), because a person spans rooms. A user is
+  what an `owner` points at.
+
+## Self-asserted, for now
+
+At this tier trust is exactly today's handles: **consistent, not cryptographic**.
+`owner: julia` is a claim, not a verified identity; anyone can assert it. That's
+deliberate: it shapes the model right so scoping, attribution, and routing have
+real slots to read, ahead of verified identity (per-member SLIM binding / JWT /
+SPIRE) filling those slots with signed claims. Don't rely on it for access control.
+
+Both fields default to empty, so nothing about existing agents changes: an agent
+with no owner is unowned.
+
+## Commands
+
+```bash
+# Register a human, once, globally
+mycelium user create julia --name "Julia Valenti" --team core
+mycelium user ls
+mycelium user show julia          # record + the agents she owns + summed budget
+
+# Bind an agent to its owner
+mycelium agent create release-agent --cwd ~/repo --owner julia --team core
+mycelium agent ls --owner julia   # "my agents"
+mycelium agent ls --team core     # "my team"
+
+# Who am I acting as?
+mycelium whoami
+```
+
+## Cost roll-up
+
+Budget is a per-agent field (`budget_usd_per_month`). A user's cost is the **sum of
+the budgets of the agents they own**: the honest figure this tier can report
+without a per-action cost ledger. `user show` and `whoami` roll it up per user;
+`GET /api/teams` rolls it up per team.
+
+## In the UI
+
+Agent rows show their owner and team. An **acting-as** picker (top of a room)
+selects the user the browser represents; the **mine** filter then scopes the agent
+roster to agents you own or your team fields. The acting-as choice is stored
+locally in the browser: the same self-asserted handle, no login.
+
+
+---
+
 # Episodes
 
 An episode is one recorded negotiation. Summoning the [aligner](#aligner) on a

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -387,6 +387,9 @@ mycelium agent create release-agent --cwd ~/repo --owner julia --team core
 mycelium agent ls --owner julia   # "my agents"
 mycelium agent ls --team core     # "my team"
 
+# Declare who you are on this machine (sets identity + upserts the user record)
+mycelium iam julia --name "Julia Valenti" --team core
+
 # Who am I acting as?
 mycelium whoami
 ```

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -39,6 +39,7 @@ from app.routes.plan import router as plan_router
 from app.routes.rooms import router as rooms_router
 from app.routes.sessions import router as sessions_router
 from app.routes.stream import router as stream_router
+from app.routes.users import router as users_router
 
 from .config import settings
 
@@ -198,6 +199,7 @@ app.include_router(stream_router, prefix="/api")
 app.include_router(memory_router, prefix="/api")
 app.include_router(plan_router, prefix="/api")
 app.include_router(agent_context_router, prefix="/api")
+app.include_router(users_router, prefix="/api")
 
 
 @app.get("/", tags=["health"])

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -25,7 +25,7 @@ from app.schemas import (
     MessageRead,
     MessageType,
 )
-from app.services import local_state, persister, room_channels
+from app.services import local_state, persister, principals, room_channels
 from app.services.filesystem import room_exists
 
 logger = logging.getLogger(__name__)
@@ -53,6 +53,15 @@ def _resolve_channel(name: str) -> tuple[str, local_state.CoordSessionShim | Non
 async def send_message(room_name: str, payload: MessageCreate):
     """Send a message to a room; publish it to the room's live stream."""
     channel, coord = _resolve_channel(room_name)
+
+    # A human posts under a self-asserted handle (may be unregistered), but no
+    # one may pose as an engine — engines speak only through their own runtime.
+    base_room = channel.split(":session:", 1)[0]
+    reason = principals.post_rejection_reason(
+        base_room, payload.sender_handle, allow_unregistered=True
+    )
+    if reason:
+        raise HTTPException(status_code=403, detail=reason)
 
     msg = local_state.StoredMessage(
         room_name=None if coord else channel,

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -32,7 +32,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
-from app.services import l9, room_channels
+from app.services import l9, principals, room_channels
 from app.services.filesystem import room_exists
 from app.services.l9_models import Kind
 from app.services.l9_slim import serialize_content
@@ -190,6 +190,12 @@ async def post_reply(room_name: str, body: ReplyBody):
     """Publish ``handle``'s reply as an L9 agent exchange the aligner scores."""
     if not room_exists(room_name):
         raise HTTPException(status_code=404, detail="Room not found")
+    # The reply rides as sender_role="agent", so the handle must be a real
+    # principal — a registered agent or a known user — and never an engine
+    # (engines aren't impersonable). Guard before provisioning a channel.
+    reason = principals.post_rejection_reason(room_name, body.handle, allow_unregistered=False)
+    if reason:
+        raise HTTPException(status_code=403, detail=reason)
     managed = await room_channels.manager.provision(room_name)
     room_channels.manager.refresh_lease(room_name, body.handle)
     if managed is None or managed.persister is None:

--- a/fastapi-backend/app/routes/users.py
+++ b/fastapi-backend/app/routes/users.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+User + team endpoints — the human as a first-class principal.
+
+The user store is global (people span rooms), unlike the room-scoped agent
+manifests. Owner/team on a manifest point here; these endpoints surface the
+records and the per-user / per-team budget roll-ups. Self-asserted: handles are
+consistent, not cryptographic.
+
+GET  /users            — list users, each with owned-agent + budget roll-up
+POST /users            — create/upsert a user record
+GET  /users/{handle}   — one user + the agents they own
+GET  /teams            — teams rolled up from manifests + user memberships
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from app.schemas import (
+    TeamListResponse,
+    TeamRead,
+    UserCreate,
+    UserListResponse,
+    UserRead,
+)
+from app.services import principals
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["users"])
+
+
+@router.get("/users", response_model=UserListResponse)
+async def list_users():
+    """List every registered user with their owned-agent budget roll-up."""
+    users = [UserRead(**u) for u in principals.list_users_with_rollup()]
+    return UserListResponse(users=users, total=len(users))
+
+
+@router.post("/users", response_model=UserRead, status_code=201)
+async def create_user(payload: UserCreate):
+    """Create or upsert a user in the global store."""
+    principals.write_user(payload.model_dump())
+    user = principals.user_with_rollup(payload.handle)
+    if user is None:  # pragma: no cover — just written
+        raise HTTPException(status_code=500, detail="user write did not persist")
+    return UserRead(**user)
+
+
+@router.get("/users/{handle}", response_model=UserRead)
+async def get_user(handle: str):
+    """One user record plus the agents they own."""
+    user = principals.user_with_rollup(handle)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return UserRead(**user)
+
+
+@router.get("/teams", response_model=TeamListResponse)
+async def list_teams():
+    """Teams rolled up from agent manifests and user memberships."""
+    teams = [TeamRead(**t) for t in principals.list_teams()]
+    return TeamListResponse(teams=teams, total=len(teams))

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -352,6 +352,59 @@ class MemorySearchResponse(BaseModel):
     total: int
 
 
+# ── Principal (self-asserted user store) ──────────────────────────────────────
+# The human made first-class, symmetric with agents/<handle>. An agent's owner
+# points at a users/<handle>; a team groups these handles. Trust is self-asserted
+# — the handle is consistent, not cryptographic.
+
+
+class UserCreate(BaseModel):
+    handle: str = Field(..., min_length=1, pattern=r"^[a-z0-9][a-z0-9._-]*$")
+    display_name: str = ""
+    teams: list[str] = Field(default_factory=list)
+    notify: str | None = None
+
+
+class OwnedAgentRead(BaseModel):
+    """One agent bound to a principal, with its room and manifest budget."""
+
+    room: str
+    handle: str
+    adapter: str
+    team: str | None = None
+    budget_usd_per_month: float = 0.0
+
+
+class UserRead(BaseModel):
+    handle: str
+    display_name: str = ""
+    teams: list[str] = Field(default_factory=list)
+    notify: str | None = None
+    # Budget roll-up: agents this user owns and the sum of their manifest budget
+    # caps (not measured spend — there's no per-action cost ledger at this tier).
+    owns: list[OwnedAgentRead] = Field(default_factory=list)
+    budget_usd_per_month: float = 0.0
+
+
+class UserListResponse(BaseModel):
+    users: list[UserRead]
+    total: int
+
+
+class TeamRead(BaseModel):
+    """A team, rolled up from the agents fielded under it and its member users."""
+
+    team: str
+    members: list[str] = Field(default_factory=list)
+    agent_count: int = 0
+    budget_usd_per_month: float = 0.0
+
+
+class TeamListResponse(BaseModel):
+    teams: list[TeamRead]
+    total: int
+
+
 class SubscriptionCreate(BaseModel):
     key_pattern: str = Field(..., min_length=1, description="Glob pattern for keys to watch")
     subscriber: str = Field(..., description="Agent handle subscribing")

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -55,6 +55,18 @@ def get_room_dir(room_name: str) -> Path:
     return room_dir
 
 
+def get_users_dir() -> Path:
+    """Get the global users store directory, creating it if needed.
+
+    People span rooms, so the user store is global (a sibling of ``rooms/``)
+    rather than room-scoped like ``agents/``. Records are the same
+    markdown+frontmatter format as any memory, at ``users/<handle>.md``.
+    """
+    users_dir = get_data_dir() / "users"
+    users_dir.mkdir(parents=True, exist_ok=True)
+    return users_dir
+
+
 def _sanitize_filename(key: str) -> str:
     """Convert a memory key to a safe filename.
 

--- a/fastapi-backend/app/services/principals.py
+++ b/fastapi-backend/app/services/principals.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Principal layer — the global user store plus owner/team roll-ups.
+
+A user is one record at ``users/<handle>`` (global, markdown+frontmatter). An
+agent manifest at ``rooms/<room>/agents/<handle>`` may carry ``owner`` (a user
+handle) and ``team`` (a slug). This service reads both and derives the
+per-user / per-team views the CLI and UI surface.
+
+Trust is self-asserted: handles are consistent, not cryptographic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import yaml
+
+from app.services.filesystem import (
+    get_room_dir,
+    get_users_dir,
+    list_memory_files,
+    list_room_names,
+    read_memory_file,
+    write_memory_file,
+)
+
+logger = logging.getLogger(__name__)
+
+
+#: Manifest adapter marking a first-party cognition engine (aligner, synthesizer).
+#: Engines speak only through their own runtime, never an external participation call.
+ENGINE_ADAPTER = "engine"
+
+
+def _norm(handle: str | None) -> str | None:
+    if not handle:
+        return None
+    cleaned = handle.strip().lstrip("@").lower()
+    return cleaned or None
+
+
+def _read_agent_manifest(room: str, handle: str) -> dict[str, Any] | None:
+    """Parse the `agents/<handle>` manifest in a room, or None if absent/unreadable."""
+    result = read_memory_file(get_room_dir(room), f"agents/{handle}")
+    if result is None:
+        return None
+    try:
+        data = yaml.safe_load(result[1]) or {}
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def classify_sender(room: str, handle: str) -> str:
+    """Resolve a handle to what it actually is in this room.
+
+    ``"agent"`` (a registered non-engine manifest), ``"engine"`` (an
+    ``adapter: engine`` manifest), ``"user"`` (a record in the global store), or
+    ``"unknown"`` (a phantom handle that resolves to neither).
+    """
+    h = _norm(handle)
+    if not h:
+        return "unknown"
+    manifest = _read_agent_manifest(room, h)
+    if manifest is not None:
+        return "engine" if manifest.get("adapter") == ENGINE_ADAPTER else "agent"
+    if load_user(h) is not None:
+        return "user"
+    return "unknown"
+
+
+def post_rejection_reason(room: str, handle: str, *, allow_unregistered: bool) -> str | None:
+    """Why ``handle`` may not post in ``room``, or None if it may.
+
+    An **engine** is never impersonable through a participation call (drive it
+    with ``engine invoke``). A **phantom** handle (neither agent nor user) is
+    rejected on the agent path; the human/broadcast path passes
+    ``allow_unregistered=True`` so an anonymous chat handle still works.
+    """
+    kind = classify_sender(room, handle)
+    if kind == "engine":
+        return (
+            f"'{_norm(handle)}' is an engine and can't be posted as; "
+            "drive it with `mycelium engine invoke`."
+        )
+    if kind == "unknown" and not allow_unregistered:
+        return (
+            f"'{_norm(handle)}' is not a registered agent or user; register it first "
+            "(`mycelium agent create` or `mycelium user create`)."
+        )
+    return None
+
+
+def load_user(handle: str) -> dict[str, Any] | None:
+    """Read a user record and return its normalized fields, or None."""
+    key = _norm(handle)
+    if not key:
+        return None
+    result = read_memory_file(get_users_dir(), key)
+    if result is None:
+        return None
+    _meta, content = result
+    try:
+        data = yaml.safe_load(content) or {}
+    except yaml.YAMLError:
+        logger.warning("user %s: invalid YAML", key)
+        return None
+    if not isinstance(data, dict):
+        return None
+    teams = data.get("teams") or []
+    return {
+        "handle": key,
+        "display_name": data.get("display_name", "") or "",
+        "teams": [t for t in (_norm(t) for t in teams) if t],
+        "notify": data.get("notify"),
+    }
+
+
+def list_users() -> list[dict[str, Any]]:
+    """Every user record in the global store."""
+    out: list[dict[str, Any]] = []
+    for key, _meta, _content in list_memory_files(get_users_dir(), limit=1000):
+        # The store is flat: one record per handle, no nested keys.
+        if "/" in key:
+            continue
+        user = load_user(key)
+        if user is not None:
+            out.append(user)
+    return out
+
+
+def write_user(payload: dict[str, Any]) -> dict[str, Any]:
+    """Create or upsert a user record. Returns the normalized user."""
+    handle = _norm(payload.get("handle"))
+    if not handle:
+        msg = "user handle is required"
+        raise ValueError(msg)
+    teams = [t for t in (_norm(t) for t in payload.get("teams") or []) if t]
+    body = {
+        "display_name": payload.get("display_name", "") or "",
+        "teams": teams,
+        "notify": payload.get("notify"),
+    }
+    yaml_body = yaml.safe_dump(body, sort_keys=False, default_flow_style=False).strip()
+
+    existing = read_memory_file(get_users_dir(), handle)
+    version = 1
+    if existing is not None:
+        try:
+            version = int(existing[0].get("version", 1)) + 1
+        except (TypeError, ValueError):
+            version = 1
+    write_memory_file(
+        get_users_dir(),
+        handle,
+        yaml_body,
+        created_by=payload.get("created_by", "system"),
+        version=version,
+        tags=["user-manifest"],
+    )
+    return {"handle": handle, **body}
+
+
+def iter_agent_manifests() -> list[dict[str, Any]]:
+    """Every agent manifest across all rooms, with room + parsed principal fields.
+
+    Each entry: ``{room, handle, adapter, owner, team, budget_usd_per_month}``.
+    """
+    out: list[dict[str, Any]] = []
+    for room_name in list_room_names():
+        room_dir = get_room_dir(room_name)
+        for key, _meta, content in list_memory_files(room_dir, prefix="agents/", limit=1000):
+            handle = key.removeprefix("agents/")
+            # Manifests live at agents/<handle>; skip notes + log children.
+            if "/" in handle:
+                continue
+            try:
+                data = yaml.safe_load(content) or {}
+            except yaml.YAMLError:
+                continue
+            if not isinstance(data, dict):
+                continue
+            try:
+                budget = float(data.get("budget_usd_per_month", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                budget = 0.0
+            out.append(
+                {
+                    "room": room_name,
+                    "handle": handle,
+                    "adapter": data.get("adapter", "claude_code"),
+                    "owner": _norm(data.get("owner")),
+                    "team": _norm(data.get("team")),
+                    "budget_usd_per_month": budget,
+                }
+            )
+    return out
+
+
+def _apply_rollup(user: dict[str, Any], manifests: list[dict[str, Any]]) -> dict[str, Any]:
+    """Attach the owned-agent list + summed budget cap to a user record in place."""
+    owned = [m for m in manifests if m["owner"] == user["handle"]]
+    user["owns"] = [
+        {
+            "room": m["room"],
+            "handle": m["handle"],
+            "adapter": m["adapter"],
+            "team": m["team"],
+            "budget_usd_per_month": m["budget_usd_per_month"],
+        }
+        for m in owned
+    ]
+    user["budget_usd_per_month"] = round(sum(m["budget_usd_per_month"] for m in owned), 2)
+    return user
+
+
+def user_with_rollup(handle: str) -> dict[str, Any] | None:
+    """A user record enriched with the agents they own + summed budget cap."""
+    user = load_user(handle)
+    if user is None:
+        return None
+    return _apply_rollup(user, iter_agent_manifests())
+
+
+def list_users_with_rollup() -> list[dict[str, Any]]:
+    """All users, each enriched with their owned-agent roll-up (one manifest scan)."""
+    manifests = iter_agent_manifests()
+    return [_apply_rollup(user, manifests) for user in list_users()]
+
+
+def list_teams() -> list[dict[str, Any]]:
+    """Teams rolled up from agent manifests and user records.
+
+    A team's members are the users who claim it; its budget is the sum of every
+    manifest budget fielded under that team slug.
+    """
+    manifests = iter_agent_manifests()
+    users = list_users()
+
+    teams: dict[str, dict[str, Any]] = {}
+
+    def _slot(name: str) -> dict[str, Any]:
+        return teams.setdefault(
+            name, {"team": name, "members": set(), "agent_count": 0, "budget_usd_per_month": 0.0}
+        )
+
+    for m in manifests:
+        if m["team"]:
+            slot = _slot(m["team"])
+            slot["agent_count"] += 1
+            slot["budget_usd_per_month"] += m["budget_usd_per_month"]
+    for u in users:
+        for team in u["teams"]:
+            _slot(team)["members"].add(u["handle"])
+
+    return [
+        {
+            "team": name,
+            "members": sorted(slot["members"]),
+            "agent_count": slot["agent_count"],
+            "budget_usd_per_month": round(slot["budget_usd_per_month"], 2),
+        }
+        for name, slot in sorted(teams.items())
+    ]

--- a/fastapi-backend/app/services/principals.py
+++ b/fastapi-backend/app/services/principals.py
@@ -150,6 +150,10 @@ def write_user(payload: dict[str, Any]) -> dict[str, Any]:
     existing = read_memory_file(get_users_dir(), handle)
     version = 1
     if existing is not None:
+        # Content-idempotent: re-writing the same record is a no-op (no version
+        # bump), so repeated upserts converge instead of counting up forever.
+        if existing[1].strip() == yaml_body:
+            return {"handle": handle, **body}
         try:
             version = int(existing[0].get("version", 1)) + 1
         except (TypeError, ValueError):

--- a/fastapi-backend/tests/test_principal_enforcement.py
+++ b/fastapi-backend/tests/test_principal_enforcement.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Principal enforcement: who may post as whom.
+
+Self-asserted tier, so we can't verify *identity*, but we can enforce *role*:
+an engine is never impersonable, and a phantom handle (neither a registered
+agent nor a known user) can't post through the agent path.
+"""
+
+import pytest
+import yaml
+from httpx import AsyncClient
+
+from app.services import principals
+from app.services.filesystem import get_room_dir, write_memory_file
+
+
+def _seed_agent(room: str, handle: str, *, adapter: str = "claude_code", **extra) -> None:
+    body = {"adapter": adapter, **extra}
+    write_memory_file(
+        get_room_dir(room),
+        f"agents/{handle}",
+        yaml.safe_dump(body, sort_keys=False),
+        created_by="tester",
+    )
+
+
+# ── classify_sender ───────────────────────────────────────────────────────────
+
+
+def test_classify_registered_agent():
+    _seed_agent("r", "bot", adapter="claude_code", cwd="/tmp")
+    assert principals.classify_sender("r", "bot") == "agent"
+
+
+def test_classify_engine():
+    _seed_agent("r", "aligner", adapter="engine", kind="aligner")
+    assert principals.classify_sender("r", "aligner") == "engine"
+
+
+def test_classify_user_normalized():
+    principals.write_user({"handle": "julia"})
+    assert principals.classify_sender("r", "@Julia") == "user"
+
+
+def test_classify_unknown_is_phantom():
+    assert principals.classify_sender("r", "foobar") == "unknown"
+
+
+# ── post_rejection_reason ─────────────────────────────────────────────────────
+
+
+def test_agent_path_rejects_engine_and_phantom_allows_real():
+    _seed_agent("r", "aligner", adapter="engine", kind="aligner")
+    _seed_agent("r", "bot", adapter="claude_code", cwd="/tmp")
+    principals.write_user({"handle": "julia"})
+
+    # engine: never impersonable
+    assert principals.post_rejection_reason("r", "aligner", allow_unregistered=False)
+    # phantom: neither agent nor user
+    assert principals.post_rejection_reason("r", "foobar", allow_unregistered=False)
+    # real agent + known user: allowed
+    assert principals.post_rejection_reason("r", "bot", allow_unregistered=False) is None
+    assert principals.post_rejection_reason("r", "julia", allow_unregistered=False) is None
+
+
+def test_human_path_tolerates_unregistered_but_not_engine():
+    _seed_agent("r", "aligner", adapter="engine", kind="aligner")
+    # a human may post under an unregistered handle (anonymous chat)
+    assert principals.post_rejection_reason("r", "somebody", allow_unregistered=True) is None
+    # but still cannot pose as an engine
+    assert principals.post_rejection_reason("r", "aligner", allow_unregistered=True)
+
+
+# ── /reply route guard ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reply_rejects_engine_impersonation(client: AsyncClient):
+    await client.post("/api/rooms", json={"name": "r"})
+    _seed_agent("r", "aligner", adapter="engine", kind="aligner")
+    resp = await client.post("/api/rooms/r/reply", json={"handle": "aligner", "text": "hi"})
+    assert resp.status_code == 403
+    assert "engine" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_reply_rejects_phantom_handle(client: AsyncClient):
+    await client.post("/api/rooms", json={"name": "r"})
+    resp = await client.post("/api/rooms/r/reply", json={"handle": "foobar", "text": "hi"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reply_lets_registered_agent_past_the_guard(client: AsyncClient):
+    await client.post("/api/rooms", json={"name": "r"})
+    _seed_agent("r", "bot", adapter="claude_code", cwd="/tmp")
+    resp = await client.post("/api/rooms/r/reply", json={"handle": "bot", "text": "hi"})
+    # The guard passes; with no live SLIM channel in the unit env the route then
+    # 503s. The point is it is NOT a 403 — a real agent is allowed to post.
+    assert resp.status_code != 403
+
+
+# ── broadcast (human) route guard ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_broadcast_rejects_engine_impersonation(client: AsyncClient):
+    await client.post("/api/rooms", json={"name": "r"})
+    _seed_agent("r", "aligner", adapter="engine", kind="aligner")
+    resp = await client.post(
+        "/api/rooms/r/messages",
+        json={"message_type": "broadcast", "sender_handle": "aligner", "content": "hi"},
+    )
+    assert resp.status_code == 403
+    assert "engine" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_allows_unregistered_human(client: AsyncClient):
+    await client.post("/api/rooms", json={"name": "r"})
+    resp = await client.post(
+        "/api/rooms/r/messages",
+        json={"message_type": "broadcast", "sender_handle": "user", "content": "hi"},
+    )
+    assert resp.status_code == 201

--- a/fastapi-backend/tests/test_principals.py
+++ b/fastapi-backend/tests/test_principals.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Principal layer — user store, owner/team roll-ups, endpoints.
+
+No database: users are markdown records under a temp ``users/`` dir and agent
+manifests are memory entries under each room. Trust is self-asserted.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+
+async def _register_agent(client: AsyncClient, room: str, handle: str, manifest: dict) -> None:
+    """Write an agent manifest the way the CLI does — a memory entry (YAML body)."""
+    import yaml
+
+    await client.post("/api/rooms", json={"name": room})
+    await client.post(
+        f"/api/rooms/{room}/memory",
+        json={
+            "items": [
+                {
+                    "key": f"agents/{handle}",
+                    "value": yaml.safe_dump(manifest, sort_keys=False),
+                    "created_by": "tester",
+                    "embed": False,
+                    "tags": ["agent-manifest"],
+                }
+            ]
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_user(client: AsyncClient):
+    resp = await client.post(
+        "/api/users",
+        json={"handle": "julia", "display_name": "Julia Valenti", "teams": ["Core"]},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["handle"] == "julia"
+    assert body["teams"] == ["core"]  # normalized
+
+    got = await client.get("/api/users/@Julia")
+    assert got.status_code == 200
+    assert got.json()["display_name"] == "Julia Valenti"
+
+
+@pytest.mark.asyncio
+async def test_unknown_user_404(client: AsyncClient):
+    assert (await client.get("/api/users/nobody")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_user_rollup_sums_owned_agent_budgets(client: AsyncClient):
+    await client.post("/api/users", json={"handle": "julia", "teams": ["core"]})
+    await _register_agent(
+        client,
+        "alpha",
+        "a1",
+        {"adapter": "claude_code", "cwd": "/tmp", "owner": "julia", "budget_usd_per_month": 5.0},
+    )
+    await _register_agent(
+        client,
+        "beta",
+        "a2",
+        {
+            "adapter": "claude_code",
+            "cwd": "/tmp",
+            "owner": "julia",
+            "team": "core",
+            "budget_usd_per_month": 7.5,
+        },
+    )
+    await _register_agent(
+        client,
+        "beta",
+        "a3",
+        {"adapter": "claude_code", "cwd": "/tmp", "owner": "sam", "budget_usd_per_month": 99.0},
+    )
+
+    user = (await client.get("/api/users/julia")).json()
+    assert {o["handle"] for o in user["owns"]} == {"a1", "a2"}
+    assert user["budget_usd_per_month"] == 12.5
+
+
+@pytest.mark.asyncio
+async def test_teams_rollup(client: AsyncClient):
+    await client.post("/api/users", json={"handle": "julia", "teams": ["core"]})
+    await _register_agent(
+        client,
+        "beta",
+        "a2",
+        {
+            "adapter": "claude_code",
+            "cwd": "/tmp",
+            "owner": "julia",
+            "team": "core",
+            "budget_usd_per_month": 7.5,
+        },
+    )
+
+    teams = {t["team"]: t for t in (await client.get("/api/teams")).json()["teams"]}
+    assert "core" in teams
+    assert teams["core"]["agent_count"] == 1
+    assert teams["core"]["budget_usd_per_month"] == 7.5
+    assert "julia" in teams["core"]["members"]

--- a/fastapi-backend/tests/test_user_store_contract.py
+++ b/fastapi-backend/tests/test_user_store_contract.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Contract drift guard for the global user store (backend side).
+
+The user store is duplicated: the thin ``uv tool`` CLI carries its own write/read
+primitives so it need not import this backend. A divergent store dir, frontmatter
+tag, version rule, slug normalization, or serialized body means a record one side
+writes is unreadable — or mis-rolled-up — by the other, silently.
+
+This test freezes the shared shape in ``contracts/user-store.json`` at the repo
+root and asserts the **backend** primitives reproduce it exactly. Its CLI twin is
+``mycelium-cli/tests/test_user_store_contract.py``.
+"""
+
+import json
+from pathlib import Path
+
+from app.services import principals
+from app.services.filesystem import get_data_dir, get_users_dir, read_memory_file
+
+_CONTRACT_PATH = Path(__file__).resolve().parent.parent.parent / "contracts" / "user-store.json"
+
+
+def _contract() -> dict:
+    return json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def test_contract_file_present():
+    assert _CONTRACT_PATH.is_file(), f"missing shared contract file at {_CONTRACT_PATH}"
+
+
+def test_store_dir_matches_contract():
+    g = _contract()
+    assert get_users_dir() == get_data_dir() / g["store_dirname"]
+
+
+def test_normalization_matches_contract():
+    g = _contract()["normalize"]
+    normalized = principals.write_user(dict(g["input"]))
+    assert normalized["handle"] == g["expected"]["handle"]
+    assert normalized["display_name"] == g["expected"]["display_name"]
+    assert normalized["teams"] == g["expected"]["teams"]
+    assert normalized["notify"] == g["expected"]["notify"]
+
+
+def test_serialized_body_and_frontmatter_match_contract():
+    """The record the backend writes matches the frozen body, tag, and version."""
+    g = _contract()
+    principals.write_user(dict(g["normalize"]["input"]))
+    record = read_memory_file(get_users_dir(), g["normalize"]["expected"]["handle"])
+    assert record is not None
+    meta, content = record
+    assert content == g["serialized_body"]
+    assert meta["tags"] == [g["manifest_tag"]]
+    assert meta["version"] == g["initial_version"]
+
+
+def test_upsert_bumps_version():
+    g = _contract()
+    principals.write_user({"handle": "julia"})
+    principals.write_user({"handle": "julia"})
+    record = read_memory_file(get_users_dir(), "julia")
+    assert record is not None
+    assert record[0]["version"] == g["initial_version"] + 1

--- a/fastapi-backend/tests/test_user_store_contract.py
+++ b/fastapi-backend/tests/test_user_store_contract.py
@@ -56,10 +56,16 @@ def test_serialized_body_and_frontmatter_match_contract():
     assert meta["version"] == g["initial_version"]
 
 
-def test_upsert_bumps_version():
+def test_upsert_is_content_idempotent():
     g = _contract()
     principals.write_user({"handle": "julia"})
+    # Same content: no version bump.
     principals.write_user({"handle": "julia"})
+    record = read_memory_file(get_users_dir(), "julia")
+    assert record is not None
+    assert record[0]["version"] == g["initial_version"]
+    # A real change bumps it.
+    principals.write_user({"handle": "julia", "display_name": "Julia"})
     record = read_memory_file(get_users_dir(), "julia")
     assert record is not None
     assert record[0]["version"] == g["initial_version"] + 1

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -31,6 +31,7 @@ from mycelium.commands import (
     plan,
     room,
     ui,
+    user,
 )
 
 app = typer.Typer(
@@ -111,6 +112,7 @@ app.command(name="network")(network.network)
 app.command(name="logs")(instance.logs)
 
 # Top-level shortcuts
+app.command(name="whoami")(user.whoami)
 app.command(name="watch")(room.watch)
 app.command(name="sync")(memory.memory_sync)
 app.command(name="connect")(hub.connect)
@@ -129,6 +131,7 @@ app.add_typer(docs.app, name="docs")
 app.add_typer(metrics.app, name="metrics")
 app.add_typer(ui.app, name="ui")
 app.add_typer(agent.app, name="agent")
+app.add_typer(user.app, name="user")
 app.add_typer(engine.app, name="engine")
 app.add_typer(openshell.app, name="openshell")
 app.add_typer(daemon.app, name="daemon")

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -113,6 +113,7 @@ app.command(name="logs")(instance.logs)
 
 # Top-level shortcuts
 app.command(name="whoami")(user.whoami)
+app.command(name="iam")(user.iam)
 app.command(name="watch")(room.watch)
 app.command(name="sync")(memory.memory_sync)
 app.command(name="connect")(hub.connect)

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -172,6 +172,58 @@ def _load_manifest(room_name: str, handle: str) -> AgentManifest | None:
         return None
 
 
+def _room_manifests(room_name: str) -> list[AgentManifest]:
+    """Every agent manifest registered in a room (skips notes + log children)."""
+    room_dir = get_room_dir(room_name)
+    out: list[AgentManifest] = []
+    for key, _meta, _content in list_memories(room_dir, prefix="agents/", limit=500):
+        handle = key.removeprefix("agents/")
+        if "/" in handle:
+            continue
+        m = _load_manifest(room_name, handle)
+        if m is not None:
+            out.append(m)
+    return out
+
+
+def load_owned_agents(*, owner: str) -> tuple[list[tuple[str, AgentManifest]], float]:
+    """Agents owned by ``owner`` across every local room, plus summed budget.
+
+    Returns ``([(room, manifest), …], total_budget_usd_per_month)``. The total is
+    the sum of each owned agent's manifest budget *cap* — a per-principal budget
+    figure, not measured spend (no per-action cost ledger exists at this tier).
+    """
+    from mycelium.filesystem import list_room_names
+
+    owner = owner.strip().lstrip("@").lower()
+    owned: list[tuple[str, AgentManifest]] = []
+    total = 0.0
+    for room_name in list_room_names():
+        for m in _room_manifests(room_name):
+            if m.owner == owner:
+                owned.append((room_name, m))
+                total += m.budget_usd_per_month
+    return owned, total
+
+
+def _warn_unknown_principal(manifest: AgentManifest) -> None:
+    """Warn (never fail) when an agent's owner has no user record.
+
+    The binding is self-asserted, so a dangling owner is a soft signal, not an
+    error — it just nudges the user to register the principal so 'my agents'
+    and budget roll-up have something to resolve.
+    """
+    if not manifest.owner:
+        return
+    from mycelium.commands.user import load_user
+
+    if load_user(manifest.owner) is None:
+        console.print(
+            f"[yellow]note:[/yellow] owner '@{manifest.owner}' has no user record. "
+            f'Register it with: mycelium user create {manifest.owner} --name "…"'
+        )
+
+
 def _load_manifest_remote(client, room_name: str, handle: str) -> AgentManifest | None:
     """Fetch a manifest from the backend memory API and rehydrate the model.
 
@@ -417,6 +469,9 @@ def _create_wizard(
 
     description = questionary.text("Description (what does this agent do?):").ask() or ""
 
+    owner = (questionary.text("Owner (a users/<handle>, optional):").ask() or "").strip() or None
+    team = (questionary.text("Team slug (optional):").ask() or "").strip() or None
+
     room_name = room_opt or _pick_room(config)
     if not room_name:
         return
@@ -429,11 +484,14 @@ def _create_wizard(
             description=description,
             budget=5.0,
             allow_from=[],
+            owner=owner,
+            team=team,
         )
     except ValidationError as exc:
         typer.secho(f"Invalid agent manifest: {exc}", fg=typer.colors.RED)
         raise typer.Exit(1) from exc
 
+    _warn_unknown_principal(manifest)
     _persist_and_describe(
         impl=impl,
         manifest=manifest,
@@ -489,6 +547,14 @@ def agent_create(
         None,
         "--allow-from",
         help="Comma-separated sender handles allowed to invoke (e.g. '@julia,@docs-agent').",
+    ),
+    owner: str | None = typer.Option(
+        None,
+        "--owner",
+        help="User (a users/<handle>) this agent belongs to. Self-asserted.",
+    ),
+    team: str | None = typer.Option(
+        None, "--team", help="Team slug this agent is fielded by. Self-asserted."
     ),
     handle_flag: str = typer.Option(
         "cli-user", "--as", "-H", help="Your own handle (recorded as created_by)."
@@ -548,11 +614,14 @@ def agent_create(
                 description=description,
                 budget=budget,
                 allow_from=allow_list,
+                owner=owner,
+                team=team,
             )
         except ValidationError as exc:
             typer.secho(f"Invalid agent manifest: {exc}", fg=typer.colors.RED)
             raise typer.Exit(1) from exc
 
+        _warn_unknown_principal(manifest)
         _persist_and_describe(
             impl=impl,
             manifest=manifest,
@@ -658,24 +727,25 @@ def _pick_room(config: MyceliumConfig) -> str | None:
 def agent_ls(
     ctx: typer.Context,
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
+    owner: str | None = typer.Option(
+        None, "--owner", help="Filter to agents owned by this user handle ('my agents')."
+    ),
+    team: str | None = typer.Option(
+        None, "--team", help="Filter to agents fielded by this team ('my team')."
+    ),
 ) -> None:
     """List registered agents in a room."""
     try:
         config = MyceliumConfig.load()
         room_name = _resolve_room(config, room)
-        room_dir = get_room_dir(room_name)
 
-        entries = list_memories(room_dir, prefix="agents/", limit=200)
-        # Drop notes + log children — manifests only live at agents/<handle>
-        # without further path segments.
-        manifests: list[AgentManifest] = []
-        for key, _meta, _content in entries:
-            handle = key.removeprefix("agents/")
-            if "/" in handle:
-                continue
-            m = _load_manifest(room_name, handle)
-            if m is not None:
-                manifests.append(m)
+        manifests = _room_manifests(room_name)
+        if owner:
+            wanted = owner.strip().lstrip("@").lower()
+            manifests = [m for m in manifests if m.owner == wanted]
+        if team:
+            wanted = team.strip().lstrip("@").lower()
+            manifests = [m for m in manifests if m.team == wanted]
 
         json_output = ctx.obj.get("json", False) if ctx.obj else False
         if json_output:
@@ -694,16 +764,18 @@ def agent_ls(
         table = Table(title=f"{room_name} — agents", show_lines=False)
         table.add_column("Handle", style="cyan", no_wrap=True)
         table.add_column("Adapter", style="magenta")
-        table.add_column("Cwd")
+        table.add_column("Owner", style="green")
+        table.add_column("Team", style="green")
         table.add_column("Budget", justify="right")
         table.add_column("Description", overflow="fold")
         for m in manifests:
             table.add_row(
                 f"@{m.handle}",
                 m.adapter,
-                m.cwd,
+                f"@{m.owner}" if m.owner else "[dim]—[/dim]",
+                m.team or "[dim]—[/dim]",
                 f"${m.budget_usd_per_month:.2f}/mo",
-                (m.description or "")[:80],
+                (m.description or "")[:60],
             )
         console.print(table)
     except typer.Exit:
@@ -742,6 +814,10 @@ def agent_show(
         console.print(f"[bold cyan]@{manifest.handle}[/bold cyan]  [dim]({manifest.adapter})[/dim]")
         console.print(f"  cwd: {manifest.cwd}")
         console.print(f"  budget: ${manifest.budget_usd_per_month:.2f}/mo")
+        if manifest.owner:
+            console.print(f"  owner: @{manifest.owner}")
+        if manifest.team:
+            console.print(f"  team: {manifest.team}")
         if manifest.allow_from:
             console.print(f"  allow_from: {', '.join(manifest.allow_from)}")
         if manifest.description:

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -494,6 +494,20 @@ def _consensus_quality_line(data: dict, indent: str) -> str | None:
     )
 
 
+def _agent_owner_map(room_name: str) -> dict[str, str]:
+    """Map each agent handle to its owner, for agents that declare one.
+
+    Resolved from the room's manifests so attribution reflects current
+    ownership, not a value stamped on the message.
+    """
+    try:
+        from mycelium.commands.agent import _room_manifests
+
+        return {m.handle: m.owner for m in _room_manifests(room_name) if m.owner}
+    except Exception:  # noqa: BLE001 — attribution is best-effort, never fatal
+        return {}
+
+
 def _watch_room(config: MyceliumConfig, room_name: str, timeout: int) -> None:
     """Core SSE watch loop — pretty-renders coordination and memory events."""
     import time
@@ -505,9 +519,15 @@ def _watch_room(config: MyceliumConfig, room_name: str, timeout: int) -> None:
     from rich.text import Text
 
     console = Console()
+    owners = _agent_owner_map(room_name)
 
     def ts() -> str:
         return f"[dim]{time.strftime('%H:%M:%S')}[/]"
+
+    def own_tag(handle: str) -> str:
+        """Owner attribution for an owned agent, else empty."""
+        owner = owners.get(handle)
+        return f" [dim]owned by @{owner}[/]" if owner else ""
 
     def render(msg: dict) -> str | None:
         mtype = msg.get("message_type", "") or msg.get("type", "")
@@ -593,12 +613,12 @@ def _watch_room(config: MyceliumConfig, room_name: str, timeout: int) -> None:
         if mtype == "delegate":
             recipient = msg.get("recipient_handle", "?")
             content = msg.get("content", "")
-            return f"  {ts()}  [magenta]{sender}[/] [dim]→[/] [cyan]{recipient}[/]: {content}"
+            return f"  {ts()}  [magenta]{sender}[/]{own_tag(sender)} [dim]→[/] [cyan]{recipient}[/]: {content}"
 
         if mtype in ("direct", "broadcast", "announce"):
             content = msg.get("content", "")
             color = "yellow" if mtype == "broadcast" else "blue"
-            return f"  {ts()}  [{color}]{sender}[/]: {content}"
+            return f"  {ts()}  [{color}]{sender}[/]{own_tag(sender)}: {content}"
 
         return None
 
@@ -871,6 +891,7 @@ def messages(
             return
 
         plural = "message" if len(msgs) == 1 else "messages"
+        owners = _agent_owner_map(room_name)
         typer.secho(f"\n  {room_name}  ", fg=typer.colors.CYAN, bold=True, nl=False)
         typer.secho(f"({len(msgs)} {plural}, newest first)\n", fg=typer.colors.BRIGHT_BLACK)
         for m in msgs:
@@ -879,7 +900,9 @@ def messages(
             # never truncate. Keep multi-line content readable by indenting any
             # continuation lines under the first.
             first, *rest = (m.content or "").split("\n")
-            typer.echo(f"  {stamp}  {m.sender_handle} [{m.message_type}]: {first}")
+            owner = owners.get(m.sender_handle)
+            own = f" owned by @{owner}" if owner else ""
+            typer.echo(f"  {stamp}  {m.sender_handle}{own} [{m.message_type}]: {first}")
             for line in rest:
                 typer.echo(f"              {line}")
         typer.echo()

--- a/mycelium-cli/src/mycelium/commands/user.py
+++ b/mycelium-cli/src/mycelium/commands/user.py
@@ -86,6 +86,10 @@ def _write_user(user: UserManifest, created_by: str) -> None:
     existing = read_memory(get_users_dir(), user.handle)
     version = 1
     if existing is not None:
+        # Content-idempotent: re-writing the same record is a no-op (no version
+        # bump), so `iam` / `user create` can be re-run safely and converge.
+        if existing[1].strip() == yaml_body:
+            return
         try:
             version = int(existing[0].get("version", 1)) + 1
         except (TypeError, ValueError):
@@ -297,8 +301,7 @@ def whoami(ctx: typer.Context) -> None:
         console.print(f"[bold]acting as[/bold] [cyan]@{principal}[/cyan]  [dim]({identity})[/dim]")
         if user is None:
             console.print(
-                f"[dim]Not registered. Add yourself with: "
-                f'mycelium user create {principal} --name "…"[/dim]'
+                f'[dim]Not registered. Claim it with: mycelium iam {principal} --name "…"[/dim]'
             )
         else:
             if user.display_name:
@@ -311,6 +314,61 @@ def whoami(ctx: typer.Context) -> None:
                 console.print(
                     f"  @{m.handle} [dim]({room_name})[/dim] ${m.budget_usd_per_month:.2f}/mo"
                 )
+    except typer.Exit:
+        raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None
+
+
+@doc_ref(
+    usage='mycelium iam <handle> [--name "Display Name"]',
+    desc="Set this machine's identity and ensure the user record exists.",
+    group="user",
+)
+def iam(
+    ctx: typer.Context,
+    handle: str = typer.Argument(..., help="Your user handle (lowercase slug, e.g. 'julia')."),
+    name: str | None = typer.Option(None, "--name", "-n", help="Display name to set/update."),
+    team: list[str] | None = typer.Option(None, "--team", help="Team slug to join (repeatable)."),
+) -> None:
+    """Declare who you are on this machine.
+
+    Sets ``identity.name`` (what ``whoami``, attribution, and the default reply
+    handle resolve to) and upserts the ``users/<handle>`` record so the principal
+    actually exists. The one-liner counterpart to the app's acting-as picker.
+
+    Examples:
+        mycelium iam julia --name "Julia Valenti" --team core
+    """
+    try:
+        try:
+            manifest = UserManifest(handle=handle, display_name=name or "", teams=team or [])
+        except ValidationError as exc:
+            typer.secho(f"Invalid handle: {exc}", fg=typer.colors.RED)
+            raise typer.Exit(1) from exc
+
+        config = MyceliumConfig.load()
+
+        # Preserve an existing display name / teams when the caller didn't pass them.
+        existing = load_user(manifest.handle)
+        if existing is not None:
+            if name is None:
+                manifest.display_name = existing.display_name
+            if not team:
+                manifest.teams = existing.teams
+        _write_user(manifest, created_by=manifest.handle)
+
+        config.identity.name = manifest.handle
+        config.save()
+
+        team_line = f" · teams: {', '.join(manifest.teams)}" if manifest.teams else ""
+        console.print(
+            f"[green]You are[/green] [cyan]@{manifest.handle}[/cyan]"
+            f"{f' ({manifest.display_name})' if manifest.display_name else ''}{team_line}"
+        )
+        console.print("[dim]Set as this machine's identity. Check with: mycelium whoami[/dim]")
     except typer.Exit:
         raise
     except Exception as e:

--- a/mycelium-cli/src/mycelium/commands/user.py
+++ b/mycelium-cli/src/mycelium/commands/user.py
@@ -1,0 +1,319 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+User commands — the human as a first-class, room-spanning principal.
+
+A user is one global record at ``~/.mycelium/users/<handle>`` (markdown +
+frontmatter, same format as any memory). An agent's ``owner`` points at one of
+these handles; a ``team`` groups them. Trust is self-asserted: the handle is
+consistent, not cryptographic.
+
+The store is global rather than room-scoped (unlike ``agents/<handle>``) because
+a person spans rooms.
+"""
+
+from __future__ import annotations
+
+import json as json_module
+import logging
+
+import typer
+import yaml
+from pydantic import ValidationError
+from rich.console import Console
+from rich.table import Table
+
+from mycelium.config import MyceliumConfig
+from mycelium.doc_ref import doc_ref
+from mycelium.error_handler import print_error
+from mycelium.filesystem import get_users_dir, list_memories, read_memory, write_memory
+from mycelium.protocol import AgentManifest, UserManifest
+
+app = typer.Typer(
+    help=(
+        "The human as a first-class entity. A user is a global "
+        "users/<handle> record that an agent's --owner points at."
+    ),
+    no_args_is_help=True,
+)
+console = Console()
+_log = logging.getLogger(__name__)
+
+
+def load_user(handle: str) -> UserManifest | None:
+    """Read a user record off the global store and rehydrate the model.
+
+    Returns ``None`` for both "missing" and "unreadable"; a corrupt record is
+    logged at WARNING so it never fails silently.
+    """
+    handle = handle.strip().lstrip("@").lower()
+    result = read_memory(get_users_dir(), handle)
+    if result is None:
+        return None
+    _, content = result
+    try:
+        data = yaml.safe_load(content) or {}
+    except yaml.YAMLError as exc:
+        _log.warning("user %s: invalid YAML — %s", handle, exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    data.setdefault("handle", handle)
+    try:
+        return UserManifest(**data)
+    except ValidationError as exc:
+        _log.warning("user %s: schema validation failed — %s", handle, exc)
+        return None
+
+
+def list_users() -> list[UserManifest]:
+    """All user records in the global store, newest first."""
+    out: list[UserManifest] = []
+    for key, _meta, _content in list_memories(get_users_dir(), limit=500):
+        # The store is flat — one record per handle, no nested keys.
+        if "/" in key:
+            continue
+        user = load_user(key)
+        if user is not None:
+            out.append(user)
+    return out
+
+
+def _write_user(user: UserManifest, created_by: str) -> None:
+    body = user.model_dump(exclude={"handle"})
+    yaml_body = yaml.safe_dump(body, sort_keys=False, default_flow_style=False).strip()
+    existing = read_memory(get_users_dir(), user.handle)
+    version = 1
+    if existing is not None:
+        try:
+            version = int(existing[0].get("version", 1)) + 1
+        except (TypeError, ValueError):
+            version = 1
+    write_memory(
+        get_users_dir(),
+        user.handle,
+        yaml_body,
+        created_by=created_by,
+        version=version,
+        tags=["user-manifest"],
+    )
+
+
+@doc_ref(
+    usage="mycelium user create <handle> [--name <display>] [--team <slug>]",
+    desc="Register a human as a first-class user in the global store.",
+    group="user",
+)
+@app.command("create")
+def user_create(
+    ctx: typer.Context,
+    handle: str = typer.Argument(..., help="User handle (lowercase slug, e.g. 'julia')."),
+    display_name: str = typer.Option(
+        "", "--name", "-n", help="Human-readable display name, e.g. 'Julia Valenti'."
+    ),
+    team: list[str] | None = typer.Option(
+        None, "--team", help="Team slug this person belongs to (repeatable)."
+    ),
+    notify: str | None = typer.Option(
+        None, "--notify", help="Where to route 'needs you' escalations (email/webhook)."
+    ),
+    handle_flag: str = typer.Option(
+        "cli-user", "--as", "-H", help="Your own handle (recorded as created_by)."
+    ),
+) -> None:
+    """Create (or upsert) a user in the global store.
+
+    Examples:
+        mycelium user create julia --name "Julia Valenti" --team core
+    """
+    try:
+        try:
+            user = UserManifest(
+                handle=handle,
+                display_name=display_name,
+                teams=team or [],
+                notify=notify,
+            )
+        except ValidationError as exc:
+            typer.secho(f"Invalid user: {exc}", fg=typer.colors.RED)
+            raise typer.Exit(1) from exc
+
+        _write_user(user, created_by=handle_flag)
+        teams = f" · teams: {', '.join(user.teams)}" if user.teams else ""
+        console.print(
+            f"[green]User registered:[/green] [cyan]@{user.handle}[/cyan]"
+            f"{f' ({user.display_name})' if user.display_name else ''}{teams}"
+        )
+    except typer.Exit:
+        raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None
+
+
+@doc_ref(
+    usage="mycelium user ls [--team <slug>]",
+    desc="List registered users in the global store.",
+    group="user",
+)
+@app.command("ls")
+def user_ls(
+    ctx: typer.Context,
+    team: str | None = typer.Option(None, "--team", help="Filter to one team slug."),
+) -> None:
+    """List users in the global store."""
+    try:
+        users = list_users()
+        if team:
+            wanted = team.strip().lstrip("@").lower()
+            users = [u for u in users if wanted in u.teams]
+
+        json_output = ctx.obj.get("json", False) if ctx.obj else False
+        if json_output:
+            typer.echo(json_module.dumps([u.model_dump() for u in users], indent=2, default=str))
+            return
+
+        if not users:
+            console.print("[dim]No users registered.[/dim]")
+            console.print('  Create one with: mycelium user create <handle> --name "…"')
+            return
+
+        table = Table(title="users", show_lines=False)
+        table.add_column("Handle", style="cyan", no_wrap=True)
+        table.add_column("Name")
+        table.add_column("Teams", style="magenta")
+        table.add_column("Notify", overflow="fold")
+        for u in users:
+            table.add_row(
+                f"@{u.handle}",
+                u.display_name or "",
+                ", ".join(u.teams),
+                u.notify or "",
+            )
+        console.print(table)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None
+
+
+@doc_ref(
+    usage="mycelium user show <handle>",
+    desc="Show a user's record plus the agents they own.",
+    group="user",
+)
+@app.command("show")
+def user_show(
+    ctx: typer.Context,
+    handle: str = typer.Argument(..., help="User handle."),
+) -> None:
+    """Inspect a user: record plus a roll-up of the agents they own."""
+    try:
+        user = load_user(handle)
+        if user is None:
+            console.print(f"[red]Not found:[/red] no user '{handle}' in the global store.")
+            raise typer.Exit(1)
+
+        console.print(f"[bold cyan]@{user.handle}[/bold cyan]")
+        if user.display_name:
+            console.print(f"  name: {user.display_name}")
+        if user.teams:
+            console.print(f"  teams: {', '.join(user.teams)}")
+        if user.notify:
+            console.print(f"  notify: {user.notify}")
+
+        # Roll up owned agents across every room, summing their manifest budgets.
+        owned, total = _owned_agents(user.handle)
+        if owned:
+            console.print(f"\n[bold]owns {len(owned)} agent(s)[/bold]  [dim]${total:.2f}/mo[/dim]")
+            for room_name, m in owned:
+                console.print(
+                    f"  @{m.handle} [dim]({m.adapter}, {room_name})[/dim] "
+                    f"${m.budget_usd_per_month:.2f}/mo"
+                )
+        else:
+            console.print("\n[dim]No agents owned yet.[/dim]")
+    except typer.Exit:
+        raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None
+
+
+def _owned_agents(owner: str) -> tuple[list[tuple[str, AgentManifest]], float]:
+    """Every agent whose manifest owner matches, across all rooms, + total budget.
+
+    The roll-up sums each owned agent's manifest ``budget_usd_per_month`` cap —
+    a budget figure, not measured spend (there's no per-action cost ledger yet).
+    """
+    from mycelium.commands.agent import load_owned_agents
+
+    return load_owned_agents(owner=owner)
+
+
+@doc_ref(
+    usage="mycelium whoami",
+    desc="Print the user you're acting as, plus the agents you own.",
+    group="user",
+)
+def whoami(ctx: typer.Context) -> None:
+    """Resolve the current identity to a user handle and roll up owned agents."""
+    try:
+        config = MyceliumConfig.load()
+        # The attribution handle can be session-qualified (``julia#a8f3``); the
+        # principal is the bare name it derives from.
+        identity = config.get_current_identity()
+        principal = (config.identity.name or identity).split("#", 1)[0].lower()
+
+        json_output = ctx.obj.get("json", False) if ctx.obj else False
+        user = load_user(principal)
+        owned, total = _owned_agents(principal)
+
+        if json_output:
+            typer.echo(
+                json_module.dumps(
+                    {
+                        "identity": identity,
+                        "principal": principal,
+                        "registered": user is not None,
+                        "user": user.model_dump() if user else None,
+                        "owns": [
+                            {"room": r, "handle": m.handle, "budget": m.budget_usd_per_month}
+                            for r, m in owned
+                        ],
+                        "budget_usd_per_month": total,
+                    },
+                    indent=2,
+                    default=str,
+                )
+            )
+            return
+
+        console.print(f"[bold]acting as[/bold] [cyan]@{principal}[/cyan]  [dim]({identity})[/dim]")
+        if user is None:
+            console.print(
+                f"[dim]Not registered. Add yourself with: "
+                f'mycelium user create {principal} --name "…"[/dim]'
+            )
+        else:
+            if user.display_name:
+                console.print(f"  name: {user.display_name}")
+            if user.teams:
+                console.print(f"  teams: {', '.join(user.teams)}")
+        if owned:
+            console.print(f"\n[bold]owns {len(owned)} agent(s)[/bold]  [dim]${total:.2f}/mo[/dim]")
+            for room_name, m in owned:
+                console.print(
+                    f"  @{m.handle} [dim]({room_name})[/dim] ${m.budget_usd_per_month:.2f}/mo"
+                )
+    except typer.Exit:
+        raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None

--- a/mycelium-cli/src/mycelium/docs/principals.md
+++ b/mycelium-cli/src/mycelium/docs/principals.md
@@ -36,6 +36,9 @@ mycelium agent create release-agent --cwd ~/repo --owner julia --team core
 mycelium agent ls --owner julia   # "my agents"
 mycelium agent ls --team core     # "my team"
 
+# Declare who you are on this machine (sets identity + upserts the user record)
+mycelium iam julia --name "Julia Valenti" --team core
+
 # Who am I acting as?
 mycelium whoami
 ```

--- a/mycelium-cli/src/mycelium/docs/principals.md
+++ b/mycelium-cli/src/mycelium/docs/principals.md
@@ -1,0 +1,55 @@
+# Users & teams
+
+Mycelium models *whom an agent belongs to*. Without it, every agent on the fabric
+is anonymous: presence says "agent-y is live," never "julia's agent-y is live."
+Ownership gives scoping ("my agents" vs another team's), attribution (whose agent
+edited that?), and routing (escalate back to an agent's owner).
+
+Two entities, symmetric on disk:
+
+- **Agents** are room-scoped (`rooms/{room}/agents/{handle}`). A manifest can name
+  an `owner` (a user handle) and a `team` (a slug).
+- **Users** are global (`users/{handle}`), because a person spans rooms. A user is
+  what an `owner` points at.
+
+## Self-asserted, for now
+
+At this tier trust is exactly today's handles: **consistent, not cryptographic**.
+`owner: julia` is a claim, not a verified identity; anyone can assert it. That's
+deliberate: it shapes the model right so scoping, attribution, and routing have
+real slots to read, ahead of verified identity (per-member SLIM binding / JWT /
+SPIRE) filling those slots with signed claims. Don't rely on it for access control.
+
+Both fields default to empty, so nothing about existing agents changes: an agent
+with no owner is unowned.
+
+## Commands
+
+```bash
+# Register a human, once, globally
+mycelium user create julia --name "Julia Valenti" --team core
+mycelium user ls
+mycelium user show julia          # record + the agents she owns + summed budget
+
+# Bind an agent to its owner
+mycelium agent create release-agent --cwd ~/repo --owner julia --team core
+mycelium agent ls --owner julia   # "my agents"
+mycelium agent ls --team core     # "my team"
+
+# Who am I acting as?
+mycelium whoami
+```
+
+## Cost roll-up
+
+Budget is a per-agent field (`budget_usd_per_month`). A user's cost is the **sum of
+the budgets of the agents they own**: the honest figure this tier can report
+without a per-action cost ledger. `user show` and `whoami` roll it up per user;
+`GET /api/teams` rolls it up per team.
+
+## In the UI
+
+Agent rows show their owner and team. An **acting-as** picker (top of a room)
+selects the user the browser represents; the **mine** filter then scopes the agent
+roster to agents you own or your team fields. The acting-as choice is stored
+locally in the browser: the same self-asserted handle, no login.

--- a/mycelium-cli/src/mycelium/filesystem.py
+++ b/mycelium-cli/src/mycelium/filesystem.py
@@ -35,6 +35,27 @@ def get_room_dir(room_name: str) -> Path:
     return room_dir
 
 
+def get_users_dir() -> Path:
+    """Get the global users store directory.
+
+    People span rooms, so the user store is global (a sibling of ``rooms/``)
+    rather than room-scoped like ``agents/``. Records live at
+    ``~/.mycelium/users/<handle>.md``, same markdown+frontmatter format as any
+    other memory entry.
+    """
+    users_dir = get_mycelium_dir() / "users"
+    users_dir.mkdir(parents=True, exist_ok=True)
+    return users_dir
+
+
+def list_room_names() -> list[str]:
+    """Names of every room materialized in the local store."""
+    rooms_root = get_mycelium_dir() / "rooms"
+    if not rooms_root.is_dir():
+        return []
+    return sorted(p.name for p in rooms_root.iterdir() if p.is_dir())
+
+
 def ensure_room_structure(room_dir: Path) -> None:
     """Create standard namespace subdirectories."""
     for subdir in ("decisions", "failed", "status", "context", "work", "procedures", "log"):

--- a/mycelium-cli/src/mycelium/integrations/base.py
+++ b/mycelium-cli/src/mycelium/integrations/base.py
@@ -171,8 +171,14 @@ class Integration(ABC):
         description: str,
         budget: float,
         allow_from: list[str],
+        owner: str | None = None,
+        team: str | None = None,
     ) -> AgentManifest:
         """Construct (and validate) the manifest for this family.
+
+        ``owner`` / ``team`` are the self-asserted principal binding: the
+        ``users/<handle>`` this agent belongs to and the team it's fielded by.
+        Both default to ``None`` (principal-anonymous).
 
         Raises pydantic ValidationError on bad input — the command layer
         catches it and prints a friendly message.

--- a/mycelium-cli/src/mycelium/integrations/claude_code/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/dispatch.py
@@ -50,6 +50,8 @@ class ClaudeCodeIntegration(Integration):
         description: str,
         budget: float,
         allow_from: list[str],
+        owner: str | None = None,
+        team: str | None = None,
     ) -> AgentManifest:
         return AgentManifest(
             handle=handle,
@@ -58,6 +60,8 @@ class ClaudeCodeIntegration(Integration):
             description=description,
             budget_usd_per_month=budget,
             allow_from=allow_from,
+            owner=owner,
+            team=team,
         )
 
     def register(

--- a/mycelium-cli/src/mycelium/integrations/cursor/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/cursor/dispatch.py
@@ -66,6 +66,8 @@ class CursorIntegration(Integration):
         description: str,
         budget: float,
         allow_from: list[str],
+        owner: str | None = None,
+        team: str | None = None,
     ) -> AgentManifest:
         return AgentManifest(
             handle=handle,
@@ -74,6 +76,8 @@ class CursorIntegration(Integration):
             description=description,
             budget_usd_per_month=budget,
             allow_from=allow_from,
+            owner=owner,
+            team=team,
         )
 
     def register(

--- a/mycelium-cli/src/mycelium/integrations/engine/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/engine/dispatch.py
@@ -52,6 +52,8 @@ class EngineIntegration(Integration):
         description: str,
         budget: float,
         allow_from: list[str],
+        owner: str | None = None,
+        team: str | None = None,
     ) -> AgentManifest:
         return AgentManifest(
             handle=handle,
@@ -60,6 +62,8 @@ class EngineIntegration(Integration):
             description=description,
             budget_usd_per_month=budget,
             allow_from=allow_from,
+            owner=owner,
+            team=team,
         )
 
     def register(

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -341,6 +341,20 @@ class AgentManifest(BaseModel):
     )
     description: str = Field(default="", description="One-paragraph purpose statement.")
     budget_usd_per_month: float = Field(default=5.0, ge=0.0)
+    owner: str | None = Field(
+        default=None,
+        description=(
+            "User (a `users/<handle>` in the global store) this agent belongs to. "
+            "Self-asserted: consistent, not cryptographic. None means unowned."
+        ),
+    )
+    team: str | None = Field(
+        default=None,
+        description=(
+            "Team slug this agent is fielded by; self-asserted. Scopes 'my team' "
+            "filtering and per-team budget roll-up."
+        ),
+    )
     allow_from: list[str] = Field(
         default_factory=list,
         description=(
@@ -353,8 +367,21 @@ class AgentManifest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def lowercase_handle(cls, data: dict) -> dict:
-        if isinstance(data, dict) and "handle" in data and isinstance(data["handle"], str):
-            data["handle"] = data["handle"].lower()
+        if not isinstance(data, dict):
+            return data
+        # Handle and the two principal pointers are all lowercase slugs — an
+        # owner/team is a `users/<handle>` / team slug, so `--owner Julia`
+        # binds to `users/julia`. The handle is required, so an empty result
+        # stays a string (and fails the pattern); owner/team collapse to None.
+        for field in ("handle", "owner", "team"):
+            value = data.get(field)
+            if not isinstance(value, str):
+                continue
+            normalized = value.strip().lstrip("@").lower()
+            if field == "handle":
+                data[field] = normalized
+            else:
+                data[field] = normalized or None
         return data
 
     @model_validator(mode="after")
@@ -384,3 +411,46 @@ class AgentManifest(BaseModel):
     def notes_key(self) -> str:
         """Memory key the agent's persistent notes are stored under."""
         return f"agents/{self.handle}/notes"
+
+
+# ── User primitive ───────────────────────────────────────────────────────────
+
+
+class UserManifest(BaseModel):
+    """Typed payload for a global ``users/<handle>`` record.
+
+    The human, made first-class and symmetric with ``agents/<handle>``. An
+    agent's ``owner`` points here; a ``team`` groups these handles. People span
+    rooms, so this store is global (``~/.mycelium/users/<handle>``), not
+    room-scoped. Trust is self-asserted — the handle is consistent, not
+    cryptographic.
+    """
+
+    handle: str = Field(..., min_length=1, pattern=r"^[a-z0-9][a-z0-9._-]*$")
+    display_name: str = Field(default="", description="Human-readable name, e.g. 'Julia Valenti'.")
+    teams: list[str] = Field(
+        default_factory=list,
+        description="Team slugs this person belongs to. Scopes 'my team' views.",
+    )
+    notify: str | None = Field(
+        default=None,
+        description="Where to route 'needs you' escalations (e.g. an email or webhook). Optional.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize(cls, data: dict) -> dict:
+        if not isinstance(data, dict):
+            return data
+        handle = data.get("handle")
+        if isinstance(handle, str):
+            data["handle"] = handle.strip().lstrip("@").lower()
+        teams = data.get("teams")
+        if isinstance(teams, list):
+            data["teams"] = [t.strip().lstrip("@").lower() for t in teams if str(t).strip()]
+        return data
+
+    @property
+    def memory_key(self) -> str:
+        """Store key (relative to the global users dir)."""
+        return self.handle

--- a/mycelium-cli/tests/test_principal_layer.py
+++ b/mycelium-cli/tests/test_principal_layer.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Self-asserted principal layer: agent owner/team, the user store, roll-up."""
+
+from __future__ import annotations
+
+import yaml
+
+from mycelium.commands import user as user_cmd
+from mycelium.commands.agent import load_owned_agents
+from mycelium.filesystem import get_room_dir, write_memory
+from mycelium.protocol import AgentManifest, UserManifest
+
+
+def test_manifest_owner_team_default_none() -> None:
+    """Backward compatible: a manifest with no principal is anonymous."""
+    m = AgentManifest(handle="bot", cwd="/tmp")
+    assert m.owner is None
+    assert m.team is None
+
+
+def test_manifest_normalizes_owner_and_team() -> None:
+    """Owner/team are slug pointers — lowercased, @-stripped, like the handle."""
+    m = AgentManifest(handle="Bot", cwd="/tmp", owner="@Julia", team="Core")
+    assert m.owner == "julia"
+    assert m.team == "core"
+
+
+def test_manifest_blank_owner_becomes_none() -> None:
+    m = AgentManifest(handle="bot", cwd="/tmp", owner="  ")
+    assert m.owner is None
+
+
+def test_user_manifest_normalizes() -> None:
+    u = UserManifest(handle="@Julia", display_name="Julia Valenti", teams=["@Core", "Infra"])
+    assert u.handle == "julia"
+    assert u.teams == ["core", "infra"]
+
+
+def test_user_store_roundtrip(isolated_home) -> None:  # noqa: ANN001
+    """A user written to the global store loads back as a validated model."""
+    user_cmd._write_user(
+        UserManifest(handle="julia", display_name="Julia", teams=["core"]),
+        created_by="tester",
+    )
+    loaded = user_cmd.load_user("@Julia")  # normalization on read too
+    assert loaded is not None
+    assert loaded.display_name == "Julia"
+    assert loaded.teams == ["core"]
+    assert [u.handle for u in user_cmd.list_users()] == ["julia"]
+
+
+def _seed_agent(room: str, handle: str, *, owner: str | None, budget: float) -> None:
+    manifest = AgentManifest(handle=handle, cwd="/tmp", owner=owner, budget_usd_per_month=budget)
+    body = yaml.safe_dump(manifest.model_dump(exclude={"handle"}), sort_keys=False)
+    write_memory(get_room_dir(room), manifest.memory_key, body, created_by="tester")
+
+
+def test_load_owned_agents_rolls_up_budget(isolated_home) -> None:  # noqa: ANN001
+    """Owned agents are collected across rooms and their budgets summed."""
+    _seed_agent("alpha", "a1", owner="julia", budget=5.0)
+    _seed_agent("beta", "a2", owner="julia", budget=7.5)
+    _seed_agent("beta", "a3", owner="sam", budget=99.0)
+
+    owned, total = load_owned_agents(owner="@Julia")
+    handles = sorted(m.handle for _room, m in owned)
+    assert handles == ["a1", "a2"]
+    assert total == 12.5

--- a/mycelium-cli/tests/test_user_store_contract.py
+++ b/mycelium-cli/tests/test_user_store_contract.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Contract drift guard for the global user store (CLI side).
+
+The user store is duplicated: the thin ``uv tool`` CLI carries its own
+``UserManifest`` + ``commands.user`` write/read primitives so it need not import
+the FastAPI backend. A divergent store dir, frontmatter tag, version rule, slug
+normalization, or serialized body means a record one side writes is unreadable —
+or mis-rolled-up — by the other, silently.
+
+This test freezes the shared shape in ``contracts/user-store.json`` at the repo
+root and asserts the **CLI** primitives reproduce it exactly. Its backend twin is
+``fastapi-backend/tests/test_user_store_contract.py``.
+"""
+
+import json
+from pathlib import Path
+
+import yaml
+
+from mycelium.commands import user as user_cmd
+from mycelium.filesystem import get_mycelium_dir, get_users_dir
+from mycelium.protocol import UserManifest
+
+_CONTRACT_PATH = Path(__file__).resolve().parent.parent.parent / "contracts" / "user-store.json"
+
+
+def _contract() -> dict:
+    return json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def test_contract_file_present():
+    assert _CONTRACT_PATH.is_file(), f"missing shared contract file at {_CONTRACT_PATH}"
+
+
+def test_store_dir_matches_contract(isolated_home):  # noqa: ANN001
+    g = _contract()
+    assert get_users_dir() == get_mycelium_dir() / g["store_dirname"]
+
+
+def test_normalization_matches_contract():
+    g = _contract()["normalize"]
+    u = UserManifest(**g["input"])
+    assert u.handle == g["expected"]["handle"]
+    assert u.display_name == g["expected"]["display_name"]
+    assert u.teams == g["expected"]["teams"]
+    assert u.notify == g["expected"]["notify"]
+
+
+def test_serialized_body_matches_contract():
+    """The frontmatter body the CLI writes is byte-for-byte the contract."""
+    g = _contract()
+    u = UserManifest(**g["normalize"]["input"])
+    body = u.model_dump(exclude={"handle"})
+    yaml_body = yaml.safe_dump(body, sort_keys=False, default_flow_style=False).strip()
+    assert yaml_body == g["serialized_body"]
+
+
+def test_write_applies_tag_and_version(isolated_home):  # noqa: ANN001
+    g = _contract()
+    user_cmd._write_user(UserManifest(handle="julia"), created_by="tester")
+    record = user_cmd.read_memory(get_users_dir(), "julia")
+    assert record is not None
+    assert record[0]["tags"] == [g["manifest_tag"]]
+    assert record[0]["version"] == g["initial_version"]
+    # Upsert bumps the version, matching the backend's rule.
+    user_cmd._write_user(UserManifest(handle="julia"), created_by="tester")
+    bumped = user_cmd.read_memory(get_users_dir(), "julia")
+    assert bumped is not None
+    assert bumped[0]["version"] == g["initial_version"] + 1

--- a/mycelium-cli/tests/test_user_store_contract.py
+++ b/mycelium-cli/tests/test_user_store_contract.py
@@ -64,8 +64,13 @@ def test_write_applies_tag_and_version(isolated_home):  # noqa: ANN001
     assert record is not None
     assert record[0]["tags"] == [g["manifest_tag"]]
     assert record[0]["version"] == g["initial_version"]
-    # Upsert bumps the version, matching the backend's rule.
+    # Content-idempotent: re-writing the same record does NOT bump the version.
     user_cmd._write_user(UserManifest(handle="julia"), created_by="tester")
+    same = user_cmd.read_memory(get_users_dir(), "julia")
+    assert same is not None
+    assert same[0]["version"] == g["initial_version"]
+    # A real change bumps it.
+    user_cmd._write_user(UserManifest(handle="julia", display_name="Julia"), created_by="tester")
     bumped = user_cmd.read_memory(get_users_dir(), "julia")
     assert bumped is not None
     assert bumped[0]["version"] == g["initial_version"] + 1

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
+import { CurrentUserProvider } from "@/components/current-user";
 
 export const metadata: Metadata = {
   title: "mycelium",
@@ -22,7 +23,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="min-h-screen bg-bg text-text antialiased">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
-          {children}
+          <CurrentUserProvider>{children}</CurrentUserProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -12,6 +12,7 @@ import { RoomChatBox } from "@/components/room-chat-box";
 import { RoomInspector, type Tab } from "@/components/room-inspector";
 import { RoomTour } from "@/components/room-tour";
 import { GlobalStatusItems, StatusButton } from "@/components/status-items";
+import { ActingAsPicker } from "@/components/acting-as-picker";
 import { useRoomStatus } from "@/lib/use-status";
 
 interface Room {
@@ -124,6 +125,9 @@ export default function RoomPage() {
         {room?.mas_id && (
           <span className="font-mono text-micro text-faint truncate" title="MAS id">{room.mas_id}</span>
         )}
+        <div className="ml-auto flex-shrink-0">
+          <ActingAsPicker />
+        </div>
       </header>
 
       <div className="flex flex-1 overflow-hidden">

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { UserRound } from "lucide-react";
+import { createUser, fetchUsers, logFetchError, type User } from "@/lib/api";
+import { useCurrentUser } from "@/components/current-user";
+import { Monogram } from "@/components/ui/monogram";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+/**
+ * Pick the principal the browser acts as — the self-asserted "me" that scopes
+ * "my agents" / "my team". Lists the global user store; a new handle can be
+ * registered inline. Persisted locally via the current-user context.
+ */
+export function ActingAsPicker() {
+  const { principal, setPrincipal } = useCurrentUser();
+  const [users, setUsers] = useState<User[]>([]);
+  const [open, setOpen] = useState(false);
+  const [newHandle, setNewHandle] = useState("");
+  const [newName, setNewName] = useState("");
+
+  const refresh = useCallback(() => {
+    fetchUsers().then(setUsers).catch((err) => {
+      logFetchError("fetchUsers")(err);
+      setUsers([]);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (open) refresh();
+  }, [open, refresh]);
+
+  const register = async () => {
+    const handle = newHandle.trim().replace(/^@/, "").toLowerCase();
+    if (!handle) return;
+    const created = await createUser({ handle, display_name: newName.trim() });
+    if (created) {
+      setPrincipal(created.handle);
+      setNewHandle("");
+      setNewName("");
+      setOpen(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={<Button variant="ghost" size="sm" />}
+        title="Choose the user you're acting as"
+      >
+        {principal ? (
+          <Monogram handle={principal} color="var(--muted-foreground)" className="size-5" />
+        ) : (
+          <UserRound className="size-3.5" />
+        )}
+        <span className="font-mono">{principal ? `@${principal}` : "acting as…"}</span>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-ui font-semibold text-text">Acting as</DialogTitle>
+          <DialogDescription className="text-label text-muted-foreground leading-relaxed">
+            Sets the handle your messages post under, and lets the agents list
+            filter to the ones you own. Saved in this browser; there&apos;s no login yet.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-2 space-y-4">
+          <div className="max-h-56 overflow-y-auto border border-border">
+            <button
+              type="button"
+              onClick={() => {
+                setPrincipal("");
+                setOpen(false);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-label hover:bg-surface border-b border-border last:border-b-0"
+            >
+              <span className={principal === "" ? "text-accent" : "text-muted-foreground"}>
+                Anonymous
+              </span>
+            </button>
+            {users.map((u) => (
+              <button
+                type="button"
+                key={u.handle}
+                onClick={() => {
+                  setPrincipal(u.handle);
+                  setOpen(false);
+                }}
+                className="flex w-full items-center gap-2.5 px-3 py-2 text-label hover:bg-surface border-b border-border last:border-b-0"
+              >
+                <Monogram handle={u.handle} color="var(--muted-foreground)" className="size-7" />
+                <span
+                  className={`font-mono ${principal === u.handle ? "text-accent" : "text-text"}`}
+                >
+                  @{u.handle}
+                </span>
+                {u.display_name && (
+                  <span className="text-micro text-muted-foreground truncate">
+                    {u.display_name}
+                  </span>
+                )}
+                {u.teams.length > 0 && (
+                  <span className="ml-auto text-micro text-muted-foreground">
+                    {u.teams.join(", ")}
+                  </span>
+                )}
+              </button>
+            ))}
+            {users.length === 0 && (
+              <div className="px-3 py-2 text-micro text-muted-foreground">
+                No users registered yet.
+              </div>
+            )}
+          </div>
+
+          <section className="space-y-2">
+            <div className="text-label font-semibold text-text">Register a new user</div>
+            <Input
+              placeholder="handle (e.g. julia)"
+              value={newHandle}
+              onChange={(e) => setNewHandle(e.target.value)}
+            />
+            <Input
+              placeholder="display name (optional)"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <div className="flex justify-end gap-2">
+              <DialogClose render={<Button variant="secondary" size="sm" />}>Cancel</DialogClose>
+              <Button size="sm" onClick={register} disabled={!newHandle.trim()}>
+                Register &amp; act as
+              </Button>
+            </div>
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -4,56 +4,146 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { UserRound } from "lucide-react";
-import { createUser, fetchUsers, logFetchError, type User } from "@/lib/api";
+import { ChevronLeft, Pencil, Plus, UserRound } from "lucide-react";
+import {
+  createUser,
+  fetchTeams,
+  fetchUsers,
+  logFetchError,
+  type Team,
+  type User,
+} from "@/lib/api";
 import { useCurrentUser } from "@/components/current-user";
 import { Monogram } from "@/components/ui/monogram";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { TagInput } from "@/components/ui/tag-input";
+import { CopyField } from "@/components/ui/copy-field";
 import {
   Dialog,
-  DialogClose,
   DialogContent,
-  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
 
+const SLUG = /^[a-z0-9][a-z0-9._-]*$/;
+const normHandle = (s: string) => s.trim().replace(/^@/, "").toLowerCase();
+
+interface Form {
+  handle: string;
+  displayName: string;
+  teams: string[];
+  notify: string;
+  isNew: boolean;
+}
+
+const BLANK: Form = { handle: "", displayName: "", teams: [], notify: "", isNew: true };
+
+interface BoundUser {
+  handle: string;
+  display_name: string;
+  teams: string[];
+  notify: string | null;
+}
+
+/** The `mycelium iam` command that reproduces this user record and binds the
+ *  machine's client to it — fully specified so it's deterministic on any machine
+ *  and safe to re-run (the write is content-idempotent). */
+function iamCommand(u: BoundUser): string {
+  const arg = (v: string) => (/[\s"']/.test(v) ? `"${v.replace(/"/g, '\\"')}"` : v);
+  const parts = [`mycelium iam ${u.handle}`];
+  if (u.display_name) parts.push(`--name ${arg(u.display_name)}`);
+  for (const t of u.teams) parts.push(`--team ${t}`);
+  if (u.notify) parts.push(`--notify ${arg(u.notify)}`);
+  return parts.join(" ");
+}
+
 /**
- * Pick the principal the browser acts as — the self-asserted "me" that scopes
- * "my agents" / "my team". Lists the global user store; a new handle can be
- * registered inline. Persisted locally via the current-user context.
+ * The identity surface: pick who the browser acts as (the self-asserted "me"
+ * that scopes "my agents"/"my team" and stamps the chat sender), and manage the
+ * user records inline — no CLI round-trip. Two views: a lightweight switcher and
+ * a full editor (name, teams, notify). Saved locally via the current-user context.
  */
 export function ActingAsPicker() {
   const { principal, setPrincipal } = useCurrentUser();
-  const [users, setUsers] = useState<User[]>([]);
   const [open, setOpen] = useState(false);
-  const [newHandle, setNewHandle] = useState("");
-  const [newName, setNewName] = useState("");
+  const [users, setUsers] = useState<User[]>([]);
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [view, setView] = useState<"switch" | "edit" | "bound">("switch");
+  const [form, setForm] = useState<Form>(BLANK);
+  const [bound, setBound] = useState<BoundUser | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(() => {
     fetchUsers().then(setUsers).catch((err) => {
       logFetchError("fetchUsers")(err);
       setUsers([]);
     });
+    fetchTeams().then(setTeams).catch(logFetchError("fetchTeams"));
   }, []);
 
   useEffect(() => {
-    if (open) refresh();
+    if (open) {
+      refresh();
+      setView("switch");
+      setError(null);
+    }
   }, [open, refresh]);
 
-  const register = async () => {
-    const handle = newHandle.trim().replace(/^@/, "").toLowerCase();
-    if (!handle) return;
-    const created = await createUser({ handle, display_name: newName.trim() });
-    if (created) {
-      setPrincipal(created.handle);
-      setNewHandle("");
-      setNewName("");
-      setOpen(false);
+  // Selecting or saving a user sets the browser identity AND reveals the CLI
+  // command to bind a coding-agent machine to the same identity (progressive
+  // disclosure — the command only shows once you've chosen who you are).
+  const bindTo = (u: BoundUser) => {
+    setPrincipal(u.handle);
+    setBound(u);
+    setView("bound");
+  };
+
+  const startNew = () => {
+    setForm(BLANK);
+    setError(null);
+    setView("edit");
+  };
+
+  const startEdit = (u: User) => {
+    setForm({
+      handle: u.handle,
+      displayName: u.display_name,
+      teams: u.teams,
+      notify: u.notify ?? "",
+      isNew: false,
+    });
+    setError(null);
+    setView("edit");
+  };
+
+  const save = async () => {
+    const handle = normHandle(form.handle);
+    if (!handle) {
+      setError("Enter a handle.");
+      return;
+    }
+    if (!SLUG.test(handle)) {
+      setError("Handle must be lowercase letters, digits, . _ or -, with no spaces.");
+      return;
+    }
+    try {
+      const notify = form.notify.trim() || null;
+      await createUser({ handle, display_name: form.displayName.trim(), teams: form.teams, notify });
+      refresh();
+      bindTo({ handle, display_name: form.displayName.trim(), teams: form.teams, notify });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
     }
   };
+
+  // A new handle that matches an existing user would upsert (overwrite) it —
+  // offer to edit that record instead of silently clobbering it.
+  const clash =
+    form.isNew ? users.find((u) => u.handle === normHandle(form.handle)) : undefined;
+
+  const teamSuggestions = teams.map((t) => t.team);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -68,84 +158,201 @@ export function ActingAsPicker() {
         )}
         <span className="font-mono">{principal ? `@${principal}` : "acting as…"}</span>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle className="text-ui font-semibold text-text">Acting as</DialogTitle>
-          <DialogDescription className="text-label text-muted-foreground leading-relaxed">
-            Sets the handle your messages post under, and lets the agents list
-            filter to the ones you own. Saved in this browser; there&apos;s no login yet.
-          </DialogDescription>
-        </DialogHeader>
 
-        <div className="mt-2 space-y-4">
-          <div className="max-h-56 overflow-y-auto border border-border">
-            <button
-              type="button"
-              onClick={() => {
-                setPrincipal("");
-                setOpen(false);
-              }}
-              className="flex w-full items-center gap-2 px-3 py-2 text-label hover:bg-surface border-b border-border last:border-b-0"
-            >
-              <span className={principal === "" ? "text-accent" : "text-muted-foreground"}>
-                Anonymous
-              </span>
-            </button>
-            {users.map((u) => (
+      <DialogContent className="sm:max-w-sm">
+        {view === "switch" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="text-ui font-semibold text-text">Acting as</DialogTitle>
+            </DialogHeader>
+
+            <div className="mt-2 max-h-64 overflow-y-auto border border-border">
               <button
                 type="button"
-                key={u.handle}
                 onClick={() => {
-                  setPrincipal(u.handle);
+                  setPrincipal("");
                   setOpen(false);
                 }}
-                className="flex w-full items-center gap-2.5 px-3 py-2 text-label hover:bg-surface border-b border-border last:border-b-0"
+                className="flex w-full items-center gap-2 px-3 py-2 text-label hover:bg-surface border-b border-border last:border-b-0"
               >
-                <Monogram handle={u.handle} color="var(--muted-foreground)" className="size-7" />
-                <span
-                  className={`font-mono ${principal === u.handle ? "text-accent" : "text-text"}`}
-                >
-                  @{u.handle}
+                <span className={principal === "" ? "text-accent" : "text-muted-foreground"}>
+                  Anonymous
                 </span>
-                {u.display_name && (
-                  <span className="text-micro text-muted-foreground truncate">
-                    {u.display_name}
-                  </span>
-                )}
-                {u.teams.length > 0 && (
-                  <span className="ml-auto text-micro text-muted-foreground">
-                    {u.teams.join(", ")}
-                  </span>
-                )}
               </button>
-            ))}
-            {users.length === 0 && (
-              <div className="px-3 py-2 text-micro text-muted-foreground">
-                No users registered yet.
-              </div>
-            )}
-          </div>
 
-          <section className="space-y-2">
-            <div className="text-label font-semibold text-text">Register a new user</div>
-            <Input
-              placeholder="handle (e.g. julia)"
-              value={newHandle}
-              onChange={(e) => setNewHandle(e.target.value)}
-            />
-            <Input
-              placeholder="display name (optional)"
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-            />
-            <div className="flex justify-end gap-2">
-              <DialogClose render={<Button variant="secondary" size="sm" />}>Cancel</DialogClose>
-              <Button size="sm" onClick={register} disabled={!newHandle.trim()}>
-                Register &amp; act as
-              </Button>
+              {users.map((u) => (
+                <div
+                  key={u.handle}
+                  className="group flex items-center gap-2.5 px-3 py-2 hover:bg-surface border-b border-border last:border-b-0"
+                >
+                  <button
+                    type="button"
+                    onClick={() => bindTo(u)}
+                    className="flex min-w-0 flex-1 items-center gap-2.5 text-left text-label"
+                  >
+                    <Monogram handle={u.handle} color="var(--muted-foreground)" className="size-7" />
+                    <span className="min-w-0">
+                      <span
+                        className={`block truncate font-mono ${principal === u.handle ? "text-accent" : "text-text"}`}
+                      >
+                        @{u.handle}
+                      </span>
+                      {(u.display_name || u.teams.length > 0) && (
+                        <span className="block truncate text-micro text-muted-foreground">
+                          {u.display_name}
+                          {u.teams.length > 0
+                            ? `${u.display_name ? " · " : ""}${u.teams.join(", ")}`
+                            : ""}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => startEdit(u)}
+                    aria-label={`Edit @${u.handle}`}
+                    className="flex-shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-text group-hover:opacity-100"
+                  >
+                    <Pencil className="size-3.5" />
+                  </button>
+                </div>
+              ))}
+
+              {users.length === 0 && (
+                <div className="px-3 py-2 text-micro text-muted-foreground">
+                  No users yet.
+                </div>
+              )}
             </div>
-          </section>
-        </div>
+
+            <Button variant="secondary" size="sm" onClick={startNew} className="mt-2 self-start">
+              <Plus className="size-3.5" />
+              New user
+            </Button>
+          </>
+        )}
+
+        {view === "edit" && (
+          <>
+            <DialogHeader>
+              <button
+                type="button"
+                onClick={() => setView("switch")}
+                className="mb-1 flex items-center gap-1 text-micro text-muted-foreground hover:text-text"
+              >
+                <ChevronLeft className="size-3.5" />
+                Users
+              </button>
+              <DialogTitle className="text-ui font-semibold text-text">
+                {form.isNew ? "New user" : `Edit @${form.handle}`}
+              </DialogTitle>
+            </DialogHeader>
+
+            <div className="mt-2 space-y-3">
+              <label className="block space-y-1">
+                <span className="text-micro text-muted-foreground">Handle</span>
+                <Input
+                  placeholder="e.g. julia"
+                  value={form.handle}
+                  disabled={!form.isNew}
+                  onChange={(e) => {
+                    setForm((f) => ({ ...f, handle: e.target.value }));
+                    setError(null);
+                  }}
+                />
+              </label>
+
+              {clash && (
+                <div className="text-micro text-muted-foreground">
+                  <span className="font-mono text-text">@{clash.handle}</span> already exists.{" "}
+                  <button
+                    type="button"
+                    onClick={() => startEdit(clash)}
+                    className="text-accent hover:underline"
+                  >
+                    Edit it instead
+                  </button>
+                </div>
+              )}
+
+              <label className="block space-y-1">
+                <span className="text-micro text-muted-foreground">Display name</span>
+                <Input
+                  placeholder="e.g. Julia Valenti"
+                  value={form.displayName}
+                  onChange={(e) => setForm((f) => ({ ...f, displayName: e.target.value }))}
+                />
+              </label>
+
+              <div className="space-y-1">
+                <span className="text-micro text-muted-foreground">Teams</span>
+                <TagInput
+                  value={form.teams}
+                  onChange={(teams) => setForm((f) => ({ ...f, teams }))}
+                  suggestions={teamSuggestions}
+                  placeholder="type a team, Enter to add"
+                  ariaLabel="Teams"
+                />
+              </div>
+
+              <label className="block space-y-1">
+                <span className="text-micro text-muted-foreground">
+                  Notify <span className="text-faint">(where escalations reach you)</span>
+                </span>
+                <Input
+                  placeholder="email or webhook (optional)"
+                  value={form.notify}
+                  onChange={(e) => setForm((f) => ({ ...f, notify: e.target.value }))}
+                />
+              </label>
+
+              {error && (
+                <div className="text-micro text-red leading-relaxed" role="alert">
+                  {error}
+                </div>
+              )}
+
+              <div className="flex justify-end gap-2 pt-1">
+                <Button variant="secondary" size="sm" onClick={() => setView("switch")}>
+                  Cancel
+                </Button>
+                <Button size="sm" onClick={save} disabled={!form.handle.trim()}>
+                  Save &amp; act as
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+
+        {view === "bound" && bound && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="text-ui font-semibold text-text">
+                Acting as @{bound.handle}
+              </DialogTitle>
+            </DialogHeader>
+
+            <div className="mt-2 space-y-3">
+              <p className="text-label text-muted-foreground leading-relaxed">
+                Set in this browser. To attribute a coding agent&apos;s work to{" "}
+                <span className="font-mono text-text">@{bound.handle}</span>, bind that
+                machine&apos;s client to this identity. Run it there:
+              </p>
+              <CopyField value={iamCommand(bound)} />
+              <p className="text-micro text-faint leading-relaxed">
+                Sets the machine&apos;s identity and reproduces this user record. Safe to re-run.
+              </p>
+              <div className="flex justify-end gap-2 pt-1">
+                <Button variant="secondary" size="sm" onClick={() => setView("switch")}>
+                  Switch user
+                </Button>
+                <Button size="sm" onClick={() => setOpen(false)}>
+                  Done
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -3,11 +3,14 @@
 
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Users } from "lucide-react";
-import { fetchRoomAgents, logFetchError, type AgentSummary } from "@/lib/api";
+import { fetchMessages, fetchRoomAgents, logFetchError, type AgentSummary } from "@/lib/api";
 import { Button } from "@/components/ui/button";
+import { Chip } from "@/components/ui/chip";
+import { Monogram } from "@/components/ui/monogram";
 import { EmptyState } from "@/components/empty-state";
+import { useCurrentUser } from "@/components/current-user";
 import {
   Dialog,
   DialogContent,
@@ -23,31 +26,34 @@ interface Props {
   refreshKey?: number;
 }
 
-/** Two-letter monogram from a handle: "backend-lead" → BL, "oc-test2" → OT,
- *  "main" → MA. Splits on non-alphanumerics, else first two chars. */
-function initials(handle: string): string {
-  const parts = handle.split(/[^a-z0-9]+/i).filter(Boolean);
-  const s =
-    parts.length >= 2
-      ? parts[0][0] + parts[1][0]
-      : (parts[0] ?? handle).slice(0, 2);
-  return s.toUpperCase();
+interface Person {
+  handle: string;
+  /** Team slugs, unioned from the agents this person owns. */
+  teams: string[];
+  /** True when this is the handle the browser is acting as. */
+  you: boolean;
+  /** True when they own ≥1 agent here (vs. only having posted). */
+  owns: boolean;
 }
 
-
 /**
- * Read-only roster of the addressable agents registered in a room (the
- * `agents/<handle>` manifests). Pairs with the room chat box (@-mention to
- * invoke) and the event stream (agent replies are badged) to make the whole
- * register → list → invoke → reply loop visible in the UI.
+ * Roster of who's in a room: the **people** (agent owners + anyone who's posted,
+ * plus the handle you're acting as) and the **agents** (`agents/<handle>`
+ * manifests). Pairs with the chat box (@-mention to invoke) and the event stream
+ * (replies are badged) to make the whole register → list → invoke → reply loop
+ * visible. Humans and agents share the monogram avatar, told apart by tint
+ * (muted for people, accent for agents).
  *
- * Registration / teardown are intentionally NOT here: both have spoke-local
- * side effects (mycelium-daemon manifest mirror, OpenClaw gateway config + restart)
- * that the hub cannot perform. Use `mycelium agent add` / `create` / `rm`.
+ * Agent registration / teardown are intentionally NOT here: both have
+ * spoke-local side effects (daemon manifest mirror, gateway config) the hub
+ * can't perform. Use `mycelium agent add` / `create` / `rm`.
  */
 export function AgentsPanel({ roomName, refreshKey = 0 }: Props) {
   const [agents, setAgents] = useState<AgentSummary[]>([]);
+  const [posters, setPosters] = useState<string[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const [mineOnly, setMineOnly] = useState(false);
+  const { principal } = useCurrentUser();
 
   const refresh = useCallback(() => {
     fetchRoomAgents(roomName)
@@ -59,6 +65,19 @@ export function AgentsPanel({ roomName, refreshKey = 0 }: Props) {
         logFetchError("fetchRoomAgents")(err);
         setLoaded(true);
       });
+    // Human posters come from the transcript: a room chat post is a broadcast
+    // from a handle that isn't a registered agent.
+    fetchMessages(roomName, 200)
+      .then((data) => {
+        const msgs = Array.isArray(data) ? data : (data?.messages ?? []);
+        setPosters(
+          msgs
+            .filter((m: { message_type?: string }) => m.message_type === "broadcast")
+            .map((m: { sender_handle?: string }) => m.sender_handle ?? "")
+            .filter(Boolean),
+        );
+      })
+      .catch(logFetchError("fetchMessages"));
   }, [roomName]);
 
   useEffect(() => {
@@ -67,11 +86,69 @@ export function AgentsPanel({ roomName, refreshKey = 0 }: Props) {
     return () => clearInterval(t);
   }, [refresh, refreshKey]);
 
+  const agentHandles = useMemo(() => new Set(agents.map((a) => a.handle)), [agents]);
+
+  // People = owners of the room's agents ∪ human posters ∪ the acting-as handle.
+  // Teams roll up from each person's owned agents.
+  const people = useMemo(() => {
+    const byHandle = new Map<string, Person>();
+    const add = (handle: string, owns: boolean) => {
+      const h = handle.replace(/^@/, "").toLowerCase();
+      if (!h) return;
+      const existing = byHandle.get(h);
+      if (existing) {
+        existing.owns = existing.owns || owns;
+        return;
+      }
+      byHandle.set(h, { handle: h, teams: [], you: h === principal, owns });
+    };
+    for (const a of agents) if (a.owner) add(a.owner, true);
+    for (const p of posters) if (!agentHandles.has(p)) add(p, false);
+    if (principal) add(principal, false);
+    for (const person of byHandle.values()) {
+      person.teams = [
+        ...new Set(
+          agents.filter((a) => a.owner === person.handle && a.team).map((a) => a.team as string),
+        ),
+      ];
+    }
+    return [...byHandle.values()].sort((x, y) => x.handle.localeCompare(y.handle));
+  }, [agents, posters, agentHandles, principal]);
+
+  // "Mine" scopes the agent list to the acting-as user: agents they own, plus
+  // any agent fielded by a team their own agents claim.
+  const myTeams = useMemo(
+    () =>
+      new Set(
+        agents.filter((a) => a.owner === principal && a.team).map((a) => a.team as string),
+      ),
+    [agents, principal],
+  );
+  const visibleAgents = useMemo(
+    () =>
+      !mineOnly || !principal
+        ? agents
+        : agents.filter((a) => a.owner === principal || (a.team && myTeams.has(a.team))),
+    [agents, mineOnly, principal, myTeams],
+  );
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <div className="flex items-center gap-2 border-b border-border bg-paper px-4 py-3">
-        <span className="text-label font-semibold text-text">Agents</span>
-        <span className="text-micro tabular text-muted-foreground">{agents.length}</span>
+        <span className="text-label font-semibold text-text">Members</span>
+        <span className="text-micro tabular text-muted-foreground">
+          {people.length + agents.length}
+        </span>
+        {principal && (
+          <Chip
+            variant="accent"
+            active={mineOnly}
+            onClick={() => setMineOnly((v) => !v)}
+            className="ml-1 px-2 py-0.5 text-micro"
+          >
+            mine
+          </Chip>
+        )}
         <Dialog>
           <DialogTrigger
             render={<Button variant="secondary" size="sm" className="ml-auto" />}
@@ -124,12 +201,12 @@ export function AgentsPanel({ roomName, refreshKey = 0 }: Props) {
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        {loaded && agents.length === 0 && (
+        {loaded && agents.length === 0 && people.length === 0 && (
           <EmptyState
             size="sm"
             icon={Users}
-            title="No agents registered"
-            description="Agents are registered from the CLI."
+            title="No members yet"
+            description="Agents are registered from the CLI; people appear once they own an agent or post."
             action={
               <code className="font-mono text-micro bg-surface px-1.5 py-0.5 text-accent border border-border rounded whitespace-nowrap">
                 mycelium agent add
@@ -138,30 +215,81 @@ export function AgentsPanel({ roomName, refreshKey = 0 }: Props) {
           />
         )}
 
-        {agents.map((a) => (
-          <div
-            key={a.handle}
-            className="flex items-center gap-2.5 px-3 py-2.5 border-b border-border last:border-b-0"
-          >
+        {people.length > 0 && (
+          <>
+            <SectionLabel>People</SectionLabel>
+            {people.map((p) => (
+              <div
+                key={`person-${p.handle}`}
+                className="flex items-center gap-2.5 px-3 py-2.5 border-b border-border last:border-b-0"
+              >
+                <Monogram handle={p.handle} color="var(--muted-foreground)" />
+                <div className="min-w-0 flex-1 leading-tight">
+                  <div className="flex items-center gap-1.5">
+                    <span className="font-mono text-label text-text font-semibold truncate leading-tight">
+                      @{p.handle}
+                    </span>
+                    {p.you && (
+                      <span className="text-micro text-accent font-medium">you</span>
+                    )}
+                  </div>
+                  <div className="text-micro text-muted-foreground truncate leading-tight">
+                    {p.owns ? "owner" : "posted here"}
+                    {p.teams.length > 0 ? ` · ${p.teams.join(", ")}` : ""}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </>
+        )}
+
+        {agents.length > 0 && <SectionLabel>Agents</SectionLabel>}
+        {visibleAgents.map((a) => {
+          const mine = principal !== "" && a.owner === principal;
+          return (
             <div
-              className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full font-mono text-micro font-semibold"
-              style={{ background: "color-mix(in srgb, var(--accent) 16%, transparent)", color: "var(--accent)" }}
-              aria-hidden
+              key={`agent-${a.handle}`}
+              className="flex items-center gap-2.5 px-3 py-2.5 border-b border-border last:border-b-0"
             >
-              {initials(a.handle)}
-            </div>
-            <div className="min-w-0 flex-1 leading-tight">
-              <div className="font-mono text-label text-text font-semibold truncate leading-tight">
-                {a.handle}
+              <Monogram handle={a.handle} />
+              <div className="min-w-0 flex-1 leading-tight">
+                <div className="flex items-center gap-1.5">
+                  <span className="font-mono text-label text-text font-semibold truncate leading-tight">
+                    {a.handle}
+                  </span>
+                  {a.owner && (
+                    <span
+                      className="font-mono text-micro truncate"
+                      style={{ color: mine ? "var(--accent)" : "var(--muted-foreground)" }}
+                      title={`owner: @${a.owner}`}
+                    >
+                      @{a.owner}
+                    </span>
+                  )}
+                  {a.team && (
+                    <span className="text-micro text-muted-foreground truncate" title={`team: ${a.team}`}>
+                      · {a.team}
+                    </span>
+                  )}
+                </div>
+                <div className="text-micro text-muted-foreground truncate leading-tight">
+                  {a.adapter}
+                  {a.description ? ` · ${a.description}` : ""}
+                </div>
               </div>
-              <div className="text-micro text-muted-foreground truncate leading-tight">
-                {a.adapter}
-                {a.description ? ` · ${a.description}` : ""}
-              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
+    </div>
+  );
+}
+
+/** Small uppercase divider between the People and Agents groups. */
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-3 pt-3 pb-1 text-micro font-semibold uppercase tracking-wide text-faint">
+      {children}
     </div>
   );
 }

--- a/mycelium-frontend/src/components/current-user.tsx
+++ b/mycelium-frontend/src/components/current-user.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+/**
+ * The principal the browser is acting as — the self-asserted "me" that scopes
+ * "my agents" / "my team" views. There's no auth at this tier, so identity is a
+ * locally-persisted handle the user picks from the global user store. Verified
+ * identity arrives with per-member SLIM binding.
+ */
+const STORAGE_KEY = "mycelium.principal";
+
+interface CurrentUser {
+  /** Bare user handle (lowercase), or "" when acting anonymously. */
+  principal: string;
+  setPrincipal: (handle: string) => void;
+}
+
+const CurrentUserContext = createContext<CurrentUser | null>(null);
+
+function normalize(handle: string): string {
+  return handle.trim().replace(/^@/, "").toLowerCase();
+}
+
+export function CurrentUserProvider({ children }: { children: ReactNode }) {
+  const [principal, setPrincipalState] = useState("");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const saved = window.localStorage.getItem(STORAGE_KEY);
+    if (saved) setPrincipalState(saved);
+  }, []);
+
+  const value = useMemo<CurrentUser>(
+    () => ({
+      principal,
+      setPrincipal: (handle: string) => {
+        const next = normalize(handle);
+        setPrincipalState(next);
+        if (typeof window !== "undefined") {
+          if (next) window.localStorage.setItem(STORAGE_KEY, next);
+          else window.localStorage.removeItem(STORAGE_KEY);
+        }
+      },
+    }),
+    [principal],
+  );
+
+  return (
+    <CurrentUserContext.Provider value={value}>
+      {children}
+    </CurrentUserContext.Provider>
+  );
+}
+
+export function useCurrentUser(): CurrentUser {
+  const ctx = useContext(CurrentUserContext);
+  if (!ctx) {
+    throw new Error("useCurrentUser must be used within a CurrentUserProvider");
+  }
+  return ctx;
+}

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -20,6 +20,7 @@ import { L9Inspector } from "@/components/l9-inspector";
 import { NegotiationView } from "@/components/negotiation-view";
 import { RoomSlimView } from "@/components/room-slim";
 import { EmptyState } from "@/components/empty-state";
+import { initials } from "@/components/ui/monogram";
 import { MessagesSquare } from "lucide-react";
 
 interface Event {
@@ -229,16 +230,6 @@ function toneColor(t: "accent" | "ok" | "warn" | "muted" | "ink"): string {
                         : "var(--muted-foreground)";
 }
 
-/** Two-letter monogram for a chat avatar (mirrors AgentsPanel). */
-function initials(handle: string): string {
-  const parts = handle.split(/[^a-z0-9]+/i).filter(Boolean);
-  const s =
-    parts.length >= 2
-      ? parts[0][0] + parts[1][0]
-      : (parts[0] ?? handle).slice(0, 2);
-  return s.toUpperCase();
-}
-
 const MENTION_RE = /(@[\w-]+)/g;
 
 function renderWithMentions(text: string): React.ReactNode {
@@ -284,17 +275,24 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   const view = viewProp ?? viewInternal;
   const setView = (v: View) => { if (viewProp === undefined) setViewInternal(v); onViewChange?.(v); };
   const [agentHandles, setAgentHandles] = useState<Set<string>>(new Set());
+  const [agentOwners, setAgentOwners] = useState<Map<string, string>>(new Map());
   const [invites, setInvites] = useState<PendingInvite[]>([]);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Know which senders are registered agents so their replies can be badged.
-  // Self-fetched (mirrors the chat box) so the page doesn't have to thread it.
+  // Know which senders are registered agents (to badge their replies) and whom
+  // each belongs to (to attribute them inline). Self-fetched (mirrors the chat
+  // box) so the page doesn't have to thread it; owner is resolved at render time
+  // so it always reflects the current manifest, never a stale stamp.
   useEffect(() => {
     let cancelled = false;
     const load = () =>
       fetchRoomAgents(roomName)
         .then((a) => {
-          if (!cancelled) setAgentHandles(new Set(a.map((x) => x.handle)));
+          if (cancelled) return;
+          setAgentHandles(new Set(a.map((x) => x.handle)));
+          setAgentOwners(
+            new Map(a.filter((x) => x.owner).map((x) => [x.handle, x.owner as string])),
+          );
         })
         .catch(logFetchError("fetchRoomAgents"));
     load();
@@ -628,6 +626,11 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                             style={{ color: "var(--accent)", background: "color-mix(in srgb, var(--accent) 14%, transparent)" }}
                           >
                             agent
+                          </span>
+                        )}
+                        {isAgent && agentOwners.get(ev.sender) && (
+                          <span className="text-micro text-muted-foreground truncate">
+                            owned by @{agentOwners.get(ev.sender)}
                           </span>
                         )}
                         {ev.recipient && (

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -7,37 +7,26 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { ArrowUp } from "lucide-react";
 import { fetchRoomAgents, logFetchError, sendRoomMessage, type AgentSummary } from "@/lib/api";
+import { useCurrentUser } from "@/components/current-user";
 
 interface Props {
   roomName: string;
-  /** Sender handle persisted to localStorage. Falls back to "user". */
-  defaultSender?: string;
   /** Fired after a successful POST so the parent can refresh the event stream. */
   onSent?: () => void;
 }
 
-const SENDER_STORAGE_KEY = "mycelium.chat.sender";
-
-export function RoomChatBox({ roomName, defaultSender, onSent }: Props) {
+export function RoomChatBox({ roomName, onSent }: Props) {
   const [content, setContent] = useState("");
-  const [sender, setSender] = useState<string>(() => defaultSender || "user");
+  // A human message is sent as the acting-as principal — the single source of
+  // "who am I" (the ActingAsPicker), not a per-composer handle. Anonymous falls
+  // back to "user" so the room still has a sender to attribute the message to.
+  const { principal } = useCurrentUser();
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [agents, setAgents] = useState<AgentSummary[]>([]);
   const [mention, setMention] = useState<{ start: number; query: string } | null>(null);
   const [highlight, setHighlight] = useState(0);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
-
-  // Persist sender across reloads so agents see the same handle every time.
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const saved = window.localStorage.getItem(SENDER_STORAGE_KEY);
-    if (saved) setSender(saved);
-  }, []);
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(SENDER_STORAGE_KEY, sender);
-  }, [sender]);
 
   const refreshAgents = useCallback(() => {
     fetchRoomAgents(roomName).then(setAgents).catch((err) => {
@@ -99,7 +88,7 @@ export function RoomChatBox({ roomName, defaultSender, onSent }: Props) {
   const submit = useCallback(async () => {
     const body = content.trim();
     if (!body || sending) return;
-    const handle = sender.trim() || "user";
+    const handle = principal.trim() || "user";
     setSending(true);
     setError(null);
     try {
@@ -115,7 +104,7 @@ export function RoomChatBox({ roomName, defaultSender, onSent }: Props) {
       // render, so refocus after that commit lands to keep the user typing.
       requestAnimationFrame(() => inputRef.current?.focus());
     }
-  }, [content, onSent, roomName, sender, sending]);
+  }, [content, onSent, roomName, principal, sending]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (mention !== null && candidates.length > 0) {
@@ -194,18 +183,6 @@ export function RoomChatBox({ roomName, defaultSender, onSent }: Props) {
             disabled={sending}
           />
           <div className="flex items-center gap-2 px-3 pb-2.5 pt-0.5">
-            <label className="flex items-center gap-1.5 text-micro text-muted-foreground">
-              <span>as</span>
-              <input
-                type="text"
-                value={sender}
-                onChange={(e) => setSender(e.target.value)}
-                placeholder="user"
-                aria-label="Send as handle"
-                size={Math.max(sender.length || 4, 4)}
-                className="font-mono text-micro bg-transparent text-muted-foreground rounded px-1 py-0.5 focus:outline-none focus:bg-surface hover:bg-surface transition-colors"
-              />
-            </label>
             {error && <span className="text-micro text-red truncate">{error}</span>}
             <button
               type="button"

--- a/mycelium-frontend/src/components/room-inspector.tsx
+++ b/mycelium-frontend/src/components/room-inspector.tsx
@@ -12,7 +12,7 @@ import { MemoryPanel } from "@/components/memory-panel";
 export type Tab = "agents" | "episodes" | "memory";
 
 const TABS: { id: Tab; label: string; icon: LucideIcon }[] = [
-  { id: "agents", label: "Agents", icon: Users },
+  { id: "agents", label: "Members", icon: Users },
   { id: "episodes", label: "Episodes", icon: Activity },
   { id: "memory", label: "Memory", icon: Brain },
 ];

--- a/mycelium-frontend/src/components/ui/copy-field.tsx
+++ b/mycelium-frontend/src/components/ui/copy-field.tsx
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** A read-only, monospace input with a copy button — for a command or value the
+ *  user should copy rather than retype. Selects on focus; shows a check on copy. */
+export function CopyField({ value, className }: { value: string; className?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard blocked (insecure context) — the field is still selectable
+    }
+  };
+
+  return (
+    <div className={cn("flex items-stretch gap-1.5", className)}>
+      <input
+        readOnly
+        value={value}
+        onFocus={(e) => e.currentTarget.select()}
+        className="w-full min-w-0 bg-bg border border-border px-2 py-1.5 font-mono text-micro text-text outline-none focus:border-accent"
+      />
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={copied ? "Copied" : "Copy"}
+        className="flex-shrink-0 flex items-center justify-center border border-border px-2 text-muted-foreground hover:bg-surface hover:text-text transition-colors"
+      >
+        {copied ? (
+          <Check className="size-3.5" style={{ color: "var(--green)" }} />
+        ) : (
+          <Copy className="size-3.5" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/ui/monogram.tsx
+++ b/mycelium-frontend/src/components/ui/monogram.tsx
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { cn } from "@/lib/utils";
+
+/** Two-letter monogram from a handle: "backend-lead" → BL, "oc-test2" → OT,
+ *  "main" → MA. Splits on non-alphanumerics, else first two chars. */
+export function initials(handle: string): string {
+  const parts = handle.split(/[^a-z0-9]+/i).filter(Boolean);
+  const s =
+    parts.length >= 2 ? parts[0][0] + parts[1][0] : (parts[0] ?? handle).slice(0, 2);
+  return s.toUpperCase();
+}
+
+interface Props {
+  handle: string;
+  /** Glyph + tint color. Convention: accent for agents, muted for humans. */
+  color?: string;
+  /** Override the default size-8 circle (e.g. "size-5" for a compact chip). */
+  className?: string;
+}
+
+/** Circular initials avatar shared across the agent roster, event stream, and
+ *  the acting-as picker so every handle renders the same way. */
+export function Monogram({ handle, color = "var(--accent)", className }: Props) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "flex size-8 flex-shrink-0 items-center justify-center rounded-full font-mono text-micro font-semibold",
+        className,
+      )}
+      style={{ background: `color-mix(in srgb, ${color} 16%, transparent)`, color }}
+    >
+      {initials(handle)}
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/ui/tag-input.tsx
+++ b/mycelium-frontend/src/components/ui/tag-input.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { X } from "lucide-react";
+
+const norm = (s: string) => s.trim().replace(/^@/, "").toLowerCase();
+
+interface Props {
+  value: string[];
+  onChange: (next: string[]) => void;
+  /** Known values to autocomplete from (e.g. existing team slugs). */
+  suggestions?: string[];
+  placeholder?: string;
+  ariaLabel?: string;
+}
+
+/** Chip/tag input: type a value and Enter (or comma) to add it, Backspace on an
+ *  empty field removes the last, and matching known values surface as clickable
+ *  suggestions. Values are normalized to lowercase slugs. */
+export function TagInput({ value, onChange, suggestions = [], placeholder, ariaLabel }: Props) {
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const add = (raw: string) => {
+    const t = norm(raw);
+    if (t && !value.includes(t)) onChange([...value, t]);
+    setDraft("");
+  };
+
+  const matches = useMemo(() => {
+    const d = norm(draft);
+    return suggestions.filter((s) => !value.includes(s) && (d === "" || s.includes(d))).slice(0, 8);
+  }, [suggestions, value, draft]);
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      if (draft.trim()) add(draft);
+    } else if (e.key === "Backspace" && draft === "" && value.length > 0) {
+      onChange(value.slice(0, -1));
+    }
+  };
+
+  return (
+    <div>
+      <div
+        className="flex flex-wrap items-center gap-1.5 border border-border bg-bg px-2 py-1.5 transition-colors focus-within:border-accent"
+        onClick={() => inputRef.current?.focus()}
+      >
+        {value.map((t) => (
+          <span
+            key={t}
+            className="flex items-center gap-1 rounded bg-surface px-1.5 py-0.5 font-mono text-micro text-text"
+          >
+            {t}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onChange(value.filter((v) => v !== t));
+              }}
+              aria-label={`Remove ${t}`}
+              className="text-muted-foreground hover:text-text"
+            >
+              <X className="size-3" />
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={value.length === 0 ? placeholder : ""}
+          aria-label={ariaLabel}
+          className="min-w-[8ch] flex-1 bg-transparent font-mono text-micro text-text outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+      {matches.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {matches.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => add(s)}
+              className="rounded border border-border px-1.5 py-0.5 font-mono text-micro text-muted-foreground hover:bg-surface hover:text-text transition-colors"
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -210,6 +210,10 @@ export interface AgentSummary {
   handle: string;
   description: string;
   adapter: string;
+  // Self-asserted principal binding: the users/<handle> this agent belongs to
+  // and the team it's fielded by. Absent (null) means principal-anonymous.
+  owner: string | null;
+  team: string | null;
 }
 
 /**
@@ -248,19 +252,91 @@ export async function fetchRoomAgents(roomName: string): Promise<AgentSummary[]>
 
     let description = "";
     let adapter = "claude_code";
+    let owner: string | null = null;
+    let team: string | null = null;
     if (structured) {
       description = String(structured.description || "");
       adapter = String(structured.adapter || "claude_code");
+      owner = structured.owner ? String(structured.owner) : null;
+      team = structured.team ? String(structured.team) : null;
     } else {
       const descMatch = raw.match(/description:\s*(.+)/);
       if (descMatch) description = descMatch[1].trim().replace(/^["']|["']$/g, "");
       const adMatch = raw.match(/adapter:\s*(\S+)/);
       if (adMatch) adapter = adMatch[1].trim();
+      // YAML renders an unset owner/team as `null`; treat that as anonymous.
+      const ownerMatch = raw.match(/owner:\s*(.+)/);
+      if (ownerMatch) {
+        const v = ownerMatch[1].trim().replace(/^["']|["']$/g, "");
+        owner = v && v !== "null" ? v : null;
+      }
+      const teamMatch = raw.match(/team:\s*(.+)/);
+      if (teamMatch) {
+        const v = teamMatch[1].trim().replace(/^["']|["']$/g, "");
+        team = v && v !== "null" ? v : null;
+      }
     }
-    agents.push({ handle: rest, description, adapter });
+    agents.push({ handle: rest, description, adapter, owner, team });
   }
   agents.sort((a, b) => a.handle.localeCompare(b.handle));
   return agents;
+}
+
+// ── Principals (self-asserted user store) ─────────────────────────────────────
+
+export interface OwnedAgent {
+  room: string;
+  handle: string;
+  adapter: string;
+  team: string | null;
+  budget_usd_per_month: number;
+}
+
+export interface User {
+  handle: string;
+  display_name: string;
+  teams: string[];
+  notify: string | null;
+  owns: OwnedAgent[];
+  budget_usd_per_month: number;
+}
+
+export interface Team {
+  team: string;
+  members: string[];
+  agent_count: number;
+  budget_usd_per_month: number;
+}
+
+/** List registered users with their owned-agent budget roll-up. */
+export async function fetchUsers(): Promise<User[]> {
+  const res = await fetch(`/api/users`, { cache: "no-store" });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return Array.isArray(data.users) ? data.users : [];
+}
+
+/** Teams rolled up from agent manifests and user memberships. */
+export async function fetchTeams(): Promise<Team[]> {
+  const res = await fetch(`/api/teams`, { cache: "no-store" });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return Array.isArray(data.teams) ? data.teams : [];
+}
+
+/** Create or upsert a user in the global store. */
+export async function createUser(payload: {
+  handle: string;
+  display_name?: string;
+  teams?: string[];
+}): Promise<User | null> {
+  const res = await fetch(`/api/users`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) return null;
+  return res.json();
 }
 
 // ── Metrics ──────────────────────────────────────────────────────────────────

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -324,18 +324,33 @@ export async function fetchTeams(): Promise<Team[]> {
   return Array.isArray(data.teams) ? data.teams : [];
 }
 
-/** Create or upsert a user in the global store. */
+/** Best-effort human-readable message from a FastAPI error body. */
+async function errorDetail(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    const d = data?.detail;
+    if (typeof d === "string") return d;
+    if (Array.isArray(d) && d[0]?.msg) return String(d[0].msg);
+  } catch {
+    // fall through to the status line
+  }
+  return `Request failed (${res.status})`;
+}
+
+/** Create or upsert a user in the global store. Throws with a readable message
+ *  on failure so callers can surface it instead of swallowing it. */
 export async function createUser(payload: {
   handle: string;
   display_name?: string;
   teams?: string[];
-}): Promise<User | null> {
+  notify?: string | null;
+}): Promise<User> {
   const res = await fetch(`/api/users`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
-  if (!res.ok) return null;
+  if (!res.ok) throw new Error(await errorDetail(res));
   return res.json();
 }
 


### PR DESCRIPTION
Implements the self-asserted tier of #495: give the fabric a notion of **whom an agent belongs to**, and make the human a first-class entity.

## What's here

**Model & CLI**
- `owner` / `team` on `AgentManifest` (optional, backward compatible, slug-normalized), threaded through `agent create --owner/--team` and the wizard.
- Global `users/<handle>` store (people span rooms) + `UserManifest`; `user create/ls/show` and top-level `whoami`.
- `agent ls` shows owner/team with `--owner`/`--team` filters; `user show`/`whoami` roll up per-principal budget (sum of manifest caps, **not** measured spend).

**Backend**
- `principals` service (`classify_sender`, user/team roll-ups) + `/api/users` and `/api/teams` routes; global users store mirrors the CLI.
- **Enforcement (role, not identity):** engines are non-impersonable and phantom handles can't post through the agent path; guards on `/reply` and the broadcast route.

**Frontend**
- **Members** roster (People + Agents) with a shared `Monogram` avatar (accent = agent, muted = human).
- **Acting-as** user picker drives the "mine" filters and the chat sender (replaces the old ad-hoc free-text handle).
- Inline **`owned by @user`** attribution on agent messages (CLI `room watch`/`messages` + the UI event stream), resolved live from the manifest.

**Docs & tests**
- "Users & Teams" concept page, framed as **self-asserted-until-#476**.
- `contracts/user-store.json` freezes the shared user-store shape with a drift-guard test on each side (CLI + backend), same pattern as the SLIM wire contract.
- Unit tests for the layer, roll-ups, and the enforcement guards.

## Scope boundaries (honest)
- **Attribution is ownership-only.** "Whose agent" is answerable; action-level "who did this" and a real cost ledger are out of scope.
- **Self-asserted, not verified.** The guards enforce *role*, not *identity* — nothing stops impersonating another person's registered agent. That's #476, and the concrete repro (impersonation + false attribution) is tracked there: https://github.com/mycelium-io/mycelium/issues/476#issuecomment-5294934449

## Gates
CLI: ruff + format + ty + 436 tests. Backend: ruff + format + ty + 404 tests. Frontend: tsc + build. All green.

Closes #495 (self-asserted tier).