### PR TITLE
fix(persister): append-only JSONL transcript + transcript-backed read path (#497)

### DIFF
--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -25,7 +25,7 @@ from app.schemas import (
     MessageRead,
     MessageType,
 )
-from app.services import local_state, room_channels
+from app.services import local_state, persister, room_channels
 from app.services.filesystem import room_exists
 
 logger = logging.getLogger(__name__)
@@ -71,11 +71,6 @@ async def send_message(room_name: str, payload: MessageCreate):
             msg.event_expires_at = datetime.now(UTC) + timedelta(
                 seconds=payload.metadata.ttl_seconds
             )
-    # The human's message is stored here with its own id so event semantics
-    # (status transitions, PATCH-by-id, ttl) work. Agent replies arrive over SLIM
-    # and are written into this same store by the persister — one list store,
-    # two producers, no duplication (the persister skips locally-ingested ids).
-    local_state.add_message(channel, msg)
 
     notify_payload: dict = {
         "id": str(msg.id),
@@ -91,14 +86,14 @@ async def send_message(room_name: str, payload: MessageCreate):
         notify_payload["coordination_session_id"] = str(coord.id)
     notify_payload["room_name"] = channel
 
-    # Human-in-the-room: for a real room with a live SLIM channel,
-    # the backend publishes the human's message onto the channel as their proxy —
-    # ``@``-parsing recipients so in-room agents wake, and raising consent for
-    # absent mentions. The persister is then the SINGLE writer of the room's record:
-    # it records this message (via ``ingest_local``) into both the
-    # list store and the bus, so we must NOT also write local_state / bus.publish
-    # here (that would double it). Coordination sub-rooms and the no-channel path
-    # have no persister, so they keep the direct local_state write + legacy bus.
+    # Human-in-the-room: for a real room with a live SLIM channel, the backend
+    # publishes the human's message onto the channel as their proxy — ``@``-parsing
+    # recipients so in-room agents wake, and raising consent for absent mentions.
+    # The persister records it to the durable transcript (via ``ingest_local``),
+    # which is the read path's source of truth, so we must NOT also write
+    # ``local_state`` / ``bus.publish`` here (that would double it). The no-channel
+    # path and event/non-broadcast messages have no persister, so they keep the
+    # direct ``local_state`` write + legacy bus.
     published = False
     if (
         coord is None
@@ -109,10 +104,42 @@ async def send_message(room_name: str, payload: MessageCreate):
             channel, sender=msg.sender_handle, text=msg.content
         )
         published = result is not None
+        if result is not None:
+            # Correlation key: the same envelope the persister records to the
+            # transcript, so a cold read dedups this row against its transcript copy.
+            msg.message_id = result.message_id
+    # The human's message always lands in ``local_state`` — its id backs PATCH /
+    # event semantics and it's the live lens. The persister records the same
+    # message to the durable transcript (the read path's source of truth); the two
+    # dedup by ``message_id`` on read. When published, the persister owns the bus
+    # push, so only the un-published path publishes here.
+    local_state.add_message(channel, msg)
     if not published:
         bus.publish(room_channel(channel), notify_payload)
 
     return MessageRead.model_validate(msg)
+
+
+def _read_messages(
+    channel: str, coord: local_state.CoordSessionShim | None
+) -> list[local_state.StoredMessage]:
+    """The room view: durable conversational history + in-memory event-ledger rows.
+
+    A real room's durable conversational history lives in the transcript (survives
+    restarts; both ``respond`` and ``room send`` converge there). The in-memory
+    ``local_state`` is the live lens and holds the ledger fields (ttl/status) plus
+    the ids clients already hold, so where a message is in both stores the
+    ``local_state`` row wins; the transcript only fills what memory lost (a message
+    from before a restart). Dedup is by envelope ``message_id`` (a distinct id space
+    from ``StoredMessage.id``). A coordination session has no transcript.
+    """
+    if coord is not None:
+        return local_state.list_messages(channel)
+
+    mem = local_state.list_messages(channel)
+    live_ids = {m.message_id for m in mem if m.message_id}
+    disk = [m for m in persister.conversational_messages(channel) if m.message_id not in live_ids]
+    return disk + mem
 
 
 @router.get("", response_model=MessageListResponse)
@@ -130,10 +157,10 @@ async def list_messages(
     ),
 ):
     """List messages in a room (or coordination session), newest first."""
-    channel, _coord = _resolve_channel(room_name)
+    channel, coord = _resolve_channel(room_name)
     now = datetime.now(UTC)
 
-    messages = local_state.list_messages(channel)
+    messages = _read_messages(channel, coord)
     filtered = []
     for m in messages:
         if m.event_expires_at is not None and m.event_expires_at <= now:

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -223,7 +223,9 @@ async def post_reply(room_name: str, body: ReplyBody):
     # Record into the transcript (the aligner polls it for positions). SLIM does
     # not echo a broadcast back to its own sender, so a local record is required —
     # then also broadcast so any client-connected members / the UI see it.
-    managed.persister.ingest_local(envelope, content)
+    # ``list_write=True`` so the reply is visible in the room view immediately, the
+    # same store a ``room send`` broadcast lands in (no store divergence).
+    managed.persister.ingest_local(envelope, content, list_write=True)
     try:
         await managed.channel.send(envelope, extra={"content": clean})
     except Exception:

--- a/fastapi-backend/app/services/local_state.py
+++ b/fastapi-backend/app/services/local_state.py
@@ -87,6 +87,12 @@ class StoredMessage:
     # casual reply carries the room's default). Lets the UI group/fold a
     # negotiation's turns under their episode instead of interleaving them inline.
     episode: str | None = None
+    # The L9 envelope id when this message rode the channel (respond / broadcast /
+    # agent reply). A cross-store correlation key: the same message can surface
+    # from the durable transcript and this in-memory store, and they dedup by this
+    # id (``StoredMessage.id`` is a distinct id space). ``None`` for a message that
+    # only ever lived here (an event-ledger row, or a broadcast to a dead channel).
+    message_id: str | None = None
     id: uuid.UUID = field(default_factory=uuid.uuid4)
     created_at: datetime = field(default_factory=_now)
 

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -7,10 +7,10 @@ Backend-as-room-infrastructure: the persister / durable inbox.
 The backend runs as moderator on the room's SLIM group channel and consumes it.
 This module is that consumer, and it does four things as each message flows past:
 
-1. **Persister.** Records the full transcript to the room's markdown (``log/``)
-   so it survives, is git-shareable, and is picked up by the reindex watcher —
-   memory the normal way, a *distinct* artifact from the
-   episode-scoped ``log/episodes/*`` records ``l9_episode`` writes.
+1. **Persister.** Appends each message to the room's transcript
+   (``log/transcript.jsonl``, one JSON record per line) so it survives, is
+   git-shareable, and is written O(1) per message — a *distinct* artifact from
+   the episode-scoped ``log/episodes/*`` records ``l9_episode`` writes.
 
 2. **Durable inbox.** SLIM keeps **no** messages for an offline member: a
    broadcast that happened while a member was gone is never replayed on rejoin.
@@ -38,6 +38,7 @@ import contextlib
 import json
 import logging
 import re
+import uuid
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -48,19 +49,26 @@ from app.schemas import MessageType
 from app.services import l9
 from app.services.l9_slim import ChannelReceiveTimeout
 
+# Stable namespace so a transcript record maps to the same synthetic
+# ``StoredMessage.id`` on every read (the envelope id is the seed).
+_MESSAGE_ID_NS = uuid.UUID("6f1d2c3b-4a59-6e7d-8c9b-0a1b2c3d4e5f")
+
 if TYPE_CHECKING:
     import slim_bindings
 
     from app.services.l9_models import L9
     from app.services.l9_slim import L9SlimChannel
+    from app.services.local_state import StoredMessage
 
 logger = logging.getLogger(__name__)
 
-# The transcript memory key under a room's dir (``log/transcript.md``). One
-# jsonl-bearing markdown file per room: append-only, reindex-friendly, and
-# deliberately separate from ``log/episodes/*`` (episode-scoped) so the two
-# never clobber each other.
+# The transcript is a plain append-only JSONL file per room
+# (``log/transcript.jsonl``): one JSON record per line, written O(1) per message
+# and deliberately separate from ``log/episodes/*`` (episode-scoped) so the two
+# never clobber each other. ``TRANSCRIPT_KEY`` names the legacy fenced-markdown
+# transcript (``log/transcript.md``), read once on load and migrated forward.
 TRANSCRIPT_KEY = "log/transcript"
+TRANSCRIPT_FILENAME = "log/transcript.jsonl"
 
 # An ``@``-summon token: ``@`` followed by a handle (letter/digit start, then
 # word chars or hyphens). Guarded so it doesn't fire mid-word (e.g. an email).
@@ -272,30 +280,30 @@ def record_from(
 
 # ── Transcript persistence (markdown + jsonl block) ──────────────────────────
 
-_TRANSCRIPT_HEADER = (
-    "The live room transcript — every message recorded off the SLIM channel, "
-    "one JSON record per line (distinct from the episode records under "
-    "`log/episodes/`)."
-)
+
+def _transcript_line(record: TranscriptRecord) -> str:
+    """Serialize one record to its canonical JSONL line (no trailing newline)."""
+    return json.dumps(record.to_json(), sort_keys=True)
 
 
-def render_transcript(records: list[TranscriptRecord]) -> str:
-    """The markdown body for the transcript file (a jsonl block)."""
-    lines = [
-        _TRANSCRIPT_HEADER,
-        "",
-        "```jsonl",
-        *(json.dumps(r.to_json(), sort_keys=True) for r in records),
-        "```",
-        "",
-    ]
-    return "\n".join(lines)
-
-
-def parse_transcript(body: str) -> list[TranscriptRecord]:
-    """Parse the jsonl block of a transcript body back into records."""
+def _parse_jsonl(text: str) -> list[TranscriptRecord]:
+    """Parse a plain JSONL transcript body back into records."""
     records: list[TranscriptRecord] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            records.append(TranscriptRecord.from_json(json.loads(stripped)))
+        except (json.JSONDecodeError, KeyError, TypeError):
+            logger.warning("skipping malformed transcript line")
+    return records
+
+
+def _parse_legacy_transcript(body: str) -> list[TranscriptRecord]:
+    """Parse the fenced ```jsonl``` block of a legacy ``transcript.md`` body."""
     in_block = False
+    inner: list[str] = []
     for line in body.splitlines():
         stripped = line.strip()
         if stripped == "```jsonl":
@@ -304,41 +312,143 @@ def parse_transcript(body: str) -> list[TranscriptRecord]:
         if stripped == "```":
             in_block = False
             continue
-        if in_block and stripped:
-            try:
-                records.append(TranscriptRecord.from_json(json.loads(stripped)))
-            except (json.JSONDecodeError, KeyError, TypeError):
-                logger.warning("skipping malformed transcript line")
-    return records
+        if in_block:
+            inner.append(line)
+    return _parse_jsonl("\n".join(inner))
 
 
 def load_transcript(room: str) -> list[TranscriptRecord]:
-    """Read a room's persisted transcript (empty when none exists)."""
-    from app.services.filesystem import get_room_dir, read_memory_file
+    """Read a room's persisted transcript (empty when none exists).
 
-    result = read_memory_file(get_room_dir(room), TRANSCRIPT_KEY)
-    if result is None:
+    Reads the append-only ``log/transcript.jsonl``. If only the legacy fenced
+    ``log/transcript.md`` exists, it is parsed and migrated forward in place.
+    """
+    from app.services.filesystem import (
+        delete_memory_file,
+        get_room_dir,
+        read_memory_file,
+    )
+
+    base = get_room_dir(room)
+    path = base / TRANSCRIPT_FILENAME
+    if path.exists():
+        return _parse_jsonl(path.read_text(encoding="utf-8"))
+
+    legacy = read_memory_file(base, TRANSCRIPT_KEY)
+    if legacy is None:
         return []
-    _meta, body = result
-    return parse_transcript(body)
+    _meta, body = legacy
+    records = _parse_legacy_transcript(body)
+    try:  # best-effort one-time migration to plain JSONL
+        write_transcript(room, records)
+        delete_memory_file(base, TRANSCRIPT_KEY)
+    except Exception:
+        logger.exception("transcript migration failed for room %s", room)
+    return records
+
+
+def append_transcript(room: str, record: TranscriptRecord) -> None:
+    """Append one record to ``log/transcript.jsonl`` in O(1) (best-effort)."""
+    try:
+        from app.services.filesystem import get_room_dir
+
+        path = get_room_dir(room) / TRANSCRIPT_FILENAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(_transcript_line(record) + "\n")
+    except Exception:
+        logger.exception("transcript append failed for room %s", room)
 
 
 def write_transcript(room: str, records: list[TranscriptRecord]) -> None:
-    """Persist a room's transcript to ``log/transcript.md`` (best-effort)."""
-    try:
-        from app.services.filesystem import get_room_dir, write_memory_file
+    """Rewrite a room's whole transcript to ``log/transcript.jsonl``.
 
-        base = get_room_dir(room)
-        base.mkdir(parents=True, exist_ok=True)
-        write_memory_file(
-            base,
-            TRANSCRIPT_KEY,
-            render_transcript(records),
-            created_by=l9.SYSTEM_ACTOR_ID,
-            updated_by=l9.SYSTEM_ACTOR_ID,
-        )
+    Used for migration and tests; the hot path appends via
+    :func:`append_transcript` instead of re-rendering the full list.
+    """
+    try:
+        from app.services.filesystem import get_room_dir
+
+        path = get_room_dir(room) / TRANSCRIPT_FILENAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        body = "".join(_transcript_line(r) + "\n" for r in records)
+        path.write_text(body, encoding="utf-8")
     except Exception:
         logger.exception("transcript write failed for room %s", room)
+
+
+def _conversational_text(content: dict[str, Any]) -> str | None:
+    """The human-facing chat text of a record, or None if it isn't chat.
+
+    Only a human ``message`` and an agent ``reply`` are chat; presence/ping and
+    other control payloads carry no chat text and stay out of the list.
+    """
+    payload_type = content.get("l9", {}).get("payload", {}).get("type")
+    text = content.get("content")
+    if payload_type not in ("message", "reply") or not isinstance(text, str) or not text:
+        return None
+    return text
+
+
+def stored_message_from_record(room: str, record: TranscriptRecord) -> StoredMessage | None:
+    """Project a transcript record into the ``StoredMessage`` the list/UI reads.
+
+    Returns None for a non-conversational record. The synthetic id is derived from
+    the envelope id so it's stable across reads, and ``message_id`` carries that
+    envelope id as the cross-store correlation key (dedup against ``local_state``).
+    """
+    from app.services.local_state import StoredMessage
+
+    text = _conversational_text(record.content)
+    if text is None:
+        return None
+    episode = record.content.get("l9", {}).get("header", {}).get("message", {}).get("episode")
+    seed = record.message_id or f"{record.recorded_at}:{record.sender}"
+    msg = StoredMessage(
+        room_name=room,
+        sender_handle=record.sender,
+        message_type=MessageType.BROADCAST,
+        content=text,
+        episode=episode if isinstance(episode, str) else None,
+        message_id=record.message_id or None,
+        id=uuid.uuid5(_MESSAGE_ID_NS, seed),
+    )
+    with contextlib.suppress(ValueError, TypeError):
+        msg.created_at = datetime.fromisoformat(record.recorded_at)
+    return msg
+
+
+# Per-room cache of the mapped conversational view, invalidated when the
+# transcript file changes, so a hot UI poll re-stats (cheap) rather than
+# re-parsing the whole file every read.
+_conversational_cache: dict[str, tuple[tuple[int, int], list[StoredMessage]]] = {}
+
+
+def conversational_messages(room: str) -> list[StoredMessage]:
+    """The room's conversational history, projected from the durable transcript.
+
+    The read path's source of truth for chat: it survives restarts (the transcript
+    is on disk) and both post paths converge here (``respond`` and a human
+    broadcast both land in the transcript). Event-ledger rows live only in
+    ``local_state`` and are merged in by the route.
+    """
+    from app.services.filesystem import get_room_dir
+
+    path = get_room_dir(room) / TRANSCRIPT_FILENAME
+    try:
+        st = path.stat()
+        stamp = (st.st_mtime_ns, st.st_size)
+    except OSError:
+        _conversational_cache.pop(room, None)
+        return []
+    cached = _conversational_cache.get(room)
+    if cached is not None and cached[0] == stamp:
+        return list(cached[1])
+    messages = [
+        m for r in load_transcript(room) if (m := stored_message_from_record(room, r)) is not None
+    ]
+    _conversational_cache[room] = (stamp, messages)
+    return list(messages)
 
 
 # Delivery cursors persist next to the transcript so a reconnecting agent's
@@ -659,14 +769,23 @@ class RoomPersister:
             for envelope, content in released:
                 self._ingest(envelope, content)
 
-    def ingest_local(self, envelope: L9, content: dict[str, Any]) -> None:
-        """Ingest a message the moderator published itself (the human proxy).
+    def ingest_local(
+        self, envelope: L9, content: dict[str, Any], *, list_write: bool = False
+    ) -> None:
+        """Ingest a message the moderator published itself (locally originated).
 
-        The backend speaks for the human on the fabric: it publishes
-        the human's ``exchange`` on the channel *and* records it here directly, so
-        the transcript and UI bus see it regardless of whether SLIM delivers a
+        The backend records the message into the transcript directly, so the
+        transcript and UI bus see it regardless of whether SLIM delivers a
         broadcast back to its own sender. :meth:`_ingest` de-dupes by message id,
         so a loopback of the same broadcast is a no-op.
+
+        ``list_write`` controls whether the message is also written to the
+        in-memory list store: the human-proxy broadcast path pre-writes nothing to
+        ``local_state`` (the transcript is its record, read back by
+        :func:`conversational_messages`), while ``respond`` (``/reply``) passes
+        ``list_write=True`` so an agent's turn is visible live, before it's flushed
+        to the durable transcript — otherwise ``respond`` and ``room send`` would
+        land in different stores.
 
         Also marks the message delivered in the channel's causal buffer: a locally
         ingested message never passes through ``receive_with_context``, so without
@@ -674,9 +793,9 @@ class RoomPersister:
         ``parents=[woke_id]``) is held in the buffer forever and never recorded.
         """
         self._channel.note_delivered(envelope)
-        self._ingest(envelope, content, local=True)
+        self._ingest(envelope, content, list_write=list_write)
 
-    def _ingest(self, envelope: L9, content: dict[str, Any], *, local: bool = False) -> None:
+    def _ingest(self, envelope: L9, content: dict[str, Any], *, list_write: bool = True) -> None:
         # Keepalive pings exist only to reset a member's SLIM liveness (which the
         # datapath already did before this message reached us), so they carry no
         # transcript value. Drop them here — otherwise a member's ~20s keepalive
@@ -691,13 +810,14 @@ class RoomPersister:
         record = record_from(envelope, content)
         present = set(self._members_provider())
         self.log.record(record, delivered_to=present, recipients=envelope_recipients(envelope))
-        write_transcript(self.room, self.log.records)
+        append_transcript(self.room, record)
         self._persist_cursors()
-        # A locally-ingested message (the human proxy) is already in the list store
-        # via POST /messages with its own id (for event/PATCH semantics); only
-        # messages that ARRIVE over SLIM (agent replies) have no other producer.
-        if not local:
-            self._record_to_list_store(record, content)
+        # The list store is the live/fast lens; the durable transcript is the read
+        # path's source of truth. SLIM arrivals (agent replies) and ``respond`` write
+        # here so they're visible immediately; the human-proxy broadcast skips it
+        # (``list_write=False``) since the transcript already carries it.
+        if list_write:
+            self._record_to_list_store(record)
         if self._feed_bus:
             self._publish_to_bus(record)
         # Triggers: @-summon and commit:converged (skeleton hooks). The full
@@ -741,42 +861,21 @@ class RoomPersister:
         except Exception:
             logger.debug("bus publish from persister failed for room %s", self.room, exc_info=True)
 
-    def _record_to_list_store(self, record: TranscriptRecord, content: dict[str, Any]) -> None:
-        """Record the message into the store the HTTP list/UI reads.
+    def _record_to_list_store(self, record: TranscriptRecord) -> None:
+        """Mirror a conversational record into the in-memory list store (live lens).
 
-        The persister is the **single writer** of a channel-backed room's message
-        record: ``POST /messages`` only publishes to SLIM, and everything (the
-        human's own message via ``ingest_local``, agents' replies via receive)
-        lands here. Before this, human messages reached the list via the POST
-        route but agent replies — which only ever arrive over SLIM — never did, so
-        they were invisible in the UI. Conversational messages only (presence and
-        other non-message payloads stay in the transcript/bus).
+        The durable transcript is the read path's source of truth; this write keeps
+        the message visible immediately (before a cold read re-projects the
+        transcript). Conversational payloads only — presence/control payloads stay
+        in the transcript/bus, out of the chat list. Carries the envelope id so a
+        cold read dedups this row against its transcript projection.
         """
-        # Conversational payloads only: a human ``message`` and an agent ``reply``
-        # (``build_reply`` tags replies "reply"). Presence/ping and other control
-        # payloads stay in the transcript/bus, out of the chat list.
-        payload_type = content.get("l9", {}).get("payload", {}).get("type")
-        text = content.get("content")
-        if payload_type not in ("message", "reply") or not text:
+        msg = stored_message_from_record(self.room, record)
+        if msg is None:
             return
         try:
             from app.services import local_state
 
-            created_at = None
-            with contextlib.suppress(ValueError, TypeError):
-                created_at = datetime.fromisoformat(record.recorded_at)
-            episode = (
-                content.get("l9", {}).get("header", {}).get("message", {}).get("episode") or None
-            )
-            msg = local_state.StoredMessage(
-                room_name=self.room,
-                sender_handle=record.sender,
-                message_type=MessageType.BROADCAST,
-                content=text,
-                episode=episode if isinstance(episode, str) else None,
-            )
-            if created_at is not None:
-                msg.created_at = created_at
             local_state.add_message(self.room, msg)
         except Exception:
             logger.debug("list-store write failed for room %s", self.room, exc_info=True)

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -65,9 +65,7 @@ logger = logging.getLogger(__name__)
 # The transcript is a plain append-only JSONL file per room
 # (``log/transcript.jsonl``): one JSON record per line, written O(1) per message
 # and deliberately separate from ``log/episodes/*`` (episode-scoped) so the two
-# never clobber each other. ``TRANSCRIPT_KEY`` names the legacy fenced-markdown
-# transcript (``log/transcript.md``), read once on load and migrated forward.
-TRANSCRIPT_KEY = "log/transcript"
+# never clobber each other.
 TRANSCRIPT_FILENAME = "log/transcript.jsonl"
 
 # An ``@``-summon token: ``@`` followed by a handle (letter/digit start, then
@@ -300,51 +298,14 @@ def _parse_jsonl(text: str) -> list[TranscriptRecord]:
     return records
 
 
-def _parse_legacy_transcript(body: str) -> list[TranscriptRecord]:
-    """Parse the fenced ```jsonl``` block of a legacy ``transcript.md`` body."""
-    in_block = False
-    inner: list[str] = []
-    for line in body.splitlines():
-        stripped = line.strip()
-        if stripped == "```jsonl":
-            in_block = True
-            continue
-        if stripped == "```":
-            in_block = False
-            continue
-        if in_block:
-            inner.append(line)
-    return _parse_jsonl("\n".join(inner))
-
-
 def load_transcript(room: str) -> list[TranscriptRecord]:
-    """Read a room's persisted transcript (empty when none exists).
+    """Read a room's persisted ``log/transcript.jsonl`` (empty when none exists)."""
+    from app.services.filesystem import get_room_dir
 
-    Reads the append-only ``log/transcript.jsonl``. If only the legacy fenced
-    ``log/transcript.md`` exists, it is parsed and migrated forward in place.
-    """
-    from app.services.filesystem import (
-        delete_memory_file,
-        get_room_dir,
-        read_memory_file,
-    )
-
-    base = get_room_dir(room)
-    path = base / TRANSCRIPT_FILENAME
-    if path.exists():
-        return _parse_jsonl(path.read_text(encoding="utf-8"))
-
-    legacy = read_memory_file(base, TRANSCRIPT_KEY)
-    if legacy is None:
+    path = get_room_dir(room) / TRANSCRIPT_FILENAME
+    if not path.exists():
         return []
-    _meta, body = legacy
-    records = _parse_legacy_transcript(body)
-    try:  # best-effort one-time migration to plain JSONL
-        write_transcript(room, records)
-        delete_memory_file(base, TRANSCRIPT_KEY)
-    except Exception:
-        logger.exception("transcript migration failed for room %s", room)
-    return records
+    return _parse_jsonl(path.read_text(encoding="utf-8"))
 
 
 def append_transcript(room: str, record: TranscriptRecord) -> None:
@@ -363,8 +324,8 @@ def append_transcript(room: str, record: TranscriptRecord) -> None:
 def write_transcript(room: str, records: list[TranscriptRecord]) -> None:
     """Rewrite a room's whole transcript to ``log/transcript.jsonl``.
 
-    Used for migration and tests; the hot path appends via
-    :func:`append_transcript` instead of re-rendering the full list.
+    A full-file rewrite for seeding a transcript wholesale (tests); the hot path
+    appends via :func:`append_transcript` instead of re-rendering the full list.
     """
     try:
         from app.services.filesystem import get_room_dir
@@ -445,23 +406,16 @@ def conversational_messages(room: str) -> list[StoredMessage]:
 
     path = get_room_dir(room) / TRANSCRIPT_FILENAME
     stamp = _stat_stamp(path)
-    if stamp is not None:
-        cached = _conversational_cache.get(room)
-        if cached is not None and cached[0] == stamp:
-            return list(cached[1])
-    # Fall through to load_transcript even when the .jsonl is absent: it migrates a
-    # legacy fenced transcript.md forward on first read, so a dormant legacy room
-    # (read-only browsed before it's next provisioned) isn't shown empty.
+    if stamp is None:
+        _conversational_cache.pop(room, None)
+        return []
+    cached = _conversational_cache.get(room)
+    if cached is not None and cached[0] == stamp:
+        return list(cached[1])
     messages = [
         m for r in load_transcript(room) if (m := stored_message_from_record(room, r)) is not None
     ]
-    # Re-stat when the file was absent: a legacy migration may have just created
-    # it. Cache only when it exists on disk, so a truly empty room stays cheap.
-    post = stamp if stamp is not None else _stat_stamp(path)
-    if post is not None:
-        _conversational_cache[room] = (post, messages)
-    else:
-        _conversational_cache.pop(room, None)
+    _conversational_cache[room] = (stamp, messages)
     return list(messages)
 
 

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -424,6 +424,15 @@ def stored_message_from_record(room: str, record: TranscriptRecord) -> StoredMes
 _conversational_cache: dict[str, tuple[tuple[int, int], list[StoredMessage]]] = {}
 
 
+def _stat_stamp(path: Path) -> tuple[int, int] | None:
+    """A (mtime_ns, size) cache stamp for ``path``, or None if it doesn't exist."""
+    try:
+        st = path.stat()
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
 def conversational_messages(room: str) -> list[StoredMessage]:
     """The room's conversational history, projected from the durable transcript.
 
@@ -435,19 +444,24 @@ def conversational_messages(room: str) -> list[StoredMessage]:
     from app.services.filesystem import get_room_dir
 
     path = get_room_dir(room) / TRANSCRIPT_FILENAME
-    try:
-        st = path.stat()
-        stamp = (st.st_mtime_ns, st.st_size)
-    except OSError:
-        _conversational_cache.pop(room, None)
-        return []
-    cached = _conversational_cache.get(room)
-    if cached is not None and cached[0] == stamp:
-        return list(cached[1])
+    stamp = _stat_stamp(path)
+    if stamp is not None:
+        cached = _conversational_cache.get(room)
+        if cached is not None and cached[0] == stamp:
+            return list(cached[1])
+    # Fall through to load_transcript even when the .jsonl is absent: it migrates a
+    # legacy fenced transcript.md forward on first read, so a dormant legacy room
+    # (read-only browsed before it's next provisioned) isn't shown empty.
     messages = [
         m for r in load_transcript(room) if (m := stored_message_from_record(room, r)) is not None
     ]
-    _conversational_cache[room] = (stamp, messages)
+    # Re-stat when the file was absent: a legacy migration may have just created
+    # it. Cache only when it exists on disk, so a truly empty room stays cheap.
+    post = stamp if stamp is not None else _stat_stamp(path)
+    if post is not None:
+        _conversational_cache[room] = (post, messages)
+    else:
+        _conversational_cache.pop(room, None)
     return list(messages)
 
 

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -120,6 +120,10 @@ class HumanPublishResult:
     mentioned: list[str]
     recipients: list[str]
     invites: list[PendingInvite]
+    # The published envelope's L9 message id — the correlation key the POST route
+    # stamps on its ``local_state`` row so a cold read from the durable transcript
+    # dedups against it instead of showing the human's message twice.
+    message_id: str | None = None
 
 
 @dataclass
@@ -483,12 +487,16 @@ class RoomChannelManager:
             payload_type="message",
         )
         content = serialize_content(envelope, extra={"content": text})
+        message_id = envelope.header.message.id if envelope.header.message else None
         try:
             await managed.channel.send(envelope, extra={"content": text})
         except Exception as exc:  # best-effort broadcast
             logger.warning("failed to publish human message on room %s: %s", room, exc)
         if managed.persister is not None:
-            managed.persister.ingest_local(envelope, content)
+            # Transcript-only here (``list_write=False``): the POST route owns the
+            # ``local_state`` row (its id/ledger), stamped with this envelope's id so
+            # a cold read dedups the two.
+            managed.persister.ingest_local(envelope, content, list_write=False)
 
         # Consent gate: an @-mention of an agent not on the channel invites
         # it — but the user's OWN registered agents in this room are pre-authorized
@@ -522,7 +530,9 @@ class RoomChannelManager:
                 invites.append(invite)
 
         recipients = [h for h in mentioned if h != BACKEND_AGENT]
-        return HumanPublishResult(mentioned=mentioned, recipients=recipients, invites=invites)
+        return HumanPublishResult(
+            mentioned=mentioned, recipients=recipients, invites=invites, message_id=message_id
+        )
 
     # -- consent-gated invites --
 

--- a/fastapi-backend/tests/test_messages_read_path.py
+++ b/fastapi-backend/tests/test_messages_read_path.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The transcript-backed read path (issue #497 §3).
+
+``GET /messages`` merges the durable transcript with the in-memory list store so
+the room view survives a restart and both post paths converge. These exercise the
+merge/dedup directly, node-free: they seed the transcript + list store and assert
+what ``_read_messages`` returns.
+"""
+
+from app.routes.messages import _read_messages
+from app.services import l9, local_state, persister
+from app.services.filesystem import get_room_dir
+from app.services.l9_models import Kind
+from app.services.l9_slim import serialize_content
+
+
+def _record(message_id: str, *, sender: str, text: str):
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode="urn:ioc:mycelium:episode:r:s",
+        sender=sender,
+        recipients=[l9.SYSTEM_ACTOR_ID],
+        topic="urn:concept:mycelium:r",
+        message_id=message_id,
+        payload_type="reply",
+    )
+    return persister.record_from(env, serialize_content(env, extra={"content": text}))
+
+
+def test_read_serves_the_transcript_when_memory_is_empty(tmp_path, monkeypatch):
+    """A restart wipes ``local_state`` but not the transcript: the read path still
+    returns the room's history."""
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    local_state.clear_all()
+    room = "read-restart-room"
+    get_room_dir(room)
+    persister.append_transcript(room, _record("a-1", sender="growth", text="from before restart"))
+
+    served = _read_messages(room, None)
+    assert [m.content for m in served] == ["from before restart"]
+
+
+def test_read_dedups_a_message_present_in_both_stores(tmp_path, monkeypatch):
+    """A live message is in both the list store and the transcript; the read path
+    shows it once (the list-store row wins, keeping its ledger fields and id)."""
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    local_state.clear_all()
+    room = "read-dedup-room"
+    get_room_dir(room)
+
+    record = _record("a-1", sender="growth", text="hello")
+    persister.append_transcript(room, record)
+    mem_row = persister.stored_message_from_record(room, record)
+    assert mem_row is not None
+    local_state.add_message(room, mem_row)
+
+    served = _read_messages(room, None)
+    assert len(served) == 1
+    assert served[0].id == mem_row.id  # the list-store row, not a second disk copy
+
+
+def test_read_merges_event_ledger_rows_that_only_live_in_memory(tmp_path, monkeypatch):
+    """An event row (ttl/status) never rides the transcript; it must still surface
+    alongside the transcript-backed chat."""
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    local_state.clear_all()
+    room = "read-merge-room"
+    get_room_dir(room)
+
+    persister.append_transcript(room, _record("a-1", sender="growth", text="chat"))
+    local_state.add_message(
+        room,
+        local_state.StoredMessage(
+            room_name=room,
+            sender_handle="github-poller",
+            message_type="event",
+            content="a PR opened",
+            event_kind="source_event",
+        ),
+    )
+
+    served = _read_messages(room, None)
+    assert {m.content for m in served} == {"chat", "a PR opened"}

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -506,6 +506,27 @@ def test_conversational_messages_project_from_the_durable_transcript():
     assert projected[1].episode == "urn:ioc:mycelium:episode:r:s"
 
 
+def test_conversational_messages_migrate_and_serve_a_legacy_transcript():
+    """A dormant legacy room (only the fenced transcript.md, never provisioned
+    since deploy) must not read as empty: conversational_messages falls through to
+    load_transcript, which migrates the .md forward, so the read path serves it."""
+    from app.services.filesystem import write_memory_file
+
+    room = "conv-legacy-room"
+    base = get_room_dir(room)
+    env, content = _msg_content(
+        "h-1", sender="julia", text="from the old format", payload_type="message"
+    )
+    line = persister._transcript_line(persister.record_from(env, content))
+    body = "\n".join(["The live room transcript.", "", "```jsonl", line, "```", ""])
+    write_memory_file(base, persister.TRANSCRIPT_KEY, body, created_by="x")
+    assert not (base / persister.TRANSCRIPT_FILENAME).exists()  # no .jsonl yet
+
+    projected = persister.conversational_messages(room)
+    assert [m.content for m in projected] == ["from the old format"]
+    assert (base / persister.TRANSCRIPT_FILENAME).exists()  # migrated forward on read
+
+
 def test_conversational_messages_survive_a_wiped_in_memory_store():
     """The restart bug (issue #497 §3): the in-memory list store is empty after a
     restart, but the durable transcript still projects the full history — so the

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -113,31 +113,6 @@ def test_append_transcript_is_o1_and_accumulates():
     assert "```" not in body
 
 
-def test_legacy_markdown_transcript_migrates_forward_on_load():
-    """A room persisted under the old fenced ``transcript.md`` reads back and is
-    rewritten as ``transcript.jsonl``, with the legacy file removed."""
-    from app.services.filesystem import write_memory_file
-
-    room = "legacy-room"
-    base = get_room_dir(room)
-    body = "\n".join(
-        [
-            "The live room transcript.",
-            "",
-            "```jsonl",
-            *(persister._transcript_line(_record(mid)) for mid in ("m1", "m2")),
-            "```",
-            "",
-        ]
-    )
-    write_memory_file(base, persister.TRANSCRIPT_KEY, body, created_by="x")
-
-    reloaded = persister.load_transcript(room)
-    assert [r.message_id for r in reloaded] == ["m1", "m2"]
-    assert (base / persister.TRANSCRIPT_FILENAME).exists()
-    assert read_memory_file(base, persister.TRANSCRIPT_KEY) is None
-
-
 # ── delivery-cursor persistence (D5) ─────────────────────────────────────────
 
 
@@ -504,27 +479,6 @@ def test_conversational_messages_project_from_the_durable_transcript():
         ("growth", "a-1"),
     ]
     assert projected[1].episode == "urn:ioc:mycelium:episode:r:s"
-
-
-def test_conversational_messages_migrate_and_serve_a_legacy_transcript():
-    """A dormant legacy room (only the fenced transcript.md, never provisioned
-    since deploy) must not read as empty: conversational_messages falls through to
-    load_transcript, which migrates the .md forward, so the read path serves it."""
-    from app.services.filesystem import write_memory_file
-
-    room = "conv-legacy-room"
-    base = get_room_dir(room)
-    env, content = _msg_content(
-        "h-1", sender="julia", text="from the old format", payload_type="message"
-    )
-    line = persister._transcript_line(persister.record_from(env, content))
-    body = "\n".join(["The live room transcript.", "", "```jsonl", line, "```", ""])
-    write_memory_file(base, persister.TRANSCRIPT_KEY, body, created_by="x")
-    assert not (base / persister.TRANSCRIPT_FILENAME).exists()  # no .jsonl yet
-
-    projected = persister.conversational_messages(room)
-    assert [m.content for m in projected] == ["from the old format"]
-    assert (base / persister.TRANSCRIPT_FILENAME).exists()  # migrated forward on read
 
 
 def test_conversational_messages_survive_a_wiped_in_memory_store():

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -96,6 +96,48 @@ def test_transcript_persists_in_order_and_survives_reload():
     assert reloaded[1].sender == "agent-a"
 
 
+def test_append_transcript_is_o1_and_accumulates():
+    """Appending records one at a time yields the same ordered history a
+    full rewrite would, without re-rendering the whole file."""
+    room = "append-room"
+    base = get_room_dir(room)
+    for mid in ("m1", "m2", "m3"):
+        persister.append_transcript(room, _record(mid))
+
+    reloaded = persister.load_transcript(room)
+    assert [r.message_id for r in reloaded] == ["m1", "m2", "m3"]
+    # Plain JSONL on disk: one JSON object per line, no markdown fence.
+    body = (base / persister.TRANSCRIPT_FILENAME).read_text(encoding="utf-8")
+    lines = [ln for ln in body.splitlines() if ln.strip()]
+    assert len(lines) == 3
+    assert "```" not in body
+
+
+def test_legacy_markdown_transcript_migrates_forward_on_load():
+    """A room persisted under the old fenced ``transcript.md`` reads back and is
+    rewritten as ``transcript.jsonl``, with the legacy file removed."""
+    from app.services.filesystem import write_memory_file
+
+    room = "legacy-room"
+    base = get_room_dir(room)
+    body = "\n".join(
+        [
+            "The live room transcript.",
+            "",
+            "```jsonl",
+            *(persister._transcript_line(_record(mid)) for mid in ("m1", "m2")),
+            "```",
+            "",
+        ]
+    )
+    write_memory_file(base, persister.TRANSCRIPT_KEY, body, created_by="x")
+
+    reloaded = persister.load_transcript(room)
+    assert [r.message_id for r in reloaded] == ["m1", "m2"]
+    assert (base / persister.TRANSCRIPT_FILENAME).exists()
+    assert read_memory_file(base, persister.TRANSCRIPT_KEY) is None
+
+
 # ── delivery-cursor persistence (D5) ─────────────────────────────────────────
 
 
@@ -173,8 +215,7 @@ def test_transcript_does_not_clobber_episode_records():
 
     # Both survive independently.
     assert read_memory_file(base, "log/episodes/abcd1234") is not None
-    assert read_memory_file(base, persister.TRANSCRIPT_KEY) is not None
-    assert (base / "log" / "transcript.md").exists()
+    assert (base / persister.TRANSCRIPT_FILENAME).exists()
     assert (base / "log" / "episodes" / "abcd1234.md").exists()
 
 
@@ -389,27 +430,32 @@ def test_list_store_human_and_agent_each_appear_once_in_order():
     room = "h2-invariant-room"
     p = _persister_for(room, summoned=[], converged=[])
 
-    # 1) The human's message: written by the POST route (its own producer), and
-    #    ingested locally by the persister (local=True → must NOT also list-write).
+    # 1) The human's message: written by the POST route (its own producer, stamped
+    #    with the envelope id), and ingested by the persister with list_write=False
+    #    so it is NOT double-written to the list store.
     human_env, human_content = _msg_content(
         "h-1", sender="julia", text="@smoke-agent hello", payload_type="message"
     )
     local_state.add_message(
         room,
         local_state.StoredMessage(
-            room_name=room, sender_handle="julia", message_type="broadcast", content="hello"
+            room_name=room,
+            sender_handle="julia",
+            message_type="broadcast",
+            content="hello",
+            message_id="h-1",
         ),
     )
-    p._ingest(human_env, human_content, local=True)
+    p._ingest(human_env, human_content, list_write=False)
     # Its SLIM loopback arrives on the receive path — de-duped by id, no re-write.
-    p._ingest(human_env, human_content, local=False)
+    p._ingest(human_env, human_content)
 
     # 2) The agent's reply: arrives only over SLIM (receive path) → the persister
     #    is its sole producer.
     agent_env, agent_content = _msg_content(
         "a-1", sender="smoke-agent", text="hi back", payload_type="reply"
     )
-    p._ingest(agent_env, agent_content, local=False)
+    p._ingest(agent_env, agent_content)
 
     stored = local_state.list_messages(room)
     assert [(m.sender_handle, m.content) for m in stored] == [
@@ -428,11 +474,70 @@ def test_list_store_message_carries_its_episode():
     p = _persister_for(room, summoned=[], converged=[])
 
     env, content = _msg_content("a-1", sender="growth", text="my position", payload_type="reply")
-    p._ingest(env, content, local=False)
+    p._ingest(env, content)
 
     stored = local_state.list_messages(room)
     assert len(stored) == 1
     assert stored[0].episode == "urn:ioc:mycelium:episode:r:s"
+
+
+def test_conversational_messages_project_from_the_durable_transcript():
+    """The read path's source of truth: chat records project out of the transcript
+    with their envelope id (correlation key) and episode; presence/control records
+    are skipped."""
+    room = "conv-projection-room"
+    get_room_dir(room)
+
+    for mid, sender, ptype in [
+        ("h-1", "julia", "message"),
+        ("a-1", "growth", "reply"),
+        ("p-1", "growth", "presence"),
+    ]:
+        env, content = _msg_content(
+            mid, sender=sender, text=f"{sender} says hi", payload_type=ptype
+        )
+        persister.append_transcript(room, persister.record_from(env, content))
+
+    projected = persister.conversational_messages(room)
+    assert [(m.sender_handle, m.message_id) for m in projected] == [
+        ("julia", "h-1"),
+        ("growth", "a-1"),
+    ]
+    assert projected[1].episode == "urn:ioc:mycelium:episode:r:s"
+
+
+def test_conversational_messages_survive_a_wiped_in_memory_store():
+    """The restart bug (issue #497 §3): the in-memory list store is empty after a
+    restart, but the durable transcript still projects the full history — so the
+    read path serves it regardless."""
+    from app.services import local_state
+
+    room = "conv-restart-room"
+    get_room_dir(room)
+    env, content = _msg_content("a-1", sender="growth", text="my position", payload_type="reply")
+    persister.append_transcript(room, persister.record_from(env, content))
+
+    local_state.clear_all()  # the restart: memory is gone, disk is not
+    projected = persister.conversational_messages(room)
+    assert [m.content for m in projected] == ["my position"]
+
+
+def test_conversational_projection_is_stable_and_dedups_against_the_list_store():
+    """The same message projected from disk carries the same synthetic id on every
+    read (so a UI keyed by id is stable), and shares its ``message_id`` with the
+    list-store row the persister wrote — the key the read path dedups on."""
+    from app.services import local_state
+
+    room = "conv-dedup-room"
+    p = _persister_for(room, summoned=[], converged=[])
+    env, content = _msg_content("a-1", sender="growth", text="hello", payload_type="reply")
+    p._ingest(env, content)  # writes both the transcript and the list store
+
+    disk = persister.conversational_messages(room)
+    assert persister.conversational_messages(room)[0].id == disk[0].id  # stable across reads
+    mem = local_state.list_messages(room)
+    assert len(disk) == 1 and len(mem) == 1
+    assert disk[0].message_id == mem[0].message_id == "a-1"  # one correlation key, dedupable
 
 
 def test_addressed_absent_recipient_holds_the_triggering_message():
@@ -502,6 +607,6 @@ def test_list_store_skips_presence_and_non_conversational():
     pres_env, pres_content = _msg_content(
         "p-1", sender="smoke-agent", text="joined the room", payload_type="presence"
     )
-    p._ingest(pres_env, pres_content, local=False)
+    p._ingest(pres_env, pres_content)
 
     assert local_state.list_messages(room) == []


### PR DESCRIPTION
Fixes the three problems in #497 (room transcript / message-store layer).

## 1 + 2 — append-only, plain JSONL (the scaling bug + format smell)
- `write_transcript` re-rendered the **entire** record list and rewrote the whole `log/transcript.md` on every message (O(n) per write, unbounded file, full re-parse on every read). The hot path now **appends one line** via `append_transcript` — O(1) per message.
- The transcript was semantically JSONL wrapped in a ` ```jsonl ` fence inside a `.md` file. It's now a real append-only **`log/transcript.jsonl`**, one JSON record per line, no fence. (No legacy migration — pre-release, no rooms to migrate; see #500 for a generic migration system.)

## 3 — one read path (the coherence bug)
`GET /messages` read only the in-memory `local_state` (wiped on restart), and `respond` (→ transcript) vs `room send` (→ `local_state`) landed in different stores.

- `GET /messages` now serves the **durable transcript merged with `local_state`** (`_read_messages`), so the room view **survives a restart** and both post paths converge.
- New `StoredMessage.message_id` is the **cross-store correlation key** (distinct id space from `StoredMessage.id`); the merge dedups on it — the live `local_state` row wins (keeps ledger fields + client-known id), the transcript fills what memory lost.
- `respond` (`/reply`) now writes the live store too (`list_write=True`); the human broadcast is stamped with its envelope id (threaded through `publish_human`) so the two stores collapse to one message on read.
- Event-ledger rows (ttl/status/PATCH-by-id) stay `local_state`-only and are merged in.

## Tests
- `test_persister.py`: append-is-O(1), transcript projection, restart survival, stable synthetic id + dedup key.
- New `test_messages_read_path.py`: read serves the transcript when memory is empty (restart), dedups a message in both stores, merges memory-only event rows.
- Full backend suite green (392 passed, 2 skipped); ruff + ty clean.

## Not in scope
- Segmentation/rotation + old-history compaction (the optional `NNNN.jsonl` direction in #497) — the transcript is append-only but still single-file/uncapped. Left for a follow-up.
- Message edit/retract — filed separately as #498.
