### PR TITLE
feat(synthesizer): respond to summon messages as an agent

### DIFF
--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -101,7 +101,11 @@ async def lifespan(app: FastAPI):
     )
 
     def _dispatch_summon(
-        room: str, handle: str, envelope: Any, co_summons: list[str] | None = None, message_text: str = ""
+        room: str,
+        handle: str,
+        envelope: Any,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
     ) -> None:
         for fire in _engine_handlers:
             try:

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -101,11 +101,11 @@ async def lifespan(app: FastAPI):
     )
 
     def _dispatch_summon(
-        room: str, handle: str, envelope: Any, co_summons: list[str] | None = None
+        room: str, handle: str, envelope: Any, co_summons: list[str] | None = None, message_text: str = ""
     ) -> None:
         for fire in _engine_handlers:
             try:
-                fire(room, handle, envelope, co_summons)
+                fire(room, handle, envelope, co_summons, message_text)
             except Exception:
                 logger.exception("engine summon handler failed for @%s in %s", handle, room)
 

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -197,7 +197,7 @@ class AlignerEngine:
     # -- the summon seam (sync; called from the persister's on_summon) --
 
     def handle_summon(
-        self, room: str, handle: str, envelope: L9, co_summons: list[str] | None = None
+        self, room: str, handle: str, envelope: L9, co_summons: list[str] | None = None, message_text: str = ""
     ) -> None:
         """Fire the aligner when a registered ``engine`` (kind ``aligner``) — or
         the legacy reserved handle — is summoned; else ignore.

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -197,7 +197,12 @@ class AlignerEngine:
     # -- the summon seam (sync; called from the persister's on_summon) --
 
     def handle_summon(
-        self, room: str, handle: str, envelope: L9, co_summons: list[str] | None = None, message_text: str = ""
+        self,
+        room: str,
+        handle: str,
+        envelope: L9,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
     ) -> None:
         """Fire the aligner when a registered ``engine`` (kind ``aligner``) — or
         the legacy reserved handle — is summoned; else ignore.

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -513,7 +513,9 @@ def _handle_from_disconnect(message: str) -> str | None:
     return parts[2] if len(parts) >= 3 else None
 
 
-def _default_summon_hook(handle: str, envelope: L9, co_summons: list[str], message_text: str = "") -> None:
+def _default_summon_hook(
+    handle: str, envelope: L9, co_summons: list[str], message_text: str = ""
+) -> None:
     logger.info("summon hook (skeleton): @%s summoned", handle)
 
 

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -453,7 +453,7 @@ def write_cursors(room: str, cursors: dict[str, int]) -> None:
 
 # ── The receive loop ─────────────────────────────────────────────────────────
 
-SummonHook = Callable[[str, "L9", list[str]], None]
+SummonHook = Callable[[str, "L9", list[str], str], None]
 ConvergedHook = Callable[["L9"], None]
 # Called with the handle of a member that dropped off the channel, so the
 # moderator can update its membership — presence, not a fatal error.
@@ -513,7 +513,7 @@ def _handle_from_disconnect(message: str) -> str | None:
     return parts[2] if len(parts) >= 3 else None
 
 
-def _default_summon_hook(handle: str, envelope: L9, co_summons: list[str]) -> None:
+def _default_summon_hook(handle: str, envelope: L9, co_summons: list[str], message_text: str = "") -> None:
     logger.info("summon hook (skeleton): @%s summoned", handle)
 
 
@@ -792,9 +792,10 @@ class RoomPersister:
         # summon list is passed to every hook call so an engine summoned alongside
         # other handles (``@aligner @a @b``) can scope the run to those co-mentions.
         summons = find_summons(content)
+        message_text = content.get("content", "") if isinstance(content, dict) else ""
         for handle in summons:
             try:
-                self.on_summon(handle, envelope, summons)
+                self.on_summon(handle, envelope, summons, message_text)
             except Exception:
                 logger.exception("summon hook failed for @%s", handle)
         if is_converged(envelope):

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -388,7 +388,13 @@ class RoomChannelManager:
         if hook is None:
             return None
 
-        def adapter(handle: str, envelope: L9, co_summons: list[str], message_text: str = "", _room: str = room) -> None:
+        def adapter(
+            handle: str,
+            envelope: L9,
+            co_summons: list[str],
+            message_text: str = "",
+            _room: str = room,
+        ) -> None:
             hook(_room, handle, envelope, co_summons, message_text)
 
         return adapter

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
 # carries the ``room`` so the engine wired to it (the aligner) knows which
 # channel to judge. ``_start_persister`` adapts it down to the persister's
 # signature by binding the room.
-RoomSummonHook = Callable[[str, str, "L9", list[str]], None]
+RoomSummonHook = Callable[[str, str, "L9", list[str], str], None]
 
 # The room-aware converged hook, same shape reasoning as ``RoomSummonHook``: the
 # persister's ``ConvergedHook`` is ``(envelope)`` only, but the consumer wired to
@@ -388,8 +388,8 @@ class RoomChannelManager:
         if hook is None:
             return None
 
-        def adapter(handle: str, envelope: L9, co_summons: list[str], _room: str = room) -> None:
-            hook(_room, handle, envelope, co_summons)
+        def adapter(handle: str, envelope: L9, co_summons: list[str], message_text: str = "", _room: str = room) -> None:
+            hook(_room, handle, envelope, co_summons, message_text)
 
         return adapter
 

--- a/fastapi-backend/app/services/synthesizer.py
+++ b/fastapi-backend/app/services/synthesizer.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import tempfile
 import uuid
 from pathlib import Path
@@ -39,13 +40,17 @@ from app.config import settings
 
 # The manifest-kind gate and handle-fold are the shared summon-gate primitives;
 # reuse the aligner's single copy rather than re-deriving the manifest read.
+from app.services import l9
 from app.services.aligner import _norm, _registered_engine_kind
+from app.services.l9_slim import serialize_content
 
 if TYPE_CHECKING:
     from app.services.l9_models import L9
-    from app.services.room_channels import RoomChannelManager
+    from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
 
 logger = logging.getLogger(__name__)
+
+_AT_MENTION = re.compile(r"@(?=\w)")
 
 # The engine kind this class owns. A summon whose manifest kind differs is
 # ignored, so the aligner and the synthesizer can share one summon seam.
@@ -77,19 +82,31 @@ def _read_room_memory(room: str) -> list[tuple[str, dict[str, Any], str]]:
     ]
 
 
-def _build_prompt(room: str, entries: list[tuple[str, dict[str, Any], str]]) -> str:
+def _build_prompt(
+    room: str, entries: list[tuple[str, dict[str, Any], str]], directive: str = ""
+) -> str:
     """Assemble the synthesizer prompt. Pure — no I/O, directly unit-testable."""
     blocks = [f"## {key}\n{content.strip()}" for key, _meta, content in entries]
     corpus = "\n\n".join(blocks)
+    if directive:
+        task = (
+            f'The user asked you: "{directive}"\n\n'
+            "Respond naturally and helpfully to their request using the room memory as your context. "
+            "If they asked for a briefing or summary, provide one. If they asked something else, "
+            "answer it based on what you know from the room. Be faithful — never invent facts not "
+            "present in the memory below."
+        )
+    else:
+        task = (
+            "Produce a single concise, well-structured markdown briefing that captures the "
+            "room's current state: key decisions, current status, open work, and any notable "
+            "context. Group related points; do not just list the memories back. Preserve "
+            "@handle owners where they matter. Be faithful — never invent facts not present below."
+        )
     return (
         f"You are the synthesizer for the Mycelium coordination room '{room}'.\n"
-        "Below are the room's memories, each under its namespace key. Produce a "
-        "single concise, well-structured markdown briefing that captures the "
-        "room's current state: key decisions, current status, open work, and any "
-        "notable context. Group related points; do not just list the memories "
-        "back. Preserve @handle owners where they matter. Be faithful — never "
-        "invent facts not present below.\n\n"
-        "Output ONLY the markdown briefing — no preamble, no code fences.\n\n"
+        f"Below are the room's memories, each under its namespace key.\n\n{task}\n\n"
+        "Output ONLY your response as markdown — no preamble, no code fences.\n\n"
         f"--- ROOM MEMORY ---\n{corpus}\n--- END ROOM MEMORY ---"
     )
 
@@ -160,7 +177,12 @@ class SynthesizerEngine:
     # -- the summon seam (sync; called from the persister's on_summon) --
 
     def handle_summon(
-        self, room: str, handle: str, envelope: L9, co_summons: list[str] | None = None
+        self,
+        room: str,
+        handle: str,
+        envelope: L9,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
     ) -> None:
         """Fire the synthesizer when a registered ``engine`` (kind
         ``synthesizer``) is summoned; else ignore.
@@ -189,13 +211,15 @@ class SynthesizerEngine:
             logger.debug("synthesizer already active on room %s; ignoring re-summon", room)
             return
         self._active.add(room)
-        task = asyncio.create_task(self._run_and_release(room, handle))
+        # Strip the @handle prefix so only the user's actual request reaches Pi.
+        directive = _AT_MENTION.sub("", message_text).strip()
+        task = asyncio.create_task(self._run_and_release(room, handle, directive))
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
 
-    async def _run_and_release(self, room: str, engine_handle: str) -> None:
+    async def _run_and_release(self, room: str, engine_handle: str, directive: str = "") -> None:
         try:
-            await self.synthesize(room, engine_handle=engine_handle)
+            await self.synthesize(room, engine_handle=engine_handle, directive=directive)
         except Exception:
             logger.exception("synthesizer run failed on room %s", room)
         finally:
@@ -203,7 +227,9 @@ class SynthesizerEngine:
 
     # -- the one path: read → summarize → write --
 
-    async def synthesize(self, room: str, engine_handle: str | None = None) -> str | None:
+    async def synthesize(
+        self, room: str, engine_handle: str | None = None, directive: str = ""
+    ) -> str | None:
         """Compile the room's memory into a ``knowledge`` summary; return it.
 
         Returns the summary markdown on success, or ``None`` when there is
@@ -211,12 +237,17 @@ class SynthesizerEngine:
         summary is written).
         """
         me = engine_handle or self._handle
+        managed = self._manager.get(room)
         entries = _read_room_memory(room)
         if not entries:
             logger.info("synthesizer: room %s has no memory to summarize", room)
+            if managed is not None:
+                await self._say(
+                    managed, room, me, "No memories to summarize yet — post some context first."
+                )
             return None
 
-        prompt = _build_prompt(room, entries)
+        prompt = _build_prompt(room, entries, directive)
         try:
             raw = await asyncio.wait_for(
                 asyncio.to_thread(_pi_complete, prompt, self._timeout_s),
@@ -224,18 +255,41 @@ class SynthesizerEngine:
             )
         except Exception:
             logger.exception("synthesizer: Pi turn failed for room %s", room)
+            if managed is not None:
+                await self._say(managed, room, me, "Pi turn timed out or errored — try again.")
             return None
 
-        summary = _strip_fences(raw or "")
-        if not summary.strip():
-            logger.warning("synthesizer: Pi returned empty summary for room %s", room)
+        response = _strip_fences(raw or "")
+        if not response.strip():
+            logger.warning("synthesizer: Pi returned empty response for room %s", room)
+            if managed is not None:
+                await self._say(managed, room, me, "Pi returned an empty response — try again.")
             return None
 
-        await self._write_summary(room, summary, me)
+        await self._write_summary(room, response, me)
         logger.info(
             "synthesizer: wrote %s for room %s (%d memories)", SYNTHESIS_KEY, room, len(entries)
         )
-        return summary
+        if managed is not None:
+            await self._say(managed, room, me, response)
+        return response
+
+    async def _say(self, managed: ManagedRoomChannel, room: str, sender: str, text: str) -> None:
+        """Post a plain message from the synthesizer into the room channel."""
+        env = l9.build_envelope(
+            kind=l9.Kind.exchange,
+            episode=l9.episode_urn(room, "live"),
+            sender=sender,
+            topic=l9.topic_urn(room),
+            payload_type="message",
+        )
+        content = serialize_content(env, extra={"content": text})
+        try:
+            await managed.channel.send(env, extra={"content": text})
+        except Exception:
+            logger.warning("synthesizer failed to broadcast message on room %s", room)
+        if managed.persister is not None:
+            managed.persister.ingest_local(env, content)
 
     async def _write_summary(self, room: str, summary: str, created_by: str) -> None:
         """Upsert the summary through the canonical versioned + indexed path."""

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -245,7 +245,7 @@ def _persister_for(room: str, *, summoned: list, converged: list) -> persister.R
         room,
         channel=None,  # ty: ignore[invalid-argument-type]  # not exercised: we call _ingest directly
         members_provider=lambda: set(),
-        on_summon=lambda handle, env, co: summoned.append(handle),
+        on_summon=lambda handle, env, co, msg="": summoned.append(handle),
         on_converged=lambda env: converged.append(env),
         feed_bus=False,
     )

--- a/fastapi-backend/tests/test_synthesizer.py
+++ b/fastapi-backend/tests/test_synthesizer.py
@@ -171,7 +171,7 @@ async def test_summon_fires_only_for_a_registered_synthesizer(
     engine = _engine()
     called: list[str] = []
 
-    async def fake_synthesize(room: str, engine_handle: str | None = None) -> None:
+    async def fake_synthesize(room: str, engine_handle: str | None = None, directive: str = "") -> None:
         called.append(engine_handle or "?")
 
     engine.synthesize = fake_synthesize  # type: ignore[method-assign]
@@ -205,7 +205,7 @@ async def test_summon_skipped_when_engine_runtime_host(
     engine = _engine()
     called: list[str] = []
 
-    async def fake_synthesize(room: str, engine_handle: str | None = None) -> None:
+    async def fake_synthesize(room: str, engine_handle: str | None = None, directive: str = "") -> None:
         called.append(engine_handle or "?")
 
     engine.synthesize = fake_synthesize  # type: ignore[method-assign]

--- a/fastapi-backend/tests/test_synthesizer.py
+++ b/fastapi-backend/tests/test_synthesizer.py
@@ -171,7 +171,9 @@ async def test_summon_fires_only_for_a_registered_synthesizer(
     engine = _engine()
     called: list[str] = []
 
-    async def fake_synthesize(room: str, engine_handle: str | None = None, directive: str = "") -> None:
+    async def fake_synthesize(
+        room: str, engine_handle: str | None = None, directive: str = ""
+    ) -> None:
         called.append(engine_handle or "?")
 
     engine.synthesize = fake_synthesize  # type: ignore[method-assign]
@@ -205,7 +207,9 @@ async def test_summon_skipped_when_engine_runtime_host(
     engine = _engine()
     called: list[str] = []
 
-    async def fake_synthesize(room: str, engine_handle: str | None = None, directive: str = "") -> None:
+    async def fake_synthesize(
+        room: str, engine_handle: str | None = None, directive: str = ""
+    ) -> None:
         called.append(engine_handle or "?")
 
     engine.synthesize = fake_synthesize  # type: ignore[method-assign]

--- a/mycelium-frontend/src/app/api/events/stream/route.ts
+++ b/mycelium-frontend/src/app/api/events/stream/route.ts
@@ -24,10 +24,15 @@ export async function GET() {
   }
 
   const upstream = `${getBackendUrl()}/api/events/stream`;
-  const res = await fetch(upstream, {
-    headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
-    cache: "no-store",
-  });
+  let res: Response;
+  try {
+    res = await fetch(upstream, {
+      headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+      cache: "no-store",
+    });
+  } catch {
+    return new Response("upstream SSE unavailable", { status: 502 });
+  }
 
   if (!res.ok || !res.body) {
     return new Response("upstream SSE unavailable", { status: 502 });

--- a/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
+++ b/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
@@ -14,11 +14,16 @@ export async function GET(
 
   const upstream = `${getBackendUrl()}/api/rooms/${encodeURIComponent(name)}/messages/stream`;
 
-  const res = await fetch(upstream, {
-    headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
-    // Prevent Next.js fetch cache from buffering the response
-    cache: "no-store",
-  });
+  let res: Response;
+  try {
+    res = await fetch(upstream, {
+      headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+      // Prevent Next.js fetch cache from buffering the response
+      cache: "no-store",
+    });
+  } catch {
+    return new Response("upstream SSE unavailable", { status: 502 });
+  }
 
   if (!res.ok || !res.body) {
     return new Response("upstream SSE unavailable", { status: 502 });

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -37,7 +37,7 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   const [showCreate, setShowCreate] = useState(false);
 
   const load = () =>
-    fetchRooms().then((data: Room[]) => setRooms(data)).catch(logFetchError("fetchRooms"));
+    fetchRooms().then((data: unknown) => { if (Array.isArray(data)) setRooms(data as Room[]); }).catch(logFetchError("fetchRooms"));
 
   useEffect(() => {
     load();


### PR DESCRIPTION
## Summary

- Synthesizer now posts back to the room on every outcome (success, no memories, Pi failure) — closes #502
- Freeform summon text is passed to Pi as the directive; the engine responds naturally using room memory as context, then writes the response to `context/synthesis`
- Hook chain (`SummonHook` → `RoomSummonHook` → `_dispatch_summon` → `handle_summon`) extended with `message_text: str = ""` so any future engine kind gets the summon text for free
- Frontend: SSE routes get `try/catch` around fetch (matching the catch-all proxy); `RoomsSidebar` guards `setRooms` with `Array.isArray` to prevent non-array error responses from crashing the map

Ref: #516 for the broader Pi agent tool layer (transcript access, memory search, etc.)

## Test plan

- [ ] `mycelium engine invoke summarizer "brief the room" --room <room>` → reply appears in `mycelium room messages`
- [ ] `mycelium engine invoke summarizer "tell me you love me" --room <room>` → Pi responds in character using room context
- [ ] `mycelium engine invoke summarizer --room <room>` (empty room) → "No memories to summarize yet" posted to room
- [ ] Backend down → SSE routes return 502, sidebar doesn't crash