### PR TITLE
feat(agents): structured /rooms/{room}/agents endpoint, drop frontend YAML parsing

### DIFF
--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -29,6 +29,7 @@ os.environ.setdefault("HF_HUB_OFFLINE", "1")
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.routes.agents import router as agents_router
 from app.routes.episodes import router as episodes_router
 from app.routes.invites import router as invites_router
 from app.routes.memory import router as memory_router
@@ -193,6 +194,7 @@ app.add_middleware(
 
 
 # Core routes. Health endpoints stay top-level for orchestrator probes.
+app.include_router(agents_router, prefix="/api")
 app.include_router(rooms_router, prefix="/api")
 app.include_router(messages_router, prefix="/api")
 app.include_router(invites_router, prefix="/api")

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -101,7 +101,11 @@ async def lifespan(app: FastAPI):
     )
 
     def _dispatch_summon(
-        room: str, handle: str, envelope: Any, co_summons: list[str] | None = None, message_text: str = ""
+        room: str,
+        handle: str,
+        envelope: Any,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
     ) -> None:
         for fire in _engine_handlers:
             try:

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -101,11 +101,11 @@ async def lifespan(app: FastAPI):
     )
 
     def _dispatch_summon(
-        room: str, handle: str, envelope: Any, co_summons: list[str] | None = None
+        room: str, handle: str, envelope: Any, co_summons: list[str] | None = None, message_text: str = ""
     ) -> None:
         for fire in _engine_handlers:
             try:
-                fire(room, handle, envelope, co_summons)
+                fire(room, handle, envelope, co_summons, message_text)
             except Exception:
                 logger.exception("engine summon handler failed for @%s in %s", handle, room)
 

--- a/fastapi-backend/app/routes/agents.py
+++ b/fastapi-backend/app/routes/agents.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""GET /rooms/{room_name}/agents — structured agent manifest listing."""
+
+import logging
+
+import yaml
+from fastapi import APIRouter, HTTPException
+
+from app.schemas import AgentRead
+from app.services.filesystem import get_room_dir, list_memory_files, room_exists
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/rooms/{room_name}/agents", tags=["agents"])
+
+
+def _norm(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip().lstrip("@").lower()
+    return cleaned or None
+
+
+@router.get("", response_model=list[AgentRead])
+async def list_agents(room_name: str) -> list[AgentRead]:
+    """Return every agent registered in the room as structured JSON.
+
+    Reads ``agents/<handle>`` memory entries, parses the YAML body through
+    the manifest fields, and returns a typed list. Sub-keys like
+    ``agents/<handle>/notes`` are skipped.
+    """
+    if not room_exists(room_name):
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    room_dir = get_room_dir(room_name)
+    agents: list[AgentRead] = []
+
+    for key, _meta, content in list_memory_files(room_dir, prefix="agents/", limit=1000):
+        handle = key.removeprefix("agents/")
+        if "/" in handle:
+            continue
+        try:
+            data = yaml.safe_load(content) or {}
+        except yaml.YAMLError:
+            logger.warning("room %s: skipping agent %r — invalid YAML", room_name, handle)
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        try:
+            budget = float(data.get("budget_usd_per_month", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            budget = 0.0
+
+        allow_from = data.get("allow_from") or []
+        if not isinstance(allow_from, list):
+            allow_from = []
+
+        agents.append(
+            AgentRead(
+                handle=handle,
+                adapter=str(data.get("adapter") or "claude_code"),
+                kind=str(data["kind"]) if data.get("kind") else None,
+                description=str(data.get("description") or ""),
+                cwd=str(data["cwd"]) if data.get("cwd") else None,
+                owner=_norm(data.get("owner")),
+                team=_norm(data.get("team")),
+                budget_usd_per_month=budget,
+                allow_from=[str(h) for h in allow_from if h],
+            )
+        )
+
+    agents.sort(key=lambda a: a.handle)
+    return agents

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -405,6 +405,23 @@ class TeamListResponse(BaseModel):
     total: int
 
 
+# ── Agent manifest ────────────────────────────────────────────────────────────
+
+
+class AgentRead(BaseModel):
+    """Structured view of an agent's manifest, as returned by GET /rooms/{room}/agents."""
+
+    handle: str
+    adapter: str
+    kind: str | None = None
+    description: str = ""
+    cwd: str | None = None
+    owner: str | None = None
+    team: str | None = None
+    budget_usd_per_month: float = 0.0
+    allow_from: list[str] = Field(default_factory=list)
+
+
 class SubscriptionCreate(BaseModel):
     key_pattern: str = Field(..., min_length=1, description="Glob pattern for keys to watch")
     subscriber: str = Field(..., description="Agent handle subscribing")

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -197,7 +197,7 @@ class AlignerEngine:
     # -- the summon seam (sync; called from the persister's on_summon) --
 
     def handle_summon(
-        self, room: str, handle: str, envelope: L9, co_summons: list[str] | None = None
+        self, room: str, handle: str, envelope: L9, co_summons: list[str] | None = None, message_text: str = ""
     ) -> None:
         """Fire the aligner when a registered ``engine`` (kind ``aligner``) — or
         the legacy reserved handle — is summoned; else ignore.

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -197,7 +197,12 @@ class AlignerEngine:
     # -- the summon seam (sync; called from the persister's on_summon) --
 
     def handle_summon(
-        self, room: str, handle: str, envelope: L9, co_summons: list[str] | None = None, message_text: str = ""
+        self,
+        room: str,
+        handle: str,
+        envelope: L9,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
     ) -> None:
         """Fire the aligner when a registered ``engine`` (kind ``aligner``) — or
         the legacy reserved handle — is summoned; else ignore.

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -513,7 +513,9 @@ def _handle_from_disconnect(message: str) -> str | None:
     return parts[2] if len(parts) >= 3 else None
 
 
-def _default_summon_hook(handle: str, envelope: L9, co_summons: list[str], message_text: str = "") -> None:
+def _default_summon_hook(
+    handle: str, envelope: L9, co_summons: list[str], message_text: str = ""
+) -> None:
     logger.info("summon hook (skeleton): @%s summoned", handle)
 
 

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -453,7 +453,7 @@ def write_cursors(room: str, cursors: dict[str, int]) -> None:
 
 # ── The receive loop ─────────────────────────────────────────────────────────
 
-SummonHook = Callable[[str, "L9", list[str]], None]
+SummonHook = Callable[[str, "L9", list[str], str], None]
 ConvergedHook = Callable[["L9"], None]
 # Called with the handle of a member that dropped off the channel, so the
 # moderator can update its membership — presence, not a fatal error.
@@ -513,7 +513,7 @@ def _handle_from_disconnect(message: str) -> str | None:
     return parts[2] if len(parts) >= 3 else None
 
 
-def _default_summon_hook(handle: str, envelope: L9, co_summons: list[str]) -> None:
+def _default_summon_hook(handle: str, envelope: L9, co_summons: list[str], message_text: str = "") -> None:
     logger.info("summon hook (skeleton): @%s summoned", handle)
 
 
@@ -792,9 +792,10 @@ class RoomPersister:
         # summon list is passed to every hook call so an engine summoned alongside
         # other handles (``@aligner @a @b``) can scope the run to those co-mentions.
         summons = find_summons(content)
+        message_text = content.get("content", "") if isinstance(content, dict) else ""
         for handle in summons:
             try:
-                self.on_summon(handle, envelope, summons)
+                self.on_summon(handle, envelope, summons, message_text)
             except Exception:
                 logger.exception("summon hook failed for @%s", handle)
         if is_converged(envelope):

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -388,7 +388,13 @@ class RoomChannelManager:
         if hook is None:
             return None
 
-        def adapter(handle: str, envelope: L9, co_summons: list[str], message_text: str = "", _room: str = room) -> None:
+        def adapter(
+            handle: str,
+            envelope: L9,
+            co_summons: list[str],
+            message_text: str = "",
+            _room: str = room,
+        ) -> None:
             hook(_room, handle, envelope, co_summons, message_text)
 
         return adapter

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
 # carries the ``room`` so the engine wired to it (the aligner) knows which
 # channel to judge. ``_start_persister`` adapts it down to the persister's
 # signature by binding the room.
-RoomSummonHook = Callable[[str, str, "L9", list[str]], None]
+RoomSummonHook = Callable[[str, str, "L9", list[str], str], None]
 
 # The room-aware converged hook, same shape reasoning as ``RoomSummonHook``: the
 # persister's ``ConvergedHook`` is ``(envelope)`` only, but the consumer wired to
@@ -388,8 +388,8 @@ class RoomChannelManager:
         if hook is None:
             return None
 
-        def adapter(handle: str, envelope: L9, co_summons: list[str], _room: str = room) -> None:
-            hook(_room, handle, envelope, co_summons)
+        def adapter(handle: str, envelope: L9, co_summons: list[str], message_text: str = "", _room: str = room) -> None:
+            hook(_room, handle, envelope, co_summons, message_text)
 
         return adapter
 

--- a/fastapi-backend/app/services/synthesizer.py
+++ b/fastapi-backend/app/services/synthesizer.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 import tempfile
 import uuid
 from pathlib import Path
@@ -39,13 +40,17 @@ from app.config import settings
 
 # The manifest-kind gate and handle-fold are the shared summon-gate primitives;
 # reuse the aligner's single copy rather than re-deriving the manifest read.
+from app.services import l9
 from app.services.aligner import _norm, _registered_engine_kind
+from app.services.l9_slim import serialize_content
 
 if TYPE_CHECKING:
     from app.services.l9_models import L9
-    from app.services.room_channels import RoomChannelManager
+    from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
 
 logger = logging.getLogger(__name__)
+
+_AT_MENTION = re.compile(r"@(?=\w)")
 
 # The engine kind this class owns. A summon whose manifest kind differs is
 # ignored, so the aligner and the synthesizer can share one summon seam.
@@ -77,19 +82,31 @@ def _read_room_memory(room: str) -> list[tuple[str, dict[str, Any], str]]:
     ]
 
 
-def _build_prompt(room: str, entries: list[tuple[str, dict[str, Any], str]]) -> str:
+def _build_prompt(
+    room: str, entries: list[tuple[str, dict[str, Any], str]], directive: str = ""
+) -> str:
     """Assemble the synthesizer prompt. Pure — no I/O, directly unit-testable."""
     blocks = [f"## {key}\n{content.strip()}" for key, _meta, content in entries]
     corpus = "\n\n".join(blocks)
+    if directive:
+        task = (
+            f'The user asked you: "{directive}"\n\n'
+            "Respond naturally and helpfully to their request using the room memory as your context. "
+            "If they asked for a briefing or summary, provide one. If they asked something else, "
+            "answer it based on what you know from the room. Be faithful — never invent facts not "
+            "present in the memory below."
+        )
+    else:
+        task = (
+            "Produce a single concise, well-structured markdown briefing that captures the "
+            "room's current state: key decisions, current status, open work, and any notable "
+            "context. Group related points; do not just list the memories back. Preserve "
+            "@handle owners where they matter. Be faithful — never invent facts not present below."
+        )
     return (
         f"You are the synthesizer for the Mycelium coordination room '{room}'.\n"
-        "Below are the room's memories, each under its namespace key. Produce a "
-        "single concise, well-structured markdown briefing that captures the "
-        "room's current state: key decisions, current status, open work, and any "
-        "notable context. Group related points; do not just list the memories "
-        "back. Preserve @handle owners where they matter. Be faithful — never "
-        "invent facts not present below.\n\n"
-        "Output ONLY the markdown briefing — no preamble, no code fences.\n\n"
+        f"Below are the room's memories, each under its namespace key.\n\n{task}\n\n"
+        "Output ONLY your response as markdown — no preamble, no code fences.\n\n"
         f"--- ROOM MEMORY ---\n{corpus}\n--- END ROOM MEMORY ---"
     )
 
@@ -160,7 +177,12 @@ class SynthesizerEngine:
     # -- the summon seam (sync; called from the persister's on_summon) --
 
     def handle_summon(
-        self, room: str, handle: str, envelope: L9, co_summons: list[str] | None = None
+        self,
+        room: str,
+        handle: str,
+        envelope: L9,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
     ) -> None:
         """Fire the synthesizer when a registered ``engine`` (kind
         ``synthesizer``) is summoned; else ignore.
@@ -189,13 +211,15 @@ class SynthesizerEngine:
             logger.debug("synthesizer already active on room %s; ignoring re-summon", room)
             return
         self._active.add(room)
-        task = asyncio.create_task(self._run_and_release(room, handle))
+        # Strip the @handle prefix so only the user's actual request reaches Pi.
+        directive = _AT_MENTION.sub("", message_text).strip()
+        task = asyncio.create_task(self._run_and_release(room, handle, directive))
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
 
-    async def _run_and_release(self, room: str, engine_handle: str) -> None:
+    async def _run_and_release(self, room: str, engine_handle: str, directive: str = "") -> None:
         try:
-            await self.synthesize(room, engine_handle=engine_handle)
+            await self.synthesize(room, engine_handle=engine_handle, directive=directive)
         except Exception:
             logger.exception("synthesizer run failed on room %s", room)
         finally:
@@ -203,7 +227,9 @@ class SynthesizerEngine:
 
     # -- the one path: read → summarize → write --
 
-    async def synthesize(self, room: str, engine_handle: str | None = None) -> str | None:
+    async def synthesize(
+        self, room: str, engine_handle: str | None = None, directive: str = ""
+    ) -> str | None:
         """Compile the room's memory into a ``knowledge`` summary; return it.
 
         Returns the summary markdown on success, or ``None`` when there is
@@ -211,12 +237,17 @@ class SynthesizerEngine:
         summary is written).
         """
         me = engine_handle or self._handle
+        managed = self._manager.get(room)
         entries = _read_room_memory(room)
         if not entries:
             logger.info("synthesizer: room %s has no memory to summarize", room)
+            if managed is not None:
+                await self._say(
+                    managed, room, me, "No memories to summarize yet — post some context first."
+                )
             return None
 
-        prompt = _build_prompt(room, entries)
+        prompt = _build_prompt(room, entries, directive)
         try:
             raw = await asyncio.wait_for(
                 asyncio.to_thread(_pi_complete, prompt, self._timeout_s),
@@ -224,18 +255,41 @@ class SynthesizerEngine:
             )
         except Exception:
             logger.exception("synthesizer: Pi turn failed for room %s", room)
+            if managed is not None:
+                await self._say(managed, room, me, "Pi turn timed out or errored — try again.")
             return None
 
-        summary = _strip_fences(raw or "")
-        if not summary.strip():
-            logger.warning("synthesizer: Pi returned empty summary for room %s", room)
+        response = _strip_fences(raw or "")
+        if not response.strip():
+            logger.warning("synthesizer: Pi returned empty response for room %s", room)
+            if managed is not None:
+                await self._say(managed, room, me, "Pi returned an empty response — try again.")
             return None
 
-        await self._write_summary(room, summary, me)
+        await self._write_summary(room, response, me)
         logger.info(
             "synthesizer: wrote %s for room %s (%d memories)", SYNTHESIS_KEY, room, len(entries)
         )
-        return summary
+        if managed is not None:
+            await self._say(managed, room, me, response)
+        return response
+
+    async def _say(self, managed: ManagedRoomChannel, room: str, sender: str, text: str) -> None:
+        """Post a plain message from the synthesizer into the room channel."""
+        env = l9.build_envelope(
+            kind=l9.Kind.exchange,
+            episode=l9.episode_urn(room, "live"),
+            sender=sender,
+            topic=l9.topic_urn(room),
+            payload_type="message",
+        )
+        content = serialize_content(env, extra={"content": text})
+        try:
+            await managed.channel.send(env, extra={"content": text})
+        except Exception:
+            logger.warning("synthesizer failed to broadcast message on room %s", room)
+        if managed.persister is not None:
+            managed.persister.ingest_local(env, content)
 
     async def _write_summary(self, room: str, summary: str, created_by: str) -> None:
         """Upsert the summary through the canonical versioned + indexed path."""

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -245,7 +245,7 @@ def _persister_for(room: str, *, summoned: list, converged: list) -> persister.R
         room,
         channel=None,  # ty: ignore[invalid-argument-type]  # not exercised: we call _ingest directly
         members_provider=lambda: set(),
-        on_summon=lambda handle, env, co: summoned.append(handle),
+        on_summon=lambda handle, env, co, msg="": summoned.append(handle),
         on_converged=lambda env: converged.append(env),
         feed_bus=False,
     )

--- a/fastapi-backend/tests/test_synthesizer.py
+++ b/fastapi-backend/tests/test_synthesizer.py
@@ -171,7 +171,7 @@ async def test_summon_fires_only_for_a_registered_synthesizer(
     engine = _engine()
     called: list[str] = []
 
-    async def fake_synthesize(room: str, engine_handle: str | None = None) -> None:
+    async def fake_synthesize(room: str, engine_handle: str | None = None, directive: str = "") -> None:
         called.append(engine_handle or "?")
 
     engine.synthesize = fake_synthesize  # type: ignore[method-assign]
@@ -205,7 +205,7 @@ async def test_summon_skipped_when_engine_runtime_host(
     engine = _engine()
     called: list[str] = []
 
-    async def fake_synthesize(room: str, engine_handle: str | None = None) -> None:
+    async def fake_synthesize(room: str, engine_handle: str | None = None, directive: str = "") -> None:
         called.append(engine_handle or "?")
 
     engine.synthesize = fake_synthesize  # type: ignore[method-assign]

--- a/fastapi-backend/tests/test_synthesizer.py
+++ b/fastapi-backend/tests/test_synthesizer.py
@@ -171,7 +171,9 @@ async def test_summon_fires_only_for_a_registered_synthesizer(
     engine = _engine()
     called: list[str] = []
 
-    async def fake_synthesize(room: str, engine_handle: str | None = None, directive: str = "") -> None:
+    async def fake_synthesize(
+        room: str, engine_handle: str | None = None, directive: str = ""
+    ) -> None:
         called.append(engine_handle or "?")
 
     engine.synthesize = fake_synthesize  # type: ignore[method-assign]
@@ -205,7 +207,9 @@ async def test_summon_skipped_when_engine_runtime_host(
     engine = _engine()
     called: list[str] = []
 
-    async def fake_synthesize(room: str, engine_handle: str | None = None, directive: str = "") -> None:
+    async def fake_synthesize(
+        room: str, engine_handle: str | None = None, directive: str = ""
+    ) -> None:
         called.append(engine_handle or "?")
 
     engine.synthesize = fake_synthesize  # type: ignore[method-assign]

--- a/mycelium-frontend/src/app/api/events/stream/route.ts
+++ b/mycelium-frontend/src/app/api/events/stream/route.ts
@@ -24,10 +24,15 @@ export async function GET() {
   }
 
   const upstream = `${getBackendUrl()}/api/events/stream`;
-  const res = await fetch(upstream, {
-    headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
-    cache: "no-store",
-  });
+  let res: Response;
+  try {
+    res = await fetch(upstream, {
+      headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+      cache: "no-store",
+    });
+  } catch {
+    return new Response("upstream SSE unavailable", { status: 502 });
+  }
 
   if (!res.ok || !res.body) {
     return new Response("upstream SSE unavailable", { status: 502 });

--- a/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
+++ b/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
@@ -14,11 +14,16 @@ export async function GET(
 
   const upstream = `${getBackendUrl()}/api/rooms/${encodeURIComponent(name)}/messages/stream`;
 
-  const res = await fetch(upstream, {
-    headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
-    // Prevent Next.js fetch cache from buffering the response
-    cache: "no-store",
-  });
+  let res: Response;
+  try {
+    res = await fetch(upstream, {
+      headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+      // Prevent Next.js fetch cache from buffering the response
+      cache: "no-store",
+    });
+  } catch {
+    return new Response("upstream SSE unavailable", { status: 502 });
+  }
 
   if (!res.ok || !res.body) {
     return new Response("upstream SSE unavailable", { status: 502 });

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -273,7 +273,7 @@ export function AgentsPanel({ roomName, refreshKey = 0 }: Props) {
                   )}
                 </div>
                 <div className="text-micro text-muted-foreground truncate leading-tight">
-                  {a.adapter}
+                  {a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter}
                   {a.description ? ` · ${a.description}` : ""}
                 </div>
               </div>

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -159,7 +159,7 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
                   @{a.handle}
                 </span>
                 <span className="text-micro text-muted-foreground flex-shrink-0">
-                  {a.adapter}
+                  {a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter}
                 </span>
                 {a.description && (
                   <span className="text-micro text-muted-foreground truncate min-w-0">

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -37,7 +37,7 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   const [showCreate, setShowCreate] = useState(false);
 
   const load = () =>
-    fetchRooms().then((data: Room[]) => setRooms(data)).catch(logFetchError("fetchRooms"));
+    fetchRooms().then((data: unknown) => { if (Array.isArray(data)) setRooms(data as Room[]); }).catch(logFetchError("fetchRooms"));
 
   useEffect(() => {
     load();

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -208,78 +208,21 @@ export async function respondToInvite(
 
 export interface AgentSummary {
   handle: string;
-  description: string;
   adapter: string;
-  // Self-asserted principal binding: the users/<handle> this agent belongs to
-  // and the team it's fielded by. Absent (null) means principal-anonymous.
+  kind: string | null;
+  description: string;
+  cwd: string | null;
   owner: string | null;
   team: string | null;
+  budget_usd_per_month: number;
+  allow_from: string[];
 }
 
-/**
- * List addressable agents in a room. Each agent is a memory entry under
- * `agents/<handle>` (without further path segments; `agents/<handle>/notes`
- * and `agents/<handle>/log/...` are filtered out). Used to drive the
- * `@`-mention autocomplete in the room chat box.
- */
+/** List addressable agents in a room. Used to drive `@`-mention autocomplete. */
 export async function fetchRoomAgents(roomName: string): Promise<AgentSummary[]> {
-  const res = await fetch(
-    `/api/rooms/${roomName}/memory?prefix=agents/&limit=200`,
-    { cache: "no-store" },
-  );
+  const res = await fetch(`/api/rooms/${roomName}/agents`, { cache: "no-store" });
   if (!res.ok) return [];
-  const data = await res.json();
-  const items = Array.isArray(data) ? data : data.items || data.memories || [];
-  const agents: AgentSummary[] = [];
-  for (const item of items) {
-    const key: string = item.key || "";
-    const rest = key.replace(/^agents\//, "");
-    if (!rest || rest.includes("/")) continue;
-    // The manifest is YAML. The memory API may hand it back as a raw string,
-    // a structured dict, OR (what the backend actually does) wrapped as
-    // `{text: "<yaml>"}`. Normalize to one YAML string and parse that.
-    const value = item.value;
-    let raw = "";
-    let structured: Record<string, unknown> | null = null;
-    if (typeof value === "string") {
-      raw = value;
-    } else if (value && typeof value === "object") {
-      const v = value as Record<string, unknown>;
-      if (typeof v.text === "string") raw = v.text;
-      else if (typeof v.content === "string") raw = v.content;
-      else structured = v;
-    }
-
-    let description = "";
-    let adapter = "claude_code";
-    let owner: string | null = null;
-    let team: string | null = null;
-    if (structured) {
-      description = String(structured.description || "");
-      adapter = String(structured.adapter || "claude_code");
-      owner = structured.owner ? String(structured.owner) : null;
-      team = structured.team ? String(structured.team) : null;
-    } else {
-      const descMatch = raw.match(/description:\s*(.+)/);
-      if (descMatch) description = descMatch[1].trim().replace(/^["']|["']$/g, "");
-      const adMatch = raw.match(/adapter:\s*(\S+)/);
-      if (adMatch) adapter = adMatch[1].trim();
-      // YAML renders an unset owner/team as `null`; treat that as anonymous.
-      const ownerMatch = raw.match(/owner:\s*(.+)/);
-      if (ownerMatch) {
-        const v = ownerMatch[1].trim().replace(/^["']|["']$/g, "");
-        owner = v && v !== "null" ? v : null;
-      }
-      const teamMatch = raw.match(/team:\s*(.+)/);
-      if (teamMatch) {
-        const v = teamMatch[1].trim().replace(/^["']|["']$/g, "");
-        team = v && v !== "null" ? v : null;
-      }
-    }
-    agents.push({ handle: rest, description, adapter, owner, team });
-  }
-  agents.sort((a, b) => a.handle.localeCompare(b.handle));
-  return agents;
+  return res.json();
 }
 
 // ── Principals (self-asserted user store) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `GET /api/rooms/{room_name}/agents` — reads each `agents/<handle>` memory entry, parses the YAML body in the backend through the manifest model, and returns `list[AgentRead]` as structured JSON
- `AgentRead` schema added to `schemas.py` with all manifest fields (`handle`, `adapter`, `kind`, `description`, `cwd`, `owner`, `team`, `budget_usd_per_month`, `allow_from`)
- Frontend `fetchRoomAgents` drops all YAML/regex parsing and becomes a single typed fetch; `AgentSummary` now mirrors the full manifest shape
- Members roster and `@`-mention autocomplete now show `engine · aligner` / `engine · synthesizer` instead of bare "engine" for all engine agents

Fixes #511

## Test plan

- [ ] Backend: `uv run pytest tests/ -x -q` passes
- [ ] `GET /api/rooms/{room}/agents` returns structured JSON with correct `kind` for engine agents
- [ ] Members panel shows `engine · aligner` and `engine · synthesizer` labels
- [ ] `@`-mention autocomplete shows the same
- [ ] Non-engine agents (claude_code) show their adapter unchanged