### PR TITLE
feat(l9-inspector): full envelope JSON + history backfill + readability

### DIFF
--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -198,6 +198,20 @@ async def list_messages(
     )
 
 
+@router.get("/l9")
+async def list_l9_wire(room_name: str, limit: int = Query(200, le=1000)) -> list[dict]:
+    """The room's L9 wire feed, replayed from the transcript (oldest first).
+
+    Backfills the live L9 inspector: the SSE bus carries no history, so a freshly
+    opened tab would otherwise start empty. Frames are the exact shape the bus
+    pushes, so the client projects backfill and live frames identically.
+    """
+    channel, coord = _resolve_channel(room_name)
+    if coord is not None:
+        return []  # a coordination session has no durable transcript
+    return persister.l9_wire_history(channel, limit=limit)
+
+
 @router.patch("/{message_id}", response_model=MessageRead)
 async def update_event_status(
     room_name: str,

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -419,6 +419,41 @@ def conversational_messages(room: str) -> list[StoredMessage]:
     return list(messages)
 
 
+def l9_bus_frame(room: str, record: TranscriptRecord) -> dict[str, Any]:
+    """Project a transcript record into the L9 wire frame the SSE bus carries.
+
+    The single shape the frontend L9 inspector reads (``l9_<kind>`` + the full
+    ``content`` envelope). Shared by the live push (:meth:`Persister._publish_to_bus`)
+    and the history replay (:func:`l9_wire_history`) so backfilled and live frames
+    are byte-identical.
+    """
+    episode = record.content.get("l9", {}).get("header", {}).get("message", {}).get("episode")
+    return {
+        "id": record.message_id,
+        "sender_handle": record.sender or l9.SYSTEM_ACTOR_ID,
+        "message_type": f"l9_{record.kind}",
+        "content": json.dumps(record.content),
+        "created_at": record.recorded_at,
+        "room_name": room,
+        "episode": episode if isinstance(episode, str) else None,
+    }
+
+
+def l9_wire_history(room: str, limit: int = 200) -> list[dict[str, Any]]:
+    """The room's L9 wire feed replayed from the durable transcript (oldest first).
+
+    The live inspector is fed only by the bus (SSE, no history), so a freshly
+    opened tab misses everything before it connected. This projects the transcript
+    through the same frame shape so the tab can seed itself, then append live — the
+    history-then-live pattern the room chat feed already uses. Returns at most the
+    last ``limit`` frames.
+    """
+    records = load_transcript(room)
+    if limit and len(records) > limit:
+        records = records[-limit:]
+    return [l9_bus_frame(room, r) for r in records]
+
+
 # Delivery cursors persist next to the transcript so a reconnecting agent's
 # missed tail survives a backend restart. A dot-prefixed .json — not a markdown
 # memory — so it stays out of the memory/search surface (which globs ``*.md``).
@@ -816,19 +851,7 @@ class RoomPersister:
         try:
             from app.bus import bus, room_channel
 
-            episode = (
-                record.content.get("l9", {}).get("header", {}).get("message", {}).get("episode")
-            )
-            payload = {
-                "id": record.message_id,
-                "sender_handle": record.sender or l9.SYSTEM_ACTOR_ID,
-                "message_type": f"l9_{record.kind}",
-                "content": json.dumps(record.content),
-                "created_at": record.recorded_at,
-                "room_name": self.room,
-                "episode": episode if isinstance(episode, str) else None,
-            }
-            bus.publish(room_channel(self.room), payload)
+            bus.publish(room_channel(self.room), l9_bus_frame(self.room, record))
         except Exception:
             logger.debug("bus publish from persister failed for room %s", self.room, exc_info=True)
 

--- a/fastapi-backend/tests/test_l9_history.py
+++ b/fastapi-backend/tests/test_l9_history.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""``GET /rooms/{room}/messages/l9`` — transcript replay that backfills the inspector.
+
+The live L9 inspector is fed only by the SSE bus (no history), so a freshly opened
+tab starts empty. This endpoint replays the durable transcript through the same
+frame shape the bus pushes, envelope intact — the part the conversational messages
+API drops.
+"""
+
+import json
+
+import pytest
+
+from app.services.persister import TranscriptRecord, append_transcript
+
+
+async def _create_room(client, name: str) -> None:
+    resp = await client.post("/api/rooms", json={"name": name})
+    assert resp.status_code == 201, resp.text
+
+
+def _l9_record(message_id: str, sender: str, kind: str, text: str, data: dict) -> TranscriptRecord:
+    """A transcript record carrying an L9 envelope, like a connector's reply."""
+    return TranscriptRecord(
+        message_id=message_id,
+        sender=sender,
+        kind=kind,
+        subkind=None,
+        content={
+            "content": text,
+            "l9": {
+                "header": {
+                    "kind": kind,
+                    "message": {"id": message_id, "parents": [], "episode": "urn:x:1"},
+                },
+                "payload": {"type": "data", "data": data},
+            },
+        },
+        recorded_at="2026-01-01T00:00:00+00:00",
+    )
+
+
+@pytest.mark.asyncio
+async def test_l9_history_replays_frames_with_envelope(client) -> None:
+    await _create_room(client, "wire")
+    append_transcript("wire", _l9_record("m1", "julia", "exchange", "cap at 30%", {"round": 1}))
+
+    resp = await client.get("/api/rooms/wire/messages/l9")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+
+    frame = rows[0]
+    # The bus frame shape the inspector reads: l9_<kind> + the full envelope in content.
+    assert frame["message_type"] == "l9_exchange"
+    assert frame["sender_handle"] == "julia"
+    content = json.loads(frame["content"])
+    assert content["l9"]["header"]["kind"] == "exchange"
+    assert content["l9"]["payload"]["data"] == {"round": 1}
+
+
+@pytest.mark.asyncio
+async def test_l9_history_orders_oldest_first_and_limits(client) -> None:
+    await _create_room(client, "wire")
+    for i in range(5):
+        append_transcript("wire", _l9_record(f"m{i}", "a", "exchange", f"t{i}", {"i": i}))
+
+    rows = (await client.get("/api/rooms/wire/messages/l9?limit=3")).json()
+    # Last 3 records, oldest-first.
+    ids = [json.loads(r["content"])["l9"]["header"]["message"]["id"] for r in rows]
+    assert ids == ["m2", "m3", "m4"]
+
+
+@pytest.mark.asyncio
+async def test_l9_history_empty_for_room_without_traffic(client) -> None:
+    await _create_room(client, "quiet")
+    assert (await client.get("/api/rooms/quiet/messages/l9")).json() == []

--- a/mycelium-frontend/src/components/l9-inspector.test.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.test.tsx
@@ -9,11 +9,13 @@ import { FakeEventSource } from "@/test/fake-event-source";
 vi.mock("@/lib/api", () => ({
   fetchEpisodes: vi.fn().mockResolvedValue([]),
   fetchEpisode: vi.fn().mockResolvedValue(null),
+  fetchL9History: vi.fn().mockResolvedValue([]),
   getSSEUrl: (room: string) => `/api/rooms/${room}/messages/stream`,
   logFetchError: () => () => undefined,
 }));
 
 import { envelopeJson, L9Inspector, toL9Frame } from "@/components/l9-inspector";
+import { fetchL9History } from "@/lib/api";
 
 const CREATED = "2026-08-04T10:00:00.000000+00:00";
 
@@ -178,6 +180,30 @@ describe("<L9Inspector />", () => {
     // Knowledge push renders as its own frame.
     expect(screen.getByText(/^KNOWLEDGE/)).toBeInTheDocument();
     expect(screen.getByText("decisions/scope")).toBeInTheDocument();
+  });
+
+  it("backfills history frames on mount, with no live event", async () => {
+    vi.mocked(fetchL9History).mockResolvedValueOnce([commitMessage()]);
+    render(<L9Inspector roomName="sprint" />);
+
+    // The frame comes purely from the transcript replay — nothing emitted on SSE.
+    expect(await screen.findByText(/^COMMIT/)).toBeInTheDocument();
+    expect(screen.getByText("MPC")).toBeInTheDocument();
+  });
+
+  it("dedups a backfilled frame against its live re-push (same envelope id)", async () => {
+    vi.mocked(fetchL9History).mockResolvedValueOnce([commitMessage()]);
+    render(<L9Inspector roomName="sprint" />);
+    expect(await screen.findByText(/^COMMIT/)).toBeInTheDocument();
+
+    const es = FakeEventSource.latest();
+    await act(async () => {
+      es.open();
+      es.emit(commitMessage()); // same id as the backfilled row
+    });
+
+    // Still exactly one COMMIT row — the live push was deduped by frame id.
+    expect(screen.getAllByText(/^COMMIT/)).toHaveLength(1);
   });
 
   it("expands a wire row into the full envelope JSON and collapses it again", async () => {

--- a/mycelium-frontend/src/components/l9-inspector.test.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.test.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026 Mycelium Contributors
 
 import { act } from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeEventSource } from "@/test/fake-event-source";
 
@@ -13,7 +13,7 @@ vi.mock("@/lib/api", () => ({
   logFetchError: () => () => undefined,
 }));
 
-import { L9Inspector, toL9Frame } from "@/components/l9-inspector";
+import { envelopeJson, L9Inspector, toL9Frame } from "@/components/l9-inspector";
 
 const CREATED = "2026-08-04T10:00:00.000000+00:00";
 
@@ -130,6 +130,28 @@ describe("toL9Frame", () => {
   it("returns null for plain chat (non-protocol traffic)", () => {
     expect(toL9Frame({ message_type: "broadcast", content: "hi there" })).toBeNull();
   });
+
+  it("retains the raw wire message on the frame", () => {
+    const msg = commitMessage();
+    const frame = toL9Frame(msg);
+    expect(frame?.raw).toBe(msg);
+  });
+});
+
+describe("envelopeJson", () => {
+  it("decodes the transport-encoded content string into structure", () => {
+    const json = envelopeJson(commitMessage());
+    expect(json).toContain('"subkind": "converged"');
+    expect(json).toContain('"scope": "mvp"');
+    expect(json).toContain('"parents"');
+    // The envelope must not remain a single escaped string.
+    expect(json).not.toContain('\\"header\\"');
+  });
+
+  it("leaves non-JSON content untouched", () => {
+    const json = envelopeJson({ message_type: "l9_exchange", content: "not json" });
+    expect(json).toContain('"content": "not json"');
+  });
 });
 
 describe("<L9Inspector />", () => {
@@ -156,5 +178,47 @@ describe("<L9Inspector />", () => {
     // Knowledge push renders as its own frame.
     expect(screen.getByText(/^KNOWLEDGE/)).toBeInTheDocument();
     expect(screen.getByText("decisions/scope")).toBeInTheDocument();
+  });
+
+  it("expands a wire row into the full envelope JSON and collapses it again", async () => {
+    render(<L9Inspector roomName="sprint" />);
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(commitMessage());
+    });
+
+    const row = await screen.findByRole("button", { name: /COMMIT/ });
+    expect(row).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByTestId("frame-json")).not.toBeInTheDocument();
+
+    fireEvent.click(row);
+    expect(row).toHaveAttribute("aria-expanded", "true");
+    const json = screen.getByTestId("frame-json");
+    expect(json.textContent).toContain('"subkind": "converged"');
+    expect(json.textContent).toContain('"episode": "urn:ioc:mycelium:episode:sprint:s1"');
+    expect(json.textContent).toContain('"assignments"');
+
+    fireEvent.click(row);
+    expect(screen.queryByTestId("frame-json")).not.toBeInTheDocument();
+  });
+
+  it("keeps other rows collapsed when one row is expanded (row-local state)", async () => {
+    render(<L9Inspector roomName="sprint" />);
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(commitMessage());
+      es.emit(knowledgeMessage());
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /COMMIT/ }));
+    expect(screen.getAllByTestId("frame-json")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: /KNOWLEDGE/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 });

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -3,11 +3,13 @@
 
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Radio } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { ChevronRight, Radio } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import {
+  fetchL9History,
   getSSEUrl,
+  logFetchError,
   type EpisodeMetrics,
   type L9Envelope,
 } from "@/lib/api";
@@ -169,6 +171,41 @@ export function envelopeJson(raw: Record<string, unknown>): string {
   return JSON.stringify(display, null, 2);
 }
 
+// One pass over pretty-printed JSON: quoted strings (key when a colon follows,
+// else value), literals, and numbers. Punctuation/whitespace fall between matches.
+const JSON_TOKENS = /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false|null)\b|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
+
+/** Dependency-free JSON syntax highlight for the expanded envelope. Colors keys,
+ *  strings, numbers, and literals with the app palette; everything else inherits.
+ *  Operates on the printed string, so the visible text is byte-for-byte unchanged. */
+export function highlightJson(src: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+  for (const m of src.matchAll(JSON_TOKENS)) {
+    const start = m.index ?? 0;
+    if (start > last) out.push(src.slice(last, start));
+    const [full, str, colon, lit, num] = m;
+    if (str !== undefined) {
+      out.push(
+        colon ? (
+          <span key={key++} className="text-accent">{str}</span>
+        ) : (
+          <span key={key++} style={{ color: "var(--green)" }}>{str}</span>
+        ),
+      );
+      if (colon) out.push(colon);
+    } else if (lit !== undefined) {
+      out.push(<span key={key++} className="text-red">{lit}</span>);
+    } else if (num !== undefined) {
+      out.push(<span key={key++} className="text-yellow">{num}</span>);
+    }
+    last = start + full.length;
+  }
+  if (last < src.length) out.push(src.slice(last));
+  return out;
+}
+
 // ── presentation ────────────────────────────────────────────────────────────────
 
 const KIND_TONE: Record<string, string> = {
@@ -236,8 +273,12 @@ function FrameRow({
         aria-expanded={expanded}
         onClick={() => setExpanded((prev) => !prev)}
         title={expanded ? "Collapse envelope" : "Expand full envelope JSON"}
-        className="flex items-baseline gap-2 px-4 py-2 w-full text-left cursor-pointer text-body"
+        className="group flex items-baseline gap-2 px-4 py-2 w-full text-left cursor-pointer text-body transition-colors hover:bg-hairline"
       >
+        <ChevronRight
+          aria-hidden
+          className={`size-3.5 flex-shrink-0 self-center text-faint transition-transform group-hover:text-muted-foreground ${expanded ? "rotate-90" : ""}`}
+        />
         <KindBadge kind={frame.kind} subkind={frame.subkind} />
         {frame.episode ? (
           <span className="font-mono text-micro text-accent" title={frame.episode}>
@@ -257,9 +298,9 @@ function FrameRow({
       {expanded ? (
         <pre
           data-testid="frame-json"
-          className="mx-4 mb-2 px-2.5 py-2 font-mono text-micro text-muted-foreground bg-surface border border-border overflow-x-auto whitespace-pre-wrap break-words"
+          className="mx-4 mb-2 max-h-64 overflow-auto px-2.5 py-2 font-mono text-micro text-muted-foreground bg-surface border border-border whitespace-pre-wrap break-words"
         >
-          {envelopeJson(frame.raw)}
+          {highlightJson(envelopeJson(frame.raw))}
         </pre>
       ) : null}
     </div>
@@ -278,12 +319,39 @@ export function L9Inspector({ roomName }: Props) {
   const [frames, setFrames] = useState<L9Frame[]>([]);
   const [connected, setConnected] = useState(false);
   const wireRef = useRef<HTMLDivElement>(null);
+  // Frame ids already shown, so a history-backfill row and its live re-push don't
+  // double up. Reset per room.
+  const seenIds = useRef<Set<string>>(new Set());
   // How many rows are currently expanded; while > 0 the feed stops following
   // the tail so incoming frames don't yank an open envelope out of view.
   const expandedRows = useRef(0);
   const onExpandedChange = useCallback((delta: number) => {
     expandedRows.current += delta;
   }, []);
+
+  // History backfill: the transcript replayed through the same frame shape, so a
+  // freshly opened tab isn't empty (the SSE bus below carries no history). Runs
+  // per room, before/alongside the live stream; the shared seenIds set dedups a
+  // backfilled row against any live re-push.
+  useEffect(() => {
+    let cancelled = false;
+    seenIds.current = new Set();
+    setFrames([]);
+    fetchL9History(roomName).then((rows) => {
+      if (cancelled) return;
+      const seeded: L9Frame[] = [];
+      for (const row of rows) {
+        const frame = toL9Frame(row);
+        if (frame && !seenIds.current.has(frame.id)) {
+          seenIds.current.add(frame.id);
+          seeded.push(frame);
+        }
+      }
+      // Prepend history ahead of any live frames that arrived during the fetch.
+      setFrames((prev) => [...seeded, ...prev].slice(-MAX_FRAMES));
+    }).catch(logFetchError("fetchL9History"));
+    return () => { cancelled = true; };
+  }, [roomName]);
 
   // Live L9 wire: same EventSource pattern as the room feed. (Episodes have
   // their own home in the inspector's Episodes tab + review drawer; this tab is
@@ -300,7 +368,8 @@ export function L9Inspector({ roomName }: Props) {
         try {
           const msg = JSON.parse(e.data);
           const frame = toL9Frame(msg);
-          if (!frame) return;
+          if (!frame || seenIds.current.has(frame.id)) return;
+          seenIds.current.add(frame.id);
           setFrames((prev) => [...prev, frame].slice(-MAX_FRAMES));
         } catch {
           /* ignore malformed frames */

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Radio } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import {
@@ -29,6 +29,8 @@ export interface L9Frame {
   summary: string;
   metrics: EpisodeMetrics | null;
   time: string;
+  /** The wire message this frame was projected from, kept for the expanded view. */
+  raw: Record<string, unknown>;
 }
 
 /** Short, human episode id: the trailing `:session` segment of the URN. */
@@ -146,7 +148,25 @@ export function toL9Frame(msg: Record<string, unknown>): L9Frame | null {
     summary: frameSummary(kind, content, data),
     metrics,
     time,
+    raw: msg,
   };
+}
+
+/**
+ * Pretty-print a frame's wire message. The bus transports the envelope as a
+ * JSON string under `content`; decode it so headers, payload, and parents read
+ * as structure rather than one escaped string.
+ */
+export function envelopeJson(raw: Record<string, unknown>): string {
+  let display = raw;
+  if (typeof raw.content === "string") {
+    try {
+      display = { ...raw, content: JSON.parse(raw.content) };
+    } catch {
+      /* non-JSON content stays a string */
+    }
+  }
+  return JSON.stringify(display, null, 2);
 }
 
 // ── presentation ────────────────────────────────────────────────────────────────
@@ -190,25 +210,58 @@ export function MetricsRow({ metrics }: { metrics: EpisodeMetrics }) {
   );
 }
 
-/** One live wire frame. */
-function FrameRow({ frame }: { frame: L9Frame }) {
+/** One live wire frame; click toggles the full envelope JSON below the summary. */
+function FrameRow({
+  frame,
+  onExpandedChange,
+}: {
+  frame: L9Frame;
+  onExpandedChange: (delta: number) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Report expansion to the inspector (which pauses auto-scroll while any row
+  // is open); the cleanup un-reports when the row collapses or scrolls out of
+  // the frame cap.
+  useEffect(() => {
+    if (!expanded) return;
+    onExpandedChange(1);
+    return () => onExpandedChange(-1);
+  }, [expanded, onExpandedChange]);
+
   return (
-    <div className="flex items-baseline gap-2 px-4 py-2 border-b border-border last:border-b-0 text-body">
-      <KindBadge kind={frame.kind} subkind={frame.subkind} />
-      {frame.episode ? (
-        <span className="font-mono text-micro text-accent" title={frame.episode}>
-          {shortEpisode(frame.episode)}
-        </span>
+    <div className="border-b border-border last:border-b-0">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((prev) => !prev)}
+        title={expanded ? "Collapse envelope" : "Expand full envelope JSON"}
+        className="flex items-baseline gap-2 px-4 py-2 w-full text-left cursor-pointer text-body"
+      >
+        <KindBadge kind={frame.kind} subkind={frame.subkind} />
+        {frame.episode ? (
+          <span className="font-mono text-micro text-accent" title={frame.episode}>
+            {shortEpisode(frame.episode)}
+          </span>
+        ) : null}
+        <span className="font-mono text-label text-muted-foreground truncate">{frame.sender}</span>
+        <span className="text-muted-foreground truncate">{frame.summary}</span>
+        {frame.metrics ? <MetricsRow metrics={frame.metrics} /> : null}
+        {frame.parents.length > 0 ? (
+          <span className="text-micro text-muted-foreground font-mono" title={frame.parents.join("\n")}>
+            ←{frame.parents.length}
+          </span>
+        ) : null}
+        <span className="ml-auto text-micro text-muted-foreground font-mono tabular flex-shrink-0">{frame.time}</span>
+      </button>
+      {expanded ? (
+        <pre
+          data-testid="frame-json"
+          className="mx-4 mb-2 px-2.5 py-2 font-mono text-micro text-muted-foreground bg-surface border border-border overflow-x-auto whitespace-pre-wrap break-words"
+        >
+          {envelopeJson(frame.raw)}
+        </pre>
       ) : null}
-      <span className="font-mono text-label text-muted-foreground truncate">{frame.sender}</span>
-      <span className="text-muted-foreground truncate">{frame.summary}</span>
-      {frame.metrics ? <MetricsRow metrics={frame.metrics} /> : null}
-      {frame.parents.length > 0 ? (
-        <span className="text-micro text-muted-foreground font-mono" title={frame.parents.join("\n")}>
-          ←{frame.parents.length}
-        </span>
-      ) : null}
-      <span className="ml-auto text-micro text-muted-foreground font-mono tabular flex-shrink-0">{frame.time}</span>
     </div>
   );
 }
@@ -225,6 +278,12 @@ export function L9Inspector({ roomName }: Props) {
   const [frames, setFrames] = useState<L9Frame[]>([]);
   const [connected, setConnected] = useState(false);
   const wireRef = useRef<HTMLDivElement>(null);
+  // How many rows are currently expanded; while > 0 the feed stops following
+  // the tail so incoming frames don't yank an open envelope out of view.
+  const expandedRows = useRef(0);
+  const onExpandedChange = useCallback((delta: number) => {
+    expandedRows.current += delta;
+  }, []);
 
   // Live L9 wire: same EventSource pattern as the room feed. (Episodes have
   // their own home in the inspector's Episodes tab + review drawer; this tab is
@@ -262,6 +321,7 @@ export function L9Inspector({ roomName }: Props) {
   }, [roomName]);
 
   useEffect(() => {
+    if (expandedRows.current > 0) return;
     wireRef.current?.scrollTo({ top: wireRef.current.scrollHeight, behavior: "smooth" });
   }, [frames]);
 
@@ -288,7 +348,9 @@ export function L9Inspector({ roomName }: Props) {
             description="Protocol envelopes stream here as agents coordinate: exchanges, commits, and knowledge."
           />
         ) : (
-          wire.map((frame) => <FrameRow key={frame.id} frame={frame} />)
+          wire.map((frame) => (
+            <FrameRow key={frame.id} frame={frame} onExpandedChange={onExpandedChange} />
+          ))
         )}
       </div>
     </div>

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -149,6 +149,21 @@ export function getSSEUrl(roomName: string) {
   return `/api/rooms/${roomName}/messages/stream`;
 }
 
+/** The room's L9 wire history (transcript replay), for backfilling the live
+ *  inspector on mount. Frames match the SSE bus shape, so the client projects
+ *  backfill + live identically. Returns [] on any error (best-effort). */
+export async function fetchL9History(
+  roomName: string,
+  limit = 200,
+): Promise<Record<string, unknown>[]> {
+  const res = await fetch(`/api/rooms/${roomName}/messages/l9?limit=${limit}`, {
+    cache: "no-store",
+  });
+  if (!res.ok) return [];
+  const data = await res.json();
+  return Array.isArray(data) ? data : [];
+}
+
 /** SSE endpoint for global app events (room create/delete). */
 export function getAppEventsSSEUrl() {
   return `/api/events/stream`;


### PR DESCRIPTION
Closes #501. Live-verified against a running SLIM node using the `mycelium l9 send` utility from #534.

## What

The L9 Inspector was hard to use: rows didn't expand to the underlying envelope, and the feed was **live-only** — a freshly opened tab started empty and any earlier traffic was gone. This makes it a real inspector.

- **Expand rows into the full envelope JSON** (original scope) — click a wire row to see the decoded `{header, payload}` envelope.
- **History backfill** — seed the feed from the durable transcript on mount, then append live, the same history-then-live pattern the room chat uses. No more empty tab.
- **Readable expanded view** — max-height scroll for big envelopes, dependency-free JSON syntax highlighting, and a hover + rotating-chevron affordance so rows read as clickable.

## Backend

- Extract the live bus-frame builder into `persister.l9_bus_frame()` (shared by `_publish_to_bus`), add `l9_wire_history()` replaying the transcript through that same shape, exposed as `GET /rooms/{room}/messages/l9`. This preserves the **full L9 envelope** — the conversational messages API flattens records to text and drops non-chat payloads, so it could never feed the inspector.
- `tests/test_l9_history.py`: envelope-intact replay, oldest-first + limit, empty room.

## Frontend

- `fetchL9History()` seeds `frames` on mount; live SSE appends with a shared `seenIds` set so a backfilled row and its live re-push (same envelope id) don't double up.
- `highlightJson()` — small tokenizer (keys/strings/numbers/literals), visible text byte-identical.
- Expanded `<pre>`: `max-h-64 overflow-auto`; rows get `hover:bg-hairline` + a leading chevron that rotates on expand.
- Tests: backfill-on-mount, dedup-against-live-repush (+ existing 12).