### PR TITLE
fix(rooms): sort + display room list by last activity, not creation time

### DIFF
--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -20,6 +20,7 @@ from app.services.filesystem import (
     room_exists,
     write_room_meta,
 )
+from app.services.persister import TRANSCRIPT_FILENAME
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,21 @@ def _room_read(room_name: str) -> RoomRead | None:
     if meta is None:
         return None
     return RoomRead(**meta)
+
+
+def _last_activity(room: RoomRead) -> datetime:
+    """When a room was last active: its transcript's mtime, or ``created_at``.
+
+    The transcript (``log/transcript.jsonl``) is appended to on every message
+    (see ``persister.py``), so its mtime is a cheap proxy for "last message
+    time" without parsing the file. Rooms with no messages yet fall back to
+    creation time.
+    """
+    transcript_path = get_room_dir(room.name) / TRANSCRIPT_FILENAME
+    try:
+        return datetime.fromtimestamp(transcript_path.stat().st_mtime, tz=UTC)
+    except OSError:
+        return room.created_at
 
 
 @router.post("", response_model=RoomRead, status_code=201)
@@ -101,7 +117,7 @@ async def list_rooms(
     visible = [r for r in rooms if r is not None and r.is_public]
     if name:
         visible = [r for r in visible if name.lower() in r.name.lower()]
-    visible.sort(key=lambda r: r.created_at, reverse=True)
+    visible.sort(key=_last_activity, reverse=True)
     return visible[skip : skip + limit]
 
 

--- a/fastapi-backend/app/routes/rooms.py
+++ b/fastapi-backend/app/routes/rooms.py
@@ -117,7 +117,11 @@ async def list_rooms(
     visible = [r for r in rooms if r is not None and r.is_public]
     if name:
         visible = [r for r in visible if name.lower() in r.name.lower()]
-    visible.sort(key=_last_activity, reverse=True)
+    # Stamp last-activity once, then sort + surface it (the UI shows this, not
+    # created_at — "when was this room last used" is the useful signal).
+    for r in visible:
+        r.last_activity = _last_activity(r)
+    visible.sort(key=lambda r: r.last_activity or r.created_at, reverse=True)
     return visible[skip : skip + limit]
 
 

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -29,6 +29,9 @@ class RoomRead(BaseModel):
     description: str | None = None
     is_public: bool
     created_at: datetime
+    #: When the room was last active (its transcript's mtime), or ``created_at``
+    #: for a room with no messages yet. Populated by ``GET /rooms``.
+    last_activity: datetime | None = None
     is_persistent: bool = False
     mas_id: str | None = None
     workspace_id: str | None = None

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -360,7 +360,13 @@ def read_room_meta(room_name: str) -> dict[str, Any] | None:
 
     created_at = stored.get("created_at")
     if not created_at:
-        created_at = datetime.fromtimestamp(room_dir.stat().st_mtime, tz=UTC).isoformat()
+        # A room dir predating the sidecar. Prefer the sidecar's own mtime (stable
+        # — written once at creation); fall back to the dir mtime only when there's
+        # no sidecar at all. The dir mtime bumps whenever a child file changes (the
+        # search index rewrites on startup), so on its own it drifts to "just now"
+        # on every restart.
+        fallback_path = meta_path if meta_path.exists() else room_dir
+        created_at = datetime.fromtimestamp(fallback_path.stat().st_mtime, tz=UTC).isoformat()
 
     return {
         "id": room_id(room_name),

--- a/fastapi-backend/tests/test_rooms_route.py
+++ b/fastapi-backend/tests/test_rooms_route.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""``GET /rooms`` sorts by last activity, not creation order."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from app.services.filesystem import ensure_room_structure, get_room_dir
+from app.services.persister import TranscriptRecord, append_transcript
+
+
+async def _create_room(client, name: str) -> None:
+    resp = await client.post("/api/rooms", json={"name": name})
+    assert resp.status_code == 201, resp.text
+
+
+def _touch_transcript(room: str) -> None:
+    """Append a transcript record to ``room``, bumping its file mtime to now."""
+    ensure_room_structure(get_room_dir(room))
+    append_transcript(
+        room,
+        TranscriptRecord(
+            message_id="m1",
+            sender="agent",
+            kind="broadcast",
+            subkind=None,
+            content={"text": "hi"},
+            recorded_at="2026-01-01T00:00:00+00:00",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_rooms_orders_by_last_activity(client) -> None:
+    # Created oldest-first: "alpha", then "beta", then "gamma".
+    await _create_room(client, "alpha")
+    await _create_room(client, "beta")
+    await _create_room(client, "gamma")
+
+    # "alpha" has no messages (falls back to its old created_at). "beta" gets a
+    # message now, so it should sort ahead of the newer-but-quiet "gamma".
+    _touch_transcript("beta")
+
+    resp = await client.get("/api/rooms")
+    assert resp.status_code == 200
+    names = [r["name"] for r in resp.json()]
+
+    # "beta" was just active, so it leads even though "gamma" was created later.
+    assert names.index("beta") < names.index("gamma")
+    # "alpha" has never had a message and was created first: it sorts last.
+    assert names[-1] == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_list_rooms_falls_back_to_created_at_without_transcript(client) -> None:
+    await _create_room(client, "quiet-old")
+    time.sleep(0.01)
+    await _create_room(client, "quiet-new")
+
+    resp = await client.get("/api/rooms")
+    assert resp.status_code == 200
+    names = [r["name"] for r in resp.json()]
+    assert names.index("quiet-new") < names.index("quiet-old")

--- a/fastapi-backend/tests/test_rooms_route.py
+++ b/fastapi-backend/tests/test_rooms_route.py
@@ -47,12 +47,19 @@ async def test_list_rooms_orders_by_last_activity(client) -> None:
 
     resp = await client.get("/api/rooms")
     assert resp.status_code == 200
-    names = [r["name"] for r in resp.json()]
+    rooms = resp.json()
+    names = [r["name"] for r in rooms]
 
     # "beta" was just active, so it leads even though "gamma" was created later.
     assert names.index("beta") < names.index("gamma")
     # "alpha" has never had a message and was created first: it sorts last.
     assert names[-1] == "alpha"
+
+    # Each room surfaces last_activity; the active one's is newer than its own
+    # created_at (the field the UI renders instead of creation time).
+    beta = next(r for r in rooms if r["name"] == "beta")
+    assert beta["last_activity"] is not None
+    assert beta["last_activity"] >= beta["created_at"]
 
 
 @pytest.mark.asyncio

--- a/mycelium-frontend/src/components/command-center.tsx
+++ b/mycelium-frontend/src/components/command-center.tsx
@@ -37,6 +37,8 @@ function RunSampleLink({ className = "" }: { className?: string }) {
 interface Room {
   name: string;
   created_at: string;
+  /** When the room was last active (transcript mtime); falls back to created_at. */
+  last_activity?: string | null;
   is_persistent: boolean;
 }
 
@@ -195,7 +197,7 @@ function RoomCard({ room }: { room: Room }) {
         </span>
         <div className="min-w-0 flex-1">
           <div className="truncate text-ui font-medium text-text">{room.name}</div>
-          <div className="text-micro text-muted-foreground">{relativeTime(room.created_at)}</div>
+          <div className="text-micro text-muted-foreground">{relativeTime(room.last_activity ?? room.created_at)}</div>
         </div>
         {live > 0 && (
           <span className="flex items-center gap-1.5 text-micro text-accent">


### PR DESCRIPTION
Room list ordering and the per-room timestamp were both keyed to **creation time**, which buries rooms you've actually been using and is a mostly-useless signal. This switches both to **last activity**.

## Changes

- **Sort** `GET /rooms` by last activity: the room transcript's mtime (`log/transcript.jsonl`, appended on every message) is a cheap proxy for "last message time" without parsing. Rooms with no messages fall back to `created_at`.
- **Display**: `RoomRead` now carries `last_activity`, and the room cards render it (`relativeTime(room.last_activity ?? room.created_at)`) instead of `created_at`.
- **Stabilize `created_at`** for sidecar-less rooms: fall back to the `.room.json` mtime (written once at creation) instead of the room-dir mtime. The dir mtime bumps whenever a child file changes — e.g. the search index rewrites on startup — which made quiet rooms drift to "just now" on every backend restart (and float to the top).

## Tests

`tests/test_rooms_route.py` — active-room ordering, no-transcript fallback, and the `last_activity` field. Existing `test_filesystem.py` covers the meta fallback. ruff + ty + tsc clean.