### PR TITLE
fix(frontend): align sidebar logo with wordmark baseline

### DIFF
--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -81,7 +81,7 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
         href="/"
         className="flex h-[52px] flex-shrink-0 items-center gap-2.5 border-b border-border px-4 transition-colors hover:bg-hairline"
       >
-        <Image src="/logo.png" alt="Mycelium" width={20} height={20} className="opacity-90" />
+        <Image src="/logo.png" alt="Mycelium" width={20} height={20} className="translate-y-[2px] opacity-90" />
         <span
           className="text-display leading-none text-text"
           style={{ fontFamily: "'Cormorant Garamond', Georgia, serif", fontStyle: "italic", fontWeight: 600 }}


### PR DESCRIPTION
## Summary

In the sidebar's top-left brand corner, the logo icon appeared to float above the "mycelium" wordmark instead of sitting level with it.

## Changes

- `mycelium-frontend/src/components/rooms-sidebar.tsx`: nudge the logo `<Image>` down 2px (`translate-y-[2px]`).

The icon and the italic serif wordmark were both vertically centered on the flex row's geometric center (verified via DOM measurement — both centered at the same y), so `items-center` itself was working correctly. The mismatch is optical: the logo glyph fills nearly its entire 20px box edge-to-edge, while the wordmark's line box reserves extra space above/below for ascenders (`l`, `i`) and the descender (`y`), which pushes the x-height band — where the letters visually "sit" — below the box's geometric center. Measuring the font's actual metrics (canvas `TextMetrics`) put the wordmark's x-height band center about 2.5px below the icon's ink center, which matches what a zoomed screenshot showed. A 2px downward nudge on the icon brings it in line.

## Testing

- [x] Verified visually before/after with Playwright screenshots (`pnpm dev:mock`) — logo lines up with the wordmark's x-height after the change.
- [x] `pnpm exec tsc --noEmit` passes.
- [ ] No backend changes; backend test suite not applicable.

## Related Issues

N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01A1MssxbvLjqx96UTV8j3VW)_