### PR TITLE
fix(frontend): switch main chat window to the shared ScrollArea

### DIFF
--- a/mycelium-frontend/src/components/event-stream.render.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.render.test.tsx
@@ -57,6 +57,24 @@ describe("<EventStream /> live message rendering", () => {
     expect(await screen.findByText("hello over the live channel")).toBeInTheDocument();
   });
 
+  it("auto-scrolls the ScrollArea viewport, not the outer wrapper, on new messages", async () => {
+    const scrollTo = vi.spyOn(Element.prototype, "scrollTo");
+    render(<EventStream roomName="sprint" />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(l9Exchange("stick to bottom"));
+    });
+    await screen.findByText("stick to bottom");
+
+    expect(scrollTo).toHaveBeenCalled();
+    const scrolledEl = scrollTo.mock.contexts[scrollTo.mock.contexts.length - 1] as Element;
+    expect(scrolledEl.getAttribute("data-slot")).toBe("scroll-area-viewport");
+    scrollTo.mockRestore();
+  });
+
   it("renders an l9_commit streamed over SSE as a consensus notice, not the unhandled fallback", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     render(<EventStream roomName="sprint" />);

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -21,6 +21,7 @@ import { NegotiationView } from "@/components/negotiation-view";
 import { RoomSlimView } from "@/components/room-slim";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { initials } from "@/components/ui/monogram";
 import { MessagesSquare } from "lucide-react";
 
@@ -519,11 +520,11 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
           <NegotiationView events={events} />
         </div>
       ) : view === "slim" ? (
-        <div className="flex-1 min-h-0 overflow-y-auto">
+        <ScrollArea className="flex-1 min-h-0">
           <RoomSlimView roomName={roomName} />
-        </div>
+        </ScrollArea>
       ) : (
-      <div ref={scrollRef} className="flex-1 overflow-y-auto">
+      <ScrollArea className="flex-1" viewportRef={scrollRef}>
         {view === "plan" ? (
           <RoomPlanHeader roomName={roomName} refreshTrigger={planRefreshTrigger} />
         ) : !historyLoaded ? (
@@ -720,7 +721,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
             })}
         </div>
         )}
-      </div>
+      </ScrollArea>
       )}
     </div>
   );

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -524,7 +524,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
           <RoomSlimView roomName={roomName} />
         </ScrollArea>
       ) : (
-      <ScrollArea className="flex-1" viewportRef={scrollRef}>
+      <ScrollArea className="flex-1 min-h-0" viewportRef={scrollRef}>
         {view === "plan" ? (
           <RoomPlanHeader roomName={roomName} refreshTrigger={planRefreshTrigger} />
         ) : !historyLoaded ? (

--- a/mycelium-frontend/src/components/ui/scroll-area.tsx
+++ b/mycelium-frontend/src/components/ui/scroll-area.tsx
@@ -8,8 +8,12 @@ import { cn } from "@/lib/utils"
 function ScrollArea({
   className,
   children,
+  viewportRef,
   ...props
-}: ScrollAreaPrimitive.Root.Props) {
+}: ScrollAreaPrimitive.Root.Props & {
+  /** Ref to the scrollable viewport element (e.g. for scrollTo / stick-to-bottom behavior). */
+  viewportRef?: React.Ref<HTMLDivElement>
+}) {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -17,6 +21,7 @@ function ScrollArea({
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >

--- a/mycelium-frontend/vitest.setup.ts
+++ b/mycelium-frontend/vitest.setup.ts
@@ -13,6 +13,9 @@ if (!Element.prototype.scrollTo) {
 if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
 }
+if (!Element.prototype.getAnimations) {
+  Element.prototype.getAnimations = () => [];
+}
 if (!("ResizeObserver" in globalThis)) {
   globalThis.ResizeObserver = class {
     observe() {}


### PR DESCRIPTION
## Summary

The main chat/event window (`event-stream.tsx`) scrolled with a raw `overflow-y-auto` div while the rest of the app (e.g. `rooms-sidebar.tsx`) uses the shared `ScrollArea` primitive (`components/ui/scroll-area.tsx`). This swaps both `overflow-y-auto` usages in `event-stream.tsx` — the channel/chat list and the SLIM tab — to `ScrollArea`, for consistent styled scrollbars across the app.

## Changes

- `components/ui/scroll-area.tsx`: add an optional `viewportRef` prop to `ScrollArea` so callers can get a ref to the actual scrollable **viewport** node (base-ui nests the scrollable element inside the root, it's not the outer wrapper).
- `event-stream.tsx`: wrap the channel/chat list and the SLIM view in `ScrollArea`; the existing auto-scroll-to-bottom `scrollRef` now points at `viewportRef` so `scrollRef.current?.scrollTo(...)` keeps targeting the real scrollable element.
- `vitest.setup.ts`: stub `Element.prototype.getAnimations` (jsdom doesn't implement it) — base-ui's `ScrollArea` viewport calls it internally, and it was throwing uncaught exceptions in component tests that render `ScrollArea`.
- `event-stream.render.test.tsx`: add a regression test asserting that a new SSE message calls `scrollTo` on the element with `data-slot="scroll-area-viewport"`, not the outer wrapper — this was the one real wrinkle called out in the issue.

## Testing

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (13/13, including the new auto-scroll regression test)
- [x] `npm run build` (Next.js production build) succeeds

## Related Issues

Closes #521


---
_Generated by [Claude Code](https://claude.ai/code/session_01GEyj1kwCSqyy1SHR7T42UP)_