### PR TITLE
feat(notifications): cross-room, cross-tab notification center

### DIFF
--- a/fastapi-backend/app/routes/stream.py
+++ b/fastapi-backend/app/routes/stream.py
@@ -11,6 +11,7 @@ invest here.
 GET /rooms/{room}/messages/stream — room event stream
 GET /agents/{handle}/stream       — per-agent event stream
 GET /events/stream                — global app events (room create/delete)
+GET /notifications/stream         — aggregate: every room's activity, one stream
 """
 
 import asyncio
@@ -22,7 +23,7 @@ from fastapi.responses import StreamingResponse
 
 from app.bus import agent_channel, app_channel, bus, room_channel
 from app.services import local_state
-from app.services.filesystem import room_exists
+from app.services.filesystem import list_room_names, room_exists
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,71 @@ async def stream_app_events(request: Request):
     """
     return StreamingResponse(
         _sse_from_channel(request, app_channel()),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+async def _sse_notifications(request: Request):
+    """Yield SSE frames merging the app channel with every room's channel.
+
+    One subscription in place of the UI opening a per-room stream for every
+    room the user participates in — the notification center's source feed.
+    Frames are byte-identical to the per-room stream's (``l9_*``,
+    ``coordination_join``, ``plan_updated``, each carrying ``room_name``), plus
+    the app channel's ``room_created``/``room_deleted``, which this generator
+    also uses to grow/shrink its own room subscription set live.
+    """
+    app_queue = bus.subscribe(app_channel())
+    room_queues: dict[str, asyncio.Queue] = {
+        name: bus.subscribe(room_channel(name)) for name in list_room_names()
+    }
+    pending: set[asyncio.Task] = set()
+    try:
+        yield "event: ping\ndata: {}\n\n"
+        while True:
+            if await request.is_disconnected():
+                break
+            queues = [app_queue, *room_queues.values()]
+            pending = {asyncio.ensure_future(q.get()) for q in queues}
+            done, pending = await asyncio.wait(
+                pending, timeout=15.0, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+            pending = set()
+            if not done:
+                yield ": keep-alive\n\n"
+                continue
+            for task in done:
+                payload = task.result()
+                kind = payload.get("type")
+                name = payload.get("room_name")
+                if kind == "room_created" and isinstance(name, str) and name not in room_queues:
+                    room_queues[name] = bus.subscribe(room_channel(name))
+                elif kind == "room_deleted" and isinstance(name, str):
+                    stale = room_queues.pop(name, None)
+                    if stale is not None:
+                        bus.unsubscribe(room_channel(name), stale)
+                yield f"data: {json.dumps(payload, default=str)}\n\n"
+    finally:
+        for task in pending:
+            task.cancel()
+        bus.unsubscribe(app_channel(), app_queue)
+        for name, q in room_queues.items():
+            bus.unsubscribe(room_channel(name), q)
+
+
+@router.get("/notifications/stream")
+async def stream_notifications(request: Request):
+    """Server-Sent Events stream aggregating activity across every room.
+
+    Powers the notification center: a single connection, independent of which
+    room (if any) is open, instead of the per-room stream that only carries
+    activity for whatever room is currently on screen.
+    """
+    return StreamingResponse(
+        _sse_notifications(request),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
     )

--- a/fastapi-backend/tests/test_notifications_stream.py
+++ b/fastapi-backend/tests/test_notifications_stream.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The aggregate notification stream: every room's activity, one subscription.
+
+Drives ``_sse_notifications`` directly (not over HTTP) — the generator is the
+unit under test; the surrounding ``StreamingResponse``/route wiring mirrors the
+already-untested ``_sse_from_channel`` endpoints.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from app.bus import bus, room_channel
+from app.routes.stream import _sse_notifications
+
+
+class _FakeRequest:
+    """Never reports disconnected; tests end the generator with ``aclose()``."""
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+async def _next_data_frame(gen) -> dict:
+    """Pull frames until a ``data:`` one arrives (skipping ping/keep-alive)."""
+    while True:
+        frame = await asyncio.wait_for(gen.__anext__(), timeout=2.0)
+        if frame.startswith("data: "):
+            return json.loads(frame[len("data: ") :])
+
+
+@pytest.mark.asyncio
+async def test_includes_activity_from_a_room_that_predates_the_connection(client):
+    await client.post("/api/rooms", json={"name": "eng-room"})
+
+    gen = _sse_notifications(_FakeRequest())  # type: ignore[arg-type]
+    try:
+        opening = await gen.__anext__()
+        assert opening.startswith("event: ping")
+
+        bus.publish(
+            room_channel("eng-room"),
+            {"room_name": "eng-room", "message_type": "l9_exchange", "content": "{}"},
+        )
+        frame = await _next_data_frame(gen)
+        assert frame["room_name"] == "eng-room"
+        assert frame["message_type"] == "l9_exchange"
+    finally:
+        await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_follows_a_room_created_after_the_connection(client):
+    gen = _sse_notifications(_FakeRequest())  # type: ignore[arg-type]
+    try:
+        await gen.__anext__()
+
+        create_resp = await client.post("/api/rooms", json={"name": "new-room"})
+        assert create_resp.status_code == 201
+        created = await _next_data_frame(gen)
+        assert created == {
+            "type": "room_created",
+            "room_name": "new-room",
+            "mas_id": None,
+            "created_at": created["created_at"],
+        }
+
+        bus.publish(
+            room_channel("new-room"),
+            {"room_name": "new-room", "message_type": "coordination_join", "content": "{}"},
+        )
+        frame = await _next_data_frame(gen)
+        assert frame["room_name"] == "new-room"
+        assert frame["message_type"] == "coordination_join"
+    finally:
+        await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_drops_subscription_on_room_deleted(client):
+    await client.post("/api/rooms", json={"name": "gone-room"})
+    gen = _sse_notifications(_FakeRequest())  # type: ignore[arg-type]
+    try:
+        await gen.__anext__()
+
+        delete_resp = await client.delete("/api/rooms/gone-room")
+        assert delete_resp.status_code == 204
+        deleted = await _next_data_frame(gen)
+        assert deleted == {"type": "room_deleted", "room_name": "gone-room"}
+
+        # The generator unsubscribed on the room_deleted frame — the bus has no
+        # remaining subscriber for that room's channel. Checked directly rather
+        # than waiting out the generator's 15s keep-alive timeout for a frame
+        # that (correctly) never arrives.
+        assert room_channel("gone-room") not in bus._subs
+    finally:
+        await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cleans_up_all_subscriptions_on_close(client):
+    await client.post("/api/rooms", json={"name": "room-a"})
+    await client.post("/api/rooms", json={"name": "room-b"})
+
+    gen = _sse_notifications(_FakeRequest())  # type: ignore[arg-type]
+    await gen.__anext__()
+    assert room_channel("room-a") in bus._subs
+    assert room_channel("room-b") in bus._subs
+
+    await gen.aclose()
+
+    assert room_channel("room-a") not in bus._subs
+    assert room_channel("room-b") not in bus._subs

--- a/mycelium-frontend/src/app/api/notifications/stream/route.ts
+++ b/mycelium-frontend/src/app/api/notifications/stream/route.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { getBackendUrl } from "@/lib/backend";
+import { isMockMode } from "@/mocks";
+
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache, no-transform",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+};
+
+export async function GET() {
+  // Fake-backend mode has no live room churn: hold an idle keep-alive stream
+  // open so the client's EventSource connects cleanly and never errors.
+  if (isMockMode()) {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("event: ping\ndata: {}\n\n"));
+      },
+    });
+    return new Response(stream, { headers: SSE_HEADERS });
+  }
+
+  const upstream = `${getBackendUrl()}/api/notifications/stream`;
+  let res: Response;
+  try {
+    res = await fetch(upstream, {
+      headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+      cache: "no-store",
+    });
+  } catch {
+    return new Response("upstream SSE unavailable", { status: 502 });
+  }
+
+  if (!res.ok || !res.body) {
+    return new Response("upstream SSE unavailable", { status: 502 });
+  }
+
+  // Pipe through a TransformStream so each chunk flushes immediately rather
+  // than waiting for Next.js to decide when to flush (mirrors the room stream).
+  const { readable, writable } = new TransformStream();
+  res.body.pipeTo(writable).catch(() => {/* client disconnect */});
+
+  return new Response(readable, { headers: SSE_HEADERS });
+}

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { CurrentUserProvider } from "@/components/current-user";
+import { NotificationsProvider } from "@/components/notifications-provider";
 
 export const metadata: Metadata = {
   title: "mycelium",
@@ -23,7 +24,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="min-h-screen bg-bg text-text antialiased">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
-          <CurrentUserProvider>{children}</CurrentUserProvider>
+          <CurrentUserProvider>
+            <NotificationsProvider>{children}</NotificationsProvider>
+          </CurrentUserProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/mycelium-frontend/src/components/event-stream.render.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.render.test.tsx
@@ -57,6 +57,68 @@ describe("<EventStream /> live message rendering", () => {
     expect(await screen.findByText("hello over the live channel")).toBeInTheDocument();
   });
 
+  it("renders an l9_commit streamed over SSE as a consensus notice, not the unhandled fallback", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    render(<EventStream roomName="sprint" />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit({
+        message_type: "l9_commit",
+        sender_handle: "aligner",
+        created_at: CREATED,
+        content: JSON.stringify({
+          content: "consensus reached",
+          l9: {
+            header: {
+              kind: "commit",
+              subkind: "converged",
+              message: { episode: "urn:ioc:mycelium:episode:sprint:s1" },
+            },
+            payload: { type: "consensus", data: { assignments: { stack: "next" }, metrics: { gar: 0.8 } } },
+          },
+        }),
+      });
+    });
+
+    expect(await screen.findByText("Consensus")).toBeInTheDocument();
+    expect(screen.getByText("· 1 issue agreed", { exact: false })).toBeInTheDocument();
+    expect(screen.getByText("GAR 0.80", { exact: false })).toBeInTheDocument();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("renders an l9_knowledge streamed over SSE as a knowledge notice, not the unhandled fallback", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    render(<EventStream roomName="sprint" />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit({
+        message_type: "l9_knowledge",
+        sender_handle: "system",
+        created_at: CREATED,
+        content: JSON.stringify({
+          content: "plan updated → plan/tasks.md",
+          l9: {
+            header: { kind: "knowledge", subkind: "distillation" },
+            payload: { type: "distillation", data: { key: "plan/tasks.md", updated_by: "aligner" } },
+          },
+        }),
+      });
+    });
+
+    expect(await screen.findByText("plan updated → plan/tasks.md")).toBeInTheDocument();
+    expect(screen.getByText("Knowledge")).toBeInTheDocument();
+    expect(screen.getByText("by @aligner", { exact: false })).toBeInTheDocument();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("warns loudly on an unhandled message_type instead of dropping it silently", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     render(<EventStream roomName="sprint" />);

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -49,6 +49,7 @@ const CHANNEL_VIEW_TYPES = new Set([
   "coordination_join",
   "coordination_consensus",
   "plan_updated",
+  "l9_knowledge",
 ]);
 
 // Lifecycle events that render as slim system notices (not chat rows). Used to
@@ -58,6 +59,7 @@ const SYSTEM_TYPES = new Set([
   "coordination_join",
   "coordination_consensus",
   "plan_updated",
+  "l9_knowledge",
 ]);
 
 /** Loading placeholder shaped like a short run of chat rows (avatar + lines). */
@@ -194,6 +196,39 @@ function parseEvent(msg: Record<string, unknown>): Event {
       content = (raw.content as string) || "";
       mtype = recipient ? "direct" : "broadcast";
       break;
+    case "l9_commit": {
+      // The aligner's verdict rides as an L9 "commit" envelope, not the legacy
+      // `coordination_consensus` message_type nothing on the live wire actually
+      // emits anymore. Unwrap it into the shape the (still-live)
+      // "coordination_consensus" render path and NegotiationView expect, so a
+      // real consensus renders instead of hitting the unhandled-type fallback.
+      const l9env = (raw.l9 as Record<string, unknown> | undefined) ?? {};
+      const header = (l9env.header as Record<string, unknown> | undefined) ?? {};
+      const payload = (l9env.payload as Record<string, unknown> | undefined) ?? {};
+      const data = (payload.data as Record<string, unknown> | undefined) ?? {};
+      const message = header.message as Record<string, unknown> | undefined;
+      content = (raw.content as string) || "";
+      raw = {
+        ...raw,
+        broken: header.subkind !== "converged",
+        assignments: data.assignments,
+        metrics: data.metrics,
+        episode: message?.episode,
+      };
+      mtype = "coordination_consensus";
+      break;
+    }
+    case "l9_knowledge": {
+      // A memory push (e.g. the compiled plan syncing to every member) rides as
+      // an L9 "knowledge" envelope. Recognized as its own system notice rather
+      // than falling to the unhandled-type fallback.
+      const l9env = (raw.l9 as Record<string, unknown> | undefined) ?? {};
+      const payload = (l9env.payload as Record<string, unknown> | undefined) ?? {};
+      const data = (payload.data as Record<string, unknown> | undefined) ?? {};
+      content = (raw.content as string) || `${(data.key as string) ?? "memory"} updated`;
+      raw = { ...raw, key: data.key, updated_by: data.updated_by, version: data.version };
+      break;
+    }
     default:
       // A message type nothing above handles would otherwise vanish from the
       // channel view without a trace (exactly how l9_exchange hid). Surface it
@@ -238,6 +273,7 @@ const typeStyles: Record<string, { tone: "accent" | "ok" | "warn" | "muted" | "i
   coordination_tick:      { tone: "muted",  label: "TICK" },
   coordination_consensus: { tone: "ok",     label: "CONSENSUS" },
   memory_changed:         { tone: "warn",   label: "MEMORY" },
+  l9_knowledge:           { tone: "warn",   label: "KNOWLEDGE" },
 };
 const defaultStyle = { tone: "muted" as const, label: "MSG" };
 
@@ -543,6 +579,17 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                 return (
                   <SystemNotice key={ev.id} time={ev.time} dot="var(--accent)" label="Plan">
                     {body}
+                  </SystemNotice>
+                );
+              }
+              if (ev.type === "l9_knowledge") {
+                const key = ev.raw.key as string | undefined;
+                const updatedBy = ev.raw.updated_by as string | undefined;
+                return (
+                  <SystemNotice key={ev.id} time={ev.time} dot="var(--yellow)" label="Knowledge">
+                    <span>{ev.content}</span>
+                    {key && <span className="font-mono text-muted-foreground">{key}</span>}
+                    {updatedBy ? <span>by @{updatedBy}</span> : null}
                   </SystemNotice>
                 );
               }

--- a/mycelium-frontend/src/components/notification-bell.test.tsx
+++ b/mycelium-frontend/src/components/notification-bell.test.tsx
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { act } from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeEventSource } from "@/test/fake-event-source";
+
+vi.mock("@/lib/api", () => ({
+  getNotificationsSSEUrl: () => "/api/notifications/stream",
+}));
+
+import { CurrentUserProvider } from "@/components/current-user";
+import { NotificationsProvider } from "@/components/notifications-provider";
+import { NotificationBell } from "@/components/notification-bell";
+
+const CREATED = "2026-08-15T10:00:00.000000+00:00";
+
+function renderBell() {
+  return render(
+    <CurrentUserProvider>
+      <NotificationsProvider>
+        <NotificationBell />
+      </NotificationsProvider>
+    </CurrentUserProvider>,
+  );
+}
+
+function mention() {
+  return {
+    id: "msg-1",
+    room_name: "sprint",
+    sender_handle: "alice",
+    message_type: "l9_exchange",
+    created_at: CREATED,
+    content: JSON.stringify({ content: "hey @bob take a look" }),
+  };
+}
+
+describe("<NotificationBell />", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.localStorage.setItem("mycelium.principal", "bob");
+    FakeEventSource.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+
+  it("badges an unread mention and lists it in the popover", async () => {
+    const user = userEvent.setup();
+    renderBell();
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(mention());
+    });
+
+    expect(await screen.findByLabelText("1 unread notifications")).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("1 unread notifications"));
+    expect(await screen.findByText("sprint")).toBeInTheDocument();
+    expect(screen.getByText("hey @bob take a look")).toBeInTheDocument();
+  });
+
+  it("ignores a message that doesn't mention or address the acting principal", async () => {
+    renderBell();
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit({
+        id: "msg-2",
+        room_name: "sprint",
+        sender_handle: "alice",
+        message_type: "l9_exchange",
+        created_at: CREATED,
+        content: JSON.stringify({ content: "hey @carol take a look" }),
+      });
+    });
+
+    expect(screen.getByLabelText("Notifications")).toBeInTheDocument();
+    expect(screen.queryByText(/unread/)).not.toBeInTheDocument();
+  });
+
+  it("marking all read clears the unread badge", async () => {
+    const user = userEvent.setup();
+    renderBell();
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(mention());
+    });
+    await screen.findByLabelText("1 unread notifications");
+
+    await user.click(screen.getByLabelText("1 unread notifications"));
+    const panel = await screen.findByText("Notifications");
+    await user.click(within(panel.closest("[data-slot=popover-content]")!).getByTitle("Mark all read"));
+
+    expect(screen.getByLabelText("Notifications")).toBeInTheDocument();
+  });
+
+  it("dismissing a notification removes it from the list", async () => {
+    const user = userEvent.setup();
+    renderBell();
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(mention());
+    });
+    await user.click(await screen.findByLabelText("1 unread notifications"));
+    expect(await screen.findByText("sprint")).toBeInTheDocument();
+
+    await user.click(screen.getByTitle("Dismiss"));
+    expect(screen.queryByText("hey @bob take a look")).not.toBeInTheDocument();
+  });
+});

--- a/mycelium-frontend/src/components/notification-bell.tsx
+++ b/mycelium-frontend/src/components/notification-bell.tsx
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Bell, BellOff, Check, Settings, VolumeX, X } from "lucide-react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { EmptyState } from "@/components/empty-state";
+import { useNotifications } from "@/components/notifications-provider";
+import { NotificationSettingsDialog } from "@/components/notification-settings";
+import type { NotificationKind } from "@/lib/notifications";
+
+const KIND_LABEL: Record<NotificationKind, string> = {
+  mention: "Mention",
+  direct: "Direct",
+  consensus: "Consensus",
+  knowledge: "Knowledge",
+  join: "Join",
+};
+
+const KIND_TONE: Record<NotificationKind, string> = {
+  mention: "var(--accent)",
+  direct: "var(--accent)",
+  consensus: "var(--green)",
+  knowledge: "var(--yellow)",
+  join: "var(--muted-foreground)",
+};
+
+function timeAgo(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const seconds = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (seconds < 60) return "now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+export function NotificationBell() {
+  const { notifications, unreadCount, settings, markRead, markAllRead, dismiss, clearAll, muteRoom } =
+    useNotifications();
+  const [open, setOpen] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+
+  const items = [...notifications].reverse();
+
+  return (
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          className="relative flex size-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+          aria-label={unreadCount > 0 ? `${unreadCount} unread notifications` : "Notifications"}
+        >
+          <Bell className="size-4" />
+          {unreadCount > 0 && (
+            <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold tabular text-accent-fg">
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </span>
+          )}
+          {settings.dnd && (
+            <span
+              className="absolute -bottom-0.5 -right-0.5 flex size-3 items-center justify-center rounded-full bg-surface text-muted-foreground"
+              title="Do not disturb is on"
+            >
+              <VolumeX className="size-2.5" />
+            </span>
+          )}
+        </PopoverTrigger>
+        <PopoverContent className="flex max-h-[28rem] w-80 flex-col p-0">
+          <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
+            <span className="text-label font-semibold text-text">Notifications</span>
+            <span className="text-micro tabular text-faint">{notifications.length}</span>
+            <div className="ml-auto flex items-center gap-1">
+              {notifications.length > 0 && (
+                <button
+                  onClick={markAllRead}
+                  title="Mark all read"
+                  className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+                >
+                  <Check className="size-3.5" />
+                </button>
+              )}
+              <button
+                onClick={() => setShowSettings(true)}
+                title="Notification settings"
+                className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+              >
+                <Settings className="size-3.5" />
+              </button>
+            </div>
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {items.length === 0 ? (
+              <EmptyState
+                size="sm"
+                icon={Bell}
+                title="No notifications"
+                description="Mentions, direct messages, and consensus show up here."
+                className="py-8"
+              />
+            ) : (
+              items.map((n) => (
+                <div
+                  key={n.id}
+                  className={`group flex items-start gap-2 border-b border-border px-3 py-2.5 last:border-b-0 ${
+                    n.read ? "" : "bg-accent-soft/40"
+                  }`}
+                >
+                  <span
+                    className="mt-1.5 size-1.5 flex-shrink-0 rounded-full"
+                    style={{ background: n.read ? "transparent" : "var(--accent)" }}
+                    aria-hidden
+                  />
+                  <Link
+                    href={`/room/${encodeURIComponent(n.room)}`}
+                    onClick={() => {
+                      markRead(n.id);
+                      setOpen(false);
+                    }}
+                    className="min-w-0 flex-1"
+                  >
+                    <div className="flex items-center gap-1.5">
+                      <span
+                        className="text-micro font-semibold uppercase tracking-wide"
+                        style={{ color: KIND_TONE[n.kind] }}
+                      >
+                        {KIND_LABEL[n.kind]}
+                      </span>
+                      <span className="truncate text-micro text-muted-foreground">{n.room}</span>
+                      <span className="ml-auto flex-shrink-0 text-micro tabular text-faint">{timeAgo(n.time)}</span>
+                    </div>
+                    <p className="mt-0.5 truncate text-label text-text">{n.summary || n.sender}</p>
+                  </Link>
+                  <div className="flex flex-shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        muteRoom(n.room);
+                      }}
+                      title={`Mute ${n.room}`}
+                      className="mt-0.5 flex size-5 items-center justify-center rounded text-faint hover:bg-hairline hover:text-text"
+                    >
+                      <BellOff className="size-3" />
+                    </button>
+                    <button
+                      onClick={(e) => {
+                        e.preventDefault();
+                        dismiss(n.id);
+                      }}
+                      title="Dismiss"
+                      className="mt-0.5 flex size-5 items-center justify-center rounded text-faint hover:bg-hairline hover:text-text"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+          {notifications.length > 0 && (
+            <div className="border-t border-border px-3 py-1.5">
+              <button onClick={clearAll} className="text-micro text-muted-foreground hover:text-text">
+                Clear all
+              </button>
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
+      <NotificationSettingsDialog open={showSettings} onClose={() => setShowSettings(false)} />
+    </>
+  );
+}

--- a/mycelium-frontend/src/components/notification-settings.tsx
+++ b/mycelium-frontend/src/components/notification-settings.tsx
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { X } from "lucide-react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useNotifications } from "@/components/notifications-provider";
+import type { NotificationScope } from "@/lib/notifications";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SCOPES: { id: NotificationScope; label: string; description: string }[] = [
+  { id: "needs-me", label: "Needs me", description: "Mentions, direct messages, consensus, and knowledge writes." },
+  { id: "everything", label: "Everything", description: "Also includes ambient activity, like agents joining a room." },
+];
+
+export function NotificationSettingsDialog({ open, onClose }: Props) {
+  const { settings, setSettings, desktopPermission, requestDesktopPermission, unmuteRoom } = useNotifications();
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Notification settings</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-5 py-1">
+          <section>
+            <div className="mb-2 text-micro font-semibold uppercase tracking-wide text-muted-foreground">Scope</div>
+            <div className="flex flex-col gap-1.5">
+              {SCOPES.map((s) => (
+                <label
+                  key={s.id}
+                  className="flex cursor-pointer items-start gap-2.5 rounded-lg border border-border p-2.5 has-[:checked]:border-accent has-[:checked]:bg-accent-soft/30"
+                >
+                  <input
+                    type="radio"
+                    name="notification-scope"
+                    className="sr-only"
+                    checked={settings.scope === s.id}
+                    onChange={() => setSettings({ ...settings, scope: s.id })}
+                  />
+                  <span
+                    className="mt-0.5 flex size-3.5 flex-shrink-0 items-center justify-center rounded-full border"
+                    style={{
+                      borderColor: settings.scope === s.id ? "var(--accent)" : "var(--border2)",
+                      background: settings.scope === s.id ? "var(--accent)" : "transparent",
+                    }}
+                    aria-hidden
+                  />
+                  <span className="min-w-0">
+                    <div className="text-label font-medium text-text">{s.label}</div>
+                    <div className="text-micro text-muted-foreground">{s.description}</div>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-3">
+            <div className="text-micro font-semibold uppercase tracking-wide text-muted-foreground">Delivery</div>
+
+            <label className="flex items-center gap-2.5">
+              <Checkbox
+                checked={settings.dnd}
+                onCheckedChange={(v) => setSettings({ ...settings, dnd: v === true })}
+              />
+              <span className="text-label text-text">Do not disturb (mute everything)</span>
+            </label>
+
+            <label className="flex items-center gap-2.5">
+              <Checkbox
+                checked={settings.soundEnabled}
+                onCheckedChange={(v) => setSettings({ ...settings, soundEnabled: v === true })}
+              />
+              <span className="text-label text-text">Audio ping when the tab is hidden</span>
+            </label>
+            {settings.soundEnabled && (
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={settings.soundVolume}
+                onChange={(e) => setSettings({ ...settings, soundVolume: Number(e.target.value) })}
+                className="ml-6 w-[calc(100%-1.5rem)] accent-accent"
+                aria-label="Sound volume"
+              />
+            )}
+
+            <label className="flex items-center gap-2.5">
+              <Checkbox
+                checked={settings.desktopEnabled}
+                onCheckedChange={(v) => {
+                  const enabled = v === true;
+                  setSettings({ ...settings, desktopEnabled: enabled });
+                  if (enabled && desktopPermission === "default") requestDesktopPermission();
+                }}
+              />
+              <span className="text-label text-text">Desktop notifications</span>
+            </label>
+            {settings.desktopEnabled && desktopPermission === "denied" && (
+              <p className="ml-6 text-micro text-yellow">
+                Blocked by the browser — allow notifications for this site to enable.
+              </p>
+            )}
+            {settings.desktopEnabled && desktopPermission === "unsupported" && (
+              <p className="ml-6 text-micro text-muted-foreground">Not supported in this browser.</p>
+            )}
+          </section>
+
+          {settings.mutedRooms.length > 0 && (
+            <section>
+              <div className="mb-2 text-micro font-semibold uppercase tracking-wide text-muted-foreground">
+                Muted rooms
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {settings.mutedRooms.map((room) => (
+                  <span
+                    key={room}
+                    className="flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-micro text-muted-foreground"
+                  >
+                    {room}
+                    <button
+                      onClick={() => unmuteRoom(room)}
+                      aria-label={`Unmute ${room}`}
+                      className="text-faint hover:text-text"
+                    >
+                      <X className="size-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            </section>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mycelium-frontend/src/components/notifications-provider.tsx
+++ b/mycelium-frontend/src/components/notifications-provider.tsx
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { getNotificationsSSEUrl } from "@/lib/api";
+import { useCurrentUser } from "@/components/current-user";
+import { ping, primeAudio } from "@/lib/audio-ping";
+import {
+  classify,
+  DEFAULT_SETTINGS,
+  electLeader,
+  isAdmitted,
+  loadNotifications,
+  loadSettings,
+  openCrossTabChannel,
+  saveNotifications,
+  saveSettings,
+  type NotificationSettings,
+  type StoredNotification,
+} from "@/lib/notifications";
+
+interface NotificationsContextValue {
+  notifications: StoredNotification[];
+  unreadCount: number;
+  connected: boolean;
+  settings: NotificationSettings;
+  setSettings: (settings: NotificationSettings) => void;
+  markRead: (id: string) => void;
+  markAllRead: () => void;
+  dismiss: (id: string) => void;
+  clearAll: () => void;
+  muteRoom: (room: string) => void;
+  unmuteRoom: (room: string) => void;
+  desktopPermission: NotificationPermission | "unsupported";
+  requestDesktopPermission: () => void;
+}
+
+const NotificationsContext = createContext<NotificationsContextValue | null>(null);
+
+const BASE_TITLE = "mycelium";
+
+export function NotificationsProvider({ children }: { children: ReactNode }) {
+  const { principal } = useCurrentUser();
+  const [notifications, setNotifications] = useState<StoredNotification[]>([]);
+  const [settings, setSettingsState] = useState<NotificationSettings>(DEFAULT_SETTINGS);
+  const [connected, setConnected] = useState(false);
+  const [desktopPermission, setDesktopPermission] = useState<NotificationPermission | "unsupported">(
+    "unsupported",
+  );
+
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+  const principalRef = useRef(principal);
+  principalRef.current = principal;
+  const seenIds = useRef<Set<string>>(new Set());
+  const isLeader = useRef(false);
+  const channelRef = useRef<ReturnType<typeof openCrossTabChannel> | null>(null);
+
+  // Hydrate from localStorage once the DOM is available (SSR has none).
+  useEffect(() => {
+    const stored = loadNotifications();
+    setNotifications(stored);
+    seenIds.current = new Set(stored.map((n) => n.id));
+    setSettingsState(loadSettings());
+    if (typeof window !== "undefined" && "Notification" in window) {
+      setDesktopPermission(window.Notification.permission);
+    }
+  }, []);
+
+  // Unlock the audio chime on the first user gesture (autoplay policies block
+  // sound before one).
+  useEffect(() => {
+    const unlock = () => primeAudio();
+    window.addEventListener("pointerdown", unlock, { once: true });
+    window.addEventListener("keydown", unlock, { once: true });
+    return () => {
+      window.removeEventListener("pointerdown", unlock);
+      window.removeEventListener("keydown", unlock);
+    };
+  }, []);
+
+  // Exactly one open tab is "leader" — the only one that plays the audio ping
+  // or raises a desktop Notification for a new item. Every tab still keeps its
+  // own full notification list (each holds its own SSE connection).
+  useEffect(() => {
+    electLeader((leader) => {
+      isLeader.current = leader;
+    });
+  }, []);
+
+  // Cross-tab sync: read/dismiss/clear/settings apply everywhere immediately.
+  useEffect(() => {
+    const channel = openCrossTabChannel((msg) => {
+      switch (msg.type) {
+        case "read":
+          setNotifications((prev) => prev.map((n) => (n.id === msg.id ? { ...n, read: true } : n)));
+          break;
+        case "read-all":
+          setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+          break;
+        case "dismiss":
+          setNotifications((prev) => prev.filter((n) => n.id !== msg.id));
+          break;
+        case "clear":
+          setNotifications([]);
+          break;
+        case "settings":
+          setSettingsState(msg.settings);
+          break;
+      }
+    });
+    channelRef.current = channel;
+    return () => channel.close();
+  }, []);
+
+  // Persist to localStorage whenever the list changes.
+  useEffect(() => {
+    saveNotifications(notifications);
+  }, [notifications]);
+
+  // Tab-title unread badge.
+  useEffect(() => {
+    const unread = notifications.filter((n) => !n.read).length;
+    document.title = unread > 0 ? `(${unread}) ${BASE_TITLE}` : BASE_TITLE;
+  }, [notifications]);
+
+  // The single global SSE subscription — one connection for every room the
+  // user participates in, independent of which (if any) is open.
+  useEffect(() => {
+    const url = getNotificationsSSEUrl();
+    let es: EventSource;
+    let retryTimeout: ReturnType<typeof setTimeout>;
+
+    function connect() {
+      es = new EventSource(url);
+      es.onopen = () => setConnected(true);
+      es.onmessage = (e) => {
+        try {
+          const raw = JSON.parse(e.data);
+          const n = classify(raw, principalRef.current);
+          if (!n) return;
+          if (seenIds.current.has(n.id)) return;
+          seenIds.current.add(n.id);
+          if (!isAdmitted(n, settingsRef.current)) return;
+          setNotifications((prev) => [...prev, { ...n, read: false }]);
+          if (isLeader.current && document.visibilityState !== "visible") {
+            if (settingsRef.current.soundEnabled) ping(settingsRef.current.soundVolume);
+            if (settingsRef.current.desktopEnabled && "Notification" in window && window.Notification.permission === "granted") {
+              try {
+                new window.Notification(`${n.room} · ${n.kind}`, { body: n.summary || n.sender });
+              } catch {
+                // Best-effort — a blocked/unsupported Notification() must never break the feed.
+              }
+            }
+          }
+        } catch {
+          // A malformed frame is dropped, not fatal to the connection.
+        }
+      };
+      es.onerror = () => {
+        setConnected(false);
+        es.close();
+        retryTimeout = setTimeout(connect, 5000);
+      };
+    }
+
+    connect();
+    return () => {
+      es?.close();
+      clearTimeout(retryTimeout);
+    };
+  }, []);
+
+  const setSettings = useCallback((next: NotificationSettings) => {
+    setSettingsState(next);
+    saveSettings(next);
+    channelRef.current?.post({ type: "settings", settings: next });
+  }, []);
+
+  const markRead = useCallback((id: string) => {
+    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+    channelRef.current?.post({ type: "read", id });
+  }, []);
+
+  const markAllRead = useCallback(() => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    channelRef.current?.post({ type: "read-all" });
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+    channelRef.current?.post({ type: "dismiss", id });
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setNotifications([]);
+    channelRef.current?.post({ type: "clear" });
+  }, []);
+
+  const muteRoom = useCallback(
+    (room: string) => {
+      if (settingsRef.current.mutedRooms.includes(room)) return;
+      setSettings({ ...settingsRef.current, mutedRooms: [...settingsRef.current.mutedRooms, room] });
+    },
+    [setSettings],
+  );
+
+  const unmuteRoom = useCallback(
+    (room: string) => {
+      setSettings({ ...settingsRef.current, mutedRooms: settingsRef.current.mutedRooms.filter((r) => r !== room) });
+    },
+    [setSettings],
+  );
+
+  const requestDesktopPermission = useCallback(() => {
+    if (typeof window === "undefined" || !("Notification" in window)) return;
+    window.Notification.requestPermission().then((perm) => setDesktopPermission(perm));
+  }, []);
+
+  const unreadCount = useMemo(() => notifications.filter((n) => !n.read).length, [notifications]);
+
+  const value = useMemo<NotificationsContextValue>(
+    () => ({
+      notifications,
+      unreadCount,
+      connected,
+      settings,
+      setSettings,
+      markRead,
+      markAllRead,
+      dismiss,
+      clearAll,
+      muteRoom,
+      unmuteRoom,
+      desktopPermission,
+      requestDesktopPermission,
+    }),
+    [
+      notifications,
+      unreadCount,
+      connected,
+      settings,
+      setSettings,
+      markRead,
+      markAllRead,
+      dismiss,
+      clearAll,
+      muteRoom,
+      unmuteRoom,
+      desktopPermission,
+      requestDesktopPermission,
+    ],
+  );
+
+  return <NotificationsContext.Provider value={value}>{children}</NotificationsContext.Provider>;
+}
+
+export function useNotifications(): NotificationsContextValue {
+  const ctx = useContext(NotificationsContext);
+  if (!ctx) throw new Error("useNotifications must be used within a NotificationsProvider");
+  return ctx;
+}

--- a/mycelium-frontend/src/components/notifications-provider.tsx
+++ b/mycelium-frontend/src/components/notifications-provider.tsx
@@ -154,7 +154,12 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
           seenIds.current.add(n.id);
           if (!isAdmitted(n, settingsRef.current)) return;
           setNotifications((prev) => [...prev, { ...n, read: false }]);
-          if (isLeader.current && document.visibilityState !== "visible") {
+          // Notify when this tab isn't the one you're looking at. `hasFocus()`
+          // (not visibilityState) is the right signal: it's false when you've
+          // switched to another tab, minimized, OR alt-tabbed to another app —
+          // whereas visibilityState stays "visible" for a window that's merely
+          // behind another app, so those pings would be silently dropped.
+          if (isLeader.current && !document.hasFocus()) {
             if (settingsRef.current.soundEnabled) ping(settingsRef.current.soundVolume);
             if (settingsRef.current.desktopEnabled && "Notification" in window && window.Notification.permission === "granted") {
               try {

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -10,6 +10,7 @@ import { BarChart3, Boxes, Plus, Search, SearchX } from "lucide-react";
 import { fetchRooms, getAppEventsSSEUrl, logFetchError } from "@/lib/api";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { NotificationBell } from "@/components/notification-bell";
 import { EmptyState } from "@/components/empty-state";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
@@ -162,7 +163,8 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
           <BarChart3 className="size-4" />
           Metrics
         </Link>
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-0.5">
+          <NotificationBell />
           <ThemeToggle />
         </div>
       </div>

--- a/mycelium-frontend/src/components/ui/popover.tsx
+++ b/mycelium-frontend/src/components/ui/popover.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverPortal({ ...props }: PopoverPrimitive.Portal.Props) {
+  return <PopoverPrimitive.Portal data-slot="popover-portal" {...props} />
+}
+
+function PopoverContent({
+  className,
+  sideOffset = 8,
+  align = "end",
+  ...props
+}: PopoverPrimitive.Popup.Props & Pick<PopoverPrimitive.Positioner.Props, "sideOffset" | "align">) {
+  return (
+    <PopoverPortal>
+      <PopoverPrimitive.Positioner sideOffset={sideOffset} align={align}>
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 w-80 origin-[var(--transform-origin)] rounded-xl border border-border bg-popover text-popover-foreground shadow-lg outline-none duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPortal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverPortal, PopoverContent }

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -169,6 +169,13 @@ export function getAppEventsSSEUrl() {
   return `/api/events/stream`;
 }
 
+/** SSE endpoint aggregating every room's activity into one stream — the
+ *  notification center's feed, so it doesn't have to open one connection per
+ *  room the user participates in. */
+export function getNotificationsSSEUrl() {
+  return `/api/notifications/stream`;
+}
+
 export async function sendRoomMessage(
   roomName: string,
   data: { sender_handle: string; content: string; message_type?: string },

--- a/mycelium-frontend/src/lib/audio-ping.ts
+++ b/mycelium-frontend/src/lib/audio-ping.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// Dependency-free notification chime: two short synthesized tones via the Web
+// Audio API. No asset to ship, no license to track. Browsers block audio
+// until a user gesture unlocks the page's AudioContext, so `primeAudio()`
+// should be wired to the first click/keydown the app sees; `ping()` before
+// that is a silent no-op (caught, never throws into a render path).
+
+let ctx: AudioContext | null = null;
+
+function getContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) return null;
+  if (!ctx) ctx = new Ctor();
+  return ctx;
+}
+
+/** Unlock audio playback on the first user gesture (click/keydown/touch). */
+export function primeAudio(): void {
+  const c = getContext();
+  if (c && c.state === "suspended") void c.resume();
+}
+
+function tone(c: AudioContext, freq: number, start: number, duration: number, volume: number): void {
+  const osc = c.createOscillator();
+  const gain = c.createGain();
+  osc.type = "sine";
+  osc.frequency.value = freq;
+  gain.gain.setValueAtTime(0, start);
+  gain.gain.linearRampToValueAtTime(volume, start + 0.01);
+  gain.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+  osc.connect(gain);
+  gain.connect(c.destination);
+  osc.start(start);
+  osc.stop(start + duration);
+}
+
+/** Play a short two-note chime. ``volume`` is 0–1; a no-op below ~0. */
+export function ping(volume = 0.5): void {
+  if (volume <= 0) return;
+  try {
+    const c = getContext();
+    if (!c) return;
+    if (c.state === "suspended") void c.resume();
+    const now = c.currentTime;
+    tone(c, 880, now, 0.12, volume);
+    tone(c, 1318.5, now + 0.09, 0.16, volume * 0.8);
+  } catch {
+    // Best-effort: a notification sound is never worth failing the caller over.
+  }
+}

--- a/mycelium-frontend/src/lib/notifications.test.ts
+++ b/mycelium-frontend/src/lib/notifications.test.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import { classify, DEFAULT_SETTINGS, isAdmitted } from "@/lib/notifications";
+
+const CREATED = "2026-08-15T10:00:00.000000+00:00";
+
+function l9Exchange(text: string, opts: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "msg-1",
+    room_name: "sprint",
+    sender_handle: "alice",
+    message_type: "l9_exchange",
+    created_at: CREATED,
+    content: JSON.stringify({ content: text }),
+    ...opts,
+  };
+}
+
+describe("classify", () => {
+  it("recognizes an @-mention addressed to the acting principal", () => {
+    const n = classify(l9Exchange("hey @bob can you take a look?"), "bob");
+    expect(n).toMatchObject({ room: "sprint", kind: "mention", needsMe: true });
+  });
+
+  it("ignores a mention of someone else", () => {
+    const n = classify(l9Exchange("hey @carol can you take a look?"), "bob");
+    expect(n).toBeNull();
+  });
+
+  it("recognizes a direct message by recipient handle, case-insensitively", () => {
+    const n = classify(l9Exchange("here's the plan", { recipient_handle: "Bob" }), "bob");
+    expect(n).toMatchObject({ kind: "direct", needsMe: true });
+  });
+
+  it("classifies a converged l9_commit as a needs-me consensus notification", () => {
+    const raw = {
+      room_name: "sprint",
+      sender_handle: "aligner",
+      message_type: "l9_commit",
+      created_at: CREATED,
+      content: JSON.stringify({
+        content: "consensus reached",
+        l9: { header: { subkind: "converged" } },
+      }),
+    };
+    const n = classify(raw, "bob");
+    expect(n).toMatchObject({ kind: "consensus", needsMe: true, summary: "consensus reached" });
+  });
+
+  it("classifies l9_knowledge as a needs-me knowledge notification", () => {
+    const raw = {
+      room_name: "sprint",
+      sender_handle: "system",
+      message_type: "l9_knowledge",
+      created_at: CREATED,
+      content: JSON.stringify({ content: "plan updated → plan/tasks.md" }),
+    };
+    const n = classify(raw, "bob");
+    expect(n).toMatchObject({ kind: "knowledge", needsMe: true });
+  });
+
+  it("classifies a coordination_join as ambient (not needs-me)", () => {
+    const raw = {
+      room_name: "sprint",
+      sender_handle: "system",
+      message_type: "coordination_join",
+      created_at: CREATED,
+      content: JSON.stringify({ handle: "carol" }),
+    };
+    const n = classify(raw, "bob");
+    expect(n).toMatchObject({ kind: "join", needsMe: false, summary: "carol joined" });
+  });
+
+  it("returns null for a frame with no room_name (global app events)", () => {
+    const n = classify({ type: "room_created", room_name: undefined }, "bob");
+    expect(n).toBeNull();
+  });
+
+  it("returns null for an unrecognized message_type", () => {
+    const n = classify(
+      { room_name: "sprint", message_type: "memory_changed", content: "{}" },
+      "bob",
+    );
+    expect(n).toBeNull();
+  });
+});
+
+describe("isAdmitted", () => {
+  const mention = classify(l9Exchange("hey @bob"), "bob")!;
+  const join = classify(
+    {
+      room_name: "sprint",
+      sender_handle: "system",
+      message_type: "coordination_join",
+      created_at: CREATED,
+      content: JSON.stringify({ handle: "carol" }),
+    },
+    "bob",
+  )!;
+
+  it("admits a needs-me item under the default (needs-me) scope", () => {
+    expect(isAdmitted(mention, DEFAULT_SETTINGS)).toBe(true);
+  });
+
+  it("rejects an ambient item under needs-me scope", () => {
+    expect(isAdmitted(join, DEFAULT_SETTINGS)).toBe(false);
+  });
+
+  it("admits an ambient item under everything scope", () => {
+    expect(isAdmitted(join, { ...DEFAULT_SETTINGS, scope: "everything" })).toBe(true);
+  });
+
+  it("rejects everything under global do-not-disturb", () => {
+    expect(isAdmitted(mention, { ...DEFAULT_SETTINGS, dnd: true })).toBe(false);
+  });
+
+  it("rejects a notification from a muted room", () => {
+    expect(isAdmitted(mention, { ...DEFAULT_SETTINGS, mutedRooms: ["sprint"] })).toBe(false);
+  });
+});

--- a/mycelium-frontend/src/lib/notifications.ts
+++ b/mycelium-frontend/src/lib/notifications.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// The notification center's data model: classifying a raw wire frame from
+// `/api/notifications/stream` into something worth showing, and the
+// localStorage-backed store (+ cross-tab sync) that backs the bell's inbox.
+// Framework-agnostic on purpose — `notifications-provider.tsx` is the only
+// React-aware consumer, so this stays unit-testable without rendering.
+
+export type NotificationKind = "mention" | "direct" | "consensus" | "knowledge" | "join";
+
+export interface ClassifiedNotification {
+  id: string;
+  room: string;
+  kind: NotificationKind;
+  summary: string;
+  sender: string;
+  time: string;
+  /** True for the kinds "Needs me" scope includes (mention/direct/consensus/
+   *  knowledge); false for ambient activity ("everything" scope only, e.g. a
+   *  plain join). */
+  needsMe: boolean;
+}
+
+export interface StoredNotification extends ClassifiedNotification {
+  read: boolean;
+}
+
+export type NotificationScope = "needs-me" | "everything";
+
+export interface NotificationSettings {
+  scope: NotificationScope;
+  soundEnabled: boolean;
+  soundVolume: number;
+  desktopEnabled: boolean;
+  dnd: boolean;
+  mutedRooms: string[];
+}
+
+export const DEFAULT_SETTINGS: NotificationSettings = {
+  scope: "needs-me",
+  soundEnabled: true,
+  soundVolume: 0.5,
+  desktopEnabled: false,
+  dnd: false,
+  mutedRooms: [],
+};
+
+const MENTION_RE = /@([\w-]+)/g;
+
+function mentionsHandle(text: string, handle: string): boolean {
+  if (!handle) return false;
+  MENTION_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = MENTION_RE.exec(text))) {
+    if (m[1].toLowerCase() === handle) return true;
+  }
+  return false;
+}
+
+/**
+ * Classify one raw frame off `/api/notifications/stream` (the same wire shape
+ * as a room's SSE stream, tagged with `room_name`), or return null when it
+ * isn't notification-worthy — a room lifecycle frame, a keepalive, or a
+ * message type this system doesn't surface (e.g. `plan_updated`, which
+ * narrates the same knowledge push already carried by `l9_knowledge`).
+ */
+export function classify(raw: Record<string, unknown>, principal: string): ClassifiedNotification | null {
+  const mtype = (raw.message_type as string) || "";
+  const room = raw.room_name as string | undefined;
+  if (!room) return null;
+
+  const sender = (raw.sender_handle as string) || "system";
+  const recipient = (raw.recipient_handle as string) || null;
+  const time = (raw.created_at as string) || new Date().toISOString();
+  const id = (raw.id as string) || `${room}:${mtype}:${time}:${sender}`;
+  const handle = principal.trim().replace(/^@/, "").toLowerCase();
+
+  let content: Record<string, unknown> = {};
+  try {
+    if (typeof raw.content === "string") content = JSON.parse(raw.content);
+    else if (raw.content && typeof raw.content === "object") content = raw.content as Record<string, unknown>;
+  } catch {
+    content = {};
+  }
+
+  switch (mtype) {
+    case "l9_exchange": {
+      const text = (content.content as string) || "";
+      const directed = recipient !== null && recipient.toLowerCase() === handle;
+      const mentioned = mentionsHandle(text, handle);
+      if (!directed && !mentioned) return null;
+      return {
+        id,
+        room,
+        sender,
+        time,
+        kind: directed ? "direct" : "mention",
+        summary: text.slice(0, 160),
+        needsMe: true,
+      };
+    }
+    case "l9_commit": {
+      const l9env = (content.l9 as Record<string, unknown> | undefined) ?? {};
+      const header = (l9env.header as Record<string, unknown> | undefined) ?? {};
+      const converged = header.subkind === "converged";
+      const fallback = converged ? "Consensus reached" : "Negotiation ended without agreement";
+      const text = (content.content as string) || fallback;
+      return { id, room, sender, time, kind: "consensus", summary: text.slice(0, 160), needsMe: true };
+    }
+    case "l9_knowledge": {
+      const text = (content.content as string) || "Room memory updated";
+      return { id, room, sender, time, kind: "knowledge", summary: text.slice(0, 160), needsMe: true };
+    }
+    case "coordination_join": {
+      const joinedHandle = (content.handle as string) || sender;
+      return { id, room, sender, time, kind: "join", summary: `${joinedHandle} joined`, needsMe: false };
+    }
+    default:
+      return null;
+  }
+}
+
+/** Does ``settings`` admit this classified notification (scope, per-room
+ *  mute, global do-not-disturb)? Pure predicate — the caller decides what to
+ *  do with an admitted notification (store it, ping, badge it). */
+export function isAdmitted(n: ClassifiedNotification, settings: NotificationSettings): boolean {
+  if (settings.dnd) return false;
+  if (settings.mutedRooms.includes(n.room)) return false;
+  if (settings.scope === "needs-me" && !n.needsMe) return false;
+  return true;
+}
+
+const NOTIFICATIONS_KEY = "mycelium.notifications";
+const SETTINGS_KEY = "mycelium.notification-settings";
+const MAX_STORED = 200;
+
+export function loadNotifications(): StoredNotification[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(NOTIFICATIONS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveNotifications(list: StoredNotification[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    const trimmed = list.slice(-MAX_STORED);
+    window.localStorage.setItem(NOTIFICATIONS_KEY, JSON.stringify(trimmed));
+  } catch {
+    // Storage quota/private-mode failures are non-fatal — in-memory state carries on.
+  }
+}
+
+export function loadSettings(): NotificationSettings {
+  if (typeof window === "undefined") return DEFAULT_SETTINGS;
+  try {
+    const raw = window.localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return DEFAULT_SETTINGS;
+    return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+export function saveSettings(settings: NotificationSettings): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    // Same as above — best-effort persistence only.
+  }
+}
+
+// ── Cross-tab coordination ───────────────────────────────────────────────
+
+// "add" isn't part of this protocol: every open tab holds its own SSE
+// connection to the same backend, so each tab independently classifies and
+// stores a new notification — no need to also forward it over the channel.
+// Cross-tab sync exists for the *state that isn't independently derivable*:
+// read/dismiss/clear acknowledgements and settings changes.
+export type CrossTabMessage =
+  | { type: "read"; id: string }
+  | { type: "read-all" }
+  | { type: "dismiss"; id: string }
+  | { type: "clear" }
+  | { type: "settings"; settings: NotificationSettings };
+
+const CHANNEL_NAME = "mycelium-notifications";
+
+/** Thin BroadcastChannel wrapper — a no-op shim where BroadcastChannel isn't
+ *  available (older Safari, some embedded webviews), so callers don't need
+ *  their own feature-detection branch. */
+export function openCrossTabChannel(onMessage: (msg: CrossTabMessage) => void): {
+  post: (msg: CrossTabMessage) => void;
+  close: () => void;
+} {
+  if (typeof window === "undefined" || typeof window.BroadcastChannel === "undefined") {
+    return { post: () => {}, close: () => {} };
+  }
+  const bc = new BroadcastChannel(CHANNEL_NAME);
+  bc.onmessage = (e) => onMessage(e.data as CrossTabMessage);
+  return {
+    post: (msg) => bc.postMessage(msg),
+    close: () => bc.close(),
+  };
+}
+
+/**
+ * Elect a single "leader" tab so only one tab plays the audio ping / requests
+ * a desktop Notification for a given event, even with several tabs open and
+ * each independently subscribed to the SSE stream. Uses the Web Locks API
+ * (broadly supported: Chrome/Edge/Firefox/Safari 15.4+) — a tab that acquires
+ * the lock holds it until it closes, so leadership fails over automatically.
+ * Where Web Locks is unavailable, every tab is its own leader (degrades to
+ * "every open tab pings," same as no coordination at all).
+ */
+export function electLeader(onLeadership: (isLeader: boolean) => void): void {
+  if (typeof navigator === "undefined" || !("locks" in navigator)) {
+    onLeadership(true);
+    return;
+  }
+  navigator.locks
+    .request("mycelium-notification-leader", () => {
+      onLeadership(true);
+      return new Promise<void>(() => {
+        // Held until the tab unloads (never resolves) — releasing the lock
+        // hands leadership to the next queued tab automatically.
+      });
+    })
+    .catch(() => {
+      // A held-forever lock request rejects if the page unloads mid-wait;
+      // nothing to recover — the tab is going away.
+    });
+}


### PR DESCRIPTION
Replaces the never-merged per-room audio ping (#532) with a real notifications system, scoped per #536: cross-room, cross-tab, dismissible, with an inbox instead of just a chime. **Validated live** against a running SLIM node (via `mycelium l9 send` from #534): cross-room delivery, consensus classification, inbox/badge/title, and the audio ping all confirmed.

## Changes

**Backend**
- New `GET /notifications/stream`: aggregates every room's activity (plus `room_created`/`room_deleted`) into one SSE connection, growing/shrinking its room subscription set live off the same app-channel frames the sidebar consumes. No producer changes — every room-channel payload already carries `room_name`.
- Fixes the classification bug from #536: `parseEvent` only unwrapped `l9_exchange`, so live consensus (`l9_commit`) and knowledge (`l9_knowledge`) fell through to the unhandled-type fallback — **consensus never rendered and never pinged**, despite being the headline "Needs me" case. Both now unwrap; consensus renders as a real system notice and feeds `NegotiationView`.

**Frontend**
- `lib/notifications.ts` — classifies a stream frame into `mention`/`direct`/`consensus`/`knowledge`/`join`, scoped to the acting-as principal; `isAdmitted` for scope ("Needs me" vs "Everything"), per-room mute, DND; localStorage persistence; `BroadcastChannel` cross-tab sync; Web Locks leader election so only one tab plays audio / raises a desktop notification.
- `lib/audio-ping.ts` — dependency-free synthesized two-tone chime + gesture unlock.
- `components/notifications-provider.tsx` — root-mounted provider owning the single global SSE subscription, unread state, and the tab-title badge.
- `notification-bell.tsx` / `notification-settings.tsx` — header bell/inbox (read, dismiss, mute, mark-all-read, clear) + settings (scope, sound + volume, desktop notifications, DND).
- **Ping gate is window-focus, not tab-visibility.** Gating on `document.visibilityState` only fired when you switched tabs / minimized; a window behind another app stayed `"visible"`, so alt-tab-to-another-app silently dropped the ping. Now gates on `!document.hasFocus()` — fires whenever this tab isn't the one you're looking at (other tab, minimized, or other app), matching the intent.

Client-side only for now (no server-side notification ledger), per the issue.

## Testing

- Backend: `pytest` (incl. new `test_notifications_stream.py`), ruff/format/ty.
- Frontend: `vitest` (incl. `notifications.test.ts`, `notification-bell.test.tsx`), tsc, build (confirms `/api/notifications/stream` registers as its own streaming route).
- Live: cross-room consensus fired into a room the user wasn't viewing → inbox + badge + title updated, and the audio ping fired with the tab backgrounded.

## Known follow-ups (non-blocking)
- `electLeader` isn't idempotent, so React Strict Mode double-elects in dev (one held + one pending lock from the same tab). Cosmetic; single lock holder still correct.
- A stale background leader tab that never received a user gesture holds leadership but can't unlock audio → silent. Rare; worth a re-elect-if-can't-play pass later.

## Related
Relates to #536. Supersedes #532 (recommend closing without merging its per-room ping).