### PR TITLE
fix(frontend): robust generic fetch layer for api.ts

### DIFF
--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -5,7 +5,7 @@
 
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { fetchRoom, logFetchError, type EpisodeSummary } from "@/lib/api";
+import { fetchRoom, logFetchError, type EpisodeSummary, type Room } from "@/lib/api";
 import { AppShell } from "@/components/app-shell";
 import { EventStream, type View, type NegotiationPhase } from "@/components/event-stream";
 import { RoomChatBox } from "@/components/room-chat-box";
@@ -14,13 +14,6 @@ import { RoomTour } from "@/components/room-tour";
 import { GlobalStatusItems, StatusButton } from "@/components/status-items";
 import { ActingAsPicker } from "@/components/acting-as-picker";
 import { useRoomStatus } from "@/lib/use-status";
-
-interface Room {
-  name: string;
-  mas_id?: string | null;
-  is_persistent?: boolean;
-  parent_namespace?: string | null;
-}
 
 function episodeSummaryLabel(episodes: EpisodeSummary[] | null): { text: string; color: string } | null {
   if (!episodes || episodes.length === 0) return null;

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -10,7 +10,6 @@ import {
   fetchMessages,
   fetchRoomAgents,
   fetchRoomMembers,
-  logFetchError,
   type AgentSummary,
   type EngineKind,
   type PresenceMember,
@@ -89,33 +88,27 @@ export function AgentsPanel({ roomName, refreshKey = 0 }: Props) {
   const { principal } = useCurrentUser();
 
   const refresh = useCallback(() => {
-    fetchRoomAgents(roomName)
-      .then((a) => {
-        setAgents(a);
-        setLoaded(true);
-      })
-      .catch((err) => {
-        logFetchError("fetchRoomAgents")(err);
-        setLoaded(true);
-      });
+    // fetchRoomAgents degrades to [] on failure, so no .catch is needed —
+    // `loaded` still flips so the skeleton clears either way.
+    fetchRoomAgents(roomName).then((a) => {
+      setAgents(a);
+      setLoaded(true);
+    });
     // Human posters come from the transcript: a room chat post is a broadcast
-    // from a handle that isn't a registered agent.
-    fetchMessages(roomName, 200)
-      .then((data) => {
-        const msgs = Array.isArray(data) ? data : (data?.messages ?? []);
-        setPosters(
-          msgs
-            .filter((m: { message_type?: string }) => m.message_type === "broadcast")
-            .map((m: { sender_handle?: string }) => m.sender_handle ?? "")
-            .filter(Boolean),
-        );
-      })
-      .catch(logFetchError("fetchMessages"));
+    // from a handle that isn't a registered agent. fetchMessages degrades to
+    // { messages: [] } on failure, so no .catch is needed.
+    fetchMessages(roomName, 200).then(({ messages }) => {
+      setPosters(
+        messages
+          .filter((m) => m.message_type === "broadcast")
+          .map((m) => m.sender_handle ?? "")
+          .filter(Boolean),
+      );
+    });
     // Live presence: SLIM-connected + server-held lease members. Catches handles
     // that joined via `mycelium await` without registering an agent manifest.
-    fetchRoomMembers(roomName)
-      .then(setLiveMembers)
-      .catch(logFetchError("fetchRoomMembers"));
+    // fetchRoomMembers degrades to [] on failure, so no .catch is needed.
+    fetchRoomMembers(roomName).then(setLiveMembers);
   }, [roomName]);
 
   useEffect(() => {

--- a/mycelium-frontend/src/components/command-center.tsx
+++ b/mycelium-frontend/src/components/command-center.tsx
@@ -14,8 +14,8 @@ import {
   fetchRooms,
   fetchRoomAgents,
   fetchEpisodes,
-  logFetchError,
   type EpisodeSummary,
+  type Room,
 } from "@/lib/api";
 
 // The seeded sample room the "Run a sample coordination" onboarding routes into.
@@ -32,14 +32,6 @@ function RunSampleLink({ className = "" }: { className?: string }) {
       Run a sample
     </Link>
   );
-}
-
-interface Room {
-  name: string;
-  created_at: string;
-  /** When the room was last active (transcript mtime); falls back to created_at. */
-  last_activity?: string | null;
-  is_persistent: boolean;
 }
 
 function relativeTime(iso: string): string {
@@ -75,11 +67,10 @@ export function CommandCenter() {
   const [loaded, setLoaded] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
 
+  // fetchRooms degrades to [] on failure (fire-and-forget list), so no
+  // .catch is needed — `loaded` still flips so the skeleton clears either way.
   const load = useCallback(
-    () =>
-      fetchRooms()
-        .then((data: Room[]) => { setRooms(data); setLoaded(true); })
-        .catch((e) => { logFetchError("fetchRooms")(e); setLoaded(true); }),
+    () => fetchRooms().then((data) => { setRooms(data); setLoaded(true); }),
     [],
   );
 

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -4,27 +4,12 @@
 "use client";
 
 import { useEffect, useMemo, useState, useCallback } from "react";
-import { Brain, ChevronRight, Folder, FolderOpen, FileText } from "lucide-react";
-import { fetchMemories, searchMemories } from "@/lib/api";
+import { Brain, ChevronRight, Folder, FolderOpen, FileText, AlertCircle } from "lucide-react";
+import { fetchMemories, searchMemories, type Memory, type MemorySearchResult } from "@/lib/api";
 import { DetailDrawer } from "@/components/detail-drawer";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { MemoryDetail } from "@/components/memory-detail";
-
-interface Memory {
-  key: string;
-  value: unknown;
-  content_text?: string;
-  version: number;
-  created_by: string;
-  updated_at: string;
-  file_path?: string;
-}
-
-interface SearchResult {
-  memory: Memory;
-  similarity: number;
-}
 
 interface TreeNode {
   name: string;
@@ -177,18 +162,17 @@ export function MemoryPanel({ roomName, refreshTrigger }: Props) {
   const [memories, setMemories] = useState<Memory[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<SearchResult[] | null>(null);
+  const [searchResults, setSearchResults] = useState<MemorySearchResult[] | null>(null);
   const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Memory | null>(null);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
 
+  // fetchMemories degrades to [] on failure (fire-and-forget list), so no
+  // try/catch is needed here — a failed load just shows the empty state.
   const loadData = useCallback(async () => {
-    try {
-      const mems = await fetchMemories(roomName);
-      setMemories(mems);
-    } catch {} finally {
-      setLoaded(true);
-    }
+    setMemories(await fetchMemories(roomName));
+    setLoaded(true);
   }, [roomName]);
 
   const contributors = useMemo(
@@ -199,11 +183,14 @@ export function MemoryPanel({ roomName, refreshTrigger }: Props) {
   useEffect(() => { loadData(); }, [loadData, refreshTrigger]);
 
   const handleSearch = async () => {
-    if (!searchQuery.trim()) { setSearchResults(null); return; }
+    if (!searchQuery.trim()) { setSearchResults(null); setSearchError(null); return; }
     setSearching(true);
+    setSearchError(null);
     try {
-      const data = await searchMemories(roomName, searchQuery);
-      setSearchResults(data.results || []);
+      setSearchResults(await searchMemories(roomName, searchQuery));
+    } catch (err) {
+      setSearchError(err instanceof Error ? err.message : "Search failed");
+      setSearchResults(null);
     } finally {
       setSearching(false);
     }
@@ -262,6 +249,12 @@ export function MemoryPanel({ roomName, refreshTrigger }: Props) {
               {searching ? "…" : "Search"}
             </button>
           </div>
+          {searchError && (
+            <p role="alert" className="mt-2 flex items-center gap-1.5 text-micro text-red">
+              <AlertCircle className="size-3.5 flex-shrink-0" />
+              {searchError}
+            </p>
+          )}
         </div>
 
         {/* Search results — flat list with similarity scores */}

--- a/mycelium-frontend/src/components/metrics-screen.tsx
+++ b/mycelium-frontend/src/components/metrics-screen.tsx
@@ -686,11 +686,11 @@ export function MetricsScreen() {
   useEffect(() => {
     let cancelled = false;
     const load = async () => {
-      const b = await fetchBackendMetrics();
+      const b = await fetchBackendMetrics<BackendMetrics>();
       if (cancelled) return;
       setBackend(b);
       setBackendUnreachable(b == null);
-      const c = await fetchCollectorMetrics();
+      const c = await fetchCollectorMetrics<CollectorMetrics>();
       if (cancelled) return;
       setCollector(c);
       const h = await fetchHosts();

--- a/mycelium-frontend/src/components/room-plan-header.tsx
+++ b/mycelium-frontend/src/components/room-plan-header.tsx
@@ -12,7 +12,7 @@ import {
   type PlanResponse,
   type PlanFile,
 } from "@/lib/api";
-import { ListChecks } from "lucide-react";
+import { ListChecks, AlertCircle } from "lucide-react";
 import { MarkdownContent } from "./markdown-content";
 import { EmptyState } from "@/components/empty-state";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -39,11 +39,12 @@ export function RoomPlanHeader({ roomName, refreshTrigger }: Props) {
   const [titleDraft, setTitleDraft] = useState("");
   const [open, setOpen] = useState<Open>({ kind: "tasks" });
   const [newTaskText, setNewTaskText] = useState("");
+  const [actionError, setActionError] = useState<string | null>(null);
 
+  // fetchPlan degrades to an empty plan on failure, so no try/catch is
+  // needed here — a failed load just shows the "no tasks yet" empty state.
   const load = useCallback(async () => {
-    try {
-      setPlan(await fetchPlan(roomName));
-    } catch {}
+    setPlan(await fetchPlan(roomName));
   }, [roomName]);
 
   // Reload on mount, on refreshTrigger bumps, and on a slow poll. A
@@ -62,22 +63,39 @@ export function RoomPlanHeader({ roomName, refreshTrigger }: Props) {
   };
 
   const saveTitle = async () => {
-    await setPlanTitle(roomName, titleDraft.trim());
-    setEditingTitle(false);
-    await load();
+    setActionError(null);
+    try {
+      await setPlanTitle(roomName, titleDraft.trim());
+      setEditingTitle(false);
+      await load();
+    } catch (err) {
+      // Keep the editor open so the draft (and the retry) isn't lost.
+      setActionError(err instanceof Error ? err.message : "Failed to save title");
+    }
   };
 
   const onToggleTask = async (taskId: string, done: boolean) => {
-    await togglePlanTask(roomName, taskId, done);
-    await load();
+    setActionError(null);
+    try {
+      await togglePlanTask(roomName, taskId, done);
+      await load();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to update task");
+    }
   };
 
   const onAddTask = async () => {
     const text = newTaskText.trim();
     if (!text) return;
+    setActionError(null);
     setNewTaskText("");
-    await addPlanTask(roomName, text);
-    await load();
+    try {
+      await addPlanTask(roomName, text);
+      await load();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to add task");
+      setNewTaskText(text); // restore the draft so the user doesn't retype it
+    }
   };
 
   const toggleOpen = (next: Open) => {
@@ -161,6 +179,13 @@ export function RoomPlanHeader({ roomName, refreshTrigger }: Props) {
           </Chip>
         ))}
       </div>
+
+      {actionError && (
+        <p role="alert" className="mx-8 mb-3 flex items-center gap-1.5 text-micro text-red">
+          <AlertCircle className="size-3.5 flex-shrink-0" />
+          {actionError}
+        </p>
+      )}
 
       {/* Inline disclosure */}
       {open.kind === "tasks" && (

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -7,18 +7,12 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { BarChart3, Boxes, Plus, Search, SearchX } from "lucide-react";
-import { fetchRooms, getAppEventsSSEUrl, logFetchError } from "@/lib/api";
+import { fetchRooms, getAppEventsSSEUrl, type Room } from "@/lib/api";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { NotificationBell } from "@/components/notification-bell";
 import { EmptyState } from "@/components/empty-state";
 import { ScrollArea } from "@/components/ui/scroll-area";
-
-interface Room {
-  name: string;
-  created_at: string;
-  is_persistent: boolean;
-}
 
 // The sidebar lives inside each page's AppShell, so navigation remounts it. A
 // module-level cache lets a fresh mount paint the last-known rooms immediately
@@ -42,10 +36,9 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   const [query, setQuery] = useState("");
   const [showCreate, setShowCreate] = useState(false);
 
-  const load = () =>
-    fetchRooms().then((data: unknown) => {
-      if (Array.isArray(data)) { roomsCache = data as Room[]; setRooms(roomsCache); }
-    }).catch(logFetchError("fetchRooms"));
+  // fetchRooms degrades to [] on failure (fire-and-forget list), so no
+  // .catch is needed — a failed poll just leaves the last-known rooms in place.
+  const load = () => fetchRooms().then((data) => { roomsCache = data; setRooms(roomsCache); });
 
   useEffect(() => {
     load();

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -19,53 +19,166 @@ export const logFetchError =
     return undefined;
   };
 
-export async function fetchRooms() {
-  const res = await fetch(`/api/rooms`, { cache: "no-store" });
-  return res.json();
+/** Thrown by `apiFetch` (no `fallback`) on a non-2xx response or a payload
+ *  that fails its shape guard. `message` is the backend's FastAPI `detail`
+ *  when present, else a status-line fallback. */
+export class ApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
 }
 
-export async function fetchRoom(name: string) {
-  const res = await fetch(`/api/rooms/${name}`, { cache: "no-store" });
-  return res.json();
+/** Best-effort human-readable message from a FastAPI error body. */
+async function errorDetail(res: Response): Promise<string> {
+  try {
+    const data = await res.json();
+    const d = data?.detail;
+    if (typeof d === "string") return d;
+    if (Array.isArray(d) && d[0]?.msg) return String(d[0].msg);
+  } catch {
+    // fall through to the status line
+  }
+  return `Request failed (${res.status})`;
 }
 
-export async function createRoom(data: { name: string; is_persistent?: boolean }) {
-  const res = await fetch(`/api/rooms`, {
+interface ApiFetchOptions<T> extends RequestInit {
+  /** Returned instead of throwing when the request fails (network error,
+   *  non-2xx, or a shape-guard rejection). Omit to let the caller handle the
+   *  rejected promise — the right choice for user-initiated mutations, where
+   *  the failure needs to reach the UI rather than disappear into a default. */
+  fallback?: T;
+  /** Narrows/validates the parsed JSON. A payload that fails the guard is
+   *  treated the same as a failed request (falls back, or throws). */
+  guard?: (data: unknown) => data is T;
+}
+
+/**
+ * The one fetch path every function below routes through: checks `res.ok`,
+ * parses the backend's `{ detail: ... }` error shape, and optionally
+ * validates the success shape. Callers pick one of two contracts:
+ *   - pass `fallback` for a fire-and-forget read (state setter callers) that
+ *     should degrade to a safe default instead of throwing;
+ *   - omit it for a mutation or a read whose caller needs to see the failure
+ *     (throws `ApiError` with the backend's message).
+ */
+async function apiFetch<T = unknown>(path: string, opts: ApiFetchOptions<T> = {}): Promise<T> {
+  const { fallback, guard, ...init } = opts;
+  const hasFallback = "fallback" in opts;
+
+  let res: Response;
+  try {
+    res = await fetch(path, init);
+  } catch (err) {
+    logFetchError(path)(err);
+    if (hasFallback) return fallback as T;
+    throw err;
+  }
+
+  if (!res.ok) {
+    const message = await errorDetail(res);
+    if (hasFallback) {
+      logFetchError(path)(new Error(message));
+      return fallback as T;
+    }
+    throw new ApiError(message, res.status);
+  }
+
+  let data: unknown = null;
+  try {
+    data = await res.json();
+  } catch (err) {
+    if (hasFallback) {
+      logFetchError(path)(err);
+      return fallback as T;
+    }
+    throw new ApiError(`Invalid JSON response from ${path}`, res.status);
+  }
+
+  if (guard && !guard(data)) {
+    const message = `Unexpected response shape from ${path}`;
+    if (hasFallback) {
+      logFetchError(path)(new Error(message));
+      return fallback as T;
+    }
+    throw new ApiError(message, res.status);
+  }
+
+  return data as T;
+}
+
+const isArray = (d: unknown): d is unknown[] => Array.isArray(d);
+
+// ── Rooms ────────────────────────────────────────────────────────────────────
+
+export interface Room {
+  id?: number;
+  name: string;
+  description?: string | null;
+  is_public?: boolean;
+  created_at: string;
+  /** When the room was last active (transcript mtime); falls back to created_at. */
+  last_activity?: string | null;
+  is_persistent: boolean;
+  mas_id?: string | null;
+  workspace_id?: string | null;
+}
+
+export async function fetchRooms(): Promise<Room[]> {
+  return apiFetch<Room[]>(`/api/rooms`, { cache: "no-store", fallback: [], guard: isArray as (d: unknown) => d is Room[] });
+}
+
+export async function fetchRoom(name: string): Promise<Room> {
+  return apiFetch<Room>(`/api/rooms/${name}`, { cache: "no-store" });
+}
+
+export async function createRoom(data: { name: string; is_persistent?: boolean }): Promise<Room> {
+  return apiFetch<Room>(`/api/rooms`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ ...data, is_public: true }),
   });
-  if (!res.ok) {
-    // Surface the backend's reason (FastAPI returns `{ detail: ... }`) so the
-    // caller can show it instead of failing silently.
-    let detail = `Failed to create room (${res.status})`;
-    try {
-      const body = await res.json();
-      if (body?.detail) {
-        detail = typeof body.detail === "string" ? body.detail : JSON.stringify(body.detail);
-      }
-    } catch {
-      /* non-JSON error body: keep the status-based message */
-    }
-    throw new Error(detail);
-  }
-  return res.json();
 }
 
-export async function fetchMemories(roomName: string, prefix?: string) {
+// ── Memory ───────────────────────────────────────────────────────────────────
+
+export interface Memory {
+  key: string;
+  value: unknown;
+  content_text?: string;
+  version: number;
+  created_by: string;
+  updated_at: string;
+  file_path?: string;
+}
+
+export async function fetchMemories(roomName: string, prefix?: string): Promise<Memory[]> {
   const params = new URLSearchParams({ limit: "50" });
   if (prefix) params.set("prefix", prefix);
-  const res = await fetch(`/api/rooms/${roomName}/memory?${params}`, { cache: "no-store" });
-  return res.json();
+  return apiFetch<Memory[]>(`/api/rooms/${roomName}/memory?${params}`, {
+    cache: "no-store",
+    fallback: [],
+    guard: isArray as (d: unknown) => d is Memory[],
+  });
 }
 
-export async function searchMemories(roomName: string, query: string) {
-  const res = await fetch(`/api/rooms/${roomName}/memory/search`, {
+export interface MemorySearchResult {
+  memory: Memory;
+  similarity: number;
+}
+
+/** Semantic search, triggered by a user action — throws (rather than falling
+ *  back to empty) so the search UI can distinguish "no results" from "the
+ *  request failed" and show the latter instead of silently showing nothing. */
+export async function searchMemories(roomName: string, query: string): Promise<MemorySearchResult[]> {
+  const data = await apiFetch<{ results?: MemorySearchResult[] }>(`/api/rooms/${roomName}/memory/search`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query, limit: 10 }),
   });
-  return res.json();
+  return data.results ?? [];
 }
 
 // ── Plan ─────────────────────────────────────────────────────────────────────
@@ -97,26 +210,26 @@ export interface PlanResponse {
 }
 
 export async function fetchPlan(roomName: string): Promise<PlanResponse> {
-  const res = await fetch(`/api/rooms/${roomName}/plan`, { cache: "no-store" });
-  if (!res.ok) {
-    return { room: roomName, title: null, files: [], tasks: [], open_count: 0, done_count: 0 };
-  }
-  return res.json();
+  return apiFetch<PlanResponse>(`/api/rooms/${roomName}/plan`, {
+    cache: "no-store",
+    fallback: { room: roomName, title: null, files: [], tasks: [], open_count: 0, done_count: 0 },
+  });
 }
 
-export async function setPlanTitle(roomName: string, text: string): Promise<string | null> {
-  const res = await fetch(`/api/rooms/${roomName}/plan/title`, {
+/** Mutations below throw `ApiError` on failure so the plan header can surface
+ *  the reason instead of silently discarding the edit or the checklist toggle. */
+
+export async function setPlanTitle(roomName: string, text: string): Promise<string> {
+  const data = await apiFetch<{ title?: string }>(`/api/rooms/${roomName}/plan/title`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text }),
   });
-  if (!res.ok) return null;
-  const data = await res.json();
-  return data.title ?? null;
+  return data.title ?? "";
 }
 
 export async function togglePlanTask(roomName: string, taskId: string, done: boolean): Promise<PlanTask> {
-  const res = await fetch(
+  return apiFetch<PlanTask>(
     `/api/rooms/${roomName}/plan/tasks/${encodeURIComponent(taskId)}/toggle`,
     {
       method: "POST",
@@ -124,26 +237,51 @@ export async function togglePlanTask(roomName: string, taskId: string, done: boo
       body: JSON.stringify({ done }),
     },
   );
-  return res.json();
 }
 
 export async function addPlanTask(roomName: string, text: string, slug = "tasks"): Promise<PlanTask> {
-  const res = await fetch(`/api/rooms/${roomName}/plan/tasks`, {
+  return apiFetch<PlanTask>(`/api/rooms/${roomName}/plan/tasks`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ text, slug }),
   });
-  return res.json();
 }
 
-export async function fetchMessages(roomName: string, limit?: number) {
+// ── Messages ─────────────────────────────────────────────────────────────────
+
+export interface RoomMessage {
+  id?: string;
+  message_type?: string;
+  type?: string;
+  content?: unknown;
+  sender_handle?: string;
+  updated_by?: string;
+  recipient_handle?: string | null;
+  created_at?: string;
+  key?: string;
+  version?: number;
+  episode?: string | null;
+  [key: string]: unknown;
+}
+
+export interface MessagesResponse {
+  messages: RoomMessage[];
+  total?: number;
+}
+
+const isMessagesResponse = (d: unknown): d is MessagesResponse =>
+  !!d && typeof d === "object" && Array.isArray((d as { messages?: unknown }).messages);
+
+export async function fetchMessages(roomName: string, limit?: number): Promise<MessagesResponse> {
   const url = limit
     ? `/api/rooms/${roomName}/messages?limit=${limit}`
     : `/api/rooms/${roomName}/messages`;
-  const res = await fetch(url, { cache: "no-store" });
-  return res.json();
+  return apiFetch<MessagesResponse>(url, {
+    cache: "no-store",
+    fallback: { messages: [] },
+    guard: isMessagesResponse,
+  });
 }
-
 
 export function getSSEUrl(roomName: string) {
   return `/api/rooms/${roomName}/messages/stream`;
@@ -156,12 +294,11 @@ export async function fetchL9History(
   roomName: string,
   limit = 200,
 ): Promise<Record<string, unknown>[]> {
-  const res = await fetch(`/api/rooms/${roomName}/messages/l9?limit=${limit}`, {
+  return apiFetch<Record<string, unknown>[]>(`/api/rooms/${roomName}/messages/l9?limit=${limit}`, {
     cache: "no-store",
+    fallback: [],
+    guard: isArray as (d: unknown) => d is Record<string, unknown>[],
   });
-  if (!res.ok) return [];
-  const data = await res.json();
-  return Array.isArray(data) ? data : [];
 }
 
 /** SSE endpoint for global app events (room create/delete). */
@@ -179,17 +316,12 @@ export function getNotificationsSSEUrl() {
 export async function sendRoomMessage(
   roomName: string,
   data: { sender_handle: string; content: string; message_type?: string },
-) {
-  const res = await fetch(`/api/rooms/${roomName}/messages`, {
+): Promise<RoomMessage> {
+  return apiFetch<RoomMessage>(`/api/rooms/${roomName}/messages`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ message_type: "broadcast", ...data }),
   });
-  if (!res.ok) {
-    const detail = await res.text().catch(() => "");
-    throw new Error(`send failed (${res.status}): ${detail.slice(0, 200)}`);
-  }
-  return res.json();
 }
 
 /**
@@ -209,23 +341,26 @@ export interface PendingInvite {
 
 /** Open (pending or queued) consent requests for a room. */
 export async function fetchPendingInvites(roomName: string): Promise<PendingInvite[]> {
-  const res = await fetch(`/api/rooms/${roomName}/invites`, { cache: "no-store" });
-  if (!res.ok) return [];
-  const data = await res.json();
-  return (data.invites || []) as PendingInvite[];
+  const data = await apiFetch<{ invites?: PendingInvite[] }>(`/api/rooms/${roomName}/invites`, {
+    cache: "no-store",
+    fallback: {},
+  });
+  return data.invites ?? [];
 }
 
-/** Accept or decline a consent prompt. Only `accept` invites (or queues) the agent. */
+/** Accept or decline a consent prompt. Only `accept` invites (or queues) the
+ *  agent. Fire-and-forget from the UI's perspective (the dialog has already
+ *  closed by the time this resolves), so it degrades to `null` on failure
+ *  rather than surfacing a rejected promise with nowhere to show it. */
 export async function respondToInvite(
   roomName: string,
   inviteId: string,
   decision: "accept" | "decline",
 ): Promise<PendingInvite | null> {
-  const res = await fetch(`/api/rooms/${roomName}/invites/${inviteId}/${decision}`, {
+  return apiFetch<PendingInvite | null>(`/api/rooms/${roomName}/invites/${inviteId}/${decision}`, {
     method: "POST",
+    fallback: null,
   });
-  if (!res.ok) return null;
-  return res.json();
 }
 
 export interface AgentSummary {
@@ -241,9 +376,11 @@ export interface AgentSummary {
 
 /** List addressable agents in a room. Used to drive `@`-mention autocomplete. */
 export async function fetchRoomAgents(roomName: string): Promise<AgentSummary[]> {
-  const res = await fetch(`/api/rooms/${roomName}/agents`, { cache: "no-store" });
-  if (!res.ok) return [];
-  return res.json();
+  return apiFetch<AgentSummary[]>(`/api/rooms/${roomName}/agents`, {
+    cache: "no-store",
+    fallback: [],
+    guard: isArray as (d: unknown) => d is AgentSummary[],
+  });
 }
 
 export type EngineKind = "aligner" | "synthesizer";
@@ -255,25 +392,11 @@ export async function createEngine(
   roomName: string,
   data: { handle: string; kind: EngineKind; description?: string; created_by?: string },
 ): Promise<AgentSummary> {
-  const res = await fetch(`/api/rooms/${roomName}/engines`, {
+  return apiFetch<AgentSummary>(`/api/rooms/${roomName}/engines`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
   });
-  if (!res.ok) {
-    // Surface the backend's reason (FastAPI `{ detail: ... }`) instead of failing silently.
-    let detail = `Failed to register engine (${res.status})`;
-    try {
-      const body = await res.json();
-      if (body?.detail) {
-        detail = typeof body.detail === "string" ? body.detail : JSON.stringify(body.detail);
-      }
-    } catch {
-      /* non-JSON error body: keep the status-based message */
-    }
-    throw new Error(detail);
-  }
-  return res.json();
 }
 
 export type PresenceKind = "slim" | "lease";
@@ -288,10 +411,11 @@ export interface PresenceMember {
 
 /** Live presence set for a room: SLIM-connected + server-held lease members. */
 export async function fetchRoomMembers(roomName: string): Promise<PresenceMember[]> {
-  const res = await fetch(`/api/rooms/${roomName}/sessions/members`, { cache: "no-store" });
-  if (!res.ok) return [];
-  const data = await res.json();
-  return Array.isArray(data?.members) ? data.members : [];
+  const data = await apiFetch<{ members?: PresenceMember[] }>(`/api/rooms/${roomName}/sessions/members`, {
+    cache: "no-store",
+    fallback: {},
+  });
+  return Array.isArray(data.members) ? data.members : [];
 }
 
 // ── Principals (self-asserted user store) ─────────────────────────────────────
@@ -319,62 +443,45 @@ export interface Team {
 
 /** List registered users with their owned-agent roll-up. */
 export async function fetchUsers(): Promise<User[]> {
-  const res = await fetch(`/api/users`, { cache: "no-store" });
-  if (!res.ok) return [];
-  const data = await res.json();
+  const data = await apiFetch<{ users?: User[] }>(`/api/users`, { cache: "no-store", fallback: {} });
   return Array.isArray(data.users) ? data.users : [];
 }
 
 /** Teams rolled up from agent manifests and user memberships. */
 export async function fetchTeams(): Promise<Team[]> {
-  const res = await fetch(`/api/teams`, { cache: "no-store" });
-  if (!res.ok) return [];
-  const data = await res.json();
+  const data = await apiFetch<{ teams?: Team[] }>(`/api/teams`, { cache: "no-store", fallback: {} });
   return Array.isArray(data.teams) ? data.teams : [];
 }
 
-/** Best-effort human-readable message from a FastAPI error body. */
-async function errorDetail(res: Response): Promise<string> {
-  try {
-    const data = await res.json();
-    const d = data?.detail;
-    if (typeof d === "string") return d;
-    if (Array.isArray(d) && d[0]?.msg) return String(d[0].msg);
-  } catch {
-    // fall through to the status line
-  }
-  return `Request failed (${res.status})`;
-}
-
-/** Create or upsert a user in the global store. Throws with a readable message
- *  on failure so callers can surface it instead of swallowing it. */
+/** Create or upsert a user in the global store. Throws `ApiError` with a
+ *  readable message on failure so callers can surface it instead of
+ *  swallowing it. */
 export async function createUser(payload: {
   handle: string;
   display_name?: string;
   teams?: string[];
   notify?: string | null;
 }): Promise<User> {
-  const res = await fetch(`/api/users`, {
+  return apiFetch<User>(`/api/users`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
-  if (!res.ok) throw new Error(await errorDetail(res));
-  return res.json();
 }
 
 // ── Metrics ──────────────────────────────────────────────────────────────────
 
-export async function fetchBackendMetrics() {
-  const res = await fetch(`/api/observability`, { cache: "no-store" });
-  if (!res.ok) return null;
-  return res.json();
+// The backend/collector metrics payloads are large, loosely-structured, and
+// shaped differently by each consumer (the metrics screen wants the full
+// dashboard shape; the status bar wants just a couple of counters), so these
+// stay generic rather than forcing one shared interface — callers supply the
+// slice of the shape they actually read.
+export async function fetchBackendMetrics<T = Record<string, unknown>>(): Promise<T | null> {
+  return apiFetch<T | null>(`/api/observability`, { cache: "no-store", fallback: null });
 }
 
-export async function fetchCollectorMetrics() {
-  const res = await fetch(`/api/observability/collector`, { cache: "no-store" });
-  if (!res.ok) return null;
-  return res.json();
+export async function fetchCollectorMetrics<T = Record<string, unknown>>(): Promise<T | null> {
+  return apiFetch<T | null>(`/api/observability/collector`, { cache: "no-store", fallback: null });
 }
 
 // ── Traces & Logs ────────────────────────────────────────────────────────────
@@ -389,9 +496,7 @@ export interface HostInfo {
 }
 
 export async function fetchHosts(): Promise<{ hosts: HostInfo[] } | null> {
-  const res = await fetch(`/api/observability/hosts`, { cache: "no-store" });
-  if (!res.ok) return null;
-  return res.json();
+  return apiFetch<{ hosts: HostInfo[] } | null>(`/api/observability/hosts`, { cache: "no-store", fallback: null });
 }
 
 // ── L9 protocol / episodes ─────────────────────────────────────────────────────
@@ -448,10 +553,11 @@ export interface EpisodeDetail extends EpisodeSummary {
 
 /** Episode summaries for a room, newest first. */
 export async function fetchEpisodes(roomName: string): Promise<EpisodeSummary[]> {
-  const res = await fetch(`/api/rooms/${roomName}/episodes`, { cache: "no-store" });
-  if (!res.ok) return [];
-  const data = await res.json();
-  return (data.episodes || []) as EpisodeSummary[];
+  const data = await apiFetch<{ episodes?: EpisodeSummary[] }>(`/api/rooms/${roomName}/episodes`, {
+    cache: "no-store",
+    fallback: {},
+  });
+  return data.episodes ?? [];
 }
 
 /** One episode plus its full L9 envelope chain, or null if unknown. */
@@ -459,12 +565,10 @@ export async function fetchEpisode(
   roomName: string,
   shortId: string,
 ): Promise<EpisodeDetail | null> {
-  const res = await fetch(
+  return apiFetch<EpisodeDetail | null>(
     `/api/rooms/${roomName}/episodes/${encodeURIComponent(shortId)}`,
-    { cache: "no-store" },
+    { cache: "no-store", fallback: null },
   );
-  if (!res.ok) return null;
-  return res.json();
 }
 
 // ── SLIM coordination fabric (the `/health` coordination block) ──────────────
@@ -500,8 +604,9 @@ export interface CoordinationStatus {
 /** Read the SLIM coordination telemetry from the backend `/health` endpoint.
  *  Fail-soft: returns null when the backend is unreachable or has no block. */
 export async function fetchCoordination(): Promise<CoordinationStatus | null> {
-  const res = await fetch(`/api/health`, { cache: "no-store" });
-  if (!res.ok) return null;
-  const data = await res.json();
-  return data?.coordination ?? null;
+  const data = await apiFetch<{ coordination?: CoordinationStatus }>(`/api/health`, {
+    cache: "no-store",
+    fallback: {},
+  });
+  return data.coordination ?? null;
 }

--- a/mycelium-frontend/src/lib/use-status.ts
+++ b/mycelium-frontend/src/lib/use-status.ts
@@ -12,6 +12,15 @@ import {
   type EpisodeSummary,
 } from "@/lib/api";
 
+/** The slice of the collector's metrics payload the status bar reads: total
+ *  spend and per-model token totals (to find the primary model). */
+interface CollectorSpendShape {
+  counters?: {
+    cost_usd?: { total?: number };
+    tokens?: { by_model?: Record<string, { total?: number }> };
+  };
+}
+
 export interface RoomStatus {
   agents: number | null;
   episodes: EpisodeSummary[] | null;
@@ -60,7 +69,7 @@ export function useGlobalStatus(): GlobalStatus {
     let cancelled = false;
     const load = async () => {
       try {
-        const col = await fetchCollectorMetrics();
+        const col = await fetchCollectorMetrics<CollectorSpendShape>();
         if (!cancelled && col) {
           const cost = col.counters?.cost_usd;
           setSpend(typeof cost?.total === "number" ? cost.total : null);


### PR DESCRIPTION
## Summary

`api.ts` had ~15 fetch functions with inconsistent error handling: some called `res.json()` raw with no `!res.ok` check (`fetchRooms`, `fetchRoom`, `fetchMessages`, `fetchMemories`, `searchMemories`), letting an error response silently masquerade as data — the root cause of crashes like `filtered.map is not a function` (fixed point-by-point in #511). Others (`togglePlanTask`, `addPlanTask`) had *no* error handling at all: a failed mutation just silently did nothing or corrupted state.

This adds one generic `apiFetch` wrapper every function now routes through, and fixes the concrete component-level gaps where a failure had nowhere to go.

## Changes

- **`apiFetch<T>`** (in `src/lib/api.ts`): checks `res.ok`, parses the backend's `{ detail: ... }` error body into an `ApiError`, and optionally validates the success shape with a guard. Callers pick one of two contracts:
  - `fallback` — for fire-and-forget list reads (rooms, memories, agents, episodes, members, users, teams, plan, coordination, metrics, ...) that should degrade to a safe default instead of throwing.
  - no fallback — for mutations and user-triggered reads (`createRoom`, `sendRoomMessage`, `createEngine`, `createUser`, `togglePlanTask`, `addPlanTask`, `setPlanTitle`, `searchMemories`) that throw an `ApiError` so the caller can surface it.
- Migrated every function in `api.ts` onto `apiFetch`, replacing the per-function snowflakes.
- **`room-plan-header.tsx`**: `saveTitle`/`onToggleTask`/`onAddTask` previously had zero error handling (the underlying calls didn't even check `res.ok`). Now they catch `ApiError` and show an inline error instead of silently discarding the edit; a failed "add task" restores the typed draft instead of losing it.
- **`memory-panel.tsx`**: search now surfaces a failed request as an inline error instead of an unhandled rejection (`searchMemories` now throws on failure rather than being called with no `.catch`).
- Deduped the `Room` type — it had three divergent local copies (`rooms-sidebar.tsx`, `command-center.tsx`, the room page) — into a single export from `api.ts`.
- Minor simplification of a couple of call sites (`agents-panel.tsx`, `rooms-sidebar.tsx`, `command-center.tsx`) now that the functions they call are guaranteed to resolve rather than reject.

## Testing

- [x] `npm run lint` (`tsc --noEmit`) passes
- [x] `npm test` (vitest) passes — 39/39
- [x] `npm run build` (Next.js production build) succeeds
- [x] Manual smoke test against the mock backend (`MYCELIUM_UI_MOCK=1`) via a headless browser: opened a room, edited the plan title, added and toggled plan tasks, ran a memory search — no console/runtime errors beyond a pre-existing mock gap (the `/agents` and `/sessions/members` routes aren't mocked, which now correctly logs and falls back to an empty list instead of crashing).

## Related Issues

Closes #515


---
_Generated by [Claude Code](https://claude.ai/code/session_01CKCVnDAnfUDRsZcsdxRH8T)_