### PR TITLE
Add L9 raise-up whitelist contract and rendering for plan/knowledge events

### DIFF
--- a/contracts/l9-surface.json
+++ b/contracts/l9-surface.json
@@ -1,0 +1,29 @@
+{
+  "_comment": [
+    "Frozen 'raise-up' whitelist — the L9 / coordination message types promoted",
+    "from the L9 inspector into the primary channel/chat surface, alongside real",
+    "chat (broadcast/direct/announce/delegate). Everything else stays confined",
+    "to the detail view (the frontend's L9 inspector tab; the CLI has no",
+    "separate inspector, so its own richer `room watch` branches — ticks,",
+    "session start, raw memory_changed — are a CLI-native superset, not part",
+    "of this shared list).",
+    "",
+    "Both the frontend (mycelium-frontend/src/components/event-stream.tsx) and",
+    "the CLI (mycelium-cli/src/mycelium/commands/room.py) carry their own copy",
+    "of this list rather than importing this file at runtime: the frontend's",
+    "Docker build context is mycelium-frontend/ only (no repo root), and the",
+    "CLI is a thin `uv tool` install that doesn't ship the monorepo tree. A",
+    "drift between the two copies means one surface silently promotes a",
+    "lifecycle event the other omits (or vice versa).",
+    "",
+    "Tests: mycelium-frontend/src/components/event-stream.contract.test.ts,",
+    "mycelium-cli/tests/test_l9_surface_contract.py"
+  ],
+
+  "raise_up_types": [
+    "coordination_join",
+    "coordination_consensus",
+    "plan_updated",
+    "l9_knowledge"
+  ]
+}

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -28,6 +28,24 @@ from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
 from mycelium.exceptions import ConfigNotFoundError, MyceliumError
 
+# The L9 "raise-up" whitelist: message types promoted onto the primary channel
+# surface (here, `room watch`'s live stream) rather than staying inspector-only.
+# Must mirror contracts/l9-surface.json's `raise_up_types` byte-for-byte — the
+# frontend (mycelium-frontend/src/components/event-stream.tsx) carries an
+# independent copy, and tests/test_l9_surface_contract.py asserts both stay in
+# sync with the contract so the two surfaces can't silently drift apart.
+# (`room watch` also renders CLI-native detail — ticks, session start, raw
+# memory_changed — that has no frontend-inspector equivalent to hide behind;
+# that detail is intentionally outside this shared list.)
+L9_RAISE_UP_TYPES = frozenset(
+    {
+        "coordination_join",
+        "coordination_consensus",
+        "plan_updated",
+        "l9_knowledge",
+    }
+)
+
 
 def _typed_client(config: MyceliumConfig):
     """Get a typed OpenAPI client."""
@@ -603,6 +621,29 @@ def _watch_room(config: MyceliumConfig, room_name: str, timeout: int) -> None:
             if quality_line:
                 lines.append(f"[dim]{quality_line}[/]")
             return "\n".join(lines)
+
+        if mtype == "plan_updated":
+            kind = data.get("kind")
+            if kind == "task_toggled":
+                mark = "[green]✓[/]" if data.get("done") else "[dim]○[/]"
+                return f"  {ts()}  [bold]plan[/] {mark} [dim]{data.get('text', 'task')}[/]"
+            if kind == "task_added":
+                return f"  {ts()}  [bold]plan[/] + [dim]{data.get('text', 'task')}[/]"
+            if kind == "title_set":
+                by = data.get("updated_by")
+                suffix = f" [dim]by {by}[/]" if by else ""
+                return (
+                    f"  {ts()}  [bold]plan[/] title set to [dim]{data.get('title', '')}[/]{suffix}"
+                )
+            return f"  {ts()}  [bold]plan[/] updated"
+
+        if mtype == "l9_knowledge":
+            l9_payload = data.get("l9", {}).get("payload", {}).get("data", {})
+            key = l9_payload.get("key", "memory")
+            by = l9_payload.get("updated_by")
+            text = data.get("content") or f"{key} updated"
+            suffix = f" [dim]by {by}[/]" if by else ""
+            return f"  {ts()}  [yellow]knowledge[/] {text}{suffix}"
 
         if mtype == "memory_changed":
             key = data.get("key", "?")

--- a/mycelium-cli/tests/test_l9_surface_contract.py
+++ b/mycelium-cli/tests/test_l9_surface_contract.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Contract drift guard for the shared L9 "raise-up" whitelist (CLI side).
+
+The frontend (mycelium-frontend/src/components/event-stream.tsx) carries its
+own copy of this list so its Docker build (context: mycelium-frontend/ only)
+need not reach outside its own tree. This test freezes the shared whitelist in
+``contracts/l9-surface.json`` at the repo root and asserts the **CLI**
+primitive reproduces it exactly. The frontend suite asserts its own copy
+against the same file
+(``mycelium-frontend/src/components/event-stream.contract.test.ts``). One
+frozen source, two asserters — so neither copy can drift without turning a
+fast unit gate red.
+"""
+
+import json
+from pathlib import Path
+
+from mycelium.commands.room import L9_RAISE_UP_TYPES
+
+_CONTRACT_PATH = Path(__file__).resolve().parent.parent.parent / "contracts" / "l9-surface.json"
+
+
+def _contract() -> dict:
+    return json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+def test_contract_file_present():
+    assert _CONTRACT_PATH.is_file(), f"missing shared contract file at {_CONTRACT_PATH}"
+
+
+def test_raise_up_types_match_contract():
+    """The CLI's raise-up whitelist matches the frozen contract byte-for-byte."""
+    g = _contract()
+    assert frozenset(g["raise_up_types"]) == L9_RAISE_UP_TYPES

--- a/mycelium-frontend/src/components/event-stream.contract.test.ts
+++ b/mycelium-frontend/src/components/event-stream.contract.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// Contract drift guard for the shared L9 "raise-up" whitelist (frontend side).
+//
+// The CLI (mycelium-cli/src/mycelium/commands/room.py) carries its own copy of
+// this list so the thin `uv tool` CLI need not import the frontend, and the
+// frontend carries its own copy so its Docker build (context: mycelium-frontend/
+// only) need not reach outside its own tree. This test freezes the shared
+// whitelist in contracts/l9-surface.json at the repo root and asserts the
+// frontend's copy reproduces it exactly. The CLI suite asserts its own copy
+// against the same file (mycelium-cli/tests/test_l9_surface_contract.py). One
+// frozen source, two asserters — so neither copy can drift without turning a
+// fast unit gate red.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { L9_RAISE_UP_TYPES } from "@/components/event-stream";
+
+const CONTRACT_PATH = path.resolve(__dirname, "../../../contracts/l9-surface.json");
+
+function contract(): { raise_up_types: string[] } {
+  return JSON.parse(readFileSync(CONTRACT_PATH, "utf-8"));
+}
+
+describe("L9 raise-up whitelist contract", () => {
+  it("matches contracts/l9-surface.json byte-for-byte", () => {
+    const g = contract();
+    expect(new Set(L9_RAISE_UP_TYPES)).toEqual(new Set(g.raise_up_types));
+    expect(L9_RAISE_UP_TYPES.length).toBe(g.raise_up_types.length);
+  });
+});

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -40,28 +40,31 @@ interface Event {
 }
 
 const CHAT_TYPES = new Set(["broadcast", "direct", "announce", "delegate"]);
+
+// The L9 "raise-up" whitelist: message types promoted from the L9 inspector
+// into the primary channel/chat surface. This must mirror
+// contracts/l9-surface.json's `raise_up_types` byte-for-byte — the CLI
+// (mycelium-cli/src/mycelium/commands/room.py) carries an independent copy,
+// and event-stream.contract.test.ts asserts both stay in sync with the
+// contract so the two surfaces can't silently drift apart.
+export const L9_RAISE_UP_TYPES = [
+  "coordination_join",
+  "coordination_consensus",
+  "plan_updated",
+  "l9_knowledge",
+];
+
 // Event types that appear in the chat-channel view alongside real chat.
 // Joins + consensus belong here so the room's chat surface narrates the
 // negotiation lifecycle ("alice joined session X", "CONSENSUS in session X
 // → plan/tasks.md", "TIMEOUT in session X, no agreement") instead of
 // burying it all under the EVENTS tab.
-const CHANNEL_VIEW_TYPES = new Set([
-  ...CHAT_TYPES,
-  "coordination_join",
-  "coordination_consensus",
-  "plan_updated",
-  "l9_knowledge",
-]);
+const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES]);
 
 // Lifecycle events that render as slim system notices (not chat rows). Used to
 // decide message grouping: a chat message only groups under the sender above it
 // when no system notice interrupts the run.
-const SYSTEM_TYPES = new Set([
-  "coordination_join",
-  "coordination_consensus",
-  "plan_updated",
-  "l9_knowledge",
-]);
+const SYSTEM_TYPES = new Set(L9_RAISE_UP_TYPES);
 
 /** Loading placeholder shaped like a short run of chat rows (avatar + lines). */
 function ChannelSkeleton() {


### PR DESCRIPTION
## Summary

Introduces a shared "raise-up" whitelist that controls which L9 coordination message types are promoted from the inspector into the primary channel/chat surface (rather than staying detail-only). Implements the whitelist as a frozen contract file (`contracts/l9-surface.json`) with independent copies in both the CLI and frontend, guarded by drift-detection tests. Adds CLI rendering for `plan_updated` and `l9_knowledge` message types to display plan changes and knowledge updates in the live stream.

## Changes

- **Frozen contract file** (`contracts/l9-surface.json`): Single source of truth for the L9 raise-up whitelist (`coordination_join`, `coordination_consensus`, `plan_updated`, `l9_knowledge`), with detailed comments explaining the rationale and test coverage.

- **CLI side** (`mycelium-cli/`):
  - Added `L9_RAISE_UP_TYPES` constant in `room.py` mirroring the contract.
  - Implemented rendering for `plan_updated` events (task toggled/added, title set) with visual indicators (✓ for done, ○ for pending, + for added).
  - Implemented rendering for `l9_knowledge` events showing key and updater attribution.
  - Added `test_l9_surface_contract.py` to assert the CLI's whitelist matches the contract byte-for-byte.

- **Frontend side** (`mycelium-frontend/`):
  - Extracted `L9_RAISE_UP_TYPES` as an exported constant in `event-stream.tsx`.
  - Refactored `CHANNEL_VIEW_TYPES` and `SYSTEM_TYPES` to derive from the shared whitelist, eliminating duplication.
  - Added `event-stream.contract.test.ts` to assert the frontend's whitelist matches the contract byte-for-byte.

## Testing

- Unit tests added for both CLI and frontend to detect drift between their independent copies and the frozen contract.
- Existing rendering logic for other message types remains unchanged; new renderers follow the established pattern.
- No manual testing required; contract tests will fail immediately if either copy diverges from the source.

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Format check passes (`uv run ruff format --check .`)

https://claude.ai/code/session_01QE9BKWWDtZ84hzCSByDRn5