### PR TITLE
Broadcast direct memory writes as knowledge:extraction

### DIFF
--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -40,7 +40,7 @@ from app.schemas import (
     SubscriptionCreate,
     SubscriptionRead,
 )
-from app.services import local_state, search_index
+from app.services import local_state, memory_sync, search_index
 from app.services.embedding import embed_text
 from app.services.filesystem import (
     delete_memory_file,
@@ -115,6 +115,78 @@ def _notify_change(room_name: str, key: str, updated_by: str, version: int) -> N
     for sub in local_state.list_subscriptions(room_name):
         if fnmatch.fnmatch(key, sub.key_pattern):
             bus.publish(agent_channel(sub.subscriber), payload)
+
+
+# Strong refs for the fire-and-forget broadcasts below — an unreferenced
+# asyncio task can be garbage-collected mid-flight (mirrors
+# RoomChannelManager._tasks / PlanSyncEngine._tasks).
+_broadcast_tasks: set[asyncio.Task[Any]] = set()
+
+
+def _broadcast_memory_write(
+    room_name: str,
+    *,
+    key: str,
+    content: str,
+    version: int,
+    base_version: int | None,
+    created_by: str,
+    updated_by: str,
+    updated_at: str,
+) -> None:
+    """Schedule an ``extraction`` knowledge push mirroring a direct memory write.
+
+    Fire-and-forget — the write has already landed on disk and in the index by
+    the time this runs, so a broadcast failure must never surface as a write
+    failure. Scoped to shared rooms: a room with no live channel
+    (``RoomChannelManager.get`` returns ``None`` — not yet provisioned, or
+    purely local) is a silent no-op, same as the plan-sync consumer.
+    """
+    from app.services import room_channels
+
+    managed = room_channels.manager.get(room_name)
+    if managed is None:
+        return
+    write = memory_sync.KnowledgeWrite(
+        key=key,
+        content=content,
+        version=version,
+        base_version=base_version,
+        created_by=created_by,
+        updated_by=updated_by,
+        updated_at=updated_at,
+    )
+    recipients = room_channels.manager.members(room_name)
+    task = asyncio.create_task(_send_memory_write_knowledge(room_name, managed, write, recipients))
+    _broadcast_tasks.add(task)
+    task.add_done_callback(_broadcast_tasks.discard)
+
+
+async def _send_memory_write_knowledge(
+    room_name: str, managed: Any, write: memory_sync.KnowledgeWrite, recipients: list[str]
+) -> None:
+    """Broadcast ``write`` on the room channel and record it locally.
+
+    Mirrors ``plan_sync.PlanSyncEngine._broadcast_knowledge``: send over SLIM,
+    then ``ingest_local`` so the transcript/UI bus see it even if SLIM never
+    loops the broadcast back to the moderator. ``ingest_local`` only records —
+    it never re-enters this write path, so this cannot re-trigger itself.
+    """
+    from app.services.l9_slim import serialize_content
+
+    envelope = memory_sync.build_knowledge_envelope(
+        room=room_name,
+        write=write,
+        recipients=recipients,
+        subkind=memory_sync.MEMORY_WRITE_SUBKIND,
+    )
+    content = serialize_content(envelope, extra={"content": f"memory updated → {write.key}"})
+    try:
+        await managed.channel.send(envelope, extra={"content": content["content"]})
+    except Exception:
+        logger.warning("failed to broadcast memory-write knowledge on room %s", room_name)
+    if managed.persister is not None:
+        managed.persister.ingest_local(envelope, content)
 
 
 @router.post("", response_model=list[MemoryRead], status_code=201)
@@ -232,6 +304,16 @@ async def create_memories(room_name: str, payload: MemoryBatchCreate):
             )
         )
         _notify_change(room_name, item.key, item.created_by, new_version)
+        _broadcast_memory_write(
+            room_name,
+            key=item.key,
+            content=body.rstrip("\n") + "\n",
+            version=new_version,
+            base_version=current_version if existing else None,
+            created_by=created_by,
+            updated_by=item.created_by,
+            updated_at=now.isoformat(),
+        )
 
     for embedded in write_metrics:
         record_memory_write(scope="namespace", embedded=embedded)

--- a/fastapi-backend/app/services/memory_sync.py
+++ b/fastapi-backend/app/services/memory_sync.py
@@ -10,9 +10,11 @@ running agent's working set updates mid-task (the one thing git can't stream).
 This module owns both halves of that seam:
 
 1. **Emit** — :func:`build_knowledge_envelope` wraps a :class:`KnowledgeWrite`
-   (key + markdown body + version metadata) as a ``knowledge:distillation``
-   envelope broadcast on the room channel. Converged content (the compiled plan)
-   flows out this way (see :mod:`app.services.plan_sync`).
+   (key + markdown body + version metadata) as a ``knowledge`` envelope
+   broadcast on the room channel. Converged content (the compiled plan) flows
+   out ``knowledge:distillation`` (see :mod:`app.services.plan_sync`); a direct
+   ``memory set`` write flows out ``knowledge:extraction`` (see
+   ``app.routes.memory.create_memories``) — same shape, distinct subkind.
 
 2. **Apply** — :func:`apply_knowledge` writes the carried markdown into a local
    store and reindexes the JSONL. It is the receiver half every connector runs
@@ -42,11 +44,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# The ``knowledge`` subkind a memory-sync write rides as. ``distillation`` (from
-# the SLIM-native subkind table, l9.VALID_SUBKINDS) is converged content
-# distilled to a shareable artifact — exactly the compiled plan.
+# The ``knowledge`` subkinds a memory-sync write rides as (both from the
+# SLIM-native subkind table, l9.VALID_SUBKINDS). ``distillation`` is converged
+# content distilled to a shareable artifact — the compiled plan
+# (:mod:`app.services.plan_sync`). ``extraction`` is a raw ``memory set`` write
+# broadcast as-is, with no negotiation behind it — kept distinct so a reader
+# can tell "the room agreed to this" from "someone just wrote this".
 KNOWLEDGE_SUBKIND = "distillation"
-KNOWLEDGE_PAYLOAD_TYPE = "distillation"
+MEMORY_WRITE_SUBKIND = "extraction"
 
 
 @dataclass
@@ -124,21 +129,26 @@ def build_knowledge_envelope(
     room: str,
     write: KnowledgeWrite,
     recipients: list[str],
+    subkind: str = KNOWLEDGE_SUBKIND,
 ) -> L9:
-    """Build the ``knowledge:distillation`` envelope that carries ``write``.
+    """Build the ``knowledge`` envelope that carries ``write``.
 
     Broadcast on the room channel; every connector applies it locally. Emitted
     with empty causal parents — like the aligner's terminal verdict, a broadcast
     memory push must be releasable by every member regardless of what each has
-    seen (the rich causal chain stays in the episode record).
+    seen (the rich causal chain stays in the episode record). ``subkind``
+    defaults to the converged-plan shape (:data:`KNOWLEDGE_SUBKIND`); a raw
+    ``memory set`` write passes :data:`MEMORY_WRITE_SUBKIND` instead. The
+    payload's ``type`` always mirrors ``subkind`` so a reader can tell the two
+    apart without unpacking ``data``.
     """
     return l9.build_envelope(
         kind=Kind.knowledge,
-        subkind=KNOWLEDGE_SUBKIND,
+        subkind=subkind,
         episode=l9.episode_urn(room, "knowledge"),
         recipients=recipients,
         topic=l9.topic_urn(room),
-        payload_type=KNOWLEDGE_PAYLOAD_TYPE,
+        payload_type=subkind,
         payload_data=write.to_payload(),
     )
 

--- a/fastapi-backend/tests/test_memory_write_broadcast.py
+++ b/fastapi-backend/tests/test_memory_write_broadcast.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Tests for the direct-write → ``knowledge:extraction`` broadcast (#544).
+
+A ``memory set`` (``POST /rooms/{room}/memory``) already writes the file +
+index; this is the producer half that mirrors it onto the room channel so
+other members' stores converge — the same wire shape ``plan_sync`` uses for
+the compiled plan, but tagged ``extraction`` (a raw write) instead of
+``distillation`` (converged content). The broadcast is scheduled as a
+fire-and-forget background task, so tests drain ``memory_route._broadcast_tasks``
+before asserting on what was sent.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.routes import memory as memory_route
+from app.services import memory_sync, room_channels
+from tests.fakes import FakeChannel, FakeManaged, FakePersister
+
+
+async def _drain_broadcasts() -> None:
+    """Await every in-flight fire-and-forget broadcast task, then let its
+    done-callback (which discards it from the tracking set) run."""
+    tasks = list(memory_route._broadcast_tasks)
+    if tasks:
+        await asyncio.gather(*tasks)
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_memory_write_broadcasts_extraction_knowledge(client: AsyncClient):
+    await client.post("/api/rooms", json={"name": "bcast-room"})
+
+    channel = FakeChannel()
+    persister = FakePersister()
+    managed = FakeManaged(room="bcast-room", channel=channel, persister=persister)
+
+    with (
+        patch.object(room_channels.manager, "get", return_value=managed),
+        patch.object(room_channels.manager, "members", return_value=["a", "b"]),
+    ):
+        resp = await client.post(
+            "/api/rooms/bcast-room/memory",
+            json={
+                "items": [
+                    {"key": "notes/x", "value": "hello", "created_by": "alice", "embed": False}
+                ]
+            },
+        )
+        assert resp.status_code == 201
+        await _drain_broadcasts()
+
+    assert len(channel.sent) == 1
+    envelope, _extra = channel.sent[0]
+    assert envelope.header.kind.value == "knowledge"
+    assert envelope.header.subkind == memory_sync.MEMORY_WRITE_SUBKIND
+    assert envelope.header.subkind != memory_sync.KNOWLEDGE_SUBKIND
+
+    write = memory_sync.knowledge_write_from_envelope(envelope)
+    assert write is not None
+    assert write.key == "notes/x"
+    assert write.version == 1
+    assert write.base_version is None
+    assert write.created_by == "alice" and write.updated_by == "alice"
+
+    # ingest_local recorded it too, so the transcript/UI bus see it even if
+    # SLIM never loops the broadcast back to the moderator.
+    assert len(persister.ingested) == 1
+
+
+@pytest.mark.asyncio
+async def test_memory_write_broadcast_threads_base_version_on_upsert(client: AsyncClient):
+    await client.post("/api/rooms", json={"name": "bcast-room2"})
+
+    channel = FakeChannel()
+    managed = FakeManaged(room="bcast-room2", channel=channel, persister=None)
+
+    with (
+        patch.object(room_channels.manager, "get", return_value=managed),
+        patch.object(room_channels.manager, "members", return_value=["a"]),
+    ):
+        await client.post(
+            "/api/rooms/bcast-room2/memory",
+            json={"items": [{"key": "k", "value": "v1", "created_by": "alice", "embed": False}]},
+        )
+        await _drain_broadcasts()
+        await client.post(
+            "/api/rooms/bcast-room2/memory",
+            json={"items": [{"key": "k", "value": "v2", "created_by": "bob", "embed": False}]},
+        )
+        await _drain_broadcasts()
+
+    assert len(channel.sent) == 2
+    second = memory_sync.knowledge_write_from_envelope(channel.sent[1][0])
+    assert second is not None
+    assert second.version == 2
+    assert second.base_version == 1
+    assert second.updated_by == "bob"
+
+
+@pytest.mark.asyncio
+async def test_memory_write_skips_broadcast_without_live_channel(client: AsyncClient):
+    """No provisioned/live channel (e.g. a not-yet-shared room): silent no-op."""
+    await client.post("/api/rooms", json={"name": "local-only-room"})
+
+    with patch.object(room_channels.manager, "get", return_value=None):
+        resp = await client.post(
+            "/api/rooms/local-only-room/memory",
+            json={"items": [{"key": "k", "value": "v", "created_by": "alice", "embed": False}]},
+        )
+        assert resp.status_code == 201
+        await _drain_broadcasts()
+
+    assert memory_route._broadcast_tasks == set()


### PR DESCRIPTION
## Summary

`memory set` (`POST /rooms/{room}/memory`) wrote the file + index but emitted nothing on the room channel, so a direct write never reached other members' stores the way the consensus-compiled plan does after `plan_sync`. This wires the write path so it produces the same `knowledge` broadcast, tagged distinctly from converged content.

## Changes

- `app/services/memory_sync.py`: `build_knowledge_envelope` now takes an optional `subkind` (default unchanged: `distillation`). Added `MEMORY_WRITE_SUBKIND = "extraction"` — an already-valid-but-previously-unused subkind in `l9.VALID_SUBKINDS`, so **no contract change** is needed in `contracts/slim-l9-wire.json` and both the backend and CLI wire-contract tests stay green as-is. `extraction` (raw write) is kept semantically distinct from `distillation` (converged/negotiated content).
- `app/routes/memory.py`: after `create_memories` writes each item to disk + the index, it schedules a fire-and-forget broadcast (`_broadcast_memory_write` → `_send_memory_write_knowledge`) mirroring `plan_sync.PlanSyncEngine._broadcast_knowledge`'s shape — `build_knowledge_envelope` → `channel.send()` → `persister.ingest_local()`. A broadcast failure is logged and swallowed; it never fails the write, which has already landed by the time it runs.
- Scoped to rooms with a live channel: `RoomChannelManager.get(room)` returning `None` (not yet provisioned / local-only) is a silent no-op, the same guard `plan_sync` uses.
- Loop safety: `ingest_local` only records into the transcript/bus — it never re-enters the write path — so there's no rebroadcast loop from this producer. (Note: nothing in the backend currently applies an *inbound* `knowledge` envelope automatically — that consumer wiring is a separate, pre-existing gap outside this ticket's scope.)
- Both existing display surfaces (`room.py` renderer, `event-stream.tsx`) already render any `l9_knowledge` message type keyed off `kind`, not `subkind`, so the new `extraction` writes render correctly with no frontend changes.

## Testing

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 426 passed, 6 skipped (pre-existing skips)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)
- [x] Added `fastapi-backend/tests/test_memory_write_broadcast.py` covering: a create broadcasts `knowledge:extraction` with the right write fields; an upsert threads `base_version`/bumps `version`; a room with no live channel is a silent no-op.
- [x] CLI's mirrored wire-contract test also verified green (`mycelium-cli && uv run pytest tests/test_slim_l9_wire.py -q`), confirming the reused `extraction` subkind required no contract edits.

## Related Issues

Implements #544 (context packet referenced #547 for the display half, already done).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qg3jewRwUZrxduKKxJ9uGi)_