### PR TITLE
Apply inbound knowledge envelopes on receive

### DIFF
--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -25,6 +25,14 @@ This module is that consumer, and it does four things as each message flows past
    ``on_converged`` seam the plan-sync consumer runs ``plan_compiler`` off of;
    the persister itself does **not** compile — it just fires the seam.
 
+5. **Memory-sync receiver.** On a ``knowledge`` envelope — from a real SLIM
+   arrival or the sender's own :meth:`RoomPersister.ingest_local` loopback
+   alike — it applies the carried write to this backend's local store via
+   :func:`app.services.memory_sync.apply_knowledge`, closing the loop the
+   emit side (``_broadcast_memory_write`` / :mod:`app.services.plan_sync`)
+   opens. Unlike the summon/converged hooks this isn't a pluggable engine
+   seam: the applier is stateless and version-idempotent, so it always runs.
+
 The pure pieces (:class:`DeliveryLog`, the transcript read/write, the trigger
 detection) carry no SLIM dependency and are unit-tested without a node;
 :class:`RoomPersister` is the thin async loop that drives them over a live
@@ -46,7 +54,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from app.schemas import MessageType
-from app.services import l9
+from app.services import l9, memory_sync
 from app.services.l9_slim import ChannelReceiveTimeout
 
 # Stable namespace so a transcript record maps to the same synthetic
@@ -603,17 +611,25 @@ class RoomPersister:
         # publishes itself (the human proxy) is recorded/fed to the bus exactly
         # once even if SLIM loops the broadcast back to the moderator.
         self._ingested_ids: set[str] = set()
+        # Strong refs to in-flight knowledge-apply tasks (apply_knowledge does file
+        # IO + reindexing, so it can't run inline in the sync ``_ingest`` call);
+        # without this the task could be GC'd mid-flight.
+        self._knowledge_tasks: set[asyncio.Task[None]] = set()
         # Health counters surfaced via RoomChannelManager.status(). ``receive_errors``
         # is genuine (fatal) transport faults; ``transient_errors`` is recoverable
         # membership-churn receive errors (retried, not lost) — split so the health
         # surface distinguishes "the channel is faulting" from "the channel is
         # churning". ``reserve_failures``/``reserve_skipped`` make the two ways a
         # missed-message re-serve fails to land visible instead of log-only.
+        # ``knowledge_applied``/``knowledge_conflicts`` are the memory-sync receiver's
+        # equivalent: how many inbound writes converged vs. lost to a stale base.
         self.reserves = 0
         self.receive_errors = 0
         self.transient_errors = 0
         self.reserve_failures = 0
         self.reserve_skipped = 0
+        self.knowledge_applied = 0
+        self.knowledge_conflicts = 0
 
     def _persist_cursors(self) -> None:
         """Snapshot the delivery cursors to disk (best-effort, per mutation)."""
@@ -840,6 +856,38 @@ class RoomPersister:
                 self.on_converged(envelope)
             except Exception:
                 logger.exception("converged hook failed")
+        if memory_sync.is_knowledge(envelope):
+            self._schedule_knowledge_apply(envelope)
+
+    def _schedule_knowledge_apply(self, envelope: L9) -> None:
+        """Apply an inbound ``knowledge`` write off the ingest path.
+
+        Fires for a real SLIM arrival and for the sender's own
+        :meth:`ingest_local` loopback alike — ``apply_knowledge`` is
+        version-idempotent (see :mod:`app.services.memory_sync`), so re-applying
+        a write this store already holds is a silent no-op, not a double-write.
+        Scheduled as a tracked background task since ``_ingest`` is sync but the
+        applier does file IO + reindexing; never re-broadcasts, so this cannot
+        loop with the emit side (``_broadcast_memory_write`` / ``plan_sync``).
+        """
+        write = memory_sync.knowledge_write_from_envelope(envelope)
+        if write is None:
+            logger.warning("malformed knowledge envelope on room %s; not applied", self.room)
+            return
+        task = asyncio.create_task(self._apply_knowledge(write))
+        self._knowledge_tasks.add(task)
+        task.add_done_callback(self._knowledge_tasks.discard)
+
+    async def _apply_knowledge(self, write: memory_sync.KnowledgeWrite) -> None:
+        try:
+            result = await memory_sync.apply_knowledge(self.room, write)
+        except Exception:
+            logger.exception("apply_knowledge failed for %s/%s", self.room, write.key)
+            return
+        if result.conflict:
+            self.knowledge_conflicts += 1
+        elif result.applied:
+            self.knowledge_applied += 1
 
     def _publish_to_bus(self, record: TranscriptRecord) -> None:
         """Feed the recorded message to the in-process bus so the SSE UI sees it.

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -229,6 +229,12 @@ class RoomChannelManager:
                     "transient_errors": (
                         managed.persister.transient_errors if managed.persister else 0
                     ),
+                    "knowledge_applied": (
+                        managed.persister.knowledge_applied if managed.persister else 0
+                    ),
+                    "knowledge_conflicts": (
+                        managed.persister.knowledge_conflicts if managed.persister else 0
+                    ),
                 }
             )
         return {

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -11,7 +11,7 @@ round trip over a real SLIM node is in ``test_l9_over_slim_roundtrip.py``
 
 import pytest
 
-from app.services import l9, persister
+from app.services import l9, memory_sync, persister
 from app.services.filesystem import get_room_dir, read_memory_file
 from app.services.l9_models import Kind
 
@@ -585,3 +585,136 @@ def test_list_store_skips_presence_and_non_conversational():
     p._ingest(pres_env, pres_content)
 
     assert local_state.list_messages(room) == []
+
+
+# ── knowledge apply: inbound memory-sync writes converge the local store ─────
+
+
+@pytest.fixture(autouse=True)
+def _stub_embeddings(monkeypatch):
+    """Applying a knowledge write reindexes through the embedder; stub it so
+    these tests never load the fastembed ONNX model (matches
+    ``test_memory_sync.py``'s fixture)."""
+    monkeypatch.setattr("app.services.embedding._STUB", True)
+
+
+def _knowledge_envelope(
+    *,
+    room: str,
+    key: str = "plan/tasks.md",
+    content: str = "# Plan\n\n- [ ] first task\n",
+    version: int = 1,
+    base_version: int | None = None,
+    subkind: str = memory_sync.KNOWLEDGE_SUBKIND,
+):
+    """A `knowledge` envelope; `build_knowledge_envelope` mints a fresh random
+    message id per call, so distinct calls are never deduped against each other."""
+    from app.services.l9_slim import serialize_content
+
+    write = memory_sync.KnowledgeWrite(
+        key=key,
+        content=content,
+        version=version,
+        created_by="system",
+        updated_by="system",
+        updated_at="2026-08-04T00:00:00+00:00",
+        base_version=base_version,
+    )
+    env = memory_sync.build_knowledge_envelope(
+        room=room, write=write, recipients=["bob"], subkind=subkind
+    )
+    return env, serialize_content(env)
+
+
+@pytest.mark.asyncio
+async def test_ingest_applies_inbound_knowledge_write_to_local_store():
+    """A `knowledge` envelope arriving on the channel writes the carried markdown
+    into this backend's local store — the receive half of cross-store memory
+    convergence (#549)."""
+    room = "knowledge-room-1"
+    p = _persister_for(room, summoned=[], converged=[])
+
+    env, content = _knowledge_envelope(room=room, version=1)
+    p._ingest(env, content)
+    for task in list(p._knowledge_tasks):
+        await task
+
+    got = read_memory_file(get_room_dir(room), "plan/tasks.md")
+    assert got is not None
+    assert got[1] == "# Plan\n\n- [ ] first task"
+    assert p.knowledge_applied == 1
+    assert p.knowledge_conflicts == 0
+
+
+@pytest.mark.asyncio
+async def test_ingest_applies_extraction_subkind_the_same_way():
+    """`extraction` (a raw ``memory set``) applies identically to `distillation`
+    — the applier is subkind-agnostic."""
+    room = "knowledge-room-2"
+    p = _persister_for(room, summoned=[], converged=[])
+
+    env, content = _knowledge_envelope(
+        room=room,
+        key="notes/idea.md",
+        content="an idea\n",
+        version=1,
+        subkind=memory_sync.MEMORY_WRITE_SUBKIND,
+    )
+    p._ingest(env, content)
+    for task in list(p._knowledge_tasks):
+        await task
+
+    got = read_memory_file(get_room_dir(room), "notes/idea.md")
+    assert got is not None
+    assert got[1] == "an idea"
+    assert p.knowledge_applied == 1
+
+
+@pytest.mark.asyncio
+async def test_ingest_knowledge_loopback_is_idempotent_not_a_double_write():
+    """The sender's own broadcast loops back through ``ingest_local`` /
+    ``_ingest`` too. Applying it again must be a silent no-op (same version) —
+    never a re-broadcast or a double-write — so two hosts can't ping-pong."""
+    room = "knowledge-room-3"
+    p = _persister_for(room, summoned=[], converged=[])
+
+    env, content = _knowledge_envelope(room=room, version=1)
+    p._ingest(env, content)
+    for task in list(p._knowledge_tasks):
+        await task
+    assert p.knowledge_applied == 1
+
+    # Same write, same version, arriving again (e.g. a second connector's own
+    # loopback of the same broadcast, or a redelivery).
+    env2, content2 = _knowledge_envelope(room=room, version=1)
+    p._ingest(env2, content2)
+    for task in list(p._knowledge_tasks):
+        await task
+
+    assert p.knowledge_applied == 1  # unchanged: idempotent, not a second write
+    assert p.knowledge_conflicts == 0
+
+
+@pytest.mark.asyncio
+async def test_ingest_knowledge_stale_base_is_a_conflict_not_a_merge():
+    """An incoming write behind the local version is rejected (last-write-wins);
+    the newer local content survives untouched."""
+    room = "knowledge-room-4"
+    p = _persister_for(room, summoned=[], converged=[])
+
+    newer, newer_content = _knowledge_envelope(room=room, content="v2 content\n", version=2)
+    p._ingest(newer, newer_content)
+    for task in list(p._knowledge_tasks):
+        await task
+    assert p.knowledge_applied == 1
+
+    stale, stale_content = _knowledge_envelope(room=room, content="v1 content\n", version=1)
+    p._ingest(stale, stale_content)
+    for task in list(p._knowledge_tasks):
+        await task
+
+    got = read_memory_file(get_room_dir(room), "plan/tasks.md")
+    assert got is not None
+    assert got[1] == "v2 content"  # the newer local content was not overwritten
+    assert p.knowledge_applied == 1  # the stale write did not count as applied
+    assert p.knowledge_conflicts == 1


### PR DESCRIPTION
## Summary

The producer half (#544/#548) emits `knowledge` envelopes on memory writes (`extraction`) and consensus plan-sync (`distillation`), but nothing on the receiving backend applied an inbound `knowledge` envelope to its local memory store — a broadcast reaching another host updated that host's transcript/UI but never wrote the carried markdown into its `.mycelium/` store. This closes that gap.

## Changes

- `RoomPersister._ingest` (`fastapi-backend/app/services/persister.py`) — the single dispatch point every inbound SLIM message *and* the sender's own `ingest_local` loopback flows through — now calls the existing `memory_sync.apply_knowledge` applier whenever it sees a `knowledge` envelope. Subkind-agnostic, so `distillation` (compiled plans) and `extraction` (direct `memory set` writes) converge the same way.
- The apply runs as a tracked background task (`_schedule_knowledge_apply` / `_apply_knowledge`) since `_ingest` is sync but the applier does file IO + reindexing.
- No new loop-guard needed: `apply_knowledge` only writes files and reindexes — it never re-broadcasts, so it can't re-trigger the emit side (`_broadcast_memory_write` / `plan_sync`). Its existing version check already makes a same-machine loopback a silent no-op, so this can't ping-pong between hosts.
- Added `knowledge_applied` / `knowledge_conflicts` counters on `RoomPersister`, surfaced through `RoomChannelManager.status()` (the `/health` endpoint), mirroring the existing `reserves`/`receive_errors` pattern.

## Testing

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 430 passed, 6 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)

Added 4 new tests in `test_persister.py`:
- inbound `knowledge` envelope applies the carried write to the local store
- `extraction` subkind applies identically to `distillation` (applier is subkind-agnostic)
- a loopback re-delivery of the same version is a silent no-op, not a double-write
- a stale-base write is rejected as a conflict (last-write-wins, no merge) and doesn't clobber newer local content

Also ran the CLI's shared wire-contract test (`mycelium-cli/tests/test_slim_l9_wire.py`) — unaffected, still green.

## Related Issues

Closes #549


---
_Generated by [Claude Code](https://claude.ai/code/session_01RjwfVFk8gCtMtGfs6UoUb8)_