### PR TITLE
Add `mycelium join`, the thin-spoke member client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,8 +233,19 @@ jobs:
           tests/test_slim_roundtrip.py
           tests/test_l9_over_slim_roundtrip.py
 
-      # The CLI has no live-node slices: `await`/`respond` are pure HTTP (the
-      # SLIM member connector that needed a node was removed with the daemon).
+      - name: CLI deps
+        working-directory: mycelium-cli
+        run: uv sync --group dev --extra engine
+
+      # `await`/`respond` are pure HTTP, but the thin spoke (`mycelium join`) is a
+      # real SLIM member — the only CLI path that needs a node. Its node-free
+      # semantics are covered in the unit job; this proves it receives traffic it
+      # did not emit, which is the whole point of the spoke.
+      - name: CLI live-node slices
+        working-directory: mycelium-cli
+        env:
+          MYCELIUM_SLIM_ENDPOINT: http://127.0.0.1:46357
+        run: uv run pytest -q tests/test_spoke_roundtrip.py
 
       - name: SLIM node logs (on failure)
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ backend is each room's **moderator**; agents (and the human, by proxy) are membe
 `.mycelium/rooms/{room}/{key}.md`. Search is a **local embedding index** (fastembed
 ONNX, `BAAI/bge-small-en-v1.5`, 384-dim, no external service) persisted as JSONL
 per room. `memory set` writes the markdown and updates the index; direct file
-writes work too; run `mycelium reindex` to resync. Sharing is git.
+writes work too; run `mycelium reindex` to resync. Git can version or back up the
+files, but it is **not** the sharing path — see **Sharing is the live channel** below.
 
 **L9 rides SLIM.** Coordination messages carry additive IOC **L9** JSON envelopes:
 `exchange` (ticks/replies), `commit:converged|resolved|rejected`, `knowledge`.
@@ -156,8 +157,11 @@ is no litellm dependency.
   `members()` is the union of live SLIM members and lease holders. This is why
   turn-based agents never miss a tick. The **durable inbox** (`persister.py`)
   re-serves missed point-to-point messages on rejoin (SLIM has no offline replay).
-- **Git for sharing.** Rooms can be shared via git push/pull; cross-machine is the
-  same channel over a shared SLIM node (`mycelium hub host` / `mycelium connect`).
+- **Sharing is the live channel.** Cross-machine sharing is the same SLIM channel over a
+  shared node (`mycelium hub host` / `mycelium connect` / `mycelium join`), plus
+  `mycelium room clone --from <api-url>` for a point-in-time HTTP snapshot. Git can back
+  up or version the `.mycelium/` files but is **not** a sharing mechanism — no room flow
+  pushes or pulls over git.
 - **One moderator per room; spokes are members.** Cross-machine memory sync runs
   hub → spoke over the room's channel: the hub broadcasts a `knowledge` envelope on
   every `memory set`, and `mycelium join` (`mycelium/spoke.py`) holds membership on a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,13 @@ is no litellm dependency.
   re-serves missed point-to-point messages on rejoin (SLIM has no offline replay).
 - **Git for sharing.** Rooms can be shared via git push/pull; cross-machine is the
   same channel over a shared SLIM node (`mycelium hub host` / `mycelium connect`).
+- **One moderator per room; spokes are members.** Cross-machine memory sync runs
+  hub → spoke over the room's channel: the hub broadcasts a `knowledge` envelope on
+  every `memory set`, and `mycelium join` (`mycelium/spoke.py`) holds membership on a
+  second machine and applies each one to its own local store. A second backend on the
+  same room is *not* the path — each would moderate its own MLS group and nothing
+  would cross. Moderator federation / multi-master is deliberately out of scope.
+  The spoke's own writes reaching the hub is not built yet.
 - **No Ensue references in code.** We took inspiration from their API design but the
   implementation is independent.
 - **L9 envelopes are additive, never required of agents.** Ticks are `exchange`,

--- a/contracts/slim-l9-wire.json
+++ b/contracts/slim-l9-wire.json
@@ -2,8 +2,8 @@
   "_comment": [
     "Frozen SLIM+L9 wire-compat contract constants — the single source of truth both",
     "the FastAPI backend (fastapi-backend/app/services/{slim_client,l9,l9_slim}.py)",
-    "and the CLI daemon (mycelium-cli/src/mycelium/slim/{naming,client,l9}.py +",
-    "daemon/connector.py) MUST reproduce byte-for-byte. See D2 in",
+    "and the CLI (mycelium-cli/src/mycelium/slim/{naming,client,l9}.py +",
+    "mycelium/spoke.py) MUST reproduce byte-for-byte. See D2 in",
     "docs/slim-native-rebuild-bible.md (Part IV, Known debt register).",
     "",
     "Both test suites read THIS file and assert their own primitives against it, so",
@@ -91,7 +91,7 @@
   },
 
   "knowledge": {
-    "_comment": "A frozen serialized L9 'knowledge:distillation' envelope — the memory-sync wire shape (Step 8, bible §11). The backend PRODUCES it via memory_sync.build_knowledge_envelope(room, write, recipients) + KnowledgeWrite.to_payload() (serialized with l9.envelope_to_dict); the CLI daemon PARSES it via slim/l9.payload_data_of and applies it in daemon/connector.apply_knowledge_message. The two must agree byte-for-byte on the payload.data write fields or cross-machine memory sync (Step 9) silently drifts. build_knowledge_envelope mints a fresh random message.id per call, so 'expected_envelope.header.message.id' is the sentinel 'MESSAGE_ID_PLACEHOLDER' — the backend test normalizes the produced id to it before comparing (the id is not part of the shared contract; every other field is).",
+    "_comment": "A frozen serialized L9 'knowledge:distillation' envelope — the memory-sync wire shape (Step 8, bible §11). The backend PRODUCES it via memory_sync.build_knowledge_envelope(room, write, recipients) + KnowledgeWrite.to_payload() (serialized with l9.envelope_to_dict); the CLI PARSES it via slim/l9.payload_data_of and applies it in spoke.apply_message (the thin spoke `mycelium join` runs). The two must agree byte-for-byte on the payload.data write fields or cross-machine memory sync (Step 9) silently drifts. build_knowledge_envelope mints a fresh random message.id per call, so 'expected_envelope.header.message.id' is the sentinel 'MESSAGE_ID_PLACEHOLDER' — the backend test normalizes the produced id to it before comparing (the id is not part of the shared contract; every other field is).",
     "room": "acme",
     "recipients": ["bob"],
     "message_id_placeholder": "MESSAGE_ID_PLACEHOLDER",

--- a/docs/cross-machine.md
+++ b/docs/cross-machine.md
@@ -15,8 +15,9 @@ node**. This is the LAN path; the open-internet path is documented at the bottom
   One moderator per room; see the traps below.
 - **Spoke (member).** Points at the hub's node with `mycelium connect
   http://<hub-ip>:46357`, then registers an agent that participates as a resident
-  runtime (`mycelium await --loop`) on the room channel. A spoke is a *member* of
-  the channel, never a second moderator.
+  runtime (`mycelium await --loop`) on the room channel, and runs `mycelium join` to
+  receive the room's memory writes. A spoke is a *member* of the channel, never a
+  second moderator.
 
 Membership is addressed by **identity** (`workspace/room/agent`), never by host, so the
 moderator invites a spoke's agent exactly as it would a local one: the consent →
@@ -66,12 +67,45 @@ mycelium respond --room planning --handle spoke-agent "canary works if we cap ro
 
 On agreement the aligner emits `commit:converged`, records the episode, and compiles
 `plan/tasks.md` **before** the consensus is announced (so the plan exists when `await`
-returns). The plan syncs as a `knowledge` memory to every machine. Each agent reads it
+returns). The plan syncs as a `knowledge` memory to every machine holding membership
+(see [Receiving memory on a spoke](#receiving-memory-on-a-spoke)). Each agent reads it
 and works its half:
 
 ```bash
 mycelium plan tasks --room planning        # the shared @handle checklist
 ```
+
+## Receiving memory on a spoke
+
+A room's memory writes ride the channel as `knowledge` envelopes: the hub broadcasts one
+on every `memory set`, and the compiled plan syncs the same way. Receiving them means
+holding membership, which `mycelium join` does:
+
+```bash
+# Spoke — resident, Ctrl-C to stop
+mycelium join --room planning --handle spoke-agent
+```
+
+It asks the hub's moderator to invite it, then writes every inbound memory into the
+spoke's own `~/.mycelium/rooms/planning/`. A `memory set` on the hub lands here:
+
+```bash
+# Hub
+mycelium memory set --room planning context/decision.md "we ship canary"
+
+# Spoke — same content, its own store
+mycelium memory get --room planning context/decision.md
+```
+
+Ordering is last-write-wins by version. A re-delivered write at a version the spoke
+already holds is a silent no-op, and a write built on a base *behind* the local file is
+reported as a conflict and dropped rather than clobbering newer local content — nothing
+is merged automatically.
+
+Two limits worth knowing. The direction is **hub → spoke only**: a spoke's own
+`memory set` stays local for now. And the CLI has no local embedding index, so memories
+that arrive this way are on disk but not searchable until `mycelium sync` against a
+backend.
 
 ## Traps
 

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -442,6 +442,7 @@ def _generate_cli_reference() -> tuple[str, list[tuple[str, str]]]:
     import mycelium.commands.hub  # noqa: F401
     import mycelium.commands.install  # noqa: F401
     import mycelium.commands.instance  # noqa: F401
+    import mycelium.commands.join  # noqa: F401
     import mycelium.commands.memory  # noqa: F401
     import mycelium.commands.participate  # noqa: F401
     import mycelium.commands.plan  # noqa: F401

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -627,16 +627,23 @@ cursor-agent login            # one-time, interactive
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium sync</span> [<span class="flag">--no-reindex</span>]</code>
+          <code><span class="cmd">mycelium watch</span> [room]</code>
         </div>
-        <div class="cmd-ref-body">Sync the active room with the backend: fetch all memories from the API and write them locally.</div>
+        <div class="cmd-ref-body">Stream live room activity via SSE. Messages appear in real time as other agents write.</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium watch</span> [room]</code>
+          <code><span class="cmd">mycelium join</span> [<span class="flag">--room</span> <span class="arg">&lt;room&gt;</span>] [<span class="flag">--handle</span> <span class="arg">&lt;handle&gt;</span>]</code>
         </div>
-        <div class="cmd-ref-body">Stream live room activity via SSE. Messages appear in real time as other agents write.</div>
+        <div class="cmd-ref-body">Join a hub-hosted room as a member and apply its memory writes to this machine.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium sync</span> [<span class="flag">--no-reindex</span>]</code>
+        </div>
+        <div class="cmd-ref-body">Sync the active room with the backend: fetch all memories from the API and write them locally.</div>
       </div>
 
       <div class="cmd-ref">

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -22,6 +22,7 @@ from mycelium.commands import (
     hub,
     install,
     instance,
+    join,
     memory,
     metrics,
     network,
@@ -121,6 +122,9 @@ app.command(name="connect")(hub.connect)
 # Participation primitives — join a room's SLIM channel and reply, no daemon.
 app.command(name="await")(participate.await_room)
 app.command(name="respond")(participate.respond)
+
+# Thin spoke — hold membership on a hub-hosted room and apply its memory writes.
+app.command(name="join")(join.join)
 
 # Command groups
 app.add_typer(room.app, name="room")

--- a/mycelium-cli/src/mycelium/commands/join.py
+++ b/mycelium-cli/src/mycelium/commands/join.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""``join`` — enroll this machine as a member of a room hosted on another.
+
+``mycelium connect`` points this machine at a hub's SLIM node; ``mycelium join``
+is what actually puts it on a room's channel and keeps it there. The process is a
+resident foreground member: it holds membership and writes every ``knowledge``
+envelope the hub broadcasts into this machine's own store, so a ``memory set`` on
+the hub lands here.
+
+It is a **member**, never a moderator. The hub that provisioned the room is its
+sole moderator; a second moderator would be a second MLS group, which is why two
+backends on one node never converged. See :mod:`mycelium.spoke`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import typer
+
+from mycelium.commands.room import _resolve_room
+from mycelium.config import MyceliumConfig
+from mycelium.doc_ref import doc_ref
+from mycelium.error_handler import print_error
+from mycelium.identity import get_current_handle
+from mycelium.spoke import SpokeCounters, run_spoke
+
+if TYPE_CHECKING:
+    from mycelium.filesystem import KnowledgeApplyResult
+
+
+@doc_ref(
+    usage="mycelium join [--room <room>] [--handle <handle>]",
+    desc="Join a hub-hosted room as a member and apply its memory writes to this machine.",
+    group="other",
+)
+def join(
+    ctx: typer.Context,
+    room: str | None = typer.Option(None, "--room", "-r", help="Room (default: active room)"),
+    handle: str | None = typer.Option(
+        None, "--handle", help="Handle to join as (default: your configured identity)"
+    ),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Only report conflicts and errors"),
+) -> None:
+    """Stay resident on a room's channel, applying inbound memory writes locally.
+
+    Runs until Ctrl-C. Memories that arrive are written to ~/.mycelium/rooms/<room>/
+    but are not indexed for search until you run `mycelium sync` — the CLI has no
+    local embedding index.
+    """
+    try:
+        config = MyceliumConfig.load()
+        room_name = _resolve_room(config, room)
+        joining_as = handle or get_current_handle(config)
+        if not joining_as:
+            typer.secho(
+                "  ⟫  no identity configured — pass --handle or run `mycelium iam <name>`",
+                fg=typer.colors.RED,
+            )
+            raise typer.Exit(2)
+
+        counters = SpokeCounters()
+
+        def _on_joined() -> None:
+            if not quiet:
+                typer.secho(
+                    f"  ⟫  @{joining_as} joined {room_name} as a member "
+                    f"via {config.slim.node_endpoint} — applying memory writes "
+                    "(Ctrl-C to stop)",
+                    fg=typer.colors.CYAN,
+                )
+
+        def _on_apply(result: KnowledgeApplyResult) -> None:
+            if result.conflict:
+                current = result.current or {}
+                typer.secho(
+                    f"  ⟫  conflict on {result.key}: kept local v{current.get('version')} "
+                    f"by {current.get('updated_by')!r}, rejected incoming v{result.version}",
+                    fg=typer.colors.YELLOW,
+                )
+            elif result.applied and not quiet:
+                typer.secho(f"  ⟫  applied {result.key} v{result.version}", fg=typer.colors.GREEN)
+
+        try:
+            asyncio.run(
+                run_spoke(
+                    api_url=config.server.api_url,
+                    node_endpoint=config.slim.node_endpoint,
+                    room=room_name,
+                    handle=joining_as,
+                    counters=counters,
+                    on_joined=_on_joined,
+                    on_apply=_on_apply,
+                )
+            )
+        except KeyboardInterrupt:
+            pass
+
+        typer.echo(
+            f"\n  [Left {room_name}] applied={counters.applied} "
+            f"conflicts={counters.conflicts} ignored={counters.ignored}"
+        )
+    except typer.Exit:
+        raise
+    except KeyboardInterrupt:
+        typer.echo("\n  [Stopped]")
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from e

--- a/mycelium-cli/src/mycelium/slim/member.py
+++ b/mycelium-cli/src/mycelium/slim/member.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Ephemeral SLIM room membership — join, publish once, leave (dev/testing).
+"""SLIM room membership from outside the backend — join, then publish or receive.
 
 The CLI's ``l9 send`` / ``slim send`` plumbing (see ``mycelium.commands.wire``)
 needs to put real bytes on a room's SLIM channel so the backend's own
@@ -19,16 +19,28 @@ connector makes on every reconnect (``POST /rooms/{room}/sessions``,
 ``app/routes/sessions.py::join_room`` → ``room_channels.manager.invite_in_background``).
 That call is fire-and-forget on the backend side, with its own retrying
 handshake, so asking before this process has even connected to the node is fine.
+
+The same handshake admits a *long-lived* member: :func:`joined_member` holds the
+session open instead of publishing once and leaving, which is how the thin spoke
+(``mycelium join``, see :mod:`mycelium.spoke`) receives a room's traffic on a
+machine that is not the moderator.
 """
 
 from __future__ import annotations
 
 import asyncio
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
 
 import httpx
 
 from mycelium.slim.client import SlimClient, SlimError
 from mycelium.slim.naming import DEFAULT_WORKSPACE, SlimIdentity, node_reachable
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    import slim_bindings
 
 # How long to wait, after asking the backend to invite us, for the moderator's
 # handshake to land and admit us into the encrypted group. Comfortably inside the
@@ -42,7 +54,7 @@ _HTTP_TIMEOUT_S = 10.0
 
 
 class SlimSendError(SlimError):
-    """A join/connect/publish attempt as an ephemeral room member failed."""
+    """A join/connect/publish attempt as a room member failed."""
 
 
 async def announce_presence(api_url: str, room: str, handle: str) -> None:
@@ -58,25 +70,29 @@ async def announce_presence(api_url: str, room: str, handle: str) -> None:
     resp.raise_for_status()
 
 
-async def publish_once(
+@asynccontextmanager
+async def joined_member(
     *,
     api_url: str,
     node_endpoint: str,
     room: str,
     handle: str,
-    payload: bytes,
     workspace: str = DEFAULT_WORKSPACE,
     join_timeout_s: float = DEFAULT_JOIN_TIMEOUT_S,
-) -> None:
-    """Join ``room`` as ``handle`` over a live SLIM connection, publish once, leave.
+) -> AsyncIterator[slim_bindings.Session]:
+    """Join ``room``'s channel as member ``handle`` and yield the live session.
 
     Connects a new SLIM app under ``workspace/room/handle``, asks the backend to
-    invite it in, waits to be admitted into the moderator's encrypted group,
-    publishes ``payload`` verbatim, and disconnects. Raises :class:`SlimSendError`
-    if the node is unreachable or the invite never lands within
-    ``join_timeout_s``; raises :class:`~mycelium.slim.client.SlimUnavailableError`
-    (via ``SlimClient.connect``) if ``slim_bindings`` has no wheel for this
-    platform — both are :class:`~mycelium.slim.client.SlimError`.
+    invite it in, and waits to be admitted into the moderator's encrypted group.
+    The caller gets the group session for as long as the block runs; the app is
+    torn down on exit. **Member only** — no group is created here, so joining
+    never races a second moderator onto the room's channel.
+
+    Raises :class:`SlimSendError` if the node is unreachable or the invite never
+    lands within ``join_timeout_s``; raises
+    :class:`~mycelium.slim.client.SlimUnavailableError` (via
+    ``SlimClient.connect``) if ``slim_bindings`` has no wheel for this platform —
+    both are :class:`~mycelium.slim.client.SlimError`.
     """
     if not node_reachable(node_endpoint):
         raise SlimSendError(
@@ -95,6 +111,28 @@ async def publish_once(
                 f"timed out waiting to be invited into room {room!r} as @{handle} "
                 "— is the backend up and moderating this room?"
             ) from exc
-        await SlimClient.publish(session, payload)
+        yield session
     finally:
         await client.close()
+
+
+async def publish_once(
+    *,
+    api_url: str,
+    node_endpoint: str,
+    room: str,
+    handle: str,
+    payload: bytes,
+    workspace: str = DEFAULT_WORKSPACE,
+    join_timeout_s: float = DEFAULT_JOIN_TIMEOUT_S,
+) -> None:
+    """Join ``room`` as ``handle`` over a live SLIM connection, publish once, leave."""
+    async with joined_member(
+        api_url=api_url,
+        node_endpoint=node_endpoint,
+        room=room,
+        handle=handle,
+        workspace=workspace,
+        join_timeout_s=join_timeout_s,
+    ) as session:
+        await SlimClient.publish(session, payload)

--- a/mycelium-cli/src/mycelium/spoke.py
+++ b/mycelium-cli/src/mycelium/spoke.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The thin spoke — a room **member** that applies inbound ``knowledge`` locally.
+
+A room's channel has exactly one moderator: the always-on backend that provisioned
+it (``fastapi-backend/app/services/room_channels.py``). Standing up a second
+backend against the same node and room does *not* share a group — each becomes its
+own moderator with its own MLS session, so nothing crosses. Receiving another
+machine's writes means joining as a **member**, which is what this module does.
+
+The receive half of the memory-sync seam already existed on both sides and was
+simply never connected across machines: the hub broadcasts a ``knowledge``
+envelope on every ``memory set``, and :func:`mycelium.filesystem.apply_knowledge`
+is the local applier (last-write-wins by version, idempotent re-delivery,
+stale-base writes recorded as conflicts rather than clobbering). The spoke is the
+process in between — it holds membership and feeds one to the other.
+
+Deliberately *not* a persister. The backend's ``RoomPersister`` also owns the
+transcript, delivery cursors, the SSE bus and episode hooks, all of which are
+moderator-authoritative. A spoke is a passive consumer of one envelope kind, so it
+borrows only the apply path; message-level dedup is unnecessary because the
+version check already makes a replay a no-op.
+
+Search stays hub-side: the CLI has no local embedding index, so memories that
+arrive here are not searchable until a ``mycelium sync`` / ``mycelium memory
+reindex`` against a backend.
+
+Membership is gated by the room's shared-secret PSK (``mint_shared_secret``,
+keyed on ``workspace/room``) — the same dev-tier D1 model every other member uses.
+A spoke is exactly as authenticated as any connector, no more: per-agent identity
+(JWT/SPIRE) remains a prerequisite for anything hosted or multi-user (issue #446).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from mycelium.filesystem import apply_knowledge, get_room_dir
+from mycelium.slim import l9
+from mycelium.slim.client import SlimClient, SlimReceiveTimeout
+from mycelium.slim.member import DEFAULT_JOIN_TIMEOUT_S, joined_member
+from mycelium.slim.naming import DEFAULT_WORKSPACE
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from mycelium.filesystem import KnowledgeApplyResult
+
+logger = logging.getLogger(__name__)
+
+# How long a single receive waits before yielding control. A quiet room is the
+# normal case, not an error: the timeout just paces the loop so a Ctrl-C is
+# noticed promptly.
+DEFAULT_RECEIVE_TIMEOUT_S = 30.0
+
+# Mirrors the backend's ``l9.SYSTEM_ACTOR_ID`` — the actor recorded for a write
+# that names none.
+SYSTEM_ACTOR = "system"
+
+
+@dataclass
+class SpokeCounters:
+    """What this spoke has done with the traffic it received.
+
+    ``applied``/``conflicts`` mirror the backend persister's counters of the same
+    name, so a spoke's health reads the same way as a hub's.
+    """
+
+    applied: int = 0
+    conflicts: int = 0
+    ignored: int = 0
+
+    def record(self, result: KnowledgeApplyResult) -> None:
+        if result.conflict:
+            self.conflicts += 1
+        elif result.applied:
+            self.applied += 1
+        else:
+            self.ignored += 1
+
+
+def knowledge_write_of(content: dict[str, Any]) -> dict[str, Any] | None:
+    """The memory write a decoded message carries, or ``None`` if it carries none.
+
+    ``None`` covers both "not a ``knowledge`` message" and "malformed payload" —
+    neither is an error for a spoke, which sees a room's whole traffic and applies
+    only the memory-sync slice of it. Subkind-agnostic on purpose: a
+    ``distillation`` (compiled plan) and an ``extraction`` (raw ``memory set``)
+    apply identically.
+    """
+    if l9.kind_of(content) != l9.KNOWLEDGE_KIND:
+        return None
+    data = l9.payload_data_of(content)
+    key = data.get("key")
+    body = data.get("content")
+    if not isinstance(key, str) or not key or not isinstance(body, str):
+        return None
+    try:
+        version = int(data.get("version", 1))
+    except (TypeError, ValueError):
+        version = 1
+    actor = str(data.get("updated_by") or data.get("created_by") or SYSTEM_ACTOR)
+    return {
+        "key": key,
+        "content": body,
+        "version": version,
+        "created_by": str(data.get("created_by") or actor),
+        "updated_by": actor,
+    }
+
+
+def apply_message(room_dir: Path, payload: bytes) -> KnowledgeApplyResult | None:
+    """Decode one inbound frame and apply the memory write it carries.
+
+    Returns ``None`` when the frame is unparseable or carries no memory write.
+    """
+    content = l9.parse(payload)
+    if content is None:
+        return None
+    write = knowledge_write_of(content)
+    if write is None:
+        return None
+    return apply_knowledge(room_dir, **write)
+
+
+async def receive_and_apply(
+    session: Any,
+    room_dir: Path,
+    *,
+    counters: SpokeCounters,
+    on_apply: Callable[[KnowledgeApplyResult], None] | None = None,
+    receive_timeout_s: float = DEFAULT_RECEIVE_TIMEOUT_S,
+    max_messages: int | None = None,
+) -> SpokeCounters:
+    """Receive on ``session`` forever, applying every ``knowledge`` write locally.
+
+    Runs until cancelled. ``max_messages`` bounds the loop for tests. A receive
+    timeout is a quiet room, not a failure; a malformed frame is skipped rather
+    than dropping membership, since one bad publisher must not take the spoke off
+    the channel.
+    """
+    seen = 0
+    while max_messages is None or seen < max_messages:
+        try:
+            message = await SlimClient.receive_message(session, timeout_s=receive_timeout_s)
+        except SlimReceiveTimeout:
+            continue
+        seen += 1
+        try:
+            result = apply_message(room_dir, message.payload)
+        except Exception:
+            logger.exception("failed to apply an inbound message")
+            continue
+        if result is None:
+            continue
+        counters.record(result)
+        if on_apply is not None:
+            on_apply(result)
+    return counters
+
+
+async def run_spoke(
+    *,
+    api_url: str,
+    node_endpoint: str,
+    room: str,
+    handle: str,
+    workspace: str = DEFAULT_WORKSPACE,
+    counters: SpokeCounters | None = None,
+    on_joined: Callable[[], None] | None = None,
+    on_apply: Callable[[KnowledgeApplyResult], None] | None = None,
+    join_timeout_s: float = DEFAULT_JOIN_TIMEOUT_S,
+    receive_timeout_s: float = DEFAULT_RECEIVE_TIMEOUT_S,
+    max_messages: int | None = None,
+) -> SpokeCounters:
+    """Join ``room`` as a member and apply its ``knowledge`` traffic to this store.
+
+    Writes land in this machine's own ``~/.mycelium/rooms/{room}/``, which is what
+    makes the hub's ``memory set`` show up here.
+    """
+    tally = counters if counters is not None else SpokeCounters()
+    async with joined_member(
+        api_url=api_url,
+        node_endpoint=node_endpoint,
+        room=room,
+        handle=handle,
+        workspace=workspace,
+        join_timeout_s=join_timeout_s,
+    ) as session:
+        if on_joined is not None:
+            on_joined()
+        await receive_and_apply(
+            session,
+            get_room_dir(room),
+            counters=tally,
+            on_apply=on_apply,
+            receive_timeout_s=receive_timeout_s,
+            max_messages=max_messages,
+        )
+    return tally

--- a/mycelium-cli/tests/test_spoke.py
+++ b/mycelium-cli/tests/test_spoke.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for ``mycelium.spoke`` — the thin-spoke member's receive→apply path.
+
+Node-free: the inbound frames are the **frozen contract envelope** the backend
+actually produces (``contracts/slim-l9-wire.json``), so these assert the spoke
+applies real hub traffic rather than a shape invented here. ``run_spoke``'s join
+is exercised against :class:`~tests.conftest.FakeSlimClient` and the httpx fakes.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mycelium import spoke as spoke_module
+from mycelium.filesystem import read_memory, write_memory
+from mycelium.slim import member
+from mycelium.spoke import SpokeCounters, apply_message, knowledge_write_of, run_spoke
+from tests.conftest import FakeHTTPX, FakeSlimClient
+
+_CONTRACT_PATH = Path(__file__).resolve().parent.parent.parent / "contracts" / "slim-l9-wire.json"
+
+
+def _contract_knowledge() -> dict[str, Any]:
+    with _CONTRACT_PATH.open() as fh:
+        return json.load(fh)["knowledge"]
+
+
+def _frame(*, version: int | None = None, content: str | None = None) -> bytes:
+    """The wire bytes of the contract's ``knowledge:distillation`` envelope."""
+    envelope = copy.deepcopy(_contract_knowledge()["expected_envelope"])
+    if version is not None:
+        envelope["payload"]["data"]["version"] = version
+    if content is not None:
+        envelope["payload"]["data"]["content"] = content
+    return json.dumps({"content": "", "l9": envelope}).encode()
+
+
+# ── decode ────────────────────────────────────────────────────────────────────
+
+
+def test_knowledge_write_of_reads_the_contract_write() -> None:
+    write = knowledge_write_of(json.loads(_frame().decode()))
+
+    expected = _contract_knowledge()["write"]
+    assert write is not None
+    assert write["key"] == expected["key"]
+    assert write["content"] == expected["content"]
+    assert write["version"] == expected["version"]
+    assert write["created_by"] == expected["created_by"]
+    assert write["updated_by"] == expected["updated_by"]
+
+
+def test_non_knowledge_message_carries_no_write() -> None:
+    exchange = {"content": "hello", "l9": {"header": {"kind": "exchange"}}}
+    assert knowledge_write_of(exchange) is None
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {},
+        {"key": "a.md"},  # no content
+        {"content": "body"},  # no key
+        {"key": "", "content": "body"},  # empty key
+        {"key": "a.md", "content": 42},  # content not markdown
+    ],
+)
+def test_malformed_knowledge_payload_carries_no_write(data: dict[str, Any]) -> None:
+    content = {"l9": {"header": {"kind": "knowledge"}, "payload": {"data": data}}}
+    assert knowledge_write_of(content) is None
+
+
+def test_unparseable_frame_is_skipped(tmp_path: Path) -> None:
+    assert apply_message(tmp_path, b"not json at all") is None
+
+
+# ── apply ─────────────────────────────────────────────────────────────────────
+
+
+def test_applies_an_inbound_write_to_the_local_store(tmp_path: Path) -> None:
+    result = apply_message(tmp_path, _frame())
+
+    assert result is not None
+    assert result.applied and not result.conflict
+
+    expected = _contract_knowledge()["write"]
+    stored = read_memory(tmp_path, expected["key"])
+    assert stored is not None
+    meta, body = stored
+    assert body == expected["content"].strip()
+    assert meta["version"] == expected["version"]
+
+
+def test_redelivery_of_the_same_version_is_a_no_op(tmp_path: Path) -> None:
+    first = apply_message(tmp_path, _frame())
+    second = apply_message(tmp_path, _frame())
+
+    assert first is not None and first.applied
+    assert second is not None
+    assert not second.applied
+    assert not second.conflict
+    assert "idempotent" in second.reason
+
+    counters = SpokeCounters()
+    counters.record(first)
+    counters.record(second)
+    assert (counters.applied, counters.conflicts, counters.ignored) == (1, 0, 1)
+
+
+def test_stale_base_write_is_a_conflict_not_a_clobber(tmp_path: Path) -> None:
+    key = _contract_knowledge()["write"]["key"]
+    write_memory(
+        tmp_path,
+        key,
+        "the newer local content\n",
+        created_by="local",
+        updated_by="local",
+        version=5,
+    )
+
+    result = apply_message(tmp_path, _frame(version=2, content="stale incoming\n"))
+
+    assert result is not None
+    assert result.conflict
+    assert not result.applied
+    assert result.current is not None
+    assert result.current["version"] == 5
+
+    stored = read_memory(tmp_path, key)
+    assert stored is not None
+    _meta, body = stored
+    assert body == "the newer local content"  # local content survived
+
+    counters = SpokeCounters()
+    counters.record(result)
+    assert (counters.applied, counters.conflicts) == (0, 1)
+
+
+def test_a_newer_version_supersedes_the_local_copy(tmp_path: Path) -> None:
+    key = _contract_knowledge()["write"]["key"]
+    write_memory(tmp_path, key, "old\n", created_by="local", updated_by="local", version=1)
+
+    result = apply_message(tmp_path, _frame(version=9, content="fresher from the hub\n"))
+
+    assert result is not None
+    assert result.applied
+    stored = read_memory(tmp_path, key)
+    assert stored is not None
+    _meta, body = stored
+    assert body == "fresher from the hub"
+
+
+# ── join + receive ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _patch_slim_client(monkeypatch: pytest.MonkeyPatch, fake_slim_client: type[FakeSlimClient]):
+    monkeypatch.setattr(member, "SlimClient", fake_slim_client)
+    monkeypatch.setattr(member, "node_reachable", lambda _endpoint: True)
+    monkeypatch.setattr(spoke_module, "SlimClient", fake_slim_client)
+    return fake_slim_client
+
+
+async def test_run_spoke_joins_as_a_member_and_applies_inbound_writes(
+    fake_httpx: FakeHTTPX, isolated_home: Path
+) -> None:
+    FakeSlimClient.inbox = [_frame()]
+
+    counters = await run_spoke(
+        api_url="http://hub:8000",
+        node_endpoint="http://hub:46357",
+        room="acme",
+        handle="spoke",
+        max_messages=1,
+    )
+
+    # Membership came from asking the hub's moderator to invite us — the member
+    # path. A spoke never creates a group of its own.
+    assert fake_httpx.calls == [
+        ("POST", "http://hub:8000/api/rooms/acme/sessions", {"agent_handle": "spoke"})
+    ]
+    assert FakeSlimClient.published == []
+    assert (counters.applied, counters.conflicts) == (1, 0)
+
+    expected = _contract_knowledge()["write"]
+    stored = read_memory(isolated_home / ".mycelium" / "rooms" / "acme", expected["key"])
+    assert stored is not None
+    _meta, body = stored
+    assert body == expected["content"].strip()
+
+
+async def test_run_spoke_ignores_traffic_that_carries_no_write(
+    fake_httpx: FakeHTTPX, isolated_home: Path
+) -> None:
+    FakeSlimClient.inbox = [
+        json.dumps({"content": "just chatter", "l9": {"header": {"kind": "exchange"}}}).encode(),
+        b"{ not json",
+    ]
+
+    counters = await run_spoke(
+        api_url="http://hub:8000",
+        node_endpoint="http://hub:46357",
+        room="acme",
+        handle="spoke",
+        max_messages=2,
+    )
+
+    assert (counters.applied, counters.conflicts, counters.ignored) == (0, 0, 0)
+
+
+async def test_run_spoke_reports_the_join_before_receiving(
+    fake_httpx: FakeHTTPX, isolated_home: Path
+) -> None:
+    events: list[str] = []
+    FakeSlimClient.inbox = [_frame()]
+
+    await run_spoke(
+        api_url="http://hub:8000",
+        node_endpoint="http://hub:46357",
+        room="acme",
+        handle="spoke",
+        on_joined=lambda: events.append("joined"),
+        on_apply=lambda result: events.append(f"applied:{result.key}"),
+        max_messages=1,
+    )
+
+    assert events == ["joined", f"applied:{_contract_knowledge()['write']['key']}"]

--- a/mycelium-cli/tests/test_spoke_roundtrip.py
+++ b/mycelium-cli/tests/test_spoke_roundtrip.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Live-node slice: a spoke joins as a member and applies a real broadcast.
+
+This is the cross-machine half of the memory-sync loop over real transport. The
+node-free tests in ``test_spoke.py`` prove the decode→apply semantics; this one
+proves a spoke actually receives traffic it did not emit. Two independent backends
+could never do this: each moderates its own MLS group, so nothing crosses. Here one
+client moderates and the *other* joins as a member, which is the supported topology.
+
+Needs a running ``slim`` node; skipped without one. Point at a node with
+``MYCELIUM_SLIM_ENDPOINT`` (default ``http://127.0.0.1:46357``), e.g. via
+``mycelium hub host``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("slim_bindings")
+
+from mycelium.filesystem import read_memory, write_memory
+from mycelium.slim.client import SlimClient
+from mycelium.slim.naming import (
+    DEFAULT_NODE_ENDPOINT,
+    DEFAULT_WORKSPACE,
+    SlimIdentity,
+    node_reachable,
+    to_channel_name,
+    to_slim_name,
+)
+from mycelium.spoke import SpokeCounters, receive_and_apply
+
+_ENDPOINT = os.getenv("MYCELIUM_SLIM_ENDPOINT", DEFAULT_NODE_ENDPOINT)
+_ROOM = "spoke-live"
+_HUB = "backend"
+_SPOKE = "spoke"
+
+pytestmark = pytest.mark.skipif(
+    not node_reachable(_ENDPOINT),
+    reason=f"no reachable SLIM node at {_ENDPOINT} (set MYCELIUM_SLIM_ENDPOINT or run `mycelium hub host`)",
+)
+
+_CONTRACT_PATH = Path(__file__).resolve().parent.parent.parent / "contracts" / "slim-l9-wire.json"
+
+
+def _knowledge_frame(*, version: int, content: str) -> tuple[bytes, str]:
+    """The wire bytes of a ``knowledge`` broadcast, and the key it writes."""
+    with _CONTRACT_PATH.open() as fh:
+        envelope: dict[str, Any] = json.load(fh)["knowledge"]["expected_envelope"]
+    envelope["payload"]["data"]["version"] = version
+    envelope["payload"]["data"]["content"] = content
+    return json.dumps({"content": "", "l9": envelope}).encode(), envelope["payload"]["data"]["key"]
+
+
+async def _hub_and_spoke(
+    room_dir: Path, frames: list[bytes], *, counters: SpokeCounters
+) -> SpokeCounters:
+    """Moderate a channel, invite a spoke, broadcast ``frames``, let the spoke apply."""
+    hub = await SlimClient(SlimIdentity(DEFAULT_WORKSPACE, _ROOM, _HUB)).connect(_ENDPOINT)
+    spoke = await SlimClient(SlimIdentity(DEFAULT_WORKSPACE, _ROOM, _SPOKE)).connect(_ENDPOINT)
+    try:
+        session = await hub.create_group(to_channel_name(DEFAULT_WORKSPACE, _ROOM))
+
+        async def spoke_side() -> SpokeCounters:
+            joined = await spoke.listen_for_session()
+            return await receive_and_apply(
+                joined,
+                room_dir,
+                counters=counters,
+                max_messages=len(frames),
+                receive_timeout_s=20.0,
+            )
+
+        spoke_task = asyncio.create_task(spoke_side())
+        try:
+            await hub.invite(session, to_slim_name(DEFAULT_WORKSPACE, _ROOM, _SPOKE))
+            for frame in frames:
+                await SlimClient.publish(session, frame)
+            return await asyncio.wait_for(spoke_task, timeout=60.0)
+        finally:
+            spoke_task.cancel()
+    finally:
+        await spoke.close()
+        await hub.close()
+
+
+async def test_spoke_applies_a_hub_broadcast_it_did_not_emit(tmp_path: Path) -> None:
+    """A hub `memory set` lands in the spoke's own store, over a real channel."""
+    frame, key = _knowledge_frame(version=3, content="decided: canary at 10%\n")
+    counters = SpokeCounters()
+
+    await _hub_and_spoke(tmp_path, [frame], counters=counters)
+
+    assert (counters.applied, counters.conflicts) == (1, 0)
+    stored = read_memory(tmp_path, key)
+    assert stored is not None
+    meta, body = stored
+    assert body == "decided: canary at 10%"
+    assert meta["version"] == 3
+
+
+async def test_redelivery_over_the_wire_is_idempotent(tmp_path: Path) -> None:
+    """The same version twice applies once — a replay is a silent no-op."""
+    frame, key = _knowledge_frame(version=3, content="decided: canary at 10%\n")
+    counters = SpokeCounters()
+
+    await _hub_and_spoke(tmp_path, [frame, frame], counters=counters)
+
+    assert counters.applied == 1
+    assert counters.conflicts == 0
+    assert counters.ignored == 1
+    stored = read_memory(tmp_path, key)
+    assert stored is not None
+    assert stored[0]["version"] == 3
+
+
+async def test_stale_base_over_the_wire_is_a_conflict(tmp_path: Path) -> None:
+    """A write behind the local version is recorded, not applied over the top."""
+    _frame_for_key, key = _knowledge_frame(version=1, content="unused\n")
+    write_memory(tmp_path, key, "newer local\n", created_by="local", updated_by="local", version=7)
+
+    stale, _key = _knowledge_frame(version=2, content="stale from the hub\n")
+    counters = SpokeCounters()
+
+    await _hub_and_spoke(tmp_path, [stale], counters=counters)
+
+    assert (counters.applied, counters.conflicts) == (0, 1)
+    stored = read_memory(tmp_path, key)
+    assert stored is not None
+    assert stored[1] == "newer local"


### PR DESCRIPTION
## Summary

The knowledge emit→apply loop had both halves but no middle. `memory set` on a hub
broadcasts a `knowledge:extraction` envelope (#544/#548) and an applier for inbound
`knowledge` exists (#549/#550) — but nothing ever *received* an envelope it hadn't
emitted itself, so the loop never crossed machines.

Standing up a second backend doesn't close it: each becomes its own moderator with its
own MLS session, so nothing crosses — not even a plain broadcast. One-moderator-per-room
is the intended topology, so the fix is a **member**.

`mycelium join <room>` is that member. It runs the same handshake the `l9 send` / `slim
send` plumbing already used — connect, ask the hub's moderator to invite us, wait to be
admitted — but holds the session open instead of publishing once, and applies every
inbound `knowledge` write into its own local store. A `memory set` on the hub now lands
on the spoke.

Verified against a live SLIM node: a moderator broadcasts, an independent member client
receives and applies it.

## Changes

- **`mycelium/spoke.py`** (new) — the receiver runtime: decode inbound frames, filter to
  `knowledge`, apply the carried write to this machine's `.mycelium/`, tracking
  `applied` / `conflicts` / `ignored` counters that mirror the backend persister's.
- **`mycelium/commands/join.py`** (new) — `mycelium join [--room R] [--handle H]`, a
  resident foreground member; per-write output, counters on exit, Ctrl-C to stop.
  Registered top-level beside `await` / `respond` / `connect`.
- **`slim/member.py`** — the join handshake moves out of `publish_once` into a
  `joined_member` context manager, so the publish-once and long-lived cases share one
  path. `publish_once` keeps its exact behavior.
- The spoke borrows only the *apply* half of the persister. The transcript, delivery
  cursors, in-process bus and episode hooks are moderator-authoritative and have no
  meaning off the hub; the version check already makes a replay a no-op, so no
  message-level dedup is needed.
- **Docs** — a "Receiving memory on a spoke" section in `docs/cross-machine.md`
  (the page previously claimed the plan "syncs to every machine", which wasn't yet
  true); regenerated `reference.html`; `generate_docs.py` imports the new command so
  its `@doc_ref` registers; CLAUDE.md gains the one-moderator/spokes-are-members note.
- **Contract** — `contracts/slim-l9-wire.json`'s comments pointed at
  `daemon/connector.py`, removed long ago with the daemon; repointed at the module that
  now parses and applies that envelope. No frozen values changed.

### Behavior and scope

Semantics carry over unchanged onto real transport: last-write-wins by version, a
re-delivered version is a silent no-op, and a stale-base write is recorded as a conflict
rather than clobbering newer local content.

Membership is gated by the room's shared-secret PSK, exactly as every other member is — a
spoke is no more authenticated than a connector, and per-agent identity (JWT/SPIRE, #446)
remains a prerequisite for anything hosted or multi-user. This PR doesn't claim to solve
that.

Two deliberate limits: direction is **hub → spoke only** (a spoke's own writes reaching
the hub is the follow-up the issue scopes out), and received memories are on disk but not
searchable until `mycelium sync`, since the CLI has no local embedding index. Moderator
federation / multi-master stays out of scope.

## Testing

- `mycelium-cli/tests/test_spoke.py` (new, node-free) — 15 tests driving the **frozen
  contract envelope** the backend actually produces, so these assert against real hub
  traffic rather than a shape invented in the test: decode, apply, idempotent
  re-delivery, stale-base conflict, newer-version supersede, malformed/non-knowledge
  frames ignored, and the join path asserting membership came from asking the moderator
  to invite (never creating a group).
- `mycelium-cli/tests/test_spoke_roundtrip.py` (new, live-node) — one client moderates,
  another **joins as a member**, and the spoke applies a broadcast it did not emit; plus
  idempotent replay and stale-base conflict over the wire. Ran green against a real SLIM
  node. This is the first CLI path that needs a node, so CI's `integration-slim` job now
  runs it (the job carried a comment saying the CLI had no such slices — no longer true).

- [x] Unit tests pass — 313 passed (CLI), 434 passed / 2 skipped (backend)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)

## Related Issues

Closes #551

Related: #544 / #548 (emit), #549 / #550 (apply), #543 (conflict/version model),
#446 (spoke identity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01As6dWbqUhAArZ83G5aSdjq

---
_Generated by [Claude Code](https://claude.ai/code/session_01As6dWbqUhAArZ83G5aSdjq)_