### PR TITLE
Add memory set --file to read the value from a file

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -416,9 +416,9 @@ cursor-agent login            # one-time, interactive
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="cmd">mycelium memory set</span> <span class="arg">&lt;key&gt;</span> <span class="arg">&lt;value&gt;</span> [<span class="flag">--handle</span> <span class="arg">&lt;handle&gt;</span>]</code>
+          <code><span class="cmd">mycelium memory set</span> <span class="arg">&lt;key&gt;</span> [<span class="arg">&lt;value&gt;</span>] [<span class="flag">--file</span> <span class="arg">&lt;path&gt;</span>] [<span class="flag">--handle</span> <span class="arg">&lt;handle&gt;</span>]</code>
         </div>
-        <div class="cmd-ref-body">Write a memory (upsert). Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Always upserts; the backend handles versioning.</div>
+        <div class="cmd-ref-body">Write a memory (upsert). The value comes from the positional argument or <code>--file</code> (<code>-</code> reads stdin) — one or the other, not both. Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Always upserts; the backend handles versioning.</div>
       </div>
 
       <div class="cmd-ref">

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -9,7 +9,9 @@ Search and subscribe use the backend API (local JSONL index).
 """
 
 import json
+import sys
 from datetime import UTC, datetime
+from pathlib import Path
 
 import typer
 from pydantic import ValidationError
@@ -76,6 +78,35 @@ def _write_local_copy(room_name: str, mem) -> None:
     )
 
 
+def _resolve_value(value: str | None, file: str | None) -> str:
+    """Resolve the memory value from the positional arg or a file.
+
+    ``--file -`` reads stdin. The file's text is used verbatim; the two sources
+    are mutually exclusive and exactly one must be given.
+    """
+    if value is not None and file is not None:
+        console.print("[red]Error:[/red] pass either a value or --file, not both.")
+        raise typer.Exit(1)
+
+    if file is not None:
+        if file == "-":
+            return sys.stdin.read()
+        try:
+            return Path(file).read_text(encoding="utf-8")
+        except OSError as exc:
+            console.print(f"[red]Error:[/red] cannot read {file}: {exc.strerror or exc}")
+            raise typer.Exit(1) from exc
+        except UnicodeDecodeError as exc:
+            console.print(f"[red]Error:[/red] {file} is not valid UTF-8 text.")
+            raise typer.Exit(1) from exc
+
+    if value is None:
+        console.print("[red]Error:[/red] provide a value or --file <path> (use '-' for stdin).")
+        raise typer.Exit(1)
+
+    return value
+
+
 def _get_active_room(room: str | None) -> str:
     """Get room name from arg or active config."""
     if room:
@@ -91,14 +122,17 @@ def _get_active_room(room: str | None) -> str:
 
 
 @doc_ref(
-    usage="mycelium memory set <key> <value> [--handle <handle>]",
-    desc="Write a memory (upsert). Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Always upserts; the backend handles versioning.",
+    usage="mycelium memory set <key> [<value>] [--file <path>] [--handle <handle>]",
+    desc="Write a memory (upsert). The value comes from the positional argument or <code>--file</code> (<code>-</code> reads stdin) — one or the other, not both. Structured category keys (<code>work/</code>, <code>decisions/</code>, <code>status/</code>, <code>context/</code>) are auto-validated. Always upserts; the backend handles versioning.",
     group="memory",
 )
 @app.command(name="set")
 def memory_set(
     key: str = typer.Argument(..., help="Memory key (e.g. 'status/deploy', 'project/config')"),
-    value: str = typer.Argument(..., help="Memory value (string or JSON)"),
+    value: str | None = typer.Argument(None, help="Memory value (string or JSON)"),
+    file: str | None = typer.Option(
+        None, "--file", "-f", help="Read the value from a file ('-' for stdin)"
+    ),
     room: str | None = typer.Option(
         None, "--room", "-r", help="Room name (defaults to active room)"
     ),
@@ -107,6 +141,9 @@ def memory_set(
     tags: str | None = typer.Option(None, "--tags", "-t", help="Comma-separated tags"),
 ) -> None:
     """Write a memory to a room's persistent namespace (upsert).
+
+    The value comes from the positional argument or --file; they are mutually
+    exclusive and one is required.
 
     Keys with a known category prefix (work/, decisions/, context/, status/) are
     validated for slug format. Other keys pass through freely.
@@ -117,12 +154,15 @@ def memory_set(
         mycelium memory set status/deploy ACTIVE
         mycelium memory set decisions/db-choice "Chose AgensGraph for graph+SQL+vector"
         mycelium memory set work/api-server "Built 12 endpoints with auth"
+        mycelium memory set reference/spec --file spec.md
+        cat notes.md | mycelium memory set context/notes -f -
     """
     from mycelium_backend_client.api.memory import (
         create_memories_api_rooms_room_name_memory_post as create_api,
     )
     from mycelium_backend_client.models import MemoryBatchCreate, MemoryCreate
 
+    value = _resolve_value(value, file)
     room_name = _get_active_room(room)
 
     # Validate structured keys when category prefix is recognized

--- a/mycelium-cli/tests/test_memory_commands.py
+++ b/mycelium-cli/tests/test_memory_commands.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Unit tests for ``mycelium memory`` (get / ls / search).
+"""Unit tests for ``mycelium memory`` (set / get / ls / search).
 
 Node-free: ``get`` and ``ls`` read the local markdown under a temp home
-(``isolated_home``); ``search`` goes through the backend, whose API ``.sync`` is
-stubbed. No live stack.
+(``isolated_home``); ``set`` and ``search`` go through the backend, whose API
+``.sync`` is stubbed. No live stack.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -26,6 +28,99 @@ def _home(isolated_home) -> None:
 
 def _seed(room: str, key: str, value: str) -> None:
     write_memory(get_room_dir(room), key, value, created_by="tester")
+
+
+def _stub_create(monkeypatch: pytest.MonkeyPatch) -> list:
+    """Stub the create-memories API, returning the batches it was handed."""
+    import datetime
+    import uuid
+
+    from mycelium_backend_client.models import MemoryRead
+
+    class _Client:
+        def __enter__(self):
+            return object()
+
+        def __exit__(self, *_a):
+            return False
+
+    monkeypatch.setattr(memory_cmd, "_get_client", lambda: _Client())
+
+    captured: list = []
+    stamp = datetime.datetime(2026, 6, 1)  # noqa: DTZ001
+
+    def _sync(*, room_name: str, client, body):  # noqa: ANN001, ARG001
+        captured.append(body)
+        item = body.items[0]
+        return [
+            MemoryRead(
+                id=uuid.uuid4(),
+                key=item.key,
+                value=item.value,
+                version=1,
+                created_by=item.created_by,
+                room_name=room_name,
+                created_at=stamp,
+                updated_at=stamp,
+            )
+        ]
+
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.memory.create_memories_api_rooms_room_name_memory_post.sync",
+        _sync,
+    )
+    return captured
+
+
+def test_memory_set_file_value_round_trips(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    captured = _stub_create(monkeypatch)
+    spec = tmp_path / "spec.md"
+    spec.write_text('# Spec\n\nLine "two" with quotes & newlines.\n', encoding="utf-8")
+
+    result = runner.invoke(
+        memory_cmd.app, ["set", "reference/spec", "--file", str(spec), "--room", "demo"]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured[0].items[0].value == spec.read_text(encoding="utf-8")
+
+
+def test_memory_set_file_dash_reads_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _stub_create(monkeypatch)
+
+    result = runner.invoke(
+        memory_cmd.app,
+        ["set", "context/notes", "-f", "-", "--room", "demo"],
+        input="piped body\n",
+    )
+    assert result.exit_code == 0, result.output
+    # context/ is a structured category, so the piped text lands in the value's text field
+    assert captured[0].items[0].value["text"] == "piped body\n"
+
+
+def test_memory_set_rejects_both_value_and_file(tmp_path: Path) -> None:
+    spec = tmp_path / "spec.md"
+    spec.write_text("body", encoding="utf-8")
+
+    result = runner.invoke(
+        memory_cmd.app, ["set", "reference/spec", "inline", "--file", str(spec), "--room", "demo"]
+    )
+    assert result.exit_code == 1
+    assert "not both" in result.output
+
+
+def test_memory_set_rejects_neither_value_nor_file() -> None:
+    result = runner.invoke(memory_cmd.app, ["set", "reference/spec", "--room", "demo"])
+    assert result.exit_code == 1
+    assert "--file" in result.output
+
+
+def test_memory_set_missing_file_errors(tmp_path: Path) -> None:
+    result = runner.invoke(
+        memory_cmd.app,
+        ["set", "reference/spec", "--file", str(tmp_path / "nope.md"), "--room", "demo"],
+    )
+    assert result.exit_code == 1
+    assert "cannot read" in result.output
 
 
 def test_memory_get_prints_key_and_content() -> None:


### PR DESCRIPTION
## Summary

`mycelium memory set` only accepted the value as an inline positional string, so the only way to load a file's contents into a memory was shell substitution:

```bash
mycelium memory set reference/spec "$(cat spec.md)" --room r
```

which runs into argv length limits and quoting hazards for anything non-trivial.

This adds a generic `--file` / `-f` option that reads the value from any file — no markdown parsing, no transformation:

```bash
mycelium memory set reference/spec --file spec.md --room r
mycelium memory set context/config -f ./config.json --room r
cat notes.md | mycelium memory set context/notes -f -
```

## Changes

- `memory set` takes `--file/-f <path>`; the positional `value` is now optional. The two are mutually exclusive and one is required — both or neither exits 1 with a clear message.
- `--file -` reads stdin, so a memory can be piped in.
- File text is read verbatim via `Path(file).read_text(encoding="utf-8")`. Unreadable or non-UTF-8 files exit 1 with the reason rather than a traceback.
- Everything downstream is untouched: the resolved string feeds the existing `MemoryCreate` batch path, so key validation, structured-category handling, tags, embedding, and upsert/versioning all behave exactly as before.
- Regenerated `docs/reference.html` from the updated `@doc_ref` usage/description.

## Testing

Five new unit tests in `mycelium-cli/tests/test_memory_commands.py` (node-free, backend `.sync` stubbed): file value round-trips through the batch unchanged, `-f -` reads stdin, value+file errors, neither errors, and a missing file errors.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 303 passed
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)

## Related Issues

Closes #554

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLr9MquX2wQAAP3m1QvcS5)_