### PR TITLE
docs: correct 'sharing is git' — sharing is the live channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ backend is each room's **moderator**; agents (and the human, by proxy) are membe
 `.mycelium/rooms/{room}/{key}.md`. Search is a **local embedding index** (fastembed
 ONNX, `BAAI/bge-small-en-v1.5`, 384-dim, no external service) persisted as JSONL
 per room. `memory set` writes the markdown and updates the index; direct file
-writes work too; run `mycelium reindex` to resync. Sharing is git.
+writes work too; run `mycelium reindex` to resync. Git can version or back up the
+files, but it is **not** the sharing path — see **Sharing is the live channel** below.
 
 **L9 rides SLIM.** Coordination messages carry additive IOC **L9** JSON envelopes:
 `exchange` (ticks/replies), `commit:converged|resolved|rejected`, `knowledge`.
@@ -156,8 +157,11 @@ is no litellm dependency.
   `members()` is the union of live SLIM members and lease holders. This is why
   turn-based agents never miss a tick. The **durable inbox** (`persister.py`)
   re-serves missed point-to-point messages on rejoin (SLIM has no offline replay).
-- **Git for sharing.** Rooms can be shared via git push/pull; cross-machine is the
-  same channel over a shared SLIM node (`mycelium hub host` / `mycelium connect`).
+- **Sharing is the live channel.** Cross-machine sharing is the same SLIM channel over a
+  shared node (`mycelium hub host` / `mycelium connect`), plus
+  `mycelium room clone --from <api-url>` for a point-in-time HTTP snapshot. Git can back
+  up or version the `.mycelium/` files but is **not** a sharing mechanism — no room flow
+  pushes or pulls over git.
 - **No Ensue references in code.** We took inspiration from their API design but the
   implementation is independent.
 - **L9 envelopes are additive, never required of agents.** Ticks are `exchange`,


### PR DESCRIPTION
The codebase has no git-based room sharing flow. Cross-machine sharing runs over the SLIM channel (`mycelium hub host` / `mycelium connect`) plus `mycelium room clone --from <api-url>` (an HTTP snapshot). Git only versions/backs up the `.mycelium/` files — it is not a sharing mechanism.

Fixes two stale CLAUDE.md claims:
- `Sharing is git.` (in **State is files**)
- the `Git for sharing` key-design-decision bullet → **Sharing is the live channel**

Rescued from #553 (which is being closed in favor of the CLI-thin-client spoke model); this doc correction is independently correct and worth keeping.