### PR TITLE
Spoke = thin client: route memory reads through the hub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,12 +67,14 @@ backend is each room's **moderator**; agents (and the human, by proxy) are membe
 `app/services/room_channels.py` owns the moderator/channel lifecycle;
 `app/services/slim_client.py` wraps the `slim-bindings` client.
 
-**State is files.** Memories are markdown with YAML frontmatter at
+**State is files on the hub.** Memories are markdown with YAML frontmatter at
 `.mycelium/rooms/{room}/{key}.md`. Search is a **local embedding index** (fastembed
 ONNX, `BAAI/bge-small-en-v1.5`, 384-dim, no external service) persisted as JSONL
-per room. `memory set` writes the markdown and updates the index; direct file
-writes work too; run `mycelium reindex` to resync. Git can version or back up the
-files, but it is **not** the sharing path — see **Sharing is the live channel** below.
+per room. `memory set` writes the markdown and updates the index. This is the
+**hub's internal storage**, not a client surface: every other machine is a thin
+client that reads and writes it over HTTP (see **The spoke is a thin client**).
+Git can version or back up the files, but it is **not** the sharing path — see
+**Sharing is the live channel** below.
 
 **L9 rides SLIM.** Coordination messages carry additive IOC **L9** JSON envelopes:
 `exchange` (ticks/replies), `commit:converged|resolved|rejected`, `knowledge`.
@@ -130,11 +132,18 @@ is no litellm dependency.
   own last line, never the standing offer (no phantom convergence); numeric offers
   snap to the nearest real grid point or refuse, never to a fabricated value
   (`offer_snap.py`).
-- **Rooms are folders.** `.mycelium/rooms/{name}/` with standard subdirs:
+- **Rooms are folders on the hub.** `.mycelium/rooms/{name}/` with standard subdirs:
   `decisions/`, `failed/`, `status/`, `context/`, `work/`, `procedures/`, `log/`,
   `plan/`. The `plan/` namespace holds the room's plan: `plan/title.md` is the
   room's display title (italic hero in the UI); other `plan/{slug}.md` files carry
-  prose + `- [ ]` checklist tasks surfaced to every agent.
+  prose + `- [ ]` checklist tasks surfaced to every agent. Direct file writes still
+  work — that's a hub-operator escape hatch (run `mycelium memory reindex` after),
+  not the client model.
+- **The spoke is a thin client.** Any non-hub machine keeps **no local `.mycelium/`
+  replica**; there is one store, the hub's. `memory get`/`ls`/`search` and the
+  category views all resolve against the backend memory API, so a spoke with no
+  files still reads the room — and an unreachable hub is reported plainly rather
+  than silently answered from something stale (`commands/memory.py:_hub_session`).
 - **Rooms are always persistent.** Rooms are persistent namespaces for memory and
   coordination; a negotiation within a room is an ephemeral, recorded episode.
 - **The CLI skill is a protocol.** Post a position → await → respond → consensus →

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ mycelium plan tasks   # the - [ ] checklist the team now executes against
 
 **1. Alignment.** When agents need to agree, one participant summons the **aligner**, a first-party mediator that runs a real NEGMAS Stacked Alternating Offers negotiation. It discovers the issues from the agents' opening positions, brokers each round, addresses one agent at a time, interprets each reply, and stops the instant the agents agree. Every agent has a voice, and the result is one shared answer, not parallel outputs a human has to reconcile. From that consensus Mycelium compiles a **shared plan**: a `- [ ]` checklist at `plan/tasks.md` with `@handle` owners the whole team executes against. The arc is one line: summon → negotiate → **plan** → work. The negotiation decides *what*; the plan is *how the team carries it out*.
 
-**2. Room Memory.** Rooms are folders. Memories are markdown files at `~/.mycelium/rooms/{room}/{namespace}/{key}.md`. Any agent with file I/O can read and write room memory directly. The CLI is sugar. Memories accumulate across agents and turns, and are searchable by meaning via a local embedding index, with no external service and no database.
+**2. Room Memory.** A room's memory is one store, held by the hub. Any agent reads and writes it with `mycelium memory set` / `get` / `ls` / `search` — from any machine, with nothing to sync and no copy to drift. Memories accumulate across agents and turns, and are searchable by meaning via an embedding index that runs on the hub, with no external service and no database.
 
-**3. Peer Collaboration Environment.** Any agent joining a room reads from `~/.mycelium/rooms/{room}/` and instantly inherits everything the swarm has learned: decisions made, what failed, open questions, the room's shared plan. No repeated context-setting. Intelligence compounds instead of resetting.
+**3. Peer Collaboration Environment.** Any agent joining a room reads that memory and instantly inherits everything the swarm has learned: decisions made, what failed, open questions, the room's shared plan. No repeated context-setting. Intelligence compounds instead of resetting.
 
 ## Quick Start
 
@@ -140,7 +140,7 @@ mycelium plan tasks   # the shared - [ ] checklist the team executes against
 
 ## Architecture
 
-**Memories live on the filesystem.** Rooms are folders, memories are markdown files with YAML frontmatter at `~/.mycelium/rooms/{room}/{key}.md`. This is the source of truth. Direct writes (cat, editor, agent file I/O) always work; run `mycelium memory reindex` to refresh the search index after bypassing the CLI. Search runs against a **local embedding index** (~384-dim, on-device), with no external vector service and no database.
+**The hub holds the memory; everything else is a thin client.** On the hub, rooms are folders and memories are markdown files with YAML frontmatter at `~/.mycelium/rooms/{room}/{key}.md` — the source of truth, with search running against a **local embedding index** (~384-dim, on-device), no external vector service and no database. Every other machine keeps no replica: `mycelium memory` resolves against the hub over HTTP, so a read always reflects what the room actually says. (Operating the hub, direct file writes still work; run `mycelium memory reindex` to refresh the index after bypassing the CLI.)
 
 **One SLIM node coordinates the room.** Agents coordinate over an [AGNTCY SLIM](https://github.com/agntcy/slim) group channel per room: MLS-encrypted, shared-secret PSK auth. An always-on thin FastAPI backend is each room's **moderator**; the agents (and you, by proxy) are members. There's no database, no message broker, no separate realtime service.
 

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -69,14 +69,14 @@
     <section class="doc-section" id="rooms">
       <h1>Rooms</h1>
       <p>A room is a persistent coordination namespace. All memories, messages, and <a href="#episodes">episodes</a> are scoped to a room. A room IS its namespace; there&#x27;s no separation between the two.</p>
-      <p>Under the hood a room is a <strong>SLIM group channel</strong>: agents (and the human, by proxy) are members of one MLS-encrypted channel per room, and the backend is its always-on moderator. There&#x27;s no database: a room&#x27;s durable state is the files on disk, and sharing is git.</p>
-      <h2 id="rooms-rooms-are-directories">Rooms are Directories</h2>
-      <p>Each room maps to a directory at <code>~/.mycelium/rooms/{room_name}/</code>. Standard subdirectories are created automatically:</p>
+      <p>Under the hood a room is a <strong>SLIM group channel</strong>: agents (and the human, by proxy) are members of one MLS-encrypted channel per room, and the backend is its always-on moderator. There&#x27;s no database: a room&#x27;s durable state is files on the hub, which every other machine reads and writes over HTTP.</p>
+      <h2 id="rooms-rooms-are-directories-on-the-hub">Rooms are Directories on the Hub</h2>
+      <p>Each room maps to a directory at <code>~/.mycelium/rooms/{room_name}/</code> <strong>on the hub</strong>. Standard subdirectories are created automatically:</p>
       <pre><code>~/.mycelium/rooms/design-review/
   decisions/   context/   status/    plan/
   work/        procedures/   log/   failed/</code></pre>
       <p>The <code>plan/</code> subdir holds the room&#x27;s <a href="#plan">plan</a>: a free-form set of markdown files plus the <code>- [ ]</code> / <code>- [x]</code> checklist lines those files contain. <code>plan/title.md</code> holds the room&#x27;s display title (shown italicised above room activity in the UI). The rest are arbitrary <code>plan/{slug}.md</code> files containing prose and tasks. See <a href="#plan"><code>mycelium plan</code></a> for read/write commands and <code>plan task add|done|undo</code> for checkbox edits.</p>
-      <p>You can browse, edit, or git-track these directories directly. The backend keeps its local search index in sync via startup scans and file watching.</p>
+      <p>An operator on the hub can browse, edit, or git-track these directories directly; the backend keeps its search index in sync via startup scans and file watching. From anywhere else, reach the same state through <code>mycelium room</code> and <code>mycelium memory</code> — a spoke keeps no copy of it.</p>
       <h2 id="rooms-commands">Commands</h2>
       <pre><code><span class="cmd">mycelium room create</span> design-review     # create a room (its folder + channel)
 <span class="cmd">mycelium room use</span> design-review        # make it the active room
@@ -255,7 +255,7 @@ PATCH .../messages/{id}  {<span class="str">&quot;status&quot;</span>: <span cla
 
     <section class="doc-section" id="memory">
       <h1>Memory</h1>
-      <p>Room memory is markdown files on your filesystem: the shared source of truth, greppable and editable by any agent. A local embedding index over those files lets agents recall by meaning, but it is never an independent source of writes. Whatever stays private to one agent stays in that agent&#x27;s own local files, never indexed.</p>
+      <p>Room memory lives on the hub: one store every agent reads and writes through the CLI, chat, or the UI. An embedding index over that store lets agents recall by meaning, but it is never an independent source of writes. Whatever stays private to one agent stays in that agent&#x27;s own local files, never indexed.</p>
       <h2 id="memory-three-layers-one-source-of-truth">Three layers, one source of truth</h2>
       <p>Mycelium memory has three layers, and only the middle one is &quot;the memory&quot;:</p>
       <ol class="steps">
@@ -263,14 +263,27 @@ PATCH .../messages/{id}  {<span class="str">&quot;status&quot;</span>: <span cla
       </ol>
       <p>or per-agent notes that never leave your machine and are never indexed or shared. Anything only you need lives here.</p>
       <ol class="steps">
-        <li><strong>Room memory</strong> is the shared source of truth: markdown files under</li>
+        <li><strong>Room memory</strong> is the shared source of truth, held by the hub. Every agent</li>
       </ol>
-      <p><code>~/.mycelium/rooms/{room}/</code> that every agent in the room can read, <code>grep</code>, edit, and <code>git</code>-track. If the team should know it, write it here.</p>
+      <p>in the room reads and writes it with <code>mycelium memory</code> — from any machine, with no local copy to keep in step. If the team should know it, write it here.</p>
       <ol class="steps">
-        <li><strong>The search index</strong> is a derived view that you never write to directly. Mycelium</li>
+        <li><strong>The search index</strong> is a derived view that you never write to directly. The</li>
       </ol>
-      <p>embeds each room memory into a local index so agents can recall by meaning. It rebuilds from the files, so the files always win.</p>
-      <p>Rule of thumb: if a teammate should find it, put it in room memory. The index is how they find it; the filesystem is where it lives; your private notes stay yours.</p>
+      <p>hub embeds each room memory so agents can recall by meaning. It rebuilds from the store, so the store always wins.</p>
+      <p>Rule of thumb: if a teammate should find it, put it in room memory. The index is how they find it; the hub is where it lives; your private notes stay yours.</p>
+      <h2 id="memory-one-store-many-clients">One store, many clients</h2>
+      <p>Any machine that is not the hub is a <strong>thin client</strong>. It keeps no copy of room memory: <code>memory get</code>, <code>ls</code>, <code>search</code>, and the category views (<code>memory decisions</code>, <code>status</code>, <code>work</code>, …) all resolve against the hub over HTTP, and <code>memory set</code> writes straight to it.</p>
+      <p>That has two consequences worth knowing:</p>
+      <ul>
+        <li><strong>No drift, no sync ritual.</strong> A read reflects what the hub has right now, so</li>
+      </ul>
+      <p>two machines never disagree about what a key says.</p>
+      <ul>
+        <li><strong>Reads need the hub.</strong> If the hub is down or <code>server.api_url</code> points</li>
+      </ul>
+      <p>somewhere wrong, memory commands say so plainly rather than quietly serving something stale.</p>
+      <pre><code><span class="cmd">mycelium config get</span> server.api_url   # which hub this machine reads from
+<span class="cmd">mycelium status</span>                      # is it up?</code></pre>
       <p>Every write to room memory is embedded (384-dim, local, no API key, no external service) and indexed for semantic search.</p>
       <h2 id="memory-namespace-conventions">Namespace Conventions</h2>
       <p>Keys use <code>/</code> as a separator. The structure is a convention rather than a rule, but it makes <code>memory ls &lt;prefix&gt;/</code> very useful.</p>
@@ -290,24 +303,14 @@ PATCH .../messages/{id}  {<span class="str">&quot;status&quot;</span>: <span cla
         <div class="callout-bar"></div>
         <div class="callout-body"><strong>Always upserts.</strong> Calling <code>memory set</code> on an existing key overwrites it. The version number increments automatically so you can track changes.</div>
       </div>
-      <h2 id="memory-filesystem-native-storage">Filesystem-Native Storage</h2>
-      <p>Every memory is a markdown file at <code>~/.mycelium/rooms/{room}/{key}.md</code> with YAML frontmatter. You can read, edit, or version-control these files directly.</p>
-      <pre><code><span class="comment"># View the raw file</span>
-cat ~/.mycelium/rooms/design-review/decisions/storage.md
-
-<span class="comment"># Edit with any tool</span>
-vim ~/.mycelium/rooms/design-review/decisions/storage.md
-
-<span class="comment"># Git-track a room&#x27;s memory</span>
-cd ~/.mycelium/rooms/design-review &amp;&amp; git init</code></pre>
-      <p>The local search index auto-syncs when:</p>
-      <ul>
-        <li>You use <code>mycelium memory set</code> (immediate dual-write)</li>
-        <li>The backend starts up (incremental scan of changed files)</li>
-        <li>Files change on disk while the backend is running (file watcher)</li>
-      </ul>
-      <p>For bulk edits, you can also trigger a manual reindex:</p>
-      <pre><code><span class="cmd">mycelium memory reindex</span></code></pre>
+      <h2 id="memory-how-the-hub-stores-it">How the hub stores it</h2>
+      <p>The hub keeps each memory as a markdown file with YAML frontmatter at <code>~/.mycelium/rooms/{room}/{key}.md</code>, plus a JSONL embedding index beside it. That is internal storage, not a surface you work in — clients see it through <code>mycelium memory</code>, which is the same on the hub and on every spoke.</p>
+      <p>To see the stored form of a memory from anywhere:</p>
+      <pre><code><span class="cmd">mycelium memory get</span> decisions/storage <span class="flag">--raw</span></code></pre>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Operating the hub.</strong> On the hub itself the files are ordinary files, so an operator can inspect, back up, or bulk-edit them. Edits made outside the CLI bypass the index; run <code>mycelium memory reindex</code> afterwards to resync. The index also rebuilds when the backend starts and follows on-disk changes while it runs.</div>
+      </div>
       <h2 id="memory-semantic-search">Semantic Search</h2>
       <p>Search finds memories by meaning: cosine similarity on all-MiniLM-L6-v2 embeddings (384 dimensions, runs locally, no external service).</p>
       <pre><code><span class="cmd">mycelium memory search</span> <span class="str">&quot;what storage decisions were made&quot;</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -175,7 +175,7 @@
       <pre><code><span class="cmd">mycelium ui open</span>   # starts the frontend if it isn&#x27;t running, then opens it</code></pre>
       <p>The UI is where <strong>you</strong> work: create rooms, add agents, hand them a mission, and watch them coordinate. The CLI is where <strong>your agents</strong> work: they join, negotiate, and write memory on their own. Same rooms, two surfaces, built for each other. The commands shown below are the CLI equivalents of each UI action, so you can script or follow along in a terminal.</p>
       <h2 id="quickstart-create-a-room">Create a room</h2>
-      <p>A room is a persistent namespace for memory, agents, and coordination: a folder under <code>~/.mycelium/rooms/{room}/</code> and a SLIM group channel agents join:</p>
+      <p>A room is a persistent namespace for memory, agents, and coordination: a folder on the hub under <code>~/.mycelium/rooms/{room}/</code> and a SLIM group channel agents join. You reach it the same way from every machine — through the CLI, never by editing files on a spoke:</p>
       <pre><code><span class="comment"># Create a room and make it active</span>
 <span class="cmd">mycelium room create</span> my-project
 <span class="cmd">mycelium room use</span> my-project</code></pre>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -56,7 +56,7 @@ directly to each other.
 
 
 When agents log decisions, failures, and findings to a shared room, any agent that joins
-later can read `~/.mycelium/rooms/{room}/` and the room's shared plan to instantly inherit
+later can read the room's memory and shared plan to instantly inherit
 what the swarm learned. Intelligence doesn't reset; it compounds.
 
 Negative results matter too. An agent that logs `failed/single-writer-lock: serializing
@@ -158,7 +158,9 @@ so you can script or follow along in a terminal.
 ## Create a room
 
 A room is a persistent namespace for memory, agents, and coordination: a folder
-under `~/.mycelium/rooms/{room}/` and a SLIM group channel agents join:
+on the hub under `~/.mycelium/rooms/{room}/` and a SLIM group channel agents join.
+You reach it the same way from every machine — through the CLI, never by
+editing files on a spoke:
 
 ```bash
 # Create a room and make it active
@@ -259,13 +261,13 @@ separation between the two.
 
 Under the hood a room is a **SLIM group channel**: agents (and the human, by
 proxy) are members of one MLS-encrypted channel per room, and the backend is
-its always-on moderator. There's no database: a room's durable state is the
-files on disk, and sharing is git.
+its always-on moderator. There's no database: a room's durable state is files
+on the hub, which every other machine reads and writes over HTTP.
 
-## Rooms are Directories
+## Rooms are Directories on the Hub
 
-Each room maps to a directory at `~/.mycelium/rooms/{room_name}/`. Standard
-subdirectories are created automatically:
+Each room maps to a directory at `~/.mycelium/rooms/{room_name}/` **on the hub**.
+Standard subdirectories are created automatically:
 
 ```
 ~/.mycelium/rooms/design-review/
@@ -280,8 +282,10 @@ activity in the UI). The rest are arbitrary `plan/{slug}.md` files containing
 prose and tasks. See [`mycelium plan`](#plan) for read/write commands and
 `plan task add|done|undo` for checkbox edits.
 
-You can browse, edit, or git-track these directories directly. The backend
-keeps its local search index in sync via startup scans and file watching.
+An operator on the hub can browse, edit, or git-track these directories
+directly; the backend keeps its search index in sync via startup scans and file
+watching. From anywhere else, reach the same state through `mycelium room` and
+`mycelium memory` — a spoke keeps no copy of it.
 
 ## Commands
 
@@ -492,11 +496,10 @@ mycelium engine invoke aligner "converge on the API layer scope" -r sprint-plan
 
 # Memory
 
-Room memory is markdown files on your filesystem: the shared source of truth,
-greppable and editable by any agent. A local embedding index over those files
-lets agents recall by meaning, but it is never an independent source of writes.
-Whatever stays private to one agent stays in that agent's own local files, never
-indexed.
+Room memory lives on the hub: one store every agent reads and writes through the
+CLI, chat, or the UI. An embedding index over that store lets agents recall by
+meaning, but it is never an independent source of writes. Whatever stays private
+to one agent stays in that agent's own local files, never indexed.
 
 ## Three layers, one source of truth
 
@@ -505,16 +508,35 @@ Mycelium memory has three layers, and only the middle one is "the memory":
 1. **Your private context** is yours alone: agent-native files like `SOUL.md`
    or per-agent notes that never leave your machine and are never indexed or
    shared. Anything only you need lives here.
-2. **Room memory** is the shared source of truth: markdown files under
-   `~/.mycelium/rooms/{room}/` that every agent in the room can read, `grep`,
-   edit, and `git`-track. If the team should know it, write it here.
-3. **The search index** is a derived view that you never write to directly. Mycelium
-   embeds each room memory into a local index so agents can recall by meaning.
-   It rebuilds from the files, so the files always win.
+2. **Room memory** is the shared source of truth, held by the hub. Every agent
+   in the room reads and writes it with `mycelium memory` — from any machine,
+   with no local copy to keep in step. If the team should know it, write it here.
+3. **The search index** is a derived view that you never write to directly. The
+   hub embeds each room memory so agents can recall by meaning. It rebuilds from
+   the store, so the store always wins.
 
-Rule of thumb: if a teammate should find it, put it in room memory. The index
-is how they find it; the filesystem is where it lives; your private notes stay
-yours.
+Rule of thumb: if a teammate should find it, put it in room memory. The index is
+how they find it; the hub is where it lives; your private notes stay yours.
+
+## One store, many clients
+
+Any machine that is not the hub is a **thin client**. It keeps no copy of room
+memory: `memory get`, `ls`, `search`, and the category views (`memory decisions`,
+`status`, `work`, …) all resolve against the hub over HTTP, and `memory set`
+writes straight to it.
+
+That has two consequences worth knowing:
+
+- **No drift, no sync ritual.** A read reflects what the hub has right now, so
+  two machines never disagree about what a key says.
+- **Reads need the hub.** If the hub is down or `server.api_url` points
+  somewhere wrong, memory commands say so plainly rather than quietly serving
+  something stale.
+
+```bash
+mycelium config get server.api_url   # which hub this machine reads from
+mycelium status                      # is it up?
+```
 
 Every write to room memory is embedded (384-dim, local, no API key, no external
 service) and indexed for semantic search.
@@ -542,31 +564,24 @@ mycelium memory ls failed/
 > **Always upserts.** Calling `memory set` on an existing key overwrites it.
 > The version number increments automatically so you can track changes.
 
-## Filesystem-Native Storage
+## How the hub stores it
 
-Every memory is a markdown file at `~/.mycelium/rooms/{room}/{key}.md` with YAML
-frontmatter. You can read, edit, or version-control these files directly.
+The hub keeps each memory as a markdown file with YAML frontmatter at
+`~/.mycelium/rooms/{room}/{key}.md`, plus a JSONL embedding index beside it.
+That is internal storage, not a surface you work in — clients see it through
+`mycelium memory`, which is the same on the hub and on every spoke.
+
+To see the stored form of a memory from anywhere:
 
 ```bash
-# View the raw file
-cat ~/.mycelium/rooms/design-review/decisions/storage.md
-
-# Edit with any tool
-vim ~/.mycelium/rooms/design-review/decisions/storage.md
-
-# Git-track a room's memory
-cd ~/.mycelium/rooms/design-review && git init
+mycelium memory get decisions/storage --raw
 ```
 
-The local search index auto-syncs when:
-- You use `mycelium memory set` (immediate dual-write)
-- The backend starts up (incremental scan of changed files)
-- Files change on disk while the backend is running (file watcher)
-
-For bulk edits, you can also trigger a manual reindex:
-```bash
-mycelium memory reindex
-```
+> **Operating the hub.** On the hub itself the files are ordinary files, so an
+> operator can inspect, back up, or bulk-edit them. Edits made outside the CLI
+> bypass the index; run `mycelium memory reindex` afterwards to resync. The
+> index also rebuilds when the backend starts and follows on-disk changes while
+> it runs.
 
 ## Semantic Search
 
@@ -1027,14 +1042,15 @@ message broker, no vector store.
 Agents coordinate over an [AGNTCY SLIM](https://github.com/agntcy) group
 channel, one per room: an MLS-encrypted group with shared-secret PSK auth.
 The backend is each room's **moderator**; agents (and the human, by proxy)
-are members. Room state lives on disk as markdown files; search runs against a
-local embedding index. Coordination messages ride SLIM as additive
+are members. Room state lives on the hub as markdown files; search runs against
+a local embedding index. Every other machine is a thin client that reads and
+writes that state over HTTP. Coordination messages ride SLIM as additive
 [L9 envelopes](#l9-protocol).
 
 | Layer | Technology | Used for |
 |-------|-----------|----------|
 | Messaging | one SLIM node (MLS group channels) | per-room encrypted coordination fabric |
-| State | markdown files under `~/.mycelium/rooms/{room}/` | rooms, memories, plan: the source of truth |
+| State | markdown files on the hub, under `~/.mycelium/rooms/{room}/` | rooms, memories, plan: the source of truth |
 | Search | local ONNX embedding index (JSONL) | ~384-dim semantic recall, no external service |
 | Protocol | L9 envelopes over SLIM | `exchange` ticks/replies, `commit:*`, `knowledge` |
 | Cognition | the aligner (Pi + NEGMAS) | drives the negotiation (see [aligner](#aligner)) |
@@ -1353,10 +1369,11 @@ mycelium doctor
 The spoke reports **spoke mode** and skips checks that only apply to a
 local backend.
 
-## Step 3: Share a room
+## Step 3: Use a room from a spoke
 
-Rooms are folders. Create one on any machine, then share it so every
-machine has the same room to coordinate in.
+There is one store: the hub's. A spoke is a thin client — it keeps no
+copy of the room's memory and needs no sync step. Create the room on the
+hub, then use it from anywhere.
 
 ```bash
 # On the hub
@@ -1364,16 +1381,28 @@ mycelium room create portfolio
 mycelium room use portfolio
 ```
 
-On a spoke, pull the room's memories from the hub's backend:
+On a spoke, just make it the active room:
 
 ```bash
-mycelium room clone portfolio --from http://192.168.1.20:8000
+mycelium room use portfolio
 ```
 
-`room clone` fetches the room's memories over HTTP and writes them
-locally, then sets the room active. From here, memory is shared the
-normal way: git push/pull for durable state, and the live SLIM channel
-for coordination.
+Every memory command now resolves against the hub over HTTP:
+
+```bash
+mycelium memory ls                       # the hub's memories
+mycelium memory get decisions/allocation
+mycelium memory set decisions/allocation "60/40 equities to bonds"
+mycelium memory search "what did we decide about risk"
+```
+
+Because reads go to the hub, a spoke sees a write the moment it lands —
+there is no local copy to drift. The flip side: memory commands need the
+hub reachable, and say so plainly when it isn't.
+
+> `mycelium room clone` still exists for pulling a room's memories down
+> as files — useful for a backup or an offline read — but it is not part
+> of joining a room from a spoke.
 
 ## Step 4: Run a negotiation across machines
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -137,7 +137,7 @@
 <span class="cmd">mycelium sync</span></code></pre>
       <h2 id="architecture-stack">Stack</h2>
       <p>Mycelium runs on <strong>one SLIM node</strong> and a thin backend: no database, no message broker, no vector store.</p>
-      <p>Agents coordinate over an <a href="https://github.com/agntcy">AGNTCY SLIM</a> group channel, one per room: an MLS-encrypted group with shared-secret PSK auth. The backend is each room&#x27;s <strong>moderator</strong>; agents (and the human, by proxy) are members. Room state lives on disk as markdown files; search runs against a local embedding index. Coordination messages ride SLIM as additive <a href="#l9-protocol">L9 envelopes</a>.</p>
+      <p>Agents coordinate over an <a href="https://github.com/agntcy">AGNTCY SLIM</a> group channel, one per room: an MLS-encrypted group with shared-secret PSK auth. The backend is each room&#x27;s <strong>moderator</strong>; agents (and the human, by proxy) are members. Room state lives on the hub as markdown files; search runs against a local embedding index. Every other machine is a thin client that reads and writes that state over HTTP. Coordination messages ride SLIM as additive <a href="#l9-protocol">L9 envelopes</a>.</p>
       <div class="table-wrap">
         <table>
           <thead>
@@ -155,7 +155,7 @@
             </tr>
             <tr>
               <td>State</td>
-              <td>markdown files under <code>~/.mycelium/rooms/{room}/</code></td>
+              <td>markdown files on the hub, under <code>~/.mycelium/rooms/{room}/</code></td>
               <td>rooms, memories, plan: the source of truth</td>
             </tr>
             <tr>
@@ -425,14 +425,14 @@ cursor-agent login            # one-time, interactive
         <div class="cmd-ref-header">
           <code><span class="cmd">mycelium memory get</span> <span class="arg">&lt;key&gt;</span></code>
         </div>
-        <div class="cmd-ref-body">Read a memory by exact key.</div>
+        <div class="cmd-ref-body">Read a memory by exact key from the hub.</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
           <code><span class="cmd">mycelium memory ls</span> [prefix/]</code>
         </div>
-        <div class="cmd-ref-body">List memories. Optional prefix filters by namespace.</div>
+        <div class="cmd-ref-body">List memories from the hub. Optional prefix filters by namespace.</div>
       </div>
 
       <div class="cmd-ref">
@@ -866,14 +866,23 @@ procedures/  Reusable how-to steps (do this again later)</code></pre>
       <p>Verify:</p>
       <pre><code><span class="cmd">mycelium doctor</span></code></pre>
       <p>The spoke reports <strong>spoke mode</strong> and skips checks that only apply to a local backend.</p>
-      <h2 id="hub-and-spoke-step-3-share-a-room">Step 3: Share a room</h2>
-      <p>Rooms are folders. Create one on any machine, then share it so every machine has the same room to coordinate in.</p>
+      <h2 id="hub-and-spoke-step-3-use-a-room-from-a-spoke">Step 3: Use a room from a spoke</h2>
+      <p>There is one store: the hub&#x27;s. A spoke is a thin client — it keeps no copy of the room&#x27;s memory and needs no sync step. Create the room on the hub, then use it from anywhere.</p>
       <pre><code><span class="comment"># On the hub</span>
 <span class="cmd">mycelium room create</span> portfolio
 <span class="cmd">mycelium room use</span> portfolio</code></pre>
-      <p>On a spoke, pull the room&#x27;s memories from the hub&#x27;s backend:</p>
-      <pre><code><span class="cmd">mycelium room clone</span> portfolio <span class="flag">--from</span> http://192.168.1.20:8000</code></pre>
-      <p><code>room clone</code> fetches the room&#x27;s memories over HTTP and writes them locally, then sets the room active. From here, memory is shared the normal way: git push/pull for durable state, and the live SLIM channel for coordination.</p>
+      <p>On a spoke, just make it the active room:</p>
+      <pre><code><span class="cmd">mycelium room use</span> portfolio</code></pre>
+      <p>Every memory command now resolves against the hub over HTTP:</p>
+      <pre><code><span class="cmd">mycelium memory ls</span>                       # the hub&#x27;s memories
+<span class="cmd">mycelium memory get</span> decisions/allocation
+<span class="cmd">mycelium memory set</span> decisions/allocation <span class="str">&quot;60/40 equities to bonds&quot;</span>
+<span class="cmd">mycelium memory search</span> <span class="str">&quot;what did we decide about risk&quot;</span></code></pre>
+      <p>Because reads go to the hub, a spoke sees a write the moment it lands — there is no local copy to drift. The flip side: memory commands need the hub reachable, and say so plainly when it isn&#x27;t.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><code>mycelium room clone</code> still exists for pulling a room&#x27;s memories down as files — useful for a backup or an offline read — but it is not part of joining a room from a spoke.</div>
+      </div>
       <h2 id="hub-and-spoke-step-4-run-a-negotiation-across-machines">Step 4: Run a negotiation across machines</h2>
       <p>Register the mediator (the <a href="#aligner">aligner</a>) once in the room, then have each machine&#x27;s agent post an opening position and loop on the channel. The aligner runs a NEGMAS negotiation and stops the instant the agents agree.</p>
       <pre><code><span class="comment"># Once, on any machine: register the aligner in the room</span>

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -4,15 +4,19 @@
 """
 Memory commands — persistent namespaced memory operations.
 
-CRUD operations read/write markdown files in .mycelium/rooms/{room}/.
-Search and subscribe use the backend API (local JSONL index).
+Reads and writes resolve against the hub over HTTP; the hub owns the one store
+(markdown files + the JSONL search index). A spoke needs no local replica.
 """
 
 import json
 import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
+import httpx
 import typer
 from pydantic import ValidationError
 from rich.console import Console
@@ -22,11 +26,11 @@ from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.filesystem import (
     get_room_dir,
-    list_memories,
-    read_memory,
+    serialize_memory,
     write_memory,
 )
 from mycelium.protocol import MEMORY_CATEGORIES, MemoryLogEntry
+from mycelium_backend_client.errors import UnexpectedStatus
 
 app = typer.Typer(
     help="Read and write persistent memories scoped to rooms. Memories are markdown files in .mycelium/rooms/. Supports semantic vector search via a local JSONL index.",
@@ -41,6 +45,55 @@ def _get_client():
 
     cfg = MyceliumConfig.load()
     return Client(base_url=cfg.server.api_url, raise_on_unexpected_status=True)
+
+
+def _hub_url() -> str:
+    """The hub API URL this client resolves memory against."""
+    return MyceliumConfig.load().server.api_url
+
+
+@contextmanager
+def _hub_session() -> Iterator[Any]:
+    """Yield a hub client, reporting an unreachable hub instead of raising.
+
+    Memory lives on the hub, so a hub that is down or misconfigured is an
+    ordinary outcome to state plainly rather than a traceback.
+    """
+    with _get_client() as client:
+        try:
+            yield client
+        except httpx.HTTPError as exc:
+            console.print(f"[red]Error:[/red] can't reach the hub at {_hub_url()}: {exc}")
+            console.print(
+                "[dim]Check the hub is running ('mycelium status'), or point "
+                "server.api_url at it.[/dim]"
+            )
+            raise typer.Exit(1) from exc
+        except UnexpectedStatus as exc:
+            console.print(f"[red]Error:[/red] hub at {_hub_url()} returned HTTP {exc.status_code}.")
+            raise typer.Exit(1) from exc
+
+
+def _unset_to_none(field: Any) -> Any:
+    """Normalize a generated-client UNSET field to None."""
+    from mycelium_backend_client.types import UNSET
+
+    return None if isinstance(field, type(UNSET)) else field
+
+
+def _value_text(value: Any) -> str:
+    """Flatten a memory value to display text.
+
+    A value is either a plain string or a structured dict (category keys carry
+    ``text``/``logged_at``/``category``; a JSON memory carries its own shape).
+    Structured values with no ``text`` render as pretty JSON.
+    """
+    if hasattr(value, "to_dict"):
+        value = value.to_dict()
+    if isinstance(value, dict):
+        text = value.get("text")
+        return text if text is not None else json.dumps(value, indent=2, default=str)
+    return "" if value is None else str(value)
 
 
 def _write_local_copy(room_name: str, mem) -> None:
@@ -249,42 +302,87 @@ def memory_set(
 
 @doc_ref(
     usage="mycelium memory get <key>",
-    desc="Read a memory by exact key.",
+    desc="Read a memory by exact key from the hub.",
     group="memory",
 )
 @app.command(name="get")
 def memory_get(
     key: str = typer.Argument(..., help="Memory key"),
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
-    raw: bool = typer.Option(False, "--raw", help="Show raw markdown file content"),
+    raw: bool = typer.Option(False, "--raw", help="Show the markdown form (frontmatter + body)"),
 ) -> None:
-    """Read a memory by key (reads directly from the filesystem)."""
-    room_name = _get_active_room(room)
-    room_dir = get_room_dir(room_name)
+    """Read a memory by key (from the hub)."""
+    from mycelium_backend_client.api.memory import (
+        get_memory_api_rooms_room_name_memory_key_get as get_api,
+    )
+    from mycelium_backend_client.models import MemoryRead
 
-    result = read_memory(room_dir, key)
-    if result is None:
+    room_name = _get_active_room(room)
+
+    with _hub_session() as client:
+        try:
+            mem = get_api.sync(room_name=room_name, key=key, client=client)
+        except UnexpectedStatus as exc:
+            if exc.status_code == 404:
+                console.print(f"[red]Not found:[/red] {key}")
+                raise typer.Exit(1) from exc
+            raise
+
+    if not isinstance(mem, MemoryRead):
         console.print(f"[red]Not found:[/red] {key}")
         raise typer.Exit(1)
 
-    meta, content = result
+    content = _value_text(mem.value)
 
     if raw:
-        # Show the raw file
-        file_path = room_dir / f"{key}.md"
-        if file_path.exists():
-            console.print(file_path.read_text(encoding="utf-8"))
+        console.print(
+            serialize_memory(
+                content,
+                key=mem.key,
+                created_by=mem.created_by,
+                updated_by=_unset_to_none(mem.updated_by),
+                version=mem.version,
+                tags=_unset_to_none(mem.tags),
+                created_at=mem.created_at,
+                updated_at=mem.updated_at,
+            )
+        )
         return
 
-    version = meta.get("version", "?")
-    created_by = meta.get("created_by", "?")
-    console.print(f"[cyan]{key}[/cyan]  [dim]v{version}  {created_by}[/dim]")
+    console.print(f"[cyan]{mem.key}[/cyan]  [dim]v{mem.version}  {mem.created_by}[/dim]")
     console.print(content)
+
+
+def _fetch_memories(room_name: str, prefix: str | None, limit: int) -> list[dict[str, Any]]:
+    """Fetch a room's memories from the hub, newest-first as the hub orders them.
+
+    Returns the raw JSON records (the list endpoint is untyped in the generated
+    client), or exits with a clear message when the room is unknown.
+    """
+    from mycelium_backend_client.api.memory import (
+        list_memories_api_rooms_room_name_memory_get as list_api,
+    )
+
+    with _hub_session() as client:
+        try:
+            entries = list_api.sync(room_name=room_name, client=client, prefix=prefix, limit=limit)
+        except UnexpectedStatus as exc:
+            if exc.status_code == 404:
+                console.print(
+                    f"[red]Not found:[/red] room '{room_name}' does not exist on the hub "
+                    f"at {_hub_url()}"
+                )
+                raise typer.Exit(1) from exc
+            raise
+
+    if not isinstance(entries, list):
+        return []
+    return cast("list[dict[str, Any]]", [r for r in entries if isinstance(r, dict)])
 
 
 @doc_ref(
     usage="mycelium memory ls [prefix/]",
-    desc="List memories. Optional prefix filters by namespace.",
+    desc="List memories from the hub. Optional prefix filters by namespace.",
     group="memory",
 )
 @app.command(name="ls")
@@ -298,24 +396,26 @@ def memory_ls(
     ),
     limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
 ) -> None:
-    """List memories in a room (reads directly from the filesystem)."""
+    """List memories in a room (from the hub)."""
     prefix = namespace or prefix
     room_name = _get_active_room(room)
-    room_dir = get_room_dir(room_name)
 
-    entries = list_memories(room_dir, prefix=prefix, limit=limit)
+    entries = _fetch_memories(room_name, prefix, limit)
     if not entries:
         console.print("[dim]No memories found[/dim]")
         return
 
     console.print(f"[bold]{room_name}[/bold] ({len(entries)} memories)\n")
 
-    for key, meta, content in entries:
-        ts = str(meta.get("updated_at", ""))[:16].replace("T", " ")
-        version = meta.get("version", "?")
-        created_by = meta.get("created_by", "?")
-        console.print(f"[cyan]{key}[/cyan]  [dim]v{version}  {created_by}  {ts}[/dim]")
-        display = content[:120] if content else ""
+    for mem in entries:
+        ts = str(mem.get("updated_at", ""))[:16].replace("T", " ")
+        version = mem.get("version", "?")
+        created_by = mem.get("created_by", "?")
+        console.print(
+            f"[cyan]{mem.get('key', '?')}[/cyan]  [dim]v{version}  {created_by}  {ts}[/dim]"
+        )
+        content = _value_text(mem.get("value"))
+        display = content[:120]
         if display:
             console.print(f"  {display}{'...' if len(content) > 120 else ''}")
         console.print()
@@ -340,7 +440,7 @@ def memory_search(
 
     room_name = _get_active_room(room)
 
-    with _get_client() as client:
+    with _hub_session() as client:
         body = MemorySearchRequest(query=query, limit=limit)
         from mycelium_backend_client.models import MemorySearchResponse
 
@@ -452,12 +552,11 @@ def memory_subscribe(
 
 
 def _list_by_category(category: str, room: str | None, limit: int) -> None:
-    """Shared implementation for category-filtered listing — reads from filesystem."""
+    """Shared implementation for category-filtered listing — reads from the hub."""
     room_name = _get_active_room(room)
-    room_dir = get_room_dir(room_name)
     prefix = f"{category}/"
 
-    entries = list_memories(room_dir, prefix=prefix, limit=limit)
+    entries = _fetch_memories(room_name, prefix, limit)
     if not entries:
         console.print(f"[dim]No {category} memories found[/dim]")
         return
@@ -468,11 +567,11 @@ def _list_by_category(category: str, room: str | None, limit: int) -> None:
     table.add_column("By", style="dim")
     table.add_column("Updated", style="dim")
 
-    for key, meta, content in entries:
-        short_key = key.removeprefix(prefix)
-        display = content[:80] if content else ""
-        ts = str(meta.get("updated_at", ""))[:16].replace("T", " ")
-        created_by = meta.get("created_by", "?")
+    for mem in entries:
+        short_key = str(mem.get("key", "?")).removeprefix(prefix)
+        display = _value_text(mem.get("value"))[:80]
+        ts = str(mem.get("updated_at", ""))[:16].replace("T", " ")
+        created_by = mem.get("created_by", "?")
         table.add_row(short_key, display, created_by, ts)
 
     console.print(table)

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -96,41 +96,6 @@ def _value_text(value: Any) -> str:
     return "" if value is None else str(value)
 
 
-def _write_local_copy(room_name: str, mem) -> None:
-    """Write a local copy of a memory file from the API response.
-
-    This ensures the agent has a local file for reads and git sync,
-    even when the backend is remote.
-    """
-    from mycelium_backend_client.types import UNSET
-
-    room_dir = get_room_dir(room_name)
-
-    # Extract content from the value field
-    value = mem.value
-    if hasattr(value, "to_dict"):
-        value = value.to_dict()
-    if isinstance(value, dict):
-        content = value.get("text", str(value))
-    else:
-        content = str(value)
-
-    tags = mem.tags if not isinstance(mem.tags, type(UNSET)) else None
-    updated_by = mem.updated_by if not isinstance(mem.updated_by, type(UNSET)) else None
-
-    write_memory(
-        room_dir,
-        mem.key,
-        content,
-        created_by=mem.created_by,
-        updated_by=updated_by,
-        version=mem.version,
-        tags=tags,
-        created_at=mem.created_at,
-        updated_at=mem.updated_at,
-    )
-
-
 def _resolve_value(value: str | None, file: str | None) -> str:
     """Resolve the memory value from the positional arg or a file.
 
@@ -273,29 +238,14 @@ def memory_set(
 
     batch = MemoryBatchCreate(items=[item])
 
-    # The backend API writes the file on the server and updates the search index.
-    # We also write the file locally so the agent has a local copy for reads and git sync.
-    with _get_client() as client:
+    # The write goes to the hub, which owns the store (files + index). A spoke
+    # keeps no local copy — reads resolve against the hub (see memory_get/ls).
+    with _hub_session() as client:
         result = create_api.sync(room_name=room_name, client=client, body=batch)
         if result and isinstance(result, list) and len(result) > 0:
             mem = result[0]
-
-            # Write the file locally using the response metadata
-            _write_local_copy(room_name, mem)
-
-            # Invalidate cached ETag — room has changed
-            from mycelium.filesystem import get_mycelium_dir
-
-            etag_file = get_mycelium_dir() / "rooms" / room_name / ".sync-etag"
-            if etag_file.exists():
-                etag_file.unlink()
-
-            file_path = getattr(mem, "file_path", None)
             version_info = f"v{mem.version}" if hasattr(mem, "version") else ""
-            path_info = f"  [{file_path}]" if file_path else ""
-            console.print(
-                f"[green]Memory set:[/green] {room_name}/{key} ({version_info}){path_info}"
-            )
+            console.print(f"[green]Memory set:[/green] {room_name}/{key} ({version_info})")
         else:
             console.print(f"[green]Memory set:[/green] {room_name}/{key}")
 
@@ -484,8 +434,8 @@ def memory_rm(
         if not confirm:
             raise typer.Exit(0)
 
-    # Delete via backend (handles both file + DB)
-    with _get_client() as client:
+    # Delete on the hub, which owns the store (file + index). No local copy exists.
+    with _hub_session() as client:
         delete_api.sync_detailed(room_name=room_name, key=key, client=client)
         console.print(f"[green]Deleted:[/green] {key}")
 

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -211,13 +211,9 @@ def create(
             result = create_api.sync(client=client, body=body)
             room_data = result.to_dict() if result and hasattr(result, "to_dict") else {}
 
-        # The backend now creates the directory, but also create locally
-        # in case the CLI is running on a different machine
-        from mycelium.filesystem import ensure_room_structure, get_room_dir
-
-        room_dir = get_room_dir(name)
-        ensure_room_structure(room_dir)
-
+        # The hub owns the room dir + store; a spoke keeps no local copy. Any
+        # local dir an agent needs (e.g. agents/ for a manifest) is created
+        # lazily on write, so nothing to pre-create here.
         if json_output:
             typer.echo(json_module.dumps(room_data, indent=2, default=str))
         else:
@@ -227,7 +223,6 @@ def create(
             )
             typer.echo(f"  ID:      {room_data.get('id')}")
             typer.echo(f"  Created: {str(room_data.get('created_at', ''))[:10]}")
-            typer.echo(f"  Path:    {room_dir}")
             typer.echo("")
             typer.echo(f"  Run 'mycelium room use {name}' to make it your active room")
 

--- a/mycelium-cli/src/mycelium/docs/architecture.md
+++ b/mycelium-cli/src/mycelium/docs/architecture.md
@@ -73,14 +73,15 @@ message broker, no vector store.
 Agents coordinate over an [AGNTCY SLIM](https://github.com/agntcy) group
 channel, one per room: an MLS-encrypted group with shared-secret PSK auth.
 The backend is each room's **moderator**; agents (and the human, by proxy)
-are members. Room state lives on disk as markdown files; search runs against a
-local embedding index. Coordination messages ride SLIM as additive
+are members. Room state lives on the hub as markdown files; search runs against
+a local embedding index. Every other machine is a thin client that reads and
+writes that state over HTTP. Coordination messages ride SLIM as additive
 [L9 envelopes](#l9-protocol).
 
 | Layer | Technology | Used for |
 |-------|-----------|----------|
 | Messaging | one SLIM node (MLS group channels) | per-room encrypted coordination fabric |
-| State | markdown files under `~/.mycelium/rooms/{room}/` | rooms, memories, plan: the source of truth |
+| State | markdown files on the hub, under `~/.mycelium/rooms/{room}/` | rooms, memories, plan: the source of truth |
 | Search | local ONNX embedding index (JSONL) | ~384-dim semantic recall, no external service |
 | Protocol | L9 envelopes over SLIM | `exchange` ticks/replies, `commit:*`, `knowledge` |
 | Cognition | the aligner (Pi + NEGMAS) | drives the negotiation (see [aligner](#aligner)) |

--- a/mycelium-cli/src/mycelium/docs/guides/hub-and-spoke.md
+++ b/mycelium-cli/src/mycelium/docs/guides/hub-and-spoke.md
@@ -116,10 +116,11 @@ mycelium doctor
 The spoke reports **spoke mode** and skips checks that only apply to a
 local backend.
 
-## Step 3: Share a room
+## Step 3: Use a room from a spoke
 
-Rooms are folders. Create one on any machine, then share it so every
-machine has the same room to coordinate in.
+There is one store: the hub's. A spoke is a thin client — it keeps no
+copy of the room's memory and needs no sync step. Create the room on the
+hub, then use it from anywhere.
 
 ```bash
 # On the hub
@@ -127,16 +128,28 @@ mycelium room create portfolio
 mycelium room use portfolio
 ```
 
-On a spoke, pull the room's memories from the hub's backend:
+On a spoke, just make it the active room:
 
 ```bash
-mycelium room clone portfolio --from http://192.168.1.20:8000
+mycelium room use portfolio
 ```
 
-`room clone` fetches the room's memories over HTTP and writes them
-locally, then sets the room active. From here, memory is shared the
-normal way: git push/pull for durable state, and the live SLIM channel
-for coordination.
+Every memory command now resolves against the hub over HTTP:
+
+```bash
+mycelium memory ls                       # the hub's memories
+mycelium memory get decisions/allocation
+mycelium memory set decisions/allocation "60/40 equities to bonds"
+mycelium memory search "what did we decide about risk"
+```
+
+Because reads go to the hub, a spoke sees a write the moment it lands —
+there is no local copy to drift. The flip side: memory commands need the
+hub reachable, and say so plainly when it isn't.
+
+> `mycelium room clone` still exists for pulling a room's memories down
+> as files — useful for a backup or an offline read — but it is not part
+> of joining a room from a spoke.
 
 ## Step 4: Run a negotiation across machines
 

--- a/mycelium-cli/src/mycelium/docs/memory.md
+++ b/mycelium-cli/src/mycelium/docs/memory.md
@@ -1,10 +1,9 @@
 # Memory
 
-Room memory is markdown files on your filesystem: the shared source of truth,
-greppable and editable by any agent. A local embedding index over those files
-lets agents recall by meaning, but it is never an independent source of writes.
-Whatever stays private to one agent stays in that agent's own local files, never
-indexed.
+Room memory lives on the hub: one store every agent reads and writes through the
+CLI, chat, or the UI. An embedding index over that store lets agents recall by
+meaning, but it is never an independent source of writes. Whatever stays private
+to one agent stays in that agent's own local files, never indexed.
 
 ## Three layers, one source of truth
 
@@ -13,16 +12,35 @@ Mycelium memory has three layers, and only the middle one is "the memory":
 1. **Your private context** is yours alone: agent-native files like `SOUL.md`
    or per-agent notes that never leave your machine and are never indexed or
    shared. Anything only you need lives here.
-2. **Room memory** is the shared source of truth: markdown files under
-   `~/.mycelium/rooms/{room}/` that every agent in the room can read, `grep`,
-   edit, and `git`-track. If the team should know it, write it here.
-3. **The search index** is a derived view that you never write to directly. Mycelium
-   embeds each room memory into a local index so agents can recall by meaning.
-   It rebuilds from the files, so the files always win.
+2. **Room memory** is the shared source of truth, held by the hub. Every agent
+   in the room reads and writes it with `mycelium memory` — from any machine,
+   with no local copy to keep in step. If the team should know it, write it here.
+3. **The search index** is a derived view that you never write to directly. The
+   hub embeds each room memory so agents can recall by meaning. It rebuilds from
+   the store, so the store always wins.
 
-Rule of thumb: if a teammate should find it, put it in room memory. The index
-is how they find it; the filesystem is where it lives; your private notes stay
-yours.
+Rule of thumb: if a teammate should find it, put it in room memory. The index is
+how they find it; the hub is where it lives; your private notes stay yours.
+
+## One store, many clients
+
+Any machine that is not the hub is a **thin client**. It keeps no copy of room
+memory: `memory get`, `ls`, `search`, and the category views (`memory decisions`,
+`status`, `work`, …) all resolve against the hub over HTTP, and `memory set`
+writes straight to it.
+
+That has two consequences worth knowing:
+
+- **No drift, no sync ritual.** A read reflects what the hub has right now, so
+  two machines never disagree about what a key says.
+- **Reads need the hub.** If the hub is down or `server.api_url` points
+  somewhere wrong, memory commands say so plainly rather than quietly serving
+  something stale.
+
+```bash
+mycelium config get server.api_url   # which hub this machine reads from
+mycelium status                      # is it up?
+```
 
 Every write to room memory is embedded (384-dim, local, no API key, no external
 service) and indexed for semantic search.
@@ -50,31 +68,24 @@ mycelium memory ls failed/
 > **Always upserts.** Calling `memory set` on an existing key overwrites it.
 > The version number increments automatically so you can track changes.
 
-## Filesystem-Native Storage
+## How the hub stores it
 
-Every memory is a markdown file at `~/.mycelium/rooms/{room}/{key}.md` with YAML
-frontmatter. You can read, edit, or version-control these files directly.
+The hub keeps each memory as a markdown file with YAML frontmatter at
+`~/.mycelium/rooms/{room}/{key}.md`, plus a JSONL embedding index beside it.
+That is internal storage, not a surface you work in — clients see it through
+`mycelium memory`, which is the same on the hub and on every spoke.
+
+To see the stored form of a memory from anywhere:
 
 ```bash
-# View the raw file
-cat ~/.mycelium/rooms/design-review/decisions/storage.md
-
-# Edit with any tool
-vim ~/.mycelium/rooms/design-review/decisions/storage.md
-
-# Git-track a room's memory
-cd ~/.mycelium/rooms/design-review && git init
+mycelium memory get decisions/storage --raw
 ```
 
-The local search index auto-syncs when:
-- You use `mycelium memory set` (immediate dual-write)
-- The backend starts up (incremental scan of changed files)
-- Files change on disk while the backend is running (file watcher)
-
-For bulk edits, you can also trigger a manual reindex:
-```bash
-mycelium memory reindex
-```
+> **Operating the hub.** On the hub itself the files are ordinary files, so an
+> operator can inspect, back up, or bulk-edit them. Edits made outside the CLI
+> bypass the index; run `mycelium memory reindex` afterwards to resync. The
+> index also rebuilds when the backend starts and follows on-disk changes while
+> it runs.
 
 ## Semantic Search
 

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -50,7 +50,7 @@ directly to each other.
 
 
 When agents log decisions, failures, and findings to a shared room, any agent that joins
-later can read `~/.mycelium/rooms/{room}/` and the room's shared plan to instantly inherit
+later can read the room's memory and shared plan to instantly inherit
 what the swarm learned. Intelligence doesn't reset; it compounds.
 
 Negative results matter too. An agent that logs `failed/single-writer-lock: serializing

--- a/mycelium-cli/src/mycelium/docs/quickstart.md
+++ b/mycelium-cli/src/mycelium/docs/quickstart.md
@@ -90,7 +90,9 @@ so you can script or follow along in a terminal.
 ## Create a room
 
 A room is a persistent namespace for memory, agents, and coordination: a folder
-under `~/.mycelium/rooms/{room}/` and a SLIM group channel agents join:
+on the hub under `~/.mycelium/rooms/{room}/` and a SLIM group channel agents join.
+You reach it the same way from every machine — through the CLI, never by
+editing files on a spoke:
 
 ```bash
 # Create a room and make it active

--- a/mycelium-cli/src/mycelium/docs/rooms.md
+++ b/mycelium-cli/src/mycelium/docs/rooms.md
@@ -6,13 +6,13 @@ separation between the two.
 
 Under the hood a room is a **SLIM group channel**: agents (and the human, by
 proxy) are members of one MLS-encrypted channel per room, and the backend is
-its always-on moderator. There's no database: a room's durable state is the
-files on disk, and sharing is git.
+its always-on moderator. There's no database: a room's durable state is files
+on the hub, which every other machine reads and writes over HTTP.
 
-## Rooms are Directories
+## Rooms are Directories on the Hub
 
-Each room maps to a directory at `~/.mycelium/rooms/{room_name}/`. Standard
-subdirectories are created automatically:
+Each room maps to a directory at `~/.mycelium/rooms/{room_name}/` **on the hub**.
+Standard subdirectories are created automatically:
 
 ```
 ~/.mycelium/rooms/design-review/
@@ -27,8 +27,10 @@ activity in the UI). The rest are arbitrary `plan/{slug}.md` files containing
 prose and tasks. See [`mycelium plan`](#plan) for read/write commands and
 `plan task add|done|undo` for checkbox edits.
 
-You can browse, edit, or git-track these directories directly. The backend
-keeps its local search index in sync via startup scans and file watching.
+An operator on the hub can browse, edit, or git-track these directories
+directly; the backend keeps its search index in sync via startup scans and file
+watching. From anywhere else, reach the same state through `mycelium room` and
+`mycelium memory` — a spoke keeps no copy of it.
 
 ## Commands
 

--- a/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
@@ -15,7 +15,7 @@ Your core loop is the **negotiation protocol** below (argue, converge, plan, wor
 
 - **Rooms** are persistent namespaces. They hold memory that accumulates across sessions, and they're the channel where agents negotiate in real time.
 - **The aligner** is a dormant judge, summoned with `@aligner`, that scores whether a negotiation has converged and, on convergence, compiles the agreement into the room's shared plan.
-- **Memory** is filesystem-native. Each memory is a markdown file at `~/.mycelium/rooms/{room}/{key}.md` with YAML frontmatter. Search runs over a local embedding index that auto-syncs from the files.
+- **Memory** lives on the hub — one store for the whole room. Reach it with `mycelium memory set` / `get` / `ls` / `search`, which resolve against the hub over HTTP from whatever machine you're on. There is no local copy to read or keep in step.
 
 ## Semantic negotiation
 
@@ -125,7 +125,7 @@ mycelium memory set "failed/memcached" \
   --handle claude-agent
 ```
 
-Memories are markdown files under `~/.mycelium/rooms/<room>/`. Any agent who joins later can find them with `mycelium memory ls` or `mycelium memory search`.
+Memories are held by the hub. Any agent who joins later can find them with `mycelium memory ls` or `mycelium memory search`, wherever they're running.
 
 ### A few things to remember
 
@@ -134,25 +134,25 @@ Memories are markdown files under `~/.mycelium/rooms/<room>/`. Any agent who joi
 - **One turn per await.** Each `mycelium await` returns the single message that woke you. Do your work, post your reply (with a position marker if you're negotiating), and `await` again for the next turn. Don't try to block waiting for other agents.
 - **Run `mycelium` as single commands.** The adapter install pre-allowlists the mycelium CLI (`Bash(mycelium:*)` in `~/.claude/settings.json`) so you can run it without approval prompts, which is essential if you're a background subagent that can't answer one. But that allowlist only matches *simple* commands: **don't wrap a mycelium call in compound shell** (`mycelium await … && …`, pipes, redirects, `$(…)`, backticks). Claude Code rejects the whole compound command even when `mycelium` itself is allowed. Issue one `mycelium await` / `mycelium respond` per command.
 
-## Memory as Files
+## Reading memory
 
-Every memory is a readable, editable markdown file:
+Every memory is a key you read through the CLI:
 
+```bash
+mycelium memory ls decisions/          # browse a namespace
+mycelium memory get decisions/db       # read one key
+mycelium memory get decisions/db --raw # with its frontmatter
 ```
-~/.mycelium/rooms/my-project/decisions/db.md
-~/.mycelium/rooms/my-project/work/api.md
-~/.mycelium/rooms/my-project/context/team.md
-```
 
-You can read them with `cat`, edit with any tool, or `git` the directory. Changes are auto-indexed, so no manual reindex is needed.
+Don't go looking for these under `~/.mycelium/` — unless you're on the hub itself, they aren't there. `mycelium memory` is the way in, and it's the same command everywhere.
 
 ## The three memory layers: where to write what
 
 1. **Your private context**: your own agent-native memory (local notes, never indexed, never shared). Keep what is only relevant to you here.
-2. **Room memory**: the shared source of truth, markdown files under `~/.mycelium/rooms/{room}/`. Everything the team should see goes here, via `mycelium memory set` or a direct file write.
-3. **The search index**: a local embedding index over room-public memory files for semantic recall. You never write to it directly; it rebuilds from the files, so the files always win.
+2. **Room memory**: the shared source of truth, held by the hub. Everything the team should see goes here, via `mycelium memory set` (`--file <path>` to load a file's contents, `-` for stdin).
+3. **The search index**: an embedding index over room memory for semantic recall. You never write to it directly; it rebuilds from the store, so the store always wins.
 
-Rule of thumb: if a teammate should find it, write it to room memory. The index is how they find it; the filesystem is where it lives; your private notes stay yours.
+Rule of thumb: if a teammate should find it, write it to room memory. The index is how they find it; the hub is where it lives; your private notes stay yours.
 
 ## Memory Operations
 

--- a/mycelium-cli/tests/test_memory_commands.py
+++ b/mycelium-cli/tests/test_memory_commands.py
@@ -3,73 +3,134 @@
 
 """Unit tests for ``mycelium memory`` (set / get / ls / search).
 
-Node-free: ``get`` and ``ls`` read the local markdown under a temp home
-(``isolated_home``); ``set`` and ``search`` go through the backend, whose API
-``.sync`` is stubbed. No live stack.
+Node-free and file-free: every command resolves against the hub, so the API
+``.sync`` functions are stubbed. The temp home (``isolated_home``) deliberately
+holds no ``rooms/`` files — that is the point of the thin client, and the reads
+below still return the hub's memories.
 """
 
 from __future__ import annotations
 
+import datetime
+import uuid
 from pathlib import Path
+from typing import Any
 
+import httpx
 import pytest
 from typer.testing import CliRunner
 
 from mycelium.commands import memory as memory_cmd
-from mycelium.filesystem import get_room_dir, write_memory
+from mycelium_backend_client.errors import UnexpectedStatus
 
 runner = CliRunner()
+
+STAMP = datetime.datetime(2026, 6, 1, 12, 30, tzinfo=datetime.UTC)
 
 
 @pytest.fixture(autouse=True)
 def _home(isolated_home) -> None:
-    """Every memory test reads/writes under the temp ``~/.mycelium``."""
+    """Every memory test runs under the temp ``~/.mycelium`` (no room files)."""
 
 
-def _seed(room: str, key: str, value: str) -> None:
-    write_memory(get_room_dir(room), key, value, created_by="tester")
+class _Client:
+    def __enter__(self):
+        return object()
+
+    def __exit__(self, *_a):
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _hub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No command may open a real connection."""
+    monkeypatch.setattr(memory_cmd, "_get_client", lambda: _Client())
+
+
+def _record(key: str, value: Any, **overrides: Any) -> dict[str, Any]:
+    """A memory as the hub's list endpoint serializes it."""
+    return {
+        "key": key,
+        "value": value,
+        "created_by": "tester",
+        "version": 1,
+        "created_at": STAMP.isoformat(),
+        "updated_at": STAMP.isoformat(),
+        **overrides,
+    }
+
+
+def _memory_read(key: str, value: Any, **overrides: Any):
+    from mycelium_backend_client.models import MemoryRead
+
+    fields: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "room_name": "demo",
+        "key": key,
+        "value": value,
+        "created_by": "tester",
+        "version": 1,
+        "created_at": STAMP,
+        "updated_at": STAMP,
+    }
+    fields.update(overrides)
+    return MemoryRead(**fields)
+
+
+def _structured(**fields: Any):
+    from mycelium_backend_client.models import MemoryReadValueType0
+
+    return MemoryReadValueType0.from_dict(fields)
+
+
+def _stub_get(monkeypatch: pytest.MonkeyPatch, result: Any) -> None:
+    """Stub the get-memory API; an Exception instance is raised instead."""
+
+    def _sync(**_kw: Any):
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.memory.get_memory_api_rooms_room_name_memory_key_get.sync",
+        _sync,
+    )
+
+
+def _stub_list(monkeypatch: pytest.MonkeyPatch, result: Any) -> list[dict[str, Any]]:
+    """Stub the list-memories API; returns the kwargs it was called with."""
+    calls: list[dict[str, Any]] = []
+
+    def _sync(**kwargs: Any):
+        calls.append(kwargs)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.memory.list_memories_api_rooms_room_name_memory_get.sync",
+        _sync,
+    )
+    return calls
 
 
 def _stub_create(monkeypatch: pytest.MonkeyPatch) -> list:
     """Stub the create-memories API, returning the batches it was handed."""
-    import datetime
-    import uuid
-
-    from mycelium_backend_client.models import MemoryRead
-
-    class _Client:
-        def __enter__(self):
-            return object()
-
-        def __exit__(self, *_a):
-            return False
-
-    monkeypatch.setattr(memory_cmd, "_get_client", lambda: _Client())
-
     captured: list = []
-    stamp = datetime.datetime(2026, 6, 1)  # noqa: DTZ001
 
     def _sync(*, room_name: str, client, body):  # noqa: ANN001, ARG001
         captured.append(body)
         item = body.items[0]
-        return [
-            MemoryRead(
-                id=uuid.uuid4(),
-                key=item.key,
-                value=item.value,
-                version=1,
-                created_by=item.created_by,
-                room_name=room_name,
-                created_at=stamp,
-                updated_at=stamp,
-            )
-        ]
+        return [_memory_read(item.key, item.value, room_name=room_name, created_by=item.created_by)]
 
     monkeypatch.setattr(
         "mycelium_backend_client.api.memory.create_memories_api_rooms_room_name_memory_post.sync",
         _sync,
     )
     return captured
+
+
+# ── set ──────────────────────────────────────────────────────────────────────
 
 
 def test_memory_set_file_value_round_trips(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -123,75 +184,154 @@ def test_memory_set_missing_file_errors(tmp_path: Path) -> None:
     assert "cannot read" in result.output
 
 
-def test_memory_get_prints_key_and_content() -> None:
-    _seed("demo", "decisions/db", "we chose postgres")
+# ── get ──────────────────────────────────────────────────────────────────────
+
+
+def test_memory_get_reads_from_hub_without_local_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_get(monkeypatch, _memory_read("decisions/db", "we chose postgres"))
+
     result = runner.invoke(memory_cmd.app, ["get", "decisions/db", "--room", "demo"])
     assert result.exit_code == 0, result.output
     assert "decisions/db" in result.output
     assert "we chose postgres" in result.output
 
 
-def test_memory_get_missing_key_exits_nonzero() -> None:
+def test_memory_get_renders_structured_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    value = _structured(text="deploy is green", logged_at=STAMP.isoformat(), category="status")
+    _stub_get(monkeypatch, _memory_read("status/deploy", value))
+
+    result = runner.invoke(memory_cmd.app, ["get", "status/deploy", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "deploy is green" in result.output
+
+
+def test_memory_get_renders_textless_structured_value_as_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_get(monkeypatch, _memory_read("context/config", _structured(retries=3)))
+
+    result = runner.invoke(memory_cmd.app, ["get", "context/config", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "retries" in result.output
+
+
+def test_memory_get_raw_renders_markdown_form(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_get(
+        monkeypatch,
+        _memory_read("decisions/db", "we chose postgres", tags=["infra"], updated_by="other"),
+    )
+
+    result = runner.invoke(memory_cmd.app, ["get", "decisions/db", "--raw", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith("---")
+    assert "key: decisions/db" in result.output
+    assert "created_by: tester" in result.output
+    assert "we chose postgres" in result.output
+
+
+def test_memory_get_missing_key_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_get(monkeypatch, UnexpectedStatus(404, b'{"detail":"Memory not found"}'))
+
     result = runner.invoke(memory_cmd.app, ["get", "nope", "--room", "demo"])
     assert result.exit_code == 1
     assert "Not found" in result.output
 
 
-def test_memory_ls_lists_and_filters_by_prefix() -> None:
-    _seed("demo", "decisions/db", "postgres")
-    _seed("demo", "decisions/lang", "python")
-    _seed("demo", "status/sprint", "green")
+def test_memory_get_unreachable_hub_reports_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_get(monkeypatch, httpx.ConnectError("connection refused"))
 
-    listed = runner.invoke(memory_cmd.app, ["ls", "--room", "demo"])
-    assert listed.exit_code == 0, listed.output
-    assert "3 memories" in listed.output
-
-    filtered = runner.invoke(memory_cmd.app, ["ls", "decisions/", "--room", "demo"])
-    assert filtered.exit_code == 0, filtered.output
-    assert "2 memories" in filtered.output
-    assert "status/sprint" not in filtered.output
+    result = runner.invoke(memory_cmd.app, ["get", "decisions/db", "--room", "demo"])
+    assert result.exit_code == 1
+    assert "can't reach the hub at" in result.output
+    assert result.exception is None or isinstance(result.exception, SystemExit)
 
 
-def test_memory_ls_empty_prints_hint() -> None:
+def test_memory_get_hub_error_status_reports_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_get(monkeypatch, UnexpectedStatus(500, b"boom"))
+
+    result = runner.invoke(memory_cmd.app, ["get", "decisions/db", "--room", "demo"])
+    assert result.exit_code == 1
+    assert "HTTP 500" in result.output
+
+
+# ── ls ───────────────────────────────────────────────────────────────────────
+
+
+def test_memory_ls_lists_from_hub_without_local_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_list(
+        monkeypatch,
+        [_record("decisions/db", "postgres"), _record("decisions/lang", "python")],
+    )
+
+    result = runner.invoke(memory_cmd.app, ["ls", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "2 memories" in result.output
+    assert "decisions/db" in result.output
+    assert "postgres" in result.output
+
+
+def test_memory_ls_forwards_prefix_and_limit_to_hub(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_list(monkeypatch, [_record("decisions/db", "postgres")])
+
+    result = runner.invoke(memory_cmd.app, ["ls", "decisions/", "--room", "demo", "-n", "5"])
+    assert result.exit_code == 0, result.output
+    assert calls[0]["prefix"] == "decisions/"
+    assert calls[0]["limit"] == 5
+    assert calls[0]["room_name"] == "demo"
+
+
+def test_memory_ls_renders_structured_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_list(
+        monkeypatch,
+        [_record("status/sprint", {"text": "green", "logged_at": "x", "category": "status"})],
+    )
+
+    result = runner.invoke(memory_cmd.app, ["ls", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "green" in result.output
+
+
+def test_memory_ls_empty_prints_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_list(monkeypatch, [])
+
     result = runner.invoke(memory_cmd.app, ["ls", "--room", "demo"])
     assert result.exit_code == 0, result.output
     assert "No memories found" in result.output
 
 
+def test_memory_ls_unknown_room_reports_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_list(monkeypatch, UnexpectedStatus(404, b'{"detail":"Room not found"}'))
+
+    result = runner.invoke(memory_cmd.app, ["ls", "--room", "ghost"])
+    assert result.exit_code == 1
+    assert "ghost" in result.output
+
+
+def test_memory_ls_unreachable_hub_reports_cleanly(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_list(monkeypatch, httpx.ConnectError("connection refused"))
+
+    result = runner.invoke(memory_cmd.app, ["ls", "--room", "demo"])
+    assert result.exit_code == 1
+    assert "can't reach the hub at" in result.output
+
+
+def test_memory_category_view_reads_from_hub(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_list(monkeypatch, [_record("decisions/db", "postgres")])
+
+    result = runner.invoke(memory_cmd.app, ["decisions", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert calls[0]["prefix"] == "decisions/"
+    # the category prefix is stripped in the table
+    assert "postgres" in result.output
+
+
+# ── search ───────────────────────────────────────────────────────────────────
+
+
 def test_memory_search_renders_backend_results(monkeypatch: pytest.MonkeyPatch) -> None:
-    import datetime
-    import uuid
+    from mycelium_backend_client.models import MemorySearchResponse, MemorySearchResult
 
-    from mycelium_backend_client.models import (
-        MemoryRead,
-        MemorySearchResponse,
-        MemorySearchResult,
-    )
-
-    monkeypatch.setattr(memory_cmd, "_get_active_room", lambda _room: "demo")
-
-    stamp = datetime.datetime(2026, 6, 1)  # noqa: DTZ001
-
-    class _Client:
-        def __enter__(self):
-            return object()
-
-        def __exit__(self, *_a):
-            return False
-
-    monkeypatch.setattr(memory_cmd, "_get_client", lambda: _Client())
-
-    mem = MemoryRead(
-        id=uuid.uuid4(),
-        key="decisions/db",
-        value="postgres",
-        content_text="we chose postgres for durability",
-        version=1,
-        created_by="tester",
-        room_name="demo",
-        created_at=stamp,
-        updated_at=stamp,
-    )
+    mem = _memory_read("decisions/db", "postgres", content_text="we chose postgres for durability")
     resp = MemorySearchResponse(results=[MemorySearchResult(memory=mem, similarity=0.91)], total=1)
     monkeypatch.setattr(
         "mycelium_backend_client.api.memory."
@@ -209,16 +349,6 @@ def test_memory_search_renders_backend_results(monkeypatch: pytest.MonkeyPatch) 
 def test_memory_search_no_results(monkeypatch: pytest.MonkeyPatch) -> None:
     from mycelium_backend_client.models import MemorySearchResponse
 
-    monkeypatch.setattr(memory_cmd, "_get_active_room", lambda _room: "demo")
-
-    class _Client:
-        def __enter__(self):
-            return object()
-
-        def __exit__(self, *_a):
-            return False
-
-    monkeypatch.setattr(memory_cmd, "_get_client", lambda: _Client())
     monkeypatch.setattr(
         "mycelium_backend_client.api.memory."
         "search_memories_api_rooms_room_name_memory_search_post.sync",


### PR DESCRIPTION
## Summary

`memory get` / `ls` read the local `.mycelium/` replica, so a spoke with no files returned nothing while the hub held the room's memory. This routes the read path through the backend memory API — the same HTTP surface `memory search` and `room clone --from` already use — so a machine with no local files still reads the room.

Memory is unchanged as a feature: `set` / `get` / `ls` / `search` all stay fully available on a spoke. Only *where the client reads from* changes. The hub is untouched — it keeps storing markdown files plus the JSONL index, and nothing about the moderator/persister moves.

## Changes

**Read path (`mycelium-cli/src/mycelium/commands/memory.py`)**

- `memory get` calls `get_memory_api_rooms_room_name_memory_key_get` instead of `read_memory(room_dir, key)`. A 404 still prints `Not found: <key>` and exits 1.
- `memory ls` calls `list_memories_api_rooms_room_name_memory_get` via a new `_fetch_memories` helper, forwarding `prefix` and `limit` so filtering happens on the hub. An unknown room reports which room and which hub.
- `_list_by_category` — behind `memory status` / `work` / `decisions` / `context` / `procedures` — shares `_fetch_memories`. **Slightly beyond the literal get/ls scope**, but these are the same read with a prefix; leaving them local would mean `memory ls decisions/` works on a spoke while `memory decisions` silently returns nothing.
- `--raw` no longer reads a file. It rebuilds the markdown form (frontmatter + body) from the response via the existing `serialize_memory`, so it still shows the stored shape from anywhere.
- Structured values go through one `_value_text` helper: a plain string passes through, a category value renders its `text`, and a JSON memory with no `text` renders as pretty JSON.

**Offline behavior**

Reads now require the hub, which is the intended trade. `_hub_session` turns a transport failure or unexpected status into a plain message naming the configured hub URL plus what to check, instead of a traceback:

```
Error: can't reach the hub at http://localhost:8000: connection refused
Check the hub is running ('mycelium status'), or point server.api_url at it.
```

`memory search` was wrapped in the same session — it already hit the hub and had the same traceback-on-outage behavior, and leaving it out would make the file inconsistent.

**Docs (the positioning reframe)**

Backend internals are unchanged; the narrative shifts from "work with files locally" to "access via the CLI backed by the hub". `CLAUDE.md` (State is files → hub-internal storage, plus a new *spoke is a thin client* decision bullet), the memory / rooms / architecture / quickstart / overview pages, the hub-and-spoke guide (Step 3 no longer needs `room clone` to join a room), `README.md`, and the agent-facing `SKILL.md` — which had been telling agents to `cat` memory files that don't exist on a spoke. Direct file writes are demoted to a hub-operator footnote. `docs/*.html` + `llms-full.txt` regenerated.

## Testing

`tests/test_memory_commands.py` reworked: the get/ls tests previously seeded local markdown and asserted it came back. They now stub the backend API (the `_stub_create` pattern from #555) and run under an `isolated_home` with **no** `rooms/` files — the absence is the assertion. 21 tests cover hub reads without local files, structured and textless-structured rendering, `--raw` markdown reconstruction, prefix/limit forwarding, missing key, unknown room, and unreachable hub (asserting exit 1 and no traceback).

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 313 passed
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)

Not verified against a live hub — no stack running in this environment; the wire shape is taken from `fastapi-backend/app/routes/memory.py` and matches what `room clone` already consumes.

## Out of scope

- **Participation / wake** (#446) — untouched.
- **`memory set` still writes a local copy** via `_write_local_copy`. Out of scope per the handoff (`set` already goes through the hub), but it does leave a stray file on a spoke; worth a follow-up.
- `memory sync` / `reindex` / `room clone` left in place — the hub still uses reindex, and clone is still useful for a backup or offline read. They're just no longer part of the spoke read path.
- **#550** (apply inbound `knowledge` on receive) left as-is — flagged in the issue for a keep-or-revert call, not this task.

## Related Issues

Closes #557
Closes #542

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLr9MquX2wQAAP3m1QvcS5)_