### PR TITLE
feat(dev): dev OIDC issuer for identity Wave 0 (#560)

### DIFF
--- a/docs/design/dev-auth-issuer.md
+++ b/docs/design/dev-auth-issuer.md
@@ -1,0 +1,65 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Dev OIDC issuer (identity Wave 0)
+
+A lightweight, **dev/test-only** OIDC issuer so the identity work
+(`docs/design/identity-and-auth.md`, epic #560) has a real token source + JWKS to
+build and test the HTTP-API JWT gate (#561) against — without standing up Keycloak.
+
+> ⚠️ **Dev only.** It mints a valid JWT for any client with any secret and
+> authenticates nothing. Production issuers are Keycloak (humans) / SPIRE (agents),
+> tracked in #565.
+
+## Bring it up
+
+```bash
+docker compose \
+  -f mycelium-cli/src/mycelium/docker/compose.yml \
+  -f mycelium-cli/src/mycelium/docker/compose-dev.yml \
+  -f mycelium-cli/src/mycelium/docker/compose-auth-dev.yml \
+  up -d
+```
+
+## Endpoints
+
+| Caller | Issuer (`iss`) base | Discovery | JWKS |
+|--------|---------------------|-----------|------|
+| Backend gate (in-network) | `http://mycelium-auth-dev:8080/default` | `<issuer>/.well-known/openid-configuration` | `<issuer>/jwks` |
+| Host (CLI / curl) | `http://localhost:9090/default` | same paths | same paths |
+
+Keys are **RS256**, `kid: default`.
+
+## Mint a token
+
+```bash
+# Agent token — sub = client_id (the agent's handle). Mock accepts any secret.
+curl -s -X POST http://localhost:9090/default/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=client_credentials&client_id=poc-agent&client_secret=dev&scope=openid'
+```
+
+Returns `{ "access_token": "<RS256 JWT>", "token_type": "Bearer", ... }`. Decoded
+claims look like:
+
+```json
+{ "sub": "poc-agent", "iss": "http://localhost:9090/default", "aud": "...",
+  "exp": 1786846481, "iat": 1786842881 }
+```
+
+The `sub` claim is the authoritative handle the gate (#561) and handle-binding
+(#562) key off.
+
+## Wiring the gate (#561)
+
+The gate is **issuer-agnostic** — point it at this issuer's `iss` + JWKS URL via
+config. Use the **in-network** issuer (`http://mycelium-auth-dev:8080/default`) for
+the backend, since that is the host the backend reaches and the `iss` it will see.
+
+> `mock-oauth2-server` derives `iss` from the request host, so the in-network and
+> host issuers differ. That is fine for dev: configure the backend against the
+> in-network one; use the host URLs only for manual token minting. A stable `iss`
+> can be pinned later via the mock's `JSON_CONFIG` if needed.
+
+## Next
+
+- #561 — HTTP-API JWT gate (validate against this issuer's JWKS)
+- #565 — replace this with the real Keycloak (humans) + SPIRE (agents) wiring

--- a/mycelium-cli/src/mycelium/docker/compose-auth-dev.yml
+++ b/mycelium-cli/src/mycelium/docker/compose-auth-dev.yml
@@ -1,0 +1,40 @@
+# Dev-only OIDC issuer for the identity work (Wave 0 of the identity epic #560).
+#
+# ⚠️  DEV / TEST ONLY. This mock issuer mints a valid-looking JWT for ANY client
+# with ANY secret and performs no real authentication. Never run it in a
+# deployment that anything trusts. Production issuers: Keycloak / SPIRE (#565).
+#
+# Purpose: give the HTTP-API JWT gate (#561) a real issuer + JWKS to validate
+# against locally, so the identity tickets can be built and tested end-to-end
+# without standing up Keycloak.
+#
+# Bring it up alongside the dev stack (run from the repo root):
+#   docker compose \
+#     -f mycelium-cli/src/mycelium/docker/compose.yml \
+#     -f mycelium-cli/src/mycelium/docker/compose-dev.yml \
+#     -f mycelium-cli/src/mycelium/docker/compose-auth-dev.yml \
+#     up -d
+#
+# Endpoints:
+#   In-network (the backend gate):  http://mycelium-auth-dev:8080/default
+#   From the host (CLI / curl):     http://localhost:9090/default
+#   Discovery: <issuer>/.well-known/openid-configuration   JWKS: <issuer>/jwks
+#
+# Mint an agent token (mock accepts any client_id/secret):
+#   curl -s -X POST http://localhost:9090/default/token \
+#     -H 'Content-Type: application/x-www-form-urlencoded' \
+#     -d 'grant_type=client_credentials&client_id=poc-agent&client_secret=dev&scope=openid'
+#   → a RS256 JWT whose `sub` is the client_id (the agent handle).
+#
+# Note: mock-oauth2-server derives `iss` from the request host, so the
+# in-network `iss` (mycelium-auth-dev:8080) differs from the host one
+# (localhost:9090). The #561 gate is issuer-agnostic — configure it to trust the
+# in-network issuer + JWKS URL; the host URLs are for manual token minting.
+
+services:
+  mycelium-auth-dev:
+    image: ghcr.io/navikt/mock-oauth2-server:2.1.10
+    container_name: mycelium-auth-dev
+    restart: unless-stopped
+    ports:
+      - "${MYCELIUM_AUTH_DEV_PORT:-9090}:8080"


### PR DESCRIPTION
Wave 0 of the identity epic (#560). Stands up a **dev/test-only** OIDC issuer so the HTTP-API JWT gate (#561) has a real token source + JWKS to build/test against — no Keycloak needed yet.

- `compose-auth-dev.yml` — a mock OIDC provider (`navikt/mock-oauth2-server`) on :9090, on the dev compose network.
- `docs/design/dev-auth-issuer.md` — quickstart, endpoints, token-mint example, and how #561 wires to it (issuer-agnostic).

**Verified end-to-end** this session: OIDC discovery, RS256 JWKS (`kid: default`), and `client_credentials` token mint → JWT with `sub: <client_id>` (the handle) that the gate will validate.

⚠️ Dev only — mints a token for any client/secret, authenticates nothing. Real issuers (Keycloak humans / SPIRE agents) are #565.

Unblocks: #561 → #562. Part of #560.