### PR TITLE
Align docs design system with app tokens and add light/dark theme

### DIFF
--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -14,33 +14,63 @@
 <meta name="twitter:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="stylesheet" href="mycelium.css">
+<script>
+// Resolve the theme before first paint so the page never flashes the wrong one.
+(function () {
+  try {
+    var t = localStorage.getItem('mycelium-theme') || 'system';
+    var dark = t === 'dark'
+      || (t === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', dark);
+  } catch (e) {
+    document.documentElement.classList.add('dark');
+  }
+})();
+</script>
 </head>
 <body>
 <canvas id="mycelium-bg"></canvas>
-<!-- TOP NAV -->
+<!-- TOP BAR -->
 <nav class="topnav">
   <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
     <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-cell topnav-page-cell">
-    <span class="caps-mono">DOCS</span>
-  </span>
-  <div class="topnav-right">
-    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
-    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
-    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub" style="display:flex;align-items:center;"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
-  </div>
-</nav>
-<nav class="sectionnav">
-  <div class="sectionnav-inner">
-    <a href="index.html" class=""><span class="square-dot"></span>GET STARTED</a>
-    <a href="concepts.html" class=""><span class="square-dot"></span>CONCEPTS</a>
-    <a href="adapters.html" class="active"><span class="square-dot"></span>ADAPTERS</a>
-    <a href="reference.html" class=""><span class="square-dot"></span>REFERENCE</a>
-    <div class="sectionnav-right">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank">SKILL.md ↗</a>
+  <nav class="sectionnav">
+    <div class="sectionnav-inner">
+      <a href="index.html" class="">Get Started</a>
+      <a href="concepts.html" class="">Concepts</a>
+      <a href="adapters.html" class="active">Adapters</a>
+      <a href="reference.html" class="">Reference</a>
     </div>
+    <div class="sectionnav-right">
+      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+    </div>
+  </nav>
+  <div class="topnav-right">
+    <div class="resources-dropdown">
+      <button class="resources-btn" onclick="toggleResources(event)">Resources</button>
+      <div class="resources-menu" id="resources-menu">
+        <a href="index.html">Get Started</a>
+        <a href="concepts.html">Concepts</a>
+        <a href="adapters.html">Adapters</a>
+        <a href="reference.html">Reference</a>
+        <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+      </div>
+    </div>
+    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal"></i>Copy docs cmd</button>
+    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy"></i>Copy page</button>
+    <div class="theme-toggle">
+      <button class="theme-btn" id="theme-btn" aria-label="Theme" onclick="toggleThemeMenu(event)">
+        <i data-lucide="sun"></i>
+      </button>
+      <div class="theme-menu" id="theme-menu">
+      <button data-theme-set="light"><i data-lucide="sun"></i>Light</button>
+      <button data-theme-set="dark"><i data-lucide="moon"></i>Dark</button>
+      <button data-theme-set="system"><i data-lucide="monitor"></i>System</button>
+      </div>
+    </div>
+    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
   </div>
 </nav>
 <div class="layout">
@@ -337,18 +367,18 @@ curl -X POST http://localhost:8000/api/memory/search \
   -H "Content-Type: application/json" \
   -d '{"room": "my-project", "query": "what was decided about the API"}'</code></pre>
     </section>
-    <!-- FOOTER -->
-    <div class="docs-footer">
-      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
-      <span class="sep">·</span>
-      <span>Apache 2.0</span>
-      <span class="sep">·</span>
-      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
-    </div>
-
   </div>
   </main>
 </div>
+
+<!-- STATUS BAR -->
+<footer class="docs-footer">
+  <span class="sheet-no">ADP-001</span>
+  <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+  <span class="sep">·</span>
+  <span>Apache 2.0</span>
+  <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+</footer>
 
 <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 <script src="site.js"></script>

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -14,33 +14,63 @@
 <meta name="twitter:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="stylesheet" href="mycelium.css">
+<script>
+// Resolve the theme before first paint so the page never flashes the wrong one.
+(function () {
+  try {
+    var t = localStorage.getItem('mycelium-theme') || 'system';
+    var dark = t === 'dark'
+      || (t === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', dark);
+  } catch (e) {
+    document.documentElement.classList.add('dark');
+  }
+})();
+</script>
 </head>
 <body>
 <canvas id="mycelium-bg"></canvas>
-<!-- TOP NAV -->
+<!-- TOP BAR -->
 <nav class="topnav">
   <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
     <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-cell topnav-page-cell">
-    <span class="caps-mono">DOCS</span>
-  </span>
-  <div class="topnav-right">
-    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
-    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
-    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub" style="display:flex;align-items:center;"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
-  </div>
-</nav>
-<nav class="sectionnav">
-  <div class="sectionnav-inner">
-    <a href="index.html" class=""><span class="square-dot"></span>GET STARTED</a>
-    <a href="concepts.html" class="active"><span class="square-dot"></span>CONCEPTS</a>
-    <a href="adapters.html" class=""><span class="square-dot"></span>ADAPTERS</a>
-    <a href="reference.html" class=""><span class="square-dot"></span>REFERENCE</a>
-    <div class="sectionnav-right">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank">SKILL.md ↗</a>
+  <nav class="sectionnav">
+    <div class="sectionnav-inner">
+      <a href="index.html" class="">Get Started</a>
+      <a href="concepts.html" class="active">Concepts</a>
+      <a href="adapters.html" class="">Adapters</a>
+      <a href="reference.html" class="">Reference</a>
     </div>
+    <div class="sectionnav-right">
+      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+    </div>
+  </nav>
+  <div class="topnav-right">
+    <div class="resources-dropdown">
+      <button class="resources-btn" onclick="toggleResources(event)">Resources</button>
+      <div class="resources-menu" id="resources-menu">
+        <a href="index.html">Get Started</a>
+        <a href="concepts.html">Concepts</a>
+        <a href="adapters.html">Adapters</a>
+        <a href="reference.html">Reference</a>
+        <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+      </div>
+    </div>
+    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal"></i>Copy docs cmd</button>
+    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy"></i>Copy page</button>
+    <div class="theme-toggle">
+      <button class="theme-btn" id="theme-btn" aria-label="Theme" onclick="toggleThemeMenu(event)">
+        <i data-lucide="sun"></i>
+      </button>
+      <div class="theme-menu" id="theme-menu">
+      <button data-theme-set="light"><i data-lucide="sun"></i>Light</button>
+      <button data-theme-set="dark"><i data-lucide="moon"></i>Dark</button>
+      <button data-theme-set="system"><i data-lucide="monitor"></i>System</button>
+      </div>
+    </div>
+    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
   </div>
 </nav>
 <div class="layout">
@@ -591,18 +621,18 @@ PATCH .../messages/{id}  {<span class="str">&quot;status&quot;</span>: <span cla
       <p>The briefing reflects only what is in the room&#x27;s memory; the synthesizer does not invent facts. If its Pi turn fails, it writes nothing rather than a half-formed summary.</p>
       <p>The synthesizer holds no <a href="#episodes">episode</a> and drives no negotiation. It reads the room, summarizes it, and writes the result back. It shares the rest of the engine model: the summon lifecycle and <a href="#engines">where it runs</a> (backend-side), with every brain running a <strong>Pi</strong> turn.</p>
     </section>
-    <!-- FOOTER -->
-    <div class="docs-footer">
-      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
-      <span class="sep">·</span>
-      <span>Apache 2.0</span>
-      <span class="sep">·</span>
-      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
-    </div>
-
   </div>
   </main>
 </div>
+
+<!-- STATUS BAR -->
+<footer class="docs-footer">
+  <span class="sheet-no">CON-001</span>
+  <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+  <span class="sep">·</span>
+  <span>Apache 2.0</span>
+  <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+</footer>
 
 <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 <script src="site.js"></script>

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -642,52 +642,89 @@ def _head(title: str, description: str, file_name: str) -> str:
 <meta name="twitter:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="stylesheet" href="mycelium.css">
+<script>
+// Resolve the theme before first paint so the page never flashes the wrong one.
+(function () {{
+  try {{
+    var t = localStorage.getItem('mycelium-theme') || 'system';
+    var dark = t === 'dark'
+      || (t === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', dark);
+  }} catch (e) {{
+    document.documentElement.classList.add('dark');
+  }}
+}})();
+</script>
 </head>
 <body>
 <canvas id="mycelium-bg"></canvas>
 """
 
 
-def _topnav() -> str:
-    return f"""<!-- TOP NAV -->
+def _theme_toggle() -> str:
+    """Light / dark / system menu, mirroring the app's ThemeToggle."""
+    opts = [
+        ("light", "Light", "sun"),
+        ("dark", "Dark", "moon"),
+        ("system", "System", "monitor"),
+    ]
+    items = "\n".join(
+        f'      <button data-theme-set="{value}">'
+        f'<i data-lucide="{icon}"></i>{label}</button>'
+        for value, label, icon in opts
+    )
+    return f"""    <div class="theme-toggle">
+      <button class="theme-btn" id="theme-btn" aria-label="Theme" onclick="toggleThemeMenu(event)">
+        <i data-lucide="sun"></i>
+      </button>
+      <div class="theme-menu" id="theme-menu">
+{items}
+      </div>
+    </div>"""
+
+
+def _topnav(active_page_id: str) -> str:
+    """The app's shell header: brand over the rail, page tabs, right-hand actions.
+
+    The brand cell is sidebar-width so the rail reads as one column, matching
+    RoomsSidebar sitting under the workspace header in the app.
+    """
+    tabs = []
+    for page_id, file_name, _, label, *_ in PAGES:
+        cls = "active" if page_id == active_page_id else ""
+        tabs.append(f'      <a href="{file_name}" class="{cls}">{html.escape(label)}</a>')
+    return f"""<!-- TOP BAR -->
 <nav class="topnav">
   <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
     <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-cell topnav-page-cell">
-    <span class="caps-mono">DOCS</span>
-  </span>
+  <nav class="sectionnav">
+    <div class="sectionnav-inner">
+{chr(10).join(tabs)}
+    </div>
+    <div class="sectionnav-right">
+      <a href="{SKILL_MD_URL}" target="_blank" rel="noopener">SKILL.md ↗</a>
+    </div>
+  </nav>
   <div class="topnav-right">
-    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
-    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
-    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub" style="display:flex;align-items:center;">{GITHUB_SVG}</a>
+    <div class="resources-dropdown">
+      <button class="resources-btn" onclick="toggleResources(event)">Resources</button>
+      <div class="resources-menu" id="resources-menu">
+        <a href="index.html">Get Started</a>
+        <a href="concepts.html">Concepts</a>
+        <a href="adapters.html">Adapters</a>
+        <a href="reference.html">Reference</a>
+        <a href="{SKILL_MD_URL}" target="_blank" rel="noopener">SKILL.md ↗</a>
+      </div>
+    </div>
+    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal"></i>Copy docs cmd</button>
+    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy"></i>Copy page</button>
+{_theme_toggle()}
+    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub">{GITHUB_SVG}</a>
   </div>
 </nav>
 """
-
-
-def _sectionnav(active_page_id: str) -> str:
-    links = []
-    for page_id, file_name, _, label, *_ in PAGES:
-        cls = "active" if page_id == active_page_id else ""
-        links.append(
-            f'    <a href="{file_name}" class="{cls}">'
-            f'<span class="square-dot"></span>{html.escape(label).upper()}</a>'
-        )
-    right_links = [
-        f'    <a href="{SKILL_MD_URL}" target="_blank">SKILL.md ↗</a>',
-    ]
-    return (
-        '<nav class="sectionnav">\n'
-        '  <div class="sectionnav-inner">\n'
-        + "\n".join(links)
-        + '\n    <div class="sectionnav-right">\n'
-        + "\n".join(right_links)
-        + "\n    </div>\n"
-        "  </div>\n"
-        "</nav>\n"
-    )
 
 
 def _sidebar(groups: list[tuple[str, list[tuple[str, str]]]]) -> str:
@@ -720,18 +757,19 @@ def _layout_open(sidebar_html: str) -> str:
 
 
 def _layout_close(sheet_no: str, plate_title: str) -> str:
-    return """    <!-- FOOTER -->
-    <div class="docs-footer">
-      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
-      <span class="sep">·</span>
-      <span>Apache 2.0</span>
-      <span class="sep">·</span>
-      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
-    </div>
-
-  </div>
+    """Close the workspace and pin the editor-style status bar beneath it."""
+    return f"""  </div>
   </main>
 </div>
+
+<!-- STATUS BAR -->
+<footer class="docs-footer">
+  <span class="sheet-no">{html.escape(sheet_no)}</span>
+  <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+  <span class="sep">·</span>
+  <span>Apache 2.0</span>
+  <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+</footer>
 
 <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 <script src="site.js"></script>
@@ -754,8 +792,7 @@ def _render_page(
     sidebar_html = _sidebar(sidebar_groups)
     return (
         _head(title, description, file_name)
-        + _topnav()
-        + _sectionnav(page_id)
+        + _topnav(page_id)
         + _layout_open(sidebar_html)
         + content_html
         + "\n"

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,33 +14,63 @@
 <meta name="twitter:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="stylesheet" href="mycelium.css">
+<script>
+// Resolve the theme before first paint so the page never flashes the wrong one.
+(function () {
+  try {
+    var t = localStorage.getItem('mycelium-theme') || 'system';
+    var dark = t === 'dark'
+      || (t === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', dark);
+  } catch (e) {
+    document.documentElement.classList.add('dark');
+  }
+})();
+</script>
 </head>
 <body>
 <canvas id="mycelium-bg"></canvas>
-<!-- TOP NAV -->
+<!-- TOP BAR -->
 <nav class="topnav">
   <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
     <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-cell topnav-page-cell">
-    <span class="caps-mono">DOCS</span>
-  </span>
-  <div class="topnav-right">
-    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
-    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
-    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub" style="display:flex;align-items:center;"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
-  </div>
-</nav>
-<nav class="sectionnav">
-  <div class="sectionnav-inner">
-    <a href="index.html" class="active"><span class="square-dot"></span>GET STARTED</a>
-    <a href="concepts.html" class=""><span class="square-dot"></span>CONCEPTS</a>
-    <a href="adapters.html" class=""><span class="square-dot"></span>ADAPTERS</a>
-    <a href="reference.html" class=""><span class="square-dot"></span>REFERENCE</a>
-    <div class="sectionnav-right">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank">SKILL.md ↗</a>
+  <nav class="sectionnav">
+    <div class="sectionnav-inner">
+      <a href="index.html" class="active">Get Started</a>
+      <a href="concepts.html" class="">Concepts</a>
+      <a href="adapters.html" class="">Adapters</a>
+      <a href="reference.html" class="">Reference</a>
     </div>
+    <div class="sectionnav-right">
+      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+    </div>
+  </nav>
+  <div class="topnav-right">
+    <div class="resources-dropdown">
+      <button class="resources-btn" onclick="toggleResources(event)">Resources</button>
+      <div class="resources-menu" id="resources-menu">
+        <a href="index.html">Get Started</a>
+        <a href="concepts.html">Concepts</a>
+        <a href="adapters.html">Adapters</a>
+        <a href="reference.html">Reference</a>
+        <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+      </div>
+    </div>
+    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal"></i>Copy docs cmd</button>
+    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy"></i>Copy page</button>
+    <div class="theme-toggle">
+      <button class="theme-btn" id="theme-btn" aria-label="Theme" onclick="toggleThemeMenu(event)">
+        <i data-lucide="sun"></i>
+      </button>
+      <div class="theme-menu" id="theme-menu">
+      <button data-theme-set="light"><i data-lucide="sun"></i>Light</button>
+      <button data-theme-set="dark"><i data-lucide="moon"></i>Dark</button>
+      <button data-theme-set="system"><i data-lucide="monitor"></i>System</button>
+      </div>
+    </div>
+    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
   </div>
 </nav>
 <div class="layout">
@@ -221,18 +251,18 @@
 <span class="cmd">mycelium memory ls</span> decisions/</code></pre>
       <p>See the <a href="#memory">memory</a> guide for how storage and search work.</p>
     </section>
-    <!-- FOOTER -->
-    <div class="docs-footer">
-      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
-      <span class="sep">·</span>
-      <span>Apache 2.0</span>
-      <span class="sep">·</span>
-      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
-    </div>
-
   </div>
   </main>
 </div>
+
+<!-- STATUS BAR -->
+<footer class="docs-footer">
+  <span class="sheet-no">GET-001</span>
+  <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+  <span class="sep">·</span>
+  <span>Apache 2.0</span>
+  <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+</footer>
 
 <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 <script src="site.js"></script>

--- a/docs/l9-integration.html
+++ b/docs/l9-integration.html
@@ -8,36 +8,55 @@
 <meta name="robots" content="noindex, nofollow">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="stylesheet" href="mycelium.css">
+<script>
+// Resolve the theme before first paint so the page never flashes the wrong one.
+(function () {
+  try {
+    var t = localStorage.getItem('mycelium-theme') || 'system';
+    var dark = t === 'dark'
+      || (t === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', dark);
+  } catch (e) {
+    document.documentElement.classList.add('dark');
+  }
+})();
+</script>
 <style>
-  /* Ghost-page-only tweaks: this page is unlinked from the site nav. */
+  /* Ghost-page-only tweaks: this page is unlinked from the site nav. The warm
+     tan/olive palette this page used predated the shared tokens; it now draws
+     from them so it tracks both themes. */
   .ghost-banner {
-    border: 1px solid var(--rule, #cbb89a);
-    background: rgba(203, 184, 154, 0.10);
-    padding: 12px 16px; margin: 0 0 28px; border-radius: 4px;
-    font-size: 0.9rem;
+    border: 1px solid var(--border);
+    background: var(--hairline);
+    padding: 12px 16px; margin: 0 0 28px; border-radius: var(--radius-lg);
+    font-size: var(--text-body);
   }
   .ghost-banner strong { letter-spacing: 0.04em; }
   .caveat-banner {
-    border: 1px solid rgba(200,120,90,0.55);
-    background: rgba(200,120,90,0.12);
-    padding: 14px 18px; margin: 0 0 22px; border-radius: 4px;
-    font-size: 0.95rem;
+    border: 1px solid color-mix(in srgb, var(--yellow) 40%, transparent);
+    background: color-mix(in srgb, var(--yellow) 9%, transparent);
+    padding: 14px 18px; margin: 0 0 22px; border-radius: var(--radius-lg);
+    font-size: var(--text-body);
   }
-  table.l9 { border-collapse: collapse; width: 100%; margin: 18px 0; font-size: 0.92rem; }
-  table.l9 th, table.l9 td { border: 1px solid rgba(120,110,90,0.25); padding: 7px 10px; text-align: left; vertical-align: top; }
-  table.l9 th { background: rgba(203,184,154,0.12); font-weight: 600; }
+  table.l9 { border-collapse: collapse; width: 100%; margin: 18px 0; font-size: var(--text-body); }
+  table.l9 th, table.l9 td { border: 1px solid var(--border); padding: 7px 10px; text-align: left; vertical-align: top; }
+  table.l9 th { background: var(--surface); font-weight: 600; }
   table.l9 code { white-space: nowrap; }
-  .pill { display: inline-block; padding: 1px 7px; border-radius: 999px; font-size: 0.78rem; border: 1px solid rgba(120,110,90,0.35); }
-  .pill.ours { background: rgba(120,170,120,0.15); }
-  .pill.cfn  { background: rgba(120,150,200,0.15); }
-  .pill.gap  { background: rgba(200,140,120,0.15); }
-  /* Mermaid's neutral theme draws dark text; sit it on a light panel so it
-     has contrast against the site's dark background. */
+  .pill {
+    display: inline-block; padding: 1px 7px; border-radius: 999px;
+    font-size: var(--text-micro); border: 1px solid var(--border);
+    background: var(--surface); color: var(--muted-foreground);
+  }
+  .pill.ours { color: var(--green); border-color: color-mix(in srgb, var(--green) 30%, transparent); }
+  .pill.cfn  { color: var(--viz-2); border-color: color-mix(in srgb, var(--viz-2) 30%, transparent); }
+  .pill.gap  { color: var(--yellow); border-color: color-mix(in srgb, var(--yellow) 30%, transparent); }
+  /* Mermaid renders with its own neutral theme, so it keeps a light panel of
+     its own in both themes rather than inheriting the surface tokens. */
   .mermaid {
     margin: 22px 0; text-align: center;
-    background: #f5f1e8;
-    border: 1px solid rgba(120,110,90,0.35);
-    border-radius: 6px;
+    background: #f5f6f7;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
     padding: 20px 16px;
   }
   .mermaid svg { max-width: 100%; height: auto; }
@@ -58,7 +77,17 @@
     <span class="caps-mono">L9 · INTERNAL</span>
   </span>
   <div class="topnav-right">
-    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub" style="display:flex;align-items:center;"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
+    <div class="theme-toggle">
+      <button class="theme-btn" id="theme-btn" aria-label="Theme" onclick="toggleThemeMenu(event)">
+        <i data-lucide="sun"></i>
+      </button>
+      <div class="theme-menu" id="theme-menu">
+        <button data-theme-set="light"><i data-lucide="sun"></i>Light</button>
+        <button data-theme-set="dark"><i data-lucide="moon"></i>Dark</button>
+        <button data-theme-set="system"><i data-lucide="monitor"></i>System</button>
+      </div>
+    </div>
+    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
   </div>
 </nav>
 <div class="layout">
@@ -387,5 +416,17 @@ sequenceDiagram
   </div>
   </main>
 </div>
+
+<!-- STATUS BAR -->
+<footer class="docs-footer">
+  <span class="sheet-no">L9-001</span>
+  <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+  <span class="sep">·</span>
+  <span>Internal · unlinked</span>
+  <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+</footer>
+
+<script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+<script src="site.js"></script>
 </body>
 </html>

--- a/docs/mycelium-dataflow.html
+++ b/docs/mycelium-dataflow.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,28 +9,32 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="stylesheet" href="mycelium.css">
 <style>
+  /* This plate ships its own palette because it is an immersive, dark-locked
+   * scrollytelling surface rather than a reading page. The values track the
+   * app's dark token set (globals.css) so it stays on-brand; the categorical
+   * hues come from the shared diagram ramp, where hue carries meaning. */
   :root {
-    --bg: #05090f;
-    --surface: #080e18;
-    --card: #0c1524;
-    --border: #162035;
-    --accent: #38bdf8;
-    --accent2: #7dd3fc;
-    --blue: #818cf8;
-    --green: #34d399;
-    --purple: #c084fc;
-    --yellow: #67e8f9;
-    --text: #e2eaf6;
-    --muted: #4a6080;
-    --dim: #4a6a8a;
+    --bg: #0c0e11;
+    --surface: #14171c;
+    --card: #191d22;
+    --border: rgba(255, 255, 255, 0.08);
+    --accent: #5cc7d2;
+    --accent2: #5cc7d2;
+    --blue: #8fb8e8;
+    --green: #4fc296;
+    --purple: #c3a2e0;
+    --yellow: #d9a94e;
+    --text: #e8ebee;
+    --muted: #a7adb5;
+    --dim: #565d65;
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   html { scroll-behavior: smooth; }
   body {
     background: var(--bg);
     background-image:
-      radial-gradient(ellipse at 70% 10%, rgba(192,132,252,0.04) 0%, transparent 40%),
-      radial-gradient(ellipse at 20% 80%, rgba(56,189,248,0.04) 0%, transparent 40%);
+      radial-gradient(ellipse at 70% 10%, rgba(195,162,224,0.04) 0%, transparent 40%),
+      radial-gradient(ellipse at 20% 80%, rgba(92,199,210,0.04) 0%, transparent 40%);
     color: var(--text);
     font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
     line-height: 1.6;
@@ -44,9 +48,9 @@
     flex-direction: column;
     justify-content: center;
     padding: 140px 80px 80px;
-    background: radial-gradient(ellipse at 15% 60%, rgba(56,189,248,0.08) 0%, transparent 55%),
-                radial-gradient(ellipse at 80% 15%, rgba(192,132,252,0.07) 0%, transparent 50%),
-                radial-gradient(ellipse at 50% 90%, rgba(52,211,153,0.05) 0%, transparent 50%);
+    background: radial-gradient(ellipse at 15% 60%, rgba(92,199,210,0.08) 0%, transparent 55%),
+                radial-gradient(ellipse at 80% 15%, rgba(195,162,224,0.07) 0%, transparent 50%),
+                radial-gradient(ellipse at 50% 90%, rgba(79,194,150,0.05) 0%, transparent 50%);
   }
   .hero-eyebrow {
     margin-bottom: 24px;
@@ -69,7 +73,7 @@
     text-transform: uppercase;
     font-weight: 700;
     color: var(--accent);
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     line-height: 1.45;
     white-space: nowrap;
   }
@@ -102,12 +106,12 @@
   .hero-chips { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 64px; }
   .chip {
     display: inline-block; padding: 4px 12px; border-radius: 20px; font-size: 11px;
-    font-weight: 600; letter-spacing: 0.05em; font-family: 'SF Mono', monospace;
+    font-weight: 600; letter-spacing: 0.05em; font-family: 'Geist Mono', 'SF Mono', monospace;
   }
-  .chip-o { background: rgba(56,189,248,0.1);  color: var(--accent2); border: 1px solid rgba(56,189,248,0.25); }
-  .chip-b { background: rgba(129,140,248,0.1); color: var(--blue);   border: 1px solid rgba(129,140,248,0.25); }
-  .chip-g { background: rgba(52,211,153,0.08); color: var(--green);  border: 1px solid rgba(52,211,153,0.2); }
-  .chip-p { background: rgba(192,132,252,0.1); color: var(--purple); border: 1px solid rgba(192,132,252,0.22); }
+  .chip-o { background: rgba(92,199,210,0.1);  color: var(--accent2); border: 1px solid rgba(92,199,210,0.25); }
+  .chip-b { background: rgba(143,184,232,0.1); color: var(--blue);   border: 1px solid rgba(143,184,232,0.25); }
+  .chip-g { background: rgba(79,194,150,0.08); color: var(--green);  border: 1px solid rgba(79,194,150,0.2); }
+  .chip-p { background: rgba(195,162,224,0.1); color: var(--purple); border: 1px solid rgba(195,162,224,0.22); }
   .chip-y { background: rgba(103,232,249,0.08); color: var(--yellow); border: 1px solid rgba(103,232,249,0.2); }
   .scroll-hint {
     display: flex; flex-direction: column; align-items: flex-start; gap: 4px;
@@ -142,14 +146,14 @@
     width: 100%;
     height: 100%;
     background: linear-gradient(135deg, rgba(12,21,36,0.95) 0%, rgba(8,14,24,0.98) 100%);
-    border: 1px solid rgba(56,189,248,0.12);
+    border: 1px solid rgba(92,199,210,0.12);
     border-radius: 16px;
     position: relative;
     overflow: hidden;
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 0 60px rgba(56,189,248,0.04), inset 0 1px 0 rgba(56,189,248,0.08);
+    box-shadow: 0 0 60px rgba(92,199,210,0.04), inset 0 1px 0 rgba(92,199,210,0.08);
   }
 
   /* ── SCENE system ── */
@@ -187,7 +191,7 @@
     letter-spacing: 0.2em;
     text-transform: uppercase;
     color: var(--accent);
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     margin-bottom: 16px;
   }
   .sec-label.blue   { color: var(--blue); }
@@ -217,7 +221,7 @@
     letter-spacing: 0.04em;
   }
   .sec-body code {
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     font-size: 12px;
     background: rgba(255,255,255,0.06);
     padding: 2px 6px;
@@ -230,7 +234,7 @@
     border-left: 2px solid var(--accent);
     border-radius: 0 6px 6px 0;
     padding: 12px 16px;
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     font-size: 11px;
     color: var(--muted);
     line-height: 1.6;
@@ -261,7 +265,7 @@
     letter-spacing: 0.12em;
     text-transform: uppercase;
     margin-bottom: 5px;
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
   }
   .d-box .d-name { font-size: 13px; font-weight: 700; color: var(--text); }
   .d-box .d-sub  { font-size: 12.5px; color: var(--muted); margin-top: 3px; line-height: 1.4; }
@@ -288,7 +292,7 @@
     text-align: center;
     font-size: 13px;
     font-weight: 700;
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     letter-spacing: 0.12em;
     color: rgba(248,113,113,0.6);
     border-top: 1px dashed rgba(248,113,113,0.2);
@@ -307,7 +311,7 @@
     text-align: center;
     transition: border-color 0.3s;
   }
-  .pillar-card .p-label { font-size: 11px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; font-family: 'SF Mono', monospace; margin-bottom: 6px; }
+  .pillar-card .p-label { font-size: 11px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; font-family: 'Geist Mono', 'SF Mono', monospace; margin-bottom: 6px; }
   .pillar-card .p-ioc {
     font-size: 13px;
     font-weight: 700;
@@ -317,9 +321,9 @@
     letter-spacing: 0.05em;
   }
   .pillar-card .p-myc { font-size: 12px; color: var(--muted); line-height: 1.4; }
-  .pillar-card.po { border-color: rgba(56,189,248,0.35); }
-  .pillar-card.pb { border-color: rgba(129,140,248,0.35); }
-  .pillar-card.pp { border-color: rgba(192,132,252,0.35); }
+  .pillar-card.po { border-color: rgba(92,199,210,0.35); }
+  .pillar-card.pb { border-color: rgba(143,184,232,0.35); }
+  .pillar-card.pp { border-color: rgba(195,162,224,0.35); }
 
   /* ── SCENE 8a: INFRASTRUCTURE ── */
   #sc8a { flex-direction: column; gap: 14px; }
@@ -336,21 +340,21 @@
   .sc8a-box .icon { font-size: 22px; margin-bottom: 8px; }
   .sc8a-box .name { font-size: 13.5px; font-weight: 700; margin-bottom: 3px; }
   .sc8a-box .sub  { font-size: 12px; color: var(--muted); line-height: 1.4; }
-  .sc8a-box.o { border-color: rgba(56,189,248,0.35); }
-  .sc8a-box.b { border-color: rgba(129,140,248,0.35); }
-  .sc8a-box.g { border-color: rgba(52,211,153,0.3); }
-  .sc8a-box.p { border-color: rgba(192,132,252,0.3); }
+  .sc8a-box.o { border-color: rgba(92,199,210,0.35); }
+  .sc8a-box.b { border-color: rgba(143,184,232,0.35); }
+  .sc8a-box.g { border-color: rgba(79,194,150,0.3); }
+  .sc8a-box.p { border-color: rgba(195,162,224,0.3); }
   .sc8a-conn {
     width: 100%;
     height: 2px;
-    background: linear-gradient(to right, rgba(56,189,248,0.4), rgba(129,140,248,0.4), rgba(192,132,252,0.4));
+    background: linear-gradient(to right, rgba(92,199,210,0.4), rgba(143,184,232,0.4), rgba(195,162,224,0.4));
     border-radius: 2px;
     margin: 2px 0;
   }
 
   /* ── SCENE 4: PIPELINE ── */
   #sc4 { flex-direction: column; gap: 10px; padding: 32px; }
-  .pipe-header { font-size: 12px; font-weight: 700; letter-spacing: 0.15em; text-transform: uppercase; color: var(--muted); font-family: 'SF Mono', monospace; margin-bottom: 4px; }
+  .pipe-header { font-size: 12px; font-weight: 700; letter-spacing: 0.15em; text-transform: uppercase; color: var(--muted); font-family: 'Geist Mono', 'SF Mono', monospace; margin-bottom: 4px; }
   .pipe-comp {
     display: flex;
     align-items: stretch;
@@ -361,12 +365,12 @@
     border-radius: 8px;
     transition: border-color 0.4s;
   }
-  .pipe-comp.lit-b { border-color: rgba(129,140,248,0.4); }
-  .pipe-comp.lit-p { border-color: rgba(192,132,252,0.4); }
-  .pipe-comp.lit-o { border-color: rgba(56,189,248,0.4); }
+  .pipe-comp.lit-b { border-color: rgba(143,184,232,0.4); }
+  .pipe-comp.lit-p { border-color: rgba(195,162,224,0.4); }
+  .pipe-comp.lit-o { border-color: rgba(92,199,210,0.4); }
   .pipe-badge {
     width: 28px; font-size: 11px; font-weight: 800; letter-spacing: 0.08em;
-    text-transform: uppercase; font-family: 'SF Mono', monospace;
+    text-transform: uppercase; font-family: 'Geist Mono', 'SF Mono', monospace;
     writing-mode: vertical-rl; text-orientation: mixed;
     display: flex; align-items: center; justify-content: center;
     border-radius: 4px; flex-shrink: 0;
@@ -374,15 +378,15 @@
   .pipe-body { flex: 1; }
   .pipe-name { font-size: 14.5px; font-weight: 700; margin-bottom: 4px; }
   .pipe-desc { font-size: 13px; color: var(--muted); line-height: 1.5; }
-  .pipe-out  { font-size: 12px; color: var(--muted); font-family: 'SF Mono', monospace; margin-top: 6px; }
+  .pipe-out  { font-size: 12px; color: var(--muted); font-family: 'Geist Mono', 'SF Mono', monospace; margin-top: 6px; }
   .pipe-arrow { text-align: center; color: var(--accent); font-size: 16px; margin: 2px 0; }
 
   /* ── SCENE 5: TICK LOOP ── */
   #sc5 { flex-direction: column; gap: 12px; padding: 28px; }
   .tick-header { display: flex; justify-content: space-between; align-items: center; }
-  .tick-col-label { font-size: 12px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; font-family: 'SF Mono', monospace; padding: 4px 10px; border-radius: 20px; }
-  .tcl-ce { color: var(--accent); background: rgba(56,189,248,0.1); border: 1px solid rgba(56,189,248,0.2); }
-  .tcl-ag { color: var(--blue);   background: rgba(129,140,248,0.1);  border: 1px solid rgba(129,140,248,0.2); }
+  .tick-col-label { font-size: 12px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; font-family: 'Geist Mono', 'SF Mono', monospace; padding: 4px 10px; border-radius: 20px; }
+  .tcl-ce { color: var(--accent); background: rgba(92,199,210,0.1); border: 1px solid rgba(92,199,210,0.2); }
+  .tcl-ag { color: var(--blue);   background: rgba(143,184,232,0.1);  border: 1px solid rgba(143,184,232,0.2); }
   .tick-cols { display: grid; grid-template-columns: 1fr 40px 1fr; gap: 0; }
   .tick-side { display: flex; flex-direction: column; gap: 6px; }
   .tick-mid  { display: flex; flex-direction: column; align-items: center; justify-content: space-around; padding-top: 8px; }
@@ -394,12 +398,12 @@
     font-size: 11px;
     transition: border-color 0.4s, background 0.4s;
   }
-  .tick-card .tc-step { font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; font-family: 'SF Mono', monospace; margin-bottom: 4px; color: var(--muted); }
+  .tick-card .tc-step { font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; font-family: 'Geist Mono', 'SF Mono', monospace; margin-bottom: 4px; color: var(--muted); }
   .tick-card .tc-body { color: var(--text); font-weight: 600; font-size: 13px; }
-  .tick-card .tc-sub  { font-size: 12px; color: var(--muted); margin-top: 2px; line-height: 1.4; font-family: 'SF Mono', monospace; }
-  .tick-card.ce-lit { border-color: rgba(56,189,248,0.35); background: rgba(56,189,248,0.04); }
-  .tick-card.ag-lit { border-color: rgba(129,140,248,0.35);  background: rgba(129,140,248,0.04); }
-  .tick-card.ok-lit { border-color: rgba(52,211,153,0.35);  background: rgba(52,211,153,0.04); }
+  .tick-card .tc-sub  { font-size: 12px; color: var(--muted); margin-top: 2px; line-height: 1.4; font-family: 'Geist Mono', 'SF Mono', monospace; }
+  .tick-card.ce-lit { border-color: rgba(92,199,210,0.35); background: rgba(92,199,210,0.04); }
+  .tick-card.ag-lit { border-color: rgba(143,184,232,0.35);  background: rgba(143,184,232,0.04); }
+  .tick-card.ok-lit { border-color: rgba(79,194,150,0.35);  background: rgba(79,194,150,0.04); }
   .mid-arrow { font-size: 14px; }
   .mid-line  { flex: 1; width: 2px; background: linear-gradient(to bottom, var(--accent), var(--blue)); min-height: 30px; }
 
@@ -408,10 +412,10 @@
   .term-block {
     width: 100%;
     background: rgba(0,0,0,0.45);
-    border: 1px solid rgba(56,189,248,0.2);
+    border: 1px solid rgba(92,199,210,0.2);
     border-radius: 8px;
     padding: 16px 18px;
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     font-size: 13px;
     line-height: 1.7;
     color: var(--muted);
@@ -442,7 +446,7 @@
   }
   #sc8b .cfn-svc .svc-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
   #sc8b .cfn-svc .svc-name { font-size: 13.5px; font-weight: 700; }
-  #sc8b .cfn-svc .svc-port { font-size: 12.5px; color: var(--muted); font-family: 'SF Mono', monospace; margin-top: 1px; }
+  #sc8b .cfn-svc .svc-port { font-size: 12.5px; color: var(--muted); font-family: 'Geist Mono', 'SF Mono', monospace; margin-top: 1px; }
 
   /* ── SCENE 9: FINAL ── */
   #sc9 { flex-direction: column; gap: 14px; padding: 32px; }
@@ -456,25 +460,25 @@
     text-align: center;
     font-size: 13px;
   }
-  .final-box .fb-label { font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; font-family: 'SF Mono', monospace; margin-bottom: 5px; }
+  .final-box .fb-label { font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; font-family: 'Geist Mono', 'SF Mono', monospace; margin-bottom: 5px; }
   .final-box .fb-name  { font-size: 13.5px; font-weight: 700; color: var(--text); }
   .final-box .fb-sub   { font-size: 12px; color: var(--muted); margin-top: 3px; line-height: 1.3; }
-  .final-box.fo { border-color: rgba(56,189,248,0.3);  }
-  .final-box.fb { border-color: rgba(129,140,248,0.3);  }
-  .final-box.fg { border-color: rgba(52,211,153,0.3);  }
+  .final-box.fo { border-color: rgba(92,199,210,0.3);  }
+  .final-box.fb { border-color: rgba(143,184,232,0.3);  }
+  .final-box.fg { border-color: rgba(79,194,150,0.3);  }
   .final-box.fy { border-color: rgba(251,191,36,0.3);  }
-  .final-box.fp { border-color: rgba(192,132,252,0.3); }
+  .final-box.fp { border-color: rgba(195,162,224,0.3); }
   .final-arrow { color: var(--dim); font-size: 16px; flex-shrink: 0; }
   .final-summary {
-    background: rgba(56,189,248,0.05);
-    border: 1px solid rgba(56,189,248,0.2);
+    background: rgba(92,199,210,0.05);
+    border: 1px solid rgba(92,199,210,0.2);
     border-radius: 10px;
     padding: 16px;
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 12px;
   }
-  .fs-item .fs-k { font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; font-family: 'SF Mono', monospace; color: var(--muted); margin-bottom: 3px; }
+  .fs-item .fs-k { font-size: 11px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; font-family: 'Geist Mono', 'SF Mono', monospace; color: var(--muted); margin-bottom: 3px; }
   .fs-item .fs-v { font-size: 13.5px; color: var(--text); line-height: 1.4; }
 
   /* ── PROGRESS ── */
@@ -489,7 +493,7 @@
     border-top: 1px solid var(--border);
     color: var(--muted);
     font-size: 12px;
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -595,14 +599,15 @@
 
 <!-- TOP NAV -->
 <nav class="topnav">
-  <a href="https://mycelium-io.github.io/mycelium/" class="topnav-brand">
+  <a href="https://mycelium-io.github.io/mycelium/" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
-    mycelium
+    <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-sep">/</span>
-  <a href="index.html" class="topnav-page" style="text-decoration:none;">docs</a>
-  <span class="topnav-sep">/</span>
-  <span class="topnav-page">interactive overview</span>
+  <span class="topnav-cell topnav-page-cell">
+    <a href="index.html" class="topnav-page">Docs</a>
+    <span class="topnav-sep">/</span>
+    <span>Interactive overview</span>
+  </span>
   <div class="topnav-right">
     <div class="resources-dropdown">
       <button class="resources-btn" onclick="toggleResources(event)">Resources <i data-lucide="chevron-down" style="width:12px;height:12px;stroke:currentColor;vertical-align:-2px;"></i></button>
@@ -784,7 +789,7 @@
       <!-- SCENE 2: Three Pillars -->
       <div class="scene" id="sc2">
         <div style="width:100%; display:flex; flex-direction:column; gap:10px;">
-          <div style="font-size:12px; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--muted); margin-bottom:4px;">Idea &#8594; Implementation</div>
+          <div style="font-size:12px; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); margin-bottom:4px;">Idea &#8594; Implementation</div>
           <div class="pillar-row">
             <div class="pillar-card po">
               <div class="p-label" style="color:var(--accent);">Pillar 1</div>
@@ -811,7 +816,7 @@
         <div style="width:100%; display:flex; flex-direction:column; gap:8px;">
           <div class="pipe-header">the aligner · 3 stages</div>
           <div class="pipe-comp lit-b">
-            <div class="pipe-badge" style="background:rgba(129,140,248,0.1);color:var(--blue);">1</div>
+            <div class="pipe-badge" style="background:rgba(143,184,232,0.1);color:var(--blue);">1</div>
             <div class="pipe-body">
               <div class="pipe-name">Discover issues</div>
               <div class="pipe-desc">Reads the agents' opening positions</div>
@@ -820,7 +825,7 @@
           </div>
           <div class="pipe-arrow">&#8595;</div>
           <div class="pipe-comp lit-p">
-            <div class="pipe-badge" style="background:rgba(192,132,252,0.1);color:var(--purple);">2</div>
+            <div class="pipe-badge" style="background:rgba(195,162,224,0.1);color:var(--purple);">2</div>
             <div class="pipe-body">
               <div class="pipe-name">Broker each round</div>
               <div class="pipe-desc">@-addresses one agent at a time over SLIM</div>
@@ -829,14 +834,14 @@
           </div>
           <div class="pipe-arrow">&#8595;</div>
           <div class="pipe-comp lit-o">
-            <div class="pipe-badge" style="background:rgba(56,189,248,0.1);color:var(--accent);">3</div>
+            <div class="pipe-badge" style="background:rgba(92,199,210,0.1);color:var(--accent);">3</div>
             <div class="pipe-body">
               <div class="pipe-name">NEGMAS SAO termination</div>
               <div class="pipe-desc">Stacked Alternating Offers, stops on agreement</div>
               <div class="pipe-out">&#8594; commit:converged {assignments}</div>
             </div>
           </div>
-          <div style="padding:10px 14px; background:rgba(251,191,36,0.05); border:1px solid rgba(251,191,36,0.2); border-radius:8px; font-size:12.5px; color:var(--muted); font-family:'SF Mono',monospace;">
+          <div style="padding:10px 14px; background:rgba(251,191,36,0.05); border:1px solid rgba(251,191,36,0.2); border-radius:8px; font-size:12.5px; color:var(--muted); font-family:'Geist Mono', 'SF Mono',monospace;">
             <span style="color:var(--yellow);">the aligner</span> drives all three. Its brain is a persistent<br>Pi coding-agent session, with memory across rounds.
           </div>
         </div>
@@ -849,21 +854,21 @@
           <!-- header -->
           <div style="display:grid; grid-template-columns:1fr 56px 1fr; gap:6px; margin-bottom:2px;">
             <div class="tick-col-label tcl-ce" style="text-align:center;">julia-agent</div>
-            <div style="text-align:center; font-size:11px; color:var(--dim); font-family:'SF Mono',monospace; padding-top:4px;">aligner</div>
+            <div style="text-align:center; font-size:11px; color:var(--dim); font-family:'Geist Mono', 'SF Mono',monospace; padding-top:4px;">aligner</div>
             <div class="tick-col-label tcl-ag" style="text-align:center;">selina-agent</div>
           </div>
 
           <!-- episode opens -->
-          <div style="padding:7px 12px; background:rgba(56,189,248,0.04); border:1px solid rgba(56,189,248,0.12); border-radius:6px; font-size:11px; font-family:'SF Mono',monospace; color:var(--muted);">
+          <div style="padding:7px 12px; background:rgba(92,199,210,0.04); border:1px solid rgba(92,199,210,0.12); border-radius:6px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted);">
             <span style="color:var(--yellow);">the aligner</span> <span style="color:var(--muted);">read the opening positions and discovered the negotiation issues.</span>
           </div>
 
           <!-- round label -->
-          <div style="font-size:11px; letter-spacing:0.15em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--dim); text-align:center;">· round 1 ·</div>
+          <div style="font-size:11px; letter-spacing:0.15em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--dim); text-align:center;">· round 1 ·</div>
 
           <!-- CE → julia: propose -->
           <div style="display:grid; grid-template-columns:1fr 56px 1fr; gap:6px; align-items:center;">
-            <div style="background:rgba(0,0,0,0.4); border:1px solid rgba(56,189,248,0.22); border-radius:7px; padding:8px 10px; font-family:'SF Mono',monospace; font-size:11px; line-height:1.7;">
+            <div style="background:rgba(0,0,0,0.4); border:1px solid rgba(92,199,210,0.22); border-radius:7px; padding:8px 10px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11px; line-height:1.7;">
               <div style="font-size:10px; color:var(--muted); margin-bottom:5px;">← await: tick addressed to julia-agent</div>
               <span style="color:var(--yellow);">the aligner</span> <span style="color:var(--dim);">→</span> <span style="color:var(--accent);">julia-agent</span> &nbsp;<span style="color:var(--blue);">round 1</span>, your offer on:<br>
               <span style="color:var(--text); padding-left:8px; display:inline-block; margin-top:3px;">price</span><br>
@@ -873,14 +878,14 @@
               <span style="color:var(--muted); padding-left:8px; margin-top:2px; display:inline-block; font-size:10px;">+ 6 more issues…</span>
             </div>
             <div style="text-align:center; font-size:14.5px; color:var(--dim);">&#8592;</div>
-            <div style="background:rgba(0,0,0,0.15); border:1px dashed rgba(129,140,248,0.12); border-radius:7px; padding:8px 10px; font-size:11px; color:var(--dim); font-family:'SF Mono',monospace; text-align:center;">waiting…</div>
+            <div style="background:rgba(0,0,0,0.15); border:1px dashed rgba(143,184,232,0.12); border-radius:7px; padding:8px 10px; font-size:11px; color:var(--dim); font-family:'Geist Mono', 'SF Mono',monospace; text-align:center;">waiting…</div>
           </div>
 
           <!-- CE → selina: respond (reject) -->
           <div style="display:grid; grid-template-columns:1fr 56px 1fr; gap:6px; align-items:center;">
-            <div style="background:rgba(52,211,153,0.03); border:1px solid rgba(52,211,153,0.12); border-radius:7px; padding:6px 10px; font-size:11px; font-family:'SF Mono',monospace; color:var(--muted); text-align:center;">offer sent</div>
+            <div style="background:rgba(79,194,150,0.03); border:1px solid rgba(79,194,150,0.12); border-radius:7px; padding:6px 10px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); text-align:center;">offer sent</div>
             <div style="text-align:center; font-size:14.5px; color:var(--dim);">&#8594;</div>
-            <div style="background:rgba(0,0,0,0.4); border:1px solid rgba(129,140,248,0.22); border-radius:7px; padding:8px 10px; font-family:'SF Mono',monospace; font-size:11px; line-height:1.65;">
+            <div style="background:rgba(0,0,0,0.4); border:1px solid rgba(143,184,232,0.22); border-radius:7px; padding:8px 10px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11px; line-height:1.65;">
               <div style="font-size:10px; color:var(--muted); margin-bottom:4px;">← await: tick addressed to selina-agent</div>
               <span style="color:var(--green);">$</span> <span style="color:var(--text);">mycelium respond</span><br>
               <span style="color:rgba(248,113,113,0.8);">"reject: too low"</span> <span style="color:var(--blue);">-r</span> <span style="color:var(--purple);">testing-thursday-10</span> <span style="color:var(--blue);">-H</span> <span style="color:var(--accent);">selina-agent</span>
@@ -888,21 +893,21 @@
           </div>
 
           <!-- ellipsis -->
-          <div style="font-size:11px; letter-spacing:0.15em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--dim); text-align:center;">· rounds alternate (SAO) ·</div>
+          <div style="font-size:11px; letter-spacing:0.15em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--dim); text-align:center;">· rounds alternate (SAO) ·</div>
 
           <!-- final: julia accepts -->
           <div style="display:grid; grid-template-columns:1fr 56px 1fr; gap:6px; align-items:center;">
-            <div style="background:rgba(0,0,0,0.4); border:1px solid rgba(52,211,153,0.3); border-radius:7px; padding:8px 10px; font-family:'SF Mono',monospace; font-size:11px; line-height:1.65;">
+            <div style="background:rgba(0,0,0,0.4); border:1px solid rgba(79,194,150,0.3); border-radius:7px; padding:8px 10px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11px; line-height:1.65;">
               <div style="font-size:10px; color:var(--muted); margin-bottom:4px;">← await: tick addressed to julia-agent</div>
               <span style="color:var(--green);">$</span> <span style="color:var(--text);">mycelium respond</span><br>
               <span style="color:var(--green);">"accept: fair comps"</span> <span style="color:var(--blue);">-r</span> <span style="color:var(--purple);">testing-thursday-10</span> <span style="color:var(--blue);">-H</span> <span style="color:var(--accent);">julia-agent</span>
             </div>
             <div style="text-align:center; font-size:14.5px; color:var(--green);">&#8592;</div>
-            <div style="background:rgba(52,211,153,0.03); border:1px solid rgba(52,211,153,0.12); border-radius:7px; padding:6px 10px; font-size:11px; font-family:'SF Mono',monospace; color:var(--muted); text-align:center;">offer sent</div>
+            <div style="background:rgba(79,194,150,0.03); border:1px solid rgba(79,194,150,0.12); border-radius:7px; padding:6px 10px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); text-align:center;">offer sent</div>
           </div>
 
           <!-- consensus -->
-          <div style="padding:7px 12px; background:rgba(52,211,153,0.06); border:1px solid rgba(52,211,153,0.25); border-radius:7px; font-size:11px; font-family:'SF Mono',monospace; color:var(--muted); text-align:center;">
+          <div style="padding:7px 12px; background:rgba(79,194,150,0.06); border:1px solid rgba(79,194,150,0.25); border-radius:7px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); text-align:center;">
             <span style="color:var(--yellow);">the aligner</span> &rarr; commit:converged &nbsp;<span style="color:var(--green);">{assignments: {...}} &rarr; plan/tasks.md</span>
           </div>
 
@@ -912,7 +917,7 @@
       <!-- SCENE 6: Persistent Memory (terminal mockup) -->
       <div class="scene" id="sc6">
         <div style="width:100%; display:flex; flex-direction:column; gap:10px;">
-          <div style="font-size:12px; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--muted); margin-bottom:4px;">Filesystem-Native Memory</div>
+          <div style="font-size:12px; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); margin-bottom:4px;">Filesystem-Native Memory</div>
           <div class="term-block">
             <span class="prompt">$</span> <span class="cmd">mycelium memory set</span> <span class="val">"decisions/api"</span> <span class="val">"REST chosen over GraphQL"</span> <span class="flag">--handle julia-agent</span><br>
             <span class="output">Memory set: design-review/decisions/api (v1)  [rooms/design-review/decisions/api.md]</span>
@@ -935,7 +940,7 @@
             <span class="key">decisions/api</span> <span class="tdim">(similarity: 0.82, v1)</span><br>
             <span class="output">&nbsp; REST chosen over GraphQL</span>
           </div>
-          <div style="padding:8px 12px; background:rgba(52,211,153,0.05); border:1px solid rgba(52,211,153,0.2); border-radius:8px; font-size:12px; color:var(--green); text-align:center; font-family:'SF Mono',monospace;">
+          <div style="padding:8px 12px; background:rgba(79,194,150,0.05); border:1px solid rgba(79,194,150,0.2); border-radius:8px; font-size:12px; color:var(--green); text-align:center; font-family:'Geist Mono', 'SF Mono',monospace;">
             files = truth &middot; local index = search &middot; git = sharing &middot; unix = toolchain
           </div>
         </div>
@@ -944,7 +949,7 @@
       <!-- SCENE 7: Room is the briefing (terminal mockup) -->
       <div class="scene" id="sc7">
         <div style="width:100%; display:flex; flex-direction:column; gap:10px;">
-          <div style="font-size:12px; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--muted); margin-bottom:4px;">Room directory</div>
+          <div style="font-size:12px; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); margin-bottom:4px;">Room directory</div>
           <div class="term-block" style="line-height:1.8;">
             <span class="prompt">$</span> <span class="cmd">ls .mycelium/rooms/design-review/</span><br>
             <span class="output">decisions/ &nbsp;work/ &nbsp;failed/ &nbsp;status/ &nbsp;plan/ &nbsp;context/</span><br>
@@ -959,7 +964,7 @@
             <span class="tdim"># browse decisions/, failed/, work/ for the rest; no separate</span><br>
             <span class="tdim"># summary step, no stale snapshot.</span>
           </div>
-          <div style="padding:8px 12px; background:rgba(192,132,252,0.05); border:1px solid rgba(192,132,252,0.2); border-radius:8px; font-size:12px; color:var(--purple); text-align:center; font-family:'SF Mono',monospace;">
+          <div style="padding:8px 12px; background:rgba(195,162,224,0.05); border:1px solid rgba(195,162,224,0.2); border-radius:8px; font-size:12px; color:var(--purple); text-align:center; font-family:'Geist Mono', 'SF Mono',monospace;">
             new agent reads the room &#8594; absorbs swarm knowledge &#8594; zero context loss
           </div>
         </div>
@@ -970,47 +975,47 @@
         <div style="width:100%; display:flex; flex-direction:column; gap:8px;">
 
           <!-- layer label -->
-          <div style="font-size:11px; font-weight:700; letter-spacing:0.18em; text-transform:uppercase; color:var(--muted); font-family:'SF Mono',monospace; padding-left:2px;">clients</div>
+          <div style="font-size:11px; font-weight:700; letter-spacing:0.18em; text-transform:uppercase; color:var(--muted); font-family:'Geist Mono', 'SF Mono',monospace; padding-left:2px;">clients</div>
 
           <!-- mycelium-cli -->
-          <div style="padding:12px 16px; background:rgba(56,189,248,0.05); border:1px solid rgba(56,189,248,0.25); border-radius:10px; display:flex; align-items:center; justify-content:space-between;">
+          <div style="padding:12px 16px; background:rgba(92,199,210,0.05); border:1px solid rgba(92,199,210,0.25); border-radius:10px; display:flex; align-items:center; justify-content:space-between;">
             <div>
               <div style="font-size:13.5px; font-weight:700; color:var(--accent);">mycelium-cli</div>
               <div style="font-size:12px; color:var(--muted); margin-top:3px;">agent adapters &middot; Claude Code (hooks + skill) &middot; await / respond primitives</div>
             </div>
-            <div style="font-size:12px; color:var(--muted); font-family:'SF Mono',monospace; white-space:nowrap; padding-left:12px; opacity:0.6;">install / CLI</div>
+            <div style="font-size:12px; color:var(--muted); font-family:'Geist Mono', 'SF Mono',monospace; white-space:nowrap; padding-left:12px; opacity:0.6;">install / CLI</div>
           </div>
 
           <!-- connector -->
-          <div style="display:flex; justify-content:center;"><div style="width:2px; height:12px; background:linear-gradient(to bottom,rgba(56,189,248,0.4),rgba(129,140,248,0.4));"></div></div>
+          <div style="display:flex; justify-content:center;"><div style="width:2px; height:12px; background:linear-gradient(to bottom,rgba(92,199,210,0.4),rgba(143,184,232,0.4));"></div></div>
 
-          <div style="font-size:11px; font-weight:700; letter-spacing:0.18em; text-transform:uppercase; color:var(--muted); font-family:'SF Mono',monospace; padding-left:2px;">core</div>
+          <div style="font-size:11px; font-weight:700; letter-spacing:0.18em; text-transform:uppercase; color:var(--muted); font-family:'Geist Mono', 'SF Mono',monospace; padding-left:2px;">core</div>
 
           <!-- mycelium-backend -->
-          <div style="padding:12px 16px; background:rgba(129,140,248,0.05); border:1px solid rgba(129,140,248,0.3); border-radius:10px; display:flex; align-items:center; justify-content:space-between;">
+          <div style="padding:12px 16px; background:rgba(143,184,232,0.05); border:1px solid rgba(143,184,232,0.3); border-radius:10px; display:flex; align-items:center; justify-content:space-between;">
             <div>
               <div style="font-size:13.5px; font-weight:700; color:var(--blue);">mycelium-backend</div>
               <div style="font-size:12px; color:var(--muted); margin-top:3px;">FastAPI moderator &middot; the aligner (NEGMAS + Pi) &middot; plan compiler</div>
             </div>
-            <div style="font-size:12px; color:var(--blue); font-family:'SF Mono',monospace; white-space:nowrap; padding-left:12px; opacity:0.7;">:8000</div>
+            <div style="font-size:12px; color:var(--blue); font-family:'Geist Mono', 'SF Mono',monospace; white-space:nowrap; padding-left:12px; opacity:0.7;">:8000</div>
           </div>
 
           <!-- connector -->
-          <div style="display:flex; justify-content:center;"><div style="width:2px; height:12px; background:linear-gradient(to bottom,rgba(129,140,248,0.4),rgba(52,211,153,0.4));"></div></div>
+          <div style="display:flex; justify-content:center;"><div style="width:2px; height:12px; background:linear-gradient(to bottom,rgba(143,184,232,0.4),rgba(79,194,150,0.4));"></div></div>
 
-          <div style="font-size:11px; font-weight:700; letter-spacing:0.18em; text-transform:uppercase; color:var(--muted); font-family:'SF Mono',monospace; padding-left:2px;">transport &amp; state</div>
+          <div style="font-size:11px; font-weight:700; letter-spacing:0.18em; text-transform:uppercase; color:var(--muted); font-family:'Geist Mono', 'SF Mono',monospace; padding-left:2px;">transport &amp; state</div>
 
           <!-- bottom row: SLIM node, file store -->
           <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px;">
-            <div style="padding:12px 12px; background:rgba(192,132,252,0.05); border:1px solid rgba(192,132,252,0.25); border-radius:10px;">
+            <div style="padding:12px 12px; background:rgba(195,162,224,0.05); border:1px solid rgba(195,162,224,0.25); border-radius:10px;">
               <div style="font-size:13px; font-weight:700; color:var(--purple);">SLIM node</div>
               <div style="font-size:12px; color:var(--muted); margin-top:4px; line-height:1.5;">one group channel per room<br>MLS encryption · PSK auth</div>
-              <div style="font-size:12px; color:var(--purple); font-family:'SF Mono',monospace; margin-top:6px; opacity:0.7;">L9 over SLIM</div>
+              <div style="font-size:12px; color:var(--purple); font-family:'Geist Mono', 'SF Mono',monospace; margin-top:6px; opacity:0.7;">L9 over SLIM</div>
             </div>
-            <div style="padding:12px 12px; background:rgba(52,211,153,0.05); border:1px solid rgba(52,211,153,0.25); border-radius:10px;">
+            <div style="padding:12px 12px; background:rgba(79,194,150,0.05); border:1px solid rgba(79,194,150,0.25); border-radius:10px;">
               <div style="font-size:13px; font-weight:700; color:var(--green);">file store</div>
               <div style="font-size:12px; color:var(--muted); margin-top:4px; line-height:1.5;">markdown files<br>local ONNX index · no DB</div>
-              <div style="font-size:12px; color:var(--green); font-family:'SF Mono',monospace; margin-top:6px; opacity:0.7;">.mycelium/</div>
+              <div style="font-size:12px; color:var(--green); font-family:'Geist Mono', 'SF Mono',monospace; margin-top:6px; opacity:0.7;">.mycelium/</div>
             </div>
           </div>
 
@@ -1023,14 +1028,14 @@
 
           <!-- top row: node A to node B -->
           <div style="display:grid; grid-template-columns:1fr auto 1fr; gap:0; align-items:center;">
-            <div style="padding:12px 10px; background:rgba(56,189,248,0.07); border:1.5px solid rgba(56,189,248,0.45); border-radius:10px; text-align:center;">
-              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--accent); margin-bottom:4px;">Node A</div>
+            <div style="padding:12px 10px; background:rgba(92,199,210,0.07); border:1.5px solid rgba(92,199,210,0.45); border-radius:10px; text-align:center;">
+              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--accent); margin-bottom:4px;">Node A</div>
               <div style="font-size:12.5px; font-weight:700; color:var(--fg);">Mycelium</div>
               <div style="font-size:10px; color:var(--muted); margin-top:3px;">team / org</div>
             </div>
             <div style="width:32px; height:1.5px; background:rgba(255,255,255,0.15);"></div>
-            <div style="padding:12px 10px; background:rgba(129,140,248,0.07); border:1.5px solid rgba(129,140,248,0.35); border-radius:10px; text-align:center;">
-              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--blue); margin-bottom:4px;">Node B</div>
+            <div style="padding:12px 10px; background:rgba(143,184,232,0.07); border:1.5px solid rgba(143,184,232,0.35); border-radius:10px; text-align:center;">
+              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--blue); margin-bottom:4px;">Node B</div>
               <div style="font-size:12.5px; font-weight:700; color:var(--fg);">Mycelium</div>
               <div style="font-size:10px; color:var(--muted); margin-top:3px;">team / org</div>
             </div>
@@ -1045,22 +1050,22 @@
 
           <!-- bottom row: node C to node D -->
           <div style="display:grid; grid-template-columns:1fr auto 1fr; gap:0; align-items:center;">
-            <div style="padding:12px 10px; background:rgba(52,211,153,0.07); border:1.5px solid rgba(52,211,153,0.3); border-radius:10px; text-align:center;">
-              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--green); margin-bottom:4px;">Node C</div>
+            <div style="padding:12px 10px; background:rgba(79,194,150,0.07); border:1.5px solid rgba(79,194,150,0.3); border-radius:10px; text-align:center;">
+              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--green); margin-bottom:4px;">Node C</div>
               <div style="font-size:12.5px; font-weight:700; color:var(--fg);">Mycelium</div>
               <div style="font-size:10px; color:var(--muted); margin-top:3px;">team / org</div>
             </div>
             <div style="width:32px; height:1.5px; background:rgba(255,255,255,0.15);"></div>
-            <div style="padding:12px 10px; background:rgba(192,132,252,0.07); border:1.5px solid rgba(192,132,252,0.3); border-radius:10px; text-align:center;">
-              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--purple); margin-bottom:4px;">Node D</div>
+            <div style="padding:12px 10px; background:rgba(195,162,224,0.07); border:1.5px solid rgba(195,162,224,0.3); border-radius:10px; text-align:center;">
+              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--purple); margin-bottom:4px;">Node D</div>
               <div style="font-size:12.5px; font-weight:700; color:var(--fg);">Mycelium</div>
               <div style="font-size:10px; color:var(--muted); margin-top:3px;">team / org</div>
             </div>
           </div>
 
           <div style="display:flex; align-items:center; justify-content:center; gap:10px; margin-top:4px;">
-            <div style="padding:3px 10px; background:rgba(56,189,248,0.08); border:1px solid rgba(56,189,248,0.3); border-radius:20px; font-size:10px; font-weight:700; font-family:'SF Mono',monospace; color:var(--accent); letter-spacing:0.08em;">hub / spoke</div>
-            <div style="font-size:11px; color:var(--muted); font-family:'SF Mono',monospace;">each host self-contained &middot; join the same room over one SLIM channel</div>
+            <div style="padding:3px 10px; background:rgba(92,199,210,0.08); border:1px solid rgba(92,199,210,0.3); border-radius:20px; font-size:10px; font-weight:700; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--accent); letter-spacing:0.08em;">hub / spoke</div>
+            <div style="font-size:11px; color:var(--muted); font-family:'Geist Mono', 'SF Mono',monospace;">each host self-contained &middot; join the same room over one SLIM channel</div>
           </div>
 
         </div>
@@ -1069,7 +1074,7 @@
       <!-- SCENE 9: End-to-End -->
       <div class="scene" id="sc9">
         <div style="width:100%; display:flex; flex-direction:column; gap:12px;">
-          <div style="font-size:12px; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--muted); margin-bottom:2px;">end-to-end pipeline</div>
+          <div style="font-size:12px; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); margin-bottom:2px;">end-to-end pipeline</div>
           <div class="final-row">
             <div class="final-box fo">
               <div class="fb-label" style="color:var(--accent);">setup</div>

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -1,25 +1,146 @@
-/* ── mycelium design system ── */
+/* ── mycelium docs — design system ──
+ *
+ * The webapp is the source of truth. This file mirrors
+ * mycelium-frontend/src/app/globals.css: same token contract, same type scale,
+ * same radii, same register discipline. When the app's palette moves, move this
+ * with it rather than inventing a docs-only variant.
+ */
 
-@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,600&family=IBM+Plex+Sans:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,600&family=Geist+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap');
+
+/* ── Palette ─────────────────────────────────────────────────────────────
+ * Two themes, one contract. Raw values live in :root (light) and .dark.
+ *
+ * TEXT vs BACKGROUND is kept honest (the shadcn contract the app adopted): a
+ * token is either a surface you sit ON, or a foreground you paint WITH —
+ * never both.
+ *
+ *   TEXT (foreground)                     BACKGROUND (surface / fill)
+ *   ───────────────────────────────       ───────────────────────────────
+ *   --text                 primary        --bg         app canvas
+ *   --muted-foreground     secondary      --surface    rails, inputs
+ *                          — the legible  --paper      reading pane, cards
+ *                            FLOOR for    --elevated   popovers, active rows
+ *                            any text     --muted-bg   quiet fill (hover)
+ *   --faint     DECORATION ONLY —         --accent-soft  tinted accent wash
+ *               rules, disabled glyphs.
+ *               NEVER body copy.
+ *
+ * One accent, one job: primary action + active state. Green/yellow/red are
+ * reserved for true semantic state, never general emphasis.
+ * ──────────────────────────────────────────────────────────────────────── */
+:root {
+  /* surfaces */
+  --bg: #ffffff;
+  --surface: #f2f4f6;
+  --paper: #ffffff;
+  --elevated: #ffffff;
+  --muted-bg: #eceef1;
+  --hairline: rgba(17, 20, 24, 0.035);
+  /* text (audited legible on #fff, #f2f4f6 and #eceef1) */
+  --text: #14171b;
+  --muted-foreground: #545c65;
+  --faint: #9198a0;
+  /* lines */
+  --border: rgba(17, 20, 24, 0.10);
+  --border2: rgba(17, 20, 24, 0.17);
+  /* accent (one job) */
+  --accent: #0c7d8f;
+  --accent-fg: #ffffff;
+  --accent-soft: rgba(12, 125, 143, 0.10);
+  /* semantic state */
+  --green: #0d8a63;
+  --yellow: #8a6410;
+  --red: #bd3f3a;
+
+  /* Code is the system register — the one place a syntax ramp earns its keep.
+   * Tuned to sit on --paper without competing with prose. */
+  --code-comment: #6b7480;
+  --code-cmd: #0c7d8f;
+  --code-flag: #3f6ea8;
+  --code-str: #0d8a63;
+  --code-arg: #7a4fa3;
+  --code-kw: #a33f6e;
+
+  /* Diagram ramp. Reserved for the dataflow/story plates, where distinct hues
+   * carry real meaning (different subsystems). Never used in chrome or prose. */
+  --viz-1: #0c7d8f;
+  --viz-2: #3f6ea8;
+  --viz-3: #7a4fa3;
+  --viz-4: #0d8a63;
+  --viz-5: #8a6410;
+
+  /* Mycelial background canvas reads these (see site.js). */
+  --canvas-bg: #ffffff;
+  --canvas-ink: 12, 125, 143;
+  /* Dark ink on a light ground reads heavier at equal alpha, so light runs
+   * quieter than dark rather than matching it. */
+  --canvas-alpha: 0.72;
+}
+
+.dark {
+  /* surfaces */
+  --bg: #0c0e11;
+  --surface: #14171c;
+  --paper: #191d22;
+  --elevated: #21262d;
+  --muted-bg: #21262d;
+  --hairline: rgba(255, 255, 255, 0.035);
+  /* text (audited legible on #0c0e11, #14171c and #21262d) */
+  --text: #e8ebee;
+  --muted-foreground: #a7adb5;
+  --faint: #565d65;
+  /* lines */
+  --border: rgba(255, 255, 255, 0.08);
+  --border2: rgba(255, 255, 255, 0.16);
+  /* accent (one job) */
+  --accent: #5cc7d2;
+  --accent-fg: #06181b;
+  --accent-soft: rgba(92, 199, 210, 0.13);
+  /* semantic state */
+  --green: #4fc296;
+  --yellow: #d9a94e;
+  --red: #e6746f;
+
+  --code-comment: #7c848d;
+  --code-cmd: #5cc7d2;
+  --code-flag: #8fb8e8;
+  --code-str: #4fc296;
+  --code-arg: #c3a2e0;
+  --code-kw: #e08fb0;
+
+  --viz-1: #5cc7d2;
+  --viz-2: #8fb8e8;
+  --viz-3: #c3a2e0;
+  --viz-4: #4fc296;
+  --viz-5: #d9a94e;
+
+  --canvas-bg: #0c0e11;
+  --canvas-ink: 92, 199, 210;
+  --canvas-alpha: 1;
+}
+
+/* Back-compat aliases. Legacy docs markup and the standalone plate pages
+ * reference these names inline; var() resolves lazily, so aliasing once here
+ * tracks whichever theme is active. Each points at a legible on-palette value,
+ * so no surface can regress while call sites migrate. */
+:root, .dark {
+  --text2: var(--muted-foreground);
+  --muted: var(--muted-foreground);
+  --dim: var(--faint);
+  --fg: var(--text);
+  --card: var(--paper);
+  --accent2: var(--accent);
+  /* The old saturated categoricals now resolve to the diagram ramp. */
+  --blue: var(--viz-2);
+  --purple: var(--viz-3);
+  --cyan: var(--viz-1);
+}
 
 :root {
-  --bg: #0c0d10;             /* warm near-black, no blue cast */
-  --surface: #111216;        /* lifted "paper" surface */
-  --card: #14161b;
-  --border: rgba(234, 234, 234, 0.10);
-  --border2: rgba(234, 234, 234, 0.22);
-  --accent: #5dd4e0;         /* pale cyan (Onyx) */
-  --accent2: #7dd3fc;        /* lighter sibling cyan */
-  --blue: #818cf8;
-  --green: #34d399;
-  --purple: #c084fc;
-  --cyan: #67e8f9;
-  --yellow: #67e8f9; /* alias for cyan — used in dataflow */
-  --text: #eaeaea;           /* chalk-white primary */
-  --text2: #a8a6a0;          /* softer chalk (lead, secondary copy) */
-  --muted: #898781;          /* dimmed warm gray (labels, captions) */
-  --dim: rgba(234, 234, 234, 0.22);
-  --sidebar-width: 240px;
+  --sidebar-width: 236px;
+  --topbar-height: 52px;
+  --statusbar-height: 26px;
 
   /* spacing scale */
   --space-1: 4px;
@@ -31,10 +152,34 @@
   --space-7: 48px;
   --space-8: 64px;
 
-  /* mono type scale (collapsed from 7 ad-hoc sizes to 3) */
-  --mono-cap: 11px;     /* eyebrows, captions, labels */
-  --mono-code: 13px;    /* code blocks + inline code */
-  --mono-inline: 14px;  /* emphasized inline mono */
+  /* ── font-size scale (the app's five roles) ──
+   *   --text-micro   counts, timestamps, tabular nums, decorations
+   *   --text-label   secondary copy, dense labels, buttons
+   *   --text-body    default UI copy + table cells
+   *   --text-ui      subheads, prominent identifiers
+   *   --text-display serif brand wordmark
+   * Docs add one role the app has no surface for: long-form reading. */
+  --text-micro: 12px;
+  --text-label: 13px;
+  --text-body: 14px;
+  --text-ui: 16px;
+  --text-display: 25px;
+  --text-prose: 15px;
+
+  /* legacy mono-scale aliases */
+  --mono-cap: var(--text-micro);
+  --mono-code: var(--text-label);
+  --mono-inline: var(--text-body);
+
+  /* radii (app: --radius-sm/md/lg/xl) */
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --radius-xl: 14px;
+
+  --font-mono: 'Geist Mono', 'SF Mono', 'JetBrains Mono', Menlo, monospace;
+  --font-sans: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-serif: 'Cormorant Garamond', Georgia, serif;
 
   /* reading measure for prose (code/tables stay wider) */
   --measure: 72ch;
@@ -46,13 +191,22 @@ html { scroll-behavior: smooth; }
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-  font-size: 1rem;
+  font-family: var(--font-sans);
+  font-size: var(--text-prose);
   line-height: 1.65;
   min-height: 100vh;
 }
 
-/* ── MYCELIUM CANVAS BG ── */
+::selection { background: var(--accent-soft); color: var(--text); }
+
+::-webkit-scrollbar { width: 8px; height: 8px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border2); border-radius: 8px; }
+::-webkit-scrollbar-thumb:hover { background: var(--faint); }
+
+/* ── MYCELIUM CANVAS BG ──
+ * Kept, and now theme-aware (site.js repaints it off --canvas-*). It shows
+ * through the workspace gutters; the reading pane sits on near-solid paper. */
 #mycelium-bg {
   position: fixed;
   inset: 0;
@@ -61,50 +215,158 @@ body {
   height: 100%;
 }
 
-/* ── TOP NAV (instrument-panel cells) ── */
+/* ── SHELL ──
+ * Mirrors the app's AppShell: brand + rail on the left, workspace to the
+ * right, an editor status bar pinned at the bottom. */
+
+/* ── TOP BAR ── */
+/* The rails run slightly translucent over the canvas, the way the app's
+ * headers sit at bg-surface/50 — the network stays present through the chrome
+ * instead of being boxed into the gutters. */
 .topnav {
   position: fixed;
   top: 0; left: 0; right: 0;
-  height: 62px;
-  background: rgba(12, 13, 16, 0.92);
-  backdrop-filter: blur(12px);
+  height: var(--topbar-height);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: stretch;
-  padding: 0;
-  gap: 0;
   z-index: 100;
 }
 .topnav-cell {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 0 22px;
-  border-right: 1px solid var(--border);
+  gap: 10px;
+  padding: 0 16px;
   text-decoration: none;
   color: var(--text);
 }
+/* The brand cell is exactly sidebar-wide, so the rail reads as one column. */
 .topnav-brand {
-  font-family: 'Cormorant Garamond', Georgia, serif;
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  font-family: var(--font-serif);
   font-weight: 600;
   font-style: italic;
-  font-size: 24px;
+  font-size: var(--text-display);
+  line-height: 1;
   letter-spacing: -0.01em;
+  transition: background 0.15s;
 }
+.topnav-brand:hover { background: var(--hairline); text-decoration: none; }
 .topnav-brand img {
-  width: 31px;
-  height: 31px;
+  width: 20px;
+  height: 20px;
   object-fit: contain;
+  opacity: 0.9;
+  transform: translateY(2px);
 }
+/* Breadcrumb context cell, used by the standalone plate pages. */
 .topnav-page-cell {
-  gap: 9px;
-  color: var(--muted);
-  border-right: none;
-  padding-left: 14px;
+  gap: 8px;
+  color: var(--muted-foreground);
+  font-size: var(--text-label);
 }
+.topnav-page-cell .square-dot { border-color: var(--accent); }
+.topnav-sep { color: var(--faint); align-self: center; }
+.topnav-page { color: var(--muted-foreground); font-size: var(--text-label); align-self: center; }
+a.topnav-page:hover { color: var(--text); text-decoration: none; }
+.topnav-right {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+}
+.topnav-right a {
+  color: var(--muted-foreground);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  border-radius: var(--radius-md);
+  padding: 6px;
+  transition: color 0.15s, background 0.15s;
+}
+.topnav-right a:hover { color: var(--text); background: var(--hairline); text-decoration: none; }
+
+/* Human register: sentence-case sans labels, modest radius, quiet neutrals.
+ * One primary accent exists in the app; docs chrome has no primary action, so
+ * every button here is the quiet variant. */
+.copy-page-btn,
+.copy-docs-btn,
+.resources-btn,
+.install-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 10px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--muted-foreground);
+  font-family: var(--font-sans);
+  font-size: var(--text-label);
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+.copy-page-btn svg,
+.copy-docs-btn svg,
+.install-tab svg { width: 13px; height: 13px; stroke: currentColor; flex-shrink: 0; }
+.copy-page-btn:hover,
+.copy-docs-btn:hover,
+.resources-btn:hover,
+.install-tab:hover { color: var(--text); background: var(--surface); border-color: var(--border2); }
+.copy-page-btn.copied,
+.copy-docs-btn.copied { color: var(--green); border-color: var(--green); }
+
+/* ── PAGE TABS (the app's segmented control) ── */
+.sectionnav {
+  display: flex;
+  align-items: center;
+  margin-left: 12px;
+}
+.sectionnav-inner {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg);
+}
+.sectionnav a {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 10px;
+  border-radius: var(--radius-md);
+  color: var(--muted-foreground);
+  text-decoration: none;
+  font-family: var(--font-sans);
+  font-size: var(--text-label);
+  font-weight: 500;
+  transition: color 0.15s, background 0.15s;
+}
+.sectionnav a:hover { color: var(--text); text-decoration: none; }
+.sectionnav a.active {
+  background: var(--elevated);
+  color: var(--text);
+  box-shadow: inset 0 0 0 1px var(--border), 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+.sectionnav a .square-dot { display: none; }
+/* The external link sits outside the segmented control. */
+.sectionnav-right { display: flex; align-items: center; margin-left: 8px; }
+.sectionnav-right a { color: var(--muted-foreground); }
+
 .caps-mono {
-  font-family: 'SF Mono', 'JetBrains Mono', 'Fira Mono', monospace;
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
   font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -114,281 +376,205 @@ body {
   width: 8px;
   height: 8px;
   background: transparent;
-  border: 1.5px solid var(--muted);
+  border: 1.5px solid currentColor;
   flex-shrink: 0;
 }
-.topnav-page-cell .square-dot { border-color: var(--accent); }
-.topnav-right {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 0 22px 0 22px;
-  border-left: 1px solid var(--border);
-}
-.topnav-right a {
-  color: var(--muted);
-  text-decoration: none;
-  font-size: 15px;
-  font-family: 'SF Mono', monospace;
-  transition: color 0.2s;
-}
-.topnav-right a:hover { color: var(--accent); }
-.copy-page-btn {
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--muted);
-  font-size: 12px;
-  font-family: 'SF Mono', monospace;
-  padding: 5px 12px;
-  cursor: pointer;
-  transition: border-color 0.2s, color 0.2s;
-}
-.copy-page-btn:hover { border-color: var(--accent); color: var(--accent); }
-.copy-page-btn.copied { border-color: var(--green); color: var(--green); }
+.tabular { font-variant-numeric: tabular-nums; }
 
-/* ── SECTION NAV (horizontal, below topnav) ── */
-.sectionnav {
+/* ── STATUS BAR ── */
+.docs-footer {
   position: fixed;
-  top: 62px;
-  left: 0;
-  right: 0;
-  height: 44px;
-  background: rgba(12, 13, 16, 0.92);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--border);
-  z-index: 99;
-  overflow-x: auto;
-  overflow-y: hidden;
-}
-.sectionnav-inner {
+  left: 0; right: 0; bottom: 0;
+  height: var(--statusbar-height);
   display: flex;
-  align-items: stretch;
-  height: 100%;
-  padding: 0;
-  gap: 0;
-  white-space: nowrap;
-}
-.sectionnav a {
-  display: inline-flex;
   align-items: center;
   gap: 10px;
-  height: 100%;
-  padding: 0 20px;
-  color: var(--muted);
-  text-decoration: none;
-  font-family: 'SF Mono', 'JetBrains Mono', monospace;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.16em;
-  border-right: 1px solid var(--border);
-  border-bottom: 2px solid transparent;
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
-}
-.sectionnav a .square-dot { width: 7px; height: 7px; }
-.sectionnav a:hover { color: var(--text); background: rgba(255,255,255,0.02); }
-.sectionnav a:hover .square-dot { border-color: var(--text); }
-.sectionnav a.active {
-  color: var(--accent);
-  border-bottom-color: var(--accent);
-  background: rgba(56,189,248,0.04);
-}
-.sectionnav a.active .square-dot {
-  background: var(--accent);
-  border-color: var(--accent);
-}
-.sectionnav-right {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-.sectionnav-right a {
-  font-size: 11px;
-  letter-spacing: 0.14em;
-  border-left: 1px solid var(--border);
-  border-right: none;
-}
-
-/* ── DOCS FOOTER ── */
-.docs-footer {
-  margin-top: 48px;
-  padding-top: 16px;
+  padding: 0 12px;
   border-top: 1px solid var(--border);
-  font-family: 'SF Mono', monospace;
-  font-size: 12px;
-  color: var(--muted);
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 4px 12px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  font-size: var(--text-micro);
+  color: var(--muted-foreground);
+  z-index: 100;
 }
-.docs-footer a { color: var(--muted); text-decoration: none; }
-.docs-footer a:hover { color: var(--accent); }
-.docs-footer .sep { color: var(--border2); }
+.docs-footer a { color: var(--muted-foreground); text-decoration: none; border-radius: 4px; padding: 1px 5px; }
+.docs-footer a:hover { color: var(--text); background: var(--hairline); text-decoration: none; }
+.docs-footer .sep { color: var(--faint); }
+.docs-footer .tagline { margin-left: auto; color: var(--faint); }
+/* The sheet number is catalogue metadata — system register, so mono. */
+.docs-footer .sheet-no {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--faint);
+}
 
 /* ── LAYOUT ── */
 .layout {
   display: flex;
-  padding-top: 106px;
+  padding-top: var(--topbar-height);
   min-height: 100vh;
 }
 
-/* ── SIDEBAR ── */
+/* ── SIDEBAR (the app's Explorer rail) ── */
 .sidebar {
   width: var(--sidebar-width);
   flex-shrink: 0;
   position: fixed;
-  top: 106px;
-  bottom: 0;
+  top: var(--topbar-height);
+  bottom: var(--statusbar-height);
   overflow-y: auto;
-  padding: 28px 0 40px;
+  padding: 12px 0 24px;
   border-right: 1px solid var(--border);
-  background: rgba(12, 13, 16, 0.85);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
 }
-.sidebar::-webkit-scrollbar { width: 4px; }
-.sidebar::-webkit-scrollbar-track { background: transparent; }
-.sidebar::-webkit-scrollbar-thumb { background: var(--border2); border-radius: 2px; }
+.sidebar::-webkit-scrollbar { width: 6px; }
 
-.nav-section {
-  margin-bottom: 28px;
-  padding: 0 20px;
-}
+.nav-section { margin-bottom: 18px; padding: 0 8px; }
+/* Sans, not mono: a group label is human register (matches the app's "Rooms"). */
 .nav-section-label {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.15em;
+  font-size: var(--text-micro);
+  font-weight: 600;
+  letter-spacing: 0.025em;
   text-transform: uppercase;
-  color: var(--muted);
-  font-family: 'SF Mono', monospace;
-  margin-bottom: 8px;
-  padding-left: 8px;
+  color: var(--muted-foreground);
+  margin-bottom: 4px;
+  padding: 0 8px;
 }
+/* Rows mirror the app's room rows: rounded-lg, elevated + ring when active. */
 .nav-link {
   display: block;
   padding: 5px 8px;
-  border-radius: 6px;
-  color: var(--muted);
+  border-radius: var(--radius-lg);
+  color: var(--muted-foreground);
   text-decoration: none;
-  font-size: 0.8125rem;
+  font-size: var(--text-label);
+  line-height: 1.45;
   transition: color 0.15s, background 0.15s;
-  line-height: 1.4;
 }
-.nav-link:hover { color: var(--text); background: var(--card); }
-.nav-link.active { color: var(--accent); background: rgba(56,189,248,0.08); }
-.nav-link.sub {
-  padding-left: 20px;
-  font-size: 0.8125rem;
-}
-.nav-link.page {
-  font-weight: 600;
+.nav-link:hover { color: var(--text); background: var(--hairline); text-decoration: none; }
+.nav-link.active {
   color: var(--text);
-  margin-top: 6px;
+  font-weight: 500;
+  background: var(--elevated);
+  box-shadow: inset 0 0 0 1px var(--border);
 }
+.nav-link.sub { padding-left: 8px; }
+.nav-link.page { font-weight: 500; color: var(--text); margin-top: 6px; }
 .nav-link.page:first-of-type { margin-top: 0; }
-.nav-link.page.active { color: var(--accent); }
 
-/* ── MAIN CONTENT ── */
+/* ── WORKSPACE ── */
 .main {
   margin-left: var(--sidebar-width);
   flex: 1;
-  padding: 56px 64px 80px 72px;
+  padding: 28px 32px calc(var(--statusbar-height) + 40px);
   min-width: 0;
-  background: rgba(12, 13, 16, 0.25);
 }
+/* The reading pane. Near-solid so prose stays crisp; the mycelial network
+ * reads as faint texture beneath it and runs free in the gutters. */
 .main-inner {
-  max-width: 90ch;
+  max-width: 92ch;
   margin: 0 auto;
-  background: rgba(12, 13, 16, 0.6);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: color-mix(in srgb, var(--paper) 93%, transparent);
+  backdrop-filter: blur(20px) saturate(115%);
+  -webkit-backdrop-filter: blur(20px) saturate(115%);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 48px 48px 56px;
+  border-radius: var(--radius-xl);
+  padding: 44px 48px 52px;
 }
 
 /* ── SECTIONS ── */
 .doc-section {
-  margin-bottom: 88px;
-  padding-top: 8px;
-  scroll-margin-top: 122px;
+  margin-bottom: 60px;
+  scroll-margin-top: calc(var(--topbar-height) + 16px);
 }
 :target,
 h1[id], h2[id], h3[id], h4[id], section[id] {
-  scroll-margin-top: 122px;
+  scroll-margin-top: calc(var(--topbar-height) + 16px);
 }
 
-
+/* Sans caps, muted — an eyebrow is a label, not an accent moment. */
 .section-eyebrow {
-  font-size: var(--mono-cap);
-  font-weight: 700;
-  letter-spacing: 0.2em;
+  font-size: var(--text-micro);
+  font-weight: 600;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--accent);
-  font-family: 'SF Mono', monospace;
+  color: var(--muted-foreground);
   margin-bottom: var(--space-3);
 }
 
+/* The serif italic hero matches the app's room title (room-plan-header). */
+/* Headings step down gently — the app is a dense 14px UI, so docs stay closer
+ * to body size than a marketing page would. Hierarchy comes from weight and
+ * space, not scale. */
 h1 {
-  font-size: 2.5rem;
+  font-size: 1.95rem;
   font-weight: 600;
   font-style: italic;
   letter-spacing: -0.02em;
-  line-height: 1.12;
-  font-family: 'Cormorant Garamond', Georgia, serif;
-  margin-bottom: var(--space-4);
+  line-height: 1.18;
+  font-family: var(--font-serif);
+  margin-bottom: var(--space-3);
 }
 
 h2 {
-  font-size: 1.6875rem;
-  font-weight: 700;
+  font-size: 1.3125rem;
+  font-weight: 600;
   letter-spacing: -0.01em;
-  line-height: 1.25;
-  margin-bottom: var(--space-4);
-  margin-top: var(--space-8);
+  line-height: 1.3;
+  margin-bottom: var(--space-3);
+  margin-top: var(--space-7);
   color: var(--text);
 }
 
+/* Was mono + a second cyan. Subheads are human register: sans, one text color. */
 h3 {
-  font-size: 1.25rem;
-  font-weight: 700;
-  margin-bottom: var(--space-3);
-  margin-top: var(--space-6);
-  color: var(--accent2);
-  font-family: 'SF Mono', monospace;
-  letter-spacing: 0.02em;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  margin-bottom: var(--space-2);
+  margin-top: var(--space-5);
+  color: var(--text);
+}
+
+h4 {
+  font-size: var(--text-prose);
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+  margin-top: var(--space-4);
+  color: var(--text);
 }
 
 p {
   color: var(--text);
   margin-bottom: var(--space-4);
-  line-height: 1.8;
+  line-height: 1.75;
   max-width: var(--measure);
 }
 
 .main ul,
 .main ol {
-  line-height: 1.8;
+  line-height: 1.75;
   max-width: var(--measure);
+  padding-left: 1.35em;
 }
-.main li {
-  margin-bottom: 6px;
-}
-.main li:last-child {
-  margin-bottom: 0;
-}
+.main li { margin-bottom: 6px; }
+.main li:last-child { margin-bottom: 0; }
+.main li::marker { color: var(--faint); }
 
 a { color: var(--accent); text-decoration: none; }
-a:hover { text-decoration: underline; }
+a:hover { text-decoration: underline; text-underline-offset: 2px; }
 
 strong { color: var(--text); font-weight: 600; }
 
 .lead {
-  font-size: 1.1875rem;
-  color: var(--text2);
-  line-height: 1.6;
-  margin-bottom: var(--space-6);
+  font-size: 1.0625rem;
+  color: var(--muted-foreground);
+  line-height: 1.62;
+  margin-bottom: var(--space-5);
   max-width: var(--measure);
 }
 
@@ -396,29 +582,29 @@ strong { color: var(--text); font-weight: 600; }
 .divider {
   border: none;
   border-top: 1px solid var(--border);
-  margin: 48px 0;
+  margin: 40px 0;
 }
 
 /* ── CODE ── */
 code {
-  font-family: 'SF Mono', 'Fira Mono', 'Menlo', monospace;
-  font-size: var(--mono-code);
-  background: var(--card);
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 2px 6px;
-  color: var(--accent2);
+  border-radius: var(--radius-sm);
+  padding: 1px 5px;
+  color: var(--accent);
 }
 
 pre {
-  background: var(--card);
+  background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 20px 24px;
+  border-radius: var(--radius-lg);
+  padding: 16px 20px;
   overflow-x: auto;
   margin: 16px 0 24px;
   position: relative;
-  line-height: 1.4;
+  line-height: 1.55;
 }
 pre code {
   background: none;
@@ -428,112 +614,86 @@ pre code {
   color: var(--text);
 }
 .pre-label {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.15em;
+  font-size: var(--text-micro);
+  font-weight: 600;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--muted);
-  font-family: 'SF Mono', monospace;
+  color: var(--muted-foreground);
   margin-bottom: 8px;
 }
 
-.install-block {
-  position: relative;
-}
+.install-block { position: relative; }
 .install-copy-btn {
   position: absolute;
   top: 50%;
   right: 10px;
   transform: translateY(-50%);
-  background: rgba(12, 21, 36, 0.5);
+  background: var(--paper);
   border: 1px solid var(--border);
-  border-radius: 5px;
-  color: var(--muted);
-  padding: 5px;
+  border-radius: var(--radius-sm);
+  color: var(--muted-foreground);
   width: 28px;
   height: 28px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  transition: border-color 0.2s, color 0.2s;
+  transition: border-color 0.15s, color 0.15s;
 }
-.install-copy-btn:hover { border-color: var(--accent); color: var(--accent); background: var(--card); }
+.install-copy-btn:hover { border-color: var(--border2); color: var(--text); }
 .install-copy-btn.copied { border-color: var(--green); color: var(--green); }
 .install-copy-btn svg { width: 13px; height: 13px; stroke: currentColor; }
-.install-tabs {
-  display: flex;
-  gap: 4px;
-  margin-bottom: 8px;
+.install-tabs { display: flex; gap: 4px; margin-bottom: 8px; }
+.install-tab { height: 26px; font-size: var(--text-micro); }
+.install-tab.active {
+  color: var(--text);
+  background: var(--elevated);
+  border-color: var(--border2);
 }
-.install-tab {
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  color: var(--muted);
-  font-size: 11px;
-  font-family: 'SF Mono', monospace;
-  padding: 4px 10px;
-  cursor: pointer;
-  transition: border-color 0.2s, color 0.2s, background 0.2s;
-}
-.install-tab:hover { border-color: var(--accent); color: var(--accent); }
-.install-tab.active { border-color: var(--accent); color: var(--accent); background: rgba(56,189,248,0.08); }
 
-/* ── SYNTAX HIGHLIGHTING ── */
-.comment { color: var(--muted); }
-.kw { color: var(--purple); }
-.str { color: var(--green); }
-.flag { color: var(--cyan); }
-.cmd { color: var(--accent); }
-.arg { color: var(--purple); font-style: italic; }
+/* ── SYNTAX ──
+ * Code is the system register, so a syntax ramp is honest here. It is the one
+ * place in the docs that spends more than the single accent. */
+.comment { color: var(--code-comment); }
+.kw { color: var(--code-kw); }
+.str { color: var(--code-str); }
+.flag { color: var(--code-flag); }
+.cmd { color: var(--code-cmd); }
+.arg { color: var(--code-arg); font-style: italic; }
 
 /* ── CALLOUTS ── */
 .callout {
-  border-radius: 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
   margin: 20px 0;
-  font-size: 14px;
-  line-height: 1.6;
+  font-size: var(--text-body);
+  line-height: 1.65;
   overflow: hidden;
   display: flex;
+  max-width: var(--measure);
 }
-.callout-bar {
-  width: 4px;
-  flex-shrink: 0;
-  border-radius: 10px 0 0 10px;
-}
-.callout-body {
-  padding: 14px 18px;
-  border-radius: 0 10px 10px 0;
-  flex: 1;
-}
+.callout-bar { width: 3px; flex-shrink: 0; }
+.callout-body { padding: 12px 16px; flex: 1; color: var(--text); }
+.callout-body p { margin-bottom: 0; font-size: inherit; }
 .callout-info .callout-bar { background: var(--accent); }
-.callout-info .callout-body {
-  background: rgba(56,189,248,0.06);
-  color: var(--accent2);
-}
-.callout-note .callout-bar { background: var(--purple); }
-.callout-note .callout-body {
-  background: rgba(192,132,252,0.06);
-  color: #d8b4fe;
-}
-.callout-warn .callout-bar { background: #d98a4a; }
-.callout-warn .callout-body {
-  background: rgba(217,138,74,0.07);
-  color: #e6b483;
-}
-.callout strong { color: inherit; }
+.callout-info .callout-body { background: var(--accent-soft); }
+/* A "note" is an aside, not a state — neutral, no third hue. */
+.callout-note .callout-bar { background: var(--border2); }
+.callout-note .callout-body { background: var(--hairline); }
+.callout-warn .callout-bar { background: var(--yellow); }
+.callout-warn .callout-body { background: color-mix(in srgb, var(--yellow) 9%, transparent); }
+.callout strong { color: var(--text); }
 
-/* ── SCOPE BOX — "applies to / not for" audience note ── */
+/* ── SCOPE BOX ── */
 .scope-box {
   margin: 20px 0;
-  padding: 14px 18px;
+  padding: 14px 16px;
   border: 1px solid var(--border);
-  border-left: 2px solid var(--muted);
-  border-radius: 6px;
-  font-size: 13.5px;
-  line-height: 1.55;
-  background: rgba(255,255,255,0.015);
+  border-radius: var(--radius-lg);
+  font-size: var(--text-body);
+  line-height: 1.6;
+  background: var(--hairline);
+  max-width: var(--measure);
 }
 .scope-box dl {
   margin: 0;
@@ -542,145 +702,151 @@ pre code {
   gap: 8px 18px;
 }
 .scope-box dt {
-  font-family: 'SF Mono', monospace;
-  font-size: 10.5px;
+  font-size: var(--text-micro);
+  font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--muted);
-  padding-top: 3px;
+  letter-spacing: 0.05em;
+  color: var(--muted-foreground);
+  padding-top: 2px;
   white-space: nowrap;
 }
 .scope-box dd { margin: 0; color: var(--text); }
-.scope-box dd strong { color: var(--accent2); }
-.scope-box dd a { color: var(--accent); }
+.scope-box dd strong { color: var(--text); }
 
 /* ── TABLE ── */
-.table-wrap { overflow-x: auto; margin: 20px 0; }
+.table-wrap {
+  overflow-x: auto;
+  margin: 20px 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
 table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 14px;
+  font-size: var(--text-body);
 }
+/* Column headers are tabular metadata — mono is correct here. */
 th {
   text-align: left;
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--border2);
-  font-size: 11px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--muted);
-  font-family: 'SF Mono', monospace;
+  padding: 9px 14px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
   font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-foreground);
 }
 td {
-  padding: 12px 16px;
+  padding: 10px 14px;
   border-bottom: 1px solid var(--border);
   vertical-align: top;
-  line-height: 1.5;
+  line-height: 1.55;
+  color: var(--text);
 }
 tr:last-child td { border-bottom: none; }
-td:first-child { color: var(--accent2); font-family: 'SF Mono', monospace; font-size: 13px; }
-tr:hover td { background: rgba(255,255,255,0.02); }
+/* First column is usually an identifier: mono earns it, a second hue does not. */
+td:first-child { font-family: var(--font-mono); font-size: var(--mono-code); color: var(--text); }
+tr:hover td { background: var(--hairline); }
 
-/* Config table — type column reads worse when wrapped on union types like "str | None" */
-.config-table td:nth-child(2) { white-space: nowrap; }
+.config-table td:nth-child(2) { white-space: nowrap; color: var(--muted-foreground); }
 
 /* ── CARDS ── */
 .card-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(min(220px, 100%), 1fr));
-  gap: 16px;
+  gap: 12px;
   margin: 24px 0;
 }
 .card {
-  background: var(--card);
+  background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 20px;
-  transition: border-color 0.2s;
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  transition: border-color 0.15s, background 0.15s;
 }
-.card:hover { border-color: var(--border2); }
-.card-icon {
-  margin-bottom: 10px;
-  color: var(--accent);
-}
-.card-icon svg {
-  width: 20px;
-  height: 20px;
-  stroke: currentColor;
-}
-.card-title {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text);
-  margin-bottom: 6px;
-}
-.card-desc {
-  font-size: 13px;
-  color: var(--muted);
-  line-height: 1.5;
-}
+.card:hover { border-color: var(--border2); background: var(--muted-bg); }
+.card-icon { margin-bottom: 10px; color: var(--muted-foreground); }
+.card-icon svg { width: 18px; height: 18px; stroke: currentColor; }
+.card-title { font-size: var(--text-body); font-weight: 600; color: var(--text); margin-bottom: 4px; }
+.card-desc { font-size: var(--text-label); color: var(--muted-foreground); line-height: 1.5; }
 
-/* ── BADGE ── */
+/* ── BADGES ── */
 .badge {
   display: inline-block;
-  font-size: 11px;
-  font-family: 'SF Mono', monospace;
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
   font-weight: 600;
-  padding: 2px 8px;
-  border-radius: 4px;
-  letter-spacing: 0.05em;
+  padding: 1px 7px;
+  border-radius: var(--radius-sm);
+  letter-spacing: 0.03em;
   vertical-align: middle;
+  background: var(--muted-bg);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
 }
-.badge-blue   { background: rgba(129,140,248,0.15); color: var(--blue);   border: 1px solid rgba(129,140,248,0.25); }
-.badge-green  { background: rgba(52,211,153,0.12);  color: var(--green);  border: 1px solid rgba(52,211,153,0.2); }
-.badge-purple { background: rgba(192,132,252,0.12); color: var(--purple); border: 1px solid rgba(192,132,252,0.2); }
+/* Only true state gets a hue. blue/purple were emphasis, so they go neutral. */
+.badge-blue,
+.badge-purple { background: var(--muted-bg); color: var(--muted-foreground); border-color: var(--border); }
+.badge-green {
+  background: color-mix(in srgb, var(--green) 12%, transparent);
+  color: var(--green);
+  border-color: color-mix(in srgb, var(--green) 28%, transparent);
+}
 
-/* ── CHIPS (used in dataflow) ── */
+/* ── CHIPS ──
+ * Two variants in the app (neutral + accent). The plate pages additionally use
+ * the diagram ramp, where hue is information rather than decoration. */
 .chip {
-  display: inline-block; padding: 4px 12px; border-radius: 20px; font-size: 11px;
-  font-weight: 600; letter-spacing: 0.05em; font-family: 'SF Mono', monospace;
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: var(--text-label);
+  font-weight: 500;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--muted-foreground);
 }
-.chip-o { background: rgba(56,189,248,0.1);   color: var(--accent2); border: 1px solid rgba(56,189,248,0.25); }
-.chip-b { background: rgba(129,140,248,0.1);  color: var(--blue);    border: 1px solid rgba(129,140,248,0.25); }
-.chip-g { background: rgba(52,211,153,0.08);  color: var(--green);   border: 1px solid rgba(52,211,153,0.2); }
-.chip-p { background: rgba(192,132,252,0.1);  color: var(--purple);  border: 1px solid rgba(192,132,252,0.22); }
-.chip-y { background: rgba(103,232,249,0.08); color: var(--yellow);  border: 1px solid rgba(103,232,249,0.2); }
+.chip-o { color: var(--viz-1); border-color: color-mix(in srgb, var(--viz-1) 30%, transparent); }
+.chip-b { color: var(--viz-2); border-color: color-mix(in srgb, var(--viz-2) 30%, transparent); }
+.chip-g { color: var(--viz-4); border-color: color-mix(in srgb, var(--viz-4) 30%, transparent); }
+.chip-p { color: var(--viz-3); border-color: color-mix(in srgb, var(--viz-3) 30%, transparent); }
+.chip-y { color: var(--viz-5); border-color: color-mix(in srgb, var(--viz-5) 30%, transparent); }
 
 /* ── CMD REF ── */
 .cmd-ref {
   border: 1px solid var(--border);
-  border-radius: 10px;
-  margin: 12px 0;
+  border-radius: var(--radius-lg);
+  margin: 10px 0;
   overflow: hidden;
+  background: var(--paper);
 }
 .cmd-ref-header {
   display: flex;
   align-items: baseline;
   gap: 12px;
-  padding: 14px 20px;
-  background: var(--card);
-  border-bottom: 1px solid var(--border);
+  padding: 11px 16px;
+  background: var(--surface);
   cursor: pointer;
+  transition: background 0.15s;
 }
+.cmd-ref-header:hover { background: var(--muted-bg); }
 .cmd-ref-header code {
   background: none;
   border: none;
   padding: 0;
-  font-size: 14px;
-  color: var(--accent);
+  font-size: var(--text-body);
+  color: var(--text);
   font-weight: 600;
 }
-.cmd-ref-desc {
-  font-size: 13px;
-  color: var(--muted);
-}
+.cmd-ref-desc { font-size: var(--text-label); color: var(--muted-foreground); }
 .cmd-ref-body {
-  padding: 16px 20px;
-  font-size: 0.8125rem;
-  line-height: 1.6;
-  color: var(--text);
-  opacity: 0.85;
+  padding: 14px 16px;
+  border-top: 1px solid var(--border);
+  font-size: var(--text-label);
+  line-height: 1.65;
+  color: var(--muted-foreground);
 }
 
 /* ── STEP LIST ── */
@@ -688,36 +854,36 @@ tr:hover td { background: rgba(255,255,255,0.02); }
   counter-reset: step;
   list-style: none;
   margin: 20px 0;
+  padding-left: 0;
 }
 .steps li {
   counter-increment: step;
   position: relative;
-  padding-left: 44px;
-  margin-bottom: 20px;
+  padding-left: 38px;
+  margin-bottom: 18px;
 }
 .steps li::before {
   content: counter(step);
   position: absolute;
   left: 0;
-  top: 0;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: rgba(56,189,248,0.1);
-  border: 1px solid rgba(56,189,248,0.25);
-  color: var(--accent);
-  font-size: 12px;
-  font-weight: 700;
-  font-family: 'SF Mono', monospace;
+  top: 1px;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
-/* ── HEADER ANCHOR LINKS ── */
-h2[id], h3[id] {
-  position: relative;
-}
+/* ── HEADER ANCHORS ── */
+h2[id], h3[id] { position: relative; }
 .header-anchor {
   display: inline-flex;
   align-items: center;
@@ -725,92 +891,118 @@ h2[id], h3[id] {
   opacity: 0;
   transition: opacity 0.15s;
   vertical-align: middle;
-  color: var(--muted);
+  color: var(--faint);
   text-decoration: none;
 }
 .header-anchor:hover { color: var(--accent); text-decoration: none; }
-.header-anchor svg { width: 16px; height: 16px; stroke: currentColor; }
+.header-anchor svg { width: 15px; height: 15px; stroke: currentColor; }
 h2:hover .header-anchor,
 h3:hover .header-anchor,
 .header-anchor:focus { opacity: 1; }
 
-/* ── COPY DOCS CMD BUTTON ── */
-.copy-docs-btn {
+/* ── THEME TOGGLE (mirrors the app's light / dark / system menu) ── */
+.theme-toggle { position: relative; display: flex; }
+.theme-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
   background: none;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--muted);
-  font-size: 12px;
-  font-family: 'SF Mono', monospace;
-  padding: 5px 12px;
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--muted-foreground);
   cursor: pointer;
-  transition: border-color 0.2s, color 0.2s;
+  transition: color 0.15s, background 0.15s;
 }
-.copy-docs-btn:hover { border-color: var(--accent); color: var(--accent); }
-.copy-docs-btn.copied { border-color: var(--green); color: var(--green); }
-
-/* ── RESOURCES DROPDOWN ── */
-.resources-dropdown {
-  position: relative;
+.theme-btn:hover { color: var(--text); background: var(--hairline); }
+.theme-btn svg { width: 16px; height: 16px; stroke: currentColor; }
+.theme-menu {
   display: none;
-}
-.resources-btn {
-  background: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 144px;
+  background: var(--elevated);
   border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--muted);
-  font-size: 12px;
-  font-family: 'SF Mono', monospace;
-  padding: 5px 10px;
-  cursor: pointer;
-  transition: border-color 0.2s, color 0.2s;
-  white-space: nowrap;
+  border-radius: var(--radius-xl);
+  padding: 4px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18);
+  z-index: 120;
 }
-.resources-btn:hover { border-color: var(--accent); color: var(--accent); }
+.theme-menu.open { display: block; }
+.theme-menu button {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 6px 10px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-lg);
+  color: var(--muted-foreground);
+  font-family: var(--font-sans);
+  font-size: var(--text-label);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+.theme-menu button:hover { background: var(--surface); color: var(--text); }
+.theme-menu button.active { color: var(--accent); }
+.theme-menu svg { width: 16px; height: 16px; stroke: currentColor; flex-shrink: 0; }
+
+/* ── RESOURCES DROPDOWN (mobile) ── */
+.resources-dropdown { position: relative; display: none; }
 .resources-menu {
   display: none;
   position: absolute;
-  top: calc(100% + 8px);
+  top: calc(100% + 6px);
   right: 0;
-  background: var(--card);
+  background: var(--elevated);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 6px;
+  border-radius: var(--radius-xl);
+  padding: 4px;
   min-width: 180px;
-  z-index: 100;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18);
+  z-index: 120;
 }
 .resources-menu.open { display: block; }
 .resources-menu a {
   display: block;
-  padding: 8px 12px;
-  color: var(--muted);
+  padding: 7px 10px;
+  color: var(--muted-foreground);
   text-decoration: none;
-  font-size: 13px;
-  font-family: 'SF Mono', monospace;
-  border-radius: 5px;
+  font-size: var(--text-label);
+  border-radius: var(--radius-lg);
   transition: background 0.15s, color 0.15s;
 }
-.resources-menu a:hover { background: rgba(56,189,248,0.08); color: var(--accent); }
+.resources-menu a:hover { background: var(--surface); color: var(--text); text-decoration: none; }
 
 /* ── RESPONSIVE ── */
+@media (max-width: 1080px) {
+  .sectionnav a span:not(.square-dot) { font-size: var(--text-micro); }
+  .main { padding: 24px 20px calc(var(--statusbar-height) + 32px); }
+}
 @media (max-width: 860px) {
   .sidebar { display: none; }
-  .main { margin-left: 0; padding: 32px 24px 60px; }
+  .main { margin-left: 0; }
+  .topnav-brand { width: auto; }
   .resources-dropdown { display: block; }
-  .copy-page-btn { display: none; }
-  .copy-docs-btn { display: none; }
+  .copy-page-btn, .copy-docs-btn { display: none; }
+  .docs-footer .tagline { display: none; }
 }
-@media (max-width: 600px) {
+@media (max-width: 640px) {
   body { overflow-x: hidden; }
-  .topnav-page-cell, .host-indicator { display: none; }
-  .topnav-cell { padding: 0 14px; }
-  .topnav-right { gap: 12px; padding: 0 14px; }
-  .sectionnav-right { display: none; }
-  .sectionnav a { padding: 0 14px; gap: 8px; }
-  .main { padding: 24px 16px 60px; }
-  h1 { font-size: 1.75rem; }
-  h2 { font-size: 1.25rem; }
-  .main-inner { padding: 24px 16px 32px; }
-  pre { font-size: 0.75rem; overflow-x: auto; }
-  .cmd-ref-header code { font-size: 0.75rem; word-break: break-all; }
+  .sectionnav { display: none; }
+  .topnav-cell { padding: 0 12px; }
+  .main { padding: 20px 14px calc(var(--statusbar-height) + 28px); }
+  .main-inner { padding: 24px 18px 32px; border-radius: var(--radius-lg); }
+  h1 { font-size: 1.6rem; }
+  h2 { font-size: 1.2rem; }
+  pre { padding: 14px; }
+  .cmd-ref-header code { font-size: var(--text-label); word-break: break-all; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  * { transition: none !important; }
 }

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -14,33 +14,63 @@
 <meta name="twitter:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="stylesheet" href="mycelium.css">
+<script>
+// Resolve the theme before first paint so the page never flashes the wrong one.
+(function () {
+  try {
+    var t = localStorage.getItem('mycelium-theme') || 'system';
+    var dark = t === 'dark'
+      || (t === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    document.documentElement.classList.toggle('dark', dark);
+  } catch (e) {
+    document.documentElement.classList.add('dark');
+  }
+})();
+</script>
 </head>
 <body>
 <canvas id="mycelium-bg"></canvas>
-<!-- TOP NAV -->
+<!-- TOP BAR -->
 <nav class="topnav">
   <a href="https://mycelium-io.github.io" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
     <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-cell topnav-page-cell">
-    <span class="caps-mono">DOCS</span>
-  </span>
-  <div class="topnav-right">
-    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd</button>
-    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page</button>
-    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub" style="display:flex;align-items:center;"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
-  </div>
-</nav>
-<nav class="sectionnav">
-  <div class="sectionnav-inner">
-    <a href="index.html" class=""><span class="square-dot"></span>GET STARTED</a>
-    <a href="concepts.html" class=""><span class="square-dot"></span>CONCEPTS</a>
-    <a href="adapters.html" class=""><span class="square-dot"></span>ADAPTERS</a>
-    <a href="reference.html" class="active"><span class="square-dot"></span>REFERENCE</a>
-    <div class="sectionnav-right">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank">SKILL.md ↗</a>
+  <nav class="sectionnav">
+    <div class="sectionnav-inner">
+      <a href="index.html" class="">Get Started</a>
+      <a href="concepts.html" class="">Concepts</a>
+      <a href="adapters.html" class="">Adapters</a>
+      <a href="reference.html" class="active">Reference</a>
     </div>
+    <div class="sectionnav-right">
+      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+    </div>
+  </nav>
+  <div class="topnav-right">
+    <div class="resources-dropdown">
+      <button class="resources-btn" onclick="toggleResources(event)">Resources</button>
+      <div class="resources-menu" id="resources-menu">
+        <a href="index.html">Get Started</a>
+        <a href="concepts.html">Concepts</a>
+        <a href="adapters.html">Adapters</a>
+        <a href="reference.html">Reference</a>
+        <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+      </div>
+    </div>
+    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal"></i>Copy docs cmd</button>
+    <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy"></i>Copy page</button>
+    <div class="theme-toggle">
+      <button class="theme-btn" id="theme-btn" aria-label="Theme" onclick="toggleThemeMenu(event)">
+        <i data-lucide="sun"></i>
+      </button>
+      <div class="theme-menu" id="theme-menu">
+      <button data-theme-set="light"><i data-lucide="sun"></i>Light</button>
+      <button data-theme-set="dark"><i data-lucide="moon"></i>Dark</button>
+      <button data-theme-set="system"><i data-lucide="monitor"></i>System</button>
+      </div>
+    </div>
+    <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="display:block;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>
   </div>
 </nav>
 <div class="layout">
@@ -1153,18 +1183,18 @@ rm <span class="flag">-rf</span> ~/.mycelium        # remove all config and room
       <h2 id="troubleshooting-getting-help">Getting Help</h2>
       <p>Report issues at <strong>https://github.com/mycelium-io/mycelium/issues</strong></p>
     </section>
-    <!-- FOOTER -->
-    <div class="docs-footer">
-      <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
-      <span class="sep">·</span>
-      <span>Apache 2.0</span>
-      <span class="sep">·</span>
-      <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
-    </div>
-
   </div>
   </main>
 </div>
+
+<!-- STATUS BAR -->
+<footer class="docs-footer">
+  <span class="sheet-no">REF-001</span>
+  <a href="https://github.com/mycelium-io/mycelium">mycelium-io/mycelium</a>
+  <span class="sep">·</span>
+  <span>Apache 2.0</span>
+  <span class="tagline">Shared Intent &middot; Shared Memory &middot; Shared Context</span>
+</footer>
 
 <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
 <script src="site.js"></script>

--- a/docs/site.js
+++ b/docs/site.js
@@ -1,4 +1,59 @@
-  lucide.createIcons();
+  // Icons come from a third-party CDN. If it fails to load, the page must still
+  // work — a bare lucide.createIcons() here would throw and abort this whole
+  // file, taking the nav, theme toggle and background canvas down with it.
+  function icons() {
+    if (window.lucide && window.lucide.createIcons) window.lucide.createIcons();
+  }
+
+  icons();
+
+  // ── Theme (light / dark / system) ──
+  // Mirrors the app's ThemeToggle. The pre-paint resolver lives inline in the
+  // page head; this owns the menu, persistence, and telling the canvas to
+  // repaint on a theme change.
+  const THEME_KEY = 'mycelium-theme';
+  const themeMedia = window.matchMedia('(prefers-color-scheme: dark)');
+
+  function storedTheme() {
+    try { return localStorage.getItem(THEME_KEY) || 'system'; } catch (e) { return 'system'; }
+  }
+
+  function applyTheme(pref) {
+    const dark = pref === 'dark' || (pref === 'system' && themeMedia.matches);
+    document.documentElement.classList.toggle('dark', dark);
+    const btn = document.getElementById('theme-btn');
+    if (btn) {
+      btn.innerHTML = '<i data-lucide="' + (dark ? 'moon' : 'sun') + '"></i>';
+      icons();
+    }
+    document.querySelectorAll('[data-theme-set]').forEach(b => {
+      b.classList.toggle('active', b.getAttribute('data-theme-set') === pref);
+    });
+    window.dispatchEvent(new CustomEvent('mycelium:theme'));
+  }
+
+  function setTheme(pref) {
+    try { localStorage.setItem(THEME_KEY, pref); } catch (e) {}
+    applyTheme(pref);
+  }
+
+  function toggleThemeMenu(e) {
+    e.stopPropagation();
+    const menu = document.getElementById('theme-menu');
+    if (menu) menu.classList.toggle('open');
+  }
+
+  document.addEventListener('click', () => {
+    const menu = document.getElementById('theme-menu');
+    if (menu) menu.classList.remove('open');
+  });
+  document.querySelectorAll('[data-theme-set]').forEach(b => {
+    b.addEventListener('click', () => setTheme(b.getAttribute('data-theme-set')));
+  });
+  themeMedia.addEventListener('change', () => {
+    if (storedTheme() === 'system') applyTheme('system');
+  });
+  applyTheme(storedTheme());
 
   function toggleResources(e) {
     e.stopPropagation();
@@ -15,13 +70,13 @@
     navigator.clipboard.writeText(text).then(() => {
       const btn = document.querySelector('.copy-page-btn');
       const tokens = Math.round(text.length / 4).toLocaleString();
-      btn.innerHTML = '<i data-lucide="check" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copied! (~' + tokens + ' tokens)';
+      btn.innerHTML = '<i data-lucide="check"></i>Copied (~' + tokens + ' tokens)';
       btn.classList.add('copied');
-      lucide.createIcons();
+      icons();
       setTimeout(() => {
-        btn.innerHTML = '<i data-lucide="copy" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy this page';
+        btn.innerHTML = '<i data-lucide="copy"></i>Copy page';
         btn.classList.remove('copied');
-        lucide.createIcons();
+        icons();
       }, 2000);
     });
   }
@@ -38,7 +93,7 @@
     const btn = document.querySelector('.install-copy-btn');
     btn.innerHTML = '<i data-lucide="copy"></i>';
     btn.classList.remove('copied');
-    lucide.createIcons();
+    icons();
   }
 
   function copyInstallCmd(btn) {
@@ -46,11 +101,11 @@
     navigator.clipboard.writeText(cmd).then(() => {
       btn.innerHTML = '<i data-lucide="check"></i>';
       btn.classList.add('copied');
-      lucide.createIcons();
+      icons();
       setTimeout(() => {
         btn.innerHTML = '<i data-lucide="copy"></i>';
         btn.classList.remove('copied');
-        lucide.createIcons();
+        icons();
       }, 2000);
     });
   }
@@ -102,13 +157,13 @@
     const cmd = SECTION_DOCS_MAP[currentDocsSection] || 'mycelium docs --full';
     navigator.clipboard.writeText(cmd).then(() => {
       const btn = document.querySelector('.copy-docs-btn');
-      btn.innerHTML = '<i data-lucide="check" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>' + cmd;
+      btn.innerHTML = '<i data-lucide="check"></i>' + cmd;
       btn.classList.add('copied');
-      lucide.createIcons();
+      icons();
       setTimeout(() => {
-        btn.innerHTML = '<i data-lucide="terminal" style="width:13px;height:13px;stroke:currentColor;vertical-align:-2px;margin-right:6px;"></i>copy docs cmd';
+        btn.innerHTML = '<i data-lucide="terminal"></i>Copy docs cmd';
         btn.classList.remove('copied');
-        lucide.createIcons();
+        icons();
       }, 2000);
     });
   }
@@ -143,12 +198,49 @@
   var trail = new Float32Array(cols * rows);       // animated nutrient flow
   var colorIdx = new Uint8Array(cols * rows);
 
-  const BG = { r: 12, g: 13, b: 16 };
-  const COLORS = [
-    { r: 56, g: 189, b: 248 },   // cyan
-    { r: 129, g: 140, b: 248 },   // indigo
-    { r: 192, g: 132, b: 252 },   // purple
-  ];
+  // ── Palette ──
+  // Read from the stylesheet rather than hardcoded, so the network tracks the
+  // active theme. The old cyan/indigo/purple triad was three unrelated hues;
+  // the colonies now vary in depth off the single accent instead.
+  var BG = { r: 12, g: 14, b: 17 };
+  var COLORS = [{ r: 92, g: 199, b: 210 }, { r: 92, g: 199, b: 210 }, { r: 92, g: 199, b: 210 }];
+  var INK_ALPHA = 1;
+
+  function hexToRgb(hex) {
+    var h = hex.trim().replace('#', '');
+    if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16),
+    };
+  }
+
+  function mix(a, b, t) {
+    return {
+      r: Math.round(a.r + (b.r - a.r) * t),
+      g: Math.round(a.g + (b.g - a.g) * t),
+      b: Math.round(a.b + (b.b - a.b) * t),
+    };
+  }
+
+  function readPalette() {
+    var cs = getComputedStyle(document.documentElement);
+    var bg = cs.getPropertyValue('--canvas-bg');
+    var ink = cs.getPropertyValue('--canvas-ink').split(',');
+    var alpha = parseFloat(cs.getPropertyValue('--canvas-alpha'));
+    if (bg) BG = hexToRgb(bg);
+    if (ink.length === 3) {
+      var base = { r: +ink[0], g: +ink[1], b: +ink[2] };
+      // Three depths of one accent: enough variation to read as separate
+      // colonies, without spending a second hue.
+      COLORS = [base, mix(base, BG, 0.28), mix(base, BG, 0.5)];
+    }
+    if (!isNaN(alpha)) INK_ALPHA = alpha;
+  }
+
+  readPalette();
+  window.addEventListener('mycelium:theme', readPalette);
 
   canvas.style.width = '100%';
   canvas.style.height = '100%';
@@ -440,7 +532,7 @@
         if (sVal < 0.01 && tVal < 0.01) continue;
         var c = COLORS[colorIdx[idx]];
         // Structure is dim/permanent, flow is brighter/animated
-        var alpha = sVal * 0.02 + tVal * 0.2;
+        var alpha = (sVal * 0.02 + tVal * 0.2) * INK_ALPHA;
         ctx.fillStyle = 'rgba(' + c.r + ',' + c.g + ',' + c.b + ',' + alpha + ')';
         ctx.fillRect(x, y, 1, 1);
       }

--- a/docs/stories.html
+++ b/docs/stories.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -30,13 +30,13 @@
     padding: 80px;
     padding-top: 140px;
     background:
-      radial-gradient(ellipse at 15% 60%, rgba(56,189,248,0.07) 0%, transparent 55%),
-      radial-gradient(ellipse at 80% 20%, rgba(192,132,252,0.06) 0%, transparent 50%);
+      radial-gradient(ellipse at 15% 60%, rgba(92,199,210,0.07) 0%, transparent 55%),
+      radial-gradient(ellipse at 80% 20%, rgba(195,162,224,0.06) 0%, transparent 50%);
   }
   .hero-eyebrow {
     font-size: 11px; letter-spacing: 0.25em; text-transform: uppercase;
     color: var(--accent); font-weight: 700; margin-bottom: 20px;
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
   }
   .hero-title {
     font-size: clamp(32px, 4vw, 52px);
@@ -78,14 +78,14 @@
     width: 100%;
     height: 100%;
     background: linear-gradient(135deg, rgba(12,21,36,0.95) 0%, rgba(8,14,24,0.98) 100%);
-    border: 1px solid rgba(56,189,248,0.1);
+    border: 1px solid rgba(92,199,210,0.1);
     border-radius: 16px;
     position: relative;
     overflow: hidden;
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 0 60px rgba(56,189,248,0.03), inset 0 1px 0 rgba(56,189,248,0.07);
+    box-shadow: 0 0 60px rgba(92,199,210,0.03), inset 0 1px 0 rgba(92,199,210,0.07);
   }
 
   /* ── SCENES ── */
@@ -120,7 +120,7 @@
   .sec-label {
     font-size: 10px; font-weight: 700; letter-spacing: 0.2em;
     text-transform: uppercase; color: var(--accent);
-    font-family: 'SF Mono', monospace; margin-bottom: 14px;
+    font-family: 'Geist Mono', 'SF Mono', monospace; margin-bottom: 14px;
   }
   .sec-label.blue   { color: var(--blue); }
   .sec-label.green  { color: var(--green); }
@@ -137,7 +137,7 @@
   }
   .sec-body strong { color: #aaa; font-weight: 600; }
   .sec-body code {
-    font-family: 'SF Mono', monospace; font-size: 12px;
+    font-family: 'Geist Mono', 'SF Mono', monospace; font-size: 12px;
     background: rgba(255,255,255,0.06); padding: 2px 6px;
     border-radius: 4px; color: #c4c4c4;
   }
@@ -147,7 +147,7 @@
     border-left: 2px solid var(--accent);
     border-radius: 0 6px 6px 0;
     padding: 10px 14px;
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     font-size: 11px; color: var(--muted); line-height: 1.6;
   }
   .sec-detail.blue   { border-color: var(--blue); }
@@ -162,7 +162,7 @@
   /* ── USER / AGENT LABELS ── */
   .story-label {
     font-size: 10px; font-weight: 700; letter-spacing: 0.15em;
-    text-transform: uppercase; font-family: 'SF Mono', monospace;
+    text-transform: uppercase; font-family: 'Geist Mono', 'SF Mono', monospace;
     margin-bottom: 6px; margin-top: 18px;
   }
   .story-label.user    { color: var(--blue); }
@@ -171,14 +171,14 @@
     font-size: 14px; color: var(--text);
     font-style: italic; line-height: 1.55;
     padding: 10px 14px;
-    background: rgba(129,140,248,0.05);
-    border: 1px solid rgba(129,140,248,0.15);
+    background: rgba(143,184,232,0.05);
+    border: 1px solid rgba(143,184,232,0.15);
     border-radius: 7px;
     max-width: 400px;
   }
   .story-input code {
     font-style: normal; font-size: 12px;
-    background: rgba(129,140,248,0.12);
+    background: rgba(143,184,232,0.12);
     color: var(--blue); border-radius: 3px;
     padding: 1px 5px;
   }
@@ -187,10 +187,10 @@
   .term {
     width: 100%;
     background: rgba(0,0,0,0.45);
-    border: 1px solid rgba(56,189,248,0.18);
+    border: 1px solid rgba(92,199,210,0.18);
     border-radius: 8px;
     padding: 16px 18px;
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     font-size: 12.5px; line-height: 1.7;
     color: var(--muted); overflow-x: auto;
   }
@@ -212,7 +212,7 @@
   .d-box .d-label {
     font-size: 10px; font-weight: 700; letter-spacing: 0.12em;
     text-transform: uppercase; margin-bottom: 4px;
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
   }
   .d-box .d-name { font-size: 13px; font-weight: 700; color: var(--text); }
   .d-box .d-sub  { font-size: 11.5px; color: var(--muted); margin-top: 2px; }
@@ -222,7 +222,7 @@
   .footer {
     display: flex; gap: 20px; padding: 48px 80px;
     font-size: 12px; color: var(--muted);
-    font-family: 'SF Mono', monospace;
+    font-family: 'Geist Mono', 'SF Mono', monospace;
     border-top: 1px solid var(--border);
   }
   .footer a { color: var(--muted); text-decoration: none; }
@@ -254,14 +254,15 @@
 
 <!-- TOP NAV -->
 <nav class="topnav">
-  <a href="https://mycelium-io.github.io/mycelium/" class="topnav-brand">
+  <a href="https://mycelium-io.github.io/mycelium/" class="topnav-cell topnav-brand">
     <img src="logo.png" alt="Mycelium">
-    mycelium
+    <span class="brand-word">mycelium</span>
   </a>
-  <span class="topnav-sep">/</span>
-  <a href="index.html" class="topnav-page" style="text-decoration:none;">docs</a>
-  <span class="topnav-sep">/</span>
-  <span class="topnav-page">stories</span>
+  <span class="topnav-cell topnav-page-cell">
+    <a href="index.html" class="topnav-page">Docs</a>
+    <span class="topnav-sep">/</span>
+    <span>Stories</span>
+  </span>
   <div class="topnav-right">
     <div class="resources-dropdown">
       <button class="resources-btn" onclick="toggleResources(event)">Resources <i data-lucide="chevron-down" style="width:12px;height:12px;stroke:currentColor;vertical-align:-2px;"></i></button>
@@ -416,16 +417,16 @@
           </div>
           <div style="display:flex; align-items:center; gap:6px; margin-top:4px;">
             <div style="flex:1; height:1px; background:var(--border);"></div>
-            <span style="font-size:10px; color:var(--muted); font-family:'SF Mono',monospace; letter-spacing:0.1em;">written to disk</span>
+            <span style="font-size:10px; color:var(--muted); font-family:'Geist Mono', 'SF Mono',monospace; letter-spacing:0.1em;">written to disk</span>
             <div style="flex:1; height:1px; background:var(--border);"></div>
           </div>
-          <div style="background:var(--card); border:1px solid var(--border); border-radius:8px; padding:12px 16px; font-family:'SF Mono',monospace; font-size:11.5px; line-height:1.7; color:var(--muted);">
+          <div style="background:var(--card); border:1px solid var(--border); border-radius:8px; padding:12px 16px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11.5px; line-height:1.7; color:var(--muted);">
             <span style="color:var(--muted);">~/.mycelium/rooms/design-review/</span><br>
             <span style="color:var(--blue);">  decisions/</span><span style="color:var(--muted);">db.md &nbsp;&nbsp;api.md</span><br>
             <span style="color:var(--accent);">  work/</span><span style="color:var(--muted);">query-perf.md</span> <span style="color:var(--green); font-size:10px;">← just written</span><br>
             <span style="color:var(--purple);">  failed/</span><span style="color:var(--muted);">sqlite.md</span>
           </div>
-          <div style="padding:6px 12px; background:rgba(56,189,248,0.05); border:1px solid rgba(56,189,248,0.15); border-radius:6px; font-size:11px; color:var(--muted); font-family:'SF Mono',monospace; text-align:center;">
+          <div style="padding:6px 12px; background:rgba(92,199,210,0.05); border:1px solid rgba(92,199,210,0.15); border-radius:6px; font-size:11px; color:var(--muted); font-family:'Geist Mono', 'SF Mono',monospace; text-align:center;">
             local embedding index updated simultaneously
           </div>
         </div>
@@ -441,16 +442,16 @@
 <span class="dim">&nbsp;&nbsp;&nbsp;&nbsp; N+1 on user.posts, 47 queries per page load.</span><br>
 <span class="dim">&nbsp;&nbsp;&nbsp;&nbsp; Fixed with select_related. p99: 340ms → 28ms.</span><br>
 <br>
-<span style="color:rgba(52,211,153,0.6);">0.74</span>  <span class="k">decisions/db</span><br>
+<span style="color:rgba(79,194,150,0.6);">0.74</span>  <span class="k">decisions/db</span><br>
 <span class="dim">&nbsp;&nbsp;&nbsp;&nbsp; Markdown files on disk are the source of truth.</span><br>
 <span class="dim">&nbsp;&nbsp;&nbsp;&nbsp; No database; search runs on a local index.</span>
           </div>
           <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px; margin-top:4px;">
-            <div style="padding:10px 12px; background:var(--card); border:1px solid var(--border); border-radius:7px; font-size:11px; font-family:'SF Mono',monospace; color:var(--muted); line-height:1.5;">
+            <div style="padding:10px 12px; background:var(--card); border:1px solid var(--border); border-radius:7px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); line-height:1.5;">
               <div style="color:var(--accent); font-weight:700; margin-bottom:4px;">model</div>
               local ONNX index<br>~384 dimensions<br>runs locally
             </div>
-            <div style="padding:10px 12px; background:var(--card); border:1px solid var(--border); border-radius:7px; font-size:11px; font-family:'SF Mono',monospace; color:var(--muted); line-height:1.5;">
+            <div style="padding:10px 12px; background:var(--card); border:1px solid var(--border); border-radius:7px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); line-height:1.5;">
               <div style="color:var(--accent); font-weight:700; margin-bottom:4px;">metric</div>
               cosine similarity<br>no keyword match<br>no API key
             </div>
@@ -470,7 +471,7 @@
 <br>
 <span class="ok">✓</span> <span class="dim">failed/pgbouncer written to design-review</span>
           </div>
-          <div style="background:rgba(248,113,113,0.05); border:1px solid rgba(248,113,113,0.2); border-radius:8px; padding:12px 14px; font-size:12px; font-family:'SF Mono',monospace; color:rgba(248,113,113,0.7); line-height:1.55;">
+          <div style="background:rgba(248,113,113,0.05); border:1px solid rgba(248,113,113,0.2); border-radius:8px; padding:12px 14px; font-size:12px; font-family:'Geist Mono', 'SF Mono',monospace; color:rgba(248,113,113,0.7); line-height:1.55;">
             <span style="font-weight:700; display:block; margin-bottom:4px;">failed/ namespace</span>
             <span style="color:var(--muted);">Browsable to every future agent that opens the room directory. Prevents duplicate effort.</span>
           </div>
@@ -503,23 +504,23 @@
       <div class="scene" id="sc5">
         <div style="width:100%; display:flex; flex-direction:column; gap:10px;">
           <div style="display:grid; grid-template-columns:1fr auto 1fr; gap:8px; align-items:start;">
-            <div style="background:rgba(129,140,248,0.07); border:1px solid rgba(129,140,248,0.3); border-radius:8px; padding:10px 12px; font-family:'SF Mono',monospace; font-size:11.5px;">
+            <div style="background:rgba(143,184,232,0.07); border:1px solid rgba(143,184,232,0.3); border-radius:8px; padding:10px 12px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11.5px;">
               <div style="color:var(--blue); font-weight:700; margin-bottom:6px;">julia-agent</div>
               <div style="color:var(--muted); line-height:1.5;">"DB migration first: auth + frontend both depend on new schema."</div>
             </div>
             <div style="display:flex; flex-direction:column; align-items:center; gap:6px; padding-top:10px; color:var(--muted); font-size:18px;">↓<br>↑</div>
-            <div style="background:rgba(192,132,252,0.07); border:1px solid rgba(192,132,252,0.3); border-radius:8px; padding:10px 12px; font-family:'SF Mono',monospace; font-size:11.5px;">
+            <div style="background:rgba(195,162,224,0.07); border:1px solid rgba(195,162,224,0.3); border-radius:8px; padding:10px 12px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11.5px;">
               <div style="color:var(--purple); font-weight:700; margin-bottom:6px;">selina-agent</div>
               <div style="color:var(--muted); line-height:1.5;">"Frontend polish first: users churning on UX. Backend solid enough."</div>
             </div>
           </div>
           <div style="display:flex; justify-content:center;">
-            <div style="padding:10px 20px; background:rgba(56,189,248,0.08); border:1px solid rgba(56,189,248,0.25); border-radius:8px; font-size:12px; font-family:'SF Mono',monospace; color:var(--accent); text-align:center;">
+            <div style="padding:10px 20px; background:rgba(92,199,210,0.08); border:1px solid rgba(92,199,210,0.25); border-radius:8px; font-size:12px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--accent); text-align:center;">
               <div style="font-weight:700; margin-bottom:4px;">the aligner</div>
               <div style="color:var(--muted); font-size:11px;">NEGMAS Stacked Alternating Offers</div>
             </div>
           </div>
-          <div style="background:rgba(52,211,153,0.06); border:1px solid rgba(52,211,153,0.2); border-radius:8px; padding:10px 14px; font-size:11.5px; font-family:'SF Mono',monospace; color:var(--muted); line-height:1.6;">
+          <div style="background:rgba(79,194,150,0.06); border:1px solid rgba(79,194,150,0.2); border-radius:8px; padding:10px 14px; font-size:11.5px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); line-height:1.6;">
             <span style="color:var(--green); font-weight:700; display:block; margin-bottom:4px;">consensus → compiled into plan/tasks.md</span>
             scope=migration-first · quality=high<br>
             <span style="color:var(--muted);">- [ ] lead the schema migration @julia-agent</span><br>
@@ -532,23 +533,23 @@
       <div class="scene" id="sc6">
         <div style="width:100%; display:flex; flex-direction:column; gap:12px;">
           <div style="display:grid; grid-template-columns:1fr 1fr; gap:10px;">
-            <div style="background:rgba(56,189,248,0.06); border:1.5px solid rgba(56,189,248,0.3); border-radius:10px; padding:14px; text-align:center;">
-              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--accent); margin-bottom:6px;">Machine 1 · hub</div>
+            <div style="background:rgba(92,199,210,0.06); border:1.5px solid rgba(92,199,210,0.3); border-radius:10px; padding:14px; text-align:center;">
+              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--accent); margin-bottom:6px;">Machine 1 · hub</div>
               <div style="font-size:13px; font-weight:700; color:var(--text); margin-bottom:4px;">backend-agent</div>
               <div style="font-size:11px; color:var(--muted);">Claude Code adapter</div>
-              <div style="margin-top:8px; font-size:11px; color:var(--green); font-family:'SF Mono',monospace;">✓ API layer done</div>
+              <div style="margin-top:8px; font-size:11px; color:var(--green); font-family:'Geist Mono', 'SF Mono',monospace;">✓ API layer done</div>
             </div>
-            <div style="background:rgba(192,132,252,0.06); border:1.5px solid rgba(192,132,252,0.3); border-radius:10px; padding:14px; text-align:center;">
-              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'SF Mono',monospace; color:var(--purple); margin-bottom:6px;">Machine 2 · spoke</div>
+            <div style="background:rgba(195,162,224,0.06); border:1.5px solid rgba(195,162,224,0.3); border-radius:10px; padding:14px; text-align:center;">
+              <div style="font-size:10px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--purple); margin-bottom:6px;">Machine 2 · spoke</div>
               <div style="font-size:13px; font-weight:700; color:var(--text); margin-bottom:4px;">frontend-agent</div>
               <div style="font-size:11px; color:var(--muted);">joined over the hub</div>
-              <div style="margin-top:8px; font-size:11px; color:var(--blue); font-family:'SF Mono',monospace;">↳ picking up frontend</div>
+              <div style="margin-top:8px; font-size:11px; color:var(--blue); font-family:'Geist Mono', 'SF Mono',monospace;">↳ picking up frontend</div>
             </div>
           </div>
           <div style="display:flex; justify-content:center; align-items:center; gap:8px;">
-            <div style="height:1px; flex:1; background:rgba(56,189,248,0.2);"></div>
-            <div style="padding:8px 16px; background:rgba(56,189,248,0.08); border:1px solid rgba(56,189,248,0.2); border-radius:20px; font-size:11px; font-family:'SF Mono',monospace; color:var(--accent);">api-project room</div>
-            <div style="height:1px; flex:1; background:rgba(192,132,252,0.2);"></div>
+            <div style="height:1px; flex:1; background:rgba(92,199,210,0.2);"></div>
+            <div style="padding:8px 16px; background:rgba(92,199,210,0.08); border:1px solid rgba(92,199,210,0.2); border-radius:20px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--accent);">api-project room</div>
+            <div style="height:1px; flex:1; background:rgba(195,162,224,0.2);"></div>
           </div>
           <div class="term" style="font-size:11px;">
 <span class="dim">context/handoff:</span> <span class="v">"Use TypeScript client in mycelium-client/.</span><br>
@@ -563,13 +564,13 @@
       <div class="scene" id="sc7">
         <div style="width:100%; display:flex; flex-direction:column; gap:10px;">
           <div style="display:flex; align-items:center; gap:8px; flex-wrap:wrap;">
-            <div style="padding:5px 10px; background:var(--card); border:1px solid var(--border); border-radius:6px; font-size:11px; font-family:'SF Mono',monospace; color:var(--muted);">decisions/db</div>
-            <div style="padding:5px 10px; background:var(--card); border:1px solid var(--border); border-radius:6px; font-size:11px; font-family:'SF Mono',monospace; color:var(--muted);">work/api-layer</div>
-            <div style="padding:5px 10px; background:rgba(248,113,113,0.08); border:1px solid rgba(248,113,113,0.2); border-radius:6px; font-size:11px; font-family:'SF Mono',monospace; color:rgba(248,113,113,0.7);">failed/pgbouncer</div>
-            <div style="padding:5px 10px; background:rgba(56,189,248,0.08); border:1px solid rgba(56,189,248,0.2); border-radius:6px; font-size:11px; font-family:'SF Mono',monospace; color:var(--accent);">plan/tasks.md</div>
+            <div style="padding:5px 10px; background:var(--card); border:1px solid var(--border); border-radius:6px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted);">decisions/db</div>
+            <div style="padding:5px 10px; background:var(--card); border:1px solid var(--border); border-radius:6px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted);">work/api-layer</div>
+            <div style="padding:5px 10px; background:rgba(248,113,113,0.08); border:1px solid rgba(248,113,113,0.2); border-radius:6px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:rgba(248,113,113,0.7);">failed/pgbouncer</div>
+            <div style="padding:5px 10px; background:rgba(92,199,210,0.08); border:1px solid rgba(92,199,210,0.2); border-radius:6px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--accent);">plan/tasks.md</div>
           </div>
           <div style="text-align:center; font-size:18px; color:var(--accent);">↓</div>
-          <div style="padding:10px 16px; background:rgba(56,189,248,0.06); border:1px solid rgba(56,189,248,0.2); border-radius:8px; font-size:12px; font-family:'SF Mono',monospace; color:var(--accent); text-align:center;">
+          <div style="padding:10px 16px; background:rgba(92,199,210,0.06); border:1px solid rgba(92,199,210,0.2); border-radius:8px; font-size:12px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--accent); text-align:center;">
             <span style="color:var(--muted);">the room directory <em>is</em> the briefing</span>
           </div>
           <div style="text-align:center; font-size:18px; color:var(--accent);">↓</div>
@@ -579,7 +580,7 @@
 <span class="em">What failed</span>    <span class="dim">PgBouncer: do not retry.</span><br>
 <span class="em">Open tasks</span>     <span class="dim">3 open across plan/tasks.md, plan/sprint.md.</span>
           </div>
-          <div style="padding:6px 12px; background:rgba(56,189,248,0.05); border:1px solid rgba(56,189,248,0.12); border-radius:6px; font-size:11px; font-family:'SF Mono',monospace; color:var(--muted); text-align:center;">
+          <div style="padding:6px 12px; background:rgba(92,199,210,0.05); border:1px solid rgba(92,199,210,0.12); border-radius:6px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); text-align:center;">
             new agent reads the room → zero context loss
           </div>
         </div>


### PR DESCRIPTION
## Summary

Overhauls the docs site design system to mirror the app's token contract and adds full light/dark theme support with system preference detection. The docs now share the same palette, typography scale, and radius tokens as the frontend, ensuring visual consistency across the product. Includes a theme toggle menu and pre-paint theme resolution to prevent flash-of-wrong-theme.

## Changes

- **Design tokens**: Replaced ad-hoc dark palette with a dual-theme system (`:root` for light, `.dark` for dark) that mirrors `mycelium-frontend/src/app/globals.css`. Includes surfaces (bg, surface, paper, elevated, muted-bg), text colors (text, muted-foreground, faint), semantic state (green, yellow, red), code syntax ramp, and diagram visualization colors.

- **Typography scale**: Collapsed 7 ad-hoc mono sizes into a unified 5-role system (`--text-micro`, `--text-label`, `--text-body`, `--text-ui`, `--text-display`) plus `--text-prose` for long-form reading. Added font family tokens (`--font-mono`, `--font-sans`, `--font-serif`) and legacy aliases for backward compatibility.

- **Radii tokens**: Added `--radius-sm/md/lg/xl` matching the app's radius scale; updated all border-radius values to use tokens.

- **Shell layout**: Redesigned topnav as a proper app shell with brand cell (sidebar-width), segmented control page tabs, and right-hand actions. Added status bar at bottom. Sidebar now uses translucent backdrop blur matching the app's aesthetic.

- **Theme toggle**: Added light/dark/system theme menu in topnav-right with localStorage persistence and system preference detection. Pre-paint script in `<head>` resolves theme before first paint to prevent flash.

- **Canvas background**: Made mycelium-bg theme-aware via `--canvas-*` tokens; site.js repaints it on theme change.

- **Scrollbar styling**: Added webkit scrollbar styles with theme-aware colors.

- **Button/control styling**: Updated all interactive elements (copy buttons, nav links, tabs) to use new token palette and consistent hover/active states with subtle backgrounds and borders.

- **Prose styling**: Adjusted heading sizes and spacing to sit closer to body size (14px UI baseline) rather than marketing-page scale. Updated link underline offset and list marker colors.

- **Code blocks**: Updated syntax highlighting to use code color tokens (`--code-comment`, `--code-cmd`, `--code-flag`, `--code-str`, `--code-arg`, `--code-kw`).

- **HTML generation**: Updated `generate_docs.py` to emit theme pre-paint script, new topnav structure with page tabs, and theme toggle menu. Removed old mono-style caps labels in favor of human-register sans.

- **Standalone pages**: Updated `mycelium-dataflow.html` and `stories.html` to use dark theme by default and updated their inline color values to match the new palette.

- **site.js**: Added robust theme management (handles missing lucide gracefully), theme toggle menu, localStorage persistence, and system preference listener. Dispatches `mycelium:theme` event on change for canvas repainting.

## Testing

- No automated tests needed; this is a design system and UI refactor.
- Manual verification: Load docs site in light and dark modes, verify theme toggle works, check that all colors meet contrast requirements, confirm canvas background repaints on theme change, and verify page tabs and nav structure match the app's shell layout.

https://claude.ai/code/session_018FXJhFTLLWwc6nyvqGNDdu