### PR TITLE
Add HTTP-API JWT authentication gate (#561)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,16 @@ is no litellm dependency.
   both `fastapi-backend/tests/test_slim_l9_wire.py` and
   `mycelium-cli/tests/test_slim_l9_wire.py` assert against it, so neither copy can
   drift without a red unit gate.
+- **The HTTP-API JWT gate is opt-in and off by default.** `app/services/auth.py`
+  validates a bearer JWT against configured issuers + JWKS (`[auth]` in
+  config.toml → `AUTH_*` env). It's an app-wide FastAPI dependency, so a new route
+  is gated by default; health/docs stay public. Trust is a list of issuers matched
+  by exact `iss`, each with its own keys and default role — that's how the SPIRE
+  trust domain slots in later without issuer-specific code. Off by default is a
+  hard requirement, not a default worth revisiting: auth must never block the
+  try-it path. The localhost bypass reads the request's peer address, so it does
+  **not** fire for a containerized backend (published-port traffic looks like LAN
+  traffic) — the local tier is served by leaving auth off.
 - **SLIM security is a shared-secret PSK today (D1).** The group key derives from
   `MYCELIUM_SLIM_MASTER_SECRET` (set the same on every host that shares rooms);
   `MYCELIUM_SLIM_REQUIRE_SECRET=1` makes a host fail closed rather than fall back to

--- a/docs/design/dev-auth-issuer.md
+++ b/docs/design/dev-auth-issuer.md
@@ -59,7 +59,45 @@ the backend, since that is the host the backend reaches and the `iss` it will se
 > in-network one; use the host URLs only for manual token minting. A stable `iss`
 > can be pinned later via the mock's `JSON_CONFIG` if needed.
 
+In `~/.mycelium/config.toml`:
+
+```toml
+[auth]
+enabled  = true
+audience = "mycelium"      # the mock echoes the requested `scope` into `aud`
+
+[[auth.issuers]]
+issuer   = "http://mycelium-auth-dev:8080/default"
+jwks_url = "http://mycelium-auth-dev:8080/default/jwks"
+role     = "agent"
+```
+
+Then `mycelium config apply` and recreate the backend. Mint a token from the host
+(port 9090) and call the API through the published backend port:
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:9090/default/token \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=client_credentials&client_id=poc-agent&client_secret=dev&scope=mycelium' \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
+
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8000/api/rooms                      # 401
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/api/rooms                                                             # 200
+```
+
+The `iss` wrinkle above is why the token minted on `:9090` carries
+`iss: http://localhost:9090/default` while the backend trusts
+`http://mycelium-auth-dev:8080/default` — they must match, so pin the mock's
+issuer via `JSON_CONFIG` (or trust both by listing a second `[[auth.issuers]]`
+block) when driving the gate from the host.
+
+Operator-facing documentation for the gate itself lives in the docs site under
+**Reference → Guides → Authentication**
+(`mycelium-cli/src/mycelium/docs/guides/auth.md`).
+
 ## Next
 
-- #561 — HTTP-API JWT gate (validate against this issuer's JWKS)
+- ~~#561 — HTTP-API JWT gate (validate against this issuer's JWKS)~~ — landed
+- #562 — verified handle binding (consume the principal this gate resolves)
 - #565 — replace this with the real Keycloak (humans) + SPIRE (agents) wiring

--- a/docs/design/identity-and-auth.md
+++ b/docs/design/identity-and-auth.md
@@ -113,7 +113,13 @@ per-deployment opt-in.
 
 1. **HTTP-API JWT gate** — FastAPI dependency validating a bearer JWT against a
    configured JWKS/issuer; reject unauthenticated. **Disabled by default** (and
-   auto-off on localhost) so the try-it path is untouched.
+   auto-off on localhost) so the try-it path is untouched. *Landed (#561):
+   `fastapi-backend/app/services/auth.py`, configured under `[auth]`; operator
+   docs in `mycelium-cli/src/mycelium/docs/guides/auth.md`. One caveat found in
+   implementation: the localhost bypass keys off the request's peer address, so
+   it does not fire for a backend in Docker (published-port traffic arrives from
+   the bridge gateway, indistinguishable from LAN traffic) — the containerized
+   local tier is served by leaving auth disabled.*
 2. **Verified handle binding** — derive handle + role from claims; stop trusting
    body-supplied actor fields. Only active when the gate is on.
 3. **CLI human login** — `mycelium login` obtains a token (Authorization Code +

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -72,6 +72,7 @@ SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
     # CLI + Config blocks injected after architecture, before guides/troubleshooting.
     ("guides/structured-memory.md", "structured-memory",  "reference", "Guides",       "Structured Memory"),
     ("guides/hub-and-spoke.md",     "hub-and-spoke",      "reference", "Guides",       "Hub & Spoke"),
+    ("guides/auth.md",              "auth",               "reference", "Guides",       "Authentication"),
     ("troubleshooting.md",          "troubleshooting",    "reference", "Help",         "Troubleshooting"),
 ]
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1487,6 +1487,172 @@ See [Troubleshooting](#troubleshooting) for the full runbook.
 
 ---
 
+# Authentication
+
+Mycelium's backend can require a signed **bearer token** on every HTTP API call,
+validated against an OIDC issuer you configure. It is **off by default** and
+nothing about the default install changes until you turn it on.
+
+## Off by default, on purpose
+
+Auth must never be a wall between someone and trying Mycelium. A fresh install
+runs with no issuer, no tokens, and no extra containers — memory, rooms, and
+coordination all work exactly as they do today.
+
+Turn it on when a **team shares a hub over a network**. Until then, leaving it off
+is the supported configuration, not a shortcut.
+
+> Without the gate, anyone who can reach the backend's port can read and write
+> every room and post as any `@handle`. On a laptop that's fine. On a shared
+> network it is not — that is precisely the moment to enable this.
+
+## Turning it on
+
+```bash
+mycelium config set auth.enabled true
+mycelium config set auth.audience mycelium
+mycelium config apply
+```
+
+Then declare at least one trust root in `~/.mycelium/config.toml`:
+
+```toml
+[auth]
+enabled  = true
+audience = "mycelium"
+
+[[auth.issuers]]
+issuer   = "https://sso.example.com/realms/mycelium"
+jwks_url = "https://sso.example.com/realms/mycelium/protocol/openid-connect/certs"
+role     = "user"
+```
+
+Re-run `mycelium config apply` and recreate the backend so it picks up the new
+environment.
+
+### Always set an audience
+
+`audience` is optional but you should always set it when enabling auth. Without
+one, **any** token your issuer has ever minted is accepted — including a token a
+user obtained for a completely unrelated application on the same identity
+provider. That token's holder was never authorized against your hub.
+
+Setting an audience is what makes "a valid token" mean "a token meant for *this*
+hub". The backend logs a warning at startup and flags it in `/health` when auth
+is on without one.
+
+## Configuration
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `auth.enabled` | `false` | Enforce bearer-token auth on the HTTP API. |
+| `auth.issuers` | *(none)* | Trust roots, as repeatable `[[auth.issuers]]` blocks. |
+| `auth.audience` | *(unset)* | Required `aud` claim. Set this whenever auth is on. |
+| `auth.localhost_bypass` | `true` | Let loopback callers through without a token. |
+| `auth.handle_claim` | `sub` | Claim carrying the canonical `@handle`. |
+| `auth.role_claim` | `mycelium_role` | Claim distinguishing a user from an agent. |
+| `auth.leeway_s` | `60` | Clock-skew allowance on `exp` / `nbf` / `iat`. |
+| `auth.jwks_ttl_s` | `300` | How long a fetched JWKS is cached. |
+
+Each `[[auth.issuers]]` block takes `issuer` (the exact `iss` to trust),
+`jwks_url` (optional — omit to resolve it from the issuer's OIDC discovery
+document), `audience` (optional per-issuer override), and `role`.
+
+## Issuer-agnostic by design
+
+The backend trusts a configured issuer and its JWKS. It has no idea whether that
+is Keycloak, Dex, ZITADEL, Authentik, or your existing corporate SSO, and it never
+needs one particular product installed.
+
+**More than one trust root is normal.** Humans log in through an interactive OIDC
+issuer; agents present service-account tokens, possibly from an entirely separate
+root. List each as its own block:
+
+```toml
+[[auth.issuers]]
+issuer = "https://sso.example.com/realms/people"
+role   = "user"
+
+[[auth.issuers]]
+issuer = "https://sso.example.com/realms/agents"
+role   = "agent"
+```
+
+Roots are matched by exact `iss` and never become interchangeable: a token signed
+by the agent root but claiming the human root is checked against the human root's
+keys, and fails.
+
+## Handle and role
+
+Once a token validates, the request has a **principal**:
+
+- **handle** — from `auth.handle_claim` (`sub` by default), normalized the same
+  way stored handles are (leading `@` stripped, lowercased). An OIDC
+  service-account whose client id is `release-agent` therefore arrives as
+  `@release-agent`.
+- **role** — from `auth.role_claim` if the token carries it, otherwise the `role`
+  on the matched issuer block. Which root signed a token is usually the whole
+  answer to user-vs-agent, so most deployments never set a role claim at all.
+
+Today the gate proves the token and records the principal. Using it as the
+*authoritative* author of a write — replacing the `created_by` and
+`sender_handle` a request body supplies — is the next step in the identity work.
+
+## Key rotation
+
+The JWKS is fetched from your issuer and cached for `auth.jwks_ttl_s`. When a
+token arrives signed by a key ID the backend hasn't seen, it re-fetches
+immediately (rate-limited), so **rotating your signing key does not require
+restarting Mycelium**.
+
+If the issuer is briefly unreachable, previously fetched keys keep serving. The
+keys are still your issuer's; only their freshness is in doubt, and failing closed
+would take the hub down for the length of an IdP blip.
+
+## The localhost bypass
+
+With `auth.localhost_bypass` on (the default), requests whose **peer address** is
+real loopback (`127.0.0.0/8`, `::1`) skip the gate, so turning auth on can't lock
+you out of the machine the hub runs on.
+
+Two things worth knowing:
+
+- `X-Forwarded-For` is deliberately ignored. It is caller-supplied, so honouring
+  it would let any remote request claim to be local.
+- **It does not fire for a backend running in Docker.** Traffic through a
+  published port arrives from the bridge gateway, not loopback, and is
+  indistinguishable from LAN traffic — treating that as local would silently open
+  the hub to your whole network. For the containerized local tier, leave
+  `auth.enabled` off; that is the honest switch for it.
+
+## What stays open
+
+Health (`/`, `/health`) and the schema/docs routes are served without a token even
+when the gate is on: orchestrator probes are unauthenticated by nature, and the
+health payload reveals no room content. `/health` gains an `auth` block reporting
+whether the hub is gated, which issuers it trusts, and any configuration warnings.
+
+Every other route requires a token.
+
+## Failure modes
+
+| Response | Meaning |
+|----------|---------|
+| `401` + `WWW-Authenticate: Bearer` | Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token. |
+| `503` | The gate is on but unusable — no trusted issuers configured, or the issuer's JWKS is unreachable and nothing is cached. |
+
+Only asymmetric signatures are accepted (`RS*`, `PS*`, `ES*`). The `none`
+algorithm and the whole `HS*` family are refused before verification, so a public
+JWKS key can never be replayed as an HMAC secret.
+
+## Trying it locally
+
+A dev OIDC issuer ships for exactly this, so you can exercise the gate without
+standing up Keycloak. See `docs/design/dev-auth-issuer.md`.
+
+
+---
+
 # Troubleshooting
 
 ## Quick Diagnostics

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -69,12 +69,14 @@
       <a href="#config-rooms" class="nav-link sub">rooms</a>
       <a href="#config-slim" class="nav-link sub">slim</a>
       <a href="#config-engine" class="nav-link sub">engine</a>
+      <a href="#config-auth" class="nav-link sub">auth</a>
       <a href="#config-metrics" class="nav-link sub">metrics</a>
     </div>
     <div class="nav-section">
       <div class="nav-section-label">Guides</div>
       <a href="#structured-memory" class="nav-link sub">Structured Memory</a>
       <a href="#hub-and-spoke" class="nav-link sub">Hub &amp; Spoke</a>
+      <a href="#auth" class="nav-link sub">Authentication</a>
     </div>
     <div class="nav-section">
       <div class="nav-section-label">Help</div>
@@ -720,6 +722,33 @@ cursor-agent login            # one-time, interactive
 <span class="comment"># Where registered engines run their drive (backend-only).</span>
 <span class="arg">runtime</span> = <span class="str">&quot;backend&quot;</span>
 
+<span class="comment"># HTTP-API JWT gate — off by default.</span>
+<span class="cmd" id="config-auth">[auth]</span>
+
+<span class="comment"># Enforce bearer-token auth on the backend HTTP API.</span>
+<span class="arg">enabled</span> = <span class="flag">false</span>
+
+<span class="comment"># Trust roots, as repeatable [[auth.issuers]] blocks.</span>
+<span class="arg">issuers</span> = PydanticUndefined
+
+<span class="comment"># Required `aud` claim for every token. Strongly recommended whenever auth is enabled; unset means the audience is not checked.</span>
+<span class="arg">audience</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Let loopback callers through without a token, so enabling auth can&#x27;t lock an operator out of the hub machine. Does not apply to a backend in Docker, whose callers arrive from the bridge gateway rather than loopback.</span>
+<span class="arg">localhost_bypass</span> = <span class="flag">true</span>
+
+<span class="comment"># Token claim carrying the canonical @handle.</span>
+<span class="arg">handle_claim</span> = <span class="str">&quot;sub&quot;</span>
+
+<span class="comment"># Token claim distinguishing a user from an agent.</span>
+<span class="arg">role_claim</span> = <span class="str">&quot;mycelium_role&quot;</span>
+
+<span class="comment"># Clock-skew allowance in seconds on exp/nbf/iat.</span>
+<span class="arg">leeway_s</span> = 60.0
+
+<span class="comment"># How long a fetched JWKS is cached before re-fetch. Key rotation is also picked up on an unseen kid.</span>
+<span class="arg">jwks_ttl_s</span> = 300.0
+
 <span class="comment"># Configuration for the metrics collector + display.</span>
 <span class="cmd" id="config-metrics">[metrics]</span>
 
@@ -914,6 +943,155 @@ procedures/  Reusable how-to steps (do this again later)</code></pre>
       <h3 id="hub-and-spoke-doctor-reports-spoke-mode-unexpectedly"><code>doctor</code> reports &quot;spoke mode&quot; unexpectedly</h3>
       <p><code>mycelium doctor</code> infers mode from <code>server.api_url</code>. If it points at a non-local address, doctor assumes spoke mode. If you&#x27;re running the backend locally on a non-default address, set <code>server.api_url</code> to <code>http://localhost:8000</code> in <code>~/.mycelium/config.toml</code>, or force the mode with <code>mycelium doctor --mode hub</code>.</p>
       <p>See <a href="#troubleshooting">Troubleshooting</a> for the full runbook.</p>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="auth">
+      <h1>Authentication</h1>
+      <p>Mycelium&#x27;s backend can require a signed <strong>bearer token</strong> on every HTTP API call, validated against an OIDC issuer you configure. It is <strong>off by default</strong> and nothing about the default install changes until you turn it on.</p>
+      <h2 id="auth-off-by-default-on-purpose">Off by default, on purpose</h2>
+      <p>Auth must never be a wall between someone and trying Mycelium. A fresh install runs with no issuer, no tokens, and no extra containers — memory, rooms, and coordination all work exactly as they do today.</p>
+      <p>Turn it on when a <strong>team shares a hub over a network</strong>. Until then, leaving it off is the supported configuration, not a shortcut.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body">Without the gate, anyone who can reach the backend&#x27;s port can read and write every room and post as any <code>@handle</code>. On a laptop that&#x27;s fine. On a shared network it is not — that is precisely the moment to enable this.</div>
+      </div>
+      <h2 id="auth-turning-it-on">Turning it on</h2>
+      <pre><code><span class="cmd">mycelium config set</span> auth.enabled true
+<span class="cmd">mycelium config set</span> auth.audience mycelium
+<span class="cmd">mycelium config apply</span></code></pre>
+      <p>Then declare at least one trust root in <code>~/.mycelium/config.toml</code>:</p>
+      <pre><code>[auth]
+enabled  = true
+audience = &quot;mycelium&quot;
+
+[[auth.issuers]]
+issuer   = &quot;https://sso.example.com/realms/mycelium&quot;
+jwks_url = &quot;https://sso.example.com/realms/mycelium/protocol/openid-connect/certs&quot;
+role     = &quot;user&quot;</code></pre>
+      <p>Re-run <code>mycelium config apply</code> and recreate the backend so it picks up the new environment.</p>
+      <h3 id="auth-always-set-an-audience">Always set an audience</h3>
+      <p><code>audience</code> is optional but you should always set it when enabling auth. Without one, <strong>any</strong> token your issuer has ever minted is accepted — including a token a user obtained for a completely unrelated application on the same identity provider. That token&#x27;s holder was never authorized against your hub.</p>
+      <p>Setting an audience is what makes &quot;a valid token&quot; mean &quot;a token meant for <em>this</em> hub&quot;. The backend logs a warning at startup and flags it in <code>/health</code> when auth is on without one.</p>
+      <h2 id="auth-configuration">Configuration</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Default</th>
+              <th>What it does</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>auth.enabled</code></td>
+              <td><code>false</code></td>
+              <td>Enforce bearer-token auth on the HTTP API.</td>
+            </tr>
+            <tr>
+              <td><code>auth.issuers</code></td>
+              <td><em>(none)</em></td>
+              <td>Trust roots, as repeatable <code>[[auth.issuers]]</code> blocks.</td>
+            </tr>
+            <tr>
+              <td><code>auth.audience</code></td>
+              <td><em>(unset)</em></td>
+              <td>Required <code>aud</code> claim. Set this whenever auth is on.</td>
+            </tr>
+            <tr>
+              <td><code>auth.localhost_bypass</code></td>
+              <td><code>true</code></td>
+              <td>Let loopback callers through without a token.</td>
+            </tr>
+            <tr>
+              <td><code>auth.handle_claim</code></td>
+              <td><code>sub</code></td>
+              <td>Claim carrying the canonical <code>@handle</code>.</td>
+            </tr>
+            <tr>
+              <td><code>auth.role_claim</code></td>
+              <td><code>mycelium_role</code></td>
+              <td>Claim distinguishing a user from an agent.</td>
+            </tr>
+            <tr>
+              <td><code>auth.leeway_s</code></td>
+              <td><code>60</code></td>
+              <td>Clock-skew allowance on <code>exp</code> / <code>nbf</code> / <code>iat</code>.</td>
+            </tr>
+            <tr>
+              <td><code>auth.jwks_ttl_s</code></td>
+              <td><code>300</code></td>
+              <td>How long a fetched JWKS is cached.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>Each <code>[[auth.issuers]]</code> block takes <code>issuer</code> (the exact <code>iss</code> to trust), <code>jwks_url</code> (optional — omit to resolve it from the issuer&#x27;s OIDC discovery document), <code>audience</code> (optional per-issuer override), and <code>role</code>.</p>
+      <h2 id="auth-issuer-agnostic-by-design">Issuer-agnostic by design</h2>
+      <p>The backend trusts a configured issuer and its JWKS. It has no idea whether that is Keycloak, Dex, ZITADEL, Authentik, or your existing corporate SSO, and it never needs one particular product installed.</p>
+      <p><strong>More than one trust root is normal.</strong> Humans log in through an interactive OIDC issuer; agents present service-account tokens, possibly from an entirely separate root. List each as its own block:</p>
+      <pre><code>[[auth.issuers]]
+issuer = &quot;https://sso.example.com/realms/people&quot;
+role   = &quot;user&quot;
+
+[[auth.issuers]]
+issuer = &quot;https://sso.example.com/realms/agents&quot;
+role   = &quot;agent&quot;</code></pre>
+      <p>Roots are matched by exact <code>iss</code> and never become interchangeable: a token signed by the agent root but claiming the human root is checked against the human root&#x27;s keys, and fails.</p>
+      <h2 id="auth-handle-and-role">Handle and role</h2>
+      <p>Once a token validates, the request has a <strong>principal</strong>:</p>
+      <ul>
+        <li><strong>handle</strong> — from <code>auth.handle_claim</code> (<code>sub</code> by default), normalized the same</li>
+      </ul>
+      <p>way stored handles are (leading <code>@</code> stripped, lowercased). An OIDC service-account whose client id is <code>release-agent</code> therefore arrives as <code>@release-agent</code>.</p>
+      <ul>
+        <li><strong>role</strong> — from <code>auth.role_claim</code> if the token carries it, otherwise the <code>role</code></li>
+      </ul>
+      <p>on the matched issuer block. Which root signed a token is usually the whole answer to user-vs-agent, so most deployments never set a role claim at all.</p>
+      <p>Today the gate proves the token and records the principal. Using it as the <em>authoritative</em> author of a write — replacing the <code>created_by</code> and <code>sender_handle</code> a request body supplies — is the next step in the identity work.</p>
+      <h2 id="auth-key-rotation">Key rotation</h2>
+      <p>The JWKS is fetched from your issuer and cached for <code>auth.jwks_ttl_s</code>. When a token arrives signed by a key ID the backend hasn&#x27;t seen, it re-fetches immediately (rate-limited), so <strong>rotating your signing key does not require restarting Mycelium</strong>.</p>
+      <p>If the issuer is briefly unreachable, previously fetched keys keep serving. The keys are still your issuer&#x27;s; only their freshness is in doubt, and failing closed would take the hub down for the length of an IdP blip.</p>
+      <h2 id="auth-the-localhost-bypass">The localhost bypass</h2>
+      <p>With <code>auth.localhost_bypass</code> on (the default), requests whose <strong>peer address</strong> is real loopback (<code>127.0.0.0/8</code>, <code>::1</code>) skip the gate, so turning auth on can&#x27;t lock you out of the machine the hub runs on.</p>
+      <p>Two things worth knowing:</p>
+      <ul>
+        <li><code>X-Forwarded-For</code> is deliberately ignored. It is caller-supplied, so honouring</li>
+      </ul>
+      <p>it would let any remote request claim to be local.</p>
+      <ul>
+        <li><strong>It does not fire for a backend running in Docker.</strong> Traffic through a</li>
+      </ul>
+      <p>published port arrives from the bridge gateway, not loopback, and is indistinguishable from LAN traffic — treating that as local would silently open the hub to your whole network. For the containerized local tier, leave <code>auth.enabled</code> off; that is the honest switch for it.</p>
+      <h2 id="auth-what-stays-open">What stays open</h2>
+      <p>Health (<code>/</code>, <code>/health</code>) and the schema/docs routes are served without a token even when the gate is on: orchestrator probes are unauthenticated by nature, and the health payload reveals no room content. <code>/health</code> gains an <code>auth</code> block reporting whether the hub is gated, which issuers it trusts, and any configuration warnings.</p>
+      <p>Every other route requires a token.</p>
+      <h2 id="auth-failure-modes">Failure modes</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Response</th>
+              <th>Meaning</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>401</code> + <code>WWW-Authenticate: Bearer</code></td>
+              <td>Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token.</td>
+            </tr>
+            <tr>
+              <td><code>503</code></td>
+              <td>The gate is on but unusable — no trusted issuers configured, or the issuer&#x27;s JWKS is unreachable and nothing is cached.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>Only asymmetric signatures are accepted (<code>RS<em></code>, <code>PS</em></code>, <code>ES<em></code>). The <code>none</code> algorithm and the whole <code>HS</em></code> family are refused before verification, so a public JWKS key can never be replayed as an HMAC secret.</p>
+      <h2 id="auth-trying-it-locally">Trying it locally</h2>
+      <p>A dev OIDC issuer ships for exactly this, so you can exercise the gate without standing up Keycloak. See <code>docs/design/dev-auth-issuer.md</code>.</p>
     </section>
 
     <hr class="divider">

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -4,12 +4,42 @@
 from pathlib import Path
 from typing import Literal
 
-from pydantic import field_validator
+from pydantic import BaseModel, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Where a registered engine runs its NEGMAS drive. Paired with the CLI's
 # ``engine.runtime`` — flip both together.
 EngineRuntime = Literal["backend", "host"]
+
+# What a validated token's principal is. Distinguishing the two is what lets
+# handle binding (#562) treat a human and a workload differently.
+PrincipalRole = Literal["user", "agent"]
+
+
+class TrustedIssuer(BaseModel):
+    """One trust root the HTTP-API gate accepts tokens from.
+
+    Trust is a *list* of these, matched by exact ``iss``, because more than one
+    root is the normal case: the human OIDC issuer alongside (later) the SPIRE
+    trust domain. Each entry carries its own keys, audience, and default role,
+    so a new root is config, never issuer-specific code.
+    """
+
+    issuer: str
+    # Omit to resolve the JWKS URI from ``<issuer>/.well-known/openid-configuration``.
+    jwks_url: str | None = None
+    # Overrides AUTH_AUDIENCE for tokens from this issuer.
+    audience: str | None = None
+    # Role for principals from this root when the token carries no role claim —
+    # the load-bearing case, since which root signed a token usually *is* the
+    # answer to user-vs-agent.
+    role: PrincipalRole = "agent"
+
+    @field_validator("issuer", "jwks_url")
+    @classmethod
+    def _strip_trailing_slash(cls, v: str | None) -> str | None:
+        return v.rstrip("/") if isinstance(v, str) else v
+
 
 # Config file search order: local .env first, then global ~/.mycelium/.env
 _env_files = [".env"]
@@ -122,6 +152,40 @@ class Settings(BaseSettings):
     @classmethod
     def _normalize_engine_runtime(cls, v: object) -> object:
         return v.strip().lower() if isinstance(v, str) else v
+
+    # ── HTTP-API JWT gate ────────────────────────────────────────────────────
+    # Off by default, and that is a hard requirement rather than a default worth
+    # revisiting: auth must never stand between someone and trying the app
+    # (docs/design/identity-and-auth.md). With AUTH_ENABLED false the gate is
+    # inert and every request is anonymous — exactly today's behavior.
+    AUTH_ENABLED: bool = False
+    # Trust roots, as JSON over env:
+    #   AUTH_ISSUERS=[{"issuer":"https://idp/realm","jwks_url":"…","role":"user"}]
+    AUTH_ISSUERS: list[TrustedIssuer] = []
+    # Required ``aud`` when set; unset means the claim is not checked. A trusted
+    # issuer entry may override it.
+    AUTH_AUDIENCE: str | None = None
+    # Skip the gate for real loopback callers so an operator who turns auth on
+    # doesn't lock themselves out of the machine the hub runs on. Decided by the
+    # request's client address, never the bind address — see services/auth.py.
+    AUTH_LOCALHOST_BYPASS: bool = True
+    # Which claim carries the canonical @handle, and which carries user-vs-agent.
+    AUTH_HANDLE_CLAIM: str = "sub"
+    AUTH_ROLE_CLAIM: str = "mycelium_role"
+    # Clock-skew allowance (seconds) on exp/nbf/iat.
+    AUTH_LEEWAY_S: float = 60.0
+    # How long a fetched JWKS is served from cache before it is re-fetched.
+    AUTH_JWKS_TTL_S: float = 300.0
+
+    @field_validator("AUTH_AUDIENCE", mode="before")
+    @classmethod
+    def _coerce_audience(cls, v: object) -> object:
+        """Treat an empty string as "don't check aud" — compose renders an unset
+        audience as ``AUTH_AUDIENCE=``, which must not become a literal ""
+        audience that no token can ever match."""
+        if isinstance(v, str) and v.strip() == "":
+            return None
+        return v
 
     model_config = SettingsConfigDict(
         env_file=tuple(_env_files),

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -26,7 +26,7 @@ from typing import Any
 os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 os.environ.setdefault("HF_HUB_OFFLINE", "1")
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routes.agents import router as agents_router
@@ -42,6 +42,7 @@ from app.routes.rooms import router as rooms_router
 from app.routes.sessions import router as sessions_router
 from app.routes.stream import router as stream_router
 from app.routes.users import router as users_router
+from app.services.auth import auth_gate
 
 from .config import settings
 
@@ -64,6 +65,20 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logger.info("Mycelium backend starting up")
+    # Say plainly whether the HTTP surface is gated — "is this hub open?" should
+    # never require reading config to answer.
+    from app.services import auth as auth_service
+
+    if settings.AUTH_ENABLED:
+        logger.info(
+            "HTTP-API JWT gate ENABLED (issuers=%s, localhost_bypass=%s)",
+            [e.issuer for e in settings.AUTH_ISSUERS] or "<none>",
+            settings.AUTH_LOCALHOST_BYPASS,
+        )
+        for warning in auth_service.config_warnings():
+            logger.warning("auth: %s", warning)
+    else:
+        logger.info("HTTP-API JWT gate disabled — requests are unauthenticated")
     # Incremental scan of filesystem → JSONL search index
     from app.services.reindex import start_watcher, startup_scan, stop_watcher
 
@@ -182,6 +197,10 @@ app = FastAPI(
     version=_read_pkg_version(),
     openapi_url=settings.OPENAPI_URL,
     lifespan=lifespan,
+    # The JWT gate rides every route rather than a hand-picked list, so a route
+    # added later is protected without anyone remembering to opt it in. It is
+    # inert unless AUTH_ENABLED is on, and exempts health/docs itself.
+    dependencies=[Depends(auth_gate)],
 )
 
 # CORS — starlette types CORSMiddleware as a class but typeshed expects a factory.
@@ -235,6 +254,11 @@ async def root(
 
     # Storage — markdown + local JSONL, no database.
     result["storage"] = _check_storage()
+
+    # HTTP-API JWT gate — whether this hub is gated, and how.
+    from app.services import auth as auth_service
+
+    result["auth"] = auth_service.status()
 
     # Embedding model
     result["embedding"] = _check_embedding()

--- a/fastapi-backend/app/services/auth.py
+++ b/fastapi-backend/app/services/auth.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""HTTP-API JWT gate — validate a bearer token against a configured issuer + JWKS.
+
+The backend's HTTP surface is otherwise unauthenticated: whoever reaches ``:8000``
+can read and write every room. This module closes that, **as an opt-in**. With
+``AUTH_ENABLED`` false (the shipped default) the gate is inert and every request
+is anonymous, which is the whole point — auth must never be a wall between
+someone and trying the app (``docs/design/identity-and-auth.md``).
+
+It is deliberately **issuer-agnostic**: trust is a list of ``TrustedIssuer``
+entries matched by exact ``iss``, each with its own keys. Nothing here knows or
+cares whether the root is Keycloak, Dex, the dev mock issuer, or a SPIRE trust
+domain, so adding the agent trust root later (#564/#476) is a config entry.
+
+Scope is authentication only. Resolving a validated token into the *authoritative*
+actor for a write — replacing body-supplied ``created_by`` / ``sender_handle`` —
+is handle binding (#562); this module proves the token and records the principal
+on ``request.state.principal`` for that stage to consume.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import jwt
+from fastapi import HTTPException, Request
+
+from app.config import PrincipalRole, TrustedIssuer, settings
+
+logger = logging.getLogger(__name__)
+
+#: Asymmetric signatures only. ``none`` and the whole ``HS*`` family are refused
+#: before verification is attempted: with a public JWKS, accepting an HMAC
+#: algorithm would let anyone sign a token using the published key as the shared
+#: secret — the classic algorithm-confusion forgery.
+ALLOWED_ALGORITHMS = frozenset(
+    {"RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "ES256", "ES384", "ES512"}
+)
+
+#: Paths served without a token even when the gate is on. Health is here because
+#: orchestrator probes (the compose healthcheck, `mycelium doctor`) are
+#: unauthenticated by nature and reveal no room content; the schema/docs routes
+#: describe the API rather than exposing any of it.
+PUBLIC_PATHS = frozenset({"/", "/health", "/healthz", "/docs", "/redoc", "/openapi.json"})
+
+#: Shortest gap between forced JWKS re-fetches triggered by an unknown ``kid``.
+#: Rotation is picked up within this bound; without it, a flood of junk ``kid``s
+#: would be an amplified request generator pointed at the issuer.
+_ROTATION_REFRESH_COOLDOWN_S = 10.0
+
+_JWKS_FETCH_TIMEOUT_S = 5.0
+
+
+@dataclass(frozen=True)
+class Principal:
+    """The verified actor behind a request.
+
+    ``handle`` is the canonical ``@handle`` — normalized identically to
+    ``principals._norm`` so a token-derived handle and a stored one compare equal.
+    """
+
+    subject: str
+    handle: str
+    role: PrincipalRole
+    issuer: str
+    claims: dict[str, Any] = field(default_factory=dict)
+
+
+class AuthError(HTTPException):
+    """401 with the ``WWW-Authenticate`` challenge RFC 6750 expects."""
+
+    def __init__(self, detail: str, *, error: str = "invalid_token") -> None:
+        challenge = f'Bearer error="{error}", error_description="{detail}"'
+        super().__init__(status_code=401, detail=detail, headers={"WWW-Authenticate": challenge})
+
+
+@dataclass
+class _CachedKeys:
+    keyset: jwt.PyJWKSet
+    fetched_at: float
+    last_forced_refresh: float = 0.0
+
+
+class JwksCache:
+    """Fetches and caches each issuer's JWKS, and picks up key rotation.
+
+    Three behaviors matter and none of them is the default of a naive fetch:
+
+    * **Cached** for ``AUTH_JWKS_TTL_S`` so validation isn't an HTTP round trip.
+    * **Refreshed on an unseen ``kid``** (rate-limited) so a rotated signing key
+      is honoured without restarting the backend.
+    * **Stale-on-error**: if the issuer is briefly unreachable, previously fetched
+      keys keep serving. Availability wins here — the keys are still the issuer's,
+      only their freshness is in doubt, and failing closed would take the hub down
+      for the length of an IdP blip.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, _CachedKeys] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+        # Resolved ``jwks_uri`` per issuer, for entries configured without one.
+        self._discovered: dict[str, str] = {}
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._discovered.clear()
+
+    def _lock(self, url: str) -> asyncio.Lock:
+        # Single-flight per URL: a burst of concurrent requests behind an expired
+        # entry refreshes once rather than once each.
+        if url not in self._locks:
+            self._locks[url] = asyncio.Lock()
+        return self._locks[url]
+
+    async def jwks_url_for(self, entry: TrustedIssuer) -> str:
+        """The configured JWKS URL, or the one from the issuer's OIDC discovery."""
+        if entry.jwks_url:
+            return entry.jwks_url
+        if cached := self._discovered.get(entry.issuer):
+            return cached
+        discovery = f"{entry.issuer}/.well-known/openid-configuration"
+        try:
+            async with httpx.AsyncClient(timeout=_JWKS_FETCH_TIMEOUT_S) as client:
+                resp = await client.get(discovery)
+                resp.raise_for_status()
+                jwks_uri = resp.json().get("jwks_uri")
+        except (httpx.HTTPError, ValueError) as exc:
+            raise HTTPException(
+                status_code=503,
+                detail=f"OIDC discovery failed for issuer {entry.issuer}: {type(exc).__name__}",
+            )
+        if not isinstance(jwks_uri, str) or not jwks_uri:
+            raise HTTPException(
+                status_code=503,
+                detail=f"OIDC discovery for {entry.issuer} returned no jwks_uri",
+            )
+        self._discovered[entry.issuer] = jwks_uri
+        return jwks_uri
+
+    async def get_key(self, entry: TrustedIssuer, kid: str | None, alg: str) -> jwt.PyJWK:
+        """Resolve the signing key for a token header, refreshing on an unseen kid."""
+        url = await self.jwks_url_for(entry)
+        keyset = await self._keyset(url)
+        key = _select_key(keyset, kid, alg)
+        if key is None:
+            keyset = await self._keyset(url, force=True)
+            key = _select_key(keyset, kid, alg)
+        if key is None:
+            raise AuthError(
+                f"no signing key for kid={kid!r} at the issuer's JWKS"
+                if kid
+                else "no usable signing key at the issuer's JWKS"
+            )
+        return key
+
+    async def _keyset(self, url: str, *, force: bool = False) -> jwt.PyJWKSet:
+        now = time.monotonic()
+        cached = self._cache.get(url)
+        if cached is not None and not force and now - cached.fetched_at < settings.AUTH_JWKS_TTL_S:
+            return cached.keyset
+        if (
+            cached is not None
+            and force
+            and now - cached.last_forced_refresh < _ROTATION_REFRESH_COOLDOWN_S
+        ):
+            return cached.keyset
+
+        async with self._lock(url):
+            # Another waiter may have refreshed while this one queued.
+            cached = self._cache.get(url)
+            now = time.monotonic()
+            if (
+                cached is not None
+                and not force
+                and now - cached.fetched_at < settings.AUTH_JWKS_TTL_S
+            ):
+                return cached.keyset
+            if (
+                cached is not None
+                and force
+                and now - cached.last_forced_refresh < _ROTATION_REFRESH_COOLDOWN_S
+            ):
+                return cached.keyset
+            if force and cached is not None:
+                cached.last_forced_refresh = now
+
+            try:
+                async with httpx.AsyncClient(timeout=_JWKS_FETCH_TIMEOUT_S) as client:
+                    resp = await client.get(url)
+                    resp.raise_for_status()
+                    keyset = jwt.PyJWKSet.from_dict(resp.json())
+            except (httpx.HTTPError, ValueError, jwt.PyJWKSetError) as exc:
+                if cached is not None:
+                    logger.warning(
+                        "JWKS refresh failed for %s (%s) — serving cached keys", url, exc
+                    )
+                    return cached.keyset
+                raise HTTPException(
+                    status_code=503,
+                    detail=f"JWKS unavailable at {url}: {type(exc).__name__}",
+                )
+
+            self._cache[url] = _CachedKeys(
+                keyset=keyset,
+                fetched_at=time.monotonic(),
+                last_forced_refresh=now if force else 0.0,
+            )
+            return keyset
+
+
+def _select_key(keyset: jwt.PyJWKSet, kid: str | None, alg: str) -> jwt.PyJWK | None:
+    """Pick the verification key for a token header, or None if the set has none.
+
+    A ``kid`` selects exactly; without one (legal, and what some issuers emit for
+    a single-key setup) any key compatible with the header algorithm is a
+    candidate — verification itself then rejects the wrong ones.
+    """
+    candidates = [k for k in keyset.keys if _is_verification_key(k)]
+    if kid is not None:
+        return next((k for k in candidates if k.key_id == kid), None)
+    compatible = [k for k in candidates if k.algorithm_name in (None, alg)]
+    return compatible[0] if len(compatible) == 1 else None
+
+
+def _is_verification_key(key: jwt.PyJWK) -> bool:
+    """Exclude JWKS entries published for encryption rather than signing."""
+    return key.public_key_use in (None, "sig")
+
+
+#: Process-wide, so cached keys survive across requests.
+jwks_cache = JwksCache()
+
+
+def _issuer_entry(iss: object) -> TrustedIssuer | None:
+    if not isinstance(iss, str):
+        return None
+    normalized = iss.rstrip("/")
+    return next((e for e in settings.AUTH_ISSUERS if e.issuer == normalized), None)
+
+
+def _resolve_role(claims: dict[str, Any], entry: TrustedIssuer) -> PrincipalRole:
+    """Token role claim, else the issuer's default role.
+
+    Which trust root signed a token is usually the whole answer to user-vs-agent
+    (humans from the OIDC issuer, workloads from the service-account issuer or
+    SPIRE), so the issuer default carries the common case and the claim is the
+    escape hatch for one issuer serving both.
+    """
+    raw = claims.get(settings.AUTH_ROLE_CLAIM)
+    if raw is None:
+        return entry.role
+    value = str(raw).strip().lower()
+    if value not in ("user", "agent"):
+        # Coercing an unrecognised role to a default would silently mislabel the
+        # principal; a token that asserts something we can't honour is malformed.
+        raise AuthError(f"unsupported {settings.AUTH_ROLE_CLAIM!r} claim: {raw!r}")
+    return "user" if value == "user" else "agent"
+
+
+def _normalize_handle(raw: object) -> str | None:
+    """Match ``principals._norm`` so token and stored handles compare equal."""
+    if not isinstance(raw, str):
+        return None
+    return raw.strip().lstrip("@").lower() or None
+
+
+async def verify_token(token: str) -> Principal:
+    """Validate a bearer token and resolve it to a principal, or raise 401."""
+    try:
+        header = jwt.get_unverified_header(token)
+    except jwt.PyJWTError as exc:
+        raise AuthError(f"malformed token: {exc}")
+
+    alg = header.get("alg")
+    if alg not in ALLOWED_ALGORITHMS:
+        raise AuthError(f"unsupported signing algorithm: {alg!r}")
+
+    try:
+        unverified = jwt.decode(token, options={"verify_signature": False})
+    except jwt.PyJWTError as exc:
+        raise AuthError(f"malformed token: {exc}")
+
+    entry = _issuer_entry(unverified.get("iss"))
+    if entry is None:
+        raise AuthError(f"untrusted issuer: {unverified.get('iss')!r}")
+
+    key = await jwks_cache.get_key(entry, header.get("kid"), alg)
+
+    audience = entry.audience or settings.AUTH_AUDIENCE
+    try:
+        claims = jwt.decode(
+            token,
+            key=key,
+            algorithms=[alg],
+            issuer=entry.issuer,
+            audience=audience,
+            leeway=settings.AUTH_LEEWAY_S,
+            options={
+                "verify_aud": audience is not None,
+                "require": ["exp", "iss"],
+            },
+        )
+    except jwt.PyJWTError as exc:
+        raise AuthError(f"token rejected: {exc}")
+
+    handle = _normalize_handle(claims.get(settings.AUTH_HANDLE_CLAIM))
+    if handle is None:
+        raise AuthError(f"token carries no {settings.AUTH_HANDLE_CLAIM!r} claim")
+
+    return Principal(
+        subject=str(claims.get("sub") or handle),
+        handle=handle,
+        role=_resolve_role(claims, entry),
+        issuer=entry.issuer,
+        claims=claims,
+    )
+
+
+def is_loopback_client(request: Request) -> bool:
+    """Whether the request came from the machine the backend runs on.
+
+    Decided from the peer address only. ``X-Forwarded-For`` is deliberately
+    ignored: it is caller-supplied, so honouring it would let any remote request
+    claim to be local. Note that this is also why the bypass does *not* fire for
+    a backend in Docker — traffic through a published port arrives from the
+    bridge gateway and is indistinguishable from LAN traffic, so the containerized
+    local tier is served by leaving auth disabled rather than by this bypass.
+    """
+    client = request.client
+    if client is None or not client.host:
+        return False
+    try:
+        addr = ipaddress.ip_address(client.host)
+    except ValueError:
+        return False
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+        addr = addr.ipv4_mapped
+    return addr.is_loopback
+
+
+def _bearer_token(request: Request) -> str:
+    header = request.headers.get("Authorization")
+    if not header:
+        raise AuthError("missing bearer token", error="invalid_request")
+    scheme, _, token = header.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        raise AuthError("malformed Authorization header", error="invalid_request")
+    return token.strip()
+
+
+async def auth_gate(request: Request) -> Principal | None:
+    """App-wide dependency: enforce the gate and record the principal.
+
+    Applied globally rather than per-router so a route added later is protected
+    by default. Returns ``None`` — anonymous, today's behavior — when the gate is
+    off, the path is public, or a loopback caller is bypassed.
+    """
+    request.state.principal = None
+    if not settings.AUTH_ENABLED:
+        return None
+    path = request.url.path
+    if path in PUBLIC_PATHS or path.rstrip("/") in PUBLIC_PATHS:
+        return None
+    if settings.AUTH_LOCALHOST_BYPASS and is_loopback_client(request):
+        return None
+    if not settings.AUTH_ISSUERS:
+        # Enabled with nothing to trust can only fail closed: no token could ever
+        # validate, so say why rather than 401-ing every request opaquely.
+        raise HTTPException(
+            status_code=503,
+            detail="auth is enabled but no trusted issuers are configured (auth.issuers)",
+        )
+
+    principal = await verify_token(_bearer_token(request))
+    request.state.principal = principal
+    return principal
+
+
+def config_warnings() -> list[str]:
+    """Ways the gate is on but weaker than an operator probably intends."""
+    if not settings.AUTH_ENABLED:
+        return []
+    warnings: list[str] = []
+    if not settings.AUTH_ISSUERS:
+        warnings.append("auth is enabled but no trusted issuers are configured")
+    # No audience means *any* token the issuer ever minted validates here,
+    # including one a user obtained for an unrelated application on the same IdP.
+    # That token's holder was never authorized against this hub, so an audience
+    # is what makes "valid token" mean "token meant for us".
+    if not settings.AUTH_AUDIENCE and not any(e.audience for e in settings.AUTH_ISSUERS):
+        warnings.append(
+            "no audience configured — any token from a trusted issuer is accepted, "
+            "including tokens minted for other applications; set auth.audience"
+        )
+    return warnings
+
+
+def status() -> dict[str, Any]:
+    """Gate configuration for ``/health`` — what an operator needs to see to know
+    whether the hub is actually protected."""
+    result: dict[str, Any] = {
+        "enabled": settings.AUTH_ENABLED,
+        "issuers": [e.issuer for e in settings.AUTH_ISSUERS],
+        "localhost_bypass": settings.AUTH_LOCALHOST_BYPASS,
+        "audience": settings.AUTH_AUDIENCE,
+    }
+    if warnings := config_warnings():
+        result["warnings"] = warnings
+    return result

--- a/fastapi-backend/pyproject.toml
+++ b/fastapi-backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "rapidfuzz>=3.14.5",
     "slim-bindings>=2,<3",
     "negmas>=0.15.7",
+    "pyjwt[crypto]>=2.10,<3",
 ]
 
 [dependency-groups]

--- a/fastapi-backend/tests/test_auth_gate.py
+++ b/fastapi-backend/tests/test_auth_gate.py
@@ -1,0 +1,511 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""HTTP-API JWT gate (#561).
+
+Tokens are signed with RSA keys generated in-process and served through a
+stubbed JWKS endpoint, so the whole gate — signature, claims, issuer matching,
+caching, rotation — is exercised without a live issuer. The end-to-end pass
+against the real dev issuer lives in ``docs/design/dev-auth-issuer.md``.
+
+The default posture is its own assertion: with ``AUTH_ENABLED`` off, every
+request must behave exactly as it did before this gate existed.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import AsyncClient
+
+from app.config import TrustedIssuer
+from app.services import auth as auth_service
+
+ISSUER = "https://idp.test/realms/mycelium"
+JWKS_URL = f"{ISSUER}/jwks"
+AUDIENCE = "mycelium"
+
+# A protected route (any /api route is gated) and a public one.
+PROTECTED_PATH = "/api/rooms"
+PUBLIC_PATH = "/health"
+
+
+# ── key + token helpers ───────────────────────────────────────────────────────
+
+
+def _generate_key(kid: str) -> dict[str, Any]:
+    """An RSA keypair plus its public JWK, as an issuer would publish it."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    algo = jwt.get_algorithm_by_name("RS256")
+    public_jwk = algo.to_jwk(private.public_key(), as_dict=True)
+    public_jwk.update({"kid": kid, "use": "sig", "alg": "RS256"})
+    return {"private": private, "jwk": public_jwk, "kid": kid}
+
+
+def _sign(key: dict[str, Any], **overrides: Any) -> str:
+    now = int(time.time())
+    claims: dict[str, Any] = {
+        "sub": "poc-agent",
+        "iss": ISSUER,
+        "aud": AUDIENCE,
+        "iat": now,
+        "exp": now + 3600,
+    }
+    claims.update(overrides)
+    claims = {k: v for k, v in claims.items() if v is not None}
+    return jwt.encode(claims, key["private"], algorithm="RS256", headers={"kid": key["kid"]})
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def signing_key() -> dict[str, Any]:
+    return _generate_key("key-1")
+
+
+@pytest.fixture
+def jwks_server(monkeypatch, signing_key):
+    """Serve a JWKS from an in-process stub, and count how often it is fetched.
+
+    Returns a handle whose ``keys`` list can be swapped mid-test to simulate
+    rotation at the issuer.
+    """
+
+    class _Server:
+        def __init__(self) -> None:
+            self.keys: list[dict[str, Any]] = [signing_key["jwk"]]
+            self.fetches = 0
+            self.fail = False
+
+        def document(self) -> dict[str, Any]:
+            return {"keys": self.keys}
+
+    server = _Server()
+
+    class _StubResponse:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self._payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+    class _StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self) -> _StubClient:
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def get(self, url: str) -> _StubResponse:
+            if url.endswith("/.well-known/openid-configuration"):
+                return _StubResponse({"jwks_uri": JWKS_URL})
+            server.fetches += 1
+            if server.fail:
+                import httpx
+
+                raise httpx.ConnectError("issuer unreachable")
+            return _StubResponse(server.document())
+
+    monkeypatch.setattr(auth_service.httpx, "AsyncClient", _StubClient)
+    return server
+
+
+@pytest.fixture
+def auth_on(monkeypatch, jwks_server):
+    """Gate enabled, one trusted issuer, loopback bypass off.
+
+    The bypass is off because the ASGI test transport presents a loopback client
+    address — with it on, every request here would be waved through and the
+    assertions would be vacuous. It gets its own test below.
+    """
+    monkeypatch.setattr("app.config.settings.AUTH_ENABLED", True)
+    monkeypatch.setattr("app.config.settings.AUTH_LOCALHOST_BYPASS", False)
+    monkeypatch.setattr("app.config.settings.AUTH_AUDIENCE", AUDIENCE)
+    monkeypatch.setattr(
+        "app.config.settings.AUTH_ISSUERS",
+        [TrustedIssuer(issuer=ISSUER, jwks_url=JWKS_URL, role="agent")],
+    )
+    auth_service.jwks_cache.clear()
+    yield
+    auth_service.jwks_cache.clear()
+
+
+# ── off by default: the try-it path is untouched ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default_needs_no_token(client: AsyncClient):
+    assert (await client.get(PROTECTED_PATH)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_disabled_ignores_a_garbage_token(client: AsyncClient):
+    """Off means off — a bad token isn't even inspected, let alone rejected."""
+    resp = await client.get(PROTECTED_PATH, headers=_bearer("not-a-jwt"))
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_disabled_leaves_principal_unset(client: AsyncClient):
+    resp = await client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["auth"]["enabled"] is False
+
+
+# ── enabled: valid tokens pass ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_valid_token_is_accepted(client: AsyncClient, auth_on, signing_key):
+    resp = await client.get(PROTECTED_PATH, headers=_bearer(_sign(signing_key)))
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_valid_token_resolves_a_principal(auth_on, signing_key):
+    principal = await auth_service.verify_token(_sign(signing_key, sub="@Poc-Agent"))
+    # Normalized the way stored handles are, so the two compare equal.
+    assert principal.handle == "poc-agent"
+    assert principal.role == "agent"
+    assert principal.issuer == ISSUER
+
+
+@pytest.mark.asyncio
+async def test_role_claim_overrides_the_issuer_default(auth_on, signing_key):
+    principal = await auth_service.verify_token(_sign(signing_key, mycelium_role="user"))
+    assert principal.role == "user"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_role_claim_is_rejected(auth_on, signing_key):
+    """Better a 401 than a principal silently labelled something it didn't claim."""
+    with pytest.raises(auth_service.AuthError):
+        await auth_service.verify_token(_sign(signing_key, mycelium_role="superuser"))
+
+
+@pytest.mark.asyncio
+async def test_configured_handle_claim_is_honoured(monkeypatch, auth_on, signing_key):
+    monkeypatch.setattr("app.config.settings.AUTH_HANDLE_CLAIM", "preferred_username")
+    principal = await auth_service.verify_token(_sign(signing_key, preferred_username="julia"))
+    assert principal.handle == "julia"
+
+
+# ── enabled: everything else is 401 ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_token_is_401(client: AsyncClient, auth_on):
+    resp = await client.get(PROTECTED_PATH)
+    assert resp.status_code == 401
+    assert resp.headers["WWW-Authenticate"].startswith("Bearer ")
+
+
+@pytest.mark.asyncio
+async def test_non_bearer_scheme_is_401(client: AsyncClient, auth_on):
+    resp = await client.get(PROTECTED_PATH, headers={"Authorization": "Basic abc"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_forged_token_is_401(client: AsyncClient, auth_on):
+    """Signed by a key the issuer never published."""
+    forged = _generate_key("key-1")  # same kid, different key material
+    resp = await client.get(PROTECTED_PATH, headers=_bearer(_sign(forged)))
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_expired_token_is_401(client: AsyncClient, auth_on, signing_key):
+    now = int(time.time())
+    token = _sign(signing_key, iat=now - 7200, exp=now - 3600)
+    assert (await client.get(PROTECTED_PATH, headers=_bearer(token))).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wrong_audience_is_401(client: AsyncClient, auth_on, signing_key):
+    token = _sign(signing_key, aud="some-other-app")
+    assert (await client.get(PROTECTED_PATH, headers=_bearer(token))).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_wrong_issuer_is_401(client: AsyncClient, auth_on, signing_key):
+    token = _sign(signing_key, iss="https://evil.test/realms/mycelium")
+    assert (await client.get(PROTECTED_PATH, headers=_bearer(token))).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_token_without_exp_is_401(client: AsyncClient, auth_on, signing_key):
+    """A token that never expires is not a credential we accept."""
+    token = _sign(signing_key, exp=None)
+    assert (await client.get(PROTECTED_PATH, headers=_bearer(token))).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_token_without_handle_claim_is_401(client: AsyncClient, auth_on, signing_key):
+    token = _sign(signing_key, sub=None)
+    assert (await client.get(PROTECTED_PATH, headers=_bearer(token))).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_hmac_algorithm_confusion_is_refused(client: AsyncClient, auth_on, signing_key):
+    """The published RSA public key must never be usable as an HMAC secret.
+
+    Hand-rolled rather than built with ``jwt.encode``, which refuses to sign this
+    shape at all — the point is to present the attacker's wire format to the gate
+    and confirm it is turned away on the algorithm, before any key is consulted.
+    """
+    now = int(time.time())
+    public_pem = (
+        signing_key["private"]
+        .public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+
+    def _segment(payload: dict[str, Any]) -> bytes:
+        return base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=")
+
+    signing_input = b".".join(
+        [
+            _segment({"alg": "HS256", "typ": "JWT", "kid": signing_key["kid"]}),
+            _segment(
+                {"sub": "poc-agent", "iss": ISSUER, "aud": AUDIENCE, "iat": now, "exp": now + 3600}
+            ),
+        ]
+    )
+    signature = base64.urlsafe_b64encode(
+        hmac.new(public_pem, signing_input, hashlib.sha256).digest()
+    ).rstrip(b"=")
+    forged = b".".join([signing_input, signature]).decode()
+
+    assert (await client.get(PROTECTED_PATH, headers=_bearer(forged))).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_unsigned_token_is_refused(client: AsyncClient, auth_on):
+    token = jwt.encode({"sub": "poc-agent", "iss": ISSUER}, key="", algorithm="none")
+    assert (await client.get(PROTECTED_PATH, headers=_bearer(token))).status_code == 401
+
+
+# ── public paths + localhost bypass ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_stays_public_when_enabled(client: AsyncClient, auth_on):
+    """Orchestrator probes are unauthenticated by nature — compose's healthcheck
+    curls this, so gating it would mark a correctly-secured hub unhealthy."""
+    resp = await client.get(PUBLIC_PATH)
+    assert resp.status_code == 200
+    assert resp.json()["auth"]["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_localhost_bypass_lets_a_loopback_caller_through(
+    monkeypatch, client: AsyncClient, auth_on
+):
+    """The ASGI transport presents 127.0.0.1, which is what the bypass keys off."""
+    monkeypatch.setattr("app.config.settings.AUTH_LOCALHOST_BYPASS", True)
+    assert (await client.get(PROTECTED_PATH)).status_code == 200
+
+
+def test_bypass_ignores_forwarded_for_headers():
+    """A caller-supplied header must never be able to claim locality."""
+    from starlette.requests import Request
+
+    def _request(client: tuple[str, int] | None, headers: list[tuple[bytes, bytes]]) -> Request:
+        return Request(
+            {
+                "type": "http",
+                "http_version": "1.1",
+                "method": "GET",
+                "path": "/api/rooms",
+                "headers": headers,
+                "client": client,
+            }
+        )
+
+    spoofed = [(b"x-forwarded-for", b"127.0.0.1")]
+    assert auth_service.is_loopback_client(_request(("10.1.2.3", 5000), spoofed)) is False
+    assert auth_service.is_loopback_client(_request(("127.0.0.1", 5000), [])) is True
+    assert auth_service.is_loopback_client(_request(("::1", 5000), [])) is True
+    # IPv4-mapped IPv6, which a dual-stack listener reports.
+    assert auth_service.is_loopback_client(_request(("::ffff:127.0.0.1", 5000), [])) is True
+    assert auth_service.is_loopback_client(_request(None, [])) is False
+
+
+# ── JWKS caching + rotation ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_jwks_is_fetched_once_and_cached(auth_on, signing_key, jwks_server):
+    for _ in range(3):
+        await auth_service.verify_token(_sign(signing_key))
+    assert jwks_server.fetches == 1
+
+
+@pytest.mark.asyncio
+async def test_rotated_key_is_picked_up_without_restart(auth_on, signing_key, jwks_server):
+    """A token signed by a key minted after the cache was filled still validates:
+    an unseen kid forces a re-fetch."""
+    await auth_service.verify_token(_sign(signing_key))
+    assert jwks_server.fetches == 1
+
+    rotated = _generate_key("key-2")
+    jwks_server.keys = [signing_key["jwk"], rotated["jwk"]]
+
+    principal = await auth_service.verify_token(_sign(rotated))
+    assert principal.handle == "poc-agent"
+    assert jwks_server.fetches == 2
+
+
+@pytest.mark.asyncio
+async def test_unknown_kid_still_401s_after_refresh(auth_on, jwks_server):
+    """Refreshing on an unseen kid must not become a way in."""
+    stranger = _generate_key("key-unknown")
+    with pytest.raises(auth_service.AuthError):
+        await auth_service.verify_token(_sign(stranger))
+
+
+@pytest.mark.asyncio
+async def test_stale_keys_serve_through_an_issuer_outage(
+    monkeypatch, auth_on, signing_key, jwks_server
+):
+    """An IdP blip must not take the hub down — cached keys are still the
+    issuer's keys, only their freshness is in doubt."""
+    await auth_service.verify_token(_sign(signing_key))
+
+    # Expire the cache so the next call must re-fetch, then break the issuer.
+    monkeypatch.setattr("app.config.settings.AUTH_JWKS_TTL_S", 0.0)
+    jwks_server.fail = True
+
+    principal = await auth_service.verify_token(_sign(signing_key))
+    assert principal.handle == "poc-agent"
+
+
+@pytest.mark.asyncio
+async def test_jwks_url_resolved_from_discovery_when_unset(monkeypatch, auth_on, signing_key):
+    """An issuer entry with no jwks_url falls back to OIDC discovery."""
+    monkeypatch.setattr(
+        "app.config.settings.AUTH_ISSUERS",
+        [TrustedIssuer(issuer=ISSUER, role="agent")],
+    )
+    auth_service.jwks_cache.clear()
+    principal = await auth_service.verify_token(_sign(signing_key))
+    assert principal.handle == "poc-agent"
+
+
+# ── multiple trust roots ──────────────────────────────────────────────────────
+
+
+HUMAN_ISSUER = "https://sso.test/realms/people"
+
+
+@pytest.fixture
+def two_issuers(monkeypatch, auth_on, signing_key):
+    """The shape a real deployment lands on: a human OIDC issuer alongside an
+    agent/service-account one, each with its own keys.
+
+    Returns the human issuer's key; ``signing_key`` remains the agent one.
+    """
+    human_key = _generate_key("human-1")
+
+    class _StubResponse:
+        def __init__(self, payload: dict[str, Any]) -> None:
+            self._payload = payload
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return self._payload
+
+    class _StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self) -> _StubClient:
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def get(self, url: str) -> _StubResponse:
+            keys = [human_key["jwk"]] if url.startswith(HUMAN_ISSUER) else [signing_key["jwk"]]
+            return _StubResponse({"keys": keys})
+
+    monkeypatch.setattr(auth_service.httpx, "AsyncClient", _StubClient)
+    monkeypatch.setattr(
+        "app.config.settings.AUTH_ISSUERS",
+        [
+            TrustedIssuer(issuer=ISSUER, jwks_url=JWKS_URL, role="agent"),
+            TrustedIssuer(issuer=HUMAN_ISSUER, jwks_url=f"{HUMAN_ISSUER}/jwks", role="user"),
+        ],
+    )
+    auth_service.jwks_cache.clear()
+    return human_key
+
+
+@pytest.mark.asyncio
+async def test_each_issuer_carries_its_own_keys_and_role(two_issuers, signing_key):
+    """Same gate, two trust roots, role falling out of which root signed."""
+    agent = await auth_service.verify_token(_sign(signing_key))
+    assert agent.role == "agent"
+
+    human = await auth_service.verify_token(_sign(two_issuers, iss=HUMAN_ISSUER, sub="julia"))
+    assert (human.role, human.handle) == ("user", "julia")
+
+
+@pytest.mark.asyncio
+async def test_one_issuers_key_cannot_vouch_for_another(two_issuers, signing_key):
+    """Trusting two roots must not make them interchangeable — a token signed by
+    the agent root but claiming the human root is checked against the *human*
+    root's keys, and fails."""
+    token = _sign(signing_key, iss=HUMAN_ISSUER)
+    with pytest.raises(auth_service.AuthError):
+        await auth_service.verify_token(token)
+
+
+# ── misconfiguration ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enabled_with_no_issuers_fails_closed(monkeypatch, client: AsyncClient, auth_on):
+    monkeypatch.setattr("app.config.settings.AUTH_ISSUERS", [])
+    resp = await client.get(PROTECTED_PATH)
+    assert resp.status_code == 503
+    assert "issuer" in resp.json()["detail"]
+
+
+def test_missing_audience_is_warned_about(monkeypatch, auth_on):
+    """Without an audience, any token the issuer ever minted validates here —
+    the operator should be told, not left to discover it."""
+    monkeypatch.setattr("app.config.settings.AUTH_AUDIENCE", None)
+    warnings = auth_service.config_warnings()
+    assert any("audience" in w for w in warnings)
+
+
+def test_no_warnings_when_disabled(monkeypatch):
+    monkeypatch.setattr("app.config.settings.AUTH_ENABLED", False)
+    assert auth_service.config_warnings() == []

--- a/fastapi-backend/uv.lock
+++ b/fastapi-backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -73,6 +73,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
 ]
 
 [[package]]
@@ -207,6 +230,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
     { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
     { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
 ]
 
 [[package]]
@@ -784,6 +844,7 @@ dependencies = [
     { name = "negmas" },
     { name = "pip-system-certs" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "rapidfuzz" },
     { name = "slim-bindings" },
@@ -806,12 +867,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0,<0.137" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0,<0.142" },
     { name = "fastembed", specifier = ">=0.8.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "negmas", specifier = ">=0.15.7" },
     { name = "pip-system-certs", specifier = ">=5.3" },
     { name = "pydantic-settings", specifier = ">=2.5.2,<3" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10,<3" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rapidfuzz", specifier = ">=3.14.5" },
     { name = "slim-bindings", specifier = ">=2,<3" },
@@ -826,7 +888,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "respx", specifier = ">=0.22.0" },
-    { name = "ruff", specifier = ">=0.11.0,<0.16" },
+    { name = "ruff", specifier = ">=0.11.0,<0.17" },
     { name = "ty", specifier = ">=0.0.1a8" },
     { name = "watchdog", specifier = ">=6.0.0,<7" },
 ]
@@ -1157,6 +1219,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1226,6 +1297,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -139,6 +139,94 @@ class EngineConfig(BaseModel):
         return v
 
 
+class TrustedIssuer(BaseModel):
+    """One trust root the backend's HTTP-API gate accepts tokens from.
+
+    Configured as a repeatable ``[[auth.issuers]]`` block. More than one root is
+    the normal case — a human OIDC issuer alongside an agent/service-account one
+    — and each carries its own keys, audience, and default role, so adding a root
+    is config rather than code.
+    """
+
+    issuer: str = Field(
+        ...,
+        description="Exact `iss` claim value to trust, e.g. https://idp.example.com/realms/mycelium",
+    )
+    jwks_url: str | None = Field(
+        default=None,
+        description="JWKS URL for this issuer. Omit to resolve it from the issuer's OIDC discovery document.",
+    )
+    audience: str | None = Field(
+        default=None,
+        description="Required `aud` for tokens from this issuer; overrides auth.audience.",
+    )
+    role: str = Field(
+        default="agent",
+        description="Role ('user' or 'agent') for principals from this issuer when the token carries no role claim.",
+    )
+
+    @field_validator("role")
+    @classmethod
+    def _validate_role(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if normalized not in ("user", "agent"):
+            raise ValueError("role must be 'user' or 'agent'")
+        return normalized
+
+    @field_validator("issuer", "jwks_url")
+    @classmethod
+    def _strip_trailing_slash(cls, v: str | None) -> str | None:
+        return v.rstrip("/") if isinstance(v, str) else v
+
+
+class AuthConfig(BaseModel):
+    """HTTP-API JWT gate — off by default.
+
+    The backend validates a bearer token against a configured issuer + JWKS. It
+    ships **disabled**: auth must never stand between someone and trying
+    Mycelium, so the default stack needs no issuer and no tokens. Turning it on
+    is a per-deployment decision for when a team shares a hub over a network.
+
+    When enabling it, set ``audience`` as well. Without one, *any* token a
+    trusted issuer ever minted is accepted — including tokens a user obtained
+    for an unrelated application on the same IdP. The audience is what makes
+    "valid token" mean "token meant for this hub".
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Enforce bearer-token auth on the backend HTTP API.",
+    )
+    issuers: list[TrustedIssuer] = Field(
+        default_factory=list,
+        description="Trust roots, as repeatable [[auth.issuers]] blocks.",
+    )
+    audience: str | None = Field(
+        default=None,
+        description="Required `aud` claim for every token. Strongly recommended whenever auth is enabled; unset means the audience is not checked.",
+    )
+    localhost_bypass: bool = Field(
+        default=True,
+        description="Let loopback callers through without a token, so enabling auth can't lock an operator out of the hub machine. Does not apply to a backend in Docker, whose callers arrive from the bridge gateway rather than loopback.",
+    )
+    handle_claim: str = Field(
+        default="sub",
+        description="Token claim carrying the canonical @handle.",
+    )
+    role_claim: str = Field(
+        default="mycelium_role",
+        description="Token claim distinguishing a user from an agent.",
+    )
+    leeway_s: float = Field(
+        default=60.0,
+        description="Clock-skew allowance in seconds on exp/nbf/iat.",
+    )
+    jwks_ttl_s: float = Field(
+        default=300.0,
+        description="How long a fetched JWKS is cached before re-fetch. Key rotation is also picked up on an unseen kid.",
+    )
+
+
 class RuntimeConfig(BaseModel):
     """Docker runtime / environment configuration."""
 
@@ -241,6 +329,7 @@ class MyceliumConfig(BaseModel):
     slim: SlimConfig = Field(default_factory=SlimConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)
     engine: EngineConfig = Field(default_factory=EngineConfig)
+    auth: AuthConfig = Field(default_factory=AuthConfig)
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     rooms: RoomConfig = Field(default_factory=RoomConfig)
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)

--- a/mycelium-cli/src/mycelium/docker_utils.py
+++ b/mycelium-cli/src/mycelium/docker_utils.py
@@ -5,9 +5,9 @@
 Generate .env files from config.toml — makes .env a derived artifact.
 
 The canonical configuration lives in ~/.mycelium/config.toml.  This module
-renders a Docker-compatible .env from the [llm], [runtime], and [server]
-sections so that ``docker compose`` picks up the same values without users
-having to maintain two files.
+renders a Docker-compatible .env from the [llm], [runtime], [server], [engine],
+and [auth] sections so that ``docker compose`` picks up the same values without
+users having to maintain two files.
 
 One field deliberately *isn't* in config.toml: ``MYCELIUM_IMAGE_TAG``.  It's
 operational state — set as a side effect of ``mycelium pull --version`` and
@@ -18,6 +18,7 @@ We round-trip it through the existing .env on regeneration so that
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -71,6 +72,21 @@ def read_pinned_image_tag(env_path: Path | None) -> str | None:
     return _read_operator_managed_keys(env_path).get("MYCELIUM_IMAGE_TAG")
 
 
+def _render_auth_issuers(config: MyceliumConfig) -> str:
+    """Trust roots as a single-line JSON array for ``AUTH_ISSUERS``.
+
+    Emitted empty when none are configured, so compose substitution and the
+    backend's ``env_ignore_empty`` both fall through to "no trusted issuers"
+    rather than to a literal ``[]`` string.
+    """
+    if not config.auth.issuers:
+        return ""
+    return json.dumps(
+        [entry.model_dump(exclude_none=True) for entry in config.auth.issuers],
+        separators=(",", ":"),
+    )
+
+
 def generate_env_file(
     config: MyceliumConfig,
     *,
@@ -119,6 +135,19 @@ def generate_env_file(
         # (the host runtime rode the removed daemon). Emitted for the backend to
         # read; always `backend`.
         f"ENGINE_RUNTIME={config.engine.runtime}",
+        "",
+        "# ── Auth (HTTP-API JWT gate; off unless auth.enabled is set) ─────────────",
+        f"AUTH_ENABLED={str(config.auth.enabled).lower()}",
+        # Trust roots travel as one JSON array because env is the only transport
+        # into the container — the repeatable [[auth.issuers]] blocks in
+        # config.toml are the authored form.
+        f"AUTH_ISSUERS={_render_auth_issuers(config)}",
+        f"AUTH_AUDIENCE={config.auth.audience or ''}",
+        f"AUTH_LOCALHOST_BYPASS={str(config.auth.localhost_bypass).lower()}",
+        f"AUTH_HANDLE_CLAIM={config.auth.handle_claim}",
+        f"AUTH_ROLE_CLAIM={config.auth.role_claim}",
+        f"AUTH_LEEWAY_S={config.auth.leeway_s}",
+        f"AUTH_JWKS_TTL_S={config.auth.jwks_ttl_s}",
         "",
     ]
 

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -1,0 +1,162 @@
+# Authentication
+
+Mycelium's backend can require a signed **bearer token** on every HTTP API call,
+validated against an OIDC issuer you configure. It is **off by default** and
+nothing about the default install changes until you turn it on.
+
+## Off by default, on purpose
+
+Auth must never be a wall between someone and trying Mycelium. A fresh install
+runs with no issuer, no tokens, and no extra containers — memory, rooms, and
+coordination all work exactly as they do today.
+
+Turn it on when a **team shares a hub over a network**. Until then, leaving it off
+is the supported configuration, not a shortcut.
+
+> Without the gate, anyone who can reach the backend's port can read and write
+> every room and post as any `@handle`. On a laptop that's fine. On a shared
+> network it is not — that is precisely the moment to enable this.
+
+## Turning it on
+
+```bash
+mycelium config set auth.enabled true
+mycelium config set auth.audience mycelium
+mycelium config apply
+```
+
+Then declare at least one trust root in `~/.mycelium/config.toml`:
+
+```toml
+[auth]
+enabled  = true
+audience = "mycelium"
+
+[[auth.issuers]]
+issuer   = "https://sso.example.com/realms/mycelium"
+jwks_url = "https://sso.example.com/realms/mycelium/protocol/openid-connect/certs"
+role     = "user"
+```
+
+Re-run `mycelium config apply` and recreate the backend so it picks up the new
+environment.
+
+### Always set an audience
+
+`audience` is optional but you should always set it when enabling auth. Without
+one, **any** token your issuer has ever minted is accepted — including a token a
+user obtained for a completely unrelated application on the same identity
+provider. That token's holder was never authorized against your hub.
+
+Setting an audience is what makes "a valid token" mean "a token meant for *this*
+hub". The backend logs a warning at startup and flags it in `/health` when auth
+is on without one.
+
+## Configuration
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `auth.enabled` | `false` | Enforce bearer-token auth on the HTTP API. |
+| `auth.issuers` | *(none)* | Trust roots, as repeatable `[[auth.issuers]]` blocks. |
+| `auth.audience` | *(unset)* | Required `aud` claim. Set this whenever auth is on. |
+| `auth.localhost_bypass` | `true` | Let loopback callers through without a token. |
+| `auth.handle_claim` | `sub` | Claim carrying the canonical `@handle`. |
+| `auth.role_claim` | `mycelium_role` | Claim distinguishing a user from an agent. |
+| `auth.leeway_s` | `60` | Clock-skew allowance on `exp` / `nbf` / `iat`. |
+| `auth.jwks_ttl_s` | `300` | How long a fetched JWKS is cached. |
+
+Each `[[auth.issuers]]` block takes `issuer` (the exact `iss` to trust),
+`jwks_url` (optional — omit to resolve it from the issuer's OIDC discovery
+document), `audience` (optional per-issuer override), and `role`.
+
+## Issuer-agnostic by design
+
+The backend trusts a configured issuer and its JWKS. It has no idea whether that
+is Keycloak, Dex, ZITADEL, Authentik, or your existing corporate SSO, and it never
+needs one particular product installed.
+
+**More than one trust root is normal.** Humans log in through an interactive OIDC
+issuer; agents present service-account tokens, possibly from an entirely separate
+root. List each as its own block:
+
+```toml
+[[auth.issuers]]
+issuer = "https://sso.example.com/realms/people"
+role   = "user"
+
+[[auth.issuers]]
+issuer = "https://sso.example.com/realms/agents"
+role   = "agent"
+```
+
+Roots are matched by exact `iss` and never become interchangeable: a token signed
+by the agent root but claiming the human root is checked against the human root's
+keys, and fails.
+
+## Handle and role
+
+Once a token validates, the request has a **principal**:
+
+- **handle** — from `auth.handle_claim` (`sub` by default), normalized the same
+  way stored handles are (leading `@` stripped, lowercased). An OIDC
+  service-account whose client id is `release-agent` therefore arrives as
+  `@release-agent`.
+- **role** — from `auth.role_claim` if the token carries it, otherwise the `role`
+  on the matched issuer block. Which root signed a token is usually the whole
+  answer to user-vs-agent, so most deployments never set a role claim at all.
+
+Today the gate proves the token and records the principal. Using it as the
+*authoritative* author of a write — replacing the `created_by` and
+`sender_handle` a request body supplies — is the next step in the identity work.
+
+## Key rotation
+
+The JWKS is fetched from your issuer and cached for `auth.jwks_ttl_s`. When a
+token arrives signed by a key ID the backend hasn't seen, it re-fetches
+immediately (rate-limited), so **rotating your signing key does not require
+restarting Mycelium**.
+
+If the issuer is briefly unreachable, previously fetched keys keep serving. The
+keys are still your issuer's; only their freshness is in doubt, and failing closed
+would take the hub down for the length of an IdP blip.
+
+## The localhost bypass
+
+With `auth.localhost_bypass` on (the default), requests whose **peer address** is
+real loopback (`127.0.0.0/8`, `::1`) skip the gate, so turning auth on can't lock
+you out of the machine the hub runs on.
+
+Two things worth knowing:
+
+- `X-Forwarded-For` is deliberately ignored. It is caller-supplied, so honouring
+  it would let any remote request claim to be local.
+- **It does not fire for a backend running in Docker.** Traffic through a
+  published port arrives from the bridge gateway, not loopback, and is
+  indistinguishable from LAN traffic — treating that as local would silently open
+  the hub to your whole network. For the containerized local tier, leave
+  `auth.enabled` off; that is the honest switch for it.
+
+## What stays open
+
+Health (`/`, `/health`) and the schema/docs routes are served without a token even
+when the gate is on: orchestrator probes are unauthenticated by nature, and the
+health payload reveals no room content. `/health` gains an `auth` block reporting
+whether the hub is gated, which issuers it trusts, and any configuration warnings.
+
+Every other route requires a token.
+
+## Failure modes
+
+| Response | Meaning |
+|----------|---------|
+| `401` + `WWW-Authenticate: Bearer` | Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token. |
+| `503` | The gate is on but unusable — no trusted issuers configured, or the issuer's JWKS is unreachable and nothing is cached. |
+
+Only asymmetric signatures are accepted (`RS*`, `PS*`, `ES*`). The `none`
+algorithm and the whole `HS*` family are refused before verification, so a public
+JWKS key can never be replayed as an HMAC secret.
+
+## Trying it locally
+
+A dev OIDC issuer ships for exactly this, so you can exercise the gate without
+standing up Keycloak. See `docs/design/dev-auth-issuer.md`.

--- a/mycelium-cli/tests/test_docker_env_auth.py
+++ b/mycelium-cli/tests/test_docker_env_auth.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""``[auth]`` → ``.env`` materialisation for the HTTP-API JWT gate (#561).
+
+``~/.mycelium/.env`` is the only transport config.toml has into the backend
+container, so a setting that doesn't survive this rendering is a setting the
+gate never sees. The trust roots in particular are authored as repeatable
+``[[auth.issuers]]`` blocks and have to arrive as one JSON line.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from mycelium.config import MyceliumConfig, TrustedIssuer
+from mycelium.docker_utils import generate_env_file
+
+
+def _parse_env(blob: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in blob.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        out[k.strip()] = v.strip()
+    return out
+
+
+def test_default_config_ships_the_gate_disabled() -> None:
+    """The default install must render an off gate — the try-it path depends on
+    it, so this is a contract, not a preference."""
+    env = _parse_env(generate_env_file(MyceliumConfig()))
+    assert env["AUTH_ENABLED"] == "false"
+    assert env["AUTH_ISSUERS"] == ""
+    assert env["AUTH_AUDIENCE"] == ""
+
+
+def test_enabled_gate_materialises_every_setting() -> None:
+    cfg = MyceliumConfig()
+    cfg.auth.enabled = True
+    cfg.auth.audience = "mycelium"
+    cfg.auth.localhost_bypass = False
+    cfg.auth.handle_claim = "preferred_username"
+    cfg.auth.role_claim = "roles"
+
+    env = _parse_env(generate_env_file(cfg))
+    assert env["AUTH_ENABLED"] == "true"
+    assert env["AUTH_AUDIENCE"] == "mycelium"
+    assert env["AUTH_LOCALHOST_BYPASS"] == "false"
+    assert env["AUTH_HANDLE_CLAIM"] == "preferred_username"
+    assert env["AUTH_ROLE_CLAIM"] == "roles"
+
+
+def test_issuers_render_as_one_json_line() -> None:
+    """Multiple trust roots — the human + agent shape — must survive as JSON on
+    a single line, since a multi-line value would truncate at the first newline.
+    """
+    cfg = MyceliumConfig()
+    cfg.auth.enabled = True
+    cfg.auth.issuers = [
+        TrustedIssuer(issuer="https://sso.example.com/realms/people", role="user"),
+        TrustedIssuer(
+            issuer="https://sso.example.com/realms/agents",
+            jwks_url="https://sso.example.com/realms/agents/protocol/openid-connect/certs",
+            role="agent",
+        ),
+    ]
+
+    rendered = generate_env_file(cfg)
+    assert "AUTH_ISSUERS=" in rendered
+    value = _parse_env(rendered)["AUTH_ISSUERS"]
+    assert "\n" not in value
+
+    parsed = json.loads(value)
+    assert [e["issuer"] for e in parsed] == [
+        "https://sso.example.com/realms/people",
+        "https://sso.example.com/realms/agents",
+    ]
+    assert [e["role"] for e in parsed] == ["user", "agent"]
+    # An unset jwks_url is omitted rather than sent as null, so the backend
+    # falls through to OIDC discovery for that root.
+    assert "jwks_url" not in parsed[0]
+    assert parsed[1]["jwks_url"].endswith("/certs")
+
+
+def test_issuer_role_must_be_user_or_agent() -> None:
+    with pytest.raises(ValidationError):
+        TrustedIssuer(issuer="https://sso.example.com/realms/people", role="superuser")
+
+
+def test_issuer_urls_are_trailing_slash_normalised() -> None:
+    """``iss`` is matched by exact string, so a stray trailing slash in config
+    would silently reject every token from that issuer."""
+    entry = TrustedIssuer(issuer="https://sso.example.com/realms/people/")
+    assert entry.issuer == "https://sso.example.com/realms/people"


### PR DESCRIPTION
## Summary

Implements an optional, issuer-agnostic JWT bearer-token authentication gate for the backend HTTP API. The gate is **disabled by default** — the shipped configuration requires no issuer, no tokens, and no extra containers. It becomes opt-in when a team shares a hub over a network.

The implementation validates tokens against a configured OIDC issuer's JWKS, with support for multiple trust roots (e.g., separate human and agent issuers), key rotation without restart, and a localhost bypass for operator access. Public paths (`/health`, `/docs`, etc.) remain unauthenticated.

## Changes

- **`app/services/auth.py`** (new): Core JWT validation service
  - `Principal` dataclass for verified request actors (handle, role, issuer)
  - `AuthError` exception with RFC 6750 `WWW-Authenticate` challenge
  - `JwksCache` class: fetches and caches JWKS per issuer, picks up key rotation on unseen `kid`, stale-on-error fallback
  - `verify_token()`: validates bearer token signature, claims (exp, aud, iss), and resolves principal
  - `auth_gate()`: FastAPI dependency that gates `/api/*` routes, allows public paths and localhost bypass
  - Algorithm-confusion protection: rejects HMAC and `none` algorithms before key lookup

- **`app/config.py`** (modified): Configuration models
  - `PrincipalRole` type: `"user"` or `"agent"`
  - `TrustedIssuer` model: issuer URL, optional JWKS URL (resolved via OIDC discovery if omitted), optional per-issuer audience override, default role
  - Settings: `AUTH_ENABLED`, `AUTH_ISSUERS`, `AUTH_AUDIENCE`, `AUTH_LOCALHOST_BYPASS`, `AUTH_HANDLE_CLAIM`, `AUTH_ROLE_CLAIM`, `AUTH_LEEWAY_S`, `AUTH_JWKS_TTL_S`

- **`app/main.py`** (modified): Wire auth gate as a dependency on all routes

- **`mycelium-cli/src/mycelium/config.py`** (modified): CLI-side config models mirroring backend

- **`mycelium-cli/src/mycelium/docker_utils.py`** (modified): Render auth settings to `.env` for Docker, serializing issuers as JSON

- **`fastapi-backend/tests/test_auth_gate.py`** (new): Comprehensive test suite (511 lines)
  - In-process RSA key generation and JWKS stub server
  - Tests: disabled-by-default behavior, valid token acceptance, principal resolution, role claim handling, all rejection cases (missing/forged/expired/wrong-audience/wrong-issuer tokens, algorithm confusion, unsigned tokens)
  - JWKS caching and rotation without restart
  - Public path exemption and localhost bypass
  - Loopback detection (IPv4, IPv6, IPv4-mapped IPv6; rejects spoofed `X-Forwarded-For`)

- **`mycelium-cli/tests/test_docker_env_auth.py`** (new): Config → `.env` materialization tests
  - Default disabled gate
  - All settings render correctly
  - Multiple issuers serialize as one JSON line

- **Documentation** (new/modified)
  - `mycelium-cli/src/mycelium/docs/guides/auth.md`: User guide covering off-by-default philosophy, setup, configuration table, issuer-agnostic design, handle/role semantics
  - `docs/reference.html`, `docs/llms-full.txt`: Generated reference docs with auth config section
  - `docs/design/dev-auth-issuer.md`: Updated with dev issuer setup example
  - `docs/design/identity-and-auth.md`: Updated to reference the implemented gate
  - `CLAUDE.md`: Added note on auth gate opt-in design

- **Dependencies**: Added `pyjwt[crypto]>=2.10,<3` for JWT handling

## Testing

- **Unit tests pass**: 511-line test suite covers disabled-

https://claude.ai/code/session_01VTUgQe9jS75VBxrSUNcktZ