### PR TITLE
feat(auth): bind the write actor to the verified token

### DIFF
--- a/docs/design/identity-and-auth.md
+++ b/docs/design/identity-and-auth.md
@@ -101,7 +101,9 @@ come from the token**, not the request body:
 
 - `sub` (or a configured claim) → the canonical handle.
 - a role/claim distinguishes **user** vs **agent**.
-- `created_by` / `sender_handle` from the body are ignored (or must match the token).
+- `created_by` / `sender_handle` from the body no longer decide the actor: an
+  omitted or matching one is replaced by the token's handle, and one that names a
+  **different** handle is refused with a **403** rather than silently rewritten.
 
 This is what actually kills impersonation and makes attribution trustworthy across
 the whole system (memory authorship, transcript senders, L9 actors).
@@ -121,7 +123,12 @@ per-deployment opt-in.
    the bridge gateway, indistinguishable from LAN traffic) — the containerized
    local tier is served by leaving auth disabled.*
 2. **Verified handle binding** — derive handle + role from claims; stop trusting
-   body-supplied actor fields. Only active when the gate is on.
+   body-supplied actor fields. Only active when the gate is on. *Landed (#562):
+   `fastapi-backend/app/services/actor.py`, applied at the memory, message, reply
+   and engine-registration write paths. A body handle carrying a session
+   qualifier (`alice#a8f3`) is honoured as the same principal; the reader side —
+   which handle's queue an `await` may drain — is authorization rather than
+   attribution and stays with the RBAC step.*
 3. **CLI human login** — `mycelium login` obtains a token (Authorization Code +
    PKCE, or device-code for headless), stores + refreshes it; `mycelium iam`
    becomes "who am I per the token," not self-assert.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1594,9 +1594,24 @@ Once a token validates, the request has a **principal**:
   on the matched issuer block. Which root signed a token is usually the whole
   answer to user-vs-agent, so most deployments never set a role claim at all.
 
-Today the gate proves the token and records the principal. Using it as the
-*authoritative* author of a write — replacing the `created_by` and
-`sender_handle` a request body supplies — is the next step in the identity work.
+## The token is the author
+
+The principal is not just recorded — it is the **actor of record** for every write
+it makes. Memory authorship (`created_by` / `updated_by`), the transcript sender,
+and L9 actor attribution all come from the token rather than from the handle the
+request body supplies:
+
+- The body **omits** the actor, or names the **same** handle → the token's handle
+  is stored. `@Alice` and `alice` are one principal; the comparison uses the same
+  normalization as the store.
+- The body names a **different** handle → **403**. A caller acting under the wrong
+  identity gets told, rather than having its writes quietly re-attributed.
+- A **session qualifier** (`alice#a8f3` — the same person on one machine) is kept
+  as-is. The suffix rides along on the token's handle, so per-session attribution
+  survives without letting the suffix name someone else.
+
+With the gate off there is no principal, so every path keeps the self-asserted
+actor from the body exactly as before — the try-it path is unchanged.
 
 ## Key rotation
 
@@ -1639,6 +1654,7 @@ Every other route requires a token.
 | Response | Meaning |
 |----------|---------|
 | `401` + `WWW-Authenticate: Bearer` | Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token. |
+| `403` | A valid token, but the request body claims to act as a different handle. |
 | `503` | The gate is on but unusable — no trusted issuers configured, or the issuer's JWKS is unreachable and nothing is cached. |
 
 Only asymmetric signatures are accepted (`RS*`, `PS*`, `ES*`). The `none`

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1080,7 +1080,21 @@ role   = &quot;agent&quot;</code></pre>
         <li><strong>role</strong> — from <code>auth.role_claim</code> if the token carries it, otherwise the <code>role</code></li>
       </ul>
       <p>on the matched issuer block. Which root signed a token is usually the whole answer to user-vs-agent, so most deployments never set a role claim at all.</p>
-      <p>Today the gate proves the token and records the principal. Using it as the <em>authoritative</em> author of a write — replacing the <code>created_by</code> and <code>sender_handle</code> a request body supplies — is the next step in the identity work.</p>
+      <h2 id="auth-the-token-is-the-author">The token is the author</h2>
+      <p>The principal is not just recorded — it is the <strong>actor of record</strong> for every write it makes. Memory authorship (<code>created_by</code> / <code>updated_by</code>), the transcript sender, and L9 actor attribution all come from the token rather than from the handle the request body supplies:</p>
+      <ul>
+        <li>The body <strong>omits</strong> the actor, or names the <strong>same</strong> handle → the token&#x27;s handle</li>
+      </ul>
+      <p>is stored. <code>@Alice</code> and <code>alice</code> are one principal; the comparison uses the same normalization as the store.</p>
+      <ul>
+        <li>The body names a <strong>different</strong> handle → <strong>403</strong>. A caller acting under the wrong</li>
+      </ul>
+      <p>identity gets told, rather than having its writes quietly re-attributed.</p>
+      <ul>
+        <li>A <strong>session qualifier</strong> (<code>alice#a8f3</code> — the same person on one machine) is kept</li>
+      </ul>
+      <p>as-is. The suffix rides along on the token&#x27;s handle, so per-session attribution survives without letting the suffix name someone else.</p>
+      <p>With the gate off there is no principal, so every path keeps the self-asserted actor from the body exactly as before — the try-it path is unchanged.</p>
       <h2 id="auth-key-rotation">Key rotation</h2>
       <p>The JWKS is fetched from your issuer and cached for <code>auth.jwks_ttl_s</code>. When a token arrives signed by a key ID the backend hasn&#x27;t seen, it re-fetches immediately (rate-limited), so <strong>rotating your signing key does not require restarting Mycelium</strong>.</p>
       <p>If the issuer is briefly unreachable, previously fetched keys keep serving. The keys are still your issuer&#x27;s; only their freshness is in doubt, and failing closed would take the hub down for the length of an IdP blip.</p>
@@ -1111,6 +1125,10 @@ role   = &quot;agent&quot;</code></pre>
             <tr>
               <td><code>401</code> + <code>WWW-Authenticate: Bearer</code></td>
               <td>Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token.</td>
+            </tr>
+            <tr>
+              <td><code>403</code></td>
+              <td>A valid token, but the request body claims to act as a different handle.</td>
             </tr>
             <tr>
               <td><code>503</code></td>

--- a/fastapi-backend/app/routes/engines.py
+++ b/fastapi-backend/app/routes/engines.py
@@ -16,11 +16,12 @@ import logging
 import re
 
 import yaml
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from app.routes.memory import create_memories
+from app.routes.memory import upsert_memories
 from app.schemas import AgentRead, MemoryBatchCreate, MemoryCreate
+from app.services import actor
 from app.services.filesystem import get_room_dir, read_memory_file, room_exists
 
 logger = logging.getLogger(__name__)
@@ -45,7 +46,9 @@ class EngineCreate(BaseModel):
     )
     owner: str | None = None
     team: str | None = None
-    created_by: str = Field("web-ui", description="Who registered the engine.")
+    created_by: str | None = Field(
+        None, description="Who registered the engine; defaults to the web UI."
+    )
 
 
 def _norm(handle: str | None) -> str | None:
@@ -56,10 +59,15 @@ def _norm(handle: str | None) -> str | None:
 
 
 @router.post("", response_model=AgentRead, status_code=201)
-async def create_engine(room_name: str, payload: EngineCreate) -> AgentRead:
+async def create_engine(room_name: str, payload: EngineCreate, request: Request) -> AgentRead:
     """Register an engine manifest in the room and return its structured view."""
     if not room_exists(room_name):
         raise HTTPException(status_code=404, detail="Room not found")
+
+    # ``created_by`` is optional so an omitted field reads as "no claim" and a
+    # verified token can fill it — the placeholder below is only for the
+    # unauthenticated web UI, which has no identity to offer.
+    registrar = actor.bind_optional_actor(request, payload.created_by, field="created_by")
 
     kind = payload.kind.strip().lower()
     if kind not in ENGINE_KINDS:
@@ -97,7 +105,7 @@ async def create_engine(room_name: str, payload: EngineCreate) -> AgentRead:
             MemoryCreate(
                 key=key,
                 value=yaml_body,
-                created_by=payload.created_by or "web-ui",
+                created_by=registrar or "web-ui",
                 # embed=False: a manifest is registry config, not room knowledge —
                 # embedding it pollutes memory search + synthesis with roster noise.
                 embed=False,
@@ -105,7 +113,7 @@ async def create_engine(room_name: str, payload: EngineCreate) -> AgentRead:
             )
         ]
     )
-    await create_memories(room_name, batch)
+    await upsert_memories(room_name, batch)
     logger.info("room %s: registered engine @%s (kind=%s)", room_name, handle, kind)
 
     return AgentRead(

--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -40,7 +40,7 @@ from app.schemas import (
     SubscriptionCreate,
     SubscriptionRead,
 )
-from app.services import local_state, memory_sync, search_index
+from app.services import actor, local_state, memory_sync, search_index
 from app.services.embedding import embed_text
 from app.services.filesystem import (
     delete_memory_file,
@@ -190,13 +190,25 @@ async def _send_memory_write_knowledge(
 
 
 @router.post("", response_model=list[MemoryRead], status_code=201)
-async def create_memories(room_name: str, payload: MemoryBatchCreate):
+async def create_memories(room_name: str, payload: MemoryBatchCreate, request: Request):
     """Create or upsert one or more memories (batch: 1-100 items).
 
     Writes markdown files to ``.mycelium/rooms/{room_name}/`` and updates the
     JSONL search index. Conflict policy: last-write-wins ordered by the memory's
     incrementing ``version``; a write against a stale ``base_version`` is
     rejected with the current content + who/when last wrote it.
+    """
+    for item in payload.items:
+        item.created_by = actor.bind_actor(request, item.created_by, field="created_by")
+    return await upsert_memories(room_name, payload)
+
+
+async def upsert_memories(room_name: str, payload: MemoryBatchCreate) -> list[MemoryRead]:
+    """The write itself, with ``created_by`` already resolved to its true author.
+
+    Split from the route so backend-owned writers (the synthesizer, an engine
+    manifest) reuse the one correct upsert without routing their actor through a
+    request body they never had.
     """
     _require_room(room_name)
     room_dir = get_room_dir(room_name)

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -14,7 +14,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 
 from app.bus import bus, room_channel
 from app.schemas import (
@@ -25,7 +25,7 @@ from app.schemas import (
     MessageRead,
     MessageType,
 )
-from app.services import local_state, persister, principals, room_channels
+from app.services import actor, local_state, persister, principals, room_channels
 from app.services.filesystem import room_exists
 
 logger = logging.getLogger(__name__)
@@ -50,23 +50,25 @@ def _resolve_channel(name: str) -> tuple[str, local_state.CoordSessionShim | Non
 
 
 @router.post("", response_model=MessageRead, status_code=201)
-async def send_message(room_name: str, payload: MessageCreate):
+async def send_message(room_name: str, payload: MessageCreate, request: Request):
     """Send a message to a room; publish it to the room's live stream."""
     channel, coord = _resolve_channel(room_name)
+
+    # Whoever a verified token says is calling is the sender; unauthenticated, the
+    # body's handle stands as before.
+    sender_handle = actor.bind_actor(request, payload.sender_handle, field="sender_handle")
 
     # A human posts under a self-asserted handle (may be unregistered), but no
     # one may pose as an engine — engines speak only through their own runtime.
     base_room = channel.split(":session:", 1)[0]
-    reason = principals.post_rejection_reason(
-        base_room, payload.sender_handle, allow_unregistered=True
-    )
+    reason = principals.post_rejection_reason(base_room, sender_handle, allow_unregistered=True)
     if reason:
         raise HTTPException(status_code=403, detail=reason)
 
     msg = local_state.StoredMessage(
         room_name=None if coord else channel,
         coordination_session_id=coord.id if coord else None,
-        sender_handle=payload.sender_handle,
+        sender_handle=sender_handle,
         recipient_handle=payload.recipient_handle,
         message_type=payload.message_type,
         content=payload.content,

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -29,10 +29,10 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from app.services import l9, principals, room_channels
+from app.services import actor, l9, principals, room_channels
 from app.services.filesystem import room_exists
 from app.services.l9_models import Kind
 from app.services.l9_slim import serialize_content
@@ -186,23 +186,27 @@ class ReplyBody(BaseModel):
 
 
 @router.post("/reply")
-async def post_reply(room_name: str, body: ReplyBody):
+async def post_reply(room_name: str, body: ReplyBody, request: Request):
     """Publish ``handle``'s reply as an L9 agent exchange the aligner scores."""
     if not room_exists(room_name):
         raise HTTPException(status_code=404, detail="Room not found")
+    # A verified token names the replier; unauthenticated, the body's handle does.
+    # Either way it is resolved here, so the transcript sender and the L9 actor
+    # below are the same handle the room-membership guard passed.
+    handle = actor.bind_actor(request, body.handle, field="handle")
     # The reply rides as sender_role="agent", so the handle must be a real
     # principal — a registered agent or a known user — and never an engine
     # (engines aren't impersonable). Guard before provisioning a channel.
-    reason = principals.post_rejection_reason(room_name, body.handle, allow_unregistered=False)
+    reason = principals.post_rejection_reason(room_name, handle, allow_unregistered=False)
     if reason:
         raise HTTPException(status_code=403, detail=reason)
     managed = await room_channels.manager.provision(room_name)
-    room_channels.manager.refresh_lease(room_name, body.handle)
+    room_channels.manager.refresh_lease(room_name, handle)
     if managed is None or managed.persister is None:
         raise HTTPException(status_code=503, detail="No live channel for room")
 
     payload_data, clean = _parse_marker(body.text)
-    st = _await_state.get((room_name, body.handle))
+    st = _await_state.get((room_name, handle))
     woke = (st.last_tick if st else None) or {}
     woke_header = (woke.get("l9") or {}).get("header") or {}
     woke_msg = woke_header.get("message") or {}
@@ -217,7 +221,7 @@ async def post_reply(room_name: str, body: ReplyBody):
     envelope = l9.build_envelope(
         kind=Kind.exchange,
         episode=episode,
-        sender=body.handle,
+        sender=handle,
         sender_role="agent",
         recipients=[tick_sender] if tick_sender else [l9.SYSTEM_ACTOR_ID],
         topic=topic,
@@ -238,6 +242,6 @@ async def post_reply(room_name: str, body: ReplyBody):
         pass
     return {
         "room": room_name,
-        "handle": body.handle,
+        "handle": handle,
         "message_id": envelope.header.message.id if envelope.header.message else None,
     }

--- a/fastapi-backend/app/services/actor.py
+++ b/fastapi-backend/app/services/actor.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Handle binding — the *authoritative* actor behind a write.
+
+The gate (``services/auth.py``) proves a token is valid and leaves a
+:class:`~app.services.auth.Principal` on ``request.state.principal``. That alone
+changes nothing about attribution: every write path still took its actor from the
+request body (``created_by`` / ``sender_handle`` / the reply ``handle``), which is
+pure self-assertion — a valid token for ``@bob`` could still author a memory as
+``@alice``. This module is where a verified token becomes the actor of record, so
+memory authorship, the transcript sender, and L9 actor attribution all name
+whoever the token says is calling.
+
+Two rules, and the first one is the load-bearing one:
+
+* **No principal, no change.** With the gate off (the shipped default), on a
+  public path, or behind the localhost bypass, ``request.state.principal`` is
+  ``None`` and the body's self-asserted actor is used exactly as before. The
+  try-it path must not notice that this module exists.
+* **A principal is the actor.** With one present, the stored actor is derived from
+  the token. A body that *explicitly claims a different handle* is refused with a
+  403 rather than silently rewritten: a caller acting under the wrong identity has
+  a bug or is probing, and both deserve an answer rather than re-attributed writes.
+
+A body handle may carry a session qualifier (``alpha#a8f3``). That names the same
+principal, so it is honoured — the qualifier rides along on the token's handle,
+which keeps per-session attribution without letting the suffix smuggle in a
+different actor.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request
+
+from app.services.auth import Principal, normalize_handle
+
+
+def current_principal(request: Request | None) -> Principal | None:
+    """The verified principal for a request, or ``None`` when it is anonymous.
+
+    ``None`` for a request the gate never annotated — an internal caller with no
+    request at all, or a call that reached a route before the dependency ran.
+    """
+    if request is None:
+        return None
+    principal = getattr(request.state, "principal", None)
+    return principal if isinstance(principal, Principal) else None
+
+
+def bind_actor(request: Request | None, claimed: str, *, field: str = "handle") -> str:
+    """The authoritative actor for a write whose body always carries one."""
+    principal = current_principal(request)
+    if principal is None:
+        return claimed
+    return _authoritative(principal, claimed, field)
+
+
+def bind_optional_actor(
+    request: Request | None, claimed: str | None, *, field: str = "handle"
+) -> str | None:
+    """Same rule, for a body field the caller may legitimately omit.
+
+    An omitted field is not a claim, so it is filled from the token instead of
+    being read as a mismatch — which is what keeps a placeholder default (the web
+    UI's ``created_by``) from looking like impersonation.
+    """
+    principal = current_principal(request)
+    if principal is None:
+        return claimed
+    return _authoritative(principal, claimed, field)
+
+
+def _authoritative(principal: Principal, claimed: str | None, field: str) -> str:
+    base, sep, session = (claimed or "").partition("#")
+    normalized = normalize_handle(base)
+    if normalized is None:
+        return principal.handle
+    if normalized != principal.handle:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"{field} '{claimed}' does not match the authenticated principal "
+                f"'@{principal.handle}'; a request may only act as its own token."
+            ),
+        )
+    return f"{principal.handle}#{session}" if sep and session else principal.handle

--- a/fastapi-backend/app/services/auth.py
+++ b/fastapi-backend/app/services/auth.py
@@ -16,8 +16,8 @@ domain, so adding the agent trust root later (#564/#476) is a config entry.
 
 Scope is authentication only. Resolving a validated token into the *authoritative*
 actor for a write — replacing body-supplied ``created_by`` / ``sender_handle`` —
-is handle binding (#562); this module proves the token and records the principal
-on ``request.state.principal`` for that stage to consume.
+is handle binding, and lives in ``services/actor.py``; this module proves the
+token and records the principal on ``request.state.principal`` for it to consume.
 """
 
 from __future__ import annotations
@@ -265,7 +265,7 @@ def _resolve_role(claims: dict[str, Any], entry: TrustedIssuer) -> PrincipalRole
     return "user" if value == "user" else "agent"
 
 
-def _normalize_handle(raw: object) -> str | None:
+def normalize_handle(raw: object) -> str | None:
     """Match ``principals._norm`` so token and stored handles compare equal."""
     if not isinstance(raw, str):
         return None
@@ -311,7 +311,7 @@ async def verify_token(token: str) -> Principal:
     except jwt.PyJWTError as exc:
         raise AuthError(f"token rejected: {exc}")
 
-    handle = _normalize_handle(claims.get(settings.AUTH_HANDLE_CLAIM))
+    handle = normalize_handle(claims.get(settings.AUTH_HANDLE_CLAIM))
     if handle is None:
         raise AuthError(f"token carries no {settings.AUTH_HANDLE_CLAIM!r} claim")
 

--- a/fastapi-backend/app/services/synthesizer.py
+++ b/fastapi-backend/app/services/synthesizer.py
@@ -294,13 +294,13 @@ class SynthesizerEngine:
     async def _write_summary(self, room: str, summary: str, created_by: str) -> None:
         """Upsert the summary through the canonical versioned + indexed path."""
         # Lazy import: the route module imports services heavily, so importing it
-        # at module load would risk a cycle. ``create_memories`` is the single
+        # at module load would risk a cycle. ``upsert_memories`` is the single
         # source of truth for a correct (versioned, indexed, NOTIFY-ing) write —
         # reused here rather than re-implementing the upsert.
-        from app.routes.memory import create_memories
+        from app.routes.memory import upsert_memories
         from app.schemas import MemoryBatchCreate, MemoryCreate
 
-        await create_memories(
+        await upsert_memories(
             room,
             MemoryBatchCreate(
                 items=[

--- a/fastapi-backend/tests/test_auth_gate.py
+++ b/fastapi-backend/tests/test_auth_gate.py
@@ -509,3 +509,35 @@ def test_missing_audience_is_warned_about(monkeypatch, auth_on):
 def test_no_warnings_when_disabled(monkeypatch):
     monkeypatch.setattr("app.config.settings.AUTH_ENABLED", False)
     assert auth_service.config_warnings() == []
+
+
+# ── the gate feeds handle binding ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_real_token_becomes_the_author_of_a_write(
+    client: AsyncClient, auth_on, signing_key
+):
+    """End-to-end: signature → principal → stored ``created_by``.
+
+    The binding matrix lives in ``test_handle_binding``; this is the one pass
+    that proves the two stages are actually wired to each other, signature and
+    all, rather than each working against a stand-in for the other.
+    """
+    token = _sign(signing_key, sub="poc-agent")
+    await client.post("/api/rooms", json={"name": "gated"}, headers=_bearer(token))
+
+    resp = await client.post(
+        "/api/rooms/gated/memory",
+        json={"items": [{"key": "n", "value": "v", "created_by": "someone-else", "embed": False}]},
+        headers=_bearer(token),
+    )
+    assert resp.status_code == 403
+
+    resp = await client.post(
+        "/api/rooms/gated/memory",
+        json={"items": [{"key": "n", "value": "v", "created_by": "poc-agent", "embed": False}]},
+        headers=_bearer(token),
+    )
+    assert resp.status_code == 201
+    assert resp.json()[0]["created_by"] == "poc-agent"

--- a/fastapi-backend/tests/test_handle_binding.py
+++ b/fastapi-backend/tests/test_handle_binding.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Handle binding: a verified token is the actor of record.
+
+The gate proves a token; binding decides *who wrote this*. Both halves are
+asserted here — with a principal the token's handle lands in the store and a body
+claiming someone else is refused, and with no principal every path behaves
+exactly as it did before the gate existed (the default posture, and the one that
+keeps the try-it path working).
+
+The principal is injected by overriding the gate dependency rather than by
+signing a token: the token itself is ``test_auth_gate``'s subject, and the
+end-to-end pass from a real signature through to a stored author lives there too.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import yaml
+from fastapi import Request
+from httpx import AsyncClient
+
+from app.config import PrincipalRole
+from app.main import app
+from app.services.auth import Principal, auth_gate
+from app.services.filesystem import get_room_dir, read_memory_file, write_memory_file
+from app.services.persister import DeliveryLog
+
+ROOM = "bind-room"
+
+
+@pytest.fixture
+def as_principal():
+    """Act as a verified principal for the rest of the test.
+
+    Overrides the gate itself, so the routes see exactly what a validated token
+    leaves behind: a ``Principal`` on ``request.state``. Call with ``None`` to
+    assert the anonymous branch through the same wiring.
+    """
+
+    def _act_as(handle: str | None, *, role: PrincipalRole = "agent") -> None:
+        principal = (
+            None
+            if handle is None
+            else Principal(
+                subject=handle,
+                handle=handle,
+                role=role,
+                issuer="https://idp.test/realms/mycelium",
+            )
+        )
+
+        async def _fake_gate(request: Request) -> Principal | None:
+            request.state.principal = principal
+            return principal
+
+        app.dependency_overrides[auth_gate] = _fake_gate
+
+    yield _act_as
+    app.dependency_overrides.pop(auth_gate, None)
+
+
+async def _make_room(client: AsyncClient, name: str = ROOM) -> None:
+    assert (await client.post("/api/rooms", json={"name": name})).status_code in (200, 201)
+
+
+async def _write(client: AsyncClient, *, key: str, created_by: str, room: str = ROOM):
+    return await client.post(
+        f"/api/rooms/{room}/memory",
+        json={"items": [{"key": key, "value": "v", "created_by": created_by, "embed": False}]},
+    )
+
+
+def _seed_agent(room: str, handle: str, *, adapter: str = "claude_code") -> None:
+    write_memory_file(
+        get_room_dir(room),
+        f"agents/{handle}",
+        yaml.safe_dump({"adapter": adapter}, sort_keys=False),
+        created_by="tester",
+    )
+
+
+def _stored_meta(room: str, key: str) -> dict[str, Any]:
+    """The frontmatter of a memory that must exist."""
+    stored = read_memory_file(get_room_dir(room), key)
+    assert stored is not None, f"{key} was not written"
+    return stored[0]
+
+
+# ── no principal: today's behavior, unchanged ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_anonymous_memory_write_keeps_its_self_asserted_author(client: AsyncClient):
+    await _make_room(client)
+    resp = await _write(client, key="notes/a", created_by="whoever")
+    assert resp.status_code == 201
+    assert resp.json()[0]["created_by"] == "whoever"
+
+
+@pytest.mark.asyncio
+async def test_gate_off_leaves_the_body_actor_alone(client: AsyncClient, as_principal):
+    """The override is installed but resolves to no principal — the gate-off path."""
+    as_principal(None)
+    await _make_room(client)
+    resp = await _write(client, key="notes/a", created_by="whoever")
+    assert resp.status_code == 201
+    assert resp.json()[0]["created_by"] == "whoever"
+
+
+@pytest.mark.asyncio
+async def test_anonymous_message_keeps_its_self_asserted_sender(client: AsyncClient):
+    await _make_room(client)
+    resp = await client.post(
+        f"/api/rooms/{ROOM}/messages",
+        json={"message_type": "broadcast", "sender_handle": "whoever", "content": "hi"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["sender_handle"] == "whoever"
+
+
+# ── a principal is the author ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_memory_author_comes_from_the_token(client: AsyncClient, as_principal):
+    await _make_room(client)
+    as_principal("alice")
+    resp = await _write(client, key="notes/a", created_by="alice")
+    assert resp.status_code == 201
+    assert resp.json()[0]["created_by"] == "alice"
+
+    # …and it is what actually landed on disk, not just what was echoed back.
+    assert _stored_meta(ROOM, "notes/a")["created_by"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_a_body_claiming_another_handle_is_refused(client: AsyncClient, as_principal):
+    await _make_room(client)
+    as_principal("alice")
+    resp = await _write(client, key="notes/mallory", created_by="mallory")
+    assert resp.status_code == 403
+    assert "mallory" in resp.json()["detail"]
+    # The refusal is a refusal: nothing was written under either handle.
+    assert read_memory_file(get_room_dir(ROOM), "notes/mallory") is None
+
+
+@pytest.mark.asyncio
+async def test_one_impersonating_item_refuses_the_whole_batch(client: AsyncClient, as_principal):
+    await _make_room(client)
+    as_principal("alice")
+    resp = await client.post(
+        f"/api/rooms/{ROOM}/memory",
+        json={
+            "items": [
+                {"key": "notes/ok", "value": "v", "created_by": "alice", "embed": False},
+                {"key": "notes/bad", "value": "v", "created_by": "mallory", "embed": False},
+            ]
+        },
+    )
+    assert resp.status_code == 403
+    assert read_memory_file(get_room_dir(ROOM), "notes/ok") is None
+
+
+@pytest.mark.asyncio
+async def test_an_omitted_or_differently_written_handle_still_matches(
+    client: AsyncClient, as_principal
+):
+    """``@Alice`` and ``alice`` are one principal — normalization is shared with the store."""
+    await _make_room(client)
+    as_principal("alice")
+    resp = await _write(client, key="notes/cased", created_by="@Alice")
+    assert resp.status_code == 201
+    assert resp.json()[0]["created_by"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_a_session_qualifier_rides_along(client: AsyncClient, as_principal):
+    """``alice#a8f3`` is alice on one machine, not a second actor."""
+    await _make_room(client)
+    as_principal("alice")
+    resp = await _write(client, key="notes/session", created_by="alice#a8f3")
+    assert resp.status_code == 201
+    assert resp.json()[0]["created_by"] == "alice#a8f3"
+
+
+@pytest.mark.asyncio
+async def test_a_session_qualifier_cannot_smuggle_another_handle(client: AsyncClient, as_principal):
+    await _make_room(client)
+    as_principal("alice")
+    resp = await _write(client, key="notes/smuggle", created_by="mallory#a8f3")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_an_update_records_the_token_as_updated_by(client: AsyncClient, as_principal):
+    """``created_by`` stays with the original author; the token owns ``updated_by``."""
+    await _make_room(client)
+    assert (await _write(client, key="notes/shared", created_by="bob")).status_code == 201
+
+    as_principal("alice")
+    resp = await _write(client, key="notes/shared", created_by="alice")
+    assert resp.status_code == 201
+    body = resp.json()[0]
+    assert body["version"] == 2
+    assert body["created_by"] == "bob"
+    assert body["updated_by"] == "alice"
+
+
+# ── transcript sender + L9 actor ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_message_sender_comes_from_the_token(client: AsyncClient, as_principal):
+    await _make_room(client)
+    as_principal("alice")
+    resp = await client.post(
+        f"/api/rooms/{ROOM}/messages",
+        json={"message_type": "broadcast", "sender_handle": "@Alice", "content": "hi"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["sender_handle"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_message_claiming_another_sender_is_refused(client: AsyncClient, as_principal):
+    await _make_room(client)
+    as_principal("alice")
+    resp = await client.post(
+        f"/api/rooms/{ROOM}/messages",
+        json={"message_type": "broadcast", "sender_handle": "mallory", "content": "hi"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reply_claiming_another_handle_is_refused(client: AsyncClient, as_principal):
+    await _make_room(client)
+    _seed_agent(ROOM, "mallory")
+    as_principal("alice")
+    resp = await client.post(f"/api/rooms/{ROOM}/reply", json={"handle": "mallory", "text": "hi"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reply_stamps_the_token_handle_on_the_l9_actor(
+    client: AsyncClient, as_principal, monkeypatch
+):
+    """The published envelope names the token's handle, whatever the body said."""
+    from app.services import room_channels
+
+    class _Persister:
+        def __init__(self) -> None:
+            self.log = DeliveryLog([])
+            self.ingested: list[Any] = []
+
+        def ingest_local(self, envelope: Any, content: dict, list_write: bool = False) -> None:
+            self.ingested.append(envelope)
+
+    class _Channel:
+        async def send(self, envelope: Any, *, extra: dict | None = None) -> None:
+            return None
+
+    class _Managed:
+        def __init__(self) -> None:
+            self.channel = _Channel()
+            self.persister = _Persister()
+
+    managed = _Managed()
+
+    class _Manager:
+        async def provision(self, room: str, **_kw: Any) -> _Managed:
+            return managed
+
+        def refresh_lease(self, room: str, handle: str) -> None:
+            return None
+
+    monkeypatch.setattr(room_channels, "manager", _Manager())
+
+    await _make_room(client)
+    _seed_agent(ROOM, "alice")
+    as_principal("alice")
+    resp = await client.post(f"/api/rooms/{ROOM}/reply", json={"handle": "@Alice", "text": "x"})
+    assert resp.status_code == 200
+    assert resp.json()["handle"] == "alice"
+
+    envelope = managed.persister.ingested[0]
+    assert envelope.header.participants.actors[0].id == "alice"
+
+
+# ── engine registration ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_engine_registrar_defaults_to_the_web_ui_when_anonymous(client: AsyncClient):
+    await _make_room(client)
+    resp = await client.post(f"/api/rooms/{ROOM}/engines", json={"handle": "aligner"})
+    assert resp.status_code == 201
+    assert _stored_meta(ROOM, "agents/aligner")["created_by"] == "web-ui"
+
+
+@pytest.mark.asyncio
+async def test_engine_registrar_comes_from_the_token(client: AsyncClient, as_principal):
+    """An omitted ``created_by`` is filled by the token, not read as impersonation."""
+    await _make_room(client)
+    as_principal("alice")
+    resp = await client.post(f"/api/rooms/{ROOM}/engines", json={"handle": "aligner"})
+    assert resp.status_code == 201
+    assert _stored_meta(ROOM, "agents/aligner")["created_by"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_engine_registrar_claiming_another_handle_is_refused(
+    client: AsyncClient, as_principal
+):
+    await _make_room(client)
+    as_principal("alice")
+    resp = await client.post(
+        f"/api/rooms/{ROOM}/engines", json={"handle": "aligner", "created_by": "mallory"}
+    )
+    assert resp.status_code == 403

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -105,9 +105,24 @@ Once a token validates, the request has a **principal**:
   on the matched issuer block. Which root signed a token is usually the whole
   answer to user-vs-agent, so most deployments never set a role claim at all.
 
-Today the gate proves the token and records the principal. Using it as the
-*authoritative* author of a write — replacing the `created_by` and
-`sender_handle` a request body supplies — is the next step in the identity work.
+## The token is the author
+
+The principal is not just recorded — it is the **actor of record** for every write
+it makes. Memory authorship (`created_by` / `updated_by`), the transcript sender,
+and L9 actor attribution all come from the token rather than from the handle the
+request body supplies:
+
+- The body **omits** the actor, or names the **same** handle → the token's handle
+  is stored. `@Alice` and `alice` are one principal; the comparison uses the same
+  normalization as the store.
+- The body names a **different** handle → **403**. A caller acting under the wrong
+  identity gets told, rather than having its writes quietly re-attributed.
+- A **session qualifier** (`alice#a8f3` — the same person on one machine) is kept
+  as-is. The suffix rides along on the token's handle, so per-session attribution
+  survives without letting the suffix name someone else.
+
+With the gate off there is no principal, so every path keeps the self-asserted
+actor from the body exactly as before — the try-it path is unchanged.
 
 ## Key rotation
 
@@ -150,6 +165,7 @@ Every other route requires a token.
 | Response | Meaning |
 |----------|---------|
 | `401` + `WWW-Authenticate: Bearer` | Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token. |
+| `403` | A valid token, but the request body claims to act as a different handle. |
 | `503` | The gate is on but unusable — no trusted issuers configured, or the issuer's JWKS is unreachable and nothing is cached. |
 
 Only asymmetric signatures are accepted (`RS*`, `PS*`, `ES*`). The `none`


### PR DESCRIPTION
## Summary

The gate (#561) proves a token is valid but changed nothing about attribution: every write still took its author from the request body, so a valid token for `@bob` could still author a memory as `@alice`. This is the stage where a verified token becomes the **actor of record**.

`app/services/actor.py` resolves the authoritative actor from `request.state.principal` and is applied at the actor-bearing write paths. Two rules:

- **No principal, no change.** Gate off (the shipped default), public path, localhost bypass, or a backend-internal writer → the body's self-asserted actor stands exactly as before. The try-it path is untouched.
- **A principal is the actor.** The stored actor comes from the token.

**Mismatch policy** (the open question on the issue — going with the recommended option): a body that *omits* the actor or names the *same* handle gets the token's handle; a body that explicitly names a **different** handle is refused **403** rather than silently rewritten. A caller acting under the wrong identity has a bug or is probing, and both deserve an answer rather than re-attributed writes.

Two details that fall out of the store's own conventions:

- Normalization is shared with `principals._norm` (via `auth.normalize_handle`), so a token `@Alice` and a body `alice` are one principal.
- A **session qualifier** (`alice#a8f3` — the same person on one machine) names the same principal, so it is honoured and rides along on the token's handle. `mallory#a8f3` under alice's token is still a 403 — the suffix can't smuggle in a different actor.

## Changes

- **`app/services/actor.py`** (new) — `bind_actor` / `bind_optional_actor` / `current_principal`. One rule, two entry points: the optional variant exists so a body field the caller may legitimately omit is read as "no claim" rather than as a mismatch.
- **`app/routes/memory.py`** — the route binds each item's `created_by`, then delegates to a new `upsert_memories`. Binding is a pre-pass over the whole batch, so one impersonating item refuses the batch instead of writing the earlier ones first.
- **`app/routes/messages.py`** — the sender is bound before the engine/phantom guard runs, so the guard and the stored `sender_handle` are the same handle.
- **`app/routes/participate.py`** — `/reply` binds the handle before provisioning, so the transcript sender, the L9 actor, and the presence lease all name the token's handle.
- **`app/routes/engines.py`** — `created_by` becomes optional (`None`) so the web UI's `"web-ui"` placeholder is a default rather than a claim; the literal is applied after binding.
- **`create_memories` splits** into the route (which binds) and `upsert_memories` (the write), so the synthesizer and engine registration reuse the one correct versioned+indexed upsert without routing an actor through a request body they never had.
- **`auth._normalize_handle` → `auth.normalize_handle`** — it is now a cross-module contract, not a private helper.
- **Docs** — the operator guide gains a "The token is the author" section and a `403` row in the failure table; the design doc records the chosen mismatch policy and marks rollout step 2 landed. Generated docs pages regenerated.

## Testing

`tests/test_handle_binding.py` (17 cases) covers both branches: principal-present (memory author, `updated_by` on an update, message sender, L9 actor on a reply, engine registrar) and principal-absent (each path unchanged). Mismatch is asserted as 403 *and* as nothing written. `tests/test_auth_gate.py` gains one end-to-end case that runs a real signed token through to a stored `created_by`, so the two stages are proven wired to each other rather than each working against a stand-in.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 479 passed, 6 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `uv run ty check .`

## Related Issues

Closes #562. Part of #560; depends on #561 (merged).

**Deliberately out of scope**, per the build brief:

- **`await`'s `handle` query param is not bound.** Which handle's queue a caller may drain is authorization, not attribution — it belongs with RBAC, and binding it today would 403 a human awaiting on behalf of an agent that has no token of its own until #564.
- **`mycelium iam` still reflects self-asserted local identity.** It can't reflect "who the token says I am" until the CLI can obtain a token (#563/#564); the acceptance line for it carries over to that work.
- Also untouched: RBAC, SLIM channel identity (#476), and `POST /sessions` presence registration.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5vAu2qF6WirpWZrwSMJ6A)_