### PR TITLE
feat(cli): human OIDC login, one authenticated client factory (#563)

### DIFF
--- a/docs/design/identity-and-auth.md
+++ b/docs/design/identity-and-auth.md
@@ -131,7 +131,13 @@ per-deployment opt-in.
    attribution and stays with the RBAC step.*
 3. **CLI human login** — `mycelium login` obtains a token (Authorization Code +
    PKCE, or device-code for headless), stores + refreshes it; `mycelium iam`
-   becomes "who am I per the token," not self-assert.
+   becomes "who am I per the token," not self-assert. *Landed (#563):
+   `mycelium-cli/src/mycelium/{oidc,tokens,client}.py` + `commands/login.py`,
+   configured under `[login]`. The token lives in a `0600` cache rather than
+   `config.toml`, and every backend call is built by one authenticated client
+   factory (`mycelium.client`) — the seam agent credentials reuse in step 4.
+   Logged out, that factory attaches nothing, so the ungated path is byte-for-byte
+   what it was.*
 4. **Agent identity issuance** — per-agent **OIDC service-account** credentials by
    default; **SPIRE JWT-SVID as an optional upgrade** where workload attestation is
    wanted.

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -443,6 +443,7 @@ def _generate_cli_reference() -> tuple[str, list[tuple[str, str]]]:
     import mycelium.commands.hub  # noqa: F401
     import mycelium.commands.install  # noqa: F401
     import mycelium.commands.instance  # noqa: F401
+    import mycelium.commands.login  # noqa: F401
     import mycelium.commands.memory  # noqa: F401
     import mycelium.commands.participate  # noqa: F401
     import mycelium.commands.plan  # noqa: F401

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1558,6 +1558,89 @@ Each `[[auth.issuers]]` block takes `issuer` (the exact `iss` to trust),
 `jwks_url` (optional — omit to resolve it from the issuer's OIDC discovery
 document), `audience` (optional per-issuer override), and `role`.
 
+## Signing in from the CLI
+
+The gate above is the hub's half. `mycelium login` is yours: it obtains an OIDC
+token for **you**, caches it, and every later command sends it.
+
+```bash
+mycelium config set login.issuer https://sso.example.com/realms/mycelium
+mycelium config set login.audience mycelium      # match the hub's auth.audience
+mycelium login
+```
+
+Your browser opens, you sign in at your identity provider, and the CLI takes it
+from there — `mycelium memory`, `mycelium room`, `await`, `respond` and the rest
+now carry `Authorization: Bearer <token>`.
+
+**On a machine with no browser** — SSH, CI, a container — use the device flow.
+The CLI prints a URL and a short code you enter from any other device:
+
+```bash
+mycelium login --device
+```
+
+The CLI falls back to this automatically when it finds no browser to open, so
+`mycelium login` over SSH does the right thing without the flag.
+
+`mycelium logout` drops the session, and the CLI goes straight back to sending no
+token at all.
+
+### Login is opt-in, like the gate
+
+Never running `mycelium login` changes nothing: with no cached session the CLI
+sends no `Authorization` header, exactly as before this existed. That is what
+keeps it safe against an ungated hub — which is the default one.
+
+### Where the token lives
+
+In `~/.mycelium/token.json`, created mode `0600` — **not** in `config.toml`.
+Config is printed, copied between machines, and mirrored to `config.json` for the
+frontend; a token in there would leak by routine. Set `MYCELIUM_TOKEN_FILE` to
+cache it somewhere else (a CI runner with a shared home, say).
+
+The access token is renewed automatically when it expires, using the refresh
+token, on the way into the next call that needs it — you don't re-run `login` on
+a schedule. Renewal needs a refresh token, which most issuers grant only for the
+`offline_access` scope; it is in the default `login.scopes` for that reason. If
+renewal fails, the CLI drops the header and tells you to sign in again rather
+than sending a token the hub will reject.
+
+### Who you are
+
+`mycelium whoami` (and `mycelium iam` with no arguments) reports the handle from
+your **token** when you're signed in, and the self-asserted `identity.name` when
+you're not:
+
+```
+acting as @julia  (julia#a8f3)
+  signed in (https://sso.example.com/realms/mycelium, expires in 42 min)
+```
+
+Because a gated hub attributes writes to the token (see *The token is the author*
+below), a self-asserted handle that names someone else is a 403 in waiting —
+`login` and `iam` both say so when they disagree.
+
+### Configuration
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `login.issuer` | *(unset)* | OIDC issuer to log in against. Unset means no login is configured. |
+| `login.client_id` | `mycelium-cli` | OAuth client id registered for the CLI. |
+| `login.client_secret` | *(unset)* | Only for issuers that refuse public clients; PKCE means the CLI normally needs none. |
+| `login.scopes` | `openid profile email offline_access` | Scopes requested at login. |
+| `login.audience` | *(unset)* | Audience to request; should match the hub's `auth.audience`. |
+| `login.redirect_port` | `0` | Fixed loopback port for the browser redirect (`0` picks a free one). Set it when your issuer requires an exact registered redirect URI — the URI is `http://127.0.0.1:<port>/callback`. |
+
+`MYCELIUM_LOGIN_ISSUER`, `MYCELIUM_LOGIN_CLIENT_ID`, `MYCELIUM_LOGIN_CLIENT_SECRET`,
+`MYCELIUM_LOGIN_AUDIENCE` and `MYCELIUM_LOGIN_SCOPES` override the same settings,
+for a runner that has no config file to edit.
+
+The CLI is a **public client**: it authenticates with PKCE (S256) and ships no
+secret. Register it at your issuer as a public client with
+`http://127.0.0.1:*/callback` as an allowed redirect, and enable the device grant
+if you want `--device` to work.
+
 ## Issuer-agnostic by design
 
 The backend trusts a configured issuer and its JWKS. It has no idea whether that

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -100,6 +100,7 @@
       <a href="#config-slim" class="nav-link sub">slim</a>
       <a href="#config-engine" class="nav-link sub">engine</a>
       <a href="#config-auth" class="nav-link sub">auth</a>
+      <a href="#config-login" class="nav-link sub">login</a>
       <a href="#config-metrics" class="nav-link sub">metrics</a>
     </div>
     <div class="nav-section">
@@ -368,6 +369,20 @@ cursor-agent login            # one-time, interactive
           <code><span class="cmd">mycelium upgrade</span> [<span class="flag">--check</span>] [<span class="flag">--version</span> <span class="arg">&lt;version&gt;</span>]</code>
         </div>
         <div class="cmd-ref-body">Upgrade (or pin) the Mycelium CLI. Pass --version to install a specific release.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium login</span> [<span class="flag">--issuer</span> <span class="arg">URL</span>] [<span class="flag">--device</span>] [<span class="flag">--no-browser</span>] [<span class="flag">--client-id</span> <span class="arg">ID</span>]</code>
+        </div>
+        <div class="cmd-ref-body">Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code).</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium logout</span></code>
+        </div>
+        <div class="cmd-ref-body">Drop the cached OIDC session; the CLI goes back to sending no token.</div>
       </div>
 
       <div class="cmd-ref">
@@ -779,6 +794,27 @@ cursor-agent login            # one-time, interactive
 <span class="comment"># How long a fetched JWKS is cached before re-fetch. Key rotation is also picked up on an unseen kid.</span>
 <span class="arg">jwks_ttl_s</span> = 300.0
 
+<span class="comment"># Where ``mycelium login`` gets a human&#x27;s token — the client side of auth.</span>
+<span class="cmd" id="config-login">[login]</span>
+
+<span class="comment"># OIDC issuer to log in against, e.g. https://sso.example.com/realms/mycelium</span>
+<span class="arg">issuer</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># OAuth client id registered for the CLI at that issuer.</span>
+<span class="arg">client_id</span> = <span class="str">&quot;mycelium-cli&quot;</span>
+
+<span class="comment"># Client secret, only for issuers that refuse public clients. PKCE means the CLI normally needs none.</span>
+<span class="arg">client_secret</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Space-separated scopes to request. &#x27;offline_access&#x27; is what gets a refresh token from most issuers.</span>
+<span class="arg">scopes</span> = <span class="str">&quot;openid profile email offline_access&quot;</span>
+
+<span class="comment"># Audience to request for the token; should match the hub&#x27;s auth.audience.</span>
+<span class="arg">audience</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Fixed loopback port for the browser redirect (0 = pick a free one). Set this when the issuer requires an exact registered redirect URI.</span>
+<span class="arg">redirect_port</span> = 0
+
 <span class="comment"># Configuration for the metrics collector + display.</span>
 <span class="cmd" id="config-metrics">[metrics]</span>
 
@@ -1059,6 +1095,72 @@ role     = &quot;user&quot;</code></pre>
         </table>
       </div>
       <p>Each <code>[[auth.issuers]]</code> block takes <code>issuer</code> (the exact <code>iss</code> to trust), <code>jwks_url</code> (optional — omit to resolve it from the issuer&#x27;s OIDC discovery document), <code>audience</code> (optional per-issuer override), and <code>role</code>.</p>
+      <h2 id="auth-signing-in-from-the-cli">Signing in from the CLI</h2>
+      <p>The gate above is the hub&#x27;s half. <code>mycelium login</code> is yours: it obtains an OIDC token for <strong>you</strong>, caches it, and every later command sends it.</p>
+      <pre><code><span class="cmd">mycelium config set</span> login.issuer https://sso.example.com/realms/mycelium
+<span class="cmd">mycelium config set</span> login.audience mycelium      # match the hub&#x27;s auth.audience
+<span class="cmd">mycelium login</span></code></pre>
+      <p>Your browser opens, you sign in at your identity provider, and the CLI takes it from there — <code>mycelium memory</code>, <code>mycelium room</code>, <code>await</code>, <code>respond</code> and the rest now carry <code>Authorization: Bearer &lt;token&gt;</code>.</p>
+      <p><strong>On a machine with no browser</strong> — SSH, CI, a container — use the device flow. The CLI prints a URL and a short code you enter from any other device:</p>
+      <pre><code><span class="cmd">mycelium login</span> <span class="flag">--device</span></code></pre>
+      <p>The CLI falls back to this automatically when it finds no browser to open, so <code>mycelium login</code> over SSH does the right thing without the flag.</p>
+      <p><code>mycelium logout</code> drops the session, and the CLI goes straight back to sending no token at all.</p>
+      <h3 id="auth-login-is-opt-in-like-the-gate">Login is opt-in, like the gate</h3>
+      <p>Never running <code>mycelium login</code> changes nothing: with no cached session the CLI sends no <code>Authorization</code> header, exactly as before this existed. That is what keeps it safe against an ungated hub — which is the default one.</p>
+      <h3 id="auth-where-the-token-lives">Where the token lives</h3>
+      <p>In <code>~/.mycelium/token.json</code>, created mode <code>0600</code> — <strong>not</strong> in <code>config.toml</code>. Config is printed, copied between machines, and mirrored to <code>config.json</code> for the frontend; a token in there would leak by routine. Set <code>MYCELIUM_TOKEN_FILE</code> to cache it somewhere else (a CI runner with a shared home, say).</p>
+      <p>The access token is renewed automatically when it expires, using the refresh token, on the way into the next call that needs it — you don&#x27;t re-run <code>login</code> on a schedule. Renewal needs a refresh token, which most issuers grant only for the <code>offline_access</code> scope; it is in the default <code>login.scopes</code> for that reason. If renewal fails, the CLI drops the header and tells you to sign in again rather than sending a token the hub will reject.</p>
+      <h3 id="auth-who-you-are">Who you are</h3>
+      <p><code>mycelium whoami</code> (and <code>mycelium iam</code> with no arguments) reports the handle from your <strong>token</strong> when you&#x27;re signed in, and the self-asserted <code>identity.name</code> when you&#x27;re not:</p>
+      <pre><code>acting as @julia  (julia#a8f3)
+  signed in (https://sso.example.com/realms/mycelium, expires in 42 min)</code></pre>
+      <p>Because a gated hub attributes writes to the token (see <em>The token is the author</em> below), a self-asserted handle that names someone else is a 403 in waiting — <code>login</code> and <code>iam</code> both say so when they disagree.</p>
+      <h3 id="auth-configuration">Configuration</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Default</th>
+              <th>What it does</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>login.issuer</code></td>
+              <td><em>(unset)</em></td>
+              <td>OIDC issuer to log in against. Unset means no login is configured.</td>
+            </tr>
+            <tr>
+              <td><code>login.client_id</code></td>
+              <td><code>mycelium-cli</code></td>
+              <td>OAuth client id registered for the CLI.</td>
+            </tr>
+            <tr>
+              <td><code>login.client_secret</code></td>
+              <td><em>(unset)</em></td>
+              <td>Only for issuers that refuse public clients; PKCE means the CLI normally needs none.</td>
+            </tr>
+            <tr>
+              <td><code>login.scopes</code></td>
+              <td><code>openid profile email offline_access</code></td>
+              <td>Scopes requested at login.</td>
+            </tr>
+            <tr>
+              <td><code>login.audience</code></td>
+              <td><em>(unset)</em></td>
+              <td>Audience to request; should match the hub&#x27;s <code>auth.audience</code>.</td>
+            </tr>
+            <tr>
+              <td><code>login.redirect_port</code></td>
+              <td><code>0</code></td>
+              <td>Fixed loopback port for the browser redirect (<code>0</code> picks a free one). Set it when your issuer requires an exact registered redirect URI — the URI is <code>http://127.0.0.1:&lt;port&gt;/callback</code>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p><code>MYCELIUM_LOGIN_ISSUER</code>, <code>MYCELIUM_LOGIN_CLIENT_ID</code>, <code>MYCELIUM_LOGIN_CLIENT_SECRET</code>, <code>MYCELIUM_LOGIN_AUDIENCE</code> and <code>MYCELIUM_LOGIN_SCOPES</code> override the same settings, for a runner that has no config file to edit.</p>
+      <p>The CLI is a <strong>public client</strong>: it authenticates with PKCE (S256) and ships no secret. Register it at your issuer as a public client with <code>http://127.0.0.1:*/callback</code> as an allowed redirect, and enable the device grant if you want <code>--device</code> to work.</p>
       <h2 id="auth-issuer-agnostic-by-design">Issuer-agnostic by design</h2>
       <p>The backend trusts a configured issuer and its JWKS. It has no idea whether that is Keycloak, Dex, ZITADEL, Authentik, or your existing corporate SSO, and it never needs one particular product installed.</p>
       <p><strong>More than one trust root is normal.</strong> Humans log in through an interactive OIDC issuer; agents present service-account tokens, possibly from an entirely separate root. List each as its own block:</p>

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -33,6 +33,9 @@ from mycelium.commands import (
     user,
     wire,
 )
+from mycelium.commands import (
+    login as login_cmd,
+)
 
 app = typer.Typer(
     name="mycelium",
@@ -112,6 +115,8 @@ app.command(name="network")(network.network)
 app.command(name="logs")(instance.logs)
 
 # Top-level shortcuts
+app.command(name="login")(login_cmd.login)
+app.command(name="logout")(login_cmd.logout)
 app.command(name="whoami")(user.whoami)
 app.command(name="iam")(user.iam)
 app.command(name="watch")(room.watch)

--- a/mycelium-cli/src/mycelium/client.py
+++ b/mycelium-cli/src/mycelium/client.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+The one factory for clients that talk to the hub's HTTP API.
+
+Every call into the backend — the generated typed client and the raw ``httpx``
+ones alike — is built here, so there is exactly one place that decides what
+credentials a request carries. Before this, each command module built its own
+client and none of them attached anything; a bearer token added in one place
+would have authenticated one command and quietly missed the rest.
+
+**Auth is additive and off by default.** With no cached session (``mycelium
+login`` never run) the factory attaches no ``Authorization`` header and the CLI
+behaves exactly as it did before tokens existed — which is what makes it safe
+against a hub whose gate is off, i.e. the shipped default.
+
+An expired access token is refreshed here, transparently, on the way into the
+first call that needs it. A refresh that fails degrades to "no header" rather
+than failing the command: against an ungated hub the call still works, and
+against a gated one the 401 says what a fabricated error never could.
+
+Agent credentials (#564) attach at this same seam — a different credential
+source, the same one factory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from rich.console import Console
+
+if TYPE_CHECKING:
+    from mycelium.config import MyceliumConfig
+    from mycelium.tokens import StoredToken
+    from mycelium_backend_client import Client
+
+_DEFAULT_TIMEOUT_S = 30.0
+
+_stderr = Console(stderr=True)
+
+#: One warning per process when a session can't be renewed — every command would
+#: otherwise repeat it for each client it builds.
+_refresh_warned = False
+
+
+def _resolve_config(config: MyceliumConfig | None) -> MyceliumConfig:
+    from mycelium.config import MyceliumConfig
+
+    return config if config is not None else MyceliumConfig.load()
+
+
+def current_token(config: MyceliumConfig | None = None) -> StoredToken | None:
+    """The usable cached session, renewed first if it has expired.
+
+    Returns ``None`` when logged out, and also when the session is expired and
+    can't be refreshed — an expired token is worse than no token, since it turns
+    a working call against an ungated hub into a 401.
+    """
+    from mycelium.tokens import load_token
+
+    stored = load_token()
+    if stored is None or not stored.is_expired():
+        return stored
+
+    refreshed = _refresh(stored, _resolve_config(config))
+    if refreshed is not None:
+        return refreshed
+
+    global _refresh_warned  # noqa: PLW0603 — process-wide "say this once" latch
+    if not _refresh_warned:
+        _refresh_warned = True
+        _stderr.print(
+            "[yellow]Your Mycelium session has expired.[/yellow] "
+            "[dim]Run 'mycelium login' to sign in again.[/dim]"
+        )
+    return None
+
+
+def _refresh(stored: StoredToken, config: MyceliumConfig) -> StoredToken | None:
+    """Renew an expired session with its refresh token. ``None`` if it can't be."""
+    from mycelium import oidc
+    from mycelium.tokens import save_token
+
+    if not stored.refresh_token:
+        return None
+
+    endpoint = stored.token_endpoint
+    if not endpoint:
+        # Sessions cached before the endpoint was recorded, or minted by an
+        # issuer reached some other way: rediscover it.
+        issuer = stored.issuer or config.login.issuer
+        if not issuer:
+            return None
+        try:
+            endpoint = oidc.discover(issuer).token_endpoint
+        except oidc.OidcError:
+            return None
+
+    try:
+        resp = oidc.refresh_grant(
+            endpoint,
+            stored.client_id or config.login.client_id,
+            stored.refresh_token,
+            client_secret=config.login.client_secret,
+        )
+    except oidc.OidcError:
+        return None
+
+    renewed = replace(
+        stored,
+        access_token=resp.access_token,
+        # Issuers that don't rotate refresh tokens omit it; keep the one we have.
+        refresh_token=resp.refresh_token or stored.refresh_token,
+        expires_at=resp.expires_at,
+        token_endpoint=endpoint,
+        scope=resp.scope or stored.scope,
+    )
+    save_token(renewed)
+    return renewed
+
+
+def auth_headers(config: MyceliumConfig | None = None) -> dict[str, str]:
+    """``{"Authorization": "Bearer …"}`` when logged in, ``{}`` when not."""
+    token = current_token(config)
+    return {"Authorization": f"Bearer {token.access_token}"} if token else {}
+
+
+def typed_client(config: MyceliumConfig | None = None) -> Client:
+    """The generated OpenAPI client, authenticated when there's a session."""
+    from mycelium_backend_client import Client
+
+    cfg = _resolve_config(config)
+    client = Client(base_url=cfg.server.api_url, raise_on_unexpected_status=True)
+    headers = auth_headers(cfg)
+    return client.with_headers(headers) if headers else client
+
+
+def hub_client(
+    config: MyceliumConfig | None = None,
+    *,
+    base_url: str | None = None,
+    timeout: float | None = _DEFAULT_TIMEOUT_S,
+    headers: dict[str, str] | None = None,
+    **kwargs: Any,
+) -> httpx.Client:
+    """A raw ``httpx`` client against the hub, authenticated when there's a session.
+
+    ``base_url`` overrides the configured hub — ``room clone`` reads from a
+    *remote* hub — and the session still applies, since the token is the caller's
+    identity rather than a property of one address.
+    """
+    cfg = _resolve_config(config)
+    merged = {**auth_headers(cfg), **(headers or {})}
+    return httpx.Client(
+        base_url=base_url or cfg.server.api_url,
+        timeout=timeout,
+        headers=merged,
+        **kwargs,
+    )

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -32,6 +32,8 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
+from mycelium.client import hub_client
+from mycelium.client import typed_client as _typed_client
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
@@ -49,12 +51,6 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 console = Console()
-
-
-def _typed_client(config: MyceliumConfig):
-    from mycelium_backend_client import Client
-
-    return Client(base_url=config.server.api_url, raise_on_unexpected_status=True)
 
 
 def _bail_root_owned(target: Path, blocking: Path, owner_name: str) -> None:
@@ -179,11 +175,9 @@ def _is_resident(config: MyceliumConfig, room_name: str, handle: str) -> bool:
     caller falls back to the honest "not resident — queued" message rather than
     claiming liveness it can't confirm.
     """
-    import httpx
-
     try:
-        url = f"{config.server.api_url}/api/rooms/{room_name}/sessions/members"
-        resp = httpx.get(url, timeout=5.0)
+        with hub_client(config, timeout=5.0) as client:
+            resp = client.get(f"/api/rooms/{room_name}/sessions/members")
         resp.raise_for_status()
         members = resp.json().get("members", [])
     except Exception:

--- a/mycelium-cli/src/mycelium/commands/login.py
+++ b/mycelium-cli/src/mycelium/commands/login.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+``mycelium login`` / ``mycelium logout`` — obtain and drop a human's OIDC session.
+
+The browser flow (Authorization Code + PKCE) is the default; ``--device`` is the
+fallback for a shell whose browser can't reach this machine's loopback address —
+SSH, CI, a container. Both end the same way: the session lands in the ``0600``
+token cache (``mycelium.tokens``) and every subsequent backend call carries it,
+because they all build their client through ``mycelium.client``.
+
+Logging in is opt-in. Nothing here runs unless the user asks for it, and a hub
+with its gate off never needs it.
+"""
+
+from __future__ import annotations
+
+import json as json_module
+import webbrowser
+
+import typer
+from rich.console import Console
+
+from mycelium.config import MyceliumConfig
+from mycelium.doc_ref import doc_ref
+from mycelium.oidc import (
+    DevicePrompt,
+    OidcError,
+    ProviderMetadata,
+    authorization_code_login,
+    device_code_login,
+    discover,
+)
+from mycelium.tokens import StoredToken, clear_token, load_token, save_token, token_path
+
+console = Console()
+
+
+def _browser_available() -> bool:
+    """Whether this machine has a browser the CLI could actually open."""
+    try:
+        webbrowser.get()
+    except webbrowser.Error:
+        return False
+    return True
+
+
+def _announce_url(url: str) -> None:
+    console.print("[dim]Opening your browser to sign in. If it doesn't open, visit:[/dim]")
+    console.print(f"  {url}\n")
+
+
+def _announce_device(prompt: DevicePrompt) -> None:
+    target = prompt.verification_uri_complete or prompt.verification_uri
+    console.print("\n[bold]To sign in, visit:[/bold]")
+    console.print(f"  {target}")
+    console.print(f"[bold]and enter the code:[/bold] [cyan]{prompt.user_code}[/cyan]\n")
+    console.print("[dim]Waiting for you to approve…[/dim]")
+
+
+def _persist_login_config(
+    config: MyceliumConfig,
+    *,
+    issuer: str | None,
+    client_id: str | None,
+    audience: str | None,
+    scope: str | None,
+) -> None:
+    """Remember explicitly-passed login settings so the next login needs no flags."""
+    changed = False
+    for field, value in (
+        ("issuer", issuer),
+        ("client_id", client_id),
+        ("audience", audience),
+        ("scopes", scope),
+    ):
+        if value and getattr(config.login, field) != value:
+            setattr(config.login, field, value)
+            changed = True
+    if changed:
+        config.save()
+        console.print(f"[dim]Saved login settings to {MyceliumConfig.get_config_path()}[/dim]")
+
+
+def _report(token: StoredToken, config: MyceliumConfig, *, json_output: bool) -> None:
+    handle = token.handle(config.auth.handle_claim) or token.handle() or "(unknown)"
+    remaining = token.expires_in()
+
+    if json_output:
+        typer.echo(
+            json_module.dumps(
+                {
+                    "handle": handle,
+                    "issuer": token.issuer,
+                    "client_id": token.client_id,
+                    "expires_at": token.expires_at,
+                    "refreshable": bool(token.refresh_token),
+                },
+                indent=2,
+            )
+        )
+        return
+
+    console.print(f"[green]Signed in as[/green] [cyan]@{handle}[/cyan] [dim]({token.issuer})[/dim]")
+    if remaining is not None:
+        console.print(f"[dim]Access token valid for {int(remaining // 60)} min[/dim]")
+    if not token.refresh_token:
+        console.print(
+            "[dim]No refresh token was issued — add the 'offline_access' scope "
+            "if you want the session renewed automatically.[/dim]"
+        )
+    console.print(f"[dim]Session cached at {token_path()} (mode 0600).[/dim]")
+
+    # #562 binds the actor of a write to the token; a self-asserted identity that
+    # names someone else is a 403 waiting to happen, so say so now.
+    asserted = (config.identity.name or "").strip().lstrip("@").lower()
+    if asserted and asserted != handle:
+        console.print(
+            f"\n[yellow]Heads up:[/yellow] this machine writes as [cyan]@{asserted}[/cyan], "
+            f"but your token says [cyan]@{handle}[/cyan]. A gated hub refuses writes that "
+            "claim a different handle."
+        )
+        console.print(f"[dim]Align them with: mycelium iam {handle}[/dim]")
+
+
+@doc_ref(
+    usage="mycelium login [--issuer URL] [--device] [--no-browser] [--client-id ID]",
+    desc="Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code).",
+    group="setup",
+)
+def login(
+    ctx: typer.Context,
+    issuer: str | None = typer.Option(
+        None, "--issuer", help="OIDC issuer URL (default: login.issuer from config)."
+    ),
+    client_id: str | None = typer.Option(
+        None, "--client-id", help="OAuth client id to log in as (default: login.client_id)."
+    ),
+    scope: str | None = typer.Option(
+        None, "--scope", help="Space-separated scopes to request (default: login.scopes)."
+    ),
+    audience: str | None = typer.Option(
+        None, "--audience", help="Audience to request; should match the hub's auth.audience."
+    ),
+    device: bool = typer.Option(
+        False, "--device", help="Use the device-code flow (headless, SSH, CI)."
+    ),
+    no_browser: bool = typer.Option(
+        False, "--no-browser", help="Print the sign-in URL instead of opening a browser."
+    ),
+    timeout: float = typer.Option(
+        300.0, "--timeout", "-t", help="Seconds to wait for you to finish signing in."
+    ),
+) -> None:
+    """Obtain an OIDC token for the hub and cache it for subsequent commands.
+
+    Examples:
+        mycelium login
+        mycelium login --issuer https://sso.example.com/realms/mycelium
+        mycelium login --device        # headless / SSH / CI
+    """
+    config = MyceliumConfig.load()
+    json_output = ctx.obj.get("json", False) if ctx.obj else False
+
+    resolved_issuer = (issuer or config.login.issuer or "").strip().rstrip("/")
+    if not resolved_issuer:
+        console.print("[red]Error:[/red] no OIDC issuer configured.")
+        console.print(
+            "[dim]Set one with: mycelium config set login.issuer "
+            "https://sso.example.com/realms/mycelium[/dim]"
+        )
+        console.print("[dim]Or pass it once: mycelium login --issuer <url>[/dim]")
+        raise typer.Exit(1)
+
+    resolved_client_id = (client_id or config.login.client_id).strip()
+    resolved_scope = (scope or config.login.scopes).strip()
+    resolved_audience = audience or config.login.audience
+
+    try:
+        meta: ProviderMetadata = discover(resolved_issuer)
+    except OidcError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    use_device = device
+    if not use_device and not _browser_available() and meta.device_authorization_endpoint:
+        console.print(
+            "[dim]No browser available here — falling back to the device-code flow.[/dim]"
+        )
+        use_device = True
+
+    try:
+        if use_device:
+            grant = device_code_login(
+                meta,
+                resolved_client_id,
+                scope=resolved_scope,
+                audience=resolved_audience,
+                client_secret=config.login.client_secret,
+                timeout_s=timeout,
+                announce=_announce_device,
+            )
+        else:
+            grant = authorization_code_login(
+                meta,
+                resolved_client_id,
+                scope=resolved_scope,
+                audience=resolved_audience,
+                client_secret=config.login.client_secret,
+                redirect_port=config.login.redirect_port,
+                open_browser=not no_browser,
+                timeout_s=timeout,
+                announce=_announce_url,
+            )
+    except OidcError as exc:
+        console.print(f"[red]Login failed:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    token = StoredToken(
+        access_token=grant.access_token,
+        issuer=meta.issuer,
+        client_id=resolved_client_id,
+        refresh_token=grant.refresh_token,
+        expires_at=grant.expires_at,
+        token_endpoint=meta.token_endpoint,
+        scope=grant.scope or resolved_scope,
+    )
+    save_token(token)
+
+    _persist_login_config(
+        config,
+        issuer=issuer,
+        client_id=client_id,
+        audience=audience,
+        scope=scope,
+    )
+    _report(token, config, json_output=json_output)
+
+
+@doc_ref(
+    usage="mycelium logout",
+    desc="Drop the cached OIDC session; the CLI goes back to sending no token.",
+    group="setup",
+)
+def logout(ctx: typer.Context) -> None:
+    """Forget the cached session."""
+    json_output = ctx.obj.get("json", False) if ctx.obj else False
+    existed = load_token() is not None
+    clear_token()
+
+    if json_output:
+        typer.echo(json_module.dumps({"logged_out": existed}))
+        return
+    if existed:
+        console.print("[green]Signed out.[/green] [dim]Cached session removed.[/dim]")
+    else:
+        console.print("[dim]Not signed in — nothing to do.[/dim]")

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
+from mycelium.client import hub_client, typed_client
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.filesystem import (
@@ -40,11 +41,8 @@ console = Console()
 
 
 def _get_client():
-    """Get a configured OpenAPI client."""
-    from mycelium_backend_client import Client
-
-    cfg = MyceliumConfig.load()
-    return Client(base_url=cfg.server.api_url, raise_on_unexpected_status=True)
+    """The shared authenticated OpenAPI client (see ``mycelium.client``)."""
+    return typed_client()
 
 
 def _hub_url() -> str:
@@ -453,13 +451,11 @@ def memory_reindex(
 
     Run after editing memory files outside the CLI to update search.
     """
-    import httpx
-
     room_name = _get_active_room(room)
     cfg = MyceliumConfig.load()
 
     console.print(f"[dim]Re-indexing {room_name}...[/dim]")
-    with httpx.Client(base_url=cfg.server.api_url, timeout=120) as client:
+    with hub_client(cfg, timeout=120) as client:
         resp = client.post(f"/api/rooms/{room_name}/reindex")
         resp.raise_for_status()
         data = resp.json()
@@ -619,8 +615,6 @@ def memory_sync(
         mycelium sync           # fetch all memories + reindex
         mycelium sync --no-reindex
     """
-    import httpx
-
     room_name = _get_active_room(room)
     cfg = MyceliumConfig.load()
 
@@ -633,8 +627,8 @@ def memory_sync(
 
     console.print(f"[dim]Syncing {room_name} from {cfg.server.api_url}...[/dim]")
 
-    with httpx.Client(base_url=cfg.server.api_url, timeout=60) as client:
-        resp = client.get(f"/api/rooms/{room_name}/memory", params={"limit": 1000}, headers=headers)
+    with hub_client(cfg, timeout=60, headers=headers) as client:
+        resp = client.get(f"/api/rooms/{room_name}/memory", params={"limit": 1000})
 
     if resp.status_code == 304:
         console.print("[dim]Already up to date[/dim]")
@@ -689,7 +683,7 @@ def memory_sync(
 
     if not no_reindex:
         try:
-            with httpx.Client(base_url=cfg.server.api_url, timeout=120) as client:
+            with hub_client(cfg, timeout=120) as client:
                 resp = client.post(f"/api/rooms/{room_name}/reindex")
                 resp.raise_for_status()
                 data = resp.json()

--- a/mycelium-cli/src/mycelium/commands/participate.py
+++ b/mycelium-cli/src/mycelium/commands/participate.py
@@ -29,9 +29,9 @@ import json as json_module
 import os
 import subprocess
 
-import httpx
 import typer
 
+from mycelium.client import hub_client
 from mycelium.commands.room import _resolve_room
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
@@ -40,11 +40,12 @@ from mycelium.error_handler import print_error
 
 def _await_once(config: MyceliumConfig, room_name: str, handle: str, timeout: int) -> dict | None:
     """One long-poll. Returns the turn dict, or ``None`` on timeout."""
-    url = f"{config.server.api_url}/api/rooms/{room_name}/await"
+    path = f"/api/rooms/{room_name}/await"
     # The server blocks up to `timeout`; give the client a little more headroom
     # (or no cap when waiting indefinitely).
     client_timeout = float(timeout) + 15.0 if timeout > 0 else None
-    resp = httpx.get(url, params={"handle": handle, "timeout": timeout}, timeout=client_timeout)
+    with hub_client(config, timeout=client_timeout) as client:
+        resp = client.get(path, params={"handle": handle, "timeout": timeout})
     resp.raise_for_status()
     data = resp.json()
     return data if "prompt" in data else None
@@ -227,8 +228,10 @@ def respond(
     try:
         config = MyceliumConfig.load()
         room_name = _resolve_room(config, room)
-        url = f"{config.server.api_url}/api/rooms/{room_name}/reply"
-        resp = httpx.post(url, json={"handle": handle, "text": text}, timeout=30.0)
+        with hub_client(config, timeout=30.0) as client:
+            resp = client.post(
+                f"/api/rooms/{room_name}/reply", json={"handle": handle, "text": text}
+            )
         resp.raise_for_status()
         data = resp.json()
         if json_output:

--- a/mycelium-cli/src/mycelium/commands/plan.py
+++ b/mycelium-cli/src/mycelium/commands/plan.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 
 import sys
 
-import httpx
 import typer
 from rich.console import Console
 from rich.table import Table
 
+from mycelium.client import hub_client
 from mycelium.commands.room import _resolve_room
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
@@ -45,7 +45,7 @@ app.add_typer(task_app, name="task")
 def _fetch_plan(room: str | None = None) -> dict:
     cfg = MyceliumConfig.load()
     room_name = _resolve_room(cfg, room)
-    with httpx.Client(base_url=cfg.server.api_url, timeout=30) as client:
+    with hub_client(cfg, timeout=30) as client:
         resp = client.get(f"/api/rooms/{room_name}/plan")
         resp.raise_for_status()
         return resp.json()
@@ -206,7 +206,7 @@ def plan_title(
     """Read or set the room's plan title."""
     cfg = MyceliumConfig.load()
     room_name = _resolve_room(cfg, room)
-    with httpx.Client(base_url=cfg.server.api_url, timeout=30) as client:
+    with hub_client(cfg, timeout=30) as client:
         if text is None:
             data = client.get(f"/api/rooms/{room_name}/plan").json()
             title = data.get("title")
@@ -277,7 +277,7 @@ def task_add(
     """Append a new ``- [ ]`` line to a plan file."""
     cfg = MyceliumConfig.load()
     room_name = _resolve_room(cfg, room)
-    with httpx.Client(base_url=cfg.server.api_url, timeout=30) as client:
+    with hub_client(cfg, timeout=30) as client:
         resp = client.post(
             f"/api/rooms/{room_name}/plan/tasks",
             json={"text": text, "slug": file},
@@ -292,7 +292,7 @@ def task_add(
 def _toggle(task_id: str, *, done: bool, room: str | None) -> dict:
     cfg = MyceliumConfig.load()
     room_name = _resolve_room(cfg, room)
-    with httpx.Client(base_url=cfg.server.api_url, timeout=30) as client:
+    with hub_client(cfg, timeout=30) as client:
         resp = client.post(
             f"/api/rooms/{room_name}/plan/tasks/{task_id}/toggle",
             json={"done": done},

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -23,6 +23,8 @@ import os
 
 import typer
 
+from mycelium.client import hub_client
+from mycelium.client import typed_client as _typed_client
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
@@ -45,13 +47,6 @@ L9_RAISE_UP_TYPES = frozenset(
         "l9_knowledge",
     }
 )
-
-
-def _typed_client(config: MyceliumConfig):
-    """Get a typed OpenAPI client."""
-    from mycelium_backend_client import Client
-
-    return Client(base_url=config.server.api_url, raise_on_unexpected_status=True)
 
 
 app = typer.Typer(
@@ -351,8 +346,6 @@ def clone_room(
     """
     import json as _json
 
-    import httpx
-
     from mycelium.filesystem import (
         ensure_room_structure,
         get_mycelium_dir,
@@ -373,7 +366,7 @@ def clone_room(
 
         typer.echo(f"Cloning {room_name} from {api_url}...")
 
-        with httpx.Client(base_url=api_url, timeout=60) as client:
+        with hub_client(config, base_url=api_url, timeout=60) as client:
             resp = client.get(f"/api/rooms/{room_name}/memory", params={"limit": 1000})
             resp.raise_for_status()
             memories = resp.json()
@@ -418,7 +411,7 @@ def clone_room(
         # Reindex local copy against the configured backend
         typer.echo("Re-indexing...")
         try:
-            with httpx.Client(base_url=config.server.api_url, timeout=120) as client:
+            with hub_client(config, timeout=120) as client:
                 resp = client.post(f"/api/rooms/{room_name}/reindex")
                 resp.raise_for_status()
                 data = resp.json()
@@ -525,7 +518,6 @@ def _watch_room(config: MyceliumConfig, room_name: str, timeout: int) -> None:
     """Core SSE watch loop — pretty-renders coordination and memory events."""
     import time
 
-    import httpx
     from rich.console import Console
     from rich.panel import Panel
     from rich.table import Table
@@ -681,10 +673,8 @@ def _watch_room(config: MyceliumConfig, room_name: str, timeout: int) -> None:
     # coordination_join events are NOTIFY-only (not persisted), so we synthesize
     # them from the sessions list to ensure all participants are shown.
     try:
-        sess_resp = httpx.get(
-            f"{config.server.api_url}/api/rooms/{room_name}/sessions",
-            timeout=10,
-        )
+        with hub_client(config, timeout=10) as client:
+            sess_resp = client.get(f"/api/rooms/{room_name}/sessions")
         if sess_resp.status_code == 200:
             sess_body = sess_resp.json()
             participants = sess_body.get("sessions", [])
@@ -707,11 +697,8 @@ def _watch_room(config: MyceliumConfig, room_name: str, timeout: int) -> None:
         pass
 
     try:
-        hist_resp = httpx.get(
-            f"{config.server.api_url}/api/rooms/{room_name}/messages",
-            params={"limit": 50},
-            timeout=10,
-        )
+        with hub_client(config, timeout=10) as client:
+            hist_resp = client.get(f"/api/rooms/{room_name}/messages", params={"limit": 50})
         if hist_resp.status_code == 200:
             body = hist_resp.json()
             msgs = body.get("messages", body) if isinstance(body, dict) else body
@@ -722,10 +709,13 @@ def _watch_room(config: MyceliumConfig, room_name: str, timeout: int) -> None:
     except Exception:
         pass
 
-    url = f"{config.server.api_url}/api/rooms/{room_name}/messages/stream"
+    stream_path = f"/api/rooms/{room_name}/messages/stream"
     start = time.time()
 
-    with httpx.Client(timeout=None) as http, http.stream("GET", url) as response:
+    with (
+        hub_client(config, timeout=None) as http,
+        http.stream("GET", stream_path) as response,
+    ):
         for line in response.iter_lines():
             if timeout > 0 and (time.time() - start) >= timeout:
                 console.print(f"\n  [dim]Timeout after {timeout}s[/]")

--- a/mycelium-cli/src/mycelium/commands/user.py
+++ b/mycelium-cli/src/mycelium/commands/user.py
@@ -24,6 +24,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
+from mycelium.client import current_token
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
@@ -259,13 +260,24 @@ def _owned_agents(owner: str) -> list[tuple[str, AgentManifest]]:
     group="user",
 )
 def whoami(ctx: typer.Context) -> None:
-    """Resolve the current identity to a user handle and roll up owned agents."""
+    """Resolve the current identity to a user handle and roll up owned agents.
+
+    Logged in (``mycelium login``), the token is the answer: the principal is the
+    handle it asserts, which is also the handle a gated hub will attribute writes
+    to. Logged out — the default — this is the self-asserted ``identity.name``
+    exactly as before.
+    """
     try:
         config = MyceliumConfig.load()
         # The attribution handle can be session-qualified (``julia#a8f3``); the
         # principal is the bare name it derives from.
         identity = config.get_current_identity()
         principal = (config.identity.name or identity).split("#", 1)[0].lower()
+
+        token = current_token(config)
+        token_handle = token.handle(config.auth.handle_claim) if token else None
+        if token_handle:
+            principal = token_handle
 
         json_output = ctx.obj.get("json", False) if ctx.obj else False
         user = load_user(principal)
@@ -277,6 +289,14 @@ def whoami(ctx: typer.Context) -> None:
                     {
                         "identity": identity,
                         "principal": principal,
+                        "authenticated": token is not None,
+                        "token": {
+                            "handle": token_handle,
+                            "issuer": token.issuer,
+                            "expires_at": token.expires_at,
+                        }
+                        if token
+                        else None,
                         "registered": user is not None,
                         "user": user.model_dump() if user else None,
                         "owns": [{"room": r, "handle": m.handle} for r, m in owned],
@@ -288,6 +308,11 @@ def whoami(ctx: typer.Context) -> None:
             return
 
         console.print(f"[bold]acting as[/bold] [cyan]@{principal}[/cyan]  [dim]({identity})[/dim]")
+        if token is not None:
+            remaining = token.expires_in()
+            expiry = f", expires in {int(remaining // 60)} min" if remaining is not None else ""
+            source = "signed in" if token_handle else "signed in, no handle claim"
+            console.print(f"  [green]{source}[/green] [dim]({token.issuer}{expiry})[/dim]")
         if user is None:
             console.print(
                 f'[dim]Not registered. Claim it with: mycelium iam {principal} --name "…"[/dim]'
@@ -310,13 +335,15 @@ def whoami(ctx: typer.Context) -> None:
 
 
 @doc_ref(
-    usage='mycelium iam <handle> [--name "Display Name"]',
-    desc="Set this machine's identity and ensure the user record exists.",
+    usage='mycelium iam [<handle>] [--name "Display Name"]',
+    desc="Set this machine's identity (or, with no handle, report it) and ensure the user record exists.",
     group="user",
 )
 def iam(
     ctx: typer.Context,
-    handle: str = typer.Argument(..., help="Your user handle (lowercase slug, e.g. 'julia')."),
+    handle: str | None = typer.Argument(
+        None, help="Your user handle (lowercase slug, e.g. 'julia'). Omit to report who you are."
+    ),
     name: str | None = typer.Option(None, "--name", "-n", help="Display name to set/update."),
     team: list[str] | None = typer.Option(None, "--team", help="Team slug to join (repeatable)."),
 ) -> None:
@@ -326,9 +353,17 @@ def iam(
     handle resolve to) and upserts the ``users/<handle>`` record so the principal
     actually exists. The one-liner counterpart to the app's acting-as picker.
 
+    With no handle it reports the current identity instead — the token's handle
+    when signed in, the self-asserted one when not.
+
     Examples:
         mycelium iam julia --name "Julia Valenti" --team core
+        mycelium iam
     """
+    if handle is None:
+        whoami(ctx)
+        return
+
     try:
         try:
             manifest = UserManifest(handle=handle, display_name=name or "", teams=team or [])
@@ -356,6 +391,17 @@ def iam(
             f"{f' ({manifest.display_name})' if manifest.display_name else ''}{team_line}"
         )
         console.print("[dim]Set as this machine's identity. Check with: mycelium whoami[/dim]")
+
+        # A gated hub attributes writes to the token, and refuses a body that
+        # claims a different handle (#562) — so a mismatch is worth saying now
+        # rather than at the first 403.
+        token = current_token(config)
+        token_handle = token.handle(config.auth.handle_claim) if token else None
+        if token_handle and token_handle != manifest.handle:
+            console.print(
+                f"[yellow]Note:[/yellow] you're signed in as [cyan]@{token_handle}[/cyan]; "
+                "a hub with auth enabled will refuse writes claiming a different handle."
+            )
     except typer.Exit:
         raise
     except Exception as e:

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -227,6 +227,48 @@ class AuthConfig(BaseModel):
     )
 
 
+class LoginConfig(BaseModel):
+    """Where ``mycelium login`` gets a human's token — the client side of auth.
+
+    Distinct from :class:`AuthConfig`, which configures the *hub's* gate: this
+    section says which issuer this machine logs in against, that one says which
+    issuers the backend trusts. A spoke needs only this half.
+
+    Unset ``issuer`` means "no login configured", which is the default: the CLI
+    sends no token and behaves exactly as it does with no identity at all.
+    """
+
+    issuer: str | None = Field(
+        default=None,
+        description="OIDC issuer to log in against, e.g. https://sso.example.com/realms/mycelium",
+    )
+    client_id: str = Field(
+        default="mycelium-cli",
+        description="OAuth client id registered for the CLI at that issuer.",
+    )
+    client_secret: str | None = Field(
+        default=None,
+        description="Client secret, only for issuers that refuse public clients. PKCE means the CLI normally needs none.",
+    )
+    scopes: str = Field(
+        default="openid profile email offline_access",
+        description="Space-separated scopes to request. 'offline_access' is what gets a refresh token from most issuers.",
+    )
+    audience: str | None = Field(
+        default=None,
+        description="Audience to request for the token; should match the hub's auth.audience.",
+    )
+    redirect_port: int = Field(
+        default=0,
+        description="Fixed loopback port for the browser redirect (0 = pick a free one). Set this when the issuer requires an exact registered redirect URI.",
+    )
+
+    @field_validator("issuer")
+    @classmethod
+    def _strip_trailing_slash(cls, v: str | None) -> str | None:
+        return v.rstrip("/") if isinstance(v, str) else v
+
+
 class RuntimeConfig(BaseModel):
     """Docker runtime / environment configuration."""
 
@@ -330,6 +372,7 @@ class MyceliumConfig(BaseModel):
     llm: LLMConfig = Field(default_factory=LLMConfig)
     engine: EngineConfig = Field(default_factory=EngineConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
+    login: LoginConfig = Field(default_factory=LoginConfig)
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     rooms: RoomConfig = Field(default_factory=RoomConfig)
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
@@ -440,6 +483,7 @@ class MyceliumConfig(BaseModel):
             "rooms": {},
             "llm": {},
             "engine": {},
+            "login": {},
             "runtime": {},
             "metrics": {},
         }
@@ -461,6 +505,19 @@ class MyceliumConfig(BaseModel):
             env_config["llm"]["api_key"] = llm_api_key
         if llm_base_url := os.getenv("LLM_BASE_URL"):
             env_config["llm"]["base_url"] = llm_base_url
+
+        # Login (OIDC client) overrides — how a CI runner points `mycelium login`
+        # at an issuer without writing a config file.
+        if login_issuer := os.getenv("MYCELIUM_LOGIN_ISSUER"):
+            env_config["login"]["issuer"] = login_issuer
+        if login_client_id := os.getenv("MYCELIUM_LOGIN_CLIENT_ID"):
+            env_config["login"]["client_id"] = login_client_id
+        if login_client_secret := os.getenv("MYCELIUM_LOGIN_CLIENT_SECRET"):
+            env_config["login"]["client_secret"] = login_client_secret
+        if login_audience := os.getenv("MYCELIUM_LOGIN_AUDIENCE"):
+            env_config["login"]["audience"] = login_audience
+        if login_scopes := os.getenv("MYCELIUM_LOGIN_SCOPES"):
+            env_config["login"]["scopes"] = login_scopes
 
         # Metrics overrides
         if collector_url := os.getenv("MYCELIUM_COLLECTOR_URL"):
@@ -512,6 +569,7 @@ class MyceliumConfig(BaseModel):
             "slim",
             "llm",
             "engine",
+            "login",
             "runtime",
             "metrics",
             "adapters",

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -69,6 +69,89 @@ Each `[[auth.issuers]]` block takes `issuer` (the exact `iss` to trust),
 `jwks_url` (optional — omit to resolve it from the issuer's OIDC discovery
 document), `audience` (optional per-issuer override), and `role`.
 
+## Signing in from the CLI
+
+The gate above is the hub's half. `mycelium login` is yours: it obtains an OIDC
+token for **you**, caches it, and every later command sends it.
+
+```bash
+mycelium config set login.issuer https://sso.example.com/realms/mycelium
+mycelium config set login.audience mycelium      # match the hub's auth.audience
+mycelium login
+```
+
+Your browser opens, you sign in at your identity provider, and the CLI takes it
+from there — `mycelium memory`, `mycelium room`, `await`, `respond` and the rest
+now carry `Authorization: Bearer <token>`.
+
+**On a machine with no browser** — SSH, CI, a container — use the device flow.
+The CLI prints a URL and a short code you enter from any other device:
+
+```bash
+mycelium login --device
+```
+
+The CLI falls back to this automatically when it finds no browser to open, so
+`mycelium login` over SSH does the right thing without the flag.
+
+`mycelium logout` drops the session, and the CLI goes straight back to sending no
+token at all.
+
+### Login is opt-in, like the gate
+
+Never running `mycelium login` changes nothing: with no cached session the CLI
+sends no `Authorization` header, exactly as before this existed. That is what
+keeps it safe against an ungated hub — which is the default one.
+
+### Where the token lives
+
+In `~/.mycelium/token.json`, created mode `0600` — **not** in `config.toml`.
+Config is printed, copied between machines, and mirrored to `config.json` for the
+frontend; a token in there would leak by routine. Set `MYCELIUM_TOKEN_FILE` to
+cache it somewhere else (a CI runner with a shared home, say).
+
+The access token is renewed automatically when it expires, using the refresh
+token, on the way into the next call that needs it — you don't re-run `login` on
+a schedule. Renewal needs a refresh token, which most issuers grant only for the
+`offline_access` scope; it is in the default `login.scopes` for that reason. If
+renewal fails, the CLI drops the header and tells you to sign in again rather
+than sending a token the hub will reject.
+
+### Who you are
+
+`mycelium whoami` (and `mycelium iam` with no arguments) reports the handle from
+your **token** when you're signed in, and the self-asserted `identity.name` when
+you're not:
+
+```
+acting as @julia  (julia#a8f3)
+  signed in (https://sso.example.com/realms/mycelium, expires in 42 min)
+```
+
+Because a gated hub attributes writes to the token (see *The token is the author*
+below), a self-asserted handle that names someone else is a 403 in waiting —
+`login` and `iam` both say so when they disagree.
+
+### Configuration
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `login.issuer` | *(unset)* | OIDC issuer to log in against. Unset means no login is configured. |
+| `login.client_id` | `mycelium-cli` | OAuth client id registered for the CLI. |
+| `login.client_secret` | *(unset)* | Only for issuers that refuse public clients; PKCE means the CLI normally needs none. |
+| `login.scopes` | `openid profile email offline_access` | Scopes requested at login. |
+| `login.audience` | *(unset)* | Audience to request; should match the hub's `auth.audience`. |
+| `login.redirect_port` | `0` | Fixed loopback port for the browser redirect (`0` picks a free one). Set it when your issuer requires an exact registered redirect URI — the URI is `http://127.0.0.1:<port>/callback`. |
+
+`MYCELIUM_LOGIN_ISSUER`, `MYCELIUM_LOGIN_CLIENT_ID`, `MYCELIUM_LOGIN_CLIENT_SECRET`,
+`MYCELIUM_LOGIN_AUDIENCE` and `MYCELIUM_LOGIN_SCOPES` override the same settings,
+for a runner that has no config file to edit.
+
+The CLI is a **public client**: it authenticates with PKCE (S256) and ships no
+secret. Register it at your issuer as a public client with
+`http://127.0.0.1:*/callback` as an allowed redirect, and enable the device grant
+if you want `--device` to work.
+
 ## Issuer-agnostic by design
 
 The backend trusts a configured issuer and its JWKS. It has no idea whether that

--- a/mycelium-cli/src/mycelium/http_client.py
+++ b/mycelium-cli/src/mycelium/http_client.py
@@ -46,10 +46,13 @@ class MyceliumHTTPClient:
         )
 
     def _get_headers(self) -> dict[str, str]:
-        """Get default headers."""
+        """Default headers, including the session bearer when logged in."""
+        from mycelium.client import auth_headers
+
         return {
             "Content-Type": "application/json",
             "Accept": "application/json",
+            **auth_headers(self.config),
         }
 
     def _should_retry(self, exception: Exception) -> bool:

--- a/mycelium-cli/src/mycelium/oidc.py
+++ b/mycelium-cli/src/mycelium/oidc.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+OIDC login flows for ``mycelium login`` — Authorization Code + PKCE, device code,
+and the refresh-token grant.
+
+Issuer-agnostic on purpose: everything here is driven off the issuer's discovery
+document, so the same code logs in against Keycloak, Dex, ZITADEL, or the dev mock
+issuer (``docs/design/dev-auth-issuer.md``) with nothing but a different URL.
+
+Two flows, because humans sit in two different places:
+
+* **Authorization Code + PKCE** — the primary path. The browser does the login;
+  the code comes back to a loopback listener the CLI opens for the occasion. PKCE
+  (RFC 7636) is what lets the CLI be a *public* client: no client secret to ship,
+  and an intercepted code is useless without the verifier.
+* **Device code** (RFC 8628) — for a shell with no browser it can reach: SSH, CI,
+  a container. The CLI prints a URL and a short code, and polls.
+
+Nothing here touches the token cache; the caller decides what to persist.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.server
+import secrets
+import threading
+import time
+import urllib.parse
+import webbrowser
+from dataclasses import dataclass
+from typing import Any, cast
+
+import httpx
+
+_DISCOVERY_PATH = "/.well-known/openid-configuration"
+_DEVICE_CODE_GRANT = "urn:ietf:params:oauth:grant-type:device_code"
+
+_HTTP_TIMEOUT_S = 15.0
+#: Fallback poll interval when the device-code response omits one (RFC 8628 §3.2).
+_DEFAULT_DEVICE_INTERVAL_S = 5.0
+
+_CALLBACK_PATH = "/callback"
+
+_BROWSER_PAGE = """<!doctype html>
+<html><head><meta charset="utf-8"><title>Mycelium</title></head>
+<body style="font-family: system-ui, sans-serif; padding: 3rem; text-align: center">
+<h2>{heading}</h2><p style="color:#666">{detail}</p></body></html>"""
+
+
+class OidcError(Exception):
+    """A login flow could not complete. The message is user-facing."""
+
+
+@dataclass(frozen=True)
+class ProviderMetadata:
+    """The endpoints of an issuer, as advertised by its discovery document."""
+
+    issuer: str
+    token_endpoint: str
+    authorization_endpoint: str | None = None
+    device_authorization_endpoint: str | None = None
+
+
+@dataclass(frozen=True)
+class TokenResponse:
+    """A successful token grant, normalized."""
+
+    access_token: str
+    refresh_token: str | None = None
+    expires_at: float | None = None
+    scope: str | None = None
+
+
+@dataclass(frozen=True)
+class DevicePrompt:
+    """What the user has to do to finish a device-code login."""
+
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str | None = None
+    expires_in: float | None = None
+
+
+def discover(issuer: str, *, timeout_s: float = _HTTP_TIMEOUT_S) -> ProviderMetadata:
+    """Fetch an issuer's OIDC discovery document."""
+    url = issuer.rstrip("/") + _DISCOVERY_PATH
+    try:
+        resp = httpx.get(url, timeout=timeout_s, follow_redirects=True)
+        resp.raise_for_status()
+        doc = resp.json()
+    except httpx.HTTPError as exc:
+        raise OidcError(f"can't reach the issuer's discovery document at {url}: {exc}") from exc
+    except ValueError as exc:
+        raise OidcError(f"issuer returned a non-JSON discovery document at {url}") from exc
+
+    token_endpoint = doc.get("token_endpoint")
+    if not token_endpoint:
+        raise OidcError(f"issuer at {issuer} advertises no token_endpoint")
+
+    return ProviderMetadata(
+        # The document's own `issuer` is authoritative — it is the `iss` the hub
+        # will see in the token, which may differ from the URL used to reach it.
+        issuer=str(doc.get("issuer") or issuer).rstrip("/"),
+        token_endpoint=str(token_endpoint),
+        authorization_endpoint=doc.get("authorization_endpoint"),
+        device_authorization_endpoint=doc.get("device_authorization_endpoint"),
+    )
+
+
+def _open_browser(url: str) -> None:
+    """Best-effort browser launch; a failure just leaves the printed URL."""
+    try:
+        webbrowser.open(url)
+    except webbrowser.Error:
+        pass
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """A PKCE ``(verifier, S256 challenge)`` pair."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+    return verifier, challenge
+
+
+def _token_request(
+    token_endpoint: str,
+    form: dict[str, str],
+    *,
+    timeout_s: float = _HTTP_TIMEOUT_S,
+) -> dict[str, Any]:
+    """POST a token request, raising :class:`OidcError` with the issuer's reason."""
+    try:
+        resp = httpx.post(token_endpoint, data=form, timeout=timeout_s)
+    except httpx.HTTPError as exc:
+        raise OidcError(f"can't reach the token endpoint {token_endpoint}: {exc}") from exc
+
+    try:
+        body = resp.json()
+    except ValueError:
+        body = {}
+    if not isinstance(body, dict):
+        body = {}
+
+    if resp.status_code >= 400:
+        error = str(body.get("error") or f"HTTP {resp.status_code}")
+        detail = body.get("error_description")
+        raise OidcError(f"{error}: {detail}" if detail else error)
+    return body
+
+
+def _as_token_response(body: dict[str, Any]) -> TokenResponse:
+    access_token = body.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise OidcError("issuer returned no access_token")
+    expires_in = body.get("expires_in")
+    expires_at = time.time() + float(expires_in) if isinstance(expires_in, int | float) else None
+    return TokenResponse(
+        access_token=access_token,
+        refresh_token=body.get("refresh_token") or None,
+        expires_at=expires_at,
+        scope=body.get("scope") or None,
+    )
+
+
+class _CallbackServer(http.server.HTTPServer):
+    """A one-shot loopback listener for the authorization-code redirect."""
+
+    result: dict[str, str] | None = None
+
+
+class _CallbackHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler's interface
+        parsed = urllib.parse.urlparse(self.path)
+        params = {k: v[0] for k, v in urllib.parse.parse_qs(parsed.query).items()}
+
+        # A browser also asks for /favicon.ico; only the redirect finishes the flow.
+        if parsed.path != _CALLBACK_PATH or not ("code" in params or "error" in params):
+            self.send_error(404)
+            return
+
+        cast("_CallbackServer", self.server).result = params
+        if "code" in params:
+            page = _BROWSER_PAGE.format(
+                heading="You're signed in to Mycelium.",
+                detail="You can close this tab and return to your terminal.",
+            )
+        else:
+            page = _BROWSER_PAGE.format(
+                heading="Sign-in failed.",
+                detail=params.get("error_description") or params.get("error", ""),
+            )
+        body = page.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002 — base signature
+        """Silence the default stderr access log — this is a CLI, not a server."""
+
+
+def authorization_code_login(
+    meta: ProviderMetadata,
+    client_id: str,
+    *,
+    scope: str,
+    audience: str | None = None,
+    client_secret: str | None = None,
+    redirect_port: int = 0,
+    open_browser: bool = True,
+    timeout_s: float = 300.0,
+    announce: Any = None,
+) -> TokenResponse:
+    """Log in through the browser with Authorization Code + PKCE.
+
+    ``announce`` is called with the authorization URL before the wait begins, so
+    the caller can print it — the browser may fail to open, and the URL is then
+    the whole recovery path.
+    """
+    if not meta.authorization_endpoint:
+        raise OidcError(
+            f"issuer {meta.issuer} advertises no authorization_endpoint; "
+            "retry with --device for the device-code flow"
+        )
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+
+    try:
+        server = _CallbackServer(("127.0.0.1", redirect_port), _CallbackHandler)
+    except OSError as exc:
+        raise OidcError(f"can't open the loopback listener on port {redirect_port}: {exc}") from exc
+
+    with server:
+        redirect_uri = f"http://127.0.0.1:{server.server_port}{_CALLBACK_PATH}"
+        query = {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": redirect_uri,
+            "scope": scope,
+            "state": state,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }
+        if audience:
+            query["audience"] = audience
+        auth_url = f"{meta.authorization_endpoint}?{urllib.parse.urlencode(query)}"
+
+        if announce is not None:
+            announce(auth_url)
+        if open_browser:
+            # On a thread, because `webbrowser.open` waits for the browser
+            # process when it is a generic one (anything the user set in
+            # $BROWSER). Opening inline would deadlock: the browser blocks on a
+            # redirect only this loop can answer, and this loop waits for the
+            # browser.
+            threading.Thread(target=_open_browser, args=(auth_url,), daemon=True).start()
+
+        server.timeout = 1.0
+        deadline = time.monotonic() + timeout_s
+        while server.result is None and time.monotonic() < deadline:
+            server.handle_request()
+        params = server.result
+
+    if params is None:
+        raise OidcError(f"timed out after {timeout_s:.0f}s waiting for the browser redirect")
+    if "error" in params:
+        detail = params.get("error_description")
+        raise OidcError(f"{params['error']}: {detail}" if detail else params["error"])
+    if not secrets.compare_digest(params.get("state", ""), state):
+        # A mismatched state means the redirect didn't come from the request we
+        # made — the CSRF case RFC 6749 §10.12 describes. Refuse the code.
+        raise OidcError("state mismatch on the redirect; login aborted")
+
+    form = {
+        "grant_type": "authorization_code",
+        "code": params["code"],
+        "redirect_uri": redirect_uri,
+        "client_id": client_id,
+        "code_verifier": verifier,
+    }
+    if client_secret:
+        form["client_secret"] = client_secret
+    return _as_token_response(_token_request(meta.token_endpoint, form))
+
+
+def device_code_login(
+    meta: ProviderMetadata,
+    client_id: str,
+    *,
+    scope: str,
+    audience: str | None = None,
+    client_secret: str | None = None,
+    timeout_s: float = 300.0,
+    announce: Any = None,
+) -> TokenResponse:
+    """Log in without a browser on this machine (RFC 8628).
+
+    ``announce`` is called with a :class:`DevicePrompt` — the code and URL the
+    user has to visit — before polling starts.
+    """
+    if not meta.device_authorization_endpoint:
+        raise OidcError(f"issuer {meta.issuer} does not support the device-code flow")
+
+    form = {"client_id": client_id, "scope": scope}
+    if audience:
+        form["audience"] = audience
+    if client_secret:
+        form["client_secret"] = client_secret
+    body = _token_request(meta.device_authorization_endpoint, form)
+
+    device_code = body.get("device_code")
+    user_code = body.get("user_code")
+    verification_uri = body.get("verification_uri") or body.get("verification_url")
+    if not device_code or not user_code or not verification_uri:
+        raise OidcError("issuer returned an incomplete device-authorization response")
+
+    expires_in = body.get("expires_in")
+    if announce is not None:
+        announce(
+            DevicePrompt(
+                user_code=str(user_code),
+                verification_uri=str(verification_uri),
+                verification_uri_complete=body.get("verification_uri_complete"),
+                expires_in=float(expires_in) if isinstance(expires_in, int | float) else None,
+            )
+        )
+
+    interval = float(body.get("interval") or _DEFAULT_DEVICE_INTERVAL_S)
+    # The issuer's own expiry bounds the wait when it is shorter than ours.
+    limit = min(timeout_s, float(expires_in)) if isinstance(expires_in, int | float) else timeout_s
+    deadline = time.monotonic() + limit
+
+    poll = {
+        "grant_type": _DEVICE_CODE_GRANT,
+        "device_code": str(device_code),
+        "client_id": client_id,
+    }
+    if client_secret:
+        poll["client_secret"] = client_secret
+
+    while time.monotonic() < deadline:
+        time.sleep(interval)
+        try:
+            return _as_token_response(_token_request(meta.token_endpoint, poll))
+        except OidcError as exc:
+            reason = str(exc)
+            if reason.startswith("authorization_pending"):
+                continue
+            if reason.startswith("slow_down"):
+                # RFC 8628 §3.5: back off by 5s and keep the new interval.
+                interval += 5.0
+                continue
+            raise
+    raise OidcError(f"timed out after {limit:.0f}s waiting for you to approve the device code")
+
+
+def refresh_grant(
+    token_endpoint: str,
+    client_id: str,
+    refresh_token: str,
+    *,
+    client_secret: str | None = None,
+    scope: str | None = None,
+) -> TokenResponse:
+    """Exchange a refresh token for a fresh access token."""
+    form = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+    }
+    if client_secret:
+        form["client_secret"] = client_secret
+    if scope:
+        form["scope"] = scope
+    return _as_token_response(_token_request(token_endpoint, form))

--- a/mycelium-cli/src/mycelium/tokens.py
+++ b/mycelium-cli/src/mycelium/tokens.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Token cache for the CLI's OIDC session (``mycelium login``).
+
+Tokens are secrets, so they deliberately do **not** live in ``config.toml``:
+that file is routinely printed, copied between machines, and mirrored into
+``config.json`` for JS consumers. The session lands in its own file,
+``~/.mycelium/token.json``, created ``0600`` so it is readable only by its owner.
+
+The CLI reads a token's claims but never *verifies* them — verification is the
+hub's job (``app/services/auth.py`` validates the signature against the issuer's
+JWKS). Claims are decoded here only to show who you are logged in as and when the
+session expires; nothing the CLI decides on their basis grants access to
+anything.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+#: Treat a token as expired this many seconds before its ``exp``, so a request
+#: can't be issued with a token that dies in flight.
+DEFAULT_LEEWAY_S = 60.0
+
+#: Overrides the cache location (tests, and CI runners with a shared home).
+TOKEN_FILE_ENV = "MYCELIUM_TOKEN_FILE"
+
+
+def token_path() -> Path:
+    """Where the session is cached (``~/.mycelium/token.json`` by default)."""
+    override = os.environ.get(TOKEN_FILE_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+
+    from mycelium.config import MyceliumConfig
+
+    return MyceliumConfig.get_global_config_dir() / "token.json"
+
+
+def decode_claims(jwt: str) -> dict[str, Any]:
+    """Decode a JWT's payload **without verifying it**.
+
+    Returns ``{}`` for anything that isn't a readable JWT — an opaque access
+    token is a legitimate thing for an issuer to hand out, and the CLI treats it
+    as "a token I can't read claims from", not as an error.
+    """
+    parts = jwt.split(".")
+    if len(parts) < 2:
+        return {}
+    payload = parts[1]
+    padding = "=" * (-len(payload) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(payload + padding)
+        claims = json.loads(raw)
+    except (ValueError, binascii.Error, UnicodeDecodeError):
+        return {}
+    return claims if isinstance(claims, dict) else {}
+
+
+@dataclass(frozen=True)
+class StoredToken:
+    """A cached OIDC session: the access token plus what it takes to renew it."""
+
+    access_token: str
+    issuer: str
+    client_id: str
+    refresh_token: str | None = None
+    #: Absolute epoch seconds, not a duration — a cached ``expires_in`` would
+    #: silently mean something different every time the file is read.
+    expires_at: float | None = None
+    token_endpoint: str | None = None
+    scope: str | None = None
+
+    @property
+    def claims(self) -> dict[str, Any]:
+        """The access token's unverified claims (``{}`` if it isn't a JWT)."""
+        return decode_claims(self.access_token)
+
+    def handle(self, claim: str = "sub") -> str | None:
+        """The ``@handle`` this token asserts, per the configured claim."""
+        value = self.claims.get(claim)
+        if not isinstance(value, str) or not value.strip():
+            return None
+        return value.strip().lstrip("@").lower()
+
+    def expires_in(self, *, now: float | None = None) -> float | None:
+        """Seconds until expiry, or ``None`` when the issuer gave no expiry."""
+        if self.expires_at is None:
+            return None
+        return self.expires_at - (time.time() if now is None else now)
+
+    def is_expired(self, *, leeway_s: float = DEFAULT_LEEWAY_S) -> bool:
+        remaining = self.expires_in()
+        return remaining is not None and remaining <= leeway_s
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "expires_at": self.expires_at,
+            "issuer": self.issuer,
+            "client_id": self.client_id,
+            "token_endpoint": self.token_endpoint,
+            "scope": self.scope,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> StoredToken | None:
+        """Rehydrate a cache entry, or ``None`` if it isn't usable."""
+        access_token = data.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            return None
+        expires_at = data.get("expires_at")
+        return cls(
+            access_token=access_token,
+            issuer=str(data.get("issuer") or ""),
+            client_id=str(data.get("client_id") or ""),
+            refresh_token=data.get("refresh_token") or None,
+            expires_at=float(expires_at) if isinstance(expires_at, int | float) else None,
+            token_endpoint=data.get("token_endpoint") or None,
+            scope=data.get("scope") or None,
+        )
+
+
+def load_token() -> StoredToken | None:
+    """The cached session, or ``None`` when logged out.
+
+    A corrupt cache reads as logged out rather than raising: every command in the
+    CLI consults this, and none of them should die because a token file got
+    truncated.
+    """
+    path = token_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return StoredToken.from_dict(data)
+
+
+def save_token(token: StoredToken) -> Path:
+    """Write the session to the cache, owner-readable only."""
+    path = token_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # os.open with 0600 rather than write_text + chmod: the file must never
+    # exist, even momentarily, with the default mode.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(token.to_dict(), fh, indent=2)
+        fh.write("\n")
+    # An older cache may predate this mode; re-assert it on every write.
+    os.chmod(path, 0o600)
+    return path
+
+
+def clear_token() -> bool:
+    """Delete the cached session. Returns whether there was one."""
+    path = token_path()
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+    return True

--- a/mycelium-cli/tests/test_login.py
+++ b/mycelium-cli/tests/test_login.py
@@ -1,0 +1,541 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""``mycelium login`` — the human OIDC session, its cache, and its injection.
+
+Four slices, matching the four things that can quietly go wrong:
+
+* **the cache** — a token file that is owner-only, round-trips, and reads as
+  "logged out" rather than raising when it's damaged;
+* **the flows** — Authorization Code + PKCE (driven against a real loopback
+  listener, with the browser faked) and device code, including the polling
+  states RFC 8628 defines;
+* **the seam** — every client built by ``mycelium.client`` carries the bearer,
+  and carries *nothing* when logged out, which is the off-by-default promise;
+* **the identity** — ``whoami`` / ``iam`` report the token's handle when there
+  is one and are untouched when there isn't.
+
+No issuer and no backend run here: ``httpx`` is stubbed at the module the code
+under test calls into.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import stat
+import threading
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from mycelium import client as client_mod
+from mycelium import oidc, tokens
+from mycelium.cli import app
+from mycelium.config import MyceliumConfig
+from mycelium.oidc import OidcError, ProviderMetadata
+from mycelium.tokens import StoredToken, clear_token, load_token, save_token, token_path
+
+runner = CliRunner()
+
+_META = ProviderMetadata(
+    issuer="https://idp.test/realms/mycelium",
+    token_endpoint="https://idp.test/realms/mycelium/token",
+    authorization_endpoint="https://idp.test/realms/mycelium/auth",
+    device_authorization_endpoint="https://idp.test/realms/mycelium/device",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep every test off the developer's real ``~/.mycelium`` and token cache."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv(tokens.TOKEN_FILE_ENV, raising=False)
+    # The "session expired" notice fires once per process; reset the latch so
+    # each test observes its own behavior.
+    monkeypatch.setattr(client_mod, "_refresh_warned", False)
+
+
+def _flat(text: str) -> str:
+    """Console output with Rich's wrapping normalized away."""
+    return " ".join(text.split())
+
+
+def _jwt(claims: dict[str, Any]) -> str:
+    """An unsigned-looking JWT — the CLI only ever decodes, never verifies."""
+
+    def seg(data: dict[str, Any]) -> str:
+        raw = json.dumps(data).encode()
+        return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+    return f"{seg({'alg': 'RS256'})}.{seg(claims)}.signature"
+
+
+class _Resp:
+    """Minimal ``httpx.Response`` stand-in for the token endpoint."""
+
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise AssertionError(f"HTTP {self.status_code}")
+
+
+def _token(**overrides: Any) -> StoredToken:
+    base = StoredToken(
+        access_token=_jwt({"sub": "julia", "exp": time.time() + 3600}),
+        issuer=_META.issuer,
+        client_id="mycelium-cli",
+        refresh_token="refresh-1",
+        expires_at=time.time() + 3600,
+        token_endpoint=_META.token_endpoint,
+    )
+    return replace(base, **overrides)
+
+
+# ── the cache ────────────────────────────────────────────────────────────────
+
+
+def test_token_cache_round_trips_and_is_owner_only() -> None:
+    token = _token()
+    path = save_token(token)
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert path == token_path()
+    assert load_token() == token
+
+
+def test_token_cache_honours_the_path_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "elsewhere" / "session.json"
+    monkeypatch.setenv(tokens.TOKEN_FILE_ENV, str(target))
+
+    save_token(_token())
+    assert target.exists()
+    assert load_token() is not None
+
+
+def test_a_damaged_cache_reads_as_logged_out() -> None:
+    save_token(_token())
+    token_path().write_text("{not json")
+
+    assert load_token() is None
+
+
+def test_logged_out_is_the_absence_of_a_file() -> None:
+    assert load_token() is None
+    assert clear_token() is False
+
+    save_token(_token())
+    assert clear_token() is True
+    assert load_token() is None
+
+
+def test_expiry_uses_a_leeway_so_a_token_never_dies_in_flight() -> None:
+    assert _token(expires_at=time.time() + 3600).is_expired() is False
+    # Inside the leeway window: still valid on the clock, treated as expired.
+    assert _token(expires_at=time.time() + 5).is_expired() is True
+    assert _token(expires_at=None).is_expired() is False
+
+
+def test_handle_comes_from_the_configured_claim() -> None:
+    token = _token(access_token=_jwt({"sub": "@Julia", "email": "julia@example.com"}))
+
+    assert token.handle() == "julia"
+    assert token.handle("email") == "julia@example.com"
+    # An opaque (non-JWT) access token has no readable claims, which is not an error.
+    assert _token(access_token="opaque").handle() is None
+
+
+# ── Authorization Code + PKCE ────────────────────────────────────────────────
+
+
+def test_authorization_code_flow_completes_with_a_verified_pkce_exchange(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_post(url: str, data: dict[str, str], timeout: float) -> _Resp:  # noqa: ARG001
+        captured["form"] = data
+        return _Resp({"access_token": "at-1", "refresh_token": "rt-1", "expires_in": 300})
+
+    monkeypatch.setattr(oidc.httpx, "post", fake_post)
+
+    def fake_browser(url: str) -> bool:
+        # Stand in for the user completing the login: the IdP redirects back to
+        # the loopback listener with a code. Real socket, real handler.
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        captured["auth_query"] = {k: v[0] for k, v in query.items()}
+        redirect = captured["auth_query"]["redirect_uri"]
+        state = captured["auth_query"]["state"]
+
+        def _visit() -> None:
+            urllib.request.urlopen(f"{redirect}?code=code-1&state={state}", timeout=5).read()  # noqa: S310
+
+        threading.Thread(target=_visit, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(oidc.webbrowser, "open", fake_browser)
+
+    grant = oidc.authorization_code_login(_META, "mycelium-cli", scope="openid", timeout_s=15)
+
+    assert grant.access_token == "at-1"
+    assert grant.refresh_token == "rt-1"
+    assert grant.expires_at is not None and grant.expires_at > time.time()
+
+    # The exchange proves possession of the verifier behind the S256 challenge.
+    verifier = captured["form"]["code_verifier"]
+    digest = hashlib.sha256(verifier.encode()).digest()
+    expected = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    assert captured["auth_query"]["code_challenge"] == expected
+    assert captured["auth_query"]["code_challenge_method"] == "S256"
+    assert captured["form"]["grant_type"] == "authorization_code"
+    assert captured["form"]["code"] == "code-1"
+
+
+def test_authorization_code_flow_refuses_a_mismatched_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_browser(url: str) -> bool:
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        redirect = query["redirect_uri"][0]
+
+        def _visit() -> None:
+            urllib.request.urlopen(f"{redirect}?code=code-1&state=not-ours", timeout=5).read()  # noqa: S310
+
+        threading.Thread(target=_visit, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(oidc.webbrowser, "open", fake_browser)
+    monkeypatch.setattr(
+        oidc.httpx, "post", lambda *_a, **_k: pytest.fail("code exchanged despite bad state")
+    )
+
+    with pytest.raises(OidcError, match="state mismatch"):
+        oidc.authorization_code_login(_META, "mycelium-cli", scope="openid", timeout_s=15)
+
+
+def test_authorization_code_flow_surfaces_the_issuers_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_browser(url: str) -> bool:
+        query = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+        redirect = query["redirect_uri"][0]
+
+        def _visit() -> None:
+            urllib.request.urlopen(  # noqa: S310
+                f"{redirect}?error=access_denied&error_description=user+said+no", timeout=5
+            ).read()
+
+        threading.Thread(target=_visit, daemon=True).start()
+        return True
+
+    monkeypatch.setattr(oidc.webbrowser, "open", fake_browser)
+
+    with pytest.raises(OidcError, match="access_denied: user said no"):
+        oidc.authorization_code_login(_META, "mycelium-cli", scope="openid", timeout_s=15)
+
+
+# ── device code ──────────────────────────────────────────────────────────────
+
+
+def test_device_flow_polls_through_pending_and_slow_down(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = [
+        _Resp(
+            {
+                "device_code": "dev-1",
+                "user_code": "WDJB-MJHT",
+                "verification_uri": "https://idp.test/device",
+                "interval": 1,
+                "expires_in": 60,
+            }
+        ),
+        _Resp({"error": "authorization_pending"}, status_code=400),
+        _Resp({"error": "slow_down"}, status_code=400),
+        _Resp({"access_token": "at-2", "expires_in": 300}),
+    ]
+    seen: list[dict[str, str]] = []
+
+    def fake_post(url: str, data: dict[str, str], timeout: float) -> _Resp:  # noqa: ARG001
+        seen.append(data)
+        return responses.pop(0)
+
+    monkeypatch.setattr(oidc.httpx, "post", fake_post)
+    monkeypatch.setattr(oidc.time, "sleep", lambda _s: None)
+
+    prompts: list[oidc.DevicePrompt] = []
+    grant = oidc.device_code_login(
+        _META, "mycelium-cli", scope="openid", timeout_s=30, announce=prompts.append
+    )
+
+    assert grant.access_token == "at-2"
+    assert prompts[0].user_code == "WDJB-MJHT"
+    assert prompts[0].verification_uri == "https://idp.test/device"
+    assert [d["grant_type"] for d in seen[1:]] == [
+        "urn:ietf:params:oauth:grant-type:device_code"
+    ] * 3
+
+
+def test_device_flow_needs_an_issuer_that_supports_it() -> None:
+    meta = ProviderMetadata(issuer=_META.issuer, token_endpoint=_META.token_endpoint)
+
+    with pytest.raises(OidcError, match="does not support the device-code flow"):
+        oidc.device_code_login(meta, "mycelium-cli", scope="openid")
+
+
+# ── the client seam ──────────────────────────────────────────────────────────
+
+
+def test_logged_out_clients_send_no_authorization_header() -> None:
+    assert client_mod.auth_headers() == {}
+
+    with client_mod.hub_client() as raw:
+        assert "authorization" not in raw.headers
+
+
+def test_every_client_carries_the_bearer_once_signed_in() -> None:
+    token = _token(access_token="at-live")
+    save_token(token)
+
+    assert client_mod.auth_headers() == {"Authorization": "Bearer at-live"}
+
+    with client_mod.hub_client(headers={"If-None-Match": "etag-1"}) as raw:
+        assert raw.headers["authorization"] == "Bearer at-live"
+        # Caller-supplied headers ride along rather than replacing the session.
+        assert raw.headers["if-none-match"] == "etag-1"
+
+    typed = client_mod.typed_client()
+    assert typed.get_httpx_client().headers["authorization"] == "Bearer at-live"
+
+
+def test_an_expired_token_is_refreshed_transparently_and_re_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    save_token(_token(access_token="at-stale", expires_at=time.time() - 10))
+
+    forms: list[dict[str, str]] = []
+
+    def fake_post(url: str, data: dict[str, str], timeout: float) -> _Resp:  # noqa: ARG001
+        forms.append(data)
+        assert url == _META.token_endpoint
+        return _Resp({"access_token": "at-fresh", "expires_in": 3600})
+
+    monkeypatch.setattr(oidc.httpx, "post", fake_post)
+
+    assert client_mod.auth_headers() == {"Authorization": "Bearer at-fresh"}
+    assert forms[0]["grant_type"] == "refresh_token"
+    assert forms[0]["refresh_token"] == "refresh-1"
+
+    # Renewed once, then served from the cache — the next call re-reads the file.
+    cached = load_token()
+    assert cached is not None
+    assert cached.access_token == "at-fresh"
+    # The issuer didn't rotate the refresh token, so the existing one is kept.
+    assert cached.refresh_token == "refresh-1"
+    assert client_mod.auth_headers() == {"Authorization": "Bearer at-fresh"}
+    assert len(forms) == 1
+
+
+def test_a_dead_session_degrades_to_no_header_rather_than_a_stale_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    save_token(_token(access_token="at-stale", expires_at=time.time() - 10))
+
+    def fake_post(url: str, data: dict[str, str], timeout: float) -> _Resp:  # noqa: ARG001
+        return _Resp({"error": "invalid_grant"}, status_code=400)
+
+    monkeypatch.setattr(oidc.httpx, "post", fake_post)
+
+    # An expired token would turn a working call against an ungated hub into a
+    # 401; sending nothing keeps the off-by-default path working.
+    assert client_mod.auth_headers() == {}
+
+
+def test_an_expired_token_with_no_refresh_token_sends_nothing() -> None:
+    save_token(_token(expires_at=time.time() - 10, refresh_token=None))
+
+    assert client_mod.auth_headers() == {}
+
+
+# ── the commands ─────────────────────────────────────────────────────────────
+
+
+def test_login_without_a_configured_issuer_says_what_to_do() -> None:
+    result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 1
+    assert "no OIDC issuer configured" in _flat(result.stdout)
+    assert "login.issuer" in _flat(result.stdout)
+    assert load_token() is None
+
+
+def test_login_caches_the_session_and_remembers_the_issuer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mycelium.commands import login as login_cmd
+
+    monkeypatch.setattr(login_cmd, "_browser_available", lambda: True)
+    monkeypatch.setattr(login_cmd, "discover", lambda _issuer: _META)
+    monkeypatch.setattr(
+        login_cmd,
+        "authorization_code_login",
+        lambda *_a, **_k: oidc.TokenResponse(
+            access_token=_jwt({"sub": "julia"}),
+            refresh_token="rt-1",
+            expires_at=time.time() + 3600,
+        ),
+    )
+
+    result = runner.invoke(app, ["login", "--issuer", "https://idp.test/realms/mycelium"])
+
+    assert result.exit_code == 0
+    assert "Signed in as @julia" in _flat(result.stdout)
+
+    cached = load_token()
+    assert cached is not None
+    assert cached.issuer == _META.issuer
+    assert cached.token_endpoint == _META.token_endpoint
+    # The issuer is remembered, so the next login (and any refresh) needs no flag.
+    assert MyceliumConfig.load().login.issuer == "https://idp.test/realms/mycelium"
+
+
+def test_login_device_flag_takes_the_device_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mycelium.commands import login as login_cmd
+
+    monkeypatch.setattr(login_cmd, "discover", lambda _issuer: _META)
+    monkeypatch.setattr(
+        login_cmd,
+        "authorization_code_login",
+        lambda *_a, **_k: pytest.fail("--device must not open a browser flow"),
+    )
+    monkeypatch.setattr(
+        login_cmd,
+        "device_code_login",
+        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": "julia"})),
+    )
+
+    result = runner.invoke(
+        app, ["login", "--device", "--issuer", "https://idp.test/realms/mycelium"]
+    )
+
+    assert result.exit_code == 0
+    assert load_token() is not None
+
+
+def test_login_falls_back_to_device_code_when_there_is_no_browser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A headless shell (SSH, CI, a container) can't be redirected to loopback."""
+    from mycelium.commands import login as login_cmd
+
+    monkeypatch.setattr(login_cmd, "_browser_available", lambda: False)
+    monkeypatch.setattr(login_cmd, "discover", lambda _issuer: _META)
+    monkeypatch.setattr(
+        login_cmd,
+        "authorization_code_login",
+        lambda *_a, **_k: pytest.fail("browser flow attempted with no browser"),
+    )
+    monkeypatch.setattr(
+        login_cmd,
+        "device_code_login",
+        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": "julia"})),
+    )
+
+    result = runner.invoke(app, ["login", "--issuer", "https://idp.test/realms/mycelium"])
+
+    assert result.exit_code == 0
+    assert "falling back to the device-code flow" in _flat(result.stdout)
+    assert load_token() is not None
+
+
+def test_login_reports_a_failed_flow_without_caching_anything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mycelium.commands import login as login_cmd
+
+    monkeypatch.setattr(login_cmd, "_browser_available", lambda: True)
+    monkeypatch.setattr(login_cmd, "discover", lambda _issuer: _META)
+
+    def boom(*_a: Any, **_k: Any) -> None:
+        raise OidcError("access_denied: user said no")
+
+    monkeypatch.setattr(login_cmd, "authorization_code_login", boom)
+
+    result = runner.invoke(app, ["login", "--issuer", "https://idp.test/realms/mycelium"])
+
+    assert result.exit_code == 1
+    assert "Login failed: access_denied" in _flat(result.stdout)
+    assert load_token() is None
+
+
+def test_logout_drops_the_session() -> None:
+    save_token(_token())
+
+    result = runner.invoke(app, ["logout"])
+
+    assert result.exit_code == 0
+    assert "Signed out" in result.stdout
+    assert load_token() is None
+    assert client_mod.auth_headers() == {}
+
+
+def test_whoami_reports_the_token_identity_when_signed_in() -> None:
+    save_token(_token(access_token=_jwt({"sub": "julia", "exp": time.time() + 3600})))
+
+    result = runner.invoke(app, ["--json", "whoami"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["authenticated"] is True
+    assert payload["principal"] == "julia"
+    assert payload["token"]["issuer"] == _META.issuer
+
+
+def test_whoami_is_unchanged_when_logged_out() -> None:
+    config = MyceliumConfig.load()
+    config.identity.name = "julia"
+    config.save()
+
+    result = runner.invoke(app, ["--json", "whoami"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["authenticated"] is False
+    assert payload["token"] is None
+    assert payload["principal"] == "julia"
+
+
+def test_iam_with_no_handle_reports_rather_than_asserting() -> None:
+    save_token(_token(access_token=_jwt({"sub": "julia", "exp": time.time() + 3600})))
+
+    result = runner.invoke(app, ["--json", "iam"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["principal"] == "julia"
+    # Reporting is read-only: nothing was written to identity.name.
+    assert MyceliumConfig.load().identity.name is None
+
+
+def test_iam_flags_a_handle_the_token_will_not_back() -> None:
+    save_token(_token(access_token=_jwt({"sub": "julia", "exp": time.time() + 3600})))
+
+    result = runner.invoke(app, ["iam", "bob"])
+
+    assert result.exit_code == 0
+    assert "you're signed in as @julia" in _flat(result.stdout)
+    assert "refuse writes claiming a different handle" in _flat(result.stdout)

--- a/mycelium-cli/tests/test_participate_cli.py
+++ b/mycelium-cli/tests/test_participate_cli.py
@@ -7,6 +7,10 @@ Node-free: ``httpx`` is stubbed so these exercise the CLI plumbing — room
 resolution, the long-poll request/parse for ``await``, the reply POST for
 ``respond``, and the ``--json`` agent contract. Membership + marker parsing now
 live server-side, so the CLI is a thin HTTP client.
+
+Both commands build their client through ``mycelium.client.hub_client``, so the
+requests here carry the session bearer when one is cached; the fake records the
+request path relative to the hub's base URL.
 """
 
 from __future__ import annotations
@@ -18,8 +22,7 @@ import pytest
 from typer.testing import CliRunner
 
 from mycelium.cli import app
-from mycelium.commands import participate
-from tests.conftest import FakeResp
+from tests.conftest import FakeHTTPX, FakeResp
 
 runner = CliRunner()
 
@@ -30,11 +33,9 @@ def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MYCELIUM_ROOM_ID", "demo")
 
 
-def test_await_prints_addressed_message(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_get(url: str, params: dict | None = None, timeout: float | None = None) -> FakeResp:
-        assert url.endswith("/api/rooms/demo/await")
-        assert params is not None and params["handle"] == "me"
-        return FakeResp(
+def test_await_prints_addressed_message(fake_httpx: FakeHTTPX) -> None:
+    fake_httpx.respond_with(
+        lambda *_a: FakeResp(
             {
                 "room": "demo",
                 "handle": "me",
@@ -45,8 +46,7 @@ def test_await_prints_addressed_message(monkeypatch: pytest.MonkeyPatch) -> None
                 "message_id": "tick-1",
             }
         )
-
-    monkeypatch.setattr(participate.httpx, "get", fake_get)
+    )
 
     result = runner.invoke(app, ["await", "--handle", "me", "--json"])
     assert result.exit_code == 0
@@ -55,35 +55,34 @@ def test_await_prints_addressed_message(monkeypatch: pytest.MonkeyPatch) -> None
     assert payload["prompt"] == "@me what is your position?"
     assert payload["sender"] == "mediator"
 
+    method, path, params = fake_httpx.calls[0]
+    assert (method, path) == ("GET", "/api/rooms/demo/await")
+    assert params["handle"] == "me"
 
-def test_await_timeout_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_get(url, params=None, timeout=None):
-        return FakeResp({"room": "demo", "handle": "me", "message": None})
 
-    monkeypatch.setattr(participate.httpx, "get", fake_get)
+def test_await_timeout_exits_nonzero(fake_httpx: FakeHTTPX) -> None:
+    fake_httpx.respond_with(lambda *_a: FakeResp({"room": "demo", "handle": "me", "message": None}))
+
     result = runner.invoke(app, ["await", "--handle", "me", "--timeout", "1", "--json"])
     assert result.exit_code == 1
     assert json.loads(result.stdout)["message"] is None
 
 
-def test_respond_posts_reply(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict = {}
-
-    def fake_post(url, json=None, timeout=None):
-        captured["url"] = url
-        captured["body"] = json
-        return FakeResp({"room": "demo", "handle": "me", "message_id": "r-1"})
-
-    monkeypatch.setattr(participate.httpx, "post", fake_post)
+def test_respond_posts_reply(fake_httpx: FakeHTTPX) -> None:
+    fake_httpx.respond_with(
+        lambda *_a: FakeResp({"room": "demo", "handle": "me", "message_id": "r-1"})
+    )
 
     result = runner.invoke(
         app,
         ["respond", "I can move to 30%. [[mycelium: stance=accept]]", "--handle", "me", "--json"],
     )
     assert result.exit_code == 0
-    assert captured["url"].endswith("/api/rooms/demo/reply")
+
+    method, path, body = fake_httpx.calls[0]
+    assert (method, path) == ("POST", "/api/rooms/demo/reply")
     # The CLI sends raw text + handle; the backend parses the marker + records it.
-    assert captured["body"] == {
+    assert body == {
         "handle": "me",
         "text": "I can move to 30%. [[mycelium: stance=accept]]",
     }


### PR DESCRIPTION
## Summary

Humans can now obtain an OIDC token for a gated hub and have every CLI call carry it. `mycelium login` runs **Authorization Code + PKCE** through the browser, with a **device-code** fallback for a shell whose browser can't reach this machine's loopback (SSH, CI, a container). The session lands in a `0600` cache — never `config.toml` — and is renewed from its refresh token transparently.

The structural half is the seam: **one authenticated client factory** (`mycelium/client.py`) now builds every backend client, typed and raw alike. Before this, each command module built its own — two typed factories plus a dozen bare `httpx` clients — so a bearer added in one place would have authenticated one command and quietly missed the rest. Agent credentials (#564) attach at this same factory with a different credential source.

**Off by default, like the gate it pairs with.** With no cached session the factory attaches no `Authorization` header and the CLI behaves exactly as before; the try-it path is untouched. A session that can't be renewed drops the header rather than sending a token the hub will reject — against an ungated hub the call still works, and against a gated one the 401 is the honest answer.

## Changes

- **`mycelium login` / `mycelium logout`** (`commands/login.py`, `oidc.py`) — PKCE (S256) browser flow with a one-shot loopback listener and `compare_digest` state check; device-code flow per RFC 8628 including `authorization_pending` / `slow_down`; both driven off the issuer's discovery document, so nothing is Keycloak-specific. Falls back to device code automatically when there is no browser to open.
- **Token cache** (`tokens.py`) — `~/.mycelium/token.json`, created `0600` via `os.open` so it never exists world-readable; `MYCELIUM_TOKEN_FILE` relocates it. Claims are decoded to report identity and expiry, never verified — verification is the hub's job.
- **One client factory** (`client.py`) — `typed_client()` (generated client's `.with_headers()`) and `hub_client()` (raw `httpx`), with refresh-on-expiry. Routed through it: both typed factories plus a third found in `agent.py`; memory reindex/sync; room clone, reindex, watch and its SSE stream; the four `plan.py` clients; the agent members probe; `MyceliumHTTPClient`; and `await` / `respond`, which the participation path depends on.
- **`[login]` config** — issuer, client_id, client_secret, scopes, audience, redirect_port, with `MYCELIUM_LOGIN_*` env overrides. Deliberately separate from `[auth]`, which configures the *hub's* gate.
- **`whoami` / `iam`** — report the handle the token asserts when signed in, the self-asserted `identity.name` when not. `iam` takes no handle now to report rather than assert. Because a gated hub attributes writes to the token (#562), both commands flag a self-asserted handle the token won't back.
- **Docs** — a "Signing in from the CLI" section in the auth guide (flows, where the token lives, config table, public-client registration), regenerated HTML reference, and the rollout step marked landed in `docs/design/identity-and-auth.md`.

## Testing

`tests/test_login.py` (26 new tests) covers the cache (mode, round-trip, damaged file reads as logged-out, leeway), both flows (the PKCE test drives a **real loopback listener** and verifies the exchanged verifier hashes to the advertised challenge; state mismatch and issuer errors are refused), the seam (bearer present when signed in, absent when not, expired-and-unrefreshable degrades to no header), and the commands.

Beyond unit tests, I stood up a throwaway OIDC issuer + hub and ran the real command end-to-end: browser flow completed, cache written `0600`, `whoami` reported the token's handle, `room ls` carried `Authorization: Bearer …`, an expired access token was refreshed transparently (issuer logged the `refresh_token` grant), and after `logout` the hub saw no header.

That run surfaced a real bug, now fixed: `webbrowser.open` waits for the browser process for any generic `$BROWSER`, which deadlocked against the callback loop — the launch happens on a thread.

**Not verified here:** no Docker daemon in this environment, so this was not driven against the #566 dev issuer; and `mock-oauth2-server` may not advertise `device_authorization_endpoint`, in which case `--device` against it reports that plainly rather than working. The device flow is unit-tested only.

- [x] Unit tests pass (`uv run pytest tests/ -q` — 344 passed)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)

## Related Issues

Closes #563. Part of #560; depends on #561 (merged) and pairs with #562. Out of scope: agent credentials (#564), SLIM channel identity (#476), RBAC.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUiz3UdYvNSA7z4r6gMqXH)_