### PR TITLE
feat(cli): per-agent OIDC service-account credentials (#564)

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -87,6 +87,7 @@ GROUP_CONFIG: list[tuple[str, str, str]] = [
     ("setup", "setup", "setup"),
     ("room", "room", "room"),
     ("session", "session", "session"),
+    ("agent", "agent", "agent"),
     ("memory", "memory", "memory"),
     ("plan", "plan", "plan"),
     ("negotiate", "negotiate", "negotiate"),

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1641,6 +1641,77 @@ secret. Register it at your issuer as a public client with
 `http://127.0.0.1:*/callback` as an allowed redirect, and enable the device grant
 if you want `--device` to work.
 
+## Agents sign in as themselves
+
+`mycelium login` is for a human. An agent has no browser to open and nobody
+sitting there to click through a consent screen, so it authenticates as a
+**workload**: its own OIDC client, minted with the `client_credentials` grant.
+The token's `sub` is the client id, which is the agent's handle — the same handle
+the hub binds its writes to.
+
+That is the property a shared secret can't give you: each agent holds a different
+credential, so **revoking one agent's client leaves every other agent working**.
+
+Point the machine at the issuer agents mint from, then give each agent its own
+client:
+
+```bash
+mycelium config set agent_auth.issuer https://sso.example.com/realms/agents
+mycelium config set agent_auth.audience mycelium     # match the hub's auth.audience
+mycelium config apply
+
+mycelium agent credential set release-agent --secret-stdin < secret.txt
+```
+
+The client id defaults to the handle; pass `--client-id` when your issuer names
+it differently. `mycelium agent credential show release-agent` reports what an
+agent resolves to (never its secret), `... ls` lists every agent on the machine,
+and `... rm` forgets one locally — revoke the client at your issuer to actually
+kill it.
+
+From then on, `mycelium await --room R --handle release-agent` and
+`mycelium respond --handle release-agent` carry **that agent's** token, including
+when they run from a shell where a human is logged in — a resident agent writes as
+itself, not as whoever started it.
+
+### Off by default here too
+
+An agent with no credential sends no token, exactly as before. Configuring
+`agent_auth.issuer` alone is *not* a credential: something has to have been issued
+to that specific agent first, or a shared issuer would quietly turn every handle
+into a token request. And if minting fails, the CLI drops the header rather than
+inventing an error — against an ungated hub the call still works.
+
+### Where the credential lives
+
+In `~/.mycelium/agent-credentials.json`, mode `0600`, alongside a cached token per
+agent under `~/.mycelium/agent-tokens/`. Client secrets are secrets, so they stay
+out of `config.toml` for the same reason your session does. `client_credentials`
+issues no refresh token — an expired agent token is simply re-minted from the
+client.
+
+For a container that runs exactly one agent and has no config file,
+`MYCELIUM_AGENT_AUTH_ISSUER`, `MYCELIUM_AGENT_AUTH_CLIENT_ID`,
+`MYCELIUM_AGENT_AUTH_CLIENT_SECRET`, `MYCELIUM_AGENT_AUTH_SCOPES` and
+`MYCELIUM_AGENT_AUTH_AUDIENCE` say the same thing in environment variables, and
+`MYCELIUM_AGENT_HANDLE` names the agent it is running as.
+
+### A credential Mycelium didn't mint
+
+`MYCELIUM_AGENT_AUTH_TOKEN` supplies a bearer token directly, used as-is and never
+renewed here. That is the seam for a token minted elsewhere — a CI job, or a JWT
+issued by a workload-identity system such as SPIRE. Trusting one is a config
+entry on the hub side too: another `[[auth.issuers]]` block with `role = "agent"`.
+Nothing about it is required, and nothing about it is on by default.
+
+### Configuration
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `agent_auth.issuer` | *(unset)* | Issuer agents mint service-account tokens from. Unset means agents send no token. |
+| `agent_auth.scopes` | *(unset)* | Scopes requested for an agent token. Most issuers want none for `client_credentials`. |
+| `agent_auth.audience` | *(unset)* | Audience to request; should match the hub's `auth.audience`. |
+
 ## Issuer-agnostic by design
 
 The backend trusts a configured issuer and its JWKS. It has no idea whether that

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -101,6 +101,7 @@
       <a href="#config-engine" class="nav-link sub">engine</a>
       <a href="#config-auth" class="nav-link sub">auth</a>
       <a href="#config-login" class="nav-link sub">login</a>
+      <a href="#config-agent-auth" class="nav-link sub">agent_auth</a>
       <a href="#config-metrics" class="nav-link sub">metrics</a>
     </div>
     <div class="nav-section">
@@ -815,6 +816,18 @@ cursor-agent login            # one-time, interactive
 <span class="comment"># Fixed loopback port for the browser redirect (0 = pick a free one). Set this when the issuer requires an exact registered redirect URI.</span>
 <span class="arg">redirect_port</span> = 0
 
+<span class="comment"># Where an *agent* gets its own token — the workload half of the client side.</span>
+<span class="cmd" id="config-agent-auth">[agent_auth]</span>
+
+<span class="comment"># OIDC issuer agents mint their service-account tokens from. Unset (default) means agents send no token.</span>
+<span class="arg">issuer</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Space-separated scopes to request for an agent token. Unset sends none, which is what most issuers want for client_credentials.</span>
+<span class="arg">scopes</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Audience to request for agent tokens; should match the hub&#x27;s auth.audience.</span>
+<span class="arg">audience</span> = <span class="str">&quot;&quot;</span>
+
 <span class="comment"># Configuration for the metrics collector + display.</span>
 <span class="cmd" id="config-metrics">[metrics]</span>
 
@@ -1161,6 +1174,53 @@ role     = &quot;user&quot;</code></pre>
       </div>
       <p><code>MYCELIUM_LOGIN_ISSUER</code>, <code>MYCELIUM_LOGIN_CLIENT_ID</code>, <code>MYCELIUM_LOGIN_CLIENT_SECRET</code>, <code>MYCELIUM_LOGIN_AUDIENCE</code> and <code>MYCELIUM_LOGIN_SCOPES</code> override the same settings, for a runner that has no config file to edit.</p>
       <p>The CLI is a <strong>public client</strong>: it authenticates with PKCE (S256) and ships no secret. Register it at your issuer as a public client with <code>http://127.0.0.1:*/callback</code> as an allowed redirect, and enable the device grant if you want <code>--device</code> to work.</p>
+      <h2 id="auth-agents-sign-in-as-themselves">Agents sign in as themselves</h2>
+      <p><code>mycelium login</code> is for a human. An agent has no browser to open and nobody sitting there to click through a consent screen, so it authenticates as a <strong>workload</strong>: its own OIDC client, minted with the <code>client_credentials</code> grant. The token&#x27;s <code>sub</code> is the client id, which is the agent&#x27;s handle — the same handle the hub binds its writes to.</p>
+      <p>That is the property a shared secret can&#x27;t give you: each agent holds a different credential, so <strong>revoking one agent&#x27;s client leaves every other agent working</strong>.</p>
+      <p>Point the machine at the issuer agents mint from, then give each agent its own client:</p>
+      <pre><code><span class="cmd">mycelium config set</span> agent_auth.issuer https://sso.example.com/realms/agents
+<span class="cmd">mycelium config set</span> agent_auth.audience mycelium     # match the hub&#x27;s auth.audience
+<span class="cmd">mycelium config apply</span>
+
+<span class="cmd">mycelium agent credential</span> set release-agent <span class="flag">--secret-stdin</span> &lt; secret.txt</code></pre>
+      <p>The client id defaults to the handle; pass <code>--client-id</code> when your issuer names it differently. <code>mycelium agent credential show release-agent</code> reports what an agent resolves to (never its secret), <code>... ls</code> lists every agent on the machine, and <code>... rm</code> forgets one locally — revoke the client at your issuer to actually kill it.</p>
+      <p>From then on, <code>mycelium await --room R --handle release-agent</code> and <code>mycelium respond --handle release-agent</code> carry <strong>that agent&#x27;s</strong> token, including when they run from a shell where a human is logged in — a resident agent writes as itself, not as whoever started it.</p>
+      <h3 id="auth-off-by-default-here-too">Off by default here too</h3>
+      <p>An agent with no credential sends no token, exactly as before. Configuring <code>agent_auth.issuer</code> alone is <em>not</em> a credential: something has to have been issued to that specific agent first, or a shared issuer would quietly turn every handle into a token request. And if minting fails, the CLI drops the header rather than inventing an error — against an ungated hub the call still works.</p>
+      <h3 id="auth-where-the-credential-lives">Where the credential lives</h3>
+      <p>In <code>~/.mycelium/agent-credentials.json</code>, mode <code>0600</code>, alongside a cached token per agent under <code>~/.mycelium/agent-tokens/</code>. Client secrets are secrets, so they stay out of <code>config.toml</code> for the same reason your session does. <code>client_credentials</code> issues no refresh token — an expired agent token is simply re-minted from the client.</p>
+      <p>For a container that runs exactly one agent and has no config file, <code>MYCELIUM_AGENT_AUTH_ISSUER</code>, <code>MYCELIUM_AGENT_AUTH_CLIENT_ID</code>, <code>MYCELIUM_AGENT_AUTH_CLIENT_SECRET</code>, <code>MYCELIUM_AGENT_AUTH_SCOPES</code> and <code>MYCELIUM_AGENT_AUTH_AUDIENCE</code> say the same thing in environment variables, and <code>MYCELIUM_AGENT_HANDLE</code> names the agent it is running as.</p>
+      <h3 id="auth-a-credential-mycelium-didnt-mint">A credential Mycelium didn&#x27;t mint</h3>
+      <p><code>MYCELIUM_AGENT_AUTH_TOKEN</code> supplies a bearer token directly, used as-is and never renewed here. That is the seam for a token minted elsewhere — a CI job, or a JWT issued by a workload-identity system such as SPIRE. Trusting one is a config entry on the hub side too: another <code>[[auth.issuers]]</code> block with <code>role = &quot;agent&quot;</code>. Nothing about it is required, and nothing about it is on by default.</p>
+      <h3 id="auth-configuration">Configuration</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Default</th>
+              <th>What it does</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>agent_auth.issuer</code></td>
+              <td><em>(unset)</em></td>
+              <td>Issuer agents mint service-account tokens from. Unset means agents send no token.</td>
+            </tr>
+            <tr>
+              <td><code>agent_auth.scopes</code></td>
+              <td><em>(unset)</em></td>
+              <td>Scopes requested for an agent token. Most issuers want none for <code>client_credentials</code>.</td>
+            </tr>
+            <tr>
+              <td><code>agent_auth.audience</code></td>
+              <td><em>(unset)</em></td>
+              <td>Audience to request; should match the hub&#x27;s <code>auth.audience</code>.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
       <h2 id="auth-issuer-agnostic-by-design">Issuer-agnostic by design</h2>
       <p>The backend trusts a configured issuer and its JWKS. It has no idea whether that is Keycloak, Dex, ZITADEL, Authentik, or your existing corporate SSO, and it never needs one particular product installed.</p>
       <p><strong>More than one trust root is normal.</strong> Humans log in through an interactive OIDC issuer; agents present service-account tokens, possibly from an entirely separate root. List each as its own block:</p>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -84,6 +84,7 @@
       <div class="nav-section-label">CLI Reference</div>
       <a href="#cli-setup" class="nav-link sub">setup</a>
       <a href="#cli-room" class="nav-link sub">room</a>
+      <a href="#cli-agent" class="nav-link sub">agent</a>
       <a href="#cli-memory" class="nav-link sub">memory</a>
       <a href="#cli-plan" class="nav-link sub">plan</a>
       <a href="#cli-adapter" class="nav-link sub">adapter</a>
@@ -456,6 +457,71 @@ cursor-agent login            # one-time, interactive
           <code><span class="cmd">mycelium room delegate</span> <span class="arg">&lt;room&gt;</span> <span class="flag">--to</span> <span class="arg">&lt;handle&gt;</span> <span class="flag">--task</span> <span class="arg">&lt;description&gt;</span></code>
         </div>
         <div class="cmd-ref-body">Delegate a task to another agent in a room.</div>
+      </div>
+
+      <h2 id="cli-agent">agent</h2>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium agent create</span> <span class="arg">&lt;handle&gt;</span> <span class="flag">--adapter</span> <span class="arg">&lt;name&gt;</span> [<span class="flag">--cwd</span> <span class="arg">&lt;path&gt;</span>]</code>
+        </div>
+        <div class="cmd-ref-body">Create a new, Mycelium-controlled agent in a room. <code>claude_code</code> and <code>cursor</code> agents are resident sessions the user keeps woken with <code>mycelium await --loop</code>.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium agent ls</span> [<span class="flag">--room</span> <span class="arg">&lt;room&gt;</span>]</code>
+        </div>
+        <div class="cmd-ref-body">List all registered agents in a room.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium agent show</span> <span class="arg">&lt;handle&gt;</span> [<span class="flag">--room</span> <span class="arg">&lt;room&gt;</span>]</code>
+        </div>
+        <div class="cmd-ref-body">Show an agent's manifest, notes, and most recent invocation log.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium agent invoke</span> <span class="arg">&lt;handle&gt;</span> &quot;<span class="arg">&lt;prompt&gt;</span>&quot; [<span class="flag">--room</span> <span class="arg">&lt;room&gt;</span>]</code>
+        </div>
+        <div class="cmd-ref-body">Send an addressed message to a registered agent. Desugars to <code>mycelium room send "@handle &lt;prompt&gt;"</code>.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium agent rm</span> <span class="arg">&lt;handle&gt;</span> [<span class="flag">--room</span> <span class="arg">&lt;room&gt;</span>] [<span class="flag">--full</span>] [<span class="flag">--force</span>]</code>
+        </div>
+        <div class="cmd-ref-body">Unregister an agent. Default keeps the underlying runtime; <code>--full</code> also tears down the underlying runtime (requires confirmation unless <code>-y</code>).</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium agent credential</span> set <span class="arg">&lt;handle&gt;</span> [<span class="flag">--client-id</span> <span class="arg">ID</span>] [<span class="flag">--secret-stdin</span>] [<span class="flag">--issuer</span> <span class="arg">URL</span>]</code>
+        </div>
+        <div class="cmd-ref-body">Give an agent its own service-account credential, stored 0600 outside <code>config.toml</code>. Only meaningful once a hub enables auth.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium agent credential</span> show <span class="arg">&lt;handle&gt;</span></code>
+        </div>
+        <div class="cmd-ref-body">Show which credential an agent resolves to. Never prints the secret.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium agent credential</span> ls</code>
+        </div>
+        <div class="cmd-ref-body">List the agents on this machine that have their own credential.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
+          <code><span class="cmd">mycelium agent credential</span> rm <span class="arg">&lt;handle&gt;</span></code>
+        </div>
+        <div class="cmd-ref-body">Forget an agent's credential on this machine.</div>
       </div>
 
       <h2 id="cli-memory">memory</h2>

--- a/mycelium-cli/src/mycelium/agent_credentials.py
+++ b/mycelium-cli/src/mycelium/agent_credentials.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Per-agent credentials — an agent's *own* token, resolved at the one client seam.
+
+A human runs ``mycelium login`` and gets a session. An agent can't: there is no
+browser to open, no consent screen to click, and nobody sitting there to do it.
+So an agent authenticates as a **workload**: its own OIDC client, minted with the
+``client_credentials`` grant, whose ``sub`` is the client id — which is the
+agent's handle, the same handle the hub binds its writes to
+(``app/services/actor.py``). Two agents on one machine therefore hold two
+different credentials, and revoking one client leaves the other untouched.
+
+Three sources, most specific first:
+
+* **A pre-minted token** (``MYCELIUM_AGENT_AUTH_TOKEN``). The seam for a
+  credential this CLI didn't obtain — a token from CI, or a JWT-SVID a SPIRE
+  sidecar wrote out. Nothing here mints or renews it; the writer owns its
+  lifetime.
+* **The environment** (``MYCELIUM_AGENT_AUTH_CLIENT_ID`` / ``…_CLIENT_SECRET``),
+  for a container that runs exactly one agent and has no config file.
+* **The credential store**, ``~/.mycelium/agent-credentials.json``, written by
+  ``mycelium agent credential set``. A secret, so it is ``0600`` and lives
+  outside ``config.toml`` — the same reason the human session does
+  (``mycelium.tokens``).
+
+The issuer itself is not a secret and is shared by every agent on the machine,
+so it comes from ``[agent_auth]`` in config (or ``MYCELIUM_AGENT_AUTH_ISSUER``).
+
+**Off by default, and silent when it can't help.** No credential configured
+means no token, which is exactly today's behavior against an ungated hub. A mint
+that fails degrades to *no header* rather than to an error: against an ungated
+hub the call still works, and against a gated one the 401 is the truthful
+answer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from rich.console import Console
+
+if TYPE_CHECKING:
+    from mycelium.config import MyceliumConfig
+
+#: Overrides the credential store location (tests, CI runners with a shared home).
+CREDENTIAL_STORE_ENV = "MYCELIUM_AGENT_CREDENTIALS_FILE"
+
+#: The handle a resident runtime is running as, when the caller doesn't name one.
+#: Already the attribution signal for a resident session, and the credential
+#: follows the identity rather than being a second, separately-set thing.
+AGENT_HANDLE_ENV = "MYCELIUM_AGENT_HANDLE"
+
+STATIC_TOKEN_ENV = "MYCELIUM_AGENT_AUTH_TOKEN"
+CLIENT_ID_ENV = "MYCELIUM_AGENT_AUTH_CLIENT_ID"
+CLIENT_SECRET_ENV = "MYCELIUM_AGENT_AUTH_CLIENT_SECRET"
+
+_stderr = Console(stderr=True)
+
+#: One warning per handle per process — every command builds several clients and
+#: each would otherwise repeat the same failure.
+_warned: set[str] = set()
+
+#: Handles are lowercase slugs, but the cache path is derived from caller input,
+#: so anything outside the slug alphabet is folded away before it reaches a path.
+_UNSAFE = re.compile(r"[^a-z0-9._-]+")
+
+
+def normalize_handle(raw: str | None) -> str | None:
+    """The canonical handle a credential is keyed by.
+
+    Matches the backend's ``auth.normalize_handle``, and drops a session
+    qualifier (``alpha#a8f3``): a session is the same agent, so it presents the
+    same credential.
+    """
+    if not isinstance(raw, str):
+        return None
+    base = raw.partition("#")[0]
+    return base.strip().lstrip("@").lower() or None
+
+
+def ambient_handle() -> str | None:
+    """The handle this process is running as, when it says so."""
+    return normalize_handle(os.environ.get(AGENT_HANDLE_ENV))
+
+
+def store_path() -> Path:
+    """Where per-agent credentials are kept (``~/.mycelium/agent-credentials.json``)."""
+    override = os.environ.get(CREDENTIAL_STORE_ENV, "").strip()
+    if override:
+        return Path(override).expanduser()
+
+    from mycelium.config import MyceliumConfig
+
+    return MyceliumConfig.get_global_config_dir() / "agent-credentials.json"
+
+
+def token_cache_path(handle: str) -> Path:
+    """Where an agent's *minted* token is cached, one file per agent."""
+    safe = _UNSAFE.sub("-", handle) or "agent"
+    return store_path().parent / "agent-tokens" / f"{safe}.json"
+
+
+@dataclass(frozen=True)
+class AgentCredential:
+    """How one agent proves who it is."""
+
+    handle: str
+    client_id: str
+    client_secret: str | None = None
+    issuer: str | None = None
+    scopes: str | None = None
+    audience: str | None = None
+    #: A token obtained elsewhere (CI, a SPIRE sidecar). Used as-is, never minted.
+    token: str | None = None
+
+    def redacted(self) -> dict[str, Any]:
+        """What this credential is, with nothing secret in it."""
+        return {
+            "handle": self.handle,
+            "client_id": self.client_id,
+            "issuer": self.issuer,
+            "scopes": self.scopes,
+            "audience": self.audience,
+            "has_secret": bool(self.client_secret),
+            "static_token": bool(self.token),
+        }
+
+
+def _read_store() -> dict[str, dict[str, Any]]:
+    """The stored per-agent entries. A damaged store reads as empty, not as an error."""
+    try:
+        data = json.loads(store_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    agents = data.get("agents")
+    if not isinstance(agents, dict):
+        return {}
+    return {k: v for k, v in agents.items() if isinstance(v, dict)}
+
+
+def _write_store(agents: dict[str, dict[str, Any]]) -> Path:
+    """Persist the store owner-readable only — it holds client secrets."""
+    path = store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # os.open with 0600 rather than write_text + chmod: the file must never exist,
+    # even momentarily, with the default mode.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump({"agents": agents}, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    # An older store may predate this mode; re-assert it on every write.
+    os.chmod(path, 0o600)
+    return path
+
+
+def save_credential(
+    handle: str,
+    *,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    issuer: str | None = None,
+    scopes: str | None = None,
+    audience: str | None = None,
+) -> Path:
+    """Record an agent's credential, replacing any entry it already had."""
+    key = normalize_handle(handle) or handle
+    agents = _read_store()
+    agents[key] = {
+        "client_id": client_id or key,
+        "client_secret": client_secret,
+        "issuer": issuer.rstrip("/") if issuer else None,
+        "scopes": scopes,
+        "audience": audience,
+    }
+    path = _write_store(agents)
+    # A stale minted token belongs to the credential that just got replaced.
+    clear_cached_token(key)
+    return path
+
+
+def remove_credential(handle: str) -> bool:
+    """Forget an agent's credential. Returns whether there was one."""
+    key = normalize_handle(handle) or handle
+    agents = _read_store()
+    if key not in agents:
+        return False
+    del agents[key]
+    _write_store(agents)
+    clear_cached_token(key)
+    return True
+
+
+def list_credentials() -> dict[str, AgentCredential]:
+    """Every stored credential, keyed by handle."""
+    return {
+        handle: AgentCredential(
+            handle=handle,
+            client_id=str(entry.get("client_id") or handle),
+            client_secret=entry.get("client_secret") or None,
+            issuer=entry.get("issuer") or None,
+            scopes=entry.get("scopes") or None,
+            audience=entry.get("audience") or None,
+        )
+        for handle, entry in _read_store().items()
+    }
+
+
+def resolve(config: MyceliumConfig, handle: str | None = None) -> AgentCredential | None:
+    """The credential an agent should present, or ``None`` when it has none.
+
+    ``None`` is the default and the common case: no agent credential configured,
+    so the caller attaches nothing and behaves as it always has.
+    """
+    resolved_handle = normalize_handle(handle) or ambient_handle()
+    if resolved_handle is None:
+        return None
+
+    stored = list_credentials().get(resolved_handle)
+    env_token = os.environ.get(STATIC_TOKEN_ENV, "").strip() or None
+    env_client_id = os.environ.get(CLIENT_ID_ENV, "").strip() or None
+    env_secret = os.environ.get(CLIENT_SECRET_ENV, "").strip() or None
+
+    # A shared issuer is configuration, not a credential: on its own it must not
+    # turn every handle into a token request. Something has to have been issued
+    # *to this agent* first.
+    if stored is None and not (env_token or env_client_id or env_secret):
+        return None
+
+    base = stored or AgentCredential(handle=resolved_handle, client_id=resolved_handle)
+    return replace(
+        base,
+        client_id=env_client_id or base.client_id,
+        client_secret=env_secret or base.client_secret,
+        issuer=base.issuer or config.agent_auth.issuer,
+        scopes=base.scopes or config.agent_auth.scopes,
+        audience=base.audience or config.agent_auth.audience,
+        token=env_token,
+    )
+
+
+def _warn_once(handle: str, message: str) -> None:
+    if handle in _warned:
+        return
+    _warned.add(handle)
+    _stderr.print(message)
+
+
+def _cached_token(handle: str, credential: AgentCredential) -> str | None:
+    """A cached mint that is still usable *and* still belongs to this credential."""
+    from mycelium.tokens import load_token
+
+    cached = load_token(token_cache_path(handle))
+    if cached is None or cached.is_expired():
+        return None
+    # A credential re-pointed at a different client or issuer must not keep
+    # presenting the token the old one minted.
+    if cached.client_id != credential.client_id:
+        return None
+    if credential.issuer and cached.issuer and cached.issuer != credential.issuer:
+        return None
+    return cached.access_token
+
+
+def clear_cached_token(handle: str) -> bool:
+    """Drop an agent's cached mint. Returns whether there was one."""
+    from mycelium.tokens import clear_token
+
+    return clear_token(token_cache_path(handle))
+
+
+def _mint(handle: str, credential: AgentCredential) -> str | None:
+    """Obtain a fresh token for the credential, caching it. ``None`` if it can't."""
+    from mycelium import oidc
+    from mycelium.tokens import StoredToken, save_token
+
+    if not credential.issuer:
+        _warn_once(
+            handle,
+            f"[yellow]@{handle} has a credential but no issuer to mint it from.[/yellow] "
+            "[dim]Set one with 'mycelium config set agent_auth.issuer <url>'.[/dim]",
+        )
+        return None
+
+    try:
+        meta = oidc.discover(credential.issuer)
+        grant = oidc.client_credentials_grant(
+            meta.token_endpoint,
+            credential.client_id,
+            credential.client_secret,
+            scope=credential.scopes,
+            audience=credential.audience,
+        )
+    except oidc.OidcError as exc:
+        _warn_once(
+            handle,
+            f"[yellow]Could not obtain a token for @{handle}:[/yellow] {exc} "
+            "[dim](continuing without one)[/dim]",
+        )
+        return None
+
+    save_token(
+        StoredToken(
+            access_token=grant.access_token,
+            issuer=meta.issuer,
+            client_id=credential.client_id,
+            # client_credentials issues no refresh token — an expired agent token
+            # is re-minted from the client itself, which is the whole point.
+            expires_at=grant.expires_at,
+            token_endpoint=meta.token_endpoint,
+            scope=grant.scope or credential.scopes,
+        ),
+        token_cache_path(handle),
+    )
+    return grant.access_token
+
+
+def access_token(config: MyceliumConfig, handle: str | None = None) -> str | None:
+    """The bearer token an agent should send, or ``None`` when it has no credential.
+
+    Re-minted transparently once the cached one is close enough to expiry that it
+    could die in flight.
+    """
+    credential = resolve(config, handle)
+    if credential is None:
+        return None
+    if credential.token:
+        return credential.token
+
+    resolved_handle = credential.handle
+    return _cached_token(resolved_handle, credential) or _mint(resolved_handle, credential)
+
+
+def describe(config: MyceliumConfig, handle: str) -> dict[str, Any]:
+    """What credential an agent resolves to, for ``agent credential show``."""
+    credential = resolve(config, handle)
+    if credential is None:
+        return {"handle": normalize_handle(handle) or handle, "configured": False}
+    cached = None
+    if not credential.token:
+        from mycelium.tokens import load_token
+
+        stored = load_token(token_cache_path(credential.handle))
+        if stored is not None:
+            remaining = stored.expires_in()
+            cached = {
+                "expires_at": stored.expires_at,
+                "expires_in_s": None if remaining is None else max(0.0, round(remaining)),
+                "expired": stored.is_expired(),
+            }
+    return {"configured": True, **credential.redacted(), "cached_token": cached}

--- a/mycelium-cli/src/mycelium/client.py
+++ b/mycelium-cli/src/mycelium/client.py
@@ -20,8 +20,12 @@ first call that needs it. A refresh that fails degrades to "no header" rather
 than failing the command: against an ungated hub the call still works, and
 against a gated one the 401 says what a fabricated error never could.
 
-Agent credentials (#564) attach at this same seam — a different credential
-source, the same one factory.
+An agent attaches here too, through the same one factory: when the caller is
+acting as an agent — ``await``/``respond`` naming a handle, or a resident runtime
+that says which handle it runs as — the credential resolved for *that agent*
+(``mycelium.agent_credentials``) is preferred over the human session, so an
+agent's writes carry the agent's own identity rather than whoever last logged in
+on the machine.
 """
 
 from __future__ import annotations
@@ -122,19 +126,32 @@ def _refresh(stored: StoredToken, config: MyceliumConfig) -> StoredToken | None:
     return renewed
 
 
-def auth_headers(config: MyceliumConfig | None = None) -> dict[str, str]:
-    """``{"Authorization": "Bearer …"}`` when logged in, ``{}`` when not."""
-    token = current_token(config)
+def auth_headers(
+    config: MyceliumConfig | None = None, *, handle: str | None = None
+) -> dict[str, str]:
+    """``{"Authorization": "Bearer …"}`` when there's a credential, ``{}`` when not.
+
+    ``handle`` names the agent the call is being made *as*. Its own credential
+    wins over the human session when it has one: a resident agent driven from a
+    developer's logged-in shell must still write as itself, not as the developer.
+    """
+    from mycelium import agent_credentials
+
+    cfg = _resolve_config(config)
+    agent_token = agent_credentials.access_token(cfg, handle)
+    if agent_token:
+        return {"Authorization": f"Bearer {agent_token}"}
+    token = current_token(cfg)
     return {"Authorization": f"Bearer {token.access_token}"} if token else {}
 
 
-def typed_client(config: MyceliumConfig | None = None) -> Client:
-    """The generated OpenAPI client, authenticated when there's a session."""
+def typed_client(config: MyceliumConfig | None = None, *, handle: str | None = None) -> Client:
+    """The generated OpenAPI client, authenticated when there's a credential."""
     from mycelium_backend_client import Client
 
     cfg = _resolve_config(config)
     client = Client(base_url=cfg.server.api_url, raise_on_unexpected_status=True)
-    headers = auth_headers(cfg)
+    headers = auth_headers(cfg, handle=handle)
     return client.with_headers(headers) if headers else client
 
 
@@ -144,16 +161,17 @@ def hub_client(
     base_url: str | None = None,
     timeout: float | None = _DEFAULT_TIMEOUT_S,
     headers: dict[str, str] | None = None,
+    handle: str | None = None,
     **kwargs: Any,
 ) -> httpx.Client:
-    """A raw ``httpx`` client against the hub, authenticated when there's a session.
+    """A raw ``httpx`` client against the hub, authenticated when there's a credential.
 
     ``base_url`` overrides the configured hub — ``room clone`` reads from a
-    *remote* hub — and the session still applies, since the token is the caller's
-    identity rather than a property of one address.
+    *remote* hub — and the credential still applies, since the token is the
+    caller's identity rather than a property of one address.
     """
     cfg = _resolve_config(config)
-    merged = {**auth_headers(cfg), **(headers or {})}
+    merged = {**auth_headers(cfg, handle=handle), **(headers or {})}
     return httpx.Client(
         base_url=base_url or cfg.server.api_url,
         timeout=timeout,

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -396,6 +396,31 @@ def _persist_and_describe(
     )
     for line in impl.describe(manifest, room=room_name):
         console.print(line)
+    _prompt_for_credential(config, manifest)
+
+
+def _prompt_for_credential(config: MyceliumConfig, manifest: AgentManifest) -> None:
+    """Point at the credential step, but only where it means something.
+
+    A hub with its gate off needs no credential, and saying otherwise on every
+    ``agent create`` would make identity look mandatory when it is the opposite.
+    So this speaks only once an issuer is configured — i.e. once this machine has
+    somewhere to mint agent tokens from — and stays silent otherwise.
+    """
+    from mycelium import agent_credentials
+
+    if not config.agent_auth.issuer:
+        return
+    if agent_credentials.resolve(config, manifest.handle) is not None:
+        return
+    console.print(
+        f"\n[dim]@{manifest.handle} has no credential of its own yet — it would "
+        f"authenticate as whoever runs it.[/dim]"
+    )
+    console.print(
+        f"[dim]Give it one with: mycelium agent credential set {manifest.handle} "
+        f"--secret-stdin[/dim]"
+    )
 
 
 #: CLI label per adapter for the wizard's cwd prompt. ``cwd`` is optional now
@@ -991,6 +1016,240 @@ def agent_rm(
         console.print(f"[green]{verb}:[/green] @{handle} from {room_name}")
     except typer.Exit:
         raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None
+
+
+# ── credential ───────────────────────────────────────────────────────────────
+#
+# An agent's own credential, so its writes carry *its* identity rather than
+# whoever happens to be logged in on the machine it runs on. Client-side only:
+# nothing here is stored in the room, because a manifest is shared state and a
+# client secret is not. See `mycelium.agent_credentials`.
+
+credential_app = typer.Typer(
+    help=(
+        "Manage an agent's own credential — the service-account client it "
+        "authenticates to a gated hub as. Not needed while the hub's gate is off."
+    ),
+    no_args_is_help=True,
+)
+app.add_typer(credential_app, name="credential")
+
+
+@doc_ref(
+    usage="mycelium agent credential set <handle> [--client-id ID] [--secret-stdin] [--issuer URL]",
+    desc=(
+        "Give an agent its own service-account credential, stored 0600 outside "
+        "<code>config.toml</code>. Only meaningful once a hub enables auth."
+    ),
+    group="agent",
+)
+@credential_app.command("set")
+def credential_set(
+    ctx: typer.Context,
+    handle: str = typer.Argument(..., help="Agent handle the credential belongs to"),
+    client_id: str | None = typer.Option(
+        None, "--client-id", help="OAuth client id (default: the handle itself)."
+    ),
+    secret: str | None = typer.Option(
+        None, "--secret", help="Client secret. Prefer --secret-stdin; this lands in shell history."
+    ),
+    secret_stdin: bool = typer.Option(
+        False, "--secret-stdin", help="Read the client secret from stdin."
+    ),
+    issuer: str | None = typer.Option(
+        None, "--issuer", help="Issuer for this agent (default: agent_auth.issuer)."
+    ),
+    scopes: str | None = typer.Option(None, "--scopes", help="Scopes to request for this agent."),
+    audience: str | None = typer.Option(
+        None, "--audience", help="Audience to request; should match the hub's auth.audience."
+    ),
+) -> None:
+    """Record the credential an agent presents to a gated hub.
+
+    The token minted from it carries the agent's handle as its `sub`, which is
+    what the hub binds the agent's writes to. Each agent gets its own client, so
+    revoking one agent's credential leaves every other agent working.
+
+    Examples:
+        mycelium agent credential set release-agent --secret-stdin < secret.txt
+        mycelium agent credential set release-agent --client-id svc-release --secret-stdin
+    """
+    from mycelium import agent_credentials
+
+    try:
+        config = MyceliumConfig.load()
+        json_output = ctx.obj.get("json", False) if ctx.obj else False
+
+        if secret_stdin:
+            secret = sys.stdin.read().strip() or None
+        elif secret is None and sys.stdin.isatty():
+            secret = (
+                typer.prompt(
+                    "Client secret (blank if the issuer needs none)", default="", hide_input=True
+                )
+                or None
+            )
+
+        path = agent_credentials.save_credential(
+            handle,
+            client_id=client_id,
+            client_secret=secret,
+            issuer=issuer,
+            scopes=scopes,
+            audience=audience,
+        )
+        resolved = agent_credentials.describe(config, handle)
+
+        if json_output:
+            typer.echo(json_module.dumps({"stored": str(path), **resolved}, indent=2))
+            return
+
+        console.print(
+            f"[green]Credential stored[/green] for [cyan]@{resolved['handle']}[/cyan] "
+            f"[dim](client_id: {resolved['client_id']})[/dim]"
+        )
+        console.print(f"[dim]Saved to {path} (mode 0600).[/dim]")
+        if not resolved.get("issuer"):
+            console.print(
+                "\n[yellow]No issuer resolved[/yellow] — the credential can't be minted yet."
+            )
+            console.print("[dim]Set one with: mycelium config set agent_auth.issuer <url>[/dim]")
+    except typer.Exit:
+        raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None
+
+
+@doc_ref(
+    usage="mycelium agent credential show <handle>",
+    desc="Show which credential an agent resolves to. Never prints the secret.",
+    group="agent",
+)
+@credential_app.command("show")
+def credential_show(
+    ctx: typer.Context,
+    handle: str = typer.Argument(..., help="Agent handle"),
+) -> None:
+    """Report an agent's resolved credential and the state of its cached token."""
+    from mycelium import agent_credentials
+
+    try:
+        config = MyceliumConfig.load()
+        json_output = ctx.obj.get("json", False) if ctx.obj else False
+        resolved = agent_credentials.describe(config, handle)
+
+        if json_output:
+            typer.echo(json_module.dumps(resolved, indent=2))
+            return
+
+        if not resolved.get("configured"):
+            console.print(
+                f"[dim]@{resolved['handle']} has no credential — it sends no token "
+                f"(which is all an ungated hub needs).[/dim]"
+            )
+            return
+
+        table = Table(show_header=False, box=None)
+        table.add_row("handle", f"@{resolved['handle']}")
+        table.add_row("client_id", resolved["client_id"] or "—")
+        table.add_row("issuer", resolved["issuer"] or "[yellow]none[/yellow]")
+        table.add_row("audience", resolved["audience"] or "—")
+        table.add_row("scopes", resolved["scopes"] or "—")
+        table.add_row("secret", "set" if resolved["has_secret"] else "—")
+        if resolved["static_token"]:
+            table.add_row("token", f"supplied via {agent_credentials.STATIC_TOKEN_ENV}")
+        cached = resolved.get("cached_token")
+        if cached:
+            state = "expired" if cached["expired"] else f"{int(cached['expires_in_s'] or 0)}s left"
+            table.add_row("cached token", state)
+        console.print(table)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None
+
+
+@doc_ref(
+    usage="mycelium agent credential ls",
+    desc="List the agents on this machine that have their own credential.",
+    group="agent",
+)
+@credential_app.command("ls")
+def credential_ls(ctx: typer.Context) -> None:
+    """List stored per-agent credentials (never their secrets)."""
+    from mycelium import agent_credentials
+
+    try:
+        stored = agent_credentials.list_credentials()
+        json_output = ctx.obj.get("json", False) if ctx.obj else False
+
+        if json_output:
+            typer.echo(
+                json_module.dumps([c.redacted() for c in stored.values()], indent=2, sort_keys=True)
+            )
+            return
+
+        if not stored:
+            console.print("[dim]No agent credentials on this machine.[/dim]")
+            return
+
+        table = Table(title="Agent credentials")
+        table.add_column("handle", style="cyan")
+        table.add_column("client_id")
+        table.add_column("issuer")
+        table.add_column("secret")
+        for cred in sorted(stored.values(), key=lambda c: c.handle):
+            table.add_row(
+                f"@{cred.handle}",
+                cred.client_id,
+                cred.issuer or "[dim]agent_auth.issuer[/dim]",
+                "set" if cred.client_secret else "—",
+            )
+        console.print(table)
+    except Exception as e:
+        verbose = ctx.obj.get("verbose", False) if ctx.obj else False
+        print_error(e, verbose=verbose)
+        raise typer.Exit(1) from None
+
+
+@doc_ref(
+    usage="mycelium agent credential rm <handle>",
+    desc="Forget an agent's credential on this machine.",
+    group="agent",
+)
+@credential_app.command("rm")
+def credential_rm(
+    ctx: typer.Context,
+    handle: str = typer.Argument(..., help="Agent handle"),
+) -> None:
+    """Drop an agent's stored credential and any token minted from it.
+
+    This is local forgetting, not revocation: the client still exists at the
+    issuer until it is revoked there.
+    """
+    from mycelium import agent_credentials
+
+    try:
+        existed = agent_credentials.remove_credential(handle)
+        json_output = ctx.obj.get("json", False) if ctx.obj else False
+        if json_output:
+            typer.echo(json_module.dumps({"removed": existed}))
+            return
+        if existed:
+            console.print(f"[green]Removed[/green] the credential for @{handle}.")
+            console.print(
+                "[dim]Revoke the client at the issuer too — this only forgot it here.[/dim]"
+            )
+        else:
+            console.print(f"[dim]@{handle} had no credential here — nothing to do.[/dim]")
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False
         print_error(e, verbose=verbose)

--- a/mycelium-cli/src/mycelium/commands/participate.py
+++ b/mycelium-cli/src/mycelium/commands/participate.py
@@ -44,7 +44,7 @@ def _await_once(config: MyceliumConfig, room_name: str, handle: str, timeout: in
     # The server blocks up to `timeout`; give the client a little more headroom
     # (or no cap when waiting indefinitely).
     client_timeout = float(timeout) + 15.0 if timeout > 0 else None
-    with hub_client(config, timeout=client_timeout) as client:
+    with hub_client(config, timeout=client_timeout, handle=handle) as client:
         resp = client.get(path, params={"handle": handle, "timeout": timeout})
     resp.raise_for_status()
     data = resp.json()
@@ -228,7 +228,7 @@ def respond(
     try:
         config = MyceliumConfig.load()
         room_name = _resolve_room(config, room)
-        with hub_client(config, timeout=30.0) as client:
+        with hub_client(config, timeout=30.0, handle=handle) as client:
             resp = client.post(
                 f"/api/rooms/{room_name}/reply", json={"handle": handle, "text": text}
             )

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -269,6 +269,42 @@ class LoginConfig(BaseModel):
         return v.rstrip("/") if isinstance(v, str) else v
 
 
+class AgentAuthConfig(BaseModel):
+    """Where an *agent* gets its own token — the workload half of the client side.
+
+    An agent is not a human: no browser, no consent screen, and nobody to run
+    ``mycelium login`` on its behalf. Its credential is its own OIDC client
+    (``client_credentials``), so the token's ``sub`` is the client id, which is
+    the agent's handle — the same handle the hub binds its writes to.
+
+    This section holds only what is *shared* by every agent on the machine (the
+    issuer and the audience to ask for). The per-agent half — which client id an
+    agent is, and its secret — is a secret, so it lives in the ``0600`` store
+    behind ``mycelium agent credential set``, never in ``config.toml``.
+
+    Unset ``issuer`` means "no agent credentials configured", which is the
+    default: agents send no token, exactly as before.
+    """
+
+    issuer: str | None = Field(
+        default=None,
+        description="OIDC issuer agents mint their service-account tokens from. Unset (default) means agents send no token.",
+    )
+    scopes: str | None = Field(
+        default=None,
+        description="Space-separated scopes to request for an agent token. Unset sends none, which is what most issuers want for client_credentials.",
+    )
+    audience: str | None = Field(
+        default=None,
+        description="Audience to request for agent tokens; should match the hub's auth.audience.",
+    )
+
+    @field_validator("issuer")
+    @classmethod
+    def _strip_trailing_slash(cls, v: str | None) -> str | None:
+        return v.rstrip("/") if isinstance(v, str) else v
+
+
 class RuntimeConfig(BaseModel):
     """Docker runtime / environment configuration."""
 
@@ -373,6 +409,7 @@ class MyceliumConfig(BaseModel):
     engine: EngineConfig = Field(default_factory=EngineConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
     login: LoginConfig = Field(default_factory=LoginConfig)
+    agent_auth: AgentAuthConfig = Field(default_factory=AgentAuthConfig)
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     rooms: RoomConfig = Field(default_factory=RoomConfig)
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
@@ -484,6 +521,7 @@ class MyceliumConfig(BaseModel):
             "llm": {},
             "engine": {},
             "login": {},
+            "agent_auth": {},
             "runtime": {},
             "metrics": {},
         }
@@ -518,6 +556,16 @@ class MyceliumConfig(BaseModel):
             env_config["login"]["audience"] = login_audience
         if login_scopes := os.getenv("MYCELIUM_LOGIN_SCOPES"):
             env_config["login"]["scopes"] = login_scopes
+
+        # Agent (service-account) overrides — how a container hands its agent an
+        # issuer without a config file. The per-agent client id and secret are
+        # secrets and stay out of config; see `mycelium.agent_credentials`.
+        if agent_issuer := os.getenv("MYCELIUM_AGENT_AUTH_ISSUER"):
+            env_config["agent_auth"]["issuer"] = agent_issuer
+        if agent_scopes := os.getenv("MYCELIUM_AGENT_AUTH_SCOPES"):
+            env_config["agent_auth"]["scopes"] = agent_scopes
+        if agent_audience := os.getenv("MYCELIUM_AGENT_AUTH_AUDIENCE"):
+            env_config["agent_auth"]["audience"] = agent_audience
 
         # Metrics overrides
         if collector_url := os.getenv("MYCELIUM_COLLECTOR_URL"):

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -152,6 +152,77 @@ secret. Register it at your issuer as a public client with
 `http://127.0.0.1:*/callback` as an allowed redirect, and enable the device grant
 if you want `--device` to work.
 
+## Agents sign in as themselves
+
+`mycelium login` is for a human. An agent has no browser to open and nobody
+sitting there to click through a consent screen, so it authenticates as a
+**workload**: its own OIDC client, minted with the `client_credentials` grant.
+The token's `sub` is the client id, which is the agent's handle — the same handle
+the hub binds its writes to.
+
+That is the property a shared secret can't give you: each agent holds a different
+credential, so **revoking one agent's client leaves every other agent working**.
+
+Point the machine at the issuer agents mint from, then give each agent its own
+client:
+
+```bash
+mycelium config set agent_auth.issuer https://sso.example.com/realms/agents
+mycelium config set agent_auth.audience mycelium     # match the hub's auth.audience
+mycelium config apply
+
+mycelium agent credential set release-agent --secret-stdin < secret.txt
+```
+
+The client id defaults to the handle; pass `--client-id` when your issuer names
+it differently. `mycelium agent credential show release-agent` reports what an
+agent resolves to (never its secret), `... ls` lists every agent on the machine,
+and `... rm` forgets one locally — revoke the client at your issuer to actually
+kill it.
+
+From then on, `mycelium await --room R --handle release-agent` and
+`mycelium respond --handle release-agent` carry **that agent's** token, including
+when they run from a shell where a human is logged in — a resident agent writes as
+itself, not as whoever started it.
+
+### Off by default here too
+
+An agent with no credential sends no token, exactly as before. Configuring
+`agent_auth.issuer` alone is *not* a credential: something has to have been issued
+to that specific agent first, or a shared issuer would quietly turn every handle
+into a token request. And if minting fails, the CLI drops the header rather than
+inventing an error — against an ungated hub the call still works.
+
+### Where the credential lives
+
+In `~/.mycelium/agent-credentials.json`, mode `0600`, alongside a cached token per
+agent under `~/.mycelium/agent-tokens/`. Client secrets are secrets, so they stay
+out of `config.toml` for the same reason your session does. `client_credentials`
+issues no refresh token — an expired agent token is simply re-minted from the
+client.
+
+For a container that runs exactly one agent and has no config file,
+`MYCELIUM_AGENT_AUTH_ISSUER`, `MYCELIUM_AGENT_AUTH_CLIENT_ID`,
+`MYCELIUM_AGENT_AUTH_CLIENT_SECRET`, `MYCELIUM_AGENT_AUTH_SCOPES` and
+`MYCELIUM_AGENT_AUTH_AUDIENCE` say the same thing in environment variables, and
+`MYCELIUM_AGENT_HANDLE` names the agent it is running as.
+
+### A credential Mycelium didn't mint
+
+`MYCELIUM_AGENT_AUTH_TOKEN` supplies a bearer token directly, used as-is and never
+renewed here. That is the seam for a token minted elsewhere — a CI job, or a JWT
+issued by a workload-identity system such as SPIRE. Trusting one is a config
+entry on the hub side too: another `[[auth.issuers]]` block with `role = "agent"`.
+Nothing about it is required, and nothing about it is on by default.
+
+### Configuration
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `agent_auth.issuer` | *(unset)* | Issuer agents mint service-account tokens from. Unset means agents send no token. |
+| `agent_auth.scopes` | *(unset)* | Scopes requested for an agent token. Most issuers want none for `client_credentials`. |
+| `agent_auth.audience` | *(unset)* | Audience to request; should match the hub's `auth.audience`. |
+
 ## Issuer-agnostic by design
 
 The backend trusts a configured issuer and its JWKS. It has no idea whether that

--- a/mycelium-cli/src/mycelium/oidc.py
+++ b/mycelium-cli/src/mycelium/oidc.py
@@ -361,6 +361,29 @@ def device_code_login(
     raise OidcError(f"timed out after {limit:.0f}s waiting for you to approve the device code")
 
 
+def client_credentials_grant(
+    token_endpoint: str,
+    client_id: str,
+    client_secret: str | None,
+    *,
+    scope: str | None = None,
+    audience: str | None = None,
+) -> TokenResponse:
+    """Mint a token for a workload's own OIDC client (RFC 6749 §4.4).
+
+    The agent path: no human, no browser, no refresh token — the client *is* the
+    identity, so an expired token is re-minted rather than renewed.
+    """
+    form = {"grant_type": "client_credentials", "client_id": client_id}
+    if client_secret:
+        form["client_secret"] = client_secret
+    if scope:
+        form["scope"] = scope
+    if audience:
+        form["audience"] = audience
+    return _as_token_response(_token_request(token_endpoint, form))
+
+
 def refresh_grant(
     token_endpoint: str,
     client_id: str,

--- a/mycelium-cli/src/mycelium/tokens.py
+++ b/mycelium-cli/src/mycelium/tokens.py
@@ -131,14 +131,17 @@ class StoredToken:
         )
 
 
-def load_token() -> StoredToken | None:
+def load_token(path: Path | None = None) -> StoredToken | None:
     """The cached session, or ``None`` when logged out.
 
     A corrupt cache reads as logged out rather than raising: every command in the
     CLI consults this, and none of them should die because a token file got
     truncated.
+
+    ``path`` selects a cache other than the human session's — an agent's minted
+    token lives in its own file (``mycelium.agent_credentials``).
     """
-    path = token_path()
+    path = path or token_path()
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
@@ -148,9 +151,9 @@ def load_token() -> StoredToken | None:
     return StoredToken.from_dict(data)
 
 
-def save_token(token: StoredToken) -> Path:
+def save_token(token: StoredToken, path: Path | None = None) -> Path:
     """Write the session to the cache, owner-readable only."""
-    path = token_path()
+    path = path or token_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     # os.open with 0600 rather than write_text + chmod: the file must never
     # exist, even momentarily, with the default mode.
@@ -163,9 +166,9 @@ def save_token(token: StoredToken) -> Path:
     return path
 
 
-def clear_token() -> bool:
+def clear_token(path: Path | None = None) -> bool:
     """Delete the cached session. Returns whether there was one."""
-    path = token_path()
+    path = path or token_path()
     try:
         path.unlink()
     except FileNotFoundError:

--- a/mycelium-cli/tests/test_agent_credentials.py
+++ b/mycelium-cli/tests/test_agent_credentials.py
@@ -1,0 +1,414 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Per-agent credentials — the store, the mint, and the seam they attach at.
+
+Four slices, matching what can quietly go wrong when an agent carries its own
+identity:
+
+* **the store** — owner-only, round-trips, and reads as "no credential" rather
+  than raising when it's damaged;
+* **resolution** — env beats store beats config defaults, a shared issuer alone
+  is not a credential, and an unknown handle resolves to nothing;
+* **the mint** — ``client_credentials`` against the issuer, cached until it is
+  near expiry, re-minted after, and never reused across a changed client;
+* **the seam** — a client built for an agent carries *that agent's* token even
+  when a human session is cached, and carries nothing when neither exists.
+
+No issuer and no backend run here: ``oidc`` is stubbed at the module the code
+under test calls into.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from mycelium import agent_credentials, oidc, tokens
+from mycelium.cli import app
+from mycelium.config import MyceliumConfig
+from mycelium.oidc import OidcError, ProviderMetadata, TokenResponse
+from mycelium.tokens import StoredToken, save_token
+
+runner = CliRunner()
+
+_META = ProviderMetadata(
+    issuer="https://idp.test/agents",
+    token_endpoint="https://idp.test/agents/token",
+)
+
+_ENV_VARS = (
+    agent_credentials.CREDENTIAL_STORE_ENV,
+    agent_credentials.AGENT_HANDLE_ENV,
+    agent_credentials.STATIC_TOKEN_ENV,
+    agent_credentials.CLIENT_ID_ENV,
+    agent_credentials.CLIENT_SECRET_ENV,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep every test off the developer's real ``~/.mycelium`` and caches."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv(tokens.TOKEN_FILE_ENV, str(tmp_path / "token.json"))
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv(agent_credentials.CREDENTIAL_STORE_ENV, str(tmp_path / "agent-creds.json"))
+    # The "say it once" latch is process-wide; a warning from one test must not
+    # silence the next.
+    agent_credentials._warned.clear()
+
+
+def _config(issuer: str | None = _META.issuer, **kwargs: Any) -> MyceliumConfig:
+    config = MyceliumConfig()
+    config.agent_auth.issuer = issuer
+    for key, value in kwargs.items():
+        setattr(config.agent_auth, key, value)
+    return config
+
+
+class _Mint:
+    """A stand-in issuer that records what it was asked for."""
+
+    def __init__(self, *, expires_in: float | None = 3600.0) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.expires_in = expires_in
+
+    def discover(self, issuer: str, **_: Any) -> ProviderMetadata:
+        return ProviderMetadata(issuer=issuer, token_endpoint=f"{issuer}/token")
+
+    def grant(
+        self,
+        token_endpoint: str,
+        client_id: str,
+        client_secret: str | None,
+        *,
+        scope: str | None = None,
+        audience: str | None = None,
+    ) -> TokenResponse:
+        self.calls.append(
+            {
+                "token_endpoint": token_endpoint,
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "scope": scope,
+                "audience": audience,
+            }
+        )
+        return TokenResponse(
+            access_token=f"token-for-{client_id}-{len(self.calls)}",
+            expires_at=None if self.expires_in is None else time.time() + self.expires_in,
+            scope=scope,
+        )
+
+
+@pytest.fixture
+def mint(monkeypatch: pytest.MonkeyPatch) -> _Mint:
+    stub = _Mint()
+    monkeypatch.setattr(oidc, "discover", stub.discover)
+    monkeypatch.setattr(oidc, "client_credentials_grant", stub.grant)
+    return stub
+
+
+# ── the store ────────────────────────────────────────────────────────────────
+
+
+def test_store_is_owner_only_and_round_trips() -> None:
+    path = agent_credentials.save_credential("release-agent", client_secret="s3cret")
+
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    stored = agent_credentials.list_credentials()["release-agent"]
+    assert stored.client_id == "release-agent"
+    assert stored.client_secret == "s3cret"
+
+
+def test_credential_defaults_its_client_id_to_the_handle() -> None:
+    agent_credentials.save_credential("@Release-Agent", client_secret="s3cret")
+
+    stored = agent_credentials.list_credentials()
+    assert "release-agent" in stored
+    assert stored["release-agent"].client_id == "release-agent"
+
+
+def test_damaged_store_reads_as_no_credentials() -> None:
+    agent_credentials.store_path().write_text("{not json", encoding="utf-8")
+
+    assert agent_credentials.list_credentials() == {}
+    assert agent_credentials.resolve(_config(), "release-agent") is None
+
+
+def test_removing_a_credential_reports_whether_there_was_one() -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+
+    assert agent_credentials.remove_credential("release-agent") is True
+    assert agent_credentials.remove_credential("release-agent") is False
+
+
+# ── resolution ───────────────────────────────────────────────────────────────
+
+
+def test_no_credential_resolves_to_none() -> None:
+    """The default: nothing configured, so nothing is sent."""
+    assert agent_credentials.resolve(_config(), "release-agent") is None
+
+
+def test_a_shared_issuer_alone_is_not_a_credential() -> None:
+    """Configuring an issuer must not turn every handle into a token request."""
+    assert agent_credentials.resolve(_config(issuer="https://idp.test/agents"), "nobody") is None
+
+
+def test_stored_credential_inherits_the_configured_issuer() -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+
+    resolved = agent_credentials.resolve(_config(audience="mycelium"), "release-agent")
+
+    assert resolved is not None
+    assert resolved.issuer == _META.issuer
+    assert resolved.audience == "mycelium"
+
+
+def test_per_agent_issuer_overrides_the_shared_one() -> None:
+    agent_credentials.save_credential(
+        "release-agent", client_secret="s3cret", issuer="https://other.test/realm"
+    )
+
+    resolved = agent_credentials.resolve(_config(), "release-agent")
+
+    assert resolved is not None
+    assert resolved.issuer == "https://other.test/realm"
+
+
+def test_environment_credential_needs_no_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A container running one agent has no config file to write into."""
+    monkeypatch.setenv(agent_credentials.CLIENT_ID_ENV, "svc-release")
+    monkeypatch.setenv(agent_credentials.CLIENT_SECRET_ENV, "from-env")
+
+    resolved = agent_credentials.resolve(_config(), "release-agent")
+
+    assert resolved is not None
+    assert resolved.client_id == "svc-release"
+    assert resolved.client_secret == "from-env"
+
+
+def test_session_qualifier_resolves_to_the_same_agent() -> None:
+    """``alpha#a8f3`` is one agent in two sessions, not two identities."""
+    agent_credentials.save_credential("alpha", client_secret="s3cret")
+
+    resolved = agent_credentials.resolve(_config(), "alpha#a8f3")
+
+    assert resolved is not None
+    assert resolved.handle == "alpha"
+
+
+def test_ambient_handle_names_the_agent_when_the_caller_does_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+    monkeypatch.setenv(agent_credentials.AGENT_HANDLE_ENV, "release-agent")
+
+    assert agent_credentials.resolve(_config(), None) is not None
+
+
+# ── the mint ─────────────────────────────────────────────────────────────────
+
+
+def test_token_is_minted_with_client_credentials(mint: _Mint) -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+    config = _config(scopes="openid", audience="mycelium")
+
+    token = agent_credentials.access_token(config, "release-agent")
+
+    assert token == "token-for-release-agent-1"
+    assert mint.calls == [
+        {
+            "token_endpoint": f"{_META.issuer}/token",
+            "client_id": "release-agent",
+            "client_secret": "s3cret",
+            "scope": "openid",
+            "audience": "mycelium",
+        }
+    ]
+
+
+def test_a_live_token_is_reused_rather_than_reminted(mint: _Mint) -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+    config = _config()
+
+    first = agent_credentials.access_token(config, "release-agent")
+    second = agent_credentials.access_token(config, "release-agent")
+
+    assert first == second
+    assert len(mint.calls) == 1
+
+
+def test_an_expiring_token_is_reminted(mint: _Mint) -> None:
+    """Expiry is judged with leeway, so a token can't die in flight."""
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+    config = _config()
+    save_token(
+        StoredToken(
+            access_token="nearly-dead",
+            issuer=_META.issuer,
+            client_id="release-agent",
+            expires_at=time.time() + 5.0,
+        ),
+        agent_credentials.token_cache_path("release-agent"),
+    )
+
+    assert agent_credentials.access_token(config, "release-agent") == "token-for-release-agent-1"
+
+
+def test_a_token_minted_for_a_different_client_is_not_reused(mint: _Mint) -> None:
+    """Re-pointing a credential must not keep presenting the old client's token."""
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+    save_token(
+        StoredToken(
+            access_token="old-client-token",
+            issuer=_META.issuer,
+            client_id="some-other-client",
+            expires_at=time.time() + 3600.0,
+        ),
+        agent_credentials.token_cache_path("release-agent"),
+    )
+
+    assert agent_credentials.access_token(_config(), "release-agent") == "token-for-release-agent-1"
+
+
+def test_replacing_a_credential_drops_the_token_it_minted(mint: _Mint) -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+    agent_credentials.access_token(_config(), "release-agent")
+
+    agent_credentials.save_credential("release-agent", client_secret="rotated")
+    agent_credentials.access_token(_config(), "release-agent")
+
+    assert [c["client_secret"] for c in mint.calls] == ["s3cret", "rotated"]
+
+
+def test_a_static_token_is_used_as_is(mint: _Mint, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SPIRE / CI seam: a credential this CLI didn't obtain and doesn't renew."""
+    monkeypatch.setenv(agent_credentials.STATIC_TOKEN_ENV, "svid-from-sidecar")
+
+    assert agent_credentials.access_token(_config(), "release-agent") == "svid-from-sidecar"
+    assert mint.calls == []
+
+
+def test_a_failed_mint_degrades_to_no_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A dead issuer must not fabricate a failure the hub never reported."""
+
+    def _boom(*_: Any, **__: Any) -> ProviderMetadata:
+        raise OidcError("issuer unreachable")
+
+    monkeypatch.setattr(oidc, "discover", _boom)
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+
+    assert agent_credentials.access_token(_config(), "release-agent") is None
+
+
+def test_a_credential_with_no_issuer_mints_nothing(mint: _Mint) -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+
+    assert agent_credentials.access_token(_config(issuer=None), "release-agent") is None
+    assert mint.calls == []
+
+
+def test_the_minted_token_cache_is_owner_only(mint: _Mint) -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+    agent_credentials.access_token(_config(), "release-agent")
+
+    path = agent_credentials.token_cache_path("release-agent")
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+# ── the seam ─────────────────────────────────────────────────────────────────
+
+
+def test_a_client_for_an_agent_carries_that_agents_token(mint: _Mint) -> None:
+    from mycelium import client as client_mod
+
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+
+    headers = client_mod.auth_headers(_config(), handle="release-agent")
+
+    assert headers == {"Authorization": "Bearer token-for-release-agent-1"}
+
+
+def test_an_agents_credential_wins_over_a_human_session(mint: _Mint) -> None:
+    """A resident agent driven from a logged-in shell still writes as itself."""
+    from mycelium import client as client_mod
+
+    save_token(StoredToken(access_token="human-token", issuer="https://idp.test", client_id="cli"))
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+
+    headers = client_mod.auth_headers(_config(), handle="release-agent")
+
+    assert headers == {"Authorization": "Bearer token-for-release-agent-1"}
+
+
+def test_an_agent_without_a_credential_falls_back_to_the_human_session(mint: _Mint) -> None:
+    from mycelium import client as client_mod
+
+    save_token(StoredToken(access_token="human-token", issuer="https://idp.test", client_id="cli"))
+
+    headers = client_mod.auth_headers(_config(), handle="release-agent")
+
+    assert headers == {"Authorization": "Bearer human-token"}
+
+
+def test_no_credential_and_no_session_sends_nothing(mint: _Mint) -> None:
+    """The off-by-default promise: identity changes nothing until it's configured."""
+    from mycelium import client as client_mod
+
+    assert client_mod.auth_headers(_config(), handle="release-agent") == {}
+
+
+# ── the commands ─────────────────────────────────────────────────────────────
+
+
+def test_credential_set_stores_and_show_never_prints_the_secret() -> None:
+    result = runner.invoke(
+        app,
+        ["agent", "credential", "set", "release-agent", "--secret-stdin"],
+        input="s3cret",
+    )
+    assert result.exit_code == 0, result.output
+    assert "s3cret" not in result.output
+
+    shown = runner.invoke(app, ["agent", "credential", "show", "release-agent"])
+    assert shown.exit_code == 0, shown.output
+    assert "s3cret" not in shown.output
+    assert "release-agent" in shown.output
+
+
+def test_credential_show_reports_an_unconfigured_agent() -> None:
+    result = runner.invoke(app, ["agent", "credential", "show", "release-agent"])
+
+    assert result.exit_code == 0, result.output
+    assert "no credential" in result.output
+
+
+def test_credential_ls_lists_stored_agents() -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+    agent_credentials.save_credential("docs-agent", client_secret="other")
+
+    result = runner.invoke(app, ["agent", "credential", "ls"])
+
+    assert result.exit_code == 0, result.output
+    assert "release-agent" in result.output
+    assert "docs-agent" in result.output
+    assert "s3cret" not in result.output
+
+
+def test_credential_rm_forgets_the_credential() -> None:
+    agent_credentials.save_credential("release-agent", client_secret="s3cret")
+
+    result = runner.invoke(app, ["--json", "agent", "credential", "rm", "release-agent"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["removed"] is True
+    assert agent_credentials.list_credentials() == {}


### PR DESCRIPTION
## Summary

Gives each agent its **own** verified identity, the default path from #564: an OIDC **service-account** (`client_credentials`) token whose `sub` is the client id — which is the agent's handle, the same handle the hub already binds writes to (#562).

An agent can't run `mycelium login`: no browser to open, nobody to click a consent screen. So it authenticates as a *workload*. The property this buys is the one the D1 shared PSK never had: each agent holds a different credential, so **revoking one agent's client leaves every other agent working**.

The hub side needed no change — the gate (#561) is already issuer-agnostic, and `test_auth_gate.py` already covers an `role = "agent"` issuer, two-root separation, and token-as-author. This is the CLI/agent half.

**Off by default at every layer.** No credential → no header → today's behavior. A configured issuer *alone* is deliberately not a credential: something has to have been issued to that specific agent, or a shared issuer would quietly turn every handle into a token request. A mint that fails drops the header rather than inventing an error — an ungated hub keeps working, a gated one answers with its own 401.

## Changes

- **`agent_credentials.py`** (new) — resolution + minting + the `0600` credential store (`~/.mycelium/agent-credentials.json`), with a cached token per agent under `~/.mycelium/agent-tokens/`. Three sources, most specific first: a pre-minted token (`MYCELIUM_AGENT_AUTH_TOKEN`), the environment (`MYCELIUM_AGENT_AUTH_CLIENT_ID` / `…_CLIENT_SECRET`, for a container with no config file), then the store.
- **`client.py`** — the credential attaches at the *one* factory from #563, not beside it. `hub_client`/`typed_client`/`auth_headers` take a `handle` naming the agent a call is made as; that agent's credential wins over the human session, so a resident agent driven from a logged-in shell still writes as itself.
- **`commands/participate.py`** — `await` and `respond` pass their `--handle`, so the resident loop presents the agent's token.
- **`oidc.py`** — `client_credentials_grant()`. No refresh token by design: an expired agent token is re-minted from the client.
- **`commands/agent.py`** — `mycelium agent credential set|show|ls|rm`. `set` prefers `--secret-stdin` over a flag that would land in shell history; `show`/`ls` never print a secret. `agent create` points at the credential step only once an issuer is configured, so identity never *looks* mandatory on the try-it path.
- **`config.py`** — `[agent_auth]` (issuer / scopes / audience) mirroring `[login]`, with `MYCELIUM_AGENT_AUTH_*` overrides. Only the non-secret, machine-wide half lives here; client secrets stay out of `config.toml` for the same reason the human session does.
- **`tokens.py`** — `load_token` / `save_token` / `clear_token` take an optional path, so an agent's mint reuses the same `0600` cache rather than a second copy of it.
- **Docs** — an "Agents sign in as themselves" section in the auth guide; regenerated `docs/reference.html` + `llms-full.txt`.

### SPIRE stays optional, as #567 requires

Nothing here knows about SPIRE. `MYCELIUM_AGENT_AUTH_TOKEN` takes a bearer token minted elsewhere as-is and never renews it — a sidecar-written JWT-SVID slots in there, and trusting it is one more `[[auth.issuers]]` block with `role = "agent"` on the hub. No server, no agent, no attestation weight on the default path.

## Testing

- `mycelium-cli/tests/test_agent_credentials.py` (28 tests): the store (owner-only, round-trip, damaged-reads-as-empty), resolution (env > store > config; a shared issuer alone is not a credential; session qualifiers resolve to the same agent), the mint (`client_credentials` args, cache reuse, re-mint near expiry, never reusing a token minted for a different client, failure degrading to no token), the seam (an agent's token beats a cached human session; nothing sent when neither exists), and the commands.
- Full CLI suite: 372 passed.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)

Not run here: a live round-trip against the #566 dev issuer (no Docker in this session). The path it exercises is the same `client_credentials` → `sub: <client_id>` shape that issue already verified end-to-end against the gate.

## Related Issues

Part of #560. Implements the default (OIDC service-account) path of #564; leaves the SPIRE upgrade as the opt-in seam described above. Unblocks #571 (`await` queue authorization now has a per-agent identity to authorize against). Depends on #561 / #562 / #563, all merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WSpcWJzDVE1e5gTZKTCQQC)_