### PR TITLE
feat(auth): authorize the await/presence handle (#571)

### DIFF
--- a/docs/design/identity-and-auth.md
+++ b/docs/design/identity-and-auth.md
@@ -128,7 +128,7 @@ per-deployment opt-in.
    and engine-registration write paths. A body handle carrying a session
    qualifier (`alice#a8f3`) is honoured as the same principal; the reader side —
    which handle's queue an `await` may drain — is authorization rather than
-   attribution and stays with the RBAC step.*
+   attribution and landed separately once agents had identities (step 5).*
 3. **CLI human login** — `mycelium login` obtains a token (Authorization Code +
    PKCE, or device-code for headless), stores + refreshes it; `mycelium iam`
    becomes "who am I per the token," not self-assert. *Landed (#563):
@@ -140,11 +140,21 @@ per-deployment opt-in.
    what it was.*
 4. **Agent identity issuance** — per-agent **OIDC service-account** credentials by
    default; **SPIRE JWT-SVID as an optional upgrade** where workload attestation is
-   wanted.
-5. **SLIM channel identity** — *optionally* move the MLS group off the dev PSK to
+   wanted. *Landed (#564): `mycelium agent credential set …` mints a
+   `client_credentials` token per agent through the same client factory as the human
+   session, so a resident agent writes as itself rather than as whoever started it.*
+5. **Handle authorization (read + presence)** — bind the handle an `await` drains
+   and the handle a join registers, not just the actor of a write. *Landed (#571):
+   `fastapi-backend/app/services/actor.py:authorize_handle`, applied at
+   `GET /rooms/{room}/await` and `POST /rooms/{room}/sessions`. A principal may act
+   as its own handle, or one whose manifest grants it (`owner` / `allow_from`) —
+   which is what turns "await on behalf of" from universal into explicit. Needed
+   step 4 first: before agents had tokens, enforcing it would have broken the
+   resident loop, which is why #562 deferred it.*
+6. **SLIM channel identity** — *optionally* move the MLS group off the dev PSK to
    per-member JWT/SPIRE (#476); the PSK remains the default. Deeper; partly gated on
    slim-bindings wiring.
-6. **Reference IdP wiring** — an optional Keycloak compose profile + an optional
+7. **Reference IdP wiring** — an optional Keycloak compose profile + an optional
    SPIRE quickstart, with issuer-agnostic config documented.
 
 ## Non-goals
@@ -156,7 +166,9 @@ per-deployment opt-in.
   must never land on someone just trying the app.
 - **Baking Keycloak in as a hard dependency.** It is a supported issuer only.
 - **Authorization / RBAC beyond identity + role.** Fine-grained per-room
-  permissions are a later layer; this doc is authentication + attribution.
+  permissions are a later layer; this doc is authentication + attribution, plus the
+  one narrow authorization question attribution can't answer on its own — *may this
+  principal act as that handle* (step 5).
 
 ## Open questions
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1767,6 +1767,40 @@ request body supplies:
 With the gate off there is no principal, so every path keeps the self-asserted
 actor from the body exactly as before — the try-it path is unchanged.
 
+## Acting as another handle
+
+Attribution answers *who wrote this*. Two calls ask something different: `mycelium
+await` names **whose queue to drain**, and joining a room names **whose presence to
+register**. Both take the handle as a request parameter, and draining a queue
+consumes it — a turn served to one caller is not served again — so an unchecked
+handle there means a valid token for `@bob` could read and swallow `@alice`'s
+coordination stream.
+
+A gated hub allows the call when either is true:
+
+- the handle **is** the token's own (a session qualifier like `alice#a8f3` still names alice), or
+- the handle's agent manifest **grants** the token's principal — its `owner`, or an entry in its `allow_from`.
+
+Anything else is a **403**. Grants are per-room, because manifests are: owning
+`@bot` in one room says nothing about a `@bot` in another.
+
+The grant is what makes "await on behalf of" explicit rather than universal. An
+agent running with its own credential needs nothing — it awaits itself. A human
+driving an agent's loop from their own session does:
+
+```bash
+mycelium agent create bot --owner alice          # alice may now await --handle bot
+mycelium agent create bot --allow-from ops-lead  # …and so may @ops-lead
+```
+
+A resident loop (`mycelium await --loop`) **stops** on a 401 or 403 rather than
+retrying: a refused identity is not a blip, and re-polling it would flood the hub
+for as long as the loop ran.
+
+With the gate off nothing is checked here either, so an ungated hub still lets any
+caller await any handle — which is also why a hub reachable beyond your machine
+wants the gate on.
+
 ## Key rotation
 
 The JWKS is fetched from your issuer and cached for `auth.jwks_ttl_s`. When a
@@ -1808,7 +1842,7 @@ Every other route requires a token.
 | Response | Meaning |
 |----------|---------|
 | `401` + `WWW-Authenticate: Bearer` | Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token. |
-| `403` | A valid token, but the request body claims to act as a different handle. |
+| `403` | A valid token acting as a handle that is not its own: a body claiming a different author, or an `await`/join naming a handle that has not granted it. |
 | `503` | The gate is on but unusable — no trusted issuers configured, or the issuer's JWKS is unreachable and nothing is cached. |
 
 Only asymmetric signatures are accepted (`RS*`, `PS*`, `ES*`). The `none`

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1323,6 +1323,19 @@ role   = &quot;agent&quot;</code></pre>
       </ul>
       <p>as-is. The suffix rides along on the token&#x27;s handle, so per-session attribution survives without letting the suffix name someone else.</p>
       <p>With the gate off there is no principal, so every path keeps the self-asserted actor from the body exactly as before — the try-it path is unchanged.</p>
+      <h2 id="auth-acting-as-another-handle">Acting as another handle</h2>
+      <p>Attribution answers <em>who wrote this</em>. Two calls ask something different: <code>mycelium await</code> names <strong>whose queue to drain</strong>, and joining a room names <strong>whose presence to register</strong>. Both take the handle as a request parameter, and draining a queue consumes it — a turn served to one caller is not served again — so an unchecked handle there means a valid token for <code>@bob</code> could read and swallow <code>@alice</code>&#x27;s coordination stream.</p>
+      <p>A gated hub allows the call when either is true:</p>
+      <ul>
+        <li>the handle <strong>is</strong> the token&#x27;s own (a session qualifier like <code>alice#a8f3</code> still names alice), or</li>
+        <li>the handle&#x27;s agent manifest <strong>grants</strong> the token&#x27;s principal — its <code>owner</code>, or an entry in its <code>allow_from</code>.</li>
+      </ul>
+      <p>Anything else is a <strong>403</strong>. Grants are per-room, because manifests are: owning <code>@bot</code> in one room says nothing about a <code>@bot</code> in another.</p>
+      <p>The grant is what makes &quot;await on behalf of&quot; explicit rather than universal. An agent running with its own credential needs nothing — it awaits itself. A human driving an agent&#x27;s loop from their own session does:</p>
+      <pre><code><span class="cmd">mycelium agent create</span> bot <span class="flag">--owner</span> alice          # alice may now await <span class="flag">--handle</span> bot
+<span class="cmd">mycelium agent create</span> bot <span class="flag">--allow-from</span> ops-lead  # …and so may @ops-lead</code></pre>
+      <p>A resident loop (<code>mycelium await --loop</code>) <strong>stops</strong> on a 401 or 403 rather than retrying: a refused identity is not a blip, and re-polling it would flood the hub for as long as the loop ran.</p>
+      <p>With the gate off nothing is checked here either, so an ungated hub still lets any caller await any handle — which is also why a hub reachable beyond your machine wants the gate on.</p>
       <h2 id="auth-key-rotation">Key rotation</h2>
       <p>The JWKS is fetched from your issuer and cached for <code>auth.jwks_ttl_s</code>. When a token arrives signed by a key ID the backend hasn&#x27;t seen, it re-fetches immediately (rate-limited), so <strong>rotating your signing key does not require restarting Mycelium</strong>.</p>
       <p>If the issuer is briefly unreachable, previously fetched keys keep serving. The keys are still your issuer&#x27;s; only their freshness is in doubt, and failing closed would take the hub down for the length of an IdP blip.</p>
@@ -1356,7 +1369,7 @@ role   = &quot;agent&quot;</code></pre>
             </tr>
             <tr>
               <td><code>403</code></td>
-              <td>A valid token, but the request body claims to act as a different handle.</td>
+              <td>A valid token acting as a handle that is not its own: a body claiming a different author, or an <code>await</code>/join naming a handle that has not granted it.</td>
             </tr>
             <tr>
               <td><code>503</code></td>

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -143,10 +143,14 @@ def _describe(room: str, handle: str, record: Any) -> dict[str, Any]:
 
 
 @router.get("/await")
-async def await_message(room_name: str, handle: str, timeout: int = 0):
+async def await_message(room_name: str, request: Request, handle: str, timeout: int = 0):
     """Long-poll for the next message addressed to ``handle`` (server-held member)."""
     if not room_exists(room_name):
         raise HTTPException(status_code=404, detail="Room not found")
+    # Draining a queue consumes it: the cursor advances, so a served turn is not
+    # served again. A verified token may therefore only drain its own handle or one
+    # that granted it — otherwise @bob's token could intercept @alice's coordination.
+    actor.authorize_handle(request, room_name, handle)
     managed = await room_channels.manager.provision(room_name)
     room_channels.manager.refresh_lease(room_name, handle)
     if managed is None or managed.persister is None:

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -21,7 +21,7 @@ import logging
 from datetime import UTC, datetime
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 
 from app.bus import bus, room_channel
 from app.schemas import (
@@ -30,7 +30,7 @@ from app.schemas import (
     ParticipantListResponse,
     ParticipantRead,
 )
-from app.services import l9, local_state, room_channels
+from app.services import actor, l9, local_state, room_channels
 from app.services.filesystem import (
     ensure_room_structure,
     get_room_dir,
@@ -63,8 +63,12 @@ async def spawn_session(room_name: str):
 
 
 @router.post("", response_model=ParticipantRead, status_code=201)
-async def join_room(room_name: str, payload: ParticipantCreate):
+async def join_room(room_name: str, payload: ParticipantCreate, request: Request):
     """Join a room — record the agent's presence. Idempotent per handle."""
+    # Presence is a claim on a handle, same as draining its queue: registering as
+    # someone else would put their name on the roster and pull their SLIM invite.
+    # Authorized before the room is created, so a claim can't leave a room behind.
+    actor.authorize_handle(request, room_name, payload.agent_handle, field="agent_handle")
     _ensure_room(room_name)
     coord = local_state.get_or_create_session(room_name)
 

--- a/fastapi-backend/app/services/actor.py
+++ b/fastapi-backend/app/services/actor.py
@@ -1,7 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Handle binding — the *authoritative* actor behind a write.
+"""Handle binding and handle authorization — who a request may act as.
+
+Two related rules live here. **Binding** answers *who wrote this* on a path whose
+body self-asserts an actor; **authorization** answers *may this principal act as
+that handle* on a path where the handle is a request parameter naming someone
+else's queue or presence slot. Both are inert without a verified token.
+
+Binding — the *authoritative* actor behind a write.
 
 The gate (``services/auth.py``) proves a token is valid and leaves a
 :class:`~app.services.auth.Principal` on ``request.state.principal``. That alone
@@ -27,12 +34,25 @@ A body handle may carry a session qualifier (``alpha#a8f3``). That names the sam
 principal, so it is honoured — the qualifier rides along on the token's handle,
 which keeps per-session attribution without letting the suffix smuggle in a
 different actor.
+
+Authorization — whose queue you may drain, whose presence you may claim.
+
+``await`` and the presence join take the handle from a request *parameter*: it
+names whose coordination stream is being read, not who is writing. Binding is the
+wrong tool there — rewriting the parameter to the token's handle would silently
+serve a different queue than the caller asked for — so the rule is a yes/no on the
+claim instead. A principal may act as its own handle, or as one whose agent
+manifest grants it (``owner``, or an entry in ``allow_from``): the explicit "act on
+behalf of" grant that carries the human-proxy and parent-agent cases. Anything else
+is a 403. Without a principal nothing is checked, so an ungated hub behaves exactly
+as it did.
 """
 
 from __future__ import annotations
 
 from fastapi import HTTPException, Request
 
+from app.services import principals
 from app.services.auth import Principal, normalize_handle
 
 
@@ -69,6 +89,45 @@ def bind_optional_actor(
     if principal is None:
         return claimed
     return _authoritative(principal, claimed, field)
+
+
+def may_act_as(principal: Principal, room: str, handle: str | None) -> bool:
+    """Whether ``principal`` may act as ``handle`` in ``room``.
+
+    Its own handle always, a session qualifier notwithstanding; another handle only
+    when that handle's manifest names the principal as ``owner`` or lists it in
+    ``allow_from``. A claim that normalizes to nothing names no handle at all, so it
+    is refused rather than read as "me" — unlike a *write*, where an omitted actor
+    is an absent claim the token fills in.
+    """
+    normalized = normalize_handle((handle or "").partition("#")[0])
+    if normalized is None:
+        return False
+    return normalized == principal.handle or principals.delegates_to(
+        room, normalized, principal.handle
+    )
+
+
+def authorize_handle(
+    request: Request | None, room: str, claimed: str | None, *, field: str = "handle"
+) -> None:
+    """Refuse a request that claims a handle its token may not act as.
+
+    A guard, not a binding: the claimed handle is left alone, because it names the
+    queue or presence slot the caller is asking about rather than the author of a
+    write.
+    """
+    principal = current_principal(request)
+    if principal is None or may_act_as(principal, room, claimed):
+        return
+    raise HTTPException(
+        status_code=403,
+        detail=(
+            f"{field} '{claimed}' is not the authenticated principal "
+            f"'@{principal.handle}' and has granted it no access; add "
+            f"'{principal.handle}' to that handle's owner or allow_from to act on its behalf."
+        ),
+    )
 
 
 def _authoritative(principal: Principal, claimed: str | None, field: str) -> str:

--- a/fastapi-backend/app/services/principals.py
+++ b/fastapi-backend/app/services/principals.py
@@ -25,6 +25,7 @@ from app.services.filesystem import (
     list_memory_files,
     list_room_names,
     read_memory_file,
+    room_exists,
     write_memory_file,
 )
 
@@ -44,7 +45,13 @@ def _norm(handle: str | None) -> str | None:
 
 
 def _read_agent_manifest(room: str, handle: str) -> dict[str, Any] | None:
-    """Parse the `agents/<handle>` manifest in a room, or None if absent/unreadable."""
+    """Parse the `agents/<handle>` manifest in a room, or None if absent/unreadable.
+
+    ``get_room_dir`` creates what it resolves, so an unknown room is answered before
+    it is asked for: a read must not bring a room into being.
+    """
+    if not room_exists(room):
+        return None
     result = read_memory_file(get_room_dir(room), f"agents/{handle}")
     if result is None:
         return None
@@ -71,6 +78,28 @@ def classify_sender(room: str, handle: str) -> str:
     if load_user(h) is not None:
         return "user"
     return "unknown"
+
+
+def delegates_to(room: str, handle: str, candidate: str) -> bool:
+    """Whether ``handle`` has granted ``candidate`` the right to act for it.
+
+    The grant is explicit and lives on the target's own manifest — its ``owner``
+    (the user who registered it) or an entry in ``allow_from``. A handle with no
+    manifest grants nothing, so an unregistered or phantom handle is never
+    delegable.
+    """
+    target, actor_handle = _norm(handle), _norm(candidate)
+    if not target or not actor_handle:
+        return False
+    manifest = _read_agent_manifest(room, target)
+    if manifest is None:
+        return False
+    if _norm(manifest.get("owner")) == actor_handle:
+        return True
+    allow_from = manifest.get("allow_from")
+    if not isinstance(allow_from, list):
+        return False
+    return any(_norm(entry) == actor_handle for entry in allow_from)
 
 
 def post_rejection_reason(room: str, handle: str, *, allow_unregistered: bool) -> str | None:

--- a/fastapi-backend/tests/conftest.py
+++ b/fastapi-backend/tests/conftest.py
@@ -11,10 +11,13 @@ in-process ``local_state`` shim which we reset per test.
 
 import pytest
 import pytest_asyncio
+from fastapi import Request
 from httpx import ASGITransport, AsyncClient
 
+from app.config import PrincipalRole
 from app.main import app
 from app.services import local_state
+from app.services.auth import Principal, auth_gate
 
 
 @pytest.fixture(autouse=True)
@@ -36,3 +39,35 @@ async def client():
     """AsyncClient wired to the FastAPI app (no database)."""
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         yield ac
+
+
+@pytest.fixture
+def as_principal():
+    """Act as a verified principal for the rest of the test.
+
+    Overrides the gate itself, so the routes see exactly what a validated token
+    leaves behind: a ``Principal`` on ``request.state``. Call with ``None`` to
+    assert the anonymous branch through the same wiring. Signing a real token is
+    ``test_auth_gate``'s subject, not every caller's.
+    """
+
+    def _act_as(handle: str | None, *, role: PrincipalRole = "agent") -> None:
+        principal = (
+            None
+            if handle is None
+            else Principal(
+                subject=handle,
+                handle=handle,
+                role=role,
+                issuer="https://idp.test/realms/mycelium",
+            )
+        )
+
+        async def _fake_gate(request: Request) -> Principal | None:
+            request.state.principal = principal
+            return principal
+
+        app.dependency_overrides[auth_gate] = _fake_gate
+
+    yield _act_as
+    app.dependency_overrides.pop(auth_gate, None)

--- a/fastapi-backend/tests/test_handle_authorization.py
+++ b/fastapi-backend/tests/test_handle_authorization.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Handle authorization: whose queue a token may drain, whose presence it may claim.
+
+Binding (``test_handle_binding``) fixed *authorship*; this fixes *access*. The
+handle on ``await`` and on the presence join is a request parameter naming someone
+else's coordination stream, so the question is not "who wrote this" but "may this
+principal act for that handle" — its own, or one whose manifest granted it.
+
+Both halves are asserted: with a principal the grant decides, and with none every
+path behaves exactly as it did before the gate existed.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from httpx import AsyncClient
+
+from app.services import principals
+from app.services.filesystem import get_room_dir, room_exists, write_memory_file
+
+ROOM = "authz-room"
+
+
+async def _make_room(client: AsyncClient, name: str = ROOM) -> None:
+    assert (await client.post("/api/rooms", json={"name": name})).status_code in (200, 201)
+
+
+def _seed_agent(
+    handle: str,
+    *,
+    room: str = ROOM,
+    owner: str | None = None,
+    allow_from: list[str] | None = None,
+) -> None:
+    """Register an agent manifest carrying whatever delegation the test needs."""
+    body: dict[str, object] = {"adapter": "claude_code"}
+    if owner is not None:
+        body["owner"] = owner
+    if allow_from is not None:
+        body["allow_from"] = allow_from
+    write_memory_file(
+        get_room_dir(room),
+        f"agents/{handle}",
+        yaml.safe_dump(body, sort_keys=False),
+        created_by="tester",
+    )
+
+
+async def _await_as(client: AsyncClient, handle: str, *, room: str = ROOM):
+    """One long-poll. No SLIM node in the unit suite, so it returns immediately."""
+    return await client.get(f"/api/rooms/{room}/await", params={"handle": handle, "timeout": 1})
+
+
+async def _join_as(client: AsyncClient, handle: str, *, room: str = ROOM):
+    return await client.post(f"/api/rooms/{room}/sessions", json={"agent_handle": handle})
+
+
+# ── no principal: today's behavior, unchanged ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_anonymous_await_may_drain_any_handle(client: AsyncClient):
+    """The ungated hub is untouched — this is the try-it path."""
+    await _make_room(client)
+    assert (await _await_as(client, "alice")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_gate_off_leaves_await_open(client: AsyncClient, as_principal):
+    """The override is installed but resolves to no principal — the gate-off path."""
+    as_principal(None)
+    await _make_room(client)
+    assert (await _await_as(client, "alice")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_anonymous_join_may_claim_any_handle(client: AsyncClient):
+    await _make_room(client)
+    assert (await _join_as(client, "alice")).status_code == 201
+
+
+# ── await: the queue is the token's own, or a granted one ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_token_may_drain_its_own_queue(client: AsyncClient, as_principal):
+    await _make_room(client)
+    as_principal("alice")
+    assert (await _await_as(client, "alice")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_a_token_may_not_drain_another_handles_queue(client: AsyncClient, as_principal):
+    """The gap this closes: @bob long-polling @alice's coordination stream."""
+    await _make_room(client)
+    _seed_agent("alice")
+    as_principal("bob")
+    resp = await _await_as(client, "alice")
+    assert resp.status_code == 403
+    assert "alice" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_an_unregistered_handle_is_not_drainable_either(client: AsyncClient, as_principal):
+    """No manifest means no grant — a phantom handle is not an open queue."""
+    await _make_room(client)
+    as_principal("bob")
+    assert (await _await_as(client, "nobody")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_the_owner_may_drain_its_agents_queue(client: AsyncClient, as_principal):
+    """The human-proxy path: `mycelium await --handle bot` run by bot's owner."""
+    await _make_room(client)
+    _seed_agent("bot", owner="alice")
+    as_principal("alice", role="user")
+    assert (await _await_as(client, "bot")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_allow_from_grants_a_non_owner(client: AsyncClient, as_principal):
+    await _make_room(client)
+    _seed_agent("bot", owner="alice", allow_from=["carol"])
+    as_principal("carol")
+    assert (await _await_as(client, "bot")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_a_grant_to_someone_else_is_not_a_grant_to_you(client: AsyncClient, as_principal):
+    await _make_room(client)
+    _seed_agent("bot", owner="alice", allow_from=["carol"])
+    as_principal("mallory")
+    assert (await _await_as(client, "bot")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_a_grant_is_scoped_to_the_room_it_is_written_in(client: AsyncClient, as_principal):
+    """Manifests are per-room, so owning @bot in one room says nothing about another."""
+    await _make_room(client)
+    await _make_room(client, "other-room")
+    _seed_agent("bot", room="other-room", owner="alice")
+    _seed_agent("bot")
+    as_principal("alice")
+    assert (await _await_as(client, "bot", room="other-room")).status_code == 200
+    assert (await _await_as(client, "bot")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_handles_are_compared_normalized(client: AsyncClient, as_principal):
+    """``@Alice`` in a manifest and ``alice`` on a token are one principal."""
+    await _make_room(client)
+    _seed_agent("bot", owner="@Alice")
+    as_principal("alice")
+    assert (await _await_as(client, "@Bot")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_a_session_qualifier_still_names_its_own_queue(client: AsyncClient, as_principal):
+    """``alice#a8f3`` is alice on one machine — her own queue, not a second actor's."""
+    await _make_room(client)
+    as_principal("alice")
+    assert (await _await_as(client, "alice#a8f3")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_a_session_qualifier_cannot_smuggle_another_queue(client: AsyncClient, as_principal):
+    await _make_room(client)
+    _seed_agent("mallory")
+    as_principal("alice")
+    assert (await _await_as(client, "mallory#a8f3")).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_an_empty_handle_names_no_queue(client: AsyncClient, as_principal):
+    """Unlike an omitted write actor, a blank parameter is not a claim to fill in."""
+    await _make_room(client)
+    as_principal("alice")
+    assert (await _await_as(client, "")).status_code == 403
+
+
+# ── presence: registering as a handle is the same claim ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_token_may_join_as_itself(client: AsyncClient, as_principal):
+    await _make_room(client)
+    as_principal("alice")
+    assert (await _join_as(client, "alice")).status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_a_token_may_not_join_as_another_handle(client: AsyncClient, as_principal):
+    await _make_room(client)
+    _seed_agent("alice")
+    as_principal("bob")
+    resp = await _join_as(client, "alice")
+    assert resp.status_code == 403
+    # The refusal is a refusal: no roster entry landed under either handle.
+    listed = await client.get(f"/api/rooms/{ROOM}/sessions")
+    assert listed.json()["participants"] == []
+
+
+@pytest.mark.asyncio
+async def test_the_owner_may_register_presence_for_its_agent(client: AsyncClient, as_principal):
+    await _make_room(client)
+    _seed_agent("bot", owner="alice")
+    as_principal("alice", role="user")
+    resp = await _join_as(client, "bot")
+    assert resp.status_code == 201
+    assert resp.json()["agent_handle"] == "bot"
+
+
+@pytest.mark.asyncio
+async def test_a_refused_join_does_not_create_the_room(client: AsyncClient, as_principal):
+    """Join creates its room on demand, so the claim is checked before anything is."""
+    as_principal("bob")
+    assert (await _join_as(client, "alice", room="ghost-room")).status_code == 403
+    assert not room_exists("ghost-room")
+
+
+# ── the rule itself ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delegates_to_reads_only_explicit_grants(client: AsyncClient):
+    await _make_room(client)
+    _seed_agent("bot", owner="alice", allow_from=["carol"])
+    _seed_agent("loner")
+    assert principals.delegates_to(ROOM, "bot", "alice")
+    assert principals.delegates_to(ROOM, "bot", "@Carol")
+    assert not principals.delegates_to(ROOM, "bot", "mallory")
+    assert not principals.delegates_to(ROOM, "loner", "alice")
+    assert not principals.delegates_to(ROOM, "unregistered", "alice")
+    assert not principals.delegates_to(ROOM, "bot", "")

--- a/fastapi-backend/tests/test_handle_binding.py
+++ b/fastapi-backend/tests/test_handle_binding.py
@@ -20,47 +20,12 @@ from typing import Any
 
 import pytest
 import yaml
-from fastapi import Request
 from httpx import AsyncClient
 
-from app.config import PrincipalRole
-from app.main import app
-from app.services.auth import Principal, auth_gate
 from app.services.filesystem import get_room_dir, read_memory_file, write_memory_file
 from app.services.persister import DeliveryLog
 
 ROOM = "bind-room"
-
-
-@pytest.fixture
-def as_principal():
-    """Act as a verified principal for the rest of the test.
-
-    Overrides the gate itself, so the routes see exactly what a validated token
-    leaves behind: a ``Principal`` on ``request.state``. Call with ``None`` to
-    assert the anonymous branch through the same wiring.
-    """
-
-    def _act_as(handle: str | None, *, role: PrincipalRole = "agent") -> None:
-        principal = (
-            None
-            if handle is None
-            else Principal(
-                subject=handle,
-                handle=handle,
-                role=role,
-                issuer="https://idp.test/realms/mycelium",
-            )
-        )
-
-        async def _fake_gate(request: Request) -> Principal | None:
-            request.state.principal = principal
-            return principal
-
-        app.dependency_overrides[auth_gate] = _fake_gate
-
-    yield _act_as
-    app.dependency_overrides.pop(auth_gate, None)
 
 
 async def _make_room(client: AsyncClient, name: str = ROOM) -> None:

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -555,12 +555,18 @@ def agent_create(
     allow_from: str | None = typer.Option(
         None,
         "--allow-from",
-        help="Comma-separated sender handles allowed to invoke (e.g. '@julia,@docs-agent').",
+        help=(
+            "Comma-separated sender handles allowed to invoke this agent, and — under "
+            "an enabled auth gate — to act on its behalf (e.g. '@julia,@docs-agent')."
+        ),
     ),
     owner: str | None = typer.Option(
         None,
         "--owner",
-        help="User (a users/<handle>) this agent belongs to. Self-asserted.",
+        help=(
+            "User (a users/<handle>) this agent belongs to. Self-asserted, and the "
+            "owner may act on the agent's behalf under an enabled auth gate."
+        ),
     ),
     team: str | None = typer.Option(
         None, "--team", help="Team slug this agent is fielded by. Self-asserted."

--- a/mycelium-cli/src/mycelium/commands/participate.py
+++ b/mycelium-cli/src/mycelium/commands/participate.py
@@ -29,6 +29,7 @@ import json as json_module
 import os
 import subprocess
 
+import httpx
 import typer
 
 from mycelium.client import hub_client
@@ -36,6 +37,10 @@ from mycelium.commands.room import _resolve_room
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
+
+#: Statuses a resident loop stops on: the hub rejected the caller's identity
+#: (401) or refused it this handle (403). Everything else is treated as a blip.
+_TERMINAL_STATUSES = frozenset({401, 403})
 
 
 def _await_once(config: MyceliumConfig, room_name: str, handle: str, timeout: int) -> dict | None:
@@ -168,7 +173,8 @@ def _await_loop(
     A timeout is not terminal here — it just means "nothing yet," so we re-await
     (keeping the presence lease warm). Ctrl-C is the clean stop. Errors on a single
     poll are surfaced and the loop backs off briefly rather than dying, so a blip in
-    the backend doesn't drop the agent out of the room.
+    the backend doesn't drop the agent out of the room. A rejected identity is the
+    exception: retrying can't earn a credential, so 401/403 ends the loop.
     """
     import time
 
@@ -185,6 +191,15 @@ def _await_loop(
         except KeyboardInterrupt:
             typer.echo("\n  [Stopped]")
             return
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code not in _TERMINAL_STATUSES:
+                typer.secho(f"  ⟫  await error: {e}; retrying…", fg=typer.colors.YELLOW)
+                time.sleep(2.0)
+                continue
+            # A refused identity is not a blip — no amount of re-polling turns a
+            # wrong or ungranted credential into an accepted one, and a resident
+            # loop that kept trying would hammer the hub for as long as it ran.
+            print_error(e)
         except Exception as e:  # noqa: BLE001 - a poll blip must not drop residency
             typer.secho(f"  ⟫  await error: {e}; retrying…", fg=typer.colors.YELLOW)
             time.sleep(2.0)

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -278,6 +278,40 @@ request body supplies:
 With the gate off there is no principal, so every path keeps the self-asserted
 actor from the body exactly as before — the try-it path is unchanged.
 
+## Acting as another handle
+
+Attribution answers *who wrote this*. Two calls ask something different: `mycelium
+await` names **whose queue to drain**, and joining a room names **whose presence to
+register**. Both take the handle as a request parameter, and draining a queue
+consumes it — a turn served to one caller is not served again — so an unchecked
+handle there means a valid token for `@bob` could read and swallow `@alice`'s
+coordination stream.
+
+A gated hub allows the call when either is true:
+
+- the handle **is** the token's own (a session qualifier like `alice#a8f3` still names alice), or
+- the handle's agent manifest **grants** the token's principal — its `owner`, or an entry in its `allow_from`.
+
+Anything else is a **403**. Grants are per-room, because manifests are: owning
+`@bot` in one room says nothing about a `@bot` in another.
+
+The grant is what makes "await on behalf of" explicit rather than universal. An
+agent running with its own credential needs nothing — it awaits itself. A human
+driving an agent's loop from their own session does:
+
+```bash
+mycelium agent create bot --owner alice          # alice may now await --handle bot
+mycelium agent create bot --allow-from ops-lead  # …and so may @ops-lead
+```
+
+A resident loop (`mycelium await --loop`) **stops** on a 401 or 403 rather than
+retrying: a refused identity is not a blip, and re-polling it would flood the hub
+for as long as the loop ran.
+
+With the gate off nothing is checked here either, so an ungated hub still lets any
+caller await any handle — which is also why a hub reachable beyond your machine
+wants the gate on.
+
 ## Key rotation
 
 The JWKS is fetched from your issuer and cached for `auth.jwks_ttl_s`. When a
@@ -319,7 +353,7 @@ Every other route requires a token.
 | Response | Meaning |
 |----------|---------|
 | `401` + `WWW-Authenticate: Bearer` | Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token. |
-| `403` | A valid token, but the request body claims to act as a different handle. |
+| `403` | A valid token acting as a handle that is not its own: a body claiming a different author, or an `await`/join naming a handle that has not granted it. |
 | `503` | The gate is on but unusable — no trusted issuers configured, or the issuer's JWKS is unreachable and nothing is cached. |
 
 Only asymmetric signatures are accepted (`RS*`, `PS*`, `ES*`). The `none`

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -356,7 +356,9 @@ class AgentManifest(BaseModel):
         description=(
             "Sender handles allowed to invoke this agent (e.g. ['@julia', '@docs-agent']). "
             "Empty list means anyone in the room can invoke. "
-            "Enforced by the daemon for claude_code / cursor."
+            "Also the 'act on behalf of' grant: with the hub's auth gate enabled, these "
+            "handles (and the owner) may await or join as this agent; an empty list "
+            "grants no one."
         ),
     )
 

--- a/mycelium-cli/tests/test_participate_cli.py
+++ b/mycelium-cli/tests/test_participate_cli.py
@@ -16,8 +16,10 @@ request path relative to the hub's base URL.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 
+import httpx
 import pytest
 from typer.testing import CliRunner
 
@@ -66,6 +68,43 @@ def test_await_timeout_exits_nonzero(fake_httpx: FakeHTTPX) -> None:
     result = runner.invoke(app, ["await", "--handle", "me", "--timeout", "1", "--json"])
     assert result.exit_code == 1
     assert json.loads(result.stdout)["message"] is None
+
+
+def _http_error(status: int, detail: str) -> httpx.HTTPStatusError:
+    """The error ``raise_for_status`` raises for a hub that refused the call."""
+    request = httpx.Request("GET", "http://hub/api/rooms/demo/await")
+    return httpx.HTTPStatusError(
+        f"HTTP {status}",
+        request=request,
+        response=httpx.Response(status, json={"detail": detail}, request=request),
+    )
+
+
+def test_resident_loop_stops_when_the_hub_refuses_the_handle(
+    fake_httpx: FakeHTTPX, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 403 ends the loop; a transient failure before it does not.
+
+    Under a gated hub, awaiting a handle the token may not act as is a standing
+    refusal — re-polling it forever would be a self-inflicted request flood.
+    """
+    monkeypatch.setattr(time, "sleep", lambda _s: None)
+    errors = iter(
+        [
+            _http_error(503, "JWKS unavailable"),
+            _http_error(403, "handle 'bot' is not the authenticated principal '@carol'"),
+        ]
+    )
+
+    def _refuse(*_a: object) -> FakeResp:
+        raise next(errors)
+
+    fake_httpx.respond_with(_refuse)
+
+    result = runner.invoke(app, ["await", "--handle", "bot", "--loop", "--json"])
+    assert result.exit_code == 1
+    # Two polls: the blip was retried, the refusal was not.
+    assert len(fake_httpx.calls) == 2
 
 
 def test_respond_posts_reply(fake_httpx: FakeHTTPX) -> None:


### PR DESCRIPTION
## Summary

Handle binding (#562/#570) made the **write** actor authoritative, but the **read** side of participation stayed unbound: `mycelium await` and the presence join take the handle from a **request parameter**, so under an enabled gate an authenticated `@bob` could long-poll — and *drain* — `@alice`'s coordination queue. Draining consumes: the cursor advances, so a turn served to the wrong caller is never served to its owner.

Which queue you may drain is **authorization, not attribution**, so the handle is *checked* rather than rewritten — rewriting the parameter to the token's handle would silently serve a different queue than the caller asked for. A principal may act as:

- its **own** handle (a session qualifier like `alice#a8f3` still names alice), or
- one whose agent manifest **grants** it — `owner`, or an entry in `allow_from`.

Anything else is a **403**. That grant is what turns "await on behalf of" from universal into explicit, and it only became enforceable once agents had tokens of their own (#564) — which is why #562 correctly deferred it.

With no principal — gate off (the shipped default), a public path, the localhost bypass — nothing is checked and every path behaves exactly as before. The try-it path is untouched.

## Changes

- **`app/services/actor.py`** — `may_act_as(principal, room, handle)` (the rule) and `authorize_handle(request, room, claimed)` (the route-facing guard). A claim that normalizes to nothing names no handle, so it is refused rather than read as "me" — unlike a write, where an omitted actor is an absent claim the token fills in.
- **`app/services/principals.py`** — `delegates_to(room, handle, candidate)` reads the manifest grant. A handle with no manifest grants nothing, so a phantom handle is never delegable. `_read_agent_manifest` now short-circuits on an unknown room: `get_room_dir` creates what it resolves, so a read was materializing the room it looked in — a refused join would have left an empty room behind.
- **Call sites** — `GET /rooms/{room_name}/await` (`app/routes/participate.py`) and `POST /rooms/{room_name}/sessions` (`app/routes/sessions.py`, authorized before the room is created).
- **CLI** — a resident `mycelium await --loop` stops on 401/403 instead of retrying. A refused identity is not a blip; re-polling it would flood the hub for as long as the loop ran. Transient failures still back off and retry as before.
- **Docs** — a new "Acting as another handle" section in the auth guide (regenerated into `reference.html` / `llms-full.txt`), `--owner` / `--allow-from` help and the manifest field description noting the delegation meaning, and the identity design rollout gains this as step 5.

Not included, and still out of scope: general RBAC / per-room roles, and SLIM channel identity (#476). `DELETE /sessions/{id}` is left alone deliberately — evicting a participant is a membership verb, not a "may I act as this handle" claim, so it belongs to the RBAC layer.

## Testing

`fastapi-backend/tests/test_handle_authorization.py` (new, 18 cases) covers both halves of the rule against the gate dependency, per the issue's acceptance criteria:

- **Gate off** — anonymous and explicitly-no-principal callers await/join as any handle, unchanged.
- **Gate on** — own queue ok; another handle with no grant → 403; with `owner` → ok; with `allow_from` → ok; a grant to someone *else* → 403; an unregistered handle → 403; an empty handle → 403.
- Grants are **per-room** (owning `@bot` in one room does not carry to another), handles compare **normalized** (`@Alice` ≡ `alice`), a session qualifier names its own queue but cannot smuggle another's.
- Presence: join as self ok, as another → 403 with no roster entry left behind, owner-delegated join ok, and a refused join does not create the room.
- `principals.delegates_to` asserted directly for the explicit-grants-only rule.

CLI: `test_resident_loop_stops_when_the_hub_refuses_the_handle` proves both branches — one transient failure retried, the following 403 ends the loop.

The `as_principal` fixture moved from `test_handle_binding.py` to `conftest.py` so both suites share one way of injecting a verified principal.

- [x] Unit tests pass — backend `498 passed, 6 skipped`; CLI `373 passed`
- [x] Linting passes (`uv run ruff check .`, both packages)
- [x] Format check passes (`uv run ruff format --check .`, both packages)
- [x] Type check passes (`uv run ty check .`, both packages)

Not verified here: the end-to-end pass against the dev issuer (#566) — these assert through the gate dependency rather than a signed token, matching how #562's suite is structured.

## Related Issues

Closes #571

Follows #562 / #570 (write-side binding — the pattern mirrored here) and #564 (agent identity, which unblocked enforcement). Part of #560.

---
_Generated by [Claude Code](https://claude.ai/code/session_0181NGzn5x8LihM7JqhCZtDh)_