### PR TITLE
feat(slim): per-member JWT channel identity behind a config seam (#476)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,11 +193,19 @@ is no litellm dependency.
   try-it path. The localhost bypass reads the request's peer address, so it does
   **not** fire for a containerized backend (published-port traffic looks like LAN
   traffic) — the local tier is served by leaving auth off.
-- **SLIM security is a shared-secret PSK today (D1).** The group key derives from
-  `MYCELIUM_SLIM_MASTER_SECRET` (set the same on every host that shares rooms);
-  `MYCELIUM_SLIM_REQUIRE_SECRET=1` makes a host fail closed rather than fall back to
-  the public dev literal. There is no per-agent identity/revocation yet: **real
-  identity (JWT/SPIRE) is a hard prerequisite before anything hosted / multi-user**.
+- **SLIM security is a shared-secret PSK by default, per-member JWT opt-in.** The
+  default group credential derives from `MYCELIUM_SLIM_MASTER_SECRET` (set the same
+  on every host that shares rooms); `MYCELIUM_SLIM_REQUIRE_SECRET=1` makes a host
+  fail closed rather than fall back to the public dev literal. It is scoped to
+  `workspace/room`, so members are indistinguishable and revocation means rotating
+  for everyone. `slim.identity = jwt` switches the plane to per-member identity:
+  each member presents **the token it already sends to the HTTP API**
+  (`app/services/slim_identity.py` + the CLI mirror `mycelium/slim/identity.py`,
+  frozen together in `contracts/slim-l9-wire.json`). Identity is the token's `sub`,
+  so members are distinct and individually revocable. Per-member identity is
+  client-side only — the node forwards ciphertext and needs no configuration;
+  the node's own `auth.jwt` is a separate transport gate. SPIRE JWT-SVIDs drop
+  into the same seam (#579).
 - **Adapter capability (be honest).** `claude_code` is proven; `cursor` is untested;
   `openclaw` and `hermes` are deprecated (they rode the removed SSE/coordination-tick
   model and have not been migrated to SLIM).

--- a/contracts/slim-l9-wire.json
+++ b/contracts/slim-l9-wire.json
@@ -32,6 +32,27 @@
     "contingency": ["negotiation"]
   },
 
+  "identity": {
+    "_comment": "Channel-identity tier selection, resolved from the environment on BOTH sides (app.services.slim_identity / mycelium.slim.identity). The two copies must agree on the variable names, the mode strings and the defaults, or a member reads a different tier than the moderator and its app presents a credential the group can't verify — a silent join failure, exactly like a diverging shared secret. Env-only for the same reason the master secret is: the backend has no config.toml and the CLI must not import the backend's Settings. `mycelium config apply` renders the authored [slim] block into these names.",
+    "modes": ["psk", "jwt"],
+    "default_mode": "psk",
+    "default_algorithm": "RS256",
+    "default_duration_s": 3600.0,
+    "token_dir_name": "slim-identity",
+    "env": {
+      "mode": "MYCELIUM_SLIM_IDENTITY",
+      "token": "MYCELIUM_SLIM_IDENTITY_TOKEN",
+      "token_file": "MYCELIUM_SLIM_IDENTITY_TOKEN_FILE",
+      "issuer": "MYCELIUM_SLIM_IDENTITY_ISSUER",
+      "audience": "MYCELIUM_SLIM_IDENTITY_AUDIENCE",
+      "jwks": "MYCELIUM_SLIM_IDENTITY_JWKS",
+      "jwks_file": "MYCELIUM_SLIM_IDENTITY_JWKS_FILE",
+      "algorithm": "MYCELIUM_SLIM_IDENTITY_ALGORITHM",
+      "duration_s": "MYCELIUM_SLIM_IDENTITY_DURATION_S",
+      "require": "MYCELIUM_SLIM_IDENTITY_REQUIRE"
+    }
+  },
+
   "shared_secret": {
     "_comment": "mint_shared_secret is keyed on workspace/room only (agent ignored). HMAC-SHA256(master_secret, 'workspace/room').hexdigest().",
     "workspace": "acme",

--- a/docs/cross-machine.md
+++ b/docs/cross-machine.md
@@ -85,7 +85,10 @@ mycelium plan tasks --room planning        # the shared @handle checklist
   `MYCELIUM_SLIM_MASTER_SECRET` to a private value **identical on every host that shares
   rooms** (a mismatch means invites silently never land, so suspect the secret before the
   network), and set `MYCELIUM_SLIM_REQUIRE_SECRET=1` to make a host refuse to start with
-  the dev default.
+  the dev default. Hosts that share an OIDC issuer can sidestep the parity problem
+  entirely with `mycelium config set slim.identity jwt` — each member then presents its
+  own token instead of a value every host has to be told out of band (see the
+  Authentication guide).
 - **Version parity.** The `slim` node image and the `slim-bindings` wheel are a matched
   pair on **both** hosts; a skew across machines is a new failure mode.
 

--- a/docs/design/identity-and-auth.md
+++ b/docs/design/identity-and-auth.md
@@ -142,8 +142,18 @@ per-deployment opt-in.
    default; **SPIRE JWT-SVID as an optional upgrade** where workload attestation is
    wanted.
 5. **SLIM channel identity** — *optionally* move the MLS group off the dev PSK to
-   per-member JWT/SPIRE (#476); the PSK remains the default. Deeper; partly gated on
-   slim-bindings wiring.
+   per-member JWT/SPIRE (#476); the PSK remains the default. *JWT slice landed:
+   `fastapi-backend/app/services/slim_identity.py` and its CLI mirror
+   `mycelium/slim/identity.py`, selected by `slim.identity = psk|jwt`. A member
+   presents the token step 3/4 already resolved — one credential authenticates the
+   API and joins the channel — via slim-bindings'
+   `IdentityProviderConfig.STATIC_JWT`, and verifies peers against the same trust
+   root the HTTP gate uses. Two findings worth carrying forward: per-member
+   identity is **entirely client-side** (the node forwards ciphertext and never
+   inspects the MLS identity, so the stock node needs no configuration), and the
+   node's own `auth.jwt` is a separate transport-level gate that members satisfy
+   with the same token. SPIRE drops into the same seam — `SpireConfig` is the
+   provider variant beside `STATIC_JWT` — as #579.*
 6. **Reference IdP wiring** — an optional Keycloak compose profile + an optional
    SPIRE quickstart, with issuer-agnostic config documented.
 
@@ -160,9 +170,11 @@ per-deployment opt-in.
 
 ## Open questions
 
-- Do agents present their SPIRE JWT-SVID **directly to the HTTP API** (one token,
-  both planes), or hold separate credentials per plane? One token is simpler if the
-  API can be configured to trust the SPIRE trust domain as an issuer.
+- ~~Do agents present their SPIRE JWT-SVID **directly to the HTTP API** (one token,
+  both planes), or hold separate credentials per plane?~~ — **resolved: one token.**
+  Step 5 presents the credential the HTTP plane already resolved as the channel
+  identity too, and takes a caller-owned token file (a SPIRE sidecar's JWT-SVID)
+  as-is, so the SPIRE case is the same shape.
 - Handle namespace: is the canonical handle the raw `sub`, or a claim mapped to the
   existing `name#session` shape? Migration of existing self-asserted handles.
 - ~~Localhost auth posture~~ — **resolved:** off by default everywhere, opt-in per

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1712,6 +1712,82 @@ Nothing about it is required, and nothing about it is on by default.
 | `agent_auth.scopes` | *(unset)* | Scopes requested for an agent token. Most issuers want none for `client_credentials`. |
 | `agent_auth.audience` | *(unset)* | Audience to request; should match the hub's `auth.audience`. |
 
+## The same token joins the SLIM channel
+
+Everything above gates the **HTTP API**. Rooms have a second plane — the SLIM
+group channel that coordination messages ride — and it authenticates members
+separately.
+
+By default that plane uses a **shared secret**: a per-room key every member
+derives offline from `MYCELIUM_SLIM_MASTER_SECRET`. It needs no infrastructure,
+which is why it ships on, but it is scoped to the room, not to you. Every member
+of a room derives the same value, so members are cryptographically
+indistinguishable, and removing one means rotating the secret for everyone.
+
+Switch the plane to per-member identity and each member instead presents **the
+token it already has** — the same one this guide has been about:
+
+```bash
+mycelium config set slim.identity jwt
+mycelium config apply
+```
+
+That is the whole client-side change. One `mycelium login`, or one agent
+service-account credential, now authenticates the API *and* joins the channel;
+identity on the channel is the token's `sub`, which is the handle. Two agents in
+a room are distinct MLS participants, and revoking one agent's client leaves
+every other member untouched.
+
+### What the moderator presents
+
+The always-on backend is every room's moderator, and it is a member like any
+other. It has no `mycelium login` to draw on, so give it its own token
+out of band:
+
+```bash
+# In ~/.mycelium/.env, or the backend's environment
+MYCELIUM_SLIM_IDENTITY_TOKEN=<the backend service account's token>
+# or, for a token some other process writes and renews:
+MYCELIUM_SLIM_IDENTITY_TOKEN_FILE=/run/secrets/moderator.jwt
+```
+
+A bearer token is deliberately not read from `config.toml` — that file is printed,
+copied between machines, and mirrored to `config.json`.
+
+### It degrades rather than locking you out
+
+With `slim.identity = jwt` and no token to present, a member joins on the shared
+secret and logs a warning. That is deliberate: an install that turned the switch on
+before wiring an issuer keeps working. Set `MYCELIUM_SLIM_IDENTITY_REQUIRE=1` on
+hosts that mean it, and they refuse to fall back instead — the twin of
+`MYCELIUM_SLIM_REQUIRE_SECRET` for the shared secret itself.
+
+### Configuration
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `slim.identity` | `psk` | `psk` (shared secret) or `jwt` (each member presents its own token). |
+| `slim.identity_issuer` | *(from `agent_auth` / `login`)* | Issuer a peer's channel token must carry. |
+| `slim.identity_audience` | *(from `agent_auth` / `login`)* | Audience a peer's channel token must carry. |
+| `slim.identity_jwks` | *(unset)* | Inline JWKS JSON for verifying peers. Unset resolves keys from the issuer. |
+| `slim.identity_jwks_file` | *(unset)* | Path to a JWKS file, for a key set too large for the environment. |
+| `slim.identity_token_file` | *(unset)* | A file holding this member's token, used as-is — a SPIRE JWT-SVID, or CI's. |
+| `slim.identity_algorithm` | `RS256` | Signing algorithm of the issuer's keys. |
+| `slim.identity_duration_s` | `3600` | How long a presented channel identity is treated as good for. |
+
+The issuer and audience default to the ones the HTTP plane already uses, so the
+common case configures neither: one credential, one trust root, both planes.
+
+### The node needs no change for this
+
+Members prove who they are **to each other**. The node routes ciphertext and never
+inspects it, so per-member channel identity works against the stock node with no
+node configuration at all.
+
+A node *can* additionally require a token to open a dataplane connection at all —
+a separate, transport-level gate. Members present the same token there too, and
+`docker/compose-slim-jwt.yml` sketches the node side of it.
+
 ## Issuer-agnostic by design
 
 The backend trusts a configured issuer and its JWKS. It has no idea whether that

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -828,6 +828,30 @@ cursor-agent login            # one-time, interactive
 <span class="comment"># SLIM node endpoint (host:port), e.g. http://127.0.0.1:46357</span>
 <span class="arg">node_endpoint</span> = <span class="str">&quot;http://127.0.0.1:46357&quot;</span>
 
+<span class="comment"># Channel identity tier: &#x27;psk&#x27; (default — the deterministic shared secret every member of a room derives, zero infrastructure) or &#x27;jwt&#x27; (each member presents its own OIDC token, so members are distinct and individually revocable).</span>
+<span class="arg">identity</span> = <span class="str">&quot;psk&quot;</span>
+
+<span class="comment"># Issuer a peer&#x27;s channel token must carry to be accepted. Unset falls back to agent_auth.issuer, then login.issuer — the same trust root as the HTTP API.</span>
+<span class="arg">identity_issuer</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Audience a peer&#x27;s channel token must carry. Unset falls back to agent_auth.audience, then login.audience.</span>
+<span class="arg">identity_audience</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Inline JWKS JSON used to verify peers. Unset resolves keys from the issuer.</span>
+<span class="arg">identity_jwks</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Path to a JWKS file used to verify peers, for a key set too large for env.</span>
+<span class="arg">identity_jwks_file</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Path to a file holding this member&#x27;s raw channel token, used as-is — a SPIRE sidecar&#x27;s JWT-SVID, or a CI-provided token. Unset resolves the token from the same credential the HTTP API uses (mycelium login, or the agent&#x27;s own).</span>
+<span class="arg">identity_token_file</span> = <span class="str">&quot;&quot;</span>
+
+<span class="comment"># Signing algorithm of the issuer&#x27;s keys (RS256, ES256, EdDSA, ...).</span>
+<span class="arg">identity_algorithm</span> = <span class="str">&quot;RS256&quot;</span>
+
+<span class="comment"># How long a presented channel identity is treated as good for, in seconds.</span>
+<span class="arg">identity_duration_s</span> = 3600.0
+
 <span class="comment"># First-party Cognition Engine runtime configuration.</span>
 <span class="cmd" id="config-engine">[engine]</span>
 
@@ -1287,6 +1311,80 @@ role     = &quot;user&quot;</code></pre>
           </tbody>
         </table>
       </div>
+      <h2 id="auth-the-same-token-joins-the-slim-channel">The same token joins the SLIM channel</h2>
+      <p>Everything above gates the <strong>HTTP API</strong>. Rooms have a second plane — the SLIM group channel that coordination messages ride — and it authenticates members separately.</p>
+      <p>By default that plane uses a <strong>shared secret</strong>: a per-room key every member derives offline from <code>MYCELIUM_SLIM_MASTER_SECRET</code>. It needs no infrastructure, which is why it ships on, but it is scoped to the room, not to you. Every member of a room derives the same value, so members are cryptographically indistinguishable, and removing one means rotating the secret for everyone.</p>
+      <p>Switch the plane to per-member identity and each member instead presents <strong>the token it already has</strong> — the same one this guide has been about:</p>
+      <pre><code><span class="cmd">mycelium config set</span> slim.identity jwt
+<span class="cmd">mycelium config apply</span></code></pre>
+      <p>That is the whole client-side change. One <code>mycelium login</code>, or one agent service-account credential, now authenticates the API <em>and</em> joins the channel; identity on the channel is the token&#x27;s <code>sub</code>, which is the handle. Two agents in a room are distinct MLS participants, and revoking one agent&#x27;s client leaves every other member untouched.</p>
+      <h3 id="auth-what-the-moderator-presents">What the moderator presents</h3>
+      <p>The always-on backend is every room&#x27;s moderator, and it is a member like any other. It has no <code>mycelium login</code> to draw on, so give it its own token out of band:</p>
+      <pre><code><span class="comment"># In ~/.mycelium/.env, or the backend&#x27;s environment</span>
+MYCELIUM_SLIM_IDENTITY_TOKEN=&lt;the backend service account&#x27;s token&gt;
+<span class="comment"># or, for a token some other process writes and renews:</span>
+MYCELIUM_SLIM_IDENTITY_TOKEN_FILE=/run/secrets/moderator.jwt</code></pre>
+      <p>A bearer token is deliberately not read from <code>config.toml</code> — that file is printed, copied between machines, and mirrored to <code>config.json</code>.</p>
+      <h3 id="auth-it-degrades-rather-than-locking-you-out">It degrades rather than locking you out</h3>
+      <p>With <code>slim.identity = jwt</code> and no token to present, a member joins on the shared secret and logs a warning. That is deliberate: an install that turned the switch on before wiring an issuer keeps working. Set <code>MYCELIUM_SLIM_IDENTITY_REQUIRE=1</code> on hosts that mean it, and they refuse to fall back instead — the twin of <code>MYCELIUM_SLIM_REQUIRE_SECRET</code> for the shared secret itself.</p>
+      <h3 id="auth-configuration">Configuration</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Key</th>
+              <th>Default</th>
+              <th>What it does</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>slim.identity</code></td>
+              <td><code>psk</code></td>
+              <td><code>psk</code> (shared secret) or <code>jwt</code> (each member presents its own token).</td>
+            </tr>
+            <tr>
+              <td><code>slim.identity_issuer</code></td>
+              <td><em>(from <code>agent_auth</code> / <code>login</code>)</em></td>
+              <td>Issuer a peer&#x27;s channel token must carry.</td>
+            </tr>
+            <tr>
+              <td><code>slim.identity_audience</code></td>
+              <td><em>(from <code>agent_auth</code> / <code>login</code>)</em></td>
+              <td>Audience a peer&#x27;s channel token must carry.</td>
+            </tr>
+            <tr>
+              <td><code>slim.identity_jwks</code></td>
+              <td><em>(unset)</em></td>
+              <td>Inline JWKS JSON for verifying peers. Unset resolves keys from the issuer.</td>
+            </tr>
+            <tr>
+              <td><code>slim.identity_jwks_file</code></td>
+              <td><em>(unset)</em></td>
+              <td>Path to a JWKS file, for a key set too large for the environment.</td>
+            </tr>
+            <tr>
+              <td><code>slim.identity_token_file</code></td>
+              <td><em>(unset)</em></td>
+              <td>A file holding this member&#x27;s token, used as-is — a SPIRE JWT-SVID, or CI&#x27;s.</td>
+            </tr>
+            <tr>
+              <td><code>slim.identity_algorithm</code></td>
+              <td><code>RS256</code></td>
+              <td>Signing algorithm of the issuer&#x27;s keys.</td>
+            </tr>
+            <tr>
+              <td><code>slim.identity_duration_s</code></td>
+              <td><code>3600</code></td>
+              <td>How long a presented channel identity is treated as good for.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>The issuer and audience default to the ones the HTTP plane already uses, so the common case configures neither: one credential, one trust root, both planes.</p>
+      <h3 id="auth-the-node-needs-no-change-for-this">The node needs no change for this</h3>
+      <p>Members prove who they are <strong>to each other</strong>. The node routes ciphertext and never inspects it, so per-member channel identity works against the stock node with no node configuration at all.</p>
+      <p>A node <em>can</em> additionally require a token to open a dataplane connection at all — a separate, transport-level gate. Members present the same token there too, and <code>docker/compose-slim-jwt.yml</code> sketches the node side of it.</p>
       <h2 id="auth-issuer-agnostic-by-design">Issuer-agnostic by design</h2>
       <p>The backend trusts a configured issuer and its JWKS. It has no idea whether that is Keycloak, Dex, ZITADEL, Authentik, or your existing corporate SSO, and it never needs one particular product installed.</p>
       <p><strong>More than one trust root is normal.</strong> Humans log in through an interactive OIDC issuer; agents present service-account tokens, possibly from an entirely separate root. List each as its own block:</p>

--- a/fastapi-backend/app/services/slim_client.py
+++ b/fastapi-backend/app/services/slim_client.py
@@ -8,6 +8,8 @@ This module provides two things:
 1. **Naming / identity** — map a mycelium ``workspace/room/agent`` triple to a
    SLIM :class:`Name` (``org/namespace/app``, with org = workspace/tenant,
    namespace = room, app = agent id) and back, plus a dev shared-secret minter.
+   Which credential an app actually presents — that shared secret, or the
+   member's own JWT — is chosen in ``slim_identity.py``.
 2. **A small client** (:class:`SlimClient`) that stands up a SLIM app, connects
    to a node, creates/joins a **group** channel, and exchanges broadcasts. It
    carries membership (invite/remove) and a close/teardown path for the
@@ -41,6 +43,8 @@ from types import ModuleType
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from app.services import slim_identity
+
 if TYPE_CHECKING:
     import slim_bindings
 
@@ -61,11 +65,11 @@ DEFAULT_CHANNEL_TOPIC = "room"
 # Master secret from which per-channel shared secrets are *deterministically*
 # derived, so every agent on a room's channel and the always-on backend
 # independently reconstruct the same credential (which seeds the group key)
-# without a key-exchange round-trip. The shared secret is the MVP identity tier;
-# JWT/SPIRE is the production path (debt D1) and is out of scope here.
+# without a key-exchange round-trip. This is the default identity tier; the
+# per-member JWT tier lives behind the same seam in ``slim_identity.py``.
 #
 # The built-in literal below is a **public dev default** — anyone with the repo
-# can derive it, so it protects nothing on its own (debt D1). A real deployment
+# can derive it, so it protects nothing on its own. A real deployment
 # sets ``MYCELIUM_SLIM_MASTER_SECRET`` to a private value; every host that shares
 # rooms must set the *same* value (it's a shared secret, not per-host). Set
 # ``MYCELIUM_SLIM_REQUIRE_SECRET=1`` to hard-refuse the dev default (fail closed
@@ -264,15 +268,29 @@ def _ensure_service_initialized(sb: ModuleType) -> None:
 _connections: dict[str, int] = {}
 
 
-async def _shared_connection(service: slim_bindings.Service, sb: ModuleType, endpoint: str) -> int:
+async def _shared_connection(
+    service: slim_bindings.Service,
+    sb: ModuleType,
+    endpoint: str,
+    *,
+    auth: slim_bindings.ClientAuthenticationConfig | None = None,
+) -> int:
     """Return the process-wide conn_id for ``endpoint``, connecting once.
 
     Callers connect sequentially (there is no first-connect race in the
     moderator→member handshake), so no lock is needed here.
+
+    ``auth`` is the credential presented to the *node* when it gates connections.
+    It applies to the first app that opens the connection: the cache is per
+    endpoint, and every later app in the process rides the same one. Each app
+    still carries its own identity to its MLS peers, which is the identity that
+    decides who a message is from.
     """
     conn_id = _connections.get(endpoint)
     if conn_id is None:
         client_config = sb.new_insecure_client_config(endpoint)
+        if auth is not None:
+            client_config.auth = auth
         # Enable idle keepalive. ``new_insecure_client_config`` leaves
         # ``keepalive=None`` → the binding's ``keep_alive_while_idle`` defaults to
         # False, so the node drops a connection after ~30s of silence (its
@@ -328,9 +346,15 @@ class SlimClient:
     connectors).
     """
 
-    def __init__(self, identity: SlimIdentity, *, secret: str | None = None) -> None:
+    def __init__(
+        self, identity: SlimIdentity, *, secret: str | None = None, token: str | None = None
+    ) -> None:
         self.identity = identity
         self._secret = secret or mint_shared_secret(identity)
+        # The bearer token this app presents as its channel identity when JWT
+        # identity is on. ``None`` resolves from the environment, which is how
+        # the always-on moderator gets its own service-account token.
+        self._token = token
         self._sb: ModuleType | None = None
         self._app: slim_bindings.App | None = None
         self._conn_id: int | None = None
@@ -347,8 +371,17 @@ class SlimClient:
 
         self._sb = sb
         self._local_name = to_slim_name(*self.identity.as_tuple())
-        self._conn_id = await _shared_connection(service, sb, endpoint)
-        self._app = service.create_app_with_secret(self._local_name, self._secret)
+        # JWT identity when it is configured *and* this member has a token;
+        # otherwise the shared-secret PSK, which is the shipped default.
+        channel_identity = slim_identity.build_configs(sb, self.identity, token=self._token)
+        auth = channel_identity.connection_auth if channel_identity else None
+        self._conn_id = await _shared_connection(service, sb, endpoint, auth=auth)
+        if channel_identity is None:
+            self._app = service.create_app_with_secret(self._local_name, self._secret)
+        else:
+            self._app = service.create_app(
+                self._local_name, channel_identity.provider, channel_identity.verifier
+            )
         await self._app.subscribe_async(self._local_name, self._conn_id)
         return self
 

--- a/fastapi-backend/app/services/slim_identity.py
+++ b/fastapi-backend/app/services/slim_identity.py
@@ -1,0 +1,371 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""SLIM channel identity: the shared-secret PSK, or a per-member JWT.
+
+Two identity tiers stand behind one seam, chosen by ``MYCELIUM_SLIM_IDENTITY``:
+
+``psk`` (the default)
+    The deterministic shared secret every member of a room derives offline
+    (:func:`~app.services.slim_client.mint_shared_secret`). Zero infrastructure,
+    which is what the try-it path needs — but it is scoped to ``workspace/room``,
+    so every member of a room is cryptographically indistinguishable and
+    revoking one means rotating the secret for all.
+
+``jwt``
+    Each member presents its **own bearer token** as its channel identity, and
+    verifies its peers' tokens against a trusted issuer. Identity is the token's
+    ``sub`` — the agent or human handle — so members are distinct MLS
+    participants and revoking one leaves the rest untouched.
+
+The token is deliberately **not a new credential**: it is the same OIDC token the
+HTTP plane already resolves (``mycelium.client`` / ``mycelium.agent_credentials``
+on the CLI side, ``MYCELIUM_SLIM_IDENTITY_TOKEN`` for the always-on backend
+moderator). One ``mycelium login`` — or one agent service account — authenticates
+the API *and* joins the channel.
+
+slim-bindings takes the presenting side as
+``IdentityProviderConfig.STATIC_JWT(StaticJwtAuth(token_file=…))``: a bearer
+token read from a file and reloaded when it changes. So a token resolved in
+memory is materialized to an owner-only file under the data dir first
+(:func:`materialize_token`), and a refreshed token is picked up by rewriting it.
+
+Resolution is **env-only on both sides** — the same shape
+``MYCELIUM_SLIM_MASTER_SECRET`` already has — so this module and its CLI mirror
+(``mycelium/slim/identity.py``) stay byte-for-byte comparable. Operators author
+the values under ``[slim]`` in ``config.toml``; ``mycelium config apply``
+renders them into the container env. The names and defaults are frozen in
+``contracts/slim-l9-wire.json``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import slim_bindings
+
+    from app.services.slim_client import SlimIdentity
+
+logger = logging.getLogger(__name__)
+
+#: The shared-secret tier: what ships, and what every default install runs.
+IDENTITY_MODE_PSK = "psk"
+
+#: The per-member tier: each member presents its own OIDC token.
+IDENTITY_MODE_JWT = "jwt"
+
+IDENTITY_MODES = (IDENTITY_MODE_PSK, IDENTITY_MODE_JWT)
+
+#: Which tier to use. Unset means :data:`IDENTITY_MODE_PSK` — turning JWT
+#: identity on must be a deliberate act, never something an install drifts into.
+IDENTITY_ENV = "MYCELIUM_SLIM_IDENTITY"
+
+#: The member's own bearer token, verbatim. The moderator's service account
+#: arrives this way; a CLI member passes its resolved token in code instead.
+TOKEN_ENV = "MYCELIUM_SLIM_IDENTITY_TOKEN"
+
+#: A file already holding the raw token — a SPIRE sidecar's JWT-SVID, or a CI
+#: runner's. Used as-is: nothing here mints or renews it, and it is handed
+#: straight to slim-bindings, which reloads it when the writer rewrites it.
+TOKEN_FILE_ENV = "MYCELIUM_SLIM_IDENTITY_TOKEN_FILE"
+
+#: The ``iss`` a peer's token must carry to be accepted.
+ISSUER_ENV = "MYCELIUM_SLIM_IDENTITY_ISSUER"
+
+#: The ``aud`` a peer's token must carry to be accepted.
+AUDIENCE_ENV = "MYCELIUM_SLIM_IDENTITY_AUDIENCE"
+
+#: Inline JWKS JSON for verifying peers. Unset falls back to autoresolve.
+JWKS_ENV = "MYCELIUM_SLIM_IDENTITY_JWKS"
+
+#: A file holding the JWKS, for a key set too large to sit in the environment.
+JWKS_FILE_ENV = "MYCELIUM_SLIM_IDENTITY_JWKS_FILE"
+
+#: Signing algorithm of the issuer's keys.
+ALGORITHM_ENV = "MYCELIUM_SLIM_IDENTITY_ALGORITHM"
+
+#: How long slim-bindings treats a presented identity as good for.
+DURATION_ENV = "MYCELIUM_SLIM_IDENTITY_DURATION_S"
+
+#: Refuse to fall back to the PSK when JWT identity was asked for and no token
+#: could be resolved. The twin of ``MYCELIUM_SLIM_REQUIRE_SECRET``: a host that
+#: means to run on verified identity fails closed rather than quietly joining
+#: with a credential anyone with the repo can derive.
+REQUIRE_ENV = "MYCELIUM_SLIM_IDENTITY_REQUIRE"
+
+#: Where the materialized token files live, under the data dir.
+TOKEN_DIR_NAME = "slim-identity"
+
+DEFAULT_ALGORITHM = "RS256"
+DEFAULT_DURATION_S = 3600.0
+
+#: Handles are lowercase slugs, but the filename is derived from caller input,
+#: so anything outside the slug alphabet is folded away before it reaches a path.
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+
+#: One warning per process per reason — every room provisions its own app and
+#: each would otherwise repeat the same line.
+_warned: set[str] = set()
+
+
+class SlimIdentityError(RuntimeError):
+    """SLIM identity is misconfigured, or JWT identity has nothing to present."""
+
+
+def _env(name: str) -> str | None:
+    return os.environ.get(name, "").strip() or None
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() not in ("", "0", "false", "no")
+
+
+def _warn_once(key: str, message: str, *args: object) -> None:
+    if key in _warned:
+        return
+    _warned.add(key)
+    logger.warning(message, *args)
+
+
+def resolve_mode() -> str:
+    """Which identity tier this process runs on. Defaults to the PSK."""
+    raw = (_env(IDENTITY_ENV) or IDENTITY_MODE_PSK).lower()
+    if raw not in IDENTITY_MODES:
+        raise SlimIdentityError(
+            f"{IDENTITY_ENV}={raw!r} is not a SLIM identity mode; "
+            f"expected one of {', '.join(IDENTITY_MODES)}"
+        )
+    return raw
+
+
+def data_dir() -> Path:
+    """The mycelium data dir the token file is written under."""
+    override = _env("MYCELIUM_DATA_DIR")
+    return Path(override).expanduser() if override else Path.home() / ".mycelium"
+
+
+def token_file_path(agent: str) -> Path:
+    """Where ``agent``'s presented token is materialized, one file per agent.
+
+    Keyed on the agent rather than the channel: one credential is the same
+    identity in every room it joins, so all its rooms read one file and a
+    refresh is written once.
+    """
+    safe = _UNSAFE.sub("-", agent) or "agent"
+    return data_dir() / TOKEN_DIR_NAME / f"{safe}.jwt"
+
+
+def materialize_token(agent: str, token: str) -> Path:
+    """Write ``token`` where slim-bindings can read it, owner-only.
+
+    Rewritten only when the contents actually change: slim-bindings watches the
+    file and reloads on change, so re-writing an identical token on every
+    connect would churn the identity for no reason.
+    """
+    path = token_file_path(agent)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        if path.read_text(encoding="utf-8") == token:
+            return path
+    except OSError:
+        pass
+    # os.open with 0600 rather than write_text + chmod: the file must never
+    # exist, even momentarily, with the default mode — it holds a bearer token.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(token)
+    # A file written before this mode was asserted keeps its old one otherwise.
+    os.chmod(path, 0o600)
+    return path
+
+
+@dataclass(frozen=True)
+class JwtIdentity:
+    """Everything the JWT tier needs: what to present, and what to accept."""
+
+    #: The bearer token to present, in memory. Materialized before use.
+    token: str | None = None
+    #: A file already holding the token, used as-is instead of materializing.
+    token_file: str | None = None
+    issuer: str | None = None
+    audience: str | None = None
+    jwks: str | None = None
+    jwks_file: str | None = None
+    algorithm: str = DEFAULT_ALGORITHM
+    duration_s: float = DEFAULT_DURATION_S
+
+    def has_token(self) -> bool:
+        return bool(self.token or self.token_file)
+
+
+def resolve_jwt_identity(*, token: str | None = None) -> JwtIdentity:
+    """The JWT tier's settings, from the environment and an in-memory token.
+
+    ``token`` is what the caller already resolved for the HTTP plane — an
+    agent's service-account token or the human session. It wins over the
+    environment, which is how one process can join as several distinct members.
+    """
+    raw_duration = _env(DURATION_ENV)
+    try:
+        duration_s = float(raw_duration) if raw_duration else DEFAULT_DURATION_S
+    except ValueError:
+        raise SlimIdentityError(f"{DURATION_ENV}={raw_duration!r} is not a number")
+    if duration_s <= 0:
+        raise SlimIdentityError(f"{DURATION_ENV}={raw_duration!r} must be positive")
+
+    return JwtIdentity(
+        token=token or _env(TOKEN_ENV),
+        token_file=_env(TOKEN_FILE_ENV),
+        issuer=_env(ISSUER_ENV),
+        audience=_env(AUDIENCE_ENV),
+        jwks=_env(JWKS_ENV),
+        jwks_file=_env(JWKS_FILE_ENV),
+        algorithm=(_env(ALGORITHM_ENV) or DEFAULT_ALGORITHM).upper(),
+        duration_s=duration_s,
+    )
+
+
+def _algorithm(sb: ModuleType, name: str) -> slim_bindings.JwtAlgorithm:
+    try:
+        return getattr(sb.JwtAlgorithm, name)
+    except AttributeError:
+        raise SlimIdentityError(
+            f"{ALGORITHM_ENV}={name!r} is not a JWT algorithm slim-bindings knows"
+        )
+
+
+def build_provider(
+    sb: ModuleType, jwt: JwtIdentity, *, agent: str
+) -> slim_bindings.IdentityProviderConfig:
+    """How this member proves who it is: its bearer token, from a file.
+
+    An in-memory token is materialized under the data dir; a ``token_file`` the
+    caller already has (a SPIRE sidecar's JWT-SVID) is passed through untouched.
+    """
+    if jwt.token_file:
+        path = jwt.token_file
+    elif jwt.token:
+        path = str(materialize_token(agent, jwt.token))
+    else:
+        raise SlimIdentityError("JWT channel identity needs a token and none was resolved")
+    return sb.IdentityProviderConfig.STATIC_JWT(
+        sb.StaticJwtAuth(
+            token_file=path,
+            duration=datetime.timedelta(seconds=jwt.duration_s),
+        )
+    )
+
+
+def build_verifier(sb: ModuleType, jwt: JwtIdentity) -> slim_bindings.IdentityVerifierConfig:
+    """How this member decides a peer's token is real.
+
+    An explicitly configured JWKS (inline or a file) pins the keys. With none,
+    the key is autoresolved from the token's issuer — which is why ``issuer``
+    and ``audience`` matter: they are what bounds who may be believed.
+    """
+    if jwt.jwks or jwt.jwks_file:
+        data = sb.JwtKeyData.DATA(jwt.jwks) if jwt.jwks else sb.JwtKeyData.FILE(str(jwt.jwks_file))
+        key = sb.JwtKeyType.DECODING(
+            sb.JwtKeyConfig(
+                algorithm=_algorithm(sb, jwt.algorithm),
+                format=sb.JwtKeyFormat.JWKS,
+                key=data,
+            )
+        )
+    else:
+        key = sb.JwtKeyType.AUTORESOLVE()
+    return sb.IdentityVerifierConfig.JWT(
+        sb.JwtAuth(
+            key=key,
+            audience=[jwt.audience] if jwt.audience else None,
+            issuer=jwt.issuer,
+            subject=None,
+            duration=datetime.timedelta(seconds=jwt.duration_s),
+        )
+    )
+
+
+def build_connection_auth(
+    sb: ModuleType, jwt: JwtIdentity, *, agent: str
+) -> slim_bindings.ClientAuthenticationConfig:
+    """The same token again, this time for the connection to the node.
+
+    App identity and transport are separate axes in SLIM: the provider/verifier
+    pair above is what MLS peers check about each other, and the node forwards
+    ciphertext without needing any of it. A node *may* additionally gate the
+    dataplane connection itself (``auth.jwt`` on its server config), and a client
+    that presents nothing is refused there. Carrying the token on both means one
+    credential covers the whole path.
+    """
+    if jwt.token_file:
+        path = jwt.token_file
+    elif jwt.token:
+        path = str(materialize_token(agent, jwt.token))
+    else:
+        raise SlimIdentityError("JWT channel identity needs a token and none was resolved")
+    return sb.ClientAuthenticationConfig.STATIC_JWT(
+        sb.StaticJwtAuth(
+            token_file=path,
+            duration=datetime.timedelta(seconds=jwt.duration_s),
+        )
+    )
+
+
+@dataclass(frozen=True)
+class ChannelIdentity:
+    """What an app presents and accepts once the JWT tier is in force."""
+
+    #: Proves this member's identity to its MLS peers.
+    provider: slim_bindings.IdentityProviderConfig
+    #: Decides whether a peer's presented identity is believable.
+    verifier: slim_bindings.IdentityVerifierConfig
+    #: Proves the same identity to the node, for a node that gates connections.
+    connection_auth: slim_bindings.ClientAuthenticationConfig
+
+
+def build_configs(
+    sb: ModuleType, identity: SlimIdentity, *, token: str | None = None
+) -> ChannelIdentity | None:
+    """What ``identity`` presents on the channel, or ``None`` to use the PSK.
+
+    ``None`` covers both off-by-default cases: the PSK tier is selected, or JWT
+    identity is selected but this member has no token to present — against an
+    issuer-less install that is exactly today's behavior, so it degrades to the
+    PSK with a warning rather than refusing to join. Set
+    ``MYCELIUM_SLIM_IDENTITY_REQUIRE`` to make that degradation an error instead.
+    """
+    if resolve_mode() != IDENTITY_MODE_JWT:
+        return None
+
+    jwt = resolve_jwt_identity(token=token)
+    if not jwt.has_token():
+        if _truthy(_env(REQUIRE_ENV)):
+            raise SlimIdentityError(
+                f"{IDENTITY_ENV}={IDENTITY_MODE_JWT} and {REQUIRE_ENV} is set, but no token "
+                f"could be resolved for @{identity.agent}: refusing to fall back to the "
+                "shared-secret PSK."
+            )
+        _warn_once(
+            f"no-token:{identity.agent}",
+            "JWT channel identity is enabled but @%s has no token to present — "
+            "joining with the shared-secret PSK instead. Set %s (or log in / give the "
+            "agent a credential); set %s to fail closed here.",
+            identity.agent,
+            TOKEN_ENV,
+            REQUIRE_ENV,
+        )
+        return None
+
+    return ChannelIdentity(
+        provider=build_provider(sb, jwt, agent=identity.agent),
+        verifier=build_verifier(sb, jwt),
+        connection_auth=build_connection_auth(sb, jwt, agent=identity.agent),
+    )

--- a/fastapi-backend/tests/test_slim_identity.py
+++ b/fastapi-backend/tests/test_slim_identity.py
@@ -1,0 +1,244 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the SLIM channel-identity seam (slim_identity.py).
+
+Node-free: these cover what is decided *before* a socket exists — which tier is
+selected, which token is presented, where it lands on disk, and the shapes handed
+to slim-bindings. Whether a node with a JWT verifier actually admits the
+resulting member is the live-node slice (``test_slim_roundtrip.py``).
+
+The behaviour these lock down hardest is the **default**: an install that
+configures nothing must go on deriving the shared secret exactly as it did
+before per-member identity existed.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from app.services import slim_identity
+from app.services.slim_client import SlimIdentity
+from app.services.slim_identity import (
+    IDENTITY_MODE_JWT,
+    IDENTITY_MODE_PSK,
+    SlimIdentityError,
+    build_configs,
+    build_provider,
+    build_verifier,
+    materialize_token,
+    resolve_jwt_identity,
+    resolve_mode,
+    token_file_path,
+)
+
+_ENV_VARS = (
+    slim_identity.IDENTITY_ENV,
+    slim_identity.TOKEN_ENV,
+    slim_identity.TOKEN_FILE_ENV,
+    slim_identity.ISSUER_ENV,
+    slim_identity.AUDIENCE_ENV,
+    slim_identity.JWKS_ENV,
+    slim_identity.JWKS_FILE_ENV,
+    slim_identity.ALGORITHM_ENV,
+    slim_identity.DURATION_ENV,
+    slim_identity.REQUIRE_ENV,
+)
+
+IDENTITY = SlimIdentity("acme", "planning", "agent-7")
+
+
+@pytest.fixture(autouse=True)
+def _clean_identity_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Start every test from an unconfigured host with its own data dir."""
+    for name in _ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    slim_identity._warned.clear()
+
+
+def _bindings():
+    return pytest.importorskip("slim_bindings")
+
+
+# ── Tier selection ──────────────────────────────────────────────────────────
+
+
+def test_default_tier_is_the_shared_secret() -> None:
+    assert resolve_mode() == IDENTITY_MODE_PSK
+
+
+def test_tier_is_selected_from_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, "JWT")
+    assert resolve_mode() == IDENTITY_MODE_JWT
+
+
+def test_an_unknown_tier_is_refused_rather_than_read_as_psk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, "spire")
+    with pytest.raises(SlimIdentityError, match="not a SLIM identity mode"):
+        resolve_mode()
+
+
+def test_psk_tier_builds_no_identity_configs() -> None:
+    """The shipped default never reaches slim-bindings' identity API at all.
+
+    The bindings stand-in is empty on purpose: touching it would raise.
+    """
+    assert build_configs(ModuleType("not-slim-bindings"), IDENTITY, token="a-token") is None
+
+
+# ── Token resolution ────────────────────────────────────────────────────────
+
+
+def test_a_caller_supplied_token_wins_over_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One process joining as several agents presents each agent's own token."""
+    monkeypatch.setenv(slim_identity.TOKEN_ENV, "ambient")
+    assert resolve_jwt_identity(token="mine").token == "mine"
+
+
+def test_the_environment_supplies_the_token_when_the_caller_does_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(slim_identity.TOKEN_ENV, "ambient")
+    assert resolve_jwt_identity().token == "ambient"
+
+
+def test_settings_are_read_from_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(slim_identity.ISSUER_ENV, "https://idp/realm")
+    monkeypatch.setenv(slim_identity.AUDIENCE_ENV, "mycelium")
+    monkeypatch.setenv(slim_identity.ALGORITHM_ENV, "es256")
+    monkeypatch.setenv(slim_identity.DURATION_ENV, "120")
+
+    jwt = resolve_jwt_identity()
+    assert jwt.issuer == "https://idp/realm"
+    assert jwt.audience == "mycelium"
+    assert jwt.algorithm == "ES256"
+    assert jwt.duration_s == 120.0
+
+
+@pytest.mark.parametrize("bad", ["soon", "0", "-1"])
+def test_an_unusable_duration_is_refused(monkeypatch: pytest.MonkeyPatch, bad: str) -> None:
+    monkeypatch.setenv(slim_identity.DURATION_ENV, bad)
+    with pytest.raises(SlimIdentityError, match=slim_identity.DURATION_ENV):
+        resolve_jwt_identity()
+
+
+# ── The token file slim-bindings reads ──────────────────────────────────────
+
+
+def test_the_token_file_is_owner_only(tmp_path: Path) -> None:
+    path = materialize_token("agent-7", "a.b.c")
+    assert path == token_file_path("agent-7")
+    assert path.is_relative_to(tmp_path)
+    assert path.read_text(encoding="utf-8") == "a.b.c"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_an_unchanged_token_is_not_rewritten() -> None:
+    """slim-bindings reloads the file when it changes; identical is not a change."""
+    path = materialize_token("agent-7", "a.b.c")
+    before = path.stat().st_mtime_ns
+    assert materialize_token("agent-7", "a.b.c").stat().st_mtime_ns == before
+
+
+def test_a_refreshed_token_replaces_the_old_one() -> None:
+    materialize_token("agent-7", "old")
+    path = materialize_token("agent-7", "new")
+    assert path.read_text(encoding="utf-8") == "new"
+
+
+def test_each_agent_gets_its_own_token_file() -> None:
+    assert token_file_path("alpha") != token_file_path("beta")
+
+
+def test_a_handle_cannot_escape_the_token_directory() -> None:
+    path = token_file_path("../../etc/passwd")
+    assert path.parent == token_file_path("x").parent
+
+
+# ── The configs handed to slim-bindings ─────────────────────────────────────
+
+
+def test_the_provider_presents_the_materialized_token() -> None:
+    sb = _bindings()
+    jwt = resolve_jwt_identity(token="a.b.c")
+    provider = build_provider(sb, jwt, agent="agent-7")
+
+    assert provider.is_static_jwt()
+    assert Path(token_file_path("agent-7")).read_text(encoding="utf-8") == "a.b.c"
+
+
+def test_a_caller_owned_token_file_is_passed_through_untouched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A SPIRE sidecar (or CI) owns the file's lifetime; nothing here rewrites it."""
+    svid = tmp_path / "svid.jwt"
+    svid.write_text("from.the.sidecar", encoding="utf-8")
+    monkeypatch.setenv(slim_identity.TOKEN_FILE_ENV, str(svid))
+
+    build_provider(_bindings(), resolve_jwt_identity(), agent="agent-7")
+    assert not token_file_path("agent-7").exists()
+
+
+def test_the_provider_refuses_to_present_nothing() -> None:
+    with pytest.raises(SlimIdentityError, match="needs a token"):
+        build_provider(_bindings(), resolve_jwt_identity(), agent="agent-7")
+
+
+def test_the_verifier_pins_a_configured_jwks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(slim_identity.JWKS_ENV, json.dumps({"keys": []}))
+    monkeypatch.setenv(slim_identity.ISSUER_ENV, "https://idp/realm")
+    verifier = build_verifier(_bindings(), resolve_jwt_identity())
+    assert verifier.is_jwt()
+
+
+def test_the_verifier_resolves_keys_from_the_issuer_when_no_jwks_is_pinned() -> None:
+    verifier = build_verifier(_bindings(), resolve_jwt_identity())
+    assert verifier.is_jwt()
+
+
+def test_an_unknown_algorithm_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(slim_identity.ALGORITHM_ENV, "RS999")
+    monkeypatch.setenv(slim_identity.JWKS_ENV, json.dumps({"keys": []}))
+    with pytest.raises(SlimIdentityError, match="not a JWT algorithm"):
+        build_verifier(_bindings(), resolve_jwt_identity())
+
+
+def test_jwt_tier_with_a_token_builds_every_half(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One token, three places it is presented: peers, peers' checks, the node."""
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, IDENTITY_MODE_JWT)
+    built = build_configs(_bindings(), IDENTITY, token="a.b.c")
+    assert built is not None
+    assert built.provider.is_static_jwt()
+    assert built.verifier.is_jwt()
+    assert built.connection_auth.is_static_jwt()
+
+
+# ── Degradation ─────────────────────────────────────────────────────────────
+
+
+def test_jwt_tier_without_a_token_falls_back_to_the_psk(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No credential is today's behaviour, so it stays joinable — but says so."""
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, IDENTITY_MODE_JWT)
+    with caplog.at_level("WARNING"):
+        assert build_configs(_bindings(), IDENTITY, token=None) is None
+    assert "no token to present" in caplog.text
+
+
+def test_the_fallback_can_be_made_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A host that means to run on verified identity fails closed instead."""
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, IDENTITY_MODE_JWT)
+    monkeypatch.setenv(slim_identity.REQUIRE_ENV, "1")
+    with pytest.raises(SlimIdentityError, match="refusing to fall back"):
+        build_configs(_bindings(), IDENTITY, token=None)

--- a/fastapi-backend/tests/test_slim_l9_wire.py
+++ b/fastapi-backend/tests/test_slim_l9_wire.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-from app.services import l9
+from app.services import l9, slim_identity
 from app.services.l9_models import Kind
 from app.services.memory_sync import KnowledgeWrite, build_knowledge_envelope
 from app.services.slim_client import (
@@ -143,3 +143,30 @@ def test_channel_name_topic_matches_contract():
     g = _contract()
     name = to_channel_name("acme", "planning")
     assert name.components() == ["acme", "planning", g["channel_topic"]]
+
+
+def test_identity_env_names_match_contract():
+    """The identity tier is selected from the same env names on both sides."""
+    g = _contract()["identity"]
+    assert list(g["modes"]) == list(slim_identity.IDENTITY_MODES)
+    assert g["default_mode"] == slim_identity.IDENTITY_MODE_PSK
+    assert g["default_algorithm"] == slim_identity.DEFAULT_ALGORITHM
+    assert g["default_duration_s"] == slim_identity.DEFAULT_DURATION_S
+    assert g["token_dir_name"] == slim_identity.TOKEN_DIR_NAME
+    env = g["env"]
+    assert env["mode"] == slim_identity.IDENTITY_ENV
+    assert env["token"] == slim_identity.TOKEN_ENV
+    assert env["token_file"] == slim_identity.TOKEN_FILE_ENV
+    assert env["issuer"] == slim_identity.ISSUER_ENV
+    assert env["audience"] == slim_identity.AUDIENCE_ENV
+    assert env["jwks"] == slim_identity.JWKS_ENV
+    assert env["jwks_file"] == slim_identity.JWKS_FILE_ENV
+    assert env["algorithm"] == slim_identity.ALGORITHM_ENV
+    assert env["duration_s"] == slim_identity.DURATION_ENV
+    assert env["require"] == slim_identity.REQUIRE_ENV
+
+
+def test_identity_defaults_to_the_shared_secret_tier(monkeypatch):
+    """An install that configures nothing stays on the PSK."""
+    monkeypatch.delenv(slim_identity.IDENTITY_ENV, raising=False)
+    assert slim_identity.resolve_mode() == _contract()["identity"]["default_mode"]

--- a/mycelium-cli/src/mycelium/client.py
+++ b/mycelium-cli/src/mycelium/client.py
@@ -126,23 +126,33 @@ def _refresh(stored: StoredToken, config: MyceliumConfig) -> StoredToken | None:
     return renewed
 
 
-def auth_headers(
-    config: MyceliumConfig | None = None, *, handle: str | None = None
-) -> dict[str, str]:
-    """``{"Authorization": "Bearer …"}`` when there's a credential, ``{}`` when not.
+def access_token(config: MyceliumConfig | None = None, *, handle: str | None = None) -> str | None:
+    """The bearer token this caller presents, or ``None`` when it has none.
 
     ``handle`` names the agent the call is being made *as*. Its own credential
     wins over the human session when it has one: a resident agent driven from a
     developer's logged-in shell must still write as itself, not as the developer.
+
+    The token is the caller's identity rather than a property of one transport,
+    so the SLIM plane resolves its channel identity through this same function
+    (``mycelium.slim.identity``) — one credential, both planes.
     """
     from mycelium import agent_credentials
 
     cfg = _resolve_config(config)
     agent_token = agent_credentials.access_token(cfg, handle)
     if agent_token:
-        return {"Authorization": f"Bearer {agent_token}"}
+        return agent_token
     token = current_token(cfg)
-    return {"Authorization": f"Bearer {token.access_token}"} if token else {}
+    return token.access_token if token else None
+
+
+def auth_headers(
+    config: MyceliumConfig | None = None, *, handle: str | None = None
+) -> dict[str, str]:
+    """``{"Authorization": "Bearer …"}`` when there's a credential, ``{}`` when not."""
+    token = access_token(config, handle=handle)
+    return {"Authorization": f"Bearer {token}"} if token else {}
 
 
 def typed_client(config: MyceliumConfig | None = None, *, handle: str | None = None) -> Client:

--- a/mycelium-cli/src/mycelium/commands/wire.py
+++ b/mycelium-cli/src/mycelium/commands/wire.py
@@ -60,6 +60,12 @@ def _parse_json_object(raw: str | None, *, label: str) -> dict:
 def _run_publish(
     config: MyceliumConfig, room: str, handle: str, payload: bytes, workspace: str | None
 ) -> None:
+    from mycelium import client as hub_client_factory
+    from mycelium.slim import settings as slim_settings
+
+    # The identity layer reads the environment (it is mirrored byte-for-byte
+    # with the backend's), so the authored [slim] block has to reach it first.
+    slim_settings.apply_identity_env(config)
     asyncio.run(
         publish_once(
             api_url=config.server.api_url,
@@ -68,6 +74,9 @@ def _run_publish(
             handle=handle,
             payload=payload,
             workspace=workspace or DEFAULT_WORKSPACE,
+            # The same credential the hub's HTTP API would get — the sender
+            # publishes as itself on the channel too, when JWT identity is on.
+            token=hub_client_factory.access_token(config, handle=handle),
         )
     )
 

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -86,6 +86,61 @@ class SlimConfig(BaseModel):
         default="http://127.0.0.1:46357",
         description="SLIM node endpoint (host:port), e.g. http://127.0.0.1:46357",
     )
+    identity: str = Field(
+        default="psk",
+        description=(
+            "Channel identity tier: 'psk' (default — the deterministic shared secret every "
+            "member of a room derives, zero infrastructure) or 'jwt' (each member presents "
+            "its own OIDC token, so members are distinct and individually revocable)."
+        ),
+    )
+    identity_issuer: str | None = Field(
+        default=None,
+        description=(
+            "Issuer a peer's channel token must carry to be accepted. Unset falls back to "
+            "agent_auth.issuer, then login.issuer — the same trust root as the HTTP API."
+        ),
+    )
+    identity_audience: str | None = Field(
+        default=None,
+        description=(
+            "Audience a peer's channel token must carry. Unset falls back to "
+            "agent_auth.audience, then login.audience."
+        ),
+    )
+    identity_jwks: str | None = Field(
+        default=None,
+        description="Inline JWKS JSON used to verify peers. Unset resolves keys from the issuer.",
+    )
+    identity_jwks_file: str | None = Field(
+        default=None,
+        description="Path to a JWKS file used to verify peers, for a key set too large for env.",
+    )
+    identity_token_file: str | None = Field(
+        default=None,
+        description=(
+            "Path to a file holding this member's raw channel token, used as-is — a SPIRE "
+            "sidecar's JWT-SVID, or a CI-provided token. Unset resolves the token from the "
+            "same credential the HTTP API uses (mycelium login, or the agent's own)."
+        ),
+    )
+    identity_algorithm: str = Field(
+        default="RS256",
+        description="Signing algorithm of the issuer's keys (RS256, ES256, EdDSA, ...).",
+    )
+    identity_duration_s: float = Field(
+        default=3600.0,
+        description="How long a presented channel identity is treated as good for, in seconds.",
+    )
+
+    @field_validator("identity")
+    @classmethod
+    def validate_identity(cls, v: str) -> str:
+        """Only the two tiers exist; a typo must not silently mean 'psk'."""
+        normalized = v.strip().lower()
+        if normalized not in ("psk", "jwt"):
+            raise ValueError(f"slim.identity must be 'psk' or 'jwt', got {v!r}")
+        return normalized
 
     @field_validator("node_endpoint")
     @classmethod

--- a/mycelium-cli/src/mycelium/docker/compose-slim-jwt.yml
+++ b/mycelium-cli/src/mycelium/docker/compose-slim-jwt.yml
@@ -1,0 +1,76 @@
+# Opt-in: gate the SLIM node's dataplane connection on a JWT (#476).
+#
+# ⚠️  PROPOSED, NOT YET VERIFIED AGAINST A LIVE NODE. The node's YAML schema is
+# derived from slim-bindings' `ServerConfig.auth: ServerAuthenticationConfig`
+# (variants BASIC | JWT, the JWT one carrying a `JwtAuth` with key/audience/
+# issuer/subject/duration). The Python record names below are a faithful
+# transcription of that struct, but the node is a separate Rust binary and its
+# serde field/tag spelling has not been confirmed here. Verify against a running
+# `ghcr.io/agntcy/slim:2.0.0` before relying on it, and correct this file in
+# place if the node names things differently.
+#
+# WHAT THIS IS NOT: per-member channel identity does **not** need this. Members
+# prove who they are to *each other* through the app-level identity provider /
+# verifier that `mycelium.slim.identity` builds — the node forwards ciphertext
+# and never inspects it. That works against the stock node with no config change
+# at all. This overlay is the separate, additional question of whether the node
+# lets an unauthenticated client open a dataplane connection in the first place.
+#
+# Bring it up alongside the dev stack and the dev issuer (from the repo root):
+#   docker compose \
+#     -f mycelium-cli/src/mycelium/docker/compose.yml \
+#     -f mycelium-cli/src/mycelium/docker/compose-dev.yml \
+#     -f mycelium-cli/src/mycelium/docker/compose-auth-dev.yml \
+#     -f mycelium-cli/src/mycelium/docker/compose-slim-jwt.yml \
+#     up -d
+#
+# The clients' half is config, not a compose change:
+#   mycelium config set slim.identity jwt
+#   mycelium config set slim.identity_issuer http://mycelium-auth-dev:8080/default
+#   mycelium config apply
+# plus MYCELIUM_SLIM_IDENTITY_TOKEN for the backend moderator's own service
+# account (see the Authentication guide).
+
+configs:
+  slim-node-config-jwt:
+    content: |
+      tracing:
+        log_level: info
+      runtime:
+        n_cores: 0
+        thread_name: "slim-data-plane"
+        drain_timeout: 10s
+      services:
+        slim/0:
+          node_id: mycelium-slim
+          dataplane:
+            servers:
+              - endpoint: "0.0.0.0:46357"
+                tls:
+                  insecure: true
+                auth:
+                  jwt:
+                    issuer: "${MYCELIUM_SLIM_IDENTITY_ISSUER:-http://mycelium-auth-dev:8080/default}"
+                    audience:
+                      - "${MYCELIUM_SLIM_IDENTITY_AUDIENCE:-mycelium}"
+                    duration: 3600s
+                    key:
+                      decoding:
+                        algorithm: RS256
+                        format: jwks
+                        key:
+                          file: /etc/slim/jwks.json
+            clients: []
+
+services:
+
+  slim:
+    configs:
+      - source: slim-node-config-jwt
+        target: /slim-config.yaml
+    volumes:
+      # The issuer's key set, fetched once from <issuer>/jwks. A node that can
+      # reach the issuer over the network can autoresolve instead; a file keeps
+      # the node's trust root explicit and independent of issuer availability
+      # at connect time.
+      - ${MYCELIUM_SLIM_JWKS_FILE:-~/.mycelium/slim-jwks.json}:/etc/slim/jwks.json:ro

--- a/mycelium-cli/src/mycelium/docker_utils.py
+++ b/mycelium-cli/src/mycelium/docker_utils.py
@@ -6,8 +6,8 @@ Generate .env files from config.toml — makes .env a derived artifact.
 
 The canonical configuration lives in ~/.mycelium/config.toml.  This module
 renders a Docker-compatible .env from the [llm], [runtime], [server], [engine],
-and [auth] sections so that ``docker compose`` picks up the same values without
-users having to maintain two files.
+[auth], and [slim] sections so that ``docker compose`` picks up the same values
+without users having to maintain two files.
 
 One field deliberately *isn't* in config.toml: ``MYCELIUM_IMAGE_TAG``.  It's
 operational state — set as a side effect of ``mycelium pull --version`` and
@@ -21,6 +21,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from mycelium.slim import settings as slim_settings
 
 if TYPE_CHECKING:
     from mycelium.config import MyceliumConfig
@@ -148,6 +150,13 @@ def generate_env_file(
         f"AUTH_ROLE_CLAIM={config.auth.role_claim}",
         f"AUTH_LEEWAY_S={config.auth.leeway_s}",
         f"AUTH_JWKS_TTL_S={config.auth.jwks_ttl_s}",
+        "",
+        "# ── SLIM channel identity (shared-secret PSK unless slim.identity = jwt) ─",
+        # The backend moderator's own token is deliberately NOT rendered here:
+        # config.toml is routinely printed and copied between machines, so a
+        # bearer token is set as MYCELIUM_SLIM_IDENTITY_TOKEN out of band (or
+        # written to slim.identity_token_file) rather than derived from it.
+        *(f"{key}={value}" for key, value in slim_settings.identity_env(config).items()),
         "",
     ]
 

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -223,6 +223,82 @@ Nothing about it is required, and nothing about it is on by default.
 | `agent_auth.scopes` | *(unset)* | Scopes requested for an agent token. Most issuers want none for `client_credentials`. |
 | `agent_auth.audience` | *(unset)* | Audience to request; should match the hub's `auth.audience`. |
 
+## The same token joins the SLIM channel
+
+Everything above gates the **HTTP API**. Rooms have a second plane — the SLIM
+group channel that coordination messages ride — and it authenticates members
+separately.
+
+By default that plane uses a **shared secret**: a per-room key every member
+derives offline from `MYCELIUM_SLIM_MASTER_SECRET`. It needs no infrastructure,
+which is why it ships on, but it is scoped to the room, not to you. Every member
+of a room derives the same value, so members are cryptographically
+indistinguishable, and removing one means rotating the secret for everyone.
+
+Switch the plane to per-member identity and each member instead presents **the
+token it already has** — the same one this guide has been about:
+
+```bash
+mycelium config set slim.identity jwt
+mycelium config apply
+```
+
+That is the whole client-side change. One `mycelium login`, or one agent
+service-account credential, now authenticates the API *and* joins the channel;
+identity on the channel is the token's `sub`, which is the handle. Two agents in
+a room are distinct MLS participants, and revoking one agent's client leaves
+every other member untouched.
+
+### What the moderator presents
+
+The always-on backend is every room's moderator, and it is a member like any
+other. It has no `mycelium login` to draw on, so give it its own token
+out of band:
+
+```bash
+# In ~/.mycelium/.env, or the backend's environment
+MYCELIUM_SLIM_IDENTITY_TOKEN=<the backend service account's token>
+# or, for a token some other process writes and renews:
+MYCELIUM_SLIM_IDENTITY_TOKEN_FILE=/run/secrets/moderator.jwt
+```
+
+A bearer token is deliberately not read from `config.toml` — that file is printed,
+copied between machines, and mirrored to `config.json`.
+
+### It degrades rather than locking you out
+
+With `slim.identity = jwt` and no token to present, a member joins on the shared
+secret and logs a warning. That is deliberate: an install that turned the switch on
+before wiring an issuer keeps working. Set `MYCELIUM_SLIM_IDENTITY_REQUIRE=1` on
+hosts that mean it, and they refuse to fall back instead — the twin of
+`MYCELIUM_SLIM_REQUIRE_SECRET` for the shared secret itself.
+
+### Configuration
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `slim.identity` | `psk` | `psk` (shared secret) or `jwt` (each member presents its own token). |
+| `slim.identity_issuer` | *(from `agent_auth` / `login`)* | Issuer a peer's channel token must carry. |
+| `slim.identity_audience` | *(from `agent_auth` / `login`)* | Audience a peer's channel token must carry. |
+| `slim.identity_jwks` | *(unset)* | Inline JWKS JSON for verifying peers. Unset resolves keys from the issuer. |
+| `slim.identity_jwks_file` | *(unset)* | Path to a JWKS file, for a key set too large for the environment. |
+| `slim.identity_token_file` | *(unset)* | A file holding this member's token, used as-is — a SPIRE JWT-SVID, or CI's. |
+| `slim.identity_algorithm` | `RS256` | Signing algorithm of the issuer's keys. |
+| `slim.identity_duration_s` | `3600` | How long a presented channel identity is treated as good for. |
+
+The issuer and audience default to the ones the HTTP plane already uses, so the
+common case configures neither: one credential, one trust root, both planes.
+
+### The node needs no change for this
+
+Members prove who they are **to each other**. The node routes ciphertext and never
+inspects it, so per-member channel identity works against the stock node with no
+node configuration at all.
+
+A node *can* additionally require a token to open a dataplane connection at all —
+a separate, transport-level gate. Members present the same token there too, and
+`docker/compose-slim-jwt.yml` sketches the node side of it.
+
 ## Issuer-agnostic by design
 
 The backend trusts a configured issuer and its JWKS. It has no idea whether that

--- a/mycelium-cli/src/mycelium/slim/__init__.py
+++ b/mycelium-cli/src/mycelium/slim/__init__.py
@@ -15,7 +15,9 @@ Two invariants keep the two halves interoperable and MUST match the backend:
 - **Naming + shared secret** (:mod:`mycelium.slim.naming`) — the
   ``workspace/room/agent`` → SLIM ``Name`` mapping and the shared-secret
   (authentication PSK) derivation are byte-for-byte the backend's, or a member
-  fails identity verification and can't join the moderator's group.
+  fails identity verification and can't join the moderator's group. The same
+  goes for :mod:`mycelium.slim.identity`, which decides whether that PSK or the
+  member's own JWT is presented.
 - **L9 wire shape** (:mod:`mycelium.slim.l9`) — an envelope rides under the
   additive ``l9`` key of a message's content JSON, in the exact shape the
   backend's ``l9.envelope_to_dict`` emits, so ``l9.parse_envelope`` accepts a
@@ -25,6 +27,12 @@ Two invariants keep the two halves interoperable and MUST match the backend:
 from __future__ import annotations
 
 from mycelium.slim.client import SlimClient, SlimUnavailableError
+from mycelium.slim.identity import (
+    IDENTITY_MODE_JWT,
+    IDENTITY_MODE_PSK,
+    SlimIdentityError,
+    resolve_mode,
+)
 from mycelium.slim.naming import (
     DEFAULT_NODE_ENDPOINT,
     DEFAULT_WORKSPACE,
@@ -38,11 +46,15 @@ from mycelium.slim.naming import (
 __all__ = [
     "DEFAULT_NODE_ENDPOINT",
     "DEFAULT_WORKSPACE",
+    "IDENTITY_MODE_JWT",
+    "IDENTITY_MODE_PSK",
     "SlimClient",
     "SlimIdentity",
+    "SlimIdentityError",
     "SlimUnavailableError",
     "mint_shared_secret",
     "node_reachable",
+    "resolve_mode",
     "to_channel_name",
     "to_slim_name",
 ]

--- a/mycelium-cli/src/mycelium/slim/client.py
+++ b/mycelium-cli/src/mycelium/slim/client.py
@@ -24,6 +24,7 @@ import datetime
 from types import ModuleType
 from typing import TYPE_CHECKING
 
+from mycelium.slim import identity as slim_identity
 from mycelium.slim.naming import (
     DEFAULT_NODE_ENDPOINT,
     SlimIdentity,
@@ -86,10 +87,25 @@ def _ensure_service_initialized(sb: ModuleType) -> None:
 _connections: dict[str, int] = {}
 
 
-async def _shared_connection(service: slim_bindings.Service, sb: ModuleType, endpoint: str) -> int:
+async def _shared_connection(
+    service: slim_bindings.Service,
+    sb: ModuleType,
+    endpoint: str,
+    *,
+    auth: slim_bindings.ClientAuthenticationConfig | None = None,
+) -> int:
+    """Return the process-wide conn_id for ``endpoint``, connecting once.
+
+    ``auth`` is the credential presented to the *node* when it gates connections;
+    it belongs to the first app that opens the connection, which every later app
+    in the process then shares. Each app still carries its own identity to its
+    MLS peers.
+    """
     conn_id = _connections.get(endpoint)
     if conn_id is None:
         client_config = sb.new_insecure_client_config(endpoint)
+        if auth is not None:
+            client_config.auth = auth
         # Enable idle keepalive. ``new_insecure_client_config`` leaves
         # ``keepalive=None`` → the binding's ``keep_alive_while_idle`` defaults to
         # False, so the node drops a connection after ~30s of silence (its
@@ -135,9 +151,14 @@ class SlimClient:
         message = await SlimClient.receive_message(session)
     """
 
-    def __init__(self, identity: SlimIdentity, *, secret: str | None = None) -> None:
+    def __init__(
+        self, identity: SlimIdentity, *, secret: str | None = None, token: str | None = None
+    ) -> None:
         self.identity = identity
         self._secret = secret or mint_shared_secret(identity)
+        # The bearer token this member presents as its channel identity when JWT
+        # identity is on — the same one it sends to the hub's HTTP API.
+        self._token = token
         self._sb: ModuleType | None = None
         self._app: slim_bindings.App | None = None
         self._conn_id: int | None = None
@@ -152,8 +173,17 @@ class SlimClient:
 
         self._sb = sb
         self._local_name = to_slim_name(*self.identity.as_tuple())
-        self._conn_id = await _shared_connection(service, sb, endpoint)
-        self._app = service.create_app_with_secret(self._local_name, self._secret)
+        # JWT identity when it is configured *and* this member has a token;
+        # otherwise the shared-secret PSK, which is the shipped default.
+        channel_identity = slim_identity.build_configs(sb, self.identity, token=self._token)
+        auth = channel_identity.connection_auth if channel_identity else None
+        self._conn_id = await _shared_connection(service, sb, endpoint, auth=auth)
+        if channel_identity is None:
+            self._app = service.create_app_with_secret(self._local_name, self._secret)
+        else:
+            self._app = service.create_app(
+                self._local_name, channel_identity.provider, channel_identity.verifier
+            )
         await self._app.subscribe_async(self._local_name, self._conn_id)
         return self
 

--- a/mycelium-cli/src/mycelium/slim/identity.py
+++ b/mycelium-cli/src/mycelium/slim/identity.py
@@ -1,0 +1,371 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""SLIM channel identity: the shared-secret PSK, or a per-member JWT (CLI side).
+
+Two identity tiers stand behind one seam, chosen by ``MYCELIUM_SLIM_IDENTITY``:
+
+``psk`` (the default)
+    The deterministic shared secret every member of a room derives offline
+    (:func:`~app.services.slim_client.mint_shared_secret`). Zero infrastructure,
+    which is what the try-it path needs — but it is scoped to ``workspace/room``,
+    so every member of a room is cryptographically indistinguishable and
+    revoking one means rotating the secret for all.
+
+``jwt``
+    Each member presents its **own bearer token** as its channel identity, and
+    verifies its peers' tokens against a trusted issuer. Identity is the token's
+    ``sub`` — the agent or human handle — so members are distinct MLS
+    participants and revoking one leaves the rest untouched.
+
+The token is deliberately **not a new credential**: it is the same OIDC token
+``mycelium.client`` already attaches to every hub call — the human session from
+``mycelium login``, or the agent's own service account
+(``mycelium.agent_credentials``). One credential authenticates the API *and*
+joins the channel.
+
+slim-bindings takes the presenting side as
+``IdentityProviderConfig.STATIC_JWT(StaticJwtAuth(token_file=…))``: a bearer
+token read from a file and reloaded when it changes. So a token resolved in
+memory is materialized to an owner-only file under the data dir first
+(:func:`materialize_token`), and a refreshed token is picked up by rewriting it.
+
+Resolution is **env-only on both sides** — the same shape
+``MYCELIUM_SLIM_MASTER_SECRET`` already has — so this module and its backend
+mirror (``app/services/slim_identity.py``) stay byte-for-byte comparable.
+Operators author the values under ``[slim]`` in ``config.toml``; ``mycelium
+config apply`` renders them into the process/container env. The names and
+defaults are frozen in ``contracts/slim-l9-wire.json``.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import slim_bindings
+
+    from mycelium.slim.naming import SlimIdentity
+
+logger = logging.getLogger("mycelium.slim")
+
+#: The shared-secret tier: what ships, and what every default install runs.
+IDENTITY_MODE_PSK = "psk"
+
+#: The per-member tier: each member presents its own OIDC token.
+IDENTITY_MODE_JWT = "jwt"
+
+IDENTITY_MODES = (IDENTITY_MODE_PSK, IDENTITY_MODE_JWT)
+
+#: Which tier to use. Unset means :data:`IDENTITY_MODE_PSK` — turning JWT
+#: identity on must be a deliberate act, never something an install drifts into.
+IDENTITY_ENV = "MYCELIUM_SLIM_IDENTITY"
+
+#: The member's own bearer token, verbatim. The moderator's service account
+#: arrives this way; a CLI member passes its resolved token in code instead.
+TOKEN_ENV = "MYCELIUM_SLIM_IDENTITY_TOKEN"
+
+#: A file already holding the raw token — a SPIRE sidecar's JWT-SVID, or a CI
+#: runner's. Used as-is: nothing here mints or renews it, and it is handed
+#: straight to slim-bindings, which reloads it when the writer rewrites it.
+TOKEN_FILE_ENV = "MYCELIUM_SLIM_IDENTITY_TOKEN_FILE"
+
+#: The ``iss`` a peer's token must carry to be accepted.
+ISSUER_ENV = "MYCELIUM_SLIM_IDENTITY_ISSUER"
+
+#: The ``aud`` a peer's token must carry to be accepted.
+AUDIENCE_ENV = "MYCELIUM_SLIM_IDENTITY_AUDIENCE"
+
+#: Inline JWKS JSON for verifying peers. Unset falls back to autoresolve.
+JWKS_ENV = "MYCELIUM_SLIM_IDENTITY_JWKS"
+
+#: A file holding the JWKS, for a key set too large to sit in the environment.
+JWKS_FILE_ENV = "MYCELIUM_SLIM_IDENTITY_JWKS_FILE"
+
+#: Signing algorithm of the issuer's keys.
+ALGORITHM_ENV = "MYCELIUM_SLIM_IDENTITY_ALGORITHM"
+
+#: How long slim-bindings treats a presented identity as good for.
+DURATION_ENV = "MYCELIUM_SLIM_IDENTITY_DURATION_S"
+
+#: Refuse to fall back to the PSK when JWT identity was asked for and no token
+#: could be resolved. The twin of ``MYCELIUM_SLIM_REQUIRE_SECRET``: a host that
+#: means to run on verified identity fails closed rather than quietly joining
+#: with a credential anyone with the repo can derive.
+REQUIRE_ENV = "MYCELIUM_SLIM_IDENTITY_REQUIRE"
+
+#: Where the materialized token files live, under the data dir.
+TOKEN_DIR_NAME = "slim-identity"
+
+DEFAULT_ALGORITHM = "RS256"
+DEFAULT_DURATION_S = 3600.0
+
+#: Handles are lowercase slugs, but the filename is derived from caller input,
+#: so anything outside the slug alphabet is folded away before it reaches a path.
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+
+#: One warning per process per reason — every room provisions its own app and
+#: each would otherwise repeat the same line.
+_warned: set[str] = set()
+
+
+class SlimIdentityError(RuntimeError):
+    """SLIM identity is misconfigured, or JWT identity has nothing to present."""
+
+
+def _env(name: str) -> str | None:
+    return os.environ.get(name, "").strip() or None
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() not in ("", "0", "false", "no")
+
+
+def _warn_once(key: str, message: str, *args: object) -> None:
+    if key in _warned:
+        return
+    _warned.add(key)
+    logger.warning(message, *args)
+
+
+def resolve_mode() -> str:
+    """Which identity tier this process runs on. Defaults to the PSK."""
+    raw = (_env(IDENTITY_ENV) or IDENTITY_MODE_PSK).lower()
+    if raw not in IDENTITY_MODES:
+        raise SlimIdentityError(
+            f"{IDENTITY_ENV}={raw!r} is not a SLIM identity mode; "
+            f"expected one of {', '.join(IDENTITY_MODES)}"
+        )
+    return raw
+
+
+def data_dir() -> Path:
+    """The mycelium data dir the token file is written under."""
+    override = _env("MYCELIUM_DATA_DIR")
+    return Path(override).expanduser() if override else Path.home() / ".mycelium"
+
+
+def token_file_path(agent: str) -> Path:
+    """Where ``agent``'s presented token is materialized, one file per agent.
+
+    Keyed on the agent rather than the channel: one credential is the same
+    identity in every room it joins, so all its rooms read one file and a
+    refresh is written once.
+    """
+    safe = _UNSAFE.sub("-", agent) or "agent"
+    return data_dir() / TOKEN_DIR_NAME / f"{safe}.jwt"
+
+
+def materialize_token(agent: str, token: str) -> Path:
+    """Write ``token`` where slim-bindings can read it, owner-only.
+
+    Rewritten only when the contents actually change: slim-bindings watches the
+    file and reloads on change, so re-writing an identical token on every
+    connect would churn the identity for no reason.
+    """
+    path = token_file_path(agent)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        if path.read_text(encoding="utf-8") == token:
+            return path
+    except OSError:
+        pass
+    # os.open with 0600 rather than write_text + chmod: the file must never
+    # exist, even momentarily, with the default mode — it holds a bearer token.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(token)
+    # A file written before this mode was asserted keeps its old one otherwise.
+    os.chmod(path, 0o600)
+    return path
+
+
+@dataclass(frozen=True)
+class JwtIdentity:
+    """Everything the JWT tier needs: what to present, and what to accept."""
+
+    #: The bearer token to present, in memory. Materialized before use.
+    token: str | None = None
+    #: A file already holding the token, used as-is instead of materializing.
+    token_file: str | None = None
+    issuer: str | None = None
+    audience: str | None = None
+    jwks: str | None = None
+    jwks_file: str | None = None
+    algorithm: str = DEFAULT_ALGORITHM
+    duration_s: float = DEFAULT_DURATION_S
+
+    def has_token(self) -> bool:
+        return bool(self.token or self.token_file)
+
+
+def resolve_jwt_identity(*, token: str | None = None) -> JwtIdentity:
+    """The JWT tier's settings, from the environment and an in-memory token.
+
+    ``token`` is what the caller already resolved for the HTTP plane — an
+    agent's service-account token or the human session. It wins over the
+    environment, which is how one process can join as several distinct members.
+    """
+    raw_duration = _env(DURATION_ENV)
+    try:
+        duration_s = float(raw_duration) if raw_duration else DEFAULT_DURATION_S
+    except ValueError:
+        raise SlimIdentityError(f"{DURATION_ENV}={raw_duration!r} is not a number")
+    if duration_s <= 0:
+        raise SlimIdentityError(f"{DURATION_ENV}={raw_duration!r} must be positive")
+
+    return JwtIdentity(
+        token=token or _env(TOKEN_ENV),
+        token_file=_env(TOKEN_FILE_ENV),
+        issuer=_env(ISSUER_ENV),
+        audience=_env(AUDIENCE_ENV),
+        jwks=_env(JWKS_ENV),
+        jwks_file=_env(JWKS_FILE_ENV),
+        algorithm=(_env(ALGORITHM_ENV) or DEFAULT_ALGORITHM).upper(),
+        duration_s=duration_s,
+    )
+
+
+def _algorithm(sb: ModuleType, name: str) -> slim_bindings.JwtAlgorithm:
+    try:
+        return getattr(sb.JwtAlgorithm, name)
+    except AttributeError:
+        raise SlimIdentityError(
+            f"{ALGORITHM_ENV}={name!r} is not a JWT algorithm slim-bindings knows"
+        )
+
+
+def build_provider(
+    sb: ModuleType, jwt: JwtIdentity, *, agent: str
+) -> slim_bindings.IdentityProviderConfig:
+    """How this member proves who it is: its bearer token, from a file.
+
+    An in-memory token is materialized under the data dir; a ``token_file`` the
+    caller already has (a SPIRE sidecar's JWT-SVID) is passed through untouched.
+    """
+    if jwt.token_file:
+        path = jwt.token_file
+    elif jwt.token:
+        path = str(materialize_token(agent, jwt.token))
+    else:
+        raise SlimIdentityError("JWT channel identity needs a token and none was resolved")
+    return sb.IdentityProviderConfig.STATIC_JWT(
+        sb.StaticJwtAuth(
+            token_file=path,
+            duration=datetime.timedelta(seconds=jwt.duration_s),
+        )
+    )
+
+
+def build_verifier(sb: ModuleType, jwt: JwtIdentity) -> slim_bindings.IdentityVerifierConfig:
+    """How this member decides a peer's token is real.
+
+    An explicitly configured JWKS (inline or a file) pins the keys. With none,
+    the key is autoresolved from the token's issuer — which is why ``issuer``
+    and ``audience`` matter: they are what bounds who may be believed.
+    """
+    if jwt.jwks or jwt.jwks_file:
+        data = sb.JwtKeyData.DATA(jwt.jwks) if jwt.jwks else sb.JwtKeyData.FILE(str(jwt.jwks_file))
+        key = sb.JwtKeyType.DECODING(
+            sb.JwtKeyConfig(
+                algorithm=_algorithm(sb, jwt.algorithm),
+                format=sb.JwtKeyFormat.JWKS,
+                key=data,
+            )
+        )
+    else:
+        key = sb.JwtKeyType.AUTORESOLVE()
+    return sb.IdentityVerifierConfig.JWT(
+        sb.JwtAuth(
+            key=key,
+            audience=[jwt.audience] if jwt.audience else None,
+            issuer=jwt.issuer,
+            subject=None,
+            duration=datetime.timedelta(seconds=jwt.duration_s),
+        )
+    )
+
+
+def build_connection_auth(
+    sb: ModuleType, jwt: JwtIdentity, *, agent: str
+) -> slim_bindings.ClientAuthenticationConfig:
+    """The same token again, this time for the connection to the node.
+
+    App identity and transport are separate axes in SLIM: the provider/verifier
+    pair above is what MLS peers check about each other, and the node forwards
+    ciphertext without needing any of it. A node *may* additionally gate the
+    dataplane connection itself (``auth.jwt`` on its server config), and a client
+    that presents nothing is refused there. Carrying the token on both means one
+    credential covers the whole path.
+    """
+    if jwt.token_file:
+        path = jwt.token_file
+    elif jwt.token:
+        path = str(materialize_token(agent, jwt.token))
+    else:
+        raise SlimIdentityError("JWT channel identity needs a token and none was resolved")
+    return sb.ClientAuthenticationConfig.STATIC_JWT(
+        sb.StaticJwtAuth(
+            token_file=path,
+            duration=datetime.timedelta(seconds=jwt.duration_s),
+        )
+    )
+
+
+@dataclass(frozen=True)
+class ChannelIdentity:
+    """What an app presents and accepts once the JWT tier is in force."""
+
+    #: Proves this member's identity to its MLS peers.
+    provider: slim_bindings.IdentityProviderConfig
+    #: Decides whether a peer's presented identity is believable.
+    verifier: slim_bindings.IdentityVerifierConfig
+    #: Proves the same identity to the node, for a node that gates connections.
+    connection_auth: slim_bindings.ClientAuthenticationConfig
+
+
+def build_configs(
+    sb: ModuleType, identity: SlimIdentity, *, token: str | None = None
+) -> ChannelIdentity | None:
+    """What ``identity`` presents on the channel, or ``None`` to use the PSK.
+
+    ``None`` covers both off-by-default cases: the PSK tier is selected, or JWT
+    identity is selected but this member has no token to present — against an
+    issuer-less install that is exactly today's behavior, so it degrades to the
+    PSK with a warning rather than refusing to join. Set
+    ``MYCELIUM_SLIM_IDENTITY_REQUIRE`` to make that degradation an error instead.
+    """
+    if resolve_mode() != IDENTITY_MODE_JWT:
+        return None
+
+    jwt = resolve_jwt_identity(token=token)
+    if not jwt.has_token():
+        if _truthy(_env(REQUIRE_ENV)):
+            raise SlimIdentityError(
+                f"{IDENTITY_ENV}={IDENTITY_MODE_JWT} and {REQUIRE_ENV} is set, but no token "
+                f"could be resolved for @{identity.agent}: refusing to fall back to the "
+                "shared-secret PSK."
+            )
+        _warn_once(
+            f"no-token:{identity.agent}",
+            "JWT channel identity is enabled but @%s has no token to present — "
+            "joining with the shared-secret PSK instead. Set %s (or log in / give the "
+            "agent a credential); set %s to fail closed here.",
+            identity.agent,
+            TOKEN_ENV,
+            REQUIRE_ENV,
+        )
+        return None
+
+    return ChannelIdentity(
+        provider=build_provider(sb, jwt, agent=identity.agent),
+        verifier=build_verifier(sb, jwt),
+        connection_auth=build_connection_auth(sb, jwt, agent=identity.agent),
+    )

--- a/mycelium-cli/src/mycelium/slim/member.py
+++ b/mycelium-cli/src/mycelium/slim/member.py
@@ -67,12 +67,15 @@ async def publish_once(
     payload: bytes,
     workspace: str = DEFAULT_WORKSPACE,
     join_timeout_s: float = DEFAULT_JOIN_TIMEOUT_S,
+    token: str | None = None,
 ) -> None:
     """Join ``room`` as ``handle`` over a live SLIM connection, publish once, leave.
 
     Connects a new SLIM app under ``workspace/room/handle``, asks the backend to
     invite it in, waits to be admitted into the moderator's encrypted group,
-    publishes ``payload`` verbatim, and disconnects. Raises :class:`SlimSendError`
+    publishes ``payload`` verbatim, and disconnects. ``token`` is the caller's
+    bearer token, presented as its channel identity when JWT identity is on and
+    ignored on the default PSK path. Raises :class:`SlimSendError`
     if the node is unreachable or the invite never lands within
     ``join_timeout_s``; raises :class:`~mycelium.slim.client.SlimUnavailableError`
     (via ``SlimClient.connect``) if ``slim_bindings`` has no wheel for this
@@ -85,7 +88,7 @@ async def publish_once(
         )
 
     identity = SlimIdentity(workspace, room, handle)
-    client = await SlimClient(identity).connect(node_endpoint)
+    client = await SlimClient(identity, token=token).connect(node_endpoint)
     try:
         await announce_presence(api_url, room, handle)
         try:

--- a/mycelium-cli/src/mycelium/slim/settings.py
+++ b/mycelium-cli/src/mycelium/slim/settings.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Turn the authored ``[slim]`` config into the environment the identity layer reads.
+
+:mod:`mycelium.slim.identity` and its backend twin resolve everything from the
+environment, byte-for-byte alike, so neither copy has to know what a
+``config.toml`` or a pydantic ``Settings`` looks like. This module is the CLI's
+one adapter between the two: it maps the authored ``[slim]`` block onto those
+variable names, once, for both consumers —
+
+* the local process, via :func:`apply_identity_env`, so a CLI joining a channel
+  on this machine honours the file the operator edited; and
+* the containers, via ``mycelium config apply`` → ``.env``
+  (``mycelium.docker_utils``), which renders the same mapping.
+
+The issuer and audience fall back to the HTTP plane's — ``[agent_auth]``, then
+``[login]``. A member's channel identity and its API identity come from the same
+credential, so making the operator restate the trust root for the second plane
+would only be a way to get them out of sync.
+
+An environment variable that is already set always wins: env over file is how
+every other setting here resolves, and a container's explicit
+``MYCELIUM_SLIM_IDENTITY_TOKEN`` must not be clobbered by a stale config file.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from mycelium.slim import identity as slim_identity
+
+if TYPE_CHECKING:
+    from mycelium.config import MyceliumConfig
+
+
+def identity_issuer(config: MyceliumConfig) -> str | None:
+    """The trust root peers' channel tokens are checked against."""
+    return config.slim.identity_issuer or config.agent_auth.issuer or config.login.issuer
+
+
+def identity_audience(config: MyceliumConfig) -> str | None:
+    """The audience peers' channel tokens must carry."""
+    return config.slim.identity_audience or config.agent_auth.audience or config.login.audience
+
+
+def identity_env(config: MyceliumConfig) -> dict[str, str]:
+    """The ``MYCELIUM_SLIM_IDENTITY*`` variables ``[slim]`` implies.
+
+    Values that aren't configured are rendered empty rather than omitted, so a
+    caller writing an env file emits ``KEY=`` and the identity layer reads it as
+    unset — the same thing an absent key means.
+    """
+    slim = config.slim
+    return {
+        slim_identity.IDENTITY_ENV: slim.identity,
+        slim_identity.TOKEN_FILE_ENV: slim.identity_token_file or "",
+        slim_identity.ISSUER_ENV: identity_issuer(config) or "",
+        slim_identity.AUDIENCE_ENV: identity_audience(config) or "",
+        slim_identity.JWKS_ENV: slim.identity_jwks or "",
+        slim_identity.JWKS_FILE_ENV: slim.identity_jwks_file or "",
+        slim_identity.ALGORITHM_ENV: slim.identity_algorithm,
+        slim_identity.DURATION_ENV: str(slim.identity_duration_s),
+    }
+
+
+def apply_identity_env(config: MyceliumConfig) -> dict[str, str]:
+    """Publish ``[slim]``'s identity settings into this process's environment.
+
+    Returns what was set. Variables already present are left alone and are not
+    reported, so an explicitly exported value keeps winning over the file.
+    """
+    applied: dict[str, str] = {}
+    for key, value in identity_env(config).items():
+        if not value or os.environ.get(key):
+            continue
+        os.environ[key] = value
+        applied[key] = value
+    return applied

--- a/mycelium-cli/tests/conftest.py
+++ b/mycelium-cli/tests/conftest.py
@@ -59,7 +59,9 @@ class FakeSlimClient:
     inbox: list[bytes] = []  # noqa: RUF012 — intentionally class-level scripted queue
     published: list[bytes] = []  # noqa: RUF012
 
-    def __init__(self, _identity: Any, *, secret: str | None = None) -> None:
+    def __init__(
+        self, _identity: Any, *, secret: str | None = None, token: str | None = None
+    ) -> None:
         pass
 
     @classmethod

--- a/mycelium-cli/tests/test_slim_identity.py
+++ b/mycelium-cli/tests/test_slim_identity.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Unit tests for the SLIM channel-identity seam (CLI mirror, slim/identity.py).
+
+Node-free: these cover what is decided *before* a socket exists — which tier is
+selected, which token is presented, where it lands on disk, and the shapes handed
+to slim-bindings. Whether a node with a JWT verifier actually admits the
+resulting member is the live-node slice.
+
+The CLI's own half is here too: the ``[slim]`` block becoming the environment
+that mirrored module reads, and the credential a member presents being the same
+one it sends to the hub's HTTP API.
+
+The behaviour these lock down hardest is the **default**: an install that
+configures nothing must go on deriving the shared secret exactly as it did
+before per-member identity existed.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from mycelium.slim import identity as slim_identity
+from mycelium.slim.identity import (
+    IDENTITY_MODE_JWT,
+    IDENTITY_MODE_PSK,
+    SlimIdentityError,
+    build_configs,
+    build_provider,
+    build_verifier,
+    materialize_token,
+    resolve_jwt_identity,
+    resolve_mode,
+    token_file_path,
+)
+from mycelium.slim.naming import SlimIdentity
+
+_ENV_VARS = (
+    slim_identity.IDENTITY_ENV,
+    slim_identity.TOKEN_ENV,
+    slim_identity.TOKEN_FILE_ENV,
+    slim_identity.ISSUER_ENV,
+    slim_identity.AUDIENCE_ENV,
+    slim_identity.JWKS_ENV,
+    slim_identity.JWKS_FILE_ENV,
+    slim_identity.ALGORITHM_ENV,
+    slim_identity.DURATION_ENV,
+    slim_identity.REQUIRE_ENV,
+)
+
+IDENTITY = SlimIdentity("acme", "planning", "agent-7")
+
+
+@pytest.fixture(autouse=True)
+def _clean_identity_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Start every test from an unconfigured host with its own data dir."""
+    for name in _ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    slim_identity._warned.clear()
+
+
+def _bindings():
+    return pytest.importorskip("slim_bindings")
+
+
+# ── Tier selection ──────────────────────────────────────────────────────────
+
+
+def test_default_tier_is_the_shared_secret() -> None:
+    assert resolve_mode() == IDENTITY_MODE_PSK
+
+
+def test_tier_is_selected_from_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, "JWT")
+    assert resolve_mode() == IDENTITY_MODE_JWT
+
+
+def test_an_unknown_tier_is_refused_rather_than_read_as_psk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, "spire")
+    with pytest.raises(SlimIdentityError, match="not a SLIM identity mode"):
+        resolve_mode()
+
+
+def test_psk_tier_builds_no_identity_configs() -> None:
+    """The shipped default never reaches slim-bindings' identity API at all.
+
+    The bindings stand-in is empty on purpose: touching it would raise.
+    """
+    assert build_configs(ModuleType("not-slim-bindings"), IDENTITY, token="a-token") is None
+
+
+# ── Token resolution ────────────────────────────────────────────────────────
+
+
+def test_a_caller_supplied_token_wins_over_the_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One process joining as several agents presents each agent's own token."""
+    monkeypatch.setenv(slim_identity.TOKEN_ENV, "ambient")
+    assert resolve_jwt_identity(token="mine").token == "mine"
+
+
+def test_the_environment_supplies_the_token_when_the_caller_does_not(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(slim_identity.TOKEN_ENV, "ambient")
+    assert resolve_jwt_identity().token == "ambient"
+
+
+def test_settings_are_read_from_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(slim_identity.ISSUER_ENV, "https://idp/realm")
+    monkeypatch.setenv(slim_identity.AUDIENCE_ENV, "mycelium")
+    monkeypatch.setenv(slim_identity.ALGORITHM_ENV, "es256")
+    monkeypatch.setenv(slim_identity.DURATION_ENV, "120")
+
+    jwt = resolve_jwt_identity()
+    assert jwt.issuer == "https://idp/realm"
+    assert jwt.audience == "mycelium"
+    assert jwt.algorithm == "ES256"
+    assert jwt.duration_s == 120.0
+
+
+@pytest.mark.parametrize("bad", ["soon", "0", "-1"])
+def test_an_unusable_duration_is_refused(monkeypatch: pytest.MonkeyPatch, bad: str) -> None:
+    monkeypatch.setenv(slim_identity.DURATION_ENV, bad)
+    with pytest.raises(SlimIdentityError, match=slim_identity.DURATION_ENV):
+        resolve_jwt_identity()
+
+
+# ── The token file slim-bindings reads ──────────────────────────────────────
+
+
+def test_the_token_file_is_owner_only(tmp_path: Path) -> None:
+    path = materialize_token("agent-7", "a.b.c")
+    assert path == token_file_path("agent-7")
+    assert path.is_relative_to(tmp_path)
+    assert path.read_text(encoding="utf-8") == "a.b.c"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_an_unchanged_token_is_not_rewritten() -> None:
+    """slim-bindings reloads the file when it changes; identical is not a change."""
+    path = materialize_token("agent-7", "a.b.c")
+    before = path.stat().st_mtime_ns
+    assert materialize_token("agent-7", "a.b.c").stat().st_mtime_ns == before
+
+
+def test_a_refreshed_token_replaces_the_old_one() -> None:
+    materialize_token("agent-7", "old")
+    path = materialize_token("agent-7", "new")
+    assert path.read_text(encoding="utf-8") == "new"
+
+
+def test_each_agent_gets_its_own_token_file() -> None:
+    assert token_file_path("alpha") != token_file_path("beta")
+
+
+def test_a_handle_cannot_escape_the_token_directory() -> None:
+    path = token_file_path("../../etc/passwd")
+    assert path.parent == token_file_path("x").parent
+
+
+# ── The configs handed to slim-bindings ─────────────────────────────────────
+
+
+def test_the_provider_presents_the_materialized_token() -> None:
+    sb = _bindings()
+    jwt = resolve_jwt_identity(token="a.b.c")
+    provider = build_provider(sb, jwt, agent="agent-7")
+
+    assert provider.is_static_jwt()
+    assert Path(token_file_path("agent-7")).read_text(encoding="utf-8") == "a.b.c"
+
+
+def test_a_caller_owned_token_file_is_passed_through_untouched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A SPIRE sidecar (or CI) owns the file's lifetime; nothing here rewrites it."""
+    svid = tmp_path / "svid.jwt"
+    svid.write_text("from.the.sidecar", encoding="utf-8")
+    monkeypatch.setenv(slim_identity.TOKEN_FILE_ENV, str(svid))
+
+    build_provider(_bindings(), resolve_jwt_identity(), agent="agent-7")
+    assert not token_file_path("agent-7").exists()
+
+
+def test_the_provider_refuses_to_present_nothing() -> None:
+    with pytest.raises(SlimIdentityError, match="needs a token"):
+        build_provider(_bindings(), resolve_jwt_identity(), agent="agent-7")
+
+
+def test_the_verifier_pins_a_configured_jwks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(slim_identity.JWKS_ENV, json.dumps({"keys": []}))
+    monkeypatch.setenv(slim_identity.ISSUER_ENV, "https://idp/realm")
+    verifier = build_verifier(_bindings(), resolve_jwt_identity())
+    assert verifier.is_jwt()
+
+
+def test_the_verifier_resolves_keys_from_the_issuer_when_no_jwks_is_pinned() -> None:
+    verifier = build_verifier(_bindings(), resolve_jwt_identity())
+    assert verifier.is_jwt()
+
+
+def test_an_unknown_algorithm_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(slim_identity.ALGORITHM_ENV, "RS999")
+    monkeypatch.setenv(slim_identity.JWKS_ENV, json.dumps({"keys": []}))
+    with pytest.raises(SlimIdentityError, match="not a JWT algorithm"):
+        build_verifier(_bindings(), resolve_jwt_identity())
+
+
+def test_jwt_tier_with_a_token_builds_every_half(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One token, three places it is presented: peers, peers' checks, the node."""
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, IDENTITY_MODE_JWT)
+    built = build_configs(_bindings(), IDENTITY, token="a.b.c")
+    assert built is not None
+    assert built.provider.is_static_jwt()
+    assert built.verifier.is_jwt()
+    assert built.connection_auth.is_static_jwt()
+
+
+# ── Degradation ─────────────────────────────────────────────────────────────
+
+
+def test_jwt_tier_without_a_token_falls_back_to_the_psk(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No credential is today's behaviour, so it stays joinable — but says so."""
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, IDENTITY_MODE_JWT)
+    with caplog.at_level("WARNING"):
+        assert build_configs(_bindings(), IDENTITY, token=None) is None
+    assert "no token to present" in caplog.text
+
+
+def test_the_fallback_can_be_made_fatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A host that means to run on verified identity fails closed instead."""
+    monkeypatch.setenv(slim_identity.IDENTITY_ENV, IDENTITY_MODE_JWT)
+    monkeypatch.setenv(slim_identity.REQUIRE_ENV, "1")
+    with pytest.raises(SlimIdentityError, match="refusing to fall back"):
+        build_configs(_bindings(), IDENTITY, token=None)
+
+
+# ── The [slim] block reaching the mirrored module ───────────────────────────
+
+
+def test_the_authored_tier_reaches_the_environment() -> None:
+    from mycelium.config import MyceliumConfig
+    from mycelium.slim import settings as slim_settings
+
+    config = MyceliumConfig()
+    config.slim.identity = IDENTITY_MODE_JWT
+    slim_settings.apply_identity_env(config)
+
+    assert resolve_mode() == IDENTITY_MODE_JWT
+
+
+def test_an_exported_value_wins_over_the_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mycelium.config import MyceliumConfig
+    from mycelium.slim import settings as slim_settings
+
+    monkeypatch.setenv(slim_identity.ISSUER_ENV, "https://exported/realm")
+    config = MyceliumConfig()
+    config.slim.identity_issuer = "https://from-the-file/realm"
+    applied = slim_settings.apply_identity_env(config)
+
+    assert slim_identity.ISSUER_ENV not in applied
+    assert resolve_jwt_identity().issuer == "https://exported/realm"
+
+
+def test_the_trust_root_falls_back_to_the_http_plane() -> None:
+    """One credential, both planes — so one issuer, not two to keep in sync."""
+    from mycelium.config import MyceliumConfig
+    from mycelium.slim import settings as slim_settings
+
+    config = MyceliumConfig()
+    config.agent_auth.issuer = "https://idp/realm"
+    config.agent_auth.audience = "mycelium"
+    slim_settings.apply_identity_env(config)
+
+    jwt = resolve_jwt_identity()
+    assert jwt.issuer == "https://idp/realm"
+    assert jwt.audience == "mycelium"
+
+
+def test_an_unknown_authored_tier_is_refused() -> None:
+    from mycelium.config import SlimConfig
+
+    with pytest.raises(ValueError, match="must be 'psk' or 'jwt'"):
+        SlimConfig(identity="spire")

--- a/mycelium-cli/tests/test_slim_l9_wire.py
+++ b/mycelium-cli/tests/test_slim_l9_wire.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import pytest
 
+from mycelium.slim import identity as slim_identity
 from mycelium.slim import l9
 from mycelium.slim.l9 import room_episode as _room_episode
 from mycelium.slim.l9 import room_topic as _room_topic
@@ -134,3 +135,30 @@ def test_channel_name_topic_matches_contract():
     g = _contract()
     name = to_channel_name("acme", "planning")
     assert name.components() == ["acme", "planning", g["channel_topic"]]
+
+
+def test_identity_env_names_match_contract():
+    """The identity tier is selected from the same env names on both sides."""
+    g = _contract()["identity"]
+    assert list(g["modes"]) == list(slim_identity.IDENTITY_MODES)
+    assert g["default_mode"] == slim_identity.IDENTITY_MODE_PSK
+    assert g["default_algorithm"] == slim_identity.DEFAULT_ALGORITHM
+    assert g["default_duration_s"] == slim_identity.DEFAULT_DURATION_S
+    assert g["token_dir_name"] == slim_identity.TOKEN_DIR_NAME
+    env = g["env"]
+    assert env["mode"] == slim_identity.IDENTITY_ENV
+    assert env["token"] == slim_identity.TOKEN_ENV
+    assert env["token_file"] == slim_identity.TOKEN_FILE_ENV
+    assert env["issuer"] == slim_identity.ISSUER_ENV
+    assert env["audience"] == slim_identity.AUDIENCE_ENV
+    assert env["jwks"] == slim_identity.JWKS_ENV
+    assert env["jwks_file"] == slim_identity.JWKS_FILE_ENV
+    assert env["algorithm"] == slim_identity.ALGORITHM_ENV
+    assert env["duration_s"] == slim_identity.DURATION_ENV
+    assert env["require"] == slim_identity.REQUIRE_ENV
+
+
+def test_identity_defaults_to_the_shared_secret_tier(monkeypatch):
+    """An install that configures nothing stays on the PSK."""
+    monkeypatch.delenv(slim_identity.IDENTITY_ENV, raising=False)
+    assert slim_identity.resolve_mode() == _contract()["identity"]["default_mode"]


### PR DESCRIPTION
## Summary

Replaces "every member of a room shares one derived secret" with an **opt-in tier where each member presents its own bearer token** as its SLIM channel identity — the *same* token it already sends to the hub's HTTP API. One `mycelium login`, or one agent service-account credential (#563/#564), now authenticates both planes. Identity on the channel is the token's `sub`, which is the handle, so members are cryptographically distinct MLS participants and revoking one client leaves every other member untouched.

**The shared-secret PSK stays the default.** An install that configures nothing calls `create_app_with_secret(name, mint_shared_secret(...))` exactly as before — the try-it path is byte-for-byte unchanged, per #567.

Three things the audit's shape didn't predict, worth reading before review:

1. **Per-member identity needs no node change at all.** `IdentityVerifierConfig` is app-level — the second argument to `service.create_app(name, provider, verifier)` — and it is how a member verifies *its peers*. The node forwards ciphertext and never inspects the MLS identity, so this works against the stock `ghcr.io/agntcy/slim:2.0.0` with zero node configuration.
2. **The node's JWT axis is a different one.** `ServerConfig.auth: ServerAuthenticationConfig{BASIC | JWT}` gates whether a client may open a *dataplane connection* — transport, not membership. Optional and orthogonal. The client half is wired (same token, as `ClientConfig.auth`); the node half is **proposed and unverified** in `docker/compose-slim-jwt.yml`.
3. **The provider is `STATIC_JWT`, not `JWT`.** `IdentityProviderConfig.JWT(ClientJwtAuth)` makes the client *sign its own* JWT from a private key — a second credential, the opposite of the goal. `STATIC_JWT(StaticJwtAuth(token_file, duration))` presents an externally-issued bearer token and auto-reloads on file change, so a refreshed OIDC token is picked up without a reconnect.

## Changes

**The seam** — `fastapi-backend/app/services/slim_identity.py` and its CLI mirror `mycelium-cli/src/mycelium/slim/identity.py`. Tier selection, token resolution, and the provider / verifier / connection-auth trio handed to slim-bindings. Resolution is **env-only on both sides**, the same shape `MYCELIUM_SLIM_MASTER_SECRET` already has, so the two copies stay byte-for-byte comparable — they diff only in their module docstrings.

**Contract** — `contracts/slim-l9-wire.json` gains an `identity` block freezing the mode strings, defaults and env names; both twin wire tests assert against it, so neither copy can drift without a red gate.

**Token materialization** — `STATIC_JWT` reads from a file, so an in-memory token lands at `<data-dir>/slim-identity/<handle>.jwt` written `0600` via `os.open` (never momentarily default-mode), and is rewritten only when the contents actually change. A caller-owned `token_file` — a SPIRE JWT-SVID, or CI's — is passed through untouched, which is the shape #579 drops into beside `STATIC_JWT`.

**Client factory** — `mycelium/client.py` grows `access_token(config, handle=…)`; `auth_headers` is now a thin wrapper over it, so the SLIM plane and the HTTP plane resolve the credential through the identical path (agent credential wins over human session, unchanged).

**Config** — `[slim]` gains `identity`, `identity_issuer`, `identity_audience`, `identity_jwks`, `identity_jwks_file`, `identity_token_file`, `identity_algorithm`, `identity_duration_s`. Issuer and audience default to the HTTP plane's (`agent_auth`, then `login`), so the common case configures neither. `mycelium config apply` renders them into the container env. A bearer token is deliberately *not* read from `config.toml`.

**Degradation** — `jwt` with no resolvable token joins on the PSK with a one-time warning (the "gate off / no token → PSK behavior" acceptance). `MYCELIUM_SLIM_IDENTITY_REQUIRE=1` fails closed instead, mirroring `MYCELIUM_SLIM_REQUIRE_SECRET`.

**Docs** — Authentication guide gains a "The same token joins the SLIM channel" section; `docs/design/identity-and-auth.md` rollout step 5 marked landed with the two findings, and the "one token or two?" open question closed; `docs/cross-machine.md` notes JWT identity sidesteps the shared-secret parity trap; `CLAUDE.md` D1 bullet rewritten. Docs site regenerated.

## Testing

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — backend **505 passed, 6 skipped**; CLI **402 passed**
- [x] Linting passes (`uv run ruff check .`) — both packages
- [x] Format check passes (`uv run ruff format --check .`) — both packages
- [x] `uv run ty check .` clean on both packages

New suites `fastapi-backend/tests/test_slim_identity.py` + `mycelium-cli/tests/test_slim_identity.py` (twins, plus CLI-only coverage of the `[slim]`→env adapter): tier selection and rejection of an unknown tier, caller-token-beats-env precedence, the `0600` token file and its no-op rewrite on an unchanged token, handle path-escape folding, provider / verifier / connection-auth construction against the real bindings, unknown-algorithm and unusable-duration refusals, PSK-default-builds-nothing, and both degradation paths.

**Not verifiable offline** — this is a live-node slice, so the payoff needs your rig:

- an MLS join with JWT identity against a node configured for it, and per-member distinctness
- an invalid / expired / revoked token being refused
- one token passing the HTTP gate *and* joining the channel
- whether `JwtKeyType.AUTORESOLVE()` (the default when no JWKS is pinned) resolves keys from the token's issuer — `slim.identity_jwks` / `_jwks_file` is the escape hatch if not
- **`docker/compose-slim-jwt.yml`'s node config spelling.** Faithfully transcribed from the `ServerConfig.auth` → `JwtAuth{key, audience, issuer, subject, duration}` struct, but the node is a separate Rust binary and its serde field/tag names are not confirmed. Flagged in-file rather than guessed silently.

## Related Issues

Refs #476 · depends on #564 (token source, merged) · SPIRE follow-up #579 · design `docs/design/identity-and-auth.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XZeVrcR54pYCg7fQJ1vcq

---
_Generated by [Claude Code](https://claude.ai/code/session_017XZeVrcR54pYCg7fQJ1vcq)_