### PR TITLE
feat(identity): pin slim-bindings + node to matched 2.1.x (MLS identity) (#586)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
           EOF
           docker run -d --name mycelium-slim -p 46357:46357 \
             -v "$RUNNER_TEMP/slim-config.yaml:/slim-config.yaml" \
-            ghcr.io/agntcy/slim:2.0.0 /slim --config /slim-config.yaml
+            ghcr.io/agntcy/slim:2.1.0 /slim --config /slim-config.yaml
           for _ in $(seq 1 30); do
             if (exec 3<>/dev/tcp/127.0.0.1/46357) 2>/dev/null; then
               exec 3>&-

--- a/fastapi-backend/pyproject.toml
+++ b/fastapi-backend/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "watchdog>=6.0.0",
     "tiktoken>=0.12.0",
     "rapidfuzz>=3.14.5",
-    "slim-bindings>=2,<3",
+    "slim-bindings>=2.1,<2.2",
     "negmas>=0.15.7",
     "pyjwt[crypto]>=2.10,<3",
 ]

--- a/fastapi-backend/uv.lock
+++ b/fastapi-backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",

--- a/fastapi-backend/uv.lock
+++ b/fastapi-backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -876,7 +876,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10,<3" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rapidfuzz", specifier = ">=3.14.5" },
-    { name = "slim-bindings", specifier = ">=2,<3" },
+    { name = "slim-bindings", specifier = ">=2.1,<2.2" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
@@ -1661,17 +1661,17 @@ wheels = [
 
 [[package]]
 name = "slim-bindings"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/cc/0841f22d32c7b5c57a6c402287d30d7f8dc48d6abb4c6b7de54c9f1b36ff/slim_bindings-2.0.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c242eb2ce33ed251301879145347ad4255d001a56bfbe7c4955eaa98929ae723", size = 18959817, upload-time = "2026-08-05T16:13:35.074Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/6b/45973eca8a94e01aad34bf5fd12a88ae0245f8632ee31c9663552c6ea233/slim_bindings-2.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fcb8efc80f33d41fc034704550ec600eba6d20d1be7634c7568ca725f87c2325", size = 18374062, upload-time = "2026-08-05T16:13:37.461Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7a/235c9836bbd900829e3b4092ab5b8602728222bb0076ca13360e7f2cffed/slim_bindings-2.0.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9d569602eb8bdb63aad16104d04f9371bf4bbfb1f6ea801c49c563e87f09bf6b", size = 19113120, upload-time = "2026-08-05T16:13:39.889Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d2/56539434db59d19131760d84adb48bdfca122b78b1550845b98d57e8256f/slim_bindings-2.0.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9d2b3e76063f307c0a8cb4e26d6fec0e19e5fd9312fb516101517a47909bec15", size = 19759699, upload-time = "2026-08-05T16:13:41.935Z" },
-    { url = "https://files.pythonhosted.org/packages/28/35/da680723dc975059b5bec01ffa4e9da53bcda32bb59145aa465d896ee766/slim_bindings-2.0.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:218383d2066f242a5d8a9bddcfc0d67d5c5585ab4b20391915280e91dd043149", size = 19111600, upload-time = "2026-08-05T16:13:44.479Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c1/823731e7ebb39a25264294dfa21d142c9f3b57d4a5444f9b68006c5a71b7/slim_bindings-2.0.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:96f9453877bd4ed4cac6cdb3f1faf608800acd5e8d496b1eda4fbc72b5561671", size = 19763962, upload-time = "2026-08-05T16:13:46.872Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/53/fb2b38bf0d12d1b81e9ee66cd3a4a96a5e7bfc2c01555b6261aadbf21de4/slim_bindings-2.0.0-py3-none-win_amd64.whl", hash = "sha256:60182551290a1d3d0377630e743a0153c58ebccea0170a870d7be6dfabb27749", size = 17248028, upload-time = "2026-08-05T16:13:49.223Z" },
-    { url = "https://files.pythonhosted.org/packages/72/56/5f2d2086f0f4f977d7fbcfe752b28bf10e1576b85a3c8603b08bfeb8637d/slim_bindings-2.0.0-py3-none-win_arm64.whl", hash = "sha256:827b1ba925b666561493cc4203139170c3669650eef7fd2d95465803b2294890", size = 16155968, upload-time = "2026-08-05T16:13:51.653Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/05/84136c26b7b8ead5c8b93a0f51b08bb81d9f426e138d6e8bae9bcef6bff9/slim_bindings-2.1.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:babed1548a5faf318ce95e7f53ffb1a0b01580f541d8e9c0444009c080c60dbd", size = 22364118, upload-time = "2026-08-13T15:39:56.672Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/e2d537bea1593a2d76024974e154455f0bc472c03851003042204bfe9c90/slim_bindings-2.1.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:21e475e6456866de0ffe1cea2c337193696075e139184f096448cae4dd72721c", size = 21663721, upload-time = "2026-08-13T15:39:59.661Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f8/2fd44d927c9a43bbb3711f95900e46795f85b545b8084e6b2a83653b2aa5/slim_bindings-2.1.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fee2cd4441661da449032e627de68add7ce9e051bef3af89e79cb75155177b26", size = 22687354, upload-time = "2026-08-13T15:40:03.004Z" },
+    { url = "https://files.pythonhosted.org/packages/49/14/8308339ef6e697102fff497b8335751bae9195507a4186557ae441696145/slim_bindings-2.1.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:61d624a1f2c757c53083e058e4acbabdf4e68fc42816ef747ebcf8814f3e1ef9", size = 23497200, upload-time = "2026-08-13T15:40:05.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/30/a3e9b6be87160e78fb5102611353d9ed8c8081a4f8fa9e70268bb05a926c/slim_bindings-2.1.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6da7e3ea5f0c8fdb2053044b8366ad0e1e38e4d076f58608fc2b8b5efb8b9340", size = 22573623, upload-time = "2026-08-13T15:40:09.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a1/c96c3ffb067c96e9374fd432c5a948ef2131724affbfba1ea9be9ede3b7a/slim_bindings-2.1.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bbe5260be7a5813436cbe733ab028af0d6fdb465f52d777e9589aa1b23d6d4eb", size = 23504184, upload-time = "2026-08-13T15:40:12.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b6/6f2ad9af6234c5f8474d091817460bdc71e09a2c4ecfd2b7ac0736f483ce/slim_bindings-2.1.0-py3-none-win_amd64.whl", hash = "sha256:0c5711ac2275a6bf6b7d4ab06311ad09872f879d1d804c33b79fbacc5041b357", size = 20835305, upload-time = "2026-08-13T15:40:16.294Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d1/f59680d020b13ee5a68b4e126e3b3539dd2a39796cf6db7477e37913f8d3/slim_bindings-2.1.0-py3-none-win_arm64.whl", hash = "sha256:482cc455e0c7ec020266c73e291ab6a43dc8aec54e73687527f0865bd90264a5", size = 19458947, upload-time = "2026-08-13T15:40:19.391Z" },
 ]
 
 [[package]]

--- a/mycelium-cli/pyproject.toml
+++ b/mycelium-cli/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "protobuf>=4.21.0",
     "rapidfuzz>=3.14.5",
     "questionary>=2.1.1",
-    "slim-bindings>=2,<3",
+    "slim-bindings>=2.1,<2.2",
 ]
 
 [project.optional-dependencies]

--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -30,13 +30,16 @@ services:
   # nothing is wired to it. `mycelium hub host` brings up this service alone.
 
   slim:
-    # Pinned to 2.0.x: the node's link-negotiation handshake must match the
-    # `slim-bindings` wheel the backend/daemon use (`>=2,<3` in both pyprojects).
-    # Mixing majors fails the handshake with "public key length is invalid", so
-    # node + bindings move in lockstep. 2.0 is also where idle group members
-    # survive on app traffic (liveness resets on any message) and evicted members
-    # cleanly rejoin — the behavior the connector keepalive + self-rejoin rely on.
-    image: ghcr.io/agntcy/slim:${SLIM_IMAGE_TAG:-2.0.0}
+    # Pinned to 2.1.x: the node's link-negotiation handshake must match the
+    # `slim-bindings` wheel the backend/daemon use (`>=2.1,<2.2` in both
+    # pyprojects). Mixing versions fails the handshake with "public key length
+    # is invalid", so node + bindings move in lockstep. 2.1.x is the first
+    # MLS-with-external-identity-capable stack (the SPIRE JWT-SVID -> MLS spike
+    # in docs/design/spire-mls-spike proved it), the prereq for #476/#579.
+    # Node 2.2.0 exists but has no matching PyPI bindings yet — stay on 2.1.x
+    # until 2.2.x bindings publish, then bump both in lockstep and re-run the
+    # spike run.sh.
+    image: ghcr.io/agntcy/slim:${SLIM_IMAGE_TAG:-2.1.0}
     pull_policy: always
     container_name: mycelium-slim
     restart: unless-stopped

--- a/mycelium-cli/uv.lock
+++ b/mycelium-cli/uv.lock
@@ -785,20 +785,20 @@ requires-dist = [
     { name = "opentelemetry-proto", specifier = ">=1.20.0,<2" },
     { name = "protobuf", specifier = ">=4.21.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.0" },
-    { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pyfiglet", specifier = ">=1.0.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
-    { name = "python-dateutil", specifier = ">=2.8.0" },
+    { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "questionary", specifier = ">=2.1.1" },
-    { name = "rapidfuzz", specifier = ">=3.10.0" },
+    { name = "rapidfuzz", specifier = ">=3.14.5" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.10" },
-    { name = "slim-bindings", specifier = ">=2,<3" },
+    { name = "slim-bindings", specifier = ">=2.1,<2.2" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8" },
@@ -809,8 +809,8 @@ provides-extras = ["engine", "dev"]
 dev = [
     { name = "mypy", specifier = ">=1.8.0" },
     { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0" },
-    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-mock", specifier = ">=3.12.0" },
     { name = "ruff", specifier = ">=0.15.10" },
     { name = "ty", specifier = ">=0.0.33" },
@@ -1414,16 +1414,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
 ]
 
 [[package]]
@@ -1471,29 +1471,29 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]
@@ -1882,17 +1882,17 @@ wheels = [
 
 [[package]]
 name = "slim-bindings"
-version = "2.0.0"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/cc/0841f22d32c7b5c57a6c402287d30d7f8dc48d6abb4c6b7de54c9f1b36ff/slim_bindings-2.0.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c242eb2ce33ed251301879145347ad4255d001a56bfbe7c4955eaa98929ae723", size = 18959817, upload-time = "2026-08-05T16:13:35.074Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/6b/45973eca8a94e01aad34bf5fd12a88ae0245f8632ee31c9663552c6ea233/slim_bindings-2.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fcb8efc80f33d41fc034704550ec600eba6d20d1be7634c7568ca725f87c2325", size = 18374062, upload-time = "2026-08-05T16:13:37.461Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/7a/235c9836bbd900829e3b4092ab5b8602728222bb0076ca13360e7f2cffed/slim_bindings-2.0.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:9d569602eb8bdb63aad16104d04f9371bf4bbfb1f6ea801c49c563e87f09bf6b", size = 19113120, upload-time = "2026-08-05T16:13:39.889Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d2/56539434db59d19131760d84adb48bdfca122b78b1550845b98d57e8256f/slim_bindings-2.0.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9d2b3e76063f307c0a8cb4e26d6fec0e19e5fd9312fb516101517a47909bec15", size = 19759699, upload-time = "2026-08-05T16:13:41.935Z" },
-    { url = "https://files.pythonhosted.org/packages/28/35/da680723dc975059b5bec01ffa4e9da53bcda32bb59145aa465d896ee766/slim_bindings-2.0.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:218383d2066f242a5d8a9bddcfc0d67d5c5585ab4b20391915280e91dd043149", size = 19111600, upload-time = "2026-08-05T16:13:44.479Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c1/823731e7ebb39a25264294dfa21d142c9f3b57d4a5444f9b68006c5a71b7/slim_bindings-2.0.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:96f9453877bd4ed4cac6cdb3f1faf608800acd5e8d496b1eda4fbc72b5561671", size = 19763962, upload-time = "2026-08-05T16:13:46.872Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/53/fb2b38bf0d12d1b81e9ee66cd3a4a96a5e7bfc2c01555b6261aadbf21de4/slim_bindings-2.0.0-py3-none-win_amd64.whl", hash = "sha256:60182551290a1d3d0377630e743a0153c58ebccea0170a870d7be6dfabb27749", size = 17248028, upload-time = "2026-08-05T16:13:49.223Z" },
-    { url = "https://files.pythonhosted.org/packages/72/56/5f2d2086f0f4f977d7fbcfe752b28bf10e1576b85a3c8603b08bfeb8637d/slim_bindings-2.0.0-py3-none-win_arm64.whl", hash = "sha256:827b1ba925b666561493cc4203139170c3669650eef7fd2d95465803b2294890", size = 16155968, upload-time = "2026-08-05T16:13:51.653Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/05/84136c26b7b8ead5c8b93a0f51b08bb81d9f426e138d6e8bae9bcef6bff9/slim_bindings-2.1.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:babed1548a5faf318ce95e7f53ffb1a0b01580f541d8e9c0444009c080c60dbd", size = 22364118, upload-time = "2026-08-13T15:39:56.672Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d8/e2d537bea1593a2d76024974e154455f0bc472c03851003042204bfe9c90/slim_bindings-2.1.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:21e475e6456866de0ffe1cea2c337193696075e139184f096448cae4dd72721c", size = 21663721, upload-time = "2026-08-13T15:39:59.661Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f8/2fd44d927c9a43bbb3711f95900e46795f85b545b8084e6b2a83653b2aa5/slim_bindings-2.1.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fee2cd4441661da449032e627de68add7ce9e051bef3af89e79cb75155177b26", size = 22687354, upload-time = "2026-08-13T15:40:03.004Z" },
+    { url = "https://files.pythonhosted.org/packages/49/14/8308339ef6e697102fff497b8335751bae9195507a4186557ae441696145/slim_bindings-2.1.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:61d624a1f2c757c53083e058e4acbabdf4e68fc42816ef747ebcf8814f3e1ef9", size = 23497200, upload-time = "2026-08-13T15:40:05.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/30/a3e9b6be87160e78fb5102611353d9ed8c8081a4f8fa9e70268bb05a926c/slim_bindings-2.1.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6da7e3ea5f0c8fdb2053044b8366ad0e1e38e4d076f58608fc2b8b5efb8b9340", size = 22573623, upload-time = "2026-08-13T15:40:09.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a1/c96c3ffb067c96e9374fd432c5a948ef2131724affbfba1ea9be9ede3b7a/slim_bindings-2.1.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bbe5260be7a5813436cbe733ab028af0d6fdb465f52d777e9589aa1b23d6d4eb", size = 23504184, upload-time = "2026-08-13T15:40:12.805Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b6/6f2ad9af6234c5f8474d091817460bdc71e09a2c4ecfd2b7ac0736f483ce/slim_bindings-2.1.0-py3-none-win_amd64.whl", hash = "sha256:0c5711ac2275a6bf6b7d4ab06311ad09872f879d1d804c33b79fbacc5041b357", size = 20835305, upload-time = "2026-08-13T15:40:16.294Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d1/f59680d020b13ee5a68b4e126e3b3539dd2a39796cf6db7477e37913f8d3/slim_bindings-2.1.0-py3-none-win_arm64.whl", hash = "sha256:482cc455e0c7ec020266c73e291ab6a43dc8aec54e73687527f0865bd90264a5", size = 19458947, upload-time = "2026-08-13T15:40:19.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #586. Part of #585, **blocks** #476/#579.

## Why
MLS-with-external-identity requires `slim-bindings` and the SLIM node to move in **lockstep** on an MLS-identity-capable version. The SPIRE JWT-SVID → MLS member spike (#583/#584) proved this on a matched **2.1.0** stack. Mismatched stacks are a real failure/confusion source — #581 ran bindings 2.1.0 against a 2.0.0 node.

## Changes
- **Pins bumped to matched 2.1.x**: both `fastapi-backend` and `mycelium-cli` pyprojects go `slim-bindings>=2,<3` → `>=2.1,<2.2`; uv.lock relocked (2.0.0 → 2.1.0). *(The cli lock also picks up some already-committed pyproject drift that its stale lock hadn't captured.)*
- **Node image → 2.1.0**: `SLIM_IMAGE_TAG` default in `compose.yml` and the CI SLIM node in `ci.yml`.
- **Lockstep contract documented** in `compose.yml`, including the **2.2.x gap**: node 2.2.0 exists but has **no PyPI Python bindings yet**, so we deliberately stay on 2.1.x (not "latest node") until 2.2.x bindings publish — then bump both and re-run the #584 spike `run.sh`.

## Verification
- `slim-bindings==2.1.0` installs; `app.services.slim_client` imports cleanly against it.
- SLIM+L9 wire contract tests pass on both sides (backend + cli).
- The #584 spike `run.sh` (SPIRE + matched 2.1.0 node/bindings, PASS/FAIL gate) is the authoritative acceptance check — to be run on the rig against a matched 2.1.x node before merge.

## Follow-up
- Track when **2.2.x Python bindings** publish; flag upstream (SLIM org) if they lag the node, then re-validate and bump in lockstep.