### PR TITLE
docs(identity): decide SVID delivery model + prove the SignerJwt floor (#587)

### DIFF
--- a/docs/design/signerjwt-floor-spike/README.md
+++ b/docs/design/signerjwt-floor-spike/README.md
@@ -1,0 +1,167 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Spike report: SignerJwt floor → SLIM MLS member (#587)
+
+**Status:** ✅ **PASS — executed 2026-08-16.** Two members, each self-signing with
+its *own* local ES256 keypair and **no SPIRE**, established a GROUP/MLS session,
+peer-verified against a shared roster JWKS, and exchanged a message both ways.
+Reproduce with `./run.sh` (Docker + openssl + the `fastapi-backend` uv env).
+**Feeds:** #476 (SignerJwt floor impl), #587 (SVID-delivery decision), #560 (epic).
+**Do not:** use `STATIC_JWT` — proven `MlsNotSupported` for MLS (#581).
+
+## Result
+
+```
+== 1/3  stock SLIM 2.1.0 node on :46358 ==
+== 2/3  self-mint each member's ES256 keypair (PKCS#8) + roster JWKS ==
+wrote /tmp/signerjwt-floor-spike/roster-jwks.json with 2 key(s): alice, bob
+== 3/3  two SignerJwt members establish MLS + exchange a message ==
+[moderator] creating GROUP/MLS session ...
+[moderator] MLS session established (no MlsNotSupported).
+[moderator] inviting participant ...
+[moderator] participant joined + peer-verified.
+[participant] received: 'alice: hello over MLS'
+[moderator] received: 'bob: ack -- peer verified'
+
+PASS: two SignerJwt-identified MLS members exchanged a verified message.
+```
+
+Stack that produced it: `slim-bindings==2.1.0` (PyPI) + `ghcr.io/agntcy/slim:2.1.0`
+node (stock, no identity block, on `:46358`). `IdentityProviderConfig.JWT`
+(SignerJwt) drove the MLS moderated session — the `session_moderator.rs` path that
+panicked in #581 under `STATIC_JWT` — with **real peer verification and no node
+change**, and with **no SPIRE server/agent and no shared PID namespace**.
+
+## Why this spike (vs the #583 SPIRE spike)
+
+#583 proved SPIRE JWT-SVIDs drive MLS — but only inside a container that **shares
+the SPIRE agent's PID namespace** (the `unix` attestor gotcha). That is a hardened-
+deployment topology, *not* how a resident mycelium agent runs: a resident agent is
+the user's own Claude/Cursor session on their own machine, with no SPIRE agent to
+attest it. #587 asks how *that* agent gets a credential the MLS channel accepts.
+
+This spike answers it with the **SignerJwt floor**: the agent generates its own
+ES256 keypair locally and self-signs a short-lived JWT. No SPIRE, no attestor, no
+Workload API socket — so it runs straight on the host, matching the real resident
+topology. This is the default resident credential path in
+[`../slim-identity-svid-delivery.md`](../slim-identity-svid-delivery.md).
+
+## The load-bearing finding: peer verification without SPIRE
+
+A SignerJwt token **carries the signer's public key in its claims**, so a verifier
+can check the signature against the key the token itself presents. But that alone
+would let *anyone* self-sign and join — so trust rests on the verifier only
+accepting keys it already knows. Each member's verifier holds a **static roster
+JWKS** (`JwtKeyType.DECODING` + `JwtKeyFormat.JWKS`) of the trusted members' public
+keys; a self-signed token is accepted iff its key is on the roster.
+
+That roster JWKS **is the deployment's registration surface** — the mycelium
+analogue of `mycelium agent credential set`: one JWK per agent, added when the agent
+joins a room, keyed by `kid = @handle`. Trust is "this public key is on the room's
+roster," distributed out of band; there is **no attestation and no issuer
+discovery**. (`JwtKeyType.AUTORESOLVE` was tried first and fails on a self-issued
+floor: with no static JWKS it falls back to OIDC discovery on the issuer, and
+`mycelium-resident` is not a URL → `relative URL without a base`.)
+
+## The proven-working pattern
+
+```python
+# Provider — sign our own JWT with our local PKCS#8 ES256 key:
+enc = slim_bindings.JwtKeyConfig(
+    algorithm=slim_bindings.JwtAlgorithm.ES256,
+    format=slim_bindings.JwtKeyFormat.PEM,
+    key=slim_bindings.JwtKeyData.DATA(value=my_pkcs8_pem),
+)
+provider = slim_bindings.IdentityProviderConfig.JWT(config=slim_bindings.ClientJwtAuth(
+    key=slim_bindings.JwtKeyType.ENCODING(key=enc),
+    audience=["mycelium-slim"], issuer="mycelium-resident",
+    subject="alice",  # the @handle == SLIM Name leaf
+    duration=datetime.timedelta(seconds=3600),
+))
+# Verifier — trust the room roster's public keys (static multi-key JWKS):
+dec = slim_bindings.JwtKeyConfig(
+    algorithm=slim_bindings.JwtAlgorithm.ES256,
+    format=slim_bindings.JwtKeyFormat.JWKS,
+    key=slim_bindings.JwtKeyData.DATA(value=roster_jwks_json),
+)
+verifier = slim_bindings.IdentityVerifierConfig.JWT(config=slim_bindings.JwtAuth(
+    key=slim_bindings.JwtKeyType.DECODING(key=dec),
+    audience=["mycelium-slim"], issuer="mycelium-resident", subject=None,
+    duration=datetime.timedelta(seconds=3600),
+))
+app = svc.create_app(slim_bindings.Name("mycelium","default","alice"), provider, verifier)
+# ... identical GROUP + MlsSettings SessionConfig, create_session, invite_async ...
+```
+
+Full runnable version: [`signerjwt_floor_spike.py`](./signerjwt_floor_spike.py); the
+roster JWKS is assembled by [`build_roster_jwks.py`](./build_roster_jwks.py).
+
+## SLIM `Name` / `subject` ↔ mycelium handle mapping
+
+| JWT `subject` / JWKS `kid` | SLIM `Name` leaf | mycelium `@handle` |
+|---|---|---|
+| `alice` | `mycelium/default/alice` | `alice` |
+| `bob`   | `mycelium/default/bob`   | `bob` |
+
+**Rule:** the JWT `subject` is the `@handle`, and the roster JWKS `kid` is the same
+`@handle` — so the verified signer maps 1:1 to the handle the hub binds writes to.
+Unlike SPIRE (where the handle is the leaf of an *attested* SPIFFE ID), here the
+handle→key binding is asserted at **registration** time and only as trustworthy as
+the roster's provenance. That is the floor's honest ceiling: it authenticates
+possession of a registered key, not a machine-attested workload identity.
+
+## How to run
+
+Requires Docker, `openssl`, and the `fastapi-backend` uv env
+(`slim-bindings==2.1.0` + `cryptography`). From this directory:
+
+```bash
+./run.sh
+```
+
+It stands up a stock SLIM 2.1.0 node on `:46358` (not `:46357` — the dev node owns
+that), self-mints each member's ES256 PKCS#8 keypair, builds the roster JWKS, runs
+the two members on the host, and exits non-zero unless it prints `PASS`. The node
+container is removed on exit.
+
+## Gotchas (record for the #476 impl)
+
+1. **Signing keys must be PKCS#8 PEM.** `openssl ecparam -genkey` emits SEC1 →
+   `InvalidKeyFormat`; convert with `openssl pkcs8 -topk8 -nocrypt` (`run.sh` does).
+   SPIRE sidesteps this — it manages its own keys — but the floor mints keys itself,
+   so this gotcha is live here.
+2. **`AUTORESOLVE` is the wrong verifier for a self-issued floor.** With no static
+   JWKS it attempts OIDC discovery on the `issuer`; a non-URL issuer →
+   `relative URL without a base`, and the invite fails with
+   `message send retries exhausted`. Use `DECODING` + a static roster JWKS.
+3. **`STATIC_JWT` still panics.** A handed-in *bearer* token → `StaticTokenProvider`
+   → `MlsNotSupported` (#581). The floor works precisely because SignerJwt is a
+   *signing* credential, not a bearer. This is the constraint that shapes the
+   "handed-in token" option in the decision doc.
+4. **Matched stack.** `slim-bindings==2.1.0` + `ghcr.io/agntcy/slim:2.1.0`. No PyPI
+   2.2.x Python binding exists yet (the node ships 2.2.0) — pin 2.1.0 on both sides.
+
+## Acceptance checklist (#587)
+
+- [x] Working way for a **resident** agent (no SPIRE, no shared PID ns) to obtain +
+      present a credential the MLS channel accepts — self-minted SignerJwt, run on
+      the host, matching a real resident topology (not the shared-PID rig).
+- [x] Mutual peer verification without SPIRE proven (roster JWKS), with the
+      registration-surface implication spelled out.
+- [x] PKCS#8 / `AUTORESOLVE` / `STATIC_JWT` constraints recorded so #476/#579 start
+      de-risked.
+- [x] `subject`/`kid` → `@handle` mapping documented.
+- [x] Reproducible harness, one-command `./run.sh`, executed PASS (output above).
+- [x] Node change needed? **No** — stock node forwards ciphertext; identity is
+      app-level.
+
+## References
+
+- #587 — SVID delivery / attestation model for resident agents (this validates the
+  default path) · [`../slim-identity-svid-delivery.md`](../slim-identity-svid-delivery.md)
+- #476 — SignerJwt floor impl · #579 — SPIRE (hardened) · #581 — `STATIC_JWT` →
+  `MlsNotSupported` · #560 — epic
+- [`../spire-mls-spike/`](../spire-mls-spike/) — the hardened SPIRE sibling (#583)
+- SLIM examples: `../_slim-research/slim-bindings/python/examples/{common,group}.py`
+- deepwiki `agntcy/slim`: SignerJwt tokens embed the signer's public key in claims;
+  the verifier's `KeyResolver` checks a static JWKS before attempting issuer
+  discovery.

--- a/docs/design/signerjwt-floor-spike/build_roster_jwks.py
+++ b/docs/design/signerjwt-floor-spike/build_roster_jwks.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Assemble the room-roster JWKS from members' ES256 public-key PEMs (spike #587).
+
+The roster JWKS is the SignerJwt floor's trust surface: the set of public keys a
+member's verifier will accept a self-signed token from. In a real mycelium
+deployment this is the moderator's view of the room's registered agents -- one JWK
+per `mycelium agent credential set`. Here it is just the two spike members.
+
+Usage: python build_roster_jwks.py <keydir> <name> [<name> ...]
+Reads <keydir>/<name>.pub.pem for each name, writes <keydir>/roster-jwks.json.
+"""
+
+import base64
+import json
+import sys
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def main() -> int:
+    keydir, names = sys.argv[1], sys.argv[2:]
+    keys = []
+    for name in names:
+        with open(f"{keydir}/{name}.pub.pem", "rb") as fh:
+            pub = load_pem_public_key(fh.read())
+        if not isinstance(pub, ec.EllipticCurvePublicKey):
+            raise TypeError(f"{name}: expected an EC P-256 public key")
+        nums = pub.public_numbers()
+        keys.append(
+            {
+                "kty": "EC",
+                "crv": "P-256",
+                "alg": "ES256",
+                "use": "sig",
+                "kid": name,  # the @handle; lets the verifier do O(1) key lookup
+                "x": _b64u(nums.x.to_bytes(32, "big")),
+                "y": _b64u(nums.y.to_bytes(32, "big")),
+            }
+        )
+    out = f"{keydir}/roster-jwks.json"
+    with open(out, "w") as fh:
+        json.dump({"keys": keys}, fh)
+    print(f"wrote {out} with {len(keys)} key(s): {', '.join(names)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/design/signerjwt-floor-spike/run.sh
+++ b/docs/design/signerjwt-floor-spike/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# One-command reproduction of the SignerJwt floor -> SLIM MLS spike (#587).
+#
+# Unlike the #583 SPIRE spike this needs NO SPIRE, NO shared PID namespace, and NO
+# in-container runner: the whole point of the floor is that a resident agent on its
+# own machine self-mints its credential. So this stands up a stock SLIM 2.1.0 node
+# and runs the two members straight on the host.
+#
+# Requires: docker, openssl, and the fastapi-backend uv env (slim-bindings==2.1.0 +
+# cryptography). Run from this directory. Tear-down is automatic.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND="$(cd "$HERE/../../../fastapi-backend" && pwd)"
+NODE_NAME="slim-signerjwt-spike"
+NODE_PORT="${NODE_PORT:-46358}"   # not :46357 -- the dev node owns that
+KEYDIR="${KEYDIR:-/tmp/signerjwt-floor-spike}"
+export SLIM_ENDPOINT="http://127.0.0.1:${NODE_PORT}"
+export KEYDIR
+
+cleanup() { docker rm -f "$NODE_NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "== 1/3  stock SLIM 2.1.0 node on :${NODE_PORT} =="
+mkdir -p "${KEYDIR:?}"
+cat > "$KEYDIR/slim-node.yaml" <<EOF
+tracing: { log_level: info }
+runtime: { n_cores: 0, thread_name: "slim-data-plane", drain_timeout: 10s }
+services:
+  slim/0:
+    dataplane:
+      servers:
+        - endpoint: "0.0.0.0:${NODE_PORT}"
+          tls: { insecure: true }
+      clients: []
+EOF
+cleanup
+docker run -d --name "$NODE_NAME" -p "${NODE_PORT}:${NODE_PORT}" \
+  -v "$KEYDIR/slim-node.yaml:/config.yaml" \
+  ghcr.io/agntcy/slim:2.1.0 /slim --config /config.yaml >/dev/null
+sleep 3
+
+echo "== 2/3  self-mint each member's ES256 keypair (PKCS#8) + roster JWKS =="
+for name in alice bob; do
+  # ecparam emits SEC1 -> InvalidKeyFormat; convert to PKCS#8 for the signer.
+  openssl ecparam -name prime256v1 -genkey -noout -out "$KEYDIR/$name.sec1.key" 2>/dev/null
+  openssl pkcs8 -topk8 -nocrypt -in "$KEYDIR/$name.sec1.key" -out "$KEYDIR/$name.pk8.pem" 2>/dev/null
+  openssl ec -in "$KEYDIR/$name.sec1.key" -pubout -out "$KEYDIR/$name.pub.pem" 2>/dev/null
+done
+( cd "$BACKEND" && uv run python "$HERE/build_roster_jwks.py" "$KEYDIR" alice bob )
+
+echo "== 3/3  two SignerJwt members establish MLS + exchange a message =="
+( cd "$BACKEND" && uv run python "$HERE/signerjwt_floor_spike.py" )

--- a/docs/design/signerjwt-floor-spike/signerjwt_floor_spike.py
+++ b/docs/design/signerjwt-floor-spike/signerjwt_floor_spike.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SignerJwt floor -> SLIM MLS member spike (issue #587).
+
+The **default resident credential path**: an agent that runs no SPIRE at all. Each
+member generates its *own* local ES256 keypair, self-signs a short-lived JWT that
+embeds its public key, and presents it as `IdentityProviderConfig.JWT` (SignerJwt).
+No SPIRE agent, no shared PID namespace, no Workload API socket -- so unlike the
+#583 SPIRE spike this matches a *real resident topology*: the agent's own machine.
+
+Two members join ONE `GROUP`/MLS channel, the moderator invites the participant,
+they verify each other's self-signed tokens, and exchange a message both ways.
+Reaching a decoded round-trip proves `IdentityProviderConfig.JWT` (SignerJwt) drives
+the MLS moderated group session -- the same `session_moderator.rs` code path that
+panicked in #581 under `STATIC_JWT`.
+
+How peer verification works without SPIRE (the load-bearing finding): the SignerJwt
+token carries the signer's public key in its claims, and each member's verifier holds
+a **static JWKS of the trusted members' public keys** (`JwtKeyType.DECODING` +
+`JwtKeyFormat.JWKS`). That JWKS is the deployment's registration surface -- the
+mycelium analogue of `mycelium agent credential set`, a public key registered when
+an agent is added to a room. There is no attestation and no issuer discovery: trust
+is "this public key is on the room's roster", distributed out of band.
+
+Run: `./run.sh` (stands up a stock SLIM 2.1.0 node on :46358, generates keys, execs
+this on the host). Env: SLIM_ENDPOINT=http://127.0.0.1:46358, KEYDIR=/tmp/... .
+
+Matched stack (proven): slim-bindings==2.1.0 (PyPI) + ghcr.io/agntcy/slim:2.1.0.
+Do NOT substitute STATIC_JWT: it returns MlsNotSupported for MLS signature keys
+(#581). Signing keys must be PKCS#8 PEM; `openssl ecparam -genkey` emits SEC1 ->
+`InvalidKeyFormat`, so `run.sh` converts with `openssl pkcs8 -topk8 -nocrypt`.
+"""
+
+import asyncio
+import datetime
+import os
+import sys
+
+import slim_bindings
+
+SLIM = os.environ.get("SLIM_ENDPOINT", "http://127.0.0.1:46358")
+KEYDIR = os.environ.get("KEYDIR", "/tmp/signerjwt-floor-spike")
+
+# A self-issued floor has no issuer discovery endpoint: the issuer/audience are just
+# labels both sides agree on, and verification rests on the JWKS, not on the issuer.
+ISSUER = os.environ.get("SIGNERJWT_ISSUER", "mycelium-resident")
+AUDIENCE = [os.environ.get("SIGNERJWT_AUDIENCE", "mycelium-slim")]
+
+ORG, NS = "mycelium", "default"
+MODERATOR = "alice"
+PARTICIPANT = "bob"
+ROOM = "mls-room"
+
+
+def _read(path: str) -> str:
+    with open(path) as fh:
+        return fh.read()
+
+
+def signerjwt_identity(name: str):
+    """Build a SignerJwt provider + JWKS verifier for one resident member.
+
+    Provider: sign our own JWT with our local PKCS#8 ES256 key (`ENCODING`).
+    Verifier: trust the room roster's public keys, a static multi-key JWKS
+    (`DECODING` + `JWKS`) -- how a member validates *every other* member's
+    self-signed token with no SPIRE and no issuer discovery.
+    """
+    encoding_key = slim_bindings.JwtKeyConfig(
+        algorithm=slim_bindings.JwtAlgorithm.ES256,
+        format=slim_bindings.JwtKeyFormat.PEM,
+        key=slim_bindings.JwtKeyData.DATA(value=_read(f"{KEYDIR}/{name}.pk8.pem")),  # type: ignore[call-arg]
+    )
+    provider = slim_bindings.IdentityProviderConfig.JWT(
+        config=slim_bindings.ClientJwtAuth(
+            key=slim_bindings.JwtKeyType.ENCODING(key=encoding_key),  # type: ignore[call-arg]
+            audience=AUDIENCE,
+            issuer=ISSUER,
+            subject=name,  # the mycelium @handle -- the SLIM Name leaf
+            duration=datetime.timedelta(seconds=3600),
+        )
+    )
+    decoding_key = slim_bindings.JwtKeyConfig(
+        algorithm=slim_bindings.JwtAlgorithm.ES256,
+        format=slim_bindings.JwtKeyFormat.JWKS,
+        key=slim_bindings.JwtKeyData.DATA(value=_read(f"{KEYDIR}/roster-jwks.json")),  # type: ignore[call-arg]
+    )
+    verifier = slim_bindings.IdentityVerifierConfig.JWT(
+        config=slim_bindings.JwtAuth(
+            key=slim_bindings.JwtKeyType.DECODING(key=decoding_key),  # type: ignore[call-arg]
+            audience=AUDIENCE,
+            issuer=ISSUER,
+            subject=None,
+            duration=datetime.timedelta(seconds=3600),
+        )
+    )
+    return provider, verifier
+
+
+def group_session_config():
+    return slim_bindings.SessionConfig(
+        session_type=slim_bindings.SessionType.GROUP,
+        max_retries=5,
+        interval=datetime.timedelta(seconds=5),
+        metadata={},
+        mls_settings=slim_bindings.MlsSettings(
+            header_integrity_validation_percent=100,
+            max_seen_control_message_ids_size=None,
+        ),
+    )
+
+
+async def make_member(svc, conn, name: str):
+    provider, verifier = signerjwt_identity(name)
+    slim_name = slim_bindings.Name(ORG, NS, name)
+    app = svc.create_app(slim_name, provider, verifier)
+    await app.subscribe_async(slim_name, conn)
+    return app, slim_name
+
+
+async def main() -> int:
+    slim_bindings.initialize_with_defaults()
+    svc = slim_bindings.get_global_service()
+    conn = await svc.connect_async(slim_bindings.new_insecure_client_config(SLIM))
+
+    # Both members authenticate with a locally self-signed SignerJwt token.
+    mod_app, _ = await make_member(svc, conn, MODERATOR)
+    part_app, part_name = await make_member(svc, conn, PARTICIPANT)
+
+    room = slim_bindings.Name(ORG, NS, ROOM)
+
+    # Moderator creates the MLS group -- the session_moderator.rs MLS-state path.
+    # If SignerJwt could not manage MLS signature keys we'd fail HERE with
+    # MlsNotSupported (as STATIC_JWT does in #581).
+    print("[moderator] creating GROUP/MLS session ...", flush=True)
+    created = mod_app.create_session(group_session_config(), room)
+    await created.completion.wait_async()
+    session = created.session
+    print("[moderator] MLS session established (no MlsNotSupported).", flush=True)
+
+    part_ready = asyncio.Event()
+
+    async def participant_wait():
+        s = await part_app.listen_for_session_async(None)
+        part_ready.set()
+        msg = await s.get_message_async(timeout=datetime.timedelta(seconds=30))
+        print(f"[participant] received: {msg.payload.decode()!r}", flush=True)
+        await s.publish_async(b"bob: ack -- peer verified", None, None)
+
+    waiter = asyncio.create_task(participant_wait())
+
+    # Moderator invites the participant by name; MLS peer verification of bob's
+    # self-signed token against the roster JWKS happens inside the invite/commit
+    # handshake.
+    await mod_app.set_route_async(part_name, conn)
+    print("[moderator] inviting participant ...", flush=True)
+    handle = await session.invite_async(part_name)
+    await handle.wait_async()
+    print("[moderator] participant joined + peer-verified.", flush=True)
+
+    await asyncio.wait_for(part_ready.wait(), timeout=30)
+    await session.publish_async(b"alice: hello over MLS", None, None)
+
+    reply = await session.get_message_async(timeout=datetime.timedelta(seconds=30))
+    print(f"[moderator] received: {reply.payload.decode()!r}", flush=True)
+
+    await asyncio.wait_for(waiter, timeout=30)
+    print("\nPASS: two SignerJwt-identified MLS members exchanged a verified message.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(asyncio.run(main()))
+    except Exception as exc:  # noqa: BLE001 -- spike: surface the exact failure
+        print(f"\nFAIL: {type(exc).__name__}: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/docs/design/slim-identity-svid-delivery.md
+++ b/docs/design/slim-identity-svid-delivery.md
@@ -3,7 +3,8 @@
 
 **Status:** Decided (default path demonstrated; #579 SPIRE impl to follow)
 **Related:** #587 (this decision), #476 (SignerJwt floor impl), #579 (SPIRE impl),
-#581 (`STATIC_JWT` → `MlsNotSupported`), #560 (epic),
+#581 (`STATIC_JWT` → `MlsNotSupported`), #585 (SLIM-channel epic),
+#560 (umbrella identity epic),
 [`identity-and-auth.md`](./identity-and-auth.md) (the umbrella identity design)
 **Proven by:** [`signerjwt-floor-spike/`](./signerjwt-floor-spike/) (default path,
 PASS 2026-08-16) and [`spire-mls-spike/`](./spire-mls-spike/) (hardened path, #583)

--- a/docs/design/slim-identity-svid-delivery.md
+++ b/docs/design/slim-identity-svid-delivery.md
@@ -1,0 +1,143 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Design: SLIM identity — SVID delivery / attestation model for resident agents
+
+**Status:** Decided (default path demonstrated; #579 SPIRE impl to follow)
+**Related:** #587 (this decision), #476 (SignerJwt floor impl), #579 (SPIRE impl),
+#581 (`STATIC_JWT` → `MlsNotSupported`), #560 (epic),
+[`identity-and-auth.md`](./identity-and-auth.md) (the umbrella identity design)
+**Proven by:** [`signerjwt-floor-spike/`](./signerjwt-floor-spike/) (default path,
+PASS 2026-08-16) and [`spire-mls-spike/`](./spire-mls-spike/) (hardened path, #583)
+
+## Problem
+
+Once #586 pinned the matched **slim-bindings 2.1.0 + node 2.1.0** stack, MLS with an
+external *signing* identity works. That plumbing is proven. What was undecided is
+**how a resident mycelium agent actually gets the credential it presents to the SLIM
+channel** — and a resident agent is the hard case: it is the user's own
+Claude/Cursor session, turn-based, on the user's own machine, with no SPIRE agent
+standing by to attest it and no held socket.
+
+This note fixes the credential-acquisition model **per topology**, with the hard
+constraints baked in so the #476/#579 implementations start de-risked.
+
+## The one constraint that rules out the obvious answer
+
+**A static *bearer* token cannot drive MLS.** Presenting an externally-minted bearer
+via `STATIC_JWT` panics `MlsOp(IdentityProviderError(MlsNotSupported))` (#581): MLS
+needs a *signing* credential (it manages per-member MLS signature keys), and a
+bearer token carries no signing key. Only two credential shapes work with MLS:
+
+- **`IdentityProviderConfig.JWT` (SignerJwt)** — a local signing keypair (ES256,
+  **PKCS#8** PEM; SEC1 → `InvalidKeyFormat`). The agent self-signs.
+- **`IdentityProviderConfig.SPIRE`** — a JWT-SVID from the Workload API; the SPIRE
+  agent holds the signing material.
+
+Everything below follows from this: the SLIM-channel credential is always a
+**signer**, never a bearer. The `MYCELIUM_AGENT_AUTH_TOKEN` bearer that the CLI
+already accepts (`agent_credentials.py`) authenticates to the **HTTP API**; it is
+*not* a SLIM-channel credential and must not be conflated with one.
+
+## The decision, per topology
+
+| Topology | Credential model | SLIM provider | Infra weight | Default? |
+|---|---|---|---|---|
+| A. Laptop / single trust domain | Shared-secret PSK (today) | `create_app_with_secret` | none | ✅ ships today |
+| B. Resident agent, identity on, no SPIRE | **SignerJwt floor** (self-minted keypair) | `IdentityProviderConfig.JWT` | none | ✅ **default resident identity path** |
+| C. Hardened / appliance | Co-located SPIRE, unix attestor | `IdentityProviderConfig.SPIRE` | SPIRE server+agent | opt-in upgrade |
+| D. Externally-minted, handed in | Signing key / JWT-SVID handed in (**not a bearer**) | JWT or SPIRE | issuer-dependent | seam, constrained |
+
+### A — Laptop / single trust domain (unchanged default)
+
+The shared-secret PSK (`mint_shared_secret` → `create_app_with_secret`), scoped to
+`workspace/room`. Zero infra, no per-agent identity, every room member
+cryptographically indistinguishable. This is the **off-by-default** posture (#567):
+identity stays off until an operator turns it on, and turning it on must never block
+the try-it path. Nothing here changes it.
+
+### B — SignerJwt floor (the default resident identity path) ✅
+
+When an operator does want per-agent identity but runs no SPIRE, a resident agent
+**mints its own credential locally**: generate an ES256 keypair (PKCS#8), self-sign
+a short-lived JWT that embeds its public key, present it as
+`IdentityProviderConfig.JWT`. No SPIRE agent, no attestor, no Workload API socket, no
+shared PID namespace — so it runs on the agent's own machine, which is exactly the
+resident topology. **Demonstrated end-to-end on the 2.1.0 stack** (two members
+establish MLS, peer-verify, exchange a message):
+[`signerjwt-floor-spike/`](./signerjwt-floor-spike/).
+
+**Peer verification without SPIRE.** A SignerJwt token carries the signer's public
+key in its claims, and each member's verifier holds a **static roster JWKS**
+(`JwtKeyType.DECODING` + `JWKS`) of the trusted members' public keys — a self-signed
+token is accepted iff its key is on the roster. That roster JWKS **is the
+registration surface**: the mycelium analogue of `mycelium agent credential set`,
+one JWK per agent (keyed by `kid = @handle`), added when the agent joins a room. The
+moderator (the backend) holds the room roster; each agent trusts the moderator's key
+plus its peers'.
+
+**Honest ceiling.** The floor authenticates *possession of a registered key*, not a
+machine-attested workload. The handle→key binding is asserted at registration and is
+only as trustworthy as the roster's provenance. That is strictly better than today's
+self-asserted `name#session` (a key can't be forged, and revocation is
+per-agent — drop its JWK from the roster) but weaker than SPIRE's attestation. It is
+the right *default* because it needs no infra; C is the upgrade when attestation
+matters.
+
+### C — Co-located SPIRE (hardened upgrade)
+
+For hardened / appliance deployments, a co-located SPIRE agent mints JWT-SVIDs via
+the `unix` workload attestor. Tightest attestation (the SVID is bound to an attested
+workload, not a registered key), heaviest deploy. **Proven on the 2.1.0 stack**
+(#583, [`spire-mls-spike/`](./spire-mls-spike/)) — same MLS mechanics as B, only the
+provider/verifier pair differs.
+
+The load-bearing operational constraint (surfaced by #584): the `unix` attestor
+identifies the workload by `SO_PEERCRED` PID, so the SPIRE agent must **share the
+workload's PID namespace** (`pid: "service:spire-agent"` / `hostPID`) and expose the
+Workload API socket on a **named volume** (a host bind-mount drops peer creds on
+Docker Desktop). Cross-namespace → `could not resolve caller information`, and the
+member hangs at "Initializing spire identity manager." This is exactly why SPIRE is
+**not** the resident default: a resident Claude/Cursor session does not run
+co-located with a SPIRE agent in a shared PID namespace. Where the `unix` attestor
+can't be co-located, a non-`unix` attestor (`k8s`, `docker`, `x509pop`, join-token)
+sources the SVID instead — which is topology D.
+
+### D — Externally-minted, handed in (a constrained seam)
+
+The `MYCELIUM_AGENT_AUTH_TOKEN` passthrough already accepts a credential this CLI
+didn't mint (from CI, a sidecar, a join-token/k8s/OIDC flow). **The constraint:**
+for the SLIM channel this must be a **signing** credential (a private key the
+SignerJwt provider signs with, or a JWT-SVID a provider can use to sign), **never a
+static bearer** — a bearer is `STATIC_JWT`, which is `MlsNotSupported`. So:
+
+- A handed-in **bearer** token → fine for the **HTTP-API** gate, useless for SLIM.
+- A handed-in **signing key** → feeds the SignerJwt provider (topology B with an
+  externally-provisioned key instead of a self-minted one).
+- A handed-in **JWT-SVID + Workload API** → topology C/SPIRE with a non-`unix`
+  attestor.
+
+D is not a separate mechanism; it is B or C with the key sourced elsewhere. The doc
+records it so no one assumes "we already pass a token through, so we're done" — the
+token we pass through today is the wrong *shape* for MLS.
+
+## What this de-risks for #476 / #579
+
+- **#476 (SignerJwt floor):** the default resident path. Implement key mint (ES256
+  PKCS#8), the roster-JWKS registration surface (`mycelium agent credential set`
+  writing a JWK; the moderator assembling the room roster), and wire
+  `IdentityProviderConfig.JWT` into `slim_client.py` behind the same off-by-default
+  switch as the PSK. The spike is the reference; `AUTORESOLVE` is a dead end for a
+  self-issued floor (use `DECODING` + static JWKS).
+- **#579 (SPIRE):** the hardened upgrade. Same MLS mechanics; the work is the deploy
+  topology (co-located agent, shared PID ns, named-volume socket) and the SPIFFE-ID
+  → `@handle` mapping (#583).
+- **Both:** the `@handle` is the JWT `subject` / JWKS `kid` (floor) or SPIFFE leaf
+  (SPIRE), and it must reconcile with the HTTP-API OIDC `sub` binding and today's
+  `name#session` shape — the open question already flagged in
+  [`identity-and-auth.md`](./identity-and-auth.md) §"Verified handle binding".
+
+## Constraints honored
+
+- Identity stays **optional / off by default** (#567); the PSK (topology A) remains
+  the zero-infra default. This note wires nothing onto the default path.
+- No `STATIC_JWT` anywhere for MLS (#581).
+- Matched stack only: `slim-bindings==2.1.0` + `ghcr.io/agntcy/slim:2.1.0`.


### PR DESCRIPTION
Closes #587.

Decides the SVID delivery / attestation model for **resident agents** and proves the default path end-to-end on the matched 2.1.0 stack.

## The decision (per topology)

| Topology | Credential | SLIM provider | Default? |
|---|---|---|---|
| A. laptop / single trust domain | shared-secret PSK (today) | `create_app_with_secret` | ✅ ships today |
| B. resident, identity on, no SPIRE | **SignerJwt floor** (self-minted ES256 key) | `IdentityProviderConfig.JWT` | ✅ **default resident identity path** |
| C. hardened / appliance | co-located SPIRE, unix attestor | `IdentityProviderConfig.SPIRE` | opt-in upgrade (#583) |
| D. externally-minted, handed in | a **signing** key / JWT-SVID, never a bearer | JWT or SPIRE | constrained seam |

The one constraint that rules out the obvious answer: **a static bearer token can't drive MLS** — `STATIC_JWT` → `MlsNotSupported` (#581). The `MYCELIUM_AGENT_AUTH_TOKEN` bearer we already pass through is the wrong *shape* for the SLIM channel; it authenticates to the HTTP API only. D is just B or C with the key sourced elsewhere.

## Demonstrated working path (acceptance)

`docs/design/signerjwt-floor-spike/` — `./run.sh` stands up a stock SLIM 2.1.0 node on `:46358`, self-mints two ES256 (PKCS#8) keypairs, builds a roster JWKS, and runs two members **on the host** (no SPIRE, no shared PID namespace — the real resident topology, unlike the #583 shared-PID rig). Executed **PASS 2026-08-16**:

```
[moderator] MLS session established (no MlsNotSupported).
[moderator] participant joined + peer-verified.
[participant] received: 'alice: hello over MLS'
[moderator] received: 'bob: ack -- peer verified'
PASS: two SignerJwt-identified MLS members exchanged a verified message.
```

**Load-bearing finding:** a SignerJwt token embeds the signer's public key in its claims; mutual peer verification without SPIRE uses a **static roster JWKS** (`JwtKeyType.DECODING`), which *is* the deployment's registration surface — the `mycelium agent credential set` analogue, `kid = @handle`. `AUTORESOLVE` is a dead end for a self-issued floor (it falls back to OIDC discovery on a non-URL issuer).

## Files

- `docs/design/slim-identity-svid-delivery.md` — the decision, per topology, with the STATIC_JWT / PKCS#8 / PID-ns constraints baked in for #476/#579.
- `docs/design/signerjwt-floor-spike/` — one-command `./run.sh` harness + report (`signerjwt_floor_spike.py`, `build_roster_jwks.py`).

## How to verify on the rig

From `docs/design/signerjwt-floor-spike/`: `./run.sh` (Docker + openssl + the `fastapi-backend` uv env). Exits non-zero unless it prints `PASS`; node container removed on exit.

Refs #476 (SignerJwt impl), #579 (SPIRE impl), #581, #560. Sits alongside `docs/design/spire-mls-spike/` (the hardened sibling) and `docs/design/identity-and-auth.md` (umbrella).