### PR TITLE
feat(identity): SPIRE/SPIFFE SLIM channel identity mode (#579)

### DIFF
--- a/contracts/slim-l9-wire.json
+++ b/contracts/slim-l9-wire.json
@@ -28,12 +28,20 @@
     "mode_env": "MYCELIUM_SLIM_IDENTITY",
     "require_env": "MYCELIUM_SLIM_IDENTITY_REQUIRE",
     "mode_default": "psk",
-    "modes": ["psk", "signerjwt"],
+    "modes": ["psk", "signerjwt", "spire"],
     "issuer": "mycelium-resident",
     "audience": "mycelium-slim",
     "alg": "ES256",
     "curve": "P-256",
-    "jwk_kid_is_handle": true
+    "jwk_kid_is_handle": true,
+    "spire": {
+      "_comment": "SPIRE/SPIFFE mode (#579): both copies build IdentityProviderConfig.SPIRE / IdentityVerifierConfig.SPIRE from SpireConfig(socket_path, target_spiffe_id, jwt_audiences, trust_domains). socket_env selects the Workload API socket (falling back to the SPIFFE-standard SPIRE_AGENT_SOCKET); a member's SPIFFE ID is spiffe://{trust_domain}/{workload_path_prefix}/{handle} and the SVID audience is the shared MLS `audience` above. These must agree across members or peer verification fails inside the MLS handshake.",
+      "socket_env": "MYCELIUM_SLIM_SPIRE_SOCKET",
+      "socket_env_fallback": "SPIRE_AGENT_SOCKET",
+      "trust_domain_env": "MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN",
+      "trust_domain_default": "mycelium.dev",
+      "workload_path_prefix": "agent"
+    }
   },
 
   "valid_subkinds": {

--- a/docs/design/spire-quickstart/README.md
+++ b/docs/design/spire-quickstart/README.md
@@ -1,0 +1,110 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Dev SPIRE quickstart — SPIRE-attested MLS members (#579)
+
+An **optional, dev-grade** rig for the `spire` SLIM channel identity mode: a SPIRE
+server + agent mint JWT-SVIDs over the SPIFFE Workload API, and two mycelium members
+present those SVIDs as their MLS identity (`IdentityProviderConfig.SPIRE` /
+`IdentityVerifierConfig.SPIRE`). It is the productization starting point for the
+`spire` mode wired into `slim_client.py`; the full appliance deployment profile is
+**#588** (not this) and revocation semantics are **#590**.
+
+> **Off by default (#567).** `psk` is the default identity mode, `signerjwt` the
+> light opt-in, `spire` the heavy opt-in. Nothing here touches the try-it path — you
+> only stand this up to exercise attested identity.
+
+> **Status.** The provider/verifier wiring and the off-by-default / degrade /
+> fail-closed behavior are unit-tested offline (`tests/test_slim_identity.py`). The
+> **live SPIRE→MLS path needs the rig** (a co-located SPIRE agent sharing the
+> workload PID namespace — see the gotcha below); it is validated on matched infra,
+> not in the offline suite. The proven reference is the #583/#584 spike
+> (`docs/design/spire-mls-spike/`, PASS on the 2.1.0 stack: two SPIRE-attested
+> members established a GROUP/MLS session on a stock `slim:2.1.0` node).
+
+## What the `spire` mode does
+
+`MYCELIUM_SLIM_IDENTITY=spire` makes each member build its SLIM app identity from a
+SPIRE `SpireConfig`:
+
+```python
+provider = slim_bindings.IdentityProviderConfig.SPIRE(config=slim_bindings.SpireConfig(
+    socket_path=socket,                                   # Workload API socket
+    target_spiffe_id="spiffe://mycelium.dev/agent/alice", # this member's SVID
+    jwt_audiences=["mycelium-slim"],                      # the MLS audience label
+    trust_domains=["mycelium.dev"],
+))
+verifier = slim_bindings.IdentityVerifierConfig.SPIRE(config=slim_bindings.SpireConfig(
+    socket_path=socket,
+    target_spiffe_id=None,          # accept any peer in the trust domain
+    jwt_audiences=["mycelium-slim"],
+    trust_domains=["mycelium.dev"],
+))
+app = svc.create_app(name, provider, verifier)
+# ... identical GROUP + MlsSettings SessionConfig as psk/signerjwt ...
+```
+
+Unlike the SignerJwt floor (#476), there is **no on-disk key** to mint: SPIRE owns
+the key material and mints the SVID on demand, and peers verify against the SPIRE
+bundle the same socket serves instead of a hand-distributed roster JWKS. Same MLS
+mechanics; tightest attestation; heaviest deploy.
+
+## Config / env
+
+| Setting | Where | Meaning |
+|---|---|---|
+| `slim.identity = "spire"` | `config.toml` → `MYCELIUM_SLIM_IDENTITY=spire` | Select the mode (off by default). |
+| `MYCELIUM_SLIM_SPIRE_SOCKET` | env (operator-managed) | Workload API socket path. Falls back to the SPIFFE-standard `SPIRE_AGENT_SOCKET`. |
+| `MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN` | env (operator-managed) | Trust domain (default `mycelium.dev`). |
+| `MYCELIUM_SLIM_IDENTITY_REQUIRE=1` | env | Fail closed instead of degrading to PSK when no socket is present. |
+
+The socket / trust-domain envs are operator-managed out of band (like
+`MYCELIUM_SLIM_MASTER_SECRET`), not derived from `config.toml` — only the mode
+selector `slim.identity` rides through `mycelium config apply`.
+
+A member's SPIFFE ID is `spiffe://{trust_domain}/agent/{handle}`. That handle ↔
+SPIFFE-leaf binding is minimal-by-design here; the full registration/reconciliation
+surface (SPIFFE leaf ↔ `@handle`) is **#589**.
+
+## The load-bearing operational gotcha (bake it in)
+
+SPIRE's `unix` workload attestor identifies the caller by its `SO_PEERCRED` **PID**,
+so the SPIRE agent must be able to introspect the workload:
+
+1. **Share the workload's PID namespace** (`pid: "service:spire-agent"` / `hostPID`).
+2. **Expose the Workload API socket on a named volume**, *not* a host bind-mount —
+   a Docker Desktop host bind drops peer creds.
+
+Cross-namespace → `could not resolve caller information`, and the member hangs at
+**"Initializing spire identity manager."** This is exactly why `spire` is **not** the
+resident default: a resident Claude/Cursor session does not run co-located with a
+SPIRE agent in a shared PID namespace. Where the `unix` attestor can't be
+co-located, source the SVID from a non-`unix` attestor (`k8s`, `docker`, `x509pop`,
+join-token) instead — topology D in
+[`../slim-identity-svid-delivery.md`](../slim-identity-svid-delivery.md).
+
+## Files
+
+- [`compose.yml`](./compose.yml) — stock `slim:2.1.0` node + SPIRE server + SPIRE
+  agent (shared PID namespace, named-volume Workload API socket).
+- [`spire-server.conf`](./spire-server.conf) — SPIRE server (dev; in-memory /
+  SQLite datastore, `mycelium.dev` trust domain).
+- [`spire-agent.conf`](./spire-agent.conf) — SPIRE agent (`unix` workload attestor,
+  join-token node attestation for the dev rig).
+- [`register-workloads.sh`](./register-workloads.sh) — create the registration
+  entries mapping each member's process to `spiffe://mycelium.dev/agent/{handle}`.
+- [`run.sh`](./run.sh) — bring the rig up, register the two workloads, and run the
+  two members; exits non-zero unless the attested MLS exchange prints `PASS`.
+
+## Matched stack only
+
+`slim-bindings==2.1.0` (PyPI) + `ghcr.io/agntcy/slim:2.1.0` node + SPIRE 1.9.x. No
+`STATIC_JWT` — a handed-in *bearer* token is `MlsNotSupported` (#581); the SVID must
+drive a *signing* provider, which `IdentityProviderConfig.SPIRE` does.
+
+## References
+
+- #579 — this ticket (SPIRE mode) · #588 — appliance profile · #589 — handle ↔
+  SPIFFE mapping · #590 — revocation · #476/#593 — the SignerJwt floor + the seam
+  this drops into · #581 — `STATIC_JWT` → `MlsNotSupported`
+- [`../spire-mls-spike/`](../spire-mls-spike/) — the proven #583/#584 spike (PASS)
+- [`../slim-identity-svid-delivery.md`](../slim-identity-svid-delivery.md) — topology
+  C (co-located SPIRE) / D (externally-minted SVID)

--- a/docs/design/spire-quickstart/compose.yml
+++ b/docs/design/spire-quickstart/compose.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Dev SPIRE-attested MLS rig (#579). Optional, off the try-it path. See README.md.
+#
+# Topology C (co-located SPIRE): the SPIRE agent shares the workload PID namespace
+# and serves the Workload API over a NAMED VOLUME (spire-socket) — the two
+# conditions the `unix` attestor needs. The stock slim node is a blind ciphertext
+# forwarder and needs no identity config.
+name: mycelium-spire-quickstart
+
+services:
+  slim:
+    image: ghcr.io/agntcy/slim:2.1.0
+    command: ["/slim", "--config", "/config.yaml"]
+    ports:
+      - "46358:46358"   # not :46357 — the dev node owns that
+    volumes:
+      - ./slim-node.yaml:/config.yaml:ro
+
+  spire-server:
+    image: ghcr.io/spiffe/spire-server:1.9.6
+    command: ["-config", "/opt/spire/conf/server/server.conf"]
+    hostname: spire-server
+    volumes:
+      - ./spire-server.conf:/opt/spire/conf/server/server.conf:ro
+      - spire-server-data:/opt/spire/data/server
+
+  spire-agent:
+    image: ghcr.io/spiffe/spire-agent:1.9.6
+    # Provide the join token via SPIRE_JOIN_TOKEN (run.sh mints it from the server).
+    command: ["-config", "/opt/spire/conf/agent/agent.conf", "-joinToken", "${SPIRE_JOIN_TOKEN}"]
+    depends_on:
+      - spire-server
+    # Share the workload's PID namespace so the unix attestor can read SO_PEERCRED.
+    pid: "host"
+    volumes:
+      - ./spire-agent.conf:/opt/spire/conf/agent/agent.conf:ro
+      - spire-agent-data:/opt/spire/data/agent
+      # Named volume, NOT a host bind — a bind drops peer creds on Docker Desktop.
+      - spire-socket:/run/spire/sockets
+
+volumes:
+  spire-server-data:
+  spire-agent-data:
+  spire-socket:

--- a/docs/design/spire-quickstart/register-workloads.sh
+++ b/docs/design/spire-quickstart/register-workloads.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Register the two demo members as SPIRE workloads (#579). Each entry maps a
+# workload selector to the SPIFFE ID the `spire` mode expects:
+#   spiffe://mycelium.dev/agent/{handle}
+#
+# The `unix:uid` selector attests any process running as that uid inside the shared
+# PID namespace — dev-grade. A real deployment uses a tighter selector (unix:path,
+# unix:sha256, k8s:sa, docker:label, ...). Run after the server+agent are up.
+set -euo pipefail
+
+TRUST_DOMAIN="${TRUST_DOMAIN:-mycelium.dev}"
+# The parent SPIFFE ID is the attested agent node; the server prints it as the
+# agent's SVID. For the join-token agent it is spiffe://<td>/spire/agent/join_token/<token>.
+PARENT_ID="${PARENT_ID:?set PARENT_ID to the agent node SPIFFE ID (see run.sh)}"
+# uid the member processes run as inside the shared PID namespace.
+WORKLOAD_UID="${WORKLOAD_UID:-$(id -u)}"
+
+register() {
+  local handle="$1"
+  docker compose exec -T spire-server \
+    /opt/spire/bin/spire-server entry create \
+      -parentID "$PARENT_ID" \
+      -spiffeID "spiffe://${TRUST_DOMAIN}/agent/${handle}" \
+      -selector "unix:uid:${WORKLOAD_UID}" \
+      -jwtSVIDTTL 300
+}
+
+for handle in "${@:-alice bob}"; do
+  echo "== registering spiffe://${TRUST_DOMAIN}/agent/${handle} =="
+  register "$handle"
+done

--- a/docs/design/spire-quickstart/run.sh
+++ b/docs/design/spire-quickstart/run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# One-command dev rig for SPIRE-attested MLS members (#579). Stands up the stock
+# SLIM 2.1.0 node + a co-located SPIRE server/agent (shared PID namespace,
+# named-volume Workload API socket), registers the two demo workloads, and runs two
+# members that present JWT-SVIDs as their MLS identity.
+#
+# Requires: docker + docker compose, and the fastapi-backend uv env
+# (slim-bindings==2.1.0). Run from this directory. Tear-down is automatic.
+#
+# NOTE: this is the dev-grade path validated on real infra (a shared PID namespace
+# is exactly what an offline unit suite can't stand up). The provider/verifier
+# wiring and off-by-default/degrade/fail-closed behavior are covered offline in
+# fastapi-backend/tests/test_slim_identity.py. The appliance profile is #588.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE"
+
+cleanup() { docker compose down -v >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "== 1/4  SPIRE server + stock slim:2.1.0 node =="
+SPIRE_JOIN_TOKEN=placeholder docker compose up -d spire-server slim
+sleep 5
+
+echo "== 2/4  mint a join token + start the co-located SPIRE agent =="
+JOIN_TOKEN="$(docker compose exec -T spire-server \
+  /opt/spire/bin/spire-server token generate -spiffeID spiffe://mycelium.dev/agent-node \
+  | sed -n 's/^Token: //p')"
+SPIRE_JOIN_TOKEN="$JOIN_TOKEN" docker compose up -d spire-agent
+sleep 5
+
+echo "== 3/4  register the two member workloads =="
+PARENT_ID="spiffe://mycelium.dev/spire/agent/join_token/${JOIN_TOKEN}" \
+  ./register-workloads.sh alice bob
+
+echo "== 4/4  two SPIRE-attested members establish MLS + exchange a message =="
+# Members connect to the node on :46358 with MYCELIUM_SLIM_IDENTITY=spire, pointed
+# at the shared Workload API socket. The demo runner lives with the spike:
+#   ../spire-mls-spike/spire_mls_spike.py  (proven PASS, #583/#584)
+# It is the same two-member GROUP/MLS exchange as the signerjwt spike, only the
+# provider/verifier variant differs.
+echo "  see ../spire-mls-spike/ for the proven two-member runner (#583/#584)."
+echo "  export MYCELIUM_SLIM_IDENTITY=spire"
+echo "  export MYCELIUM_SLIM_SPIRE_SOCKET=unix:///run/spire/sockets/agent.sock"
+echo "  export MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN=mycelium.dev"

--- a/docs/design/spire-quickstart/slim-node.yaml
+++ b/docs/design/spire-quickstart/slim-node.yaml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Stock SLIM 2.1.0 node for the SPIRE quickstart (#579). No identity block — the
+# node forwards ciphertext and never inspects identity; attestation is app-level.
+tracing: { log_level: info }
+runtime: { n_cores: 0, thread_name: "slim-data-plane", drain_timeout: 10s }
+services:
+  slim/0:
+    dataplane:
+      servers:
+        - endpoint: "0.0.0.0:46358"
+          tls: { insecure: true }
+      clients: []

--- a/docs/design/spire-quickstart/spire-agent.conf
+++ b/docs/design/spire-quickstart/spire-agent.conf
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Dev SPIRE agent for the SPIRE-attested MLS quickstart (#579). NOT production.
+#
+# The load-bearing constraint (README.md): the `unix` workload attestor identifies
+# a workload by its SO_PEERCRED PID, so this agent MUST share the workload's PID
+# namespace and expose the Workload API socket on a NAMED VOLUME — a host bind-mount
+# drops peer creds on Docker Desktop, yielding "could not resolve caller
+# information" and a member that hangs at "Initializing spire identity manager".
+agent {
+    data_dir     = "/opt/spire/data/agent"
+    log_level    = "INFO"
+    server_address = "spire-server"
+    server_port    = "8081"
+    trust_domain   = "mycelium.dev"
+    # The Workload API socket. Point MYCELIUM_SLIM_SPIRE_SOCKET (or SPIRE_AGENT_SOCKET)
+    # at this path. It lives on a named volume shared with the workload container.
+    socket_path    = "/run/spire/sockets/agent.sock"
+    # Dev trust bootstrap: the server publishes its bundle to a shared path. In a
+    # real deployment use `insecure_bootstrap = false` with a pinned bundle.
+    insecure_bootstrap = true
+}
+
+plugins {
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+
+    WorkloadAttestor "unix" {
+        plugin_data {}
+    }
+
+    KeyManager "memory" {
+        plugin_data {}
+    }
+}

--- a/docs/design/spire-quickstart/spire-server.conf
+++ b/docs/design/spire-quickstart/spire-server.conf
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Dev SPIRE server for the SPIRE-attested MLS quickstart (#579). NOT production:
+# SQLite datastore, join-token node attestation, short TTLs. See README.md.
+server {
+    bind_address = "0.0.0.0"
+    bind_port    = "8081"
+    trust_domain = "mycelium.dev"
+    data_dir     = "/opt/spire/data/server"
+    log_level    = "INFO"
+    # JWT-SVIDs (what the SLIM identity provider consumes) are signed by this
+    # issuer and validated against the bundle the agent serves over the Workload API.
+    jwt_issuer   = "mycelium.dev"
+    ca_ttl       = "24h"
+    default_x509_svid_ttl = "1h"
+    default_jwt_svid_ttl  = "5m"
+}
+
+plugins {
+    DataStore "sql" {
+        plugin_data {
+            database_type = "sqlite3"
+            connection_string = "/opt/spire/data/server/datastore.sqlite3"
+        }
+    }
+
+    # Dev node attestation: the agent presents a one-time join token. Swap for
+    # k8s/docker/x509pop in a real deployment.
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+
+    KeyManager "disk" {
+        plugin_data {
+            keys_path = "/opt/spire/data/server/keys.json"
+        }
+    }
+}

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -835,7 +835,7 @@ cursor-agent login            # one-time, interactive
 <span class="comment"># SLIM node endpoint (host:port), e.g. http://127.0.0.1:46357</span>
 <span class="arg">node_endpoint</span> = <span class="str">&quot;http://127.0.0.1:46357&quot;</span>
 
-<span class="comment"># SLIM channel identity tier: &#x27;psk&#x27; (default, off-by-default #567) is the shared-secret credential every room member derives — zero infra, no per-agent identity. &#x27;signerjwt&#x27; opts into the SignerJwt floor (#476): each member presents a per-agent self-signed ES256 identity so members are cryptographically distinct, individually revocable MLS participants. Selecting &#x27;signerjwt&#x27; with no registered key degrades to &#x27;psk&#x27; unless MYCELIUM_SLIM_IDENTITY_REQUIRE=1 fails closed.</span>
+<span class="comment"># SLIM channel identity tier: &#x27;psk&#x27; (default, off-by-default #567) is the shared-secret credential every room member derives — zero infra, no per-agent identity. &#x27;signerjwt&#x27; opts into the SignerJwt floor (#476): each member presents a per-agent self-signed ES256 identity so members are cryptographically distinct, individually revocable MLS participants. &#x27;spire&#x27; opts into SPIRE/SPIFFE (#579): each member presents a SPIRE-attested JWT-SVID from the Workload API — tightest attestation, heaviest deploy (a co-located SPIRE agent; see docs/design/spire-quickstart/). Selecting &#x27;signerjwt&#x27;/&#x27;spire&#x27; with no resolvable material degrades to &#x27;psk&#x27; unless MYCELIUM_SLIM_IDENTITY_REQUIRE=1 fails closed.</span>
 <span class="arg">identity</span> = <span class="str">&quot;psk&quot;</span>
 
 <span class="comment"># First-party Cognition Engine runtime configuration.</span>

--- a/fastapi-backend/app/services/slim_client.py
+++ b/fastapi-backend/app/services/slim_client.py
@@ -81,25 +81,38 @@ logger = logging.getLogger(__name__)
 # Warn only once per process when falling back to the public dev secret.
 _dev_secret_warned = False
 
-# Warn only once per handle when signerjwt identity degrades to the PSK.
-_signerjwt_degraded_warned: set[str] = set()
+# Warn only once per (mode, handle) when a selected identity degrades to the PSK.
+_identity_degraded_warned: set[tuple[str, str]] = set()
+
+# Per-mode hint for the degrade warning / fail-closed error: what material is
+# missing and how to provision it.
+_IDENTITY_MISSING_HINT = {
+    slim_identity.MODE_SIGNERJWT: (
+        "no signing key/roster resolved — register the agent's key (ensure_agent_keypair)"
+    ),
+    slim_identity.MODE_SPIRE: (
+        "no SPIRE Workload API socket present — start the co-located SPIRE agent "
+        "and set MYCELIUM_SLIM_SPIRE_SOCKET"
+    ),
+}
 
 
-def _warn_signerjwt_degraded(handle: str) -> None:
-    """One-time warning that ``signerjwt`` fell back to the shared-secret PSK.
+def _warn_identity_degraded(mode: str, handle: str) -> None:
+    """One-time warning that a selected identity mode fell back to the PSK.
 
     A silent downgrade is a security smell, so the fallback is announced even
     though it is the specified off-by-default behavior (#567). Set
     ``MYCELIUM_SLIM_IDENTITY_REQUIRE=1`` to refuse the fallback instead.
     """
-    if handle in _signerjwt_degraded_warned:
+    if (mode, handle) in _identity_degraded_warned:
         return
-    _signerjwt_degraded_warned.add(handle)
+    _identity_degraded_warned.add((mode, handle))
+    hint = _IDENTITY_MISSING_HINT.get(mode, "no identity material resolved")
     logger.warning(
-        "MYCELIUM_SLIM_IDENTITY=signerjwt but no signing key/roster resolved for "
-        "%r — falling back to the shared-secret PSK. Register the agent's key "
-        "(ensure_agent_keypair) or set MYCELIUM_SLIM_IDENTITY_REQUIRE=1 to fail "
-        "closed.",
+        "MYCELIUM_SLIM_IDENTITY=%s but %s for %r — falling back to the shared-secret "
+        "PSK. Set MYCELIUM_SLIM_IDENTITY_REQUIRE=1 to fail closed.",
+        mode,
+        hint,
         handle,
     )
 
@@ -380,27 +393,28 @@ class SlimClient:
         """Register the local app, selecting the identity tier (PSK default).
 
         ``psk`` (default, #567) is the shared-secret credential — the try-it path,
-        untouched. ``signerjwt`` presents a per-member self-signed ES256 identity
-        (the floor, #476): when the agent's signing key + the room roster resolve,
-        the app is created with an ``IdentityProviderConfig.JWT`` provider/verifier
-        pair so members are cryptographically distinct MLS participants. Absent that
-        material it degrades to PSK with a one-time warning, unless
-        ``MYCELIUM_SLIM_IDENTITY_REQUIRE=1`` makes it fail closed.
+        untouched. ``signerjwt`` (the floor, #476) presents a per-member self-signed
+        ES256 identity; ``spire`` (#579) presents a SPIRE-attested JWT-SVID. Both
+        resolve to an ``IdentityProviderConfig``/``IdentityVerifierConfig`` pair so
+        members are cryptographically distinct MLS participants; both share one
+        degrade/fail-closed path. Absent the mode's material it degrades to PSK with
+        a one-time warning, unless ``MYCELIUM_SLIM_IDENTITY_REQUIRE=1`` fails closed.
         """
         assert self._local_name is not None
-        if slim_identity.resolve_identity_mode() == slim_identity.MODE_SIGNERJWT:
-            material = slim_identity.resolve_signerjwt_material(self.identity.agent)
+        mode = slim_identity.resolve_identity_mode()
+        if mode != slim_identity.MODE_PSK:
+            material = slim_identity.resolve_identity_material(mode, self.identity.agent)
             if material is not None:
                 provider, verifier = material
                 return service.create_app(self._local_name, provider, verifier)
             if slim_identity.identity_required():
+                hint = _IDENTITY_MISSING_HINT.get(mode, "no identity material resolved")
                 raise SlimError(
-                    "MYCELIUM_SLIM_IDENTITY=signerjwt but no signing key/roster "
-                    f"resolved for {self.identity.agent!r}, and "
-                    "MYCELIUM_SLIM_IDENTITY_REQUIRE is set: refusing to fall back to "
-                    "the shared-secret PSK. Register the agent's key first."
+                    f"MYCELIUM_SLIM_IDENTITY={mode} but {hint} for "
+                    f"{self.identity.agent!r}, and MYCELIUM_SLIM_IDENTITY_REQUIRE is "
+                    "set: refusing to fall back to the shared-secret PSK."
                 )
-            _warn_signerjwt_degraded(self.identity.agent)
+            _warn_identity_degraded(mode, self.identity.agent)
         return service.create_app_with_secret(self._local_name, self._secret)
 
     @property

--- a/fastapi-backend/app/services/slim_identity.py
+++ b/fastapi-backend/app/services/slim_identity.py
@@ -26,9 +26,19 @@ tier (a key can't be forged; revocation is per-agent — drop the JWK from the r
 no room-wide rotation) but weaker than SPIRE's attestation (#579), which drops into
 the same seam.
 
+**SPIRE is the hardened third mode (#579).** ``MYCELIUM_SLIM_IDENTITY=spire`` sources
+a JWT-SVID from the SPIFFE Workload API instead of a self-minted key: the trust
+domain attests the workload and signs the SVID, so peers verify against the SPIRE
+bundle (``IdentityProviderConfig.SPIRE`` / ``IdentityVerifierConfig.SPIRE``) — same
+MLS mechanics, tightest attestation, heaviest deploy. It drops into the same connect
+seam as the floor; :func:`resolve_identity_material` dispatches by mode. Proven on
+the 2.1.0 stack by the #583/#584 spike (``docs/design/spire-mls-spike/``); the dev
+quickstart is ``docs/design/spire-quickstart/``.
+
 **Off by default (#567).** The identity mode is ``psk`` unless
-``MYCELIUM_SLIM_IDENTITY=signerjwt`` selects the floor. Selecting the floor with no
-resolvable key/roster degrades to the PSK with a one-time warning, unless
+``MYCELIUM_SLIM_IDENTITY=signerjwt`` selects the floor or ``=spire`` selects SPIRE.
+Selecting either with no resolvable material (a signing key/roster, or a Workload
+API socket) degrades to the PSK with a one-time warning, unless
 ``MYCELIUM_SLIM_IDENTITY_REQUIRE=1`` makes it fail closed (mirroring
 ``MYCELIUM_SLIM_REQUIRE_SECRET``). The try-it path never changes.
 
@@ -69,7 +79,8 @@ _REQUIRE_ENV = "MYCELIUM_SLIM_IDENTITY_REQUIRE"
 
 MODE_PSK = "psk"
 MODE_SIGNERJWT = "signerjwt"
-VALID_MODES = (MODE_PSK, MODE_SIGNERJWT)
+MODE_SPIRE = "spire"
+VALID_MODES = (MODE_PSK, MODE_SIGNERJWT, MODE_SPIRE)
 
 # ── Self-issued floor labels ─────────────────────────────────────────────────
 # A self-issued floor has no OIDC discovery endpoint: issuer/audience are labels
@@ -94,6 +105,29 @@ IDENTITY_SUBDIR = "slim-identity"
 _KEYS_SUBDIR = "keys"
 _ROSTER_SUBDIR = "roster"
 
+# ── SPIRE / SPIFFE (the hardened upgrade, #579) ──────────────────────────────
+# The SPIRE mode sources a JWT-SVID from the SPIFFE Workload API instead of a
+# self-minted key: the trust domain attests the workload and signs the SVID, so
+# peers verify against the SPIRE bundle rather than a hand-distributed roster.
+# It is env-configured (no on-disk keys — SPIRE owns the key material) and, like
+# ``signerjwt``, off by default (#567): ``MYCELIUM_SLIM_IDENTITY=spire`` opts in.
+#
+# ``socket_path`` is the Workload API socket the co-located SPIRE agent exposes;
+# absent it (no agent to mint the SVID) the mode degrades to PSK or fails closed
+# exactly like a missing signing key. We read our own env first, then the
+# SPIFFE-standard ``SPIRE_AGENT_SOCKET`` the dev quickstart sets.
+_SPIRE_SOCKET_ENV = "MYCELIUM_SLIM_SPIRE_SOCKET"
+_SPIRE_SOCKET_ENV_FALLBACK = "SPIRE_AGENT_SOCKET"
+_SPIRE_TRUST_DOMAIN_ENV = "MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN"
+# The audience the SVID is minted/verified for — the MLS channel label, shared
+# with the SignerJwt floor so a mixed room agrees on the ``aud`` claim.
+SPIRE_AUDIENCE = SIGNERJWT_AUDIENCE
+SPIRE_DEFAULT_TRUST_DOMAIN = "mycelium.dev"
+# A member's SPIFFE ID is ``spiffe://{trust_domain}/{prefix}/{handle}`` — a
+# minimal handle↔SPIFFE binding good enough to demo; the full registration
+# surface (SPIFFE-leaf ↔ ``@handle`` reconciliation) is #589.
+SPIRE_WORKLOAD_PATH_PREFIX = "agent"
+
 
 class SlimIdentityError(RuntimeError):
     """A SignerJwt-floor identity could not be built (bad key, empty roster, …)."""
@@ -104,7 +138,7 @@ def _truthy(value: str | None) -> bool:
 
 
 def resolve_identity_mode() -> str:
-    """The SLIM channel identity mode: ``psk`` (default) or ``signerjwt``.
+    """The SLIM channel identity mode: ``psk`` (default), ``signerjwt``, or ``spire``.
 
     An unset or unrecognized value is ``psk`` — the off-by-default posture (#567).
     """
@@ -113,11 +147,12 @@ def resolve_identity_mode() -> str:
 
 
 def identity_required() -> bool:
-    """True when a selected ``signerjwt`` mode must fail closed rather than degrade.
+    """True when a selected identity mode must fail closed rather than degrade.
 
-    Mirrors ``MYCELIUM_SLIM_REQUIRE_SECRET``: absent a resolvable key/roster the
-    default is to degrade to the PSK (try-it path unchanged), but a host that has
-    committed to identity sets this so a missing credential refuses instead.
+    Mirrors ``MYCELIUM_SLIM_REQUIRE_SECRET``: absent resolvable material (a
+    ``signerjwt`` key/roster or a ``spire`` Workload API socket) the default is to
+    degrade to the PSK (try-it path unchanged), but a host that has committed to
+    identity sets this so a missing credential refuses instead.
     """
     return _truthy(os.getenv(_REQUIRE_ENV))
 
@@ -368,3 +403,118 @@ def resolve_signerjwt_material(
     if roster is None:
         return None
     return build_signerjwt_identity(handle, key_path.read_text(), roster)
+
+
+# ── SPIRE / SPIFFE provider / verifier (#579) ────────────────────────────────
+def resolve_spire_socket() -> str | None:
+    """The Workload API socket path, or ``None`` when no SPIRE agent is configured.
+
+    Prefers ``MYCELIUM_SLIM_SPIRE_SOCKET``; falls back to the SPIFFE-standard
+    ``SPIRE_AGENT_SOCKET`` the dev quickstart exports. ``None`` means "no SPIRE
+    here" — the connect seam degrades to PSK or fails closed per
+    :func:`identity_required`.
+    """
+    for env in (_SPIRE_SOCKET_ENV, _SPIRE_SOCKET_ENV_FALLBACK):
+        value = os.getenv(env, "").strip()
+        if value:
+            return value
+    return None
+
+
+def resolve_spire_trust_domain() -> str:
+    """The SPIFFE trust domain (``MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN`` or default)."""
+    return os.getenv(_SPIRE_TRUST_DOMAIN_ENV, "").strip() or SPIRE_DEFAULT_TRUST_DOMAIN
+
+
+def spiffe_id_for(handle: str, trust_domain: str) -> str:
+    """The member's SPIFFE ID: ``spiffe://{trust_domain}/agent/{handle}``.
+
+    A minimal handle↔SPIFFE binding — enough to demo the path; the full
+    registration/reconciliation surface is #589.
+    """
+    return f"spiffe://{trust_domain}/{SPIRE_WORKLOAD_PATH_PREFIX}/{handle}"
+
+
+def _spire_socket_present(socket_path: str) -> bool:
+    """True if the Workload API socket actually exists on disk.
+
+    The path may carry a ``unix://`` scheme (SPIFFE convention); strip it before
+    the filesystem check. A configured-but-absent socket means no agent is up to
+    mint the SVID, so it degrades/fails-closed like a missing signing key.
+    """
+    path = socket_path
+    for scheme in ("unix://", "tcp://"):
+        if path.startswith(scheme):
+            path = path[len(scheme) :]
+            break
+    return Path(path).exists()
+
+
+def build_spire_identity(
+    handle: str,
+    socket_path: str,
+    trust_domain: str,
+) -> tuple[slim_bindings.IdentityProviderConfig, slim_bindings.IdentityVerifierConfig]:
+    """Build the SPIRE ``(provider, verifier)`` pair for one attested member.
+
+    Provider: our own JWT-SVID from the Workload API, addressed by our SPIFFE ID
+    (``target_spiffe_id``) and minted for the MLS audience.
+    Verifier: accept any peer whose SVID chains to the room's ``trust_domains``
+    (``target_spiffe_id=None`` — the trust domain is the boundary, not a single
+    peer), verified against the SPIRE bundle the same socket serves.
+
+    Same MLS mechanics as the SignerJwt floor; only the provider/verifier variant
+    differs (``IdentityProviderConfig.SPIRE`` / ``IdentityVerifierConfig.SPIRE``).
+    """
+    sb = _require_bindings()
+    provider = sb.IdentityProviderConfig.SPIRE(
+        config=sb.SpireConfig(
+            socket_path=socket_path,
+            target_spiffe_id=spiffe_id_for(handle, trust_domain),
+            jwt_audiences=[SPIRE_AUDIENCE],
+            trust_domains=[trust_domain],
+        )
+    )
+    verifier = sb.IdentityVerifierConfig.SPIRE(
+        config=sb.SpireConfig(
+            socket_path=socket_path,
+            target_spiffe_id=None,
+            jwt_audiences=[SPIRE_AUDIENCE],
+            trust_domains=[trust_domain],
+        )
+    )
+    return provider, verifier
+
+
+def resolve_spire_material(
+    handle: str,
+) -> tuple[slim_bindings.IdentityProviderConfig, slim_bindings.IdentityVerifierConfig] | None:
+    """Build the SPIRE identity pair from the configured Workload API socket.
+
+    Returns ``None`` when no socket is configured or the socket isn't present (no
+    co-located SPIRE agent), so the connect seam degrades to PSK or fails closed
+    per :func:`identity_required`. Unlike the SignerJwt floor there is no on-disk
+    key to mint: SPIRE owns the key material and mints the SVID on demand.
+    """
+    socket_path = resolve_spire_socket()
+    if not socket_path or not _spire_socket_present(socket_path):
+        return None
+    return build_spire_identity(handle, socket_path, resolve_spire_trust_domain())
+
+
+def resolve_identity_material(
+    mode: str,
+    handle: str,
+    data_dir: Path | None = None,
+) -> tuple[slim_bindings.IdentityProviderConfig, slim_bindings.IdentityVerifierConfig] | None:
+    """Dispatch to the selected mode's provider/verifier builder.
+
+    Returns ``None`` for ``psk`` (or any mode whose material is absent) so the one
+    connect seam handles degrade/fail-closed uniformly across ``signerjwt`` and
+    ``spire``.
+    """
+    if mode == MODE_SIGNERJWT:
+        return resolve_signerjwt_material(handle, data_dir)
+    if mode == MODE_SPIRE:
+        return resolve_spire_material(handle)
+    return None

--- a/fastapi-backend/tests/test_slim_identity.py
+++ b/fastapi-backend/tests/test_slim_identity.py
@@ -151,3 +151,89 @@ def test_material_built_when_key_and_roster_present(tmp_path):
     # Constructed slim-bindings identity configs (exact types are binding-internal).
     assert provider is not None
     assert verifier is not None
+
+
+# ── SPIRE mode (#579): socket / trust-domain / SPIFFE-ID resolution ──────────
+def test_spire_mode_selected(monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_IDENTITY", "SPIRE")
+    assert slim_identity.resolve_identity_mode() == slim_identity.MODE_SPIRE
+
+
+def test_resolve_spire_socket_none_when_unset(monkeypatch):
+    monkeypatch.delenv("MYCELIUM_SLIM_SPIRE_SOCKET", raising=False)
+    monkeypatch.delenv("SPIRE_AGENT_SOCKET", raising=False)
+    assert slim_identity.resolve_spire_socket() is None
+
+
+def test_resolve_spire_socket_prefers_mycelium_env(monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", "unix:///a.sock")
+    monkeypatch.setenv("SPIRE_AGENT_SOCKET", "unix:///b.sock")
+    assert slim_identity.resolve_spire_socket() == "unix:///a.sock"
+
+
+def test_resolve_spire_socket_falls_back_to_standard_env(monkeypatch):
+    monkeypatch.delenv("MYCELIUM_SLIM_SPIRE_SOCKET", raising=False)
+    monkeypatch.setenv("SPIRE_AGENT_SOCKET", "unix:///b.sock")
+    assert slim_identity.resolve_spire_socket() == "unix:///b.sock"
+
+
+def test_resolve_spire_trust_domain_default_and_override(monkeypatch):
+    monkeypatch.delenv("MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN", raising=False)
+    assert slim_identity.resolve_spire_trust_domain() == slim_identity.SPIRE_DEFAULT_TRUST_DOMAIN
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN", "acme.example")
+    assert slim_identity.resolve_spire_trust_domain() == "acme.example"
+
+
+def test_spiffe_id_for_builds_expected_path():
+    assert (
+        slim_identity.spiffe_id_for("alice", "mycelium.dev") == "spiffe://mycelium.dev/agent/alice"
+    )
+
+
+def test_spire_material_none_without_socket(monkeypatch):
+    monkeypatch.delenv("MYCELIUM_SLIM_SPIRE_SOCKET", raising=False)
+    monkeypatch.delenv("SPIRE_AGENT_SOCKET", raising=False)
+    assert slim_identity.resolve_spire_material("alice") is None
+
+
+def test_spire_material_none_when_socket_absent(monkeypatch, tmp_path):
+    # Configured but the socket file does not exist → no agent to mint the SVID.
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", str(tmp_path / "missing.sock"))
+    assert slim_identity.resolve_spire_material("alice") is None
+
+
+def test_spire_material_built_when_socket_present(monkeypatch, tmp_path):
+    pytest.importorskip("slim_bindings")
+    sock = tmp_path / "agent.sock"
+    sock.write_text("")  # _spire_socket_present only checks existence
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", f"unix://{sock}")
+    material = slim_identity.resolve_spire_material("alice")
+    assert material is not None
+    provider, verifier = material
+    assert provider is not None
+    assert verifier is not None
+
+
+# ── resolve_identity_material: the shared connect-seam dispatcher ─────────────
+def test_identity_material_dispatch_psk_is_none(tmp_path):
+    assert (
+        slim_identity.resolve_identity_material(slim_identity.MODE_PSK, "alice", tmp_path) is None
+    )
+
+
+def test_identity_material_dispatch_signerjwt(tmp_path):
+    pytest.importorskip("slim_bindings")
+    slim_identity.ensure_agent_keypair("alice", tmp_path)
+    material = slim_identity.resolve_identity_material(
+        slim_identity.MODE_SIGNERJWT, "alice", tmp_path
+    )
+    assert material is not None
+
+
+def test_identity_material_dispatch_spire(monkeypatch, tmp_path):
+    pytest.importorskip("slim_bindings")
+    sock = tmp_path / "agent.sock"
+    sock.write_text("")
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", str(sock))
+    material = slim_identity.resolve_identity_material(slim_identity.MODE_SPIRE, "alice")
+    assert material is not None

--- a/fastapi-backend/tests/test_slim_l9_wire.py
+++ b/fastapi-backend/tests/test_slim_l9_wire.py
@@ -77,6 +77,19 @@ def test_signerjwt_identity_constants_match_contract():
     assert g["curve"] == slim_identity.SIGNERJWT_CURVE
 
 
+def test_spire_identity_constants_match_contract():
+    """The SPIRE mode's socket/trust-domain/SPIFFE labels are frozen (#579)."""
+    s = _contract()["identity"]["spire"]
+    assert slim_identity.MODE_SPIRE in slim_identity.VALID_MODES
+    assert s["socket_env"] == slim_identity._SPIRE_SOCKET_ENV
+    assert s["socket_env_fallback"] == slim_identity._SPIRE_SOCKET_ENV_FALLBACK
+    assert s["trust_domain_env"] == slim_identity._SPIRE_TRUST_DOMAIN_ENV
+    assert s["trust_domain_default"] == slim_identity.SPIRE_DEFAULT_TRUST_DOMAIN
+    assert s["workload_path_prefix"] == slim_identity.SPIRE_WORKLOAD_PATH_PREFIX
+    # The SVID audience is the shared MLS audience label, not a separate constant.
+    assert _contract()["identity"]["audience"] == slim_identity.SPIRE_AUDIENCE
+
+
 def test_episode_and_topic_urns_match_contract():
     """The episode/topic URN forms the connector must mirror."""
     g = _contract()["urn"]

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -95,18 +95,22 @@ class SlimConfig(BaseModel):
             "per-agent identity. 'signerjwt' opts into the SignerJwt floor (#476): "
             "each member presents a per-agent self-signed ES256 identity so members "
             "are cryptographically distinct, individually revocable MLS "
-            "participants. Selecting 'signerjwt' with no registered key degrades to "
-            "'psk' unless MYCELIUM_SLIM_IDENTITY_REQUIRE=1 fails closed."
+            "participants. 'spire' opts into SPIRE/SPIFFE (#579): each member "
+            "presents a SPIRE-attested JWT-SVID from the Workload API — tightest "
+            "attestation, heaviest deploy (a co-located SPIRE agent; see "
+            "docs/design/spire-quickstart/). Selecting 'signerjwt'/'spire' with no "
+            "resolvable material degrades to 'psk' unless "
+            "MYCELIUM_SLIM_IDENTITY_REQUIRE=1 fails closed."
         ),
     )
 
     @field_validator("identity")
     @classmethod
     def _validate_identity(cls, v: str) -> str:
-        """Only ``psk`` / ``signerjwt`` are valid identity tiers."""
+        """Only ``psk`` / ``signerjwt`` / ``spire`` are valid identity tiers."""
         normalized = v.strip().lower()
-        if normalized not in ("psk", "signerjwt"):
-            raise ValueError(f"slim.identity must be 'psk' or 'signerjwt', got {v!r}")
+        if normalized not in ("psk", "signerjwt", "spire"):
+            raise ValueError(f"slim.identity must be 'psk', 'signerjwt', or 'spire', got {v!r}")
         return normalized
 
     @field_validator("node_endpoint")

--- a/mycelium-cli/src/mycelium/docker_utils.py
+++ b/mycelium-cli/src/mycelium/docker_utils.py
@@ -150,9 +150,10 @@ def generate_env_file(
         f"AUTH_JWKS_TTL_S={config.auth.jwks_ttl_s}",
         "",
         "# ── SLIM channel identity (off by default, #567) ─────────────────────────",
-        # 'psk' | 'signerjwt'. The backend + CLI both read MYCELIUM_SLIM_IDENTITY;
-        # the shared master secret / require flags stay operator-managed (out of
-        # band), same as today. See slim_identity.py.
+        # 'psk' | 'signerjwt' | 'spire'. The backend + CLI both read
+        # MYCELIUM_SLIM_IDENTITY; the shared master secret / require flags and the
+        # SPIRE socket/trust-domain envs stay operator-managed (out of band), same
+        # as today. See slim_identity.py.
         f"MYCELIUM_SLIM_IDENTITY={config.slim.identity}",
         "",
     ]

--- a/mycelium-cli/src/mycelium/slim/client.py
+++ b/mycelium-cli/src/mycelium/slim/client.py
@@ -38,25 +38,38 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("mycelium.slim")
 
-# Warn only once per handle when signerjwt identity degrades to the PSK.
-_signerjwt_degraded_warned: set[str] = set()
+# Warn only once per (mode, handle) when a selected identity degrades to the PSK.
+_identity_degraded_warned: set[tuple[str, str]] = set()
+
+# Per-mode hint for the degrade warning / fail-closed error: what material is
+# missing and how to provision it.
+_IDENTITY_MISSING_HINT = {
+    slim_identity.MODE_SIGNERJWT: (
+        "no signing key/roster resolved — register the agent's key (ensure_agent_keypair)"
+    ),
+    slim_identity.MODE_SPIRE: (
+        "no SPIRE Workload API socket present — start the co-located SPIRE agent "
+        "and set MYCELIUM_SLIM_SPIRE_SOCKET"
+    ),
+}
 
 
-def _warn_signerjwt_degraded(handle: str) -> None:
-    """One-time warning that ``signerjwt`` fell back to the shared-secret PSK.
+def _warn_identity_degraded(mode: str, handle: str) -> None:
+    """One-time warning that a selected identity mode fell back to the PSK.
 
     A silent downgrade is a security smell, so the fallback is announced even
     though it is the specified off-by-default behavior (#567). Set
     ``MYCELIUM_SLIM_IDENTITY_REQUIRE=1`` to refuse the fallback instead.
     """
-    if handle in _signerjwt_degraded_warned:
+    if (mode, handle) in _identity_degraded_warned:
         return
-    _signerjwt_degraded_warned.add(handle)
+    _identity_degraded_warned.add((mode, handle))
+    hint = _IDENTITY_MISSING_HINT.get(mode, "no identity material resolved")
     logger.warning(
-        "MYCELIUM_SLIM_IDENTITY=signerjwt but no signing key/roster resolved for "
-        "%r — falling back to the shared-secret PSK. Register the agent's key "
-        "(ensure_agent_keypair) or set MYCELIUM_SLIM_IDENTITY_REQUIRE=1 to fail "
-        "closed.",
+        "MYCELIUM_SLIM_IDENTITY=%s but %s for %r — falling back to the shared-secret "
+        "PSK. Set MYCELIUM_SLIM_IDENTITY_REQUIRE=1 to fail closed.",
+        mode,
+        hint,
         handle,
     )
 
@@ -187,26 +200,28 @@ class SlimClient:
         """Register the local app, selecting the identity tier (PSK default).
 
         Twin of the backend seam: ``psk`` (default, #567) is the shared-secret
-        credential — the try-it path, untouched. ``signerjwt`` presents this
-        member's per-agent self-signed ES256 identity (the floor, #476) when its
-        signing key + the room roster resolve; absent that material it degrades to
-        PSK with a one-time warning unless ``MYCELIUM_SLIM_IDENTITY_REQUIRE=1``
-        makes it fail closed.
+        credential — the try-it path, untouched. ``signerjwt`` (the floor, #476)
+        presents this member's per-agent self-signed ES256 identity; ``spire``
+        (#579) presents a SPIRE-attested JWT-SVID. Both resolve to a
+        provider/verifier pair through one dispatcher and share one
+        degrade/fail-closed path: absent the mode's material it degrades to PSK with
+        a one-time warning unless ``MYCELIUM_SLIM_IDENTITY_REQUIRE=1`` fails closed.
         """
         assert self._local_name is not None
-        if slim_identity.resolve_identity_mode() == slim_identity.MODE_SIGNERJWT:
-            material = slim_identity.resolve_signerjwt_material(self.identity.agent)
+        mode = slim_identity.resolve_identity_mode()
+        if mode != slim_identity.MODE_PSK:
+            material = slim_identity.resolve_identity_material(mode, self.identity.agent)
             if material is not None:
                 provider, verifier = material
                 return service.create_app(self._local_name, provider, verifier)
             if slim_identity.identity_required():
+                hint = _IDENTITY_MISSING_HINT.get(mode, "no identity material resolved")
                 raise SlimError(
-                    "MYCELIUM_SLIM_IDENTITY=signerjwt but no signing key/roster "
-                    f"resolved for {self.identity.agent!r}, and "
-                    "MYCELIUM_SLIM_IDENTITY_REQUIRE is set: refusing to fall back to "
-                    "the shared-secret PSK. Register the agent's key first."
+                    f"MYCELIUM_SLIM_IDENTITY={mode} but {hint} for "
+                    f"{self.identity.agent!r}, and MYCELIUM_SLIM_IDENTITY_REQUIRE is "
+                    "set: refusing to fall back to the shared-secret PSK."
                 )
-            _warn_signerjwt_degraded(self.identity.agent)
+            _warn_identity_degraded(mode, self.identity.agent)
         return service.create_app_with_secret(self._local_name, self._secret)
 
     @property

--- a/mycelium-cli/src/mycelium/slim/identity.py
+++ b/mycelium-cli/src/mycelium/slim/identity.py
@@ -16,11 +16,13 @@ Keep the wire constants (mode names, issuer/audience labels, algorithm/curve, th
 copies. A member deriving a different issuer/audience or JWK shape silently fails
 peer verification against the moderator, exactly the failure the contract test
 guards. ``psk`` stays the default (#567); ``MYCELIUM_SLIM_IDENTITY=signerjwt`` opts
-in, and a missing key/roster degrades to the PSK unless
-``MYCELIUM_SLIM_IDENTITY_REQUIRE=1`` fails closed.
+into the floor and ``=spire`` into SPIRE, and missing material (a key/roster, or a
+Workload API socket) degrades to the PSK unless ``MYCELIUM_SLIM_IDENTITY_REQUIRE=1``
+fails closed.
 
-See the backend module's docstring for the full design and the honest ceiling
-(possession of a registered key, not attestation; SPIRE #579 is the upgrade).
+The ``spire`` mode (#579) sources a JWT-SVID from the SPIFFE Workload API instead of
+a self-minted key — same connect seam, tightest attestation. See the backend
+module's docstring for the full design and the honest ceiling.
 """
 
 from __future__ import annotations
@@ -47,7 +49,8 @@ _REQUIRE_ENV = "MYCELIUM_SLIM_IDENTITY_REQUIRE"
 
 MODE_PSK = "psk"
 MODE_SIGNERJWT = "signerjwt"
-VALID_MODES = (MODE_PSK, MODE_SIGNERJWT)
+MODE_SPIRE = "spire"
+VALID_MODES = (MODE_PSK, MODE_SIGNERJWT, MODE_SPIRE)
 
 # ── Self-issued floor labels ─────────────────────────────────────────────────
 # A self-issued floor has no OIDC discovery endpoint: issuer/audience are labels
@@ -72,6 +75,29 @@ IDENTITY_SUBDIR = "slim-identity"
 _KEYS_SUBDIR = "keys"
 _ROSTER_SUBDIR = "roster"
 
+# ── SPIRE / SPIFFE (the hardened upgrade, #579) ──────────────────────────────
+# The SPIRE mode sources a JWT-SVID from the SPIFFE Workload API instead of a
+# self-minted key: the trust domain attests the workload and signs the SVID, so
+# peers verify against the SPIRE bundle rather than a hand-distributed roster.
+# It is env-configured (no on-disk keys — SPIRE owns the key material) and, like
+# ``signerjwt``, off by default (#567): ``MYCELIUM_SLIM_IDENTITY=spire`` opts in.
+#
+# ``socket_path`` is the Workload API socket the co-located SPIRE agent exposes;
+# absent it (no agent to mint the SVID) the mode degrades to PSK or fails closed
+# exactly like a missing signing key. We read our own env first, then the
+# SPIFFE-standard ``SPIRE_AGENT_SOCKET`` the dev quickstart sets.
+_SPIRE_SOCKET_ENV = "MYCELIUM_SLIM_SPIRE_SOCKET"
+_SPIRE_SOCKET_ENV_FALLBACK = "SPIRE_AGENT_SOCKET"
+_SPIRE_TRUST_DOMAIN_ENV = "MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN"
+# The audience the SVID is minted/verified for — the MLS channel label, shared
+# with the SignerJwt floor so a mixed room agrees on the ``aud`` claim.
+SPIRE_AUDIENCE = SIGNERJWT_AUDIENCE
+SPIRE_DEFAULT_TRUST_DOMAIN = "mycelium.dev"
+# A member's SPIFFE ID is ``spiffe://{trust_domain}/{prefix}/{handle}`` — a
+# minimal handle↔SPIFFE binding good enough to demo; the full registration
+# surface (SPIFFE-leaf ↔ ``@handle`` reconciliation) is #589.
+SPIRE_WORKLOAD_PATH_PREFIX = "agent"
+
 
 class SlimIdentityError(RuntimeError):
     """A SignerJwt-floor identity could not be built (bad key, empty roster, …)."""
@@ -82,7 +108,7 @@ def _truthy(value: str | None) -> bool:
 
 
 def resolve_identity_mode() -> str:
-    """The SLIM channel identity mode: ``psk`` (default) or ``signerjwt``.
+    """The SLIM channel identity mode: ``psk`` (default), ``signerjwt``, or ``spire``.
 
     An unset or unrecognized value is ``psk`` — the off-by-default posture (#567).
     """
@@ -91,11 +117,12 @@ def resolve_identity_mode() -> str:
 
 
 def identity_required() -> bool:
-    """True when a selected ``signerjwt`` mode must fail closed rather than degrade.
+    """True when a selected identity mode must fail closed rather than degrade.
 
-    Mirrors ``MYCELIUM_SLIM_REQUIRE_SECRET``: absent a resolvable key/roster the
-    default is to degrade to the PSK (try-it path unchanged), but a host that has
-    committed to identity sets this so a missing credential refuses instead.
+    Mirrors ``MYCELIUM_SLIM_REQUIRE_SECRET``: absent resolvable material (a
+    ``signerjwt`` key/roster or a ``spire`` Workload API socket) the default is to
+    degrade to the PSK (try-it path unchanged), but a host that has committed to
+    identity sets this so a missing credential refuses instead.
     """
     return _truthy(os.getenv(_REQUIRE_ENV))
 
@@ -346,3 +373,118 @@ def resolve_signerjwt_material(
     if roster is None:
         return None
     return build_signerjwt_identity(handle, key_path.read_text(), roster)
+
+
+# ── SPIRE / SPIFFE provider / verifier (#579) ────────────────────────────────
+def resolve_spire_socket() -> str | None:
+    """The Workload API socket path, or ``None`` when no SPIRE agent is configured.
+
+    Prefers ``MYCELIUM_SLIM_SPIRE_SOCKET``; falls back to the SPIFFE-standard
+    ``SPIRE_AGENT_SOCKET`` the dev quickstart exports. ``None`` means "no SPIRE
+    here" — the connect seam degrades to PSK or fails closed per
+    :func:`identity_required`.
+    """
+    for env in (_SPIRE_SOCKET_ENV, _SPIRE_SOCKET_ENV_FALLBACK):
+        value = os.getenv(env, "").strip()
+        if value:
+            return value
+    return None
+
+
+def resolve_spire_trust_domain() -> str:
+    """The SPIFFE trust domain (``MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN`` or default)."""
+    return os.getenv(_SPIRE_TRUST_DOMAIN_ENV, "").strip() or SPIRE_DEFAULT_TRUST_DOMAIN
+
+
+def spiffe_id_for(handle: str, trust_domain: str) -> str:
+    """The member's SPIFFE ID: ``spiffe://{trust_domain}/agent/{handle}``.
+
+    A minimal handle↔SPIFFE binding — enough to demo the path; the full
+    registration/reconciliation surface is #589.
+    """
+    return f"spiffe://{trust_domain}/{SPIRE_WORKLOAD_PATH_PREFIX}/{handle}"
+
+
+def _spire_socket_present(socket_path: str) -> bool:
+    """True if the Workload API socket actually exists on disk.
+
+    The path may carry a ``unix://`` scheme (SPIFFE convention); strip it before
+    the filesystem check. A configured-but-absent socket means no agent is up to
+    mint the SVID, so it degrades/fails-closed like a missing signing key.
+    """
+    path = socket_path
+    for scheme in ("unix://", "tcp://"):
+        if path.startswith(scheme):
+            path = path[len(scheme) :]
+            break
+    return Path(path).exists()
+
+
+def build_spire_identity(
+    handle: str,
+    socket_path: str,
+    trust_domain: str,
+) -> tuple[slim_bindings.IdentityProviderConfig, slim_bindings.IdentityVerifierConfig]:
+    """Build the SPIRE ``(provider, verifier)`` pair for one attested member.
+
+    Provider: our own JWT-SVID from the Workload API, addressed by our SPIFFE ID
+    (``target_spiffe_id``) and minted for the MLS audience.
+    Verifier: accept any peer whose SVID chains to the room's ``trust_domains``
+    (``target_spiffe_id=None`` — the trust domain is the boundary, not a single
+    peer), verified against the SPIRE bundle the same socket serves.
+
+    Same MLS mechanics as the SignerJwt floor; only the provider/verifier variant
+    differs (``IdentityProviderConfig.SPIRE`` / ``IdentityVerifierConfig.SPIRE``).
+    """
+    sb = _require_bindings()
+    provider = sb.IdentityProviderConfig.SPIRE(
+        config=sb.SpireConfig(
+            socket_path=socket_path,
+            target_spiffe_id=spiffe_id_for(handle, trust_domain),
+            jwt_audiences=[SPIRE_AUDIENCE],
+            trust_domains=[trust_domain],
+        )
+    )
+    verifier = sb.IdentityVerifierConfig.SPIRE(
+        config=sb.SpireConfig(
+            socket_path=socket_path,
+            target_spiffe_id=None,
+            jwt_audiences=[SPIRE_AUDIENCE],
+            trust_domains=[trust_domain],
+        )
+    )
+    return provider, verifier
+
+
+def resolve_spire_material(
+    handle: str,
+) -> tuple[slim_bindings.IdentityProviderConfig, slim_bindings.IdentityVerifierConfig] | None:
+    """Build the SPIRE identity pair from the configured Workload API socket.
+
+    Returns ``None`` when no socket is configured or the socket isn't present (no
+    co-located SPIRE agent), so the connect seam degrades to PSK or fails closed
+    per :func:`identity_required`. Unlike the SignerJwt floor there is no on-disk
+    key to mint: SPIRE owns the key material and mints the SVID on demand.
+    """
+    socket_path = resolve_spire_socket()
+    if not socket_path or not _spire_socket_present(socket_path):
+        return None
+    return build_spire_identity(handle, socket_path, resolve_spire_trust_domain())
+
+
+def resolve_identity_material(
+    mode: str,
+    handle: str,
+    data_dir: Path | None = None,
+) -> tuple[slim_bindings.IdentityProviderConfig, slim_bindings.IdentityVerifierConfig] | None:
+    """Dispatch to the selected mode's provider/verifier builder.
+
+    Returns ``None`` for ``psk`` (or any mode whose material is absent) so the one
+    connect seam handles degrade/fail-closed uniformly across ``signerjwt`` and
+    ``spire``.
+    """
+    if mode == MODE_SIGNERJWT:
+        return resolve_signerjwt_material(handle, data_dir)
+    if mode == MODE_SPIRE:
+        return resolve_spire_material(handle)
+    return None

--- a/mycelium-cli/tests/test_slim_identity.py
+++ b/mycelium-cli/tests/test_slim_identity.py
@@ -151,3 +151,89 @@ def test_material_built_when_key_and_roster_present(tmp_path):
     # Constructed slim-bindings identity configs (exact types are binding-internal).
     assert provider is not None
     assert verifier is not None
+
+
+# ── SPIRE mode (#579): socket / trust-domain / SPIFFE-ID resolution ──────────
+def test_spire_mode_selected(monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_IDENTITY", "SPIRE")
+    assert slim_identity.resolve_identity_mode() == slim_identity.MODE_SPIRE
+
+
+def test_resolve_spire_socket_none_when_unset(monkeypatch):
+    monkeypatch.delenv("MYCELIUM_SLIM_SPIRE_SOCKET", raising=False)
+    monkeypatch.delenv("SPIRE_AGENT_SOCKET", raising=False)
+    assert slim_identity.resolve_spire_socket() is None
+
+
+def test_resolve_spire_socket_prefers_mycelium_env(monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", "unix:///a.sock")
+    monkeypatch.setenv("SPIRE_AGENT_SOCKET", "unix:///b.sock")
+    assert slim_identity.resolve_spire_socket() == "unix:///a.sock"
+
+
+def test_resolve_spire_socket_falls_back_to_standard_env(monkeypatch):
+    monkeypatch.delenv("MYCELIUM_SLIM_SPIRE_SOCKET", raising=False)
+    monkeypatch.setenv("SPIRE_AGENT_SOCKET", "unix:///b.sock")
+    assert slim_identity.resolve_spire_socket() == "unix:///b.sock"
+
+
+def test_resolve_spire_trust_domain_default_and_override(monkeypatch):
+    monkeypatch.delenv("MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN", raising=False)
+    assert slim_identity.resolve_spire_trust_domain() == slim_identity.SPIRE_DEFAULT_TRUST_DOMAIN
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN", "acme.example")
+    assert slim_identity.resolve_spire_trust_domain() == "acme.example"
+
+
+def test_spiffe_id_for_builds_expected_path():
+    assert (
+        slim_identity.spiffe_id_for("alice", "mycelium.dev") == "spiffe://mycelium.dev/agent/alice"
+    )
+
+
+def test_spire_material_none_without_socket(monkeypatch):
+    monkeypatch.delenv("MYCELIUM_SLIM_SPIRE_SOCKET", raising=False)
+    monkeypatch.delenv("SPIRE_AGENT_SOCKET", raising=False)
+    assert slim_identity.resolve_spire_material("alice") is None
+
+
+def test_spire_material_none_when_socket_absent(monkeypatch, tmp_path):
+    # Configured but the socket file does not exist → no agent to mint the SVID.
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", str(tmp_path / "missing.sock"))
+    assert slim_identity.resolve_spire_material("alice") is None
+
+
+def test_spire_material_built_when_socket_present(monkeypatch, tmp_path):
+    pytest.importorskip("slim_bindings")
+    sock = tmp_path / "agent.sock"
+    sock.write_text("")  # _spire_socket_present only checks existence
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", f"unix://{sock}")
+    material = slim_identity.resolve_spire_material("alice")
+    assert material is not None
+    provider, verifier = material
+    assert provider is not None
+    assert verifier is not None
+
+
+# ── resolve_identity_material: the shared connect-seam dispatcher ─────────────
+def test_identity_material_dispatch_psk_is_none(tmp_path):
+    assert (
+        slim_identity.resolve_identity_material(slim_identity.MODE_PSK, "alice", tmp_path) is None
+    )
+
+
+def test_identity_material_dispatch_signerjwt(tmp_path):
+    pytest.importorskip("slim_bindings")
+    slim_identity.ensure_agent_keypair("alice", tmp_path)
+    material = slim_identity.resolve_identity_material(
+        slim_identity.MODE_SIGNERJWT, "alice", tmp_path
+    )
+    assert material is not None
+
+
+def test_identity_material_dispatch_spire(monkeypatch, tmp_path):
+    pytest.importorskip("slim_bindings")
+    sock = tmp_path / "agent.sock"
+    sock.write_text("")
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", str(sock))
+    material = slim_identity.resolve_identity_material(slim_identity.MODE_SPIRE, "alice")
+    assert material is not None

--- a/mycelium-cli/tests/test_slim_l9_wire.py
+++ b/mycelium-cli/tests/test_slim_l9_wire.py
@@ -78,6 +78,19 @@ def test_signerjwt_identity_constants_match_contract():
     assert g["curve"] == slim_identity.SIGNERJWT_CURVE
 
 
+def test_spire_identity_constants_match_contract():
+    """The CLI's SPIRE mode labels match the backend's frozen contract (#579)."""
+    s = _contract()["identity"]["spire"]
+    assert slim_identity.MODE_SPIRE in slim_identity.VALID_MODES
+    assert s["socket_env"] == slim_identity._SPIRE_SOCKET_ENV
+    assert s["socket_env_fallback"] == slim_identity._SPIRE_SOCKET_ENV_FALLBACK
+    assert s["trust_domain_env"] == slim_identity._SPIRE_TRUST_DOMAIN_ENV
+    assert s["trust_domain_default"] == slim_identity.SPIRE_DEFAULT_TRUST_DOMAIN
+    assert s["workload_path_prefix"] == slim_identity.SPIRE_WORKLOAD_PATH_PREFIX
+    # The SVID audience is the shared MLS audience label, not a separate constant.
+    assert _contract()["identity"]["audience"] == slim_identity.SPIRE_AUDIENCE
+
+
 def test_episode_and_topic_urns_match_contract():
     """The CLI's episode/topic URN forms match the backend's."""
     g = _contract()["urn"]


### PR DESCRIPTION
Closes #579. Adds **`spire`** as the third SLIM channel identity mode behind the pluggable `_create_app` seam that #476/#593 landed. Follows the handoff kickoff comment on #579.

## What

`MYCELIUM_SLIM_IDENTITY=spire` sources a **JWT-SVID from the SPIFFE Workload API** (`IdentityProviderConfig.SPIRE` / `IdentityVerifierConfig.SPIRE`) instead of a self-minted key: the trust domain attests the workload and signs the SVID, so peers verify against the SPIRE bundle rather than a hand-distributed roster. Same MLS mechanics as the SignerJwt floor; tightest attestation, heaviest deploy. Proven on the 2.1.0 stack by the #583/#584 spike — this is the productization.

## Scope (matches the #579 handoff)

- **Provider/verifier wiring** — `slim_identity.py` (backend) + its **byte-for-byte CLI mirror**: `MODE_SPIRE`, `build_spire_identity()` from `SpireConfig(socket_path, target_spiffe_id, jwt_audiences, trust_domains)`, socket/trust-domain/SPIFFE-ID resolution, and a `resolve_identity_material()` dispatcher so `signerjwt` and `spire` share **one** degrade/fail-closed path.
- **Connect seam** — `slim_client.py` + CLI `client.py`: the signerjwt-only branch generalizes to any non-`psk` mode via the dispatcher, with a per-mode degrade warning + fail-closed error.
- **Config** — `slim.identity` accepts `spire` (+ regenerated `docs/reference.html`); socket/trust-domain stay operator-managed env (like the master secret).
- **Contract** — the frozen `identity` block gains a `spire` sub-block; both `test_slim_l9_wire` copies assert it, so neither copy can drift.
- **Dev quickstart** — `docs/design/spire-quickstart/`: optional compose + SPIRE server/agent config + scripts, with the load-bearing shared-PID-namespace / named-volume-socket gotcha documented.

## Off by default (#567)

`psk` stays the default; `signerjwt` the light opt-in; `spire` the heavy opt-in. Selecting `spire` with no Workload API socket degrades to PSK with a one-time warning unless `MYCELIUM_SLIM_IDENTITY_REQUIRE=1` fails closed. The try-it path never changes.

## Testing

- Offline (this PR): socket/trust-domain/SPIFFE resolution, off-by-default defaulting, degrade/fail-closed, contract-test extension, and **provider/verifier construction against the real `slim-bindings` 2.1 API** (the SPIRE build tests run, not skip). Backend + CLI identity/wire suites green.
- **The live SPIRE→MLS path needs the co-located rig** (shared PID namespace — exactly what the offline suite can't stand up) and is validated on real infra, same pattern as #583/#584.

## Out of scope (separate tickets)

Appliance SPIRE deployment profile → #588 · handle ↔ SPIFFE-ID mapping/registration → #589 · revocation semantics → #590.