### PR TITLE
feat(identity): @handle as the identity spine across both planes (#589)

### DIFF
--- a/fastapi-backend/app/services/slim_identity.py
+++ b/fastapi-backend/app/services/slim_identity.py
@@ -64,7 +64,7 @@ import logging
 import os
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import slim_bindings
@@ -123,9 +123,9 @@ _SPIRE_TRUST_DOMAIN_ENV = "MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN"
 # with the SignerJwt floor so a mixed room agrees on the ``aud`` claim.
 SPIRE_AUDIENCE = SIGNERJWT_AUDIENCE
 SPIRE_DEFAULT_TRUST_DOMAIN = "mycelium.dev"
-# A member's SPIFFE ID is ``spiffe://{trust_domain}/{prefix}/{handle}`` — a
-# minimal handle↔SPIFFE binding good enough to demo; the full registration
-# surface (SPIFFE-leaf ↔ ``@handle`` reconciliation) is #589.
+# A member's SPIFFE ID is ``spiffe://{trust_domain}/{prefix}/{handle}`` — the
+# handle↔SPIFFE binding that makes ``@handle`` the identity spine (#589):
+# :func:`spiffe_id_for` mints it, :func:`handle_from_spiffe_id` reconciles it back.
 SPIRE_WORKLOAD_PATH_PREFIX = "agent"
 
 
@@ -429,8 +429,9 @@ def resolve_spire_trust_domain() -> str:
 def spiffe_id_for(handle: str, trust_domain: str) -> str:
     """The member's SPIFFE ID: ``spiffe://{trust_domain}/agent/{handle}``.
 
-    A minimal handle↔SPIFFE binding — enough to demo the path; the full
-    registration/reconciliation surface is #589.
+    The handle↔SPIFFE binding on the SLIM plane, where we own the credential:
+    the leaf *is* the ``@handle``. :func:`handle_from_spiffe_id` is the inverse a
+    peer uses to reconcile an observed SVID back to its handle.
     """
     return f"spiffe://{trust_domain}/{SPIRE_WORKLOAD_PATH_PREFIX}/{handle}"
 
@@ -500,6 +501,96 @@ def resolve_spire_material(
     if not socket_path or not _spire_socket_present(socket_path):
         return None
     return build_spire_identity(handle, socket_path, resolve_spire_trust_domain())
+
+
+# ── Handle ↔ channel-identity reconciliation (the identity spine, #589) ───────
+# ``@handle`` is the single logical identity across both planes. On the SLIM plane
+# we own the credential, so the handle binds *directly*: the SignerJwt JWK ``kid``
+# and the SPIFFE-ID leaf both carry the raw ``@handle``, and a peer reconciles an
+# observed credential back to its handle with the two inverses below. (On the HTTP
+# plane the OIDC ``sub`` is opaque, so handle↔sub is a binding table — the token's
+# handle claim plus the actor-authz in ``app.services.actor`` — not this equality.
+# We deliberately do not force the OIDC ``sub`` to equal the handle.)
+def handle_from_jwk(jwk: dict[str, str]) -> str | None:
+    """The ``@handle`` a roster JWK belongs to — its ``kid`` (the direct binding).
+
+    Returns ``None`` for a JWK with no ``kid``: such a key names no handle and so
+    can't be reconciled to a member.
+    """
+    kid = jwk.get("kid")
+    return kid or None
+
+
+def handle_from_spiffe_id(spiffe_id: str, trust_domain: str | None = None) -> str | None:
+    """The ``@handle`` a SPIFFE-ID names, or ``None`` if it isn't one of ours.
+
+    The inverse of :func:`spiffe_id_for`: parse ``spiffe://{td}/agent/{handle}`` and
+    return ``handle`` iff the path prefix is our workload convention (``agent``) and
+    — when ``trust_domain`` is supplied — the ID sits in that trust domain. A foreign
+    or malformed ID reconciles to nothing rather than a fabricated handle (the same
+    faithful-interpretation posture the offer snapper takes), which is what lets a
+    peer trust that a resolved handle is really the credential's handle.
+    """
+    prefix = "spiffe://"
+    if not spiffe_id.startswith(prefix):
+        return None
+    authority, _, path = spiffe_id[len(prefix) :].partition("/")
+    if not authority or not path:
+        return None
+    if trust_domain is not None and authority != trust_domain:
+        return None
+    segments = path.split("/")
+    if len(segments) != 2 or segments[0] != SPIRE_WORKLOAD_PATH_PREFIX:
+        return None
+    return segments[1] or None
+
+
+def provision_channel_identity(
+    handle: str, mode: str | None = None, data_dir: Path | None = None
+) -> dict[str, Any]:
+    """Provision ``@handle``'s SLIM channel identity for the active mode. Idempotent.
+
+    The registration-time counterpart to the connect-time
+    :func:`resolve_identity_material`: ``agent create`` calls this so a handle has a
+    usable channel credential the moment it is registered, for whichever mode is
+    active. Off-by-default is preserved — under ``psk`` nothing is provisioned.
+
+    * ``psk`` — no per-agent credential exists; a no-op.
+    * ``signerjwt`` — mint+register the local ES256 keypair (:func:`ensure_agent_keypair`),
+      whose public JWK's ``kid`` is the ``@handle``. Returns the key/roster paths + ``kid``.
+    * ``spire`` — the SVID is minted by the trust domain, not us: return the member's
+      SPIFFE-ID and the operator step to register it. Entry creation needs the SPIRE
+      server and is out of the CLI's reach, so it stays a documented operator step
+      (``provisioned`` is False).
+
+    Every result carries ``mode``, ``handle``, and ``provisioned``.
+    """
+    resolved = mode or resolve_identity_mode()
+    if resolved == MODE_SIGNERJWT:
+        key_path, jwk = ensure_agent_keypair(handle, data_dir)
+        return {
+            "mode": MODE_SIGNERJWT,
+            "handle": handle,
+            "provisioned": True,
+            "kid": jwk["kid"],
+            "key_path": str(key_path),
+            "roster_path": str(public_jwk_path(handle, data_dir)),
+        }
+    if resolved == MODE_SPIRE:
+        trust_domain = resolve_spire_trust_domain()
+        spiffe_id = spiffe_id_for(handle, trust_domain)
+        return {
+            "mode": MODE_SPIRE,
+            "handle": handle,
+            "provisioned": False,
+            "spiffe_id": spiffe_id,
+            "trust_domain": trust_domain,
+            "operator_step": (
+                f"spire-server entry create -spiffeID {spiffe_id} "
+                "-parentID <agent-node-id> -selector <workload-selector>"
+            ),
+        }
+    return {"mode": MODE_PSK, "handle": handle, "provisioned": False}
 
 
 def resolve_identity_material(

--- a/fastapi-backend/tests/test_slim_identity.py
+++ b/fastapi-backend/tests/test_slim_identity.py
@@ -237,3 +237,86 @@ def test_identity_material_dispatch_spire(monkeypatch, tmp_path):
     monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", str(sock))
     material = slim_identity.resolve_identity_material(slim_identity.MODE_SPIRE, "alice")
     assert material is not None
+
+
+# ── handle ↔ channel-identity reconciliation (the identity spine, #589) ──────
+def test_handle_from_jwk_is_the_kid():
+    _, public_pem = slim_identity.generate_es256_keypair()
+    jwk = slim_identity.public_jwk_from_pem("alice", public_pem)
+    assert slim_identity.handle_from_jwk(jwk) == "alice"
+
+
+def test_handle_from_jwk_none_without_kid():
+    assert slim_identity.handle_from_jwk({"kty": "EC"}) is None
+
+
+def test_handle_from_spiffe_id_roundtrips():
+    spiffe_id = slim_identity.spiffe_id_for("alice", "mycelium.dev")
+    assert slim_identity.handle_from_spiffe_id(spiffe_id) == "alice"
+    # Trust-domain-scoped: a matching domain resolves, a mismatched one refuses.
+    assert slim_identity.handle_from_spiffe_id(spiffe_id, "mycelium.dev") == "alice"
+    assert slim_identity.handle_from_spiffe_id(spiffe_id, "other.example") is None
+
+
+@pytest.mark.parametrize(
+    "spiffe_id",
+    [
+        "https://mycelium.dev/agent/alice",  # not a SPIFFE URI
+        "spiffe://mycelium.dev",  # no workload path
+        "spiffe://mycelium.dev/user/alice",  # foreign path prefix
+        "spiffe://mycelium.dev/agent/alice/extra",  # over-deep path
+        "spiffe://mycelium.dev/agent/",  # empty handle
+    ],
+)
+def test_handle_from_spiffe_id_refuses_foreign_or_malformed(spiffe_id):
+    # Faithful interpretation: reconcile to nothing, never a fabricated handle.
+    assert slim_identity.handle_from_spiffe_id(spiffe_id) is None
+
+
+# ── provision_channel_identity: registration-time credential minting (#589) ──
+def test_provision_psk_is_a_noop(tmp_path):
+    result = slim_identity.provision_channel_identity("alice", slim_identity.MODE_PSK, tmp_path)
+    assert result == {"mode": "psk", "handle": "alice", "provisioned": False}
+    # Off by default: nothing written under the data dir.
+    assert not slim_identity.signing_key_path("alice", tmp_path).exists()
+
+
+def test_provision_signerjwt_mints_and_registers(tmp_path):
+    result = slim_identity.provision_channel_identity(
+        "alice", slim_identity.MODE_SIGNERJWT, tmp_path
+    )
+    assert result["mode"] == "signerjwt"
+    assert result["provisioned"] is True
+    assert result["kid"] == "alice"
+    assert slim_identity.signing_key_path("alice", tmp_path).exists()
+    assert slim_identity.public_jwk_path("alice", tmp_path).exists()
+
+
+def test_provision_signerjwt_is_idempotent(tmp_path):
+    first = slim_identity.provision_channel_identity(
+        "alice", slim_identity.MODE_SIGNERJWT, tmp_path
+    )
+    key = slim_identity.signing_key_path("alice", tmp_path).read_text()
+    second = slim_identity.provision_channel_identity(
+        "alice", slim_identity.MODE_SIGNERJWT, tmp_path
+    )
+    # No key churn on re-provision (never regenerated — that would churn identity).
+    assert slim_identity.signing_key_path("alice", tmp_path).read_text() == key
+    assert first == second
+
+
+def test_provision_spire_returns_spiffe_and_operator_step(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN", "acme.example")
+    result = slim_identity.provision_channel_identity("alice", slim_identity.MODE_SPIRE, tmp_path)
+    assert result["mode"] == "spire"
+    # SVID entry creation is an external operator step, so nothing is provisioned here.
+    assert result["provisioned"] is False
+    assert result["spiffe_id"] == "spiffe://acme.example/agent/alice"
+    assert "spire-server entry create" in result["operator_step"]
+
+
+def test_provision_defaults_to_active_mode(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_IDENTITY", "signerjwt")
+    result = slim_identity.provision_channel_identity("alice", data_dir=tmp_path)
+    assert result["mode"] == "signerjwt"
+    assert result["provisioned"] is True

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -396,7 +396,45 @@ def _persist_and_describe(
     )
     for line in impl.describe(manifest, room=room_name):
         console.print(line)
+    _provision_channel_identity(manifest)
     _prompt_for_credential(config, manifest)
+
+
+def _provision_channel_identity(manifest: AgentManifest) -> None:
+    """Provision the agent's SLIM channel identity for the active mode (#589).
+
+    Registration is where ``@handle`` becomes a usable channel identity: under
+    ``signerjwt`` this mints+registers the local keypair (``kid = @handle``); under
+    ``spire`` it prints the member's SPIFFE-ID and the operator step to register the
+    SVID entry (entry creation is external to the CLI). Under the ``psk`` default it
+    is a silent no-op (off by default, #567) — the try-it path never sees identity
+    machinery. A provisioning failure is a warning, not a hard error: the manifest
+    is already written and the agent still works on the PSK.
+    """
+    from mycelium.slim import identity as slim_identity
+
+    try:
+        result = slim_identity.provision_channel_identity(manifest.handle)
+    except slim_identity.SlimIdentityError as exc:
+        console.print(f"[yellow]Could not provision channel identity: {exc}[/yellow]")
+        return
+
+    mode = result.get("mode")
+    if mode == slim_identity.MODE_SIGNERJWT:
+        console.print(
+            f"[green]SLIM channel identity ready[/green] "
+            f"[dim](signerjwt · kid {result['kid']})[/dim]"
+        )
+        console.print(f"[dim]Public JWK on the roster: {result['roster_path']}.[/dim]")
+    elif mode == slim_identity.MODE_SPIRE:
+        console.print(
+            f"[green]SLIM channel identity[/green] [dim](spire · {result['spiffe_id']})[/dim]"
+        )
+        console.print(
+            "[dim]Register the SVID entry with your SPIRE server:[/dim]\n"
+            f"[dim]  {result['operator_step']}[/dim]"
+        )
+    # psk: no per-agent identity — stay silent (off by default, #567).
 
 
 def _prompt_for_credential(config: MyceliumConfig, manifest: AgentManifest) -> None:

--- a/mycelium-cli/src/mycelium/slim/identity.py
+++ b/mycelium-cli/src/mycelium/slim/identity.py
@@ -34,7 +34,7 @@ import logging
 import os
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import slim_bindings
@@ -93,9 +93,9 @@ _SPIRE_TRUST_DOMAIN_ENV = "MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN"
 # with the SignerJwt floor so a mixed room agrees on the ``aud`` claim.
 SPIRE_AUDIENCE = SIGNERJWT_AUDIENCE
 SPIRE_DEFAULT_TRUST_DOMAIN = "mycelium.dev"
-# A member's SPIFFE ID is ``spiffe://{trust_domain}/{prefix}/{handle}`` — a
-# minimal handle↔SPIFFE binding good enough to demo; the full registration
-# surface (SPIFFE-leaf ↔ ``@handle`` reconciliation) is #589.
+# A member's SPIFFE ID is ``spiffe://{trust_domain}/{prefix}/{handle}`` — the
+# handle↔SPIFFE binding that makes ``@handle`` the identity spine (#589):
+# :func:`spiffe_id_for` mints it, :func:`handle_from_spiffe_id` reconciles it back.
 SPIRE_WORKLOAD_PATH_PREFIX = "agent"
 
 
@@ -399,8 +399,9 @@ def resolve_spire_trust_domain() -> str:
 def spiffe_id_for(handle: str, trust_domain: str) -> str:
     """The member's SPIFFE ID: ``spiffe://{trust_domain}/agent/{handle}``.
 
-    A minimal handle↔SPIFFE binding — enough to demo the path; the full
-    registration/reconciliation surface is #589.
+    The handle↔SPIFFE binding on the SLIM plane, where we own the credential:
+    the leaf *is* the ``@handle``. :func:`handle_from_spiffe_id` is the inverse a
+    peer uses to reconcile an observed SVID back to its handle.
     """
     return f"spiffe://{trust_domain}/{SPIRE_WORKLOAD_PATH_PREFIX}/{handle}"
 
@@ -470,6 +471,96 @@ def resolve_spire_material(
     if not socket_path or not _spire_socket_present(socket_path):
         return None
     return build_spire_identity(handle, socket_path, resolve_spire_trust_domain())
+
+
+# ── Handle ↔ channel-identity reconciliation (the identity spine, #589) ───────
+# ``@handle`` is the single logical identity across both planes. On the SLIM plane
+# we own the credential, so the handle binds *directly*: the SignerJwt JWK ``kid``
+# and the SPIFFE-ID leaf both carry the raw ``@handle``, and a peer reconciles an
+# observed credential back to its handle with the two inverses below. (On the HTTP
+# plane the OIDC ``sub`` is opaque, so handle↔sub is a binding table — the token's
+# handle claim plus the actor-authz in ``app.services.actor`` — not this equality.
+# We deliberately do not force the OIDC ``sub`` to equal the handle.)
+def handle_from_jwk(jwk: dict[str, str]) -> str | None:
+    """The ``@handle`` a roster JWK belongs to — its ``kid`` (the direct binding).
+
+    Returns ``None`` for a JWK with no ``kid``: such a key names no handle and so
+    can't be reconciled to a member.
+    """
+    kid = jwk.get("kid")
+    return kid or None
+
+
+def handle_from_spiffe_id(spiffe_id: str, trust_domain: str | None = None) -> str | None:
+    """The ``@handle`` a SPIFFE-ID names, or ``None`` if it isn't one of ours.
+
+    The inverse of :func:`spiffe_id_for`: parse ``spiffe://{td}/agent/{handle}`` and
+    return ``handle`` iff the path prefix is our workload convention (``agent``) and
+    — when ``trust_domain`` is supplied — the ID sits in that trust domain. A foreign
+    or malformed ID reconciles to nothing rather than a fabricated handle (the same
+    faithful-interpretation posture the offer snapper takes), which is what lets a
+    peer trust that a resolved handle is really the credential's handle.
+    """
+    prefix = "spiffe://"
+    if not spiffe_id.startswith(prefix):
+        return None
+    authority, _, path = spiffe_id[len(prefix) :].partition("/")
+    if not authority or not path:
+        return None
+    if trust_domain is not None and authority != trust_domain:
+        return None
+    segments = path.split("/")
+    if len(segments) != 2 or segments[0] != SPIRE_WORKLOAD_PATH_PREFIX:
+        return None
+    return segments[1] or None
+
+
+def provision_channel_identity(
+    handle: str, mode: str | None = None, data_dir: Path | None = None
+) -> dict[str, Any]:
+    """Provision ``@handle``'s SLIM channel identity for the active mode. Idempotent.
+
+    The registration-time counterpart to the connect-time
+    :func:`resolve_identity_material`: ``agent create`` calls this so a handle has a
+    usable channel credential the moment it is registered, for whichever mode is
+    active. Off-by-default is preserved — under ``psk`` nothing is provisioned.
+
+    * ``psk`` — no per-agent credential exists; a no-op.
+    * ``signerjwt`` — mint+register the local ES256 keypair (:func:`ensure_agent_keypair`),
+      whose public JWK's ``kid`` is the ``@handle``. Returns the key/roster paths + ``kid``.
+    * ``spire`` — the SVID is minted by the trust domain, not us: return the member's
+      SPIFFE-ID and the operator step to register it. Entry creation needs the SPIRE
+      server and is out of the CLI's reach, so it stays a documented operator step
+      (``provisioned`` is False).
+
+    Every result carries ``mode``, ``handle``, and ``provisioned``.
+    """
+    resolved = mode or resolve_identity_mode()
+    if resolved == MODE_SIGNERJWT:
+        key_path, jwk = ensure_agent_keypair(handle, data_dir)
+        return {
+            "mode": MODE_SIGNERJWT,
+            "handle": handle,
+            "provisioned": True,
+            "kid": jwk["kid"],
+            "key_path": str(key_path),
+            "roster_path": str(public_jwk_path(handle, data_dir)),
+        }
+    if resolved == MODE_SPIRE:
+        trust_domain = resolve_spire_trust_domain()
+        spiffe_id = spiffe_id_for(handle, trust_domain)
+        return {
+            "mode": MODE_SPIRE,
+            "handle": handle,
+            "provisioned": False,
+            "spiffe_id": spiffe_id,
+            "trust_domain": trust_domain,
+            "operator_step": (
+                f"spire-server entry create -spiffeID {spiffe_id} "
+                "-parentID <agent-node-id> -selector <workload-selector>"
+            ),
+        }
+    return {"mode": MODE_PSK, "handle": handle, "provisioned": False}
 
 
 def resolve_identity_material(

--- a/mycelium-cli/tests/test_slim_identity.py
+++ b/mycelium-cli/tests/test_slim_identity.py
@@ -237,3 +237,86 @@ def test_identity_material_dispatch_spire(monkeypatch, tmp_path):
     monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_SOCKET", str(sock))
     material = slim_identity.resolve_identity_material(slim_identity.MODE_SPIRE, "alice")
     assert material is not None
+
+
+# ── handle ↔ channel-identity reconciliation (the identity spine, #589) ──────
+def test_handle_from_jwk_is_the_kid():
+    _, public_pem = slim_identity.generate_es256_keypair()
+    jwk = slim_identity.public_jwk_from_pem("alice", public_pem)
+    assert slim_identity.handle_from_jwk(jwk) == "alice"
+
+
+def test_handle_from_jwk_none_without_kid():
+    assert slim_identity.handle_from_jwk({"kty": "EC"}) is None
+
+
+def test_handle_from_spiffe_id_roundtrips():
+    spiffe_id = slim_identity.spiffe_id_for("alice", "mycelium.dev")
+    assert slim_identity.handle_from_spiffe_id(spiffe_id) == "alice"
+    # Trust-domain-scoped: a matching domain resolves, a mismatched one refuses.
+    assert slim_identity.handle_from_spiffe_id(spiffe_id, "mycelium.dev") == "alice"
+    assert slim_identity.handle_from_spiffe_id(spiffe_id, "other.example") is None
+
+
+@pytest.mark.parametrize(
+    "spiffe_id",
+    [
+        "https://mycelium.dev/agent/alice",  # not a SPIFFE URI
+        "spiffe://mycelium.dev",  # no workload path
+        "spiffe://mycelium.dev/user/alice",  # foreign path prefix
+        "spiffe://mycelium.dev/agent/alice/extra",  # over-deep path
+        "spiffe://mycelium.dev/agent/",  # empty handle
+    ],
+)
+def test_handle_from_spiffe_id_refuses_foreign_or_malformed(spiffe_id):
+    # Faithful interpretation: reconcile to nothing, never a fabricated handle.
+    assert slim_identity.handle_from_spiffe_id(spiffe_id) is None
+
+
+# ── provision_channel_identity: registration-time credential minting (#589) ──
+def test_provision_psk_is_a_noop(tmp_path):
+    result = slim_identity.provision_channel_identity("alice", slim_identity.MODE_PSK, tmp_path)
+    assert result == {"mode": "psk", "handle": "alice", "provisioned": False}
+    # Off by default: nothing written under the data dir.
+    assert not slim_identity.signing_key_path("alice", tmp_path).exists()
+
+
+def test_provision_signerjwt_mints_and_registers(tmp_path):
+    result = slim_identity.provision_channel_identity(
+        "alice", slim_identity.MODE_SIGNERJWT, tmp_path
+    )
+    assert result["mode"] == "signerjwt"
+    assert result["provisioned"] is True
+    assert result["kid"] == "alice"
+    assert slim_identity.signing_key_path("alice", tmp_path).exists()
+    assert slim_identity.public_jwk_path("alice", tmp_path).exists()
+
+
+def test_provision_signerjwt_is_idempotent(tmp_path):
+    first = slim_identity.provision_channel_identity(
+        "alice", slim_identity.MODE_SIGNERJWT, tmp_path
+    )
+    key = slim_identity.signing_key_path("alice", tmp_path).read_text()
+    second = slim_identity.provision_channel_identity(
+        "alice", slim_identity.MODE_SIGNERJWT, tmp_path
+    )
+    # No key churn on re-provision (never regenerated — that would churn identity).
+    assert slim_identity.signing_key_path("alice", tmp_path).read_text() == key
+    assert first == second
+
+
+def test_provision_spire_returns_spiffe_and_operator_step(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN", "acme.example")
+    result = slim_identity.provision_channel_identity("alice", slim_identity.MODE_SPIRE, tmp_path)
+    assert result["mode"] == "spire"
+    # SVID entry creation is an external operator step, so nothing is provisioned here.
+    assert result["provisioned"] is False
+    assert result["spiffe_id"] == "spiffe://acme.example/agent/alice"
+    assert "spire-server entry create" in result["operator_step"]
+
+
+def test_provision_defaults_to_active_mode(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_IDENTITY", "signerjwt")
+    result = slim_identity.provision_channel_identity("alice", data_dir=tmp_path)
+    assert result["mode"] == "signerjwt"
+    assert result["provisioned"] is True


### PR DESCRIPTION
Closes #589.

## The model

Makes **`@handle` the single identity spine** across both planes so an agent is the same identity on the HTTP API and on the SLIM channel — closing the "verified handle binding" gap.

- **Direct on SLIM, binding-table on HTTP.** On the SLIM plane we own the credential, so the handle binds *directly*: the SignerJwt JWK `kid` and the SPIFFE-ID leaf both carry the raw `@handle` (already true on the forward path). On the HTTP plane the OIDC issuer assigns its own opaque `sub`, so handle↔sub is a **binding table** — the token's handle claim + the actor-authz that #562/#580 landed (`may_act_as`/`authorize_handle`, manifest `owner`/`allow_from`). We deliberately do **not** force the OIDC `sub` to equal the handle.
- **Handle scope = trust-domain-wide** *(the call to sanity-check on review)*. Within one appliance/trust domain, `@alice` is *one* identity, not per-room. SPIFFE IDs are already TD-scoped, so `handle_from_spiffe_id` is trust-domain-scoped and room-agnostic; room membership becomes **authorization on top of** a single identity. I hit no reason it can't hold — the per-room alternative fragments identity and is harder to unwind.

## What's in this PR

**Reconciliation inverses** (the "verifiable by peers" half), mirrored byte-for-byte in `slim_identity` (backend) + `mycelium.slim.identity` (CLI):
- `handle_from_jwk(jwk)` → the roster JWK's `kid`.
- `handle_from_spiffe_id(spiffe_id, trust_domain=None)` → parses `spiffe://{td}/agent/{handle}`, scoped to the trust domain, and **refuses foreign/malformed IDs rather than fabricating a handle** (same faithful-interpretation posture as the offer snapper).

**Registration provisions the channel identity for the active mode** — `provision_channel_identity(handle, mode)`, wired into `agent create` via `_persist_and_describe`:
- `psk` → no-op (off by default, #567; the try-it path never sees identity machinery).
- `signerjwt` → mint+register the local ES256 keypair (the existing `credential slim-key` path); `kid = @handle`.
- `spire` → returns the member's SPIFFE-ID + the operator step to register the SVID entry (entry creation needs the SPIRE server, external to the CLI — documented, not silently skipped).
- Idempotent; an existing key is reused (no identity churn).

## Contract

No new wire constants: reconciliation reuses `SPIRE_WORKLOAD_PATH_PREFIX` and the `kid = @handle` convention, both already frozen in `contracts/slim-l9-wire.json` and asserted by **both** `test_slim_l9_wire` copies. The backend↔CLI mirror rule holds (module bodies + test bodies are byte-identical bar the import line and module docstring).

## Out of scope
Appliance SPIRE deploy profile → #588 · revocation/deprovisioning → #590.

## Testing
- Offline unit tests added to both `test_slim_identity` copies: JWK/SPIFFE reconciliation (roundtrip, TD mismatch, foreign/malformed refusal), and `provision_channel_identity` under each mode (psk no-op, signerjwt mints+idempotent, spire operator-step, active-mode default).
- Backend: `549 passed, 2 skipped`. CLI: `419 passed` (one pre-existing, unrelated `test_login` failure that leaks the local user config — fails identically on the base commit).
- ruff check/format + ty clean on all touched files.

**Cross-plane resolution needs the rig** (SPIRE entry → SVID whose leaf resolves to the handle; floor JWK `kid` = handle over a live 2.1.0 node; an HTTP write + a SLIM membership for the same `@handle` reconciling) — same pattern as #593/#601, to be verified on the matched `slim-bindings==2.1.0` + `ghcr.io/agntcy/slim:2.1.0` stack.