### PR TITLE
feat(identity): revoke per-member channel identity without room-wide re-key (#590)

### DIFF
--- a/fastapi-backend/app/services/slim_identity.py
+++ b/fastapi-backend/app/services/slim_identity.py
@@ -596,6 +596,64 @@ def provision_channel_identity(
     return {"mode": MODE_PSK, "handle": handle, "provisioned": False}
 
 
+def revoke_channel_identity(
+    handle: str, mode: str | None = None, data_dir: Path | None = None
+) -> dict[str, Any]:
+    """Revoke ``@handle``'s SLIM channel identity for the active mode. Idempotent.
+
+    The deprovisioning-time inverse of :func:`provision_channel_identity`
+    (``agent rm`` calls it): it removes the per-agent credential so a removed member
+    can no longer authenticate to the room — *without a room-wide re-key*, the
+    property the shared-secret PSK never had (#590). Symmetric and idempotent:
+    revoking an already-absent member is a no-op, not an error.
+
+    * ``psk`` — there is no per-agent credential to revoke; the only lever is
+      rotating ``MYCELIUM_SLIM_MASTER_SECRET`` for the whole room (the blunt
+      instrument this tier is stuck with). A no-op here.
+    * ``signerjwt`` — drop the member's public JWK from the roster (the inverse of
+      :func:`register_public_jwk`) and delete its local signing key. Once its key is
+      off the roster, peers' static-JWKS verifiers reject its self-signed tokens, so
+      it can't rejoin with the old credential — per-agent, no room-wide rotation.
+      Returns the removed paths (empty on a second/idempotent revoke).
+    * ``spire`` — the SVID is minted by the trust domain, so revocation is deleting
+      the SPIRE registration entry (``spire-server entry delete``), external to the
+      CLI's on-disk state. Return the member's SPIFFE-ID + the operator step; the
+      appliance path (``spire_registry.revoke_workload``) runs it when the server is
+      reachable. ``revoked`` is False — there is no local material to remove.
+
+    Every result carries ``mode``, ``handle``, and ``revoked``.
+    """
+    resolved = mode or resolve_identity_mode()
+    if resolved == MODE_SIGNERJWT:
+        jwk_path = public_jwk_path(handle, data_dir)
+        key_path = signing_key_path(handle, data_dir)
+        removed: list[str] = []
+        for path in (jwk_path, key_path):
+            if path.exists():
+                path.unlink()
+                removed.append(str(path))
+        return {
+            "mode": MODE_SIGNERJWT,
+            "handle": handle,
+            "revoked": bool(removed),
+            "removed": removed,
+            "roster_path": str(jwk_path),
+            "key_path": str(key_path),
+        }
+    if resolved == MODE_SPIRE:
+        trust_domain = resolve_spire_trust_domain()
+        spiffe_id = spiffe_id_for(handle, trust_domain)
+        return {
+            "mode": MODE_SPIRE,
+            "handle": handle,
+            "revoked": False,
+            "spiffe_id": spiffe_id,
+            "trust_domain": trust_domain,
+            "operator_step": (f"spire-server entry delete -entryID <entry-id for {spiffe_id}>"),
+        }
+    return {"mode": MODE_PSK, "handle": handle, "revoked": False}
+
+
 def resolve_identity_material(
     mode: str,
     handle: str,

--- a/fastapi-backend/tests/test_slim_identity.py
+++ b/fastapi-backend/tests/test_slim_identity.py
@@ -320,3 +320,66 @@ def test_provision_defaults_to_active_mode(tmp_path, monkeypatch):
     result = slim_identity.provision_channel_identity("alice", data_dir=tmp_path)
     assert result["mode"] == "signerjwt"
     assert result["provisioned"] is True
+
+
+# ── revoke_channel_identity: the payoff — per-member revoke, no re-key (#590) ──
+def test_revoke_psk_is_a_noop(tmp_path):
+    result = slim_identity.revoke_channel_identity("alice", slim_identity.MODE_PSK, tmp_path)
+    assert result == {"mode": "psk", "handle": "alice", "revoked": False}
+
+
+def test_revoke_signerjwt_drops_jwk_and_key(tmp_path):
+    slim_identity.provision_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    assert slim_identity.public_jwk_path("bob", tmp_path).exists()
+    assert slim_identity.signing_key_path("bob", tmp_path).exists()
+
+    result = slim_identity.revoke_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    assert result["mode"] == "signerjwt"
+    assert result["revoked"] is True
+    # Off the roster: peers' static-JWKS verifiers now reject its self-signed tokens.
+    assert not slim_identity.public_jwk_path("bob", tmp_path).exists()
+    assert not slim_identity.signing_key_path("bob", tmp_path).exists()
+
+
+def test_revoke_signerjwt_leaves_other_members_untouched(tmp_path):
+    # The key property the PSK can't offer: revoking @bob leaves @alice's credential
+    # and the rest of the roster intact — no room-wide re-key.
+    slim_identity.provision_channel_identity("alice", slim_identity.MODE_SIGNERJWT, tmp_path)
+    slim_identity.provision_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+
+    slim_identity.revoke_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+
+    assert slim_identity.public_jwk_path("alice", tmp_path).exists()
+    assert slim_identity.signing_key_path("alice", tmp_path).exists()
+    roster = slim_identity.load_roster_jwks(tmp_path)
+    assert roster is not None
+    kids = {jwk["kid"] for jwk in json.loads(roster)["keys"]}
+    assert kids == {"alice"}
+
+
+def test_revoke_signerjwt_is_idempotent(tmp_path):
+    slim_identity.provision_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    first = slim_identity.revoke_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    assert first["revoked"] is True
+    # Revoking an already-absent member is a no-op, not an error.
+    second = slim_identity.revoke_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    assert second["revoked"] is False
+    assert second["removed"] == []
+
+
+def test_revoke_spire_returns_spiffe_and_operator_step(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN", "acme.example")
+    result = slim_identity.revoke_channel_identity("alice", slim_identity.MODE_SPIRE, tmp_path)
+    assert result["mode"] == "spire"
+    # Entry deletion is external (needs the SPIRE server), so nothing is removed here.
+    assert result["revoked"] is False
+    assert result["spiffe_id"] == "spiffe://acme.example/agent/alice"
+    assert "spire-server entry delete" in result["operator_step"]
+
+
+def test_revoke_defaults_to_active_mode(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_IDENTITY", "signerjwt")
+    slim_identity.provision_channel_identity("alice", data_dir=tmp_path)
+    result = slim_identity.revoke_channel_identity("alice", data_dir=tmp_path)
+    assert result["mode"] == "signerjwt"
+    assert result["revoked"] is True

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -465,6 +465,47 @@ def _register_spire_workload(handle: str, result: dict) -> None:
     )
 
 
+def _revoke_channel_identity(handle: str, mode: str) -> None:
+    """Revoke ``@handle``'s SLIM channel identity on ``agent rm`` (#590).
+
+    The deprovisioning inverse of :func:`_provision_channel_identity`: it removes the
+    per-agent credential so a removed member can't rejoin, *without re-keying the
+    room* — the payoff per-member identity has over the shared-secret PSK (@alice and
+    the rest keep working, no rotation). Dispatches by the effective tier
+    (``config.slim.identity``, the "one switch"), best-effort: a failure warns rather
+    than aborting, since the manifest is already gone.
+
+    * ``signerjwt`` — drop the member's JWK from the roster + delete its local key.
+    * ``spire`` — delete the SVID entry against the appliance SPIRE server
+      (:func:`_revoke_spire_workload`), falling back to the operator step when the
+      server isn't reachable.
+    * ``psk`` — no per-agent credential exists; note that rotating the shared secret
+      is the only (blunt, room-wide) lever this tier has.
+    """
+    from mycelium.slim import identity as slim_identity
+
+    if mode == slim_identity.MODE_SPIRE:
+        _revoke_spire_workload(handle, mode)
+        return
+
+    try:
+        result = slim_identity.revoke_channel_identity(handle, mode=mode)
+    except OSError as exc:
+        console.print(f"[yellow]Could not revoke channel identity: {exc}[/yellow]")
+        return
+
+    if result["mode"] == slim_identity.MODE_SIGNERJWT and result["revoked"]:
+        console.print(
+            f"[dim]Revoked SLIM channel identity (signerjwt · dropped @{handle} from "
+            "the roster). Peers now reject its tokens — no room re-key.[/dim]"
+        )
+    elif result["mode"] == slim_identity.MODE_PSK:
+        console.print(
+            "[dim]psk has no per-agent revocation; to fully exclude a removed member "
+            "you must rotate MYCELIUM_SLIM_MASTER_SECRET (a room-wide re-key).[/dim]"
+        )
+
+
 def _revoke_spire_workload(handle: str, mode: str) -> None:
     """Revoke ``@handle``'s SPIRE SVID entry on ``agent rm`` (spire mode only).
 
@@ -1107,10 +1148,13 @@ def agent_rm(
         if local.exists():
             local.unlink()
 
-        # 3. Revoke the SPIRE SVID entry (spire mode only; #588/#590). No-op under
-        # psk/signerjwt, or when the appliance SPIRE server isn't up — there's
-        # nothing to revoke. Best-effort: a failure is a warning, not a hard error.
-        _revoke_spire_workload(handle, config.slim.identity)
+        # 3. Revoke the agent's per-agent channel credential for the active tier
+        # (#590): signerjwt drops its JWK from the roster + deletes its local key,
+        # spire deletes the SVID entry, psk notes the room-wide-rotation limitation.
+        # The key property: the removed member can't rejoin, and the others keep
+        # working with no re-key. Best-effort: a failure is a warning, not a hard
+        # error (the manifest is already gone).
+        _revoke_channel_identity(handle, config.slim.identity)
 
         verb = "Destroyed" if will_destroy else "Unregistered"
         console.print(f"[green]{verb}:[/green] @{handle} from {room_name}")

--- a/mycelium-cli/src/mycelium/slim/identity.py
+++ b/mycelium-cli/src/mycelium/slim/identity.py
@@ -563,6 +563,64 @@ def provision_channel_identity(
     return {"mode": MODE_PSK, "handle": handle, "provisioned": False}
 
 
+def revoke_channel_identity(
+    handle: str, mode: str | None = None, data_dir: Path | None = None
+) -> dict[str, Any]:
+    """Revoke ``@handle``'s SLIM channel identity for the active mode. Idempotent.
+
+    The deprovisioning-time inverse of :func:`provision_channel_identity`
+    (``agent rm`` calls it): it removes the per-agent credential so a removed member
+    can no longer authenticate to the room — *without a room-wide re-key*, the
+    property the shared-secret PSK never had (#590). Symmetric and idempotent:
+    revoking an already-absent member is a no-op, not an error.
+
+    * ``psk`` — there is no per-agent credential to revoke; the only lever is
+      rotating ``MYCELIUM_SLIM_MASTER_SECRET`` for the whole room (the blunt
+      instrument this tier is stuck with). A no-op here.
+    * ``signerjwt`` — drop the member's public JWK from the roster (the inverse of
+      :func:`register_public_jwk`) and delete its local signing key. Once its key is
+      off the roster, peers' static-JWKS verifiers reject its self-signed tokens, so
+      it can't rejoin with the old credential — per-agent, no room-wide rotation.
+      Returns the removed paths (empty on a second/idempotent revoke).
+    * ``spire`` — the SVID is minted by the trust domain, so revocation is deleting
+      the SPIRE registration entry (``spire-server entry delete``), external to the
+      CLI's on-disk state. Return the member's SPIFFE-ID + the operator step; the
+      appliance path (``spire_registry.revoke_workload``) runs it when the server is
+      reachable. ``revoked`` is False — there is no local material to remove.
+
+    Every result carries ``mode``, ``handle``, and ``revoked``.
+    """
+    resolved = mode or resolve_identity_mode()
+    if resolved == MODE_SIGNERJWT:
+        jwk_path = public_jwk_path(handle, data_dir)
+        key_path = signing_key_path(handle, data_dir)
+        removed: list[str] = []
+        for path in (jwk_path, key_path):
+            if path.exists():
+                path.unlink()
+                removed.append(str(path))
+        return {
+            "mode": MODE_SIGNERJWT,
+            "handle": handle,
+            "revoked": bool(removed),
+            "removed": removed,
+            "roster_path": str(jwk_path),
+            "key_path": str(key_path),
+        }
+    if resolved == MODE_SPIRE:
+        trust_domain = resolve_spire_trust_domain()
+        spiffe_id = spiffe_id_for(handle, trust_domain)
+        return {
+            "mode": MODE_SPIRE,
+            "handle": handle,
+            "revoked": False,
+            "spiffe_id": spiffe_id,
+            "trust_domain": trust_domain,
+            "operator_step": (f"spire-server entry delete -entryID <entry-id for {spiffe_id}>"),
+        }
+    return {"mode": MODE_PSK, "handle": handle, "revoked": False}
+
+
 def resolve_identity_material(
     mode: str,
     handle: str,

--- a/mycelium-cli/tests/test_slim_identity.py
+++ b/mycelium-cli/tests/test_slim_identity.py
@@ -320,3 +320,66 @@ def test_provision_defaults_to_active_mode(tmp_path, monkeypatch):
     result = slim_identity.provision_channel_identity("alice", data_dir=tmp_path)
     assert result["mode"] == "signerjwt"
     assert result["provisioned"] is True
+
+
+# ── revoke_channel_identity: the payoff — per-member revoke, no re-key (#590) ──
+def test_revoke_psk_is_a_noop(tmp_path):
+    result = slim_identity.revoke_channel_identity("alice", slim_identity.MODE_PSK, tmp_path)
+    assert result == {"mode": "psk", "handle": "alice", "revoked": False}
+
+
+def test_revoke_signerjwt_drops_jwk_and_key(tmp_path):
+    slim_identity.provision_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    assert slim_identity.public_jwk_path("bob", tmp_path).exists()
+    assert slim_identity.signing_key_path("bob", tmp_path).exists()
+
+    result = slim_identity.revoke_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    assert result["mode"] == "signerjwt"
+    assert result["revoked"] is True
+    # Off the roster: peers' static-JWKS verifiers now reject its self-signed tokens.
+    assert not slim_identity.public_jwk_path("bob", tmp_path).exists()
+    assert not slim_identity.signing_key_path("bob", tmp_path).exists()
+
+
+def test_revoke_signerjwt_leaves_other_members_untouched(tmp_path):
+    # The key property the PSK can't offer: revoking @bob leaves @alice's credential
+    # and the rest of the roster intact — no room-wide re-key.
+    slim_identity.provision_channel_identity("alice", slim_identity.MODE_SIGNERJWT, tmp_path)
+    slim_identity.provision_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+
+    slim_identity.revoke_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+
+    assert slim_identity.public_jwk_path("alice", tmp_path).exists()
+    assert slim_identity.signing_key_path("alice", tmp_path).exists()
+    roster = slim_identity.load_roster_jwks(tmp_path)
+    assert roster is not None
+    kids = {jwk["kid"] for jwk in json.loads(roster)["keys"]}
+    assert kids == {"alice"}
+
+
+def test_revoke_signerjwt_is_idempotent(tmp_path):
+    slim_identity.provision_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    first = slim_identity.revoke_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    assert first["revoked"] is True
+    # Revoking an already-absent member is a no-op, not an error.
+    second = slim_identity.revoke_channel_identity("bob", slim_identity.MODE_SIGNERJWT, tmp_path)
+    assert second["revoked"] is False
+    assert second["removed"] == []
+
+
+def test_revoke_spire_returns_spiffe_and_operator_step(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_SPIRE_TRUST_DOMAIN", "acme.example")
+    result = slim_identity.revoke_channel_identity("alice", slim_identity.MODE_SPIRE, tmp_path)
+    assert result["mode"] == "spire"
+    # Entry deletion is external (needs the SPIRE server), so nothing is removed here.
+    assert result["revoked"] is False
+    assert result["spiffe_id"] == "spiffe://acme.example/agent/alice"
+    assert "spire-server entry delete" in result["operator_step"]
+
+
+def test_revoke_defaults_to_active_mode(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_SLIM_IDENTITY", "signerjwt")
+    slim_identity.provision_channel_identity("alice", data_dir=tmp_path)
+    result = slim_identity.revoke_channel_identity("alice", data_dir=tmp_path)
+    assert result["mode"] == "signerjwt"
+    assert result["revoked"] is True


### PR DESCRIPTION
Closes #590.

The payoff ticket: **revoke one member without re-keying everyone** — the reason per-member identity beats the shared-secret PSK. Builds on the merged plumbing (#476/#593 SignerJwt floor, #579/#601 SPIRE, #589/#603 the `@handle` spine).

## What changed

Added `revoke_channel_identity(handle, mode)` — the symmetric, idempotent inverse of `provision_channel_identity` — mirrored byte-for-byte in the backend (`app/services/slim_identity.py`) and CLI (`mycelium/slim/identity.py`) copies:

| tier | revoke |
|------|--------|
| `signerjwt` | drop the member's public JWK from the roster (inverse of `register_public_jwk`) + delete its local signing key. Off the roster, peers' static-JWKS verifiers reject its self-signed tokens → can't rejoin with the old credential, **no room-wide rotation**. |
| `spire` | return SPIFFE-ID + operator step (`spire-server entry delete`); entry deletion needs the SPIRE server, so the appliance path (`spire_registry.revoke_workload`) runs it, else the step is surfaced — same posture as #603's provisioning. |
| `psk` | no per-agent credential exists — a no-op; rotating `MYCELIUM_SLIM_MASTER_SECRET` is the only (blunt, room-wide) lever this tier has. |

Wired into **`agent rm`** via a `_revoke_channel_identity` dispatcher: signerjwt drops the JWK/key, spire delegates to the existing SPIRE registry deletion, psk prints the honest room-wide-rotation caveat.

## Acceptance

- ✅ Revocation wired into `agent rm` / deprovision — removes the credential per the active tier.
- ✅ **Others keep working, no re-key** — proven at the unit layer: `test_revoke_signerjwt_leaves_other_members_untouched` provisions @alice + @bob, revokes @bob, asserts @alice's key/JWK survive and the roster is left with only `alice`.
- ✅ Revoked member can't rejoin — its JWK is no longer on the roster (static-JWKS verifiers reject it).
- ✅ Idempotent — double-revoke is a no-op, not an error (`revoked: False`, `removed: []`).
- ✅ Off-by-default preserved; mirror rule holds (backend ↔ CLI copies byte-identical post-docstring).
- ✅ No new wire constant → `contracts/slim-l9-wire.json` unchanged.

## Testing

Backend + CLI unit suites cover psk no-op, signerjwt drop, the untouched-others property, idempotent double-revoke, spire operator step, and active-mode default. Both `test_slim_identity` + `test_slim_l9_wire` suites green (61 passed each); ruff + ty clean.

The **"remaining two still exchange messages after revocation, revoked one refused on rejoin"** rig verification is the issue author's on the matched 2.1.0 stack, per the division of labor in the ticket.

## Out of scope
Appliance SPIRE deploy profile (#588). No design docs added — rationale lives here.