### PR TITLE
docs(identity): validated Keycloak setup guide (human OIDC tier) (#565)

### DIFF
--- a/docs/design/dev-auth-issuer.md
+++ b/docs/design/dev-auth-issuer.md
@@ -100,4 +100,6 @@ Operator-facing documentation for the gate itself lives in the docs site under
 
 - ~~#561 — HTTP-API JWT gate (validate against this issuer's JWKS)~~ — landed
 - #562 — verified handle binding (consume the principal this gate resolves)
-- #565 — replace this with the real Keycloak (humans) + SPIRE (agents) wiring
+- ~~#565 — real Keycloak (humans) wiring~~ — landed: a validated operator guide
+  (`docs/guides/keycloak-oidc.md`) + an opt-in `compose-keycloak.yml` overlay. SPIRE
+  (agents) shipped separately in #588.

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -73,6 +73,7 @@ SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
     ("guides/structured-memory.md", "structured-memory",  "reference", "Guides",       "Structured Memory"),
     ("guides/hub-and-spoke.md",     "hub-and-spoke",      "reference", "Guides",       "Hub & Spoke"),
     ("guides/auth.md",              "auth",               "reference", "Guides",       "Authentication"),
+    ("guides/keycloak-oidc.md",     "keycloak-oidc",      "reference", "Guides",       "Keycloak / OIDC Setup"),
     ("guides/spire-identity.md",    "spire-identity",     "reference", "Guides",       "Attested Identity (SPIRE)"),
     ("troubleshooting.md",          "troubleshooting",    "reference", "Help",         "Troubleshooting"),
 ]

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1857,6 +1857,196 @@ JWKS key can never be replayed as an HMAC secret.
 A dev OIDC issuer ships for exactly this, so you can exercise the gate without
 standing up Keycloak. See `docs/design/dev-auth-issuer.md`.
 
+For the real thing — a Keycloak realm, client, and human `mycelium login`, wired
+end-to-end — follow the [Keycloak / OIDC Setup](#keycloak-oidc) guide.
+
+
+---
+
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Keycloak / OIDC setup
+
+[Authentication](#auth) explains the gate in the abstract: the backend trusts an
+OIDC issuer and validates a bearer token against its JWKS. This guide makes the
+**human OIDC tier** concrete against real **Keycloak** — realm, client, the claims
+the gate keys off, and a human `mycelium login`. Every command here was run against
+a live Keycloak; the wiring below is confirmed, not aspirational.
+
+Keycloak is a *supported* issuer, not the default. The gate stays **off by default**
+(the try-it path never touches it) — you turn it on when a team shares a hub over a
+network. Dex, ZITADEL, Authentik, or your corporate SSO slot in exactly the same
+way; nothing here is Keycloak-specific except the URLs.
+
+## Stand up Keycloak
+
+A ready-to-run Keycloak ships as an **opt-in compose overlay** — off the default
+stack, added with an extra `-f` exactly like the dev issuer. It imports a `mycelium`
+realm with a public CLI client, an audience mapper, and a demo user, so there is
+nothing to click in the admin console.
+
+```bash
+cd mycelium-cli/src/mycelium/docker
+docker compose -f compose.yml -f compose-dev.yml -f compose-keycloak.yml \
+  up -d keycloak
+```
+
+The realm is ready when discovery answers:
+
+```bash
+curl -s http://localhost:8080/realms/mycelium/.well-known/openid-configuration \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["issuer"])'
+# → http://localhost:8080/realms/mycelium
+```
+
+> **Port already in use?** Publish it elsewhere with
+> `MYCELIUM_KEYCLOAK_PORT=8085 docker compose … up -d keycloak`. The overlay pins
+> Keycloak's advertised URL to the same port, so the issuer becomes
+> `http://localhost:8085/realms/mycelium` — use that everywhere below. The admin
+> console is at `/admin` (`admin` / `admin`, override with
+> `MYCELIUM_KEYCLOAK_ADMIN[_PASSWORD]`).
+
+## What the realm ships (and what the gate expects)
+
+The imported realm (`docker/keycloak/mycelium-realm.json`) is the whole anatomy the
+gate needs. Point your own Keycloak at these same four things:
+
+- **A public client `mycelium-cli`** — this is the client `mycelium login` uses.
+  Public (no secret; it authenticates with PKCE), with the loopback redirect
+  `http://127.0.0.1:*/callback` for the browser flow and the **device grant** enabled
+  for headless login.
+- **An audience mapper** stamping `mycelium` into the access token's `aud`. This is
+  what makes `auth.audience = "mycelium"` meaningful — a token minted for some other
+  app on the same Keycloak is refused.
+- **`sub` is a UUID, so the human handle comes from `preferred_username`.** Set
+  `auth.handle_claim = "preferred_username"` for the human tier — otherwise every
+  human arrives as an opaque UUID instead of `@demo`.
+- **A demo user** (`demo` / `demo`) so a human login has someone to sign in as.
+
+> **A gotcha worth knowing if you build your own client:** the CLI's *device* flow
+> does not send PKCE parameters, so do **not** set the client to *require* PKCE
+> (`pkce.code.challenge.method`) — that rejects the device grant with
+> `Missing parameter: code_challenge_method`. Leave enforcement off; the CLI still
+> uses PKCE on the browser flow, Keycloak just doesn't mandate it on every grant.
+
+## Wire the gate
+
+The one subtlety worth understanding is **which URL goes where**, because the
+backend runs in a container and the browser/CLI run on the host:
+
+- Keycloak stamps the token `iss` as `http://localhost:8080/realms/mycelium` for
+  every caller (the overlay pins its advertised URL). That is what the browser and
+  CLI reach it by, so it is the `issuer` the gate matches.
+- The **backend can't use `localhost`** — inside the container that is the backend
+  itself. On the compose network Keycloak is reachable as `keycloak:8080`, so that
+  is where the backend fetches keys from.
+
+The gate matches `iss` by **exact string** but fetches keys from a **separately
+configured `jwks_url`**, so you point them at different hostnames on purpose. In
+`~/.mycelium/config.toml`:
+
+```toml
+[auth]
+enabled      = true
+audience     = "mycelium"
+handle_claim = "preferred_username"
+
+[[auth.issuers]]
+issuer   = "http://localhost:8080/realms/mycelium"
+jwks_url = "http://keycloak:8080/realms/mycelium/protocol/openid-connect/certs"
+role     = "user"
+
+[login]
+issuer    = "http://localhost:8080/realms/mycelium"
+client_id = "mycelium-cli"
+audience  = "mycelium"
+```
+
+Apply it and recreate the backend so it picks up the gate:
+
+```bash
+mycelium config apply
+docker compose -f compose.yml -f compose-dev.yml -f compose-keycloak.yml \
+  up -d --force-recreate mycelium-backend
+```
+
+`/health` now reports the gate on and the issuer trusted:
+
+```bash
+curl -s http://localhost:8000/health | python3 -m json.tool
+# "auth": { "enabled": true, "issuers": ["http://localhost:8080/realms/mycelium"],
+#           "audience": "mycelium", "localhost_bypass": true }
+```
+
+> **The localhost bypass does not save you here** — and that is the point. Traffic
+> from the CLI to the containerized backend arrives from the Docker bridge, not real
+> loopback, so the gate genuinely enforces. See
+> [Authentication → The localhost bypass](#auth).
+
+## Sign in with `mycelium login`
+
+```bash
+mycelium login            # opens your browser to Keycloak
+mycelium login --device   # headless: prints a URL + code to approve from any device
+```
+
+Sign in as `demo` / `demo`. The CLI caches the token (`~/.mycelium/token.json`,
+mode `0600`) and every later command carries it:
+
+```bash
+mycelium whoami
+# acting as @demo
+#   signed in (http://localhost:8080/realms/mycelium, expires in 4 min)
+
+mycelium room ls          # now authorized through the Keycloak token
+```
+
+`mycelium logout` drops the session and the CLI goes back to sending no token.
+
+## Prove the gate (what "validated" means)
+
+The same three checks that were run to confirm this guide, against the published
+backend port:
+
+```bash
+# A real Keycloak token for the demo user
+TOKEN=$(curl -s -X POST \
+  http://localhost:8080/realms/mycelium/protocol/openid-connect/token \
+  -d 'grant_type=password&client_id=mycelium-cli&username=demo&password=demo&scope=openid profile' \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
+
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8000/api/rooms              # 401  (no token)
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/api/rooms                                                     # 200  (valid)
+curl -s -o /dev/null -w '%{http_code}\n' -H 'Authorization: Bearer not.a.jwt' \
+  http://localhost:8000/api/rooms                                                     # 401  (garbage)
+```
+
+An **expired** token is refused the same way — the response is
+`401` with `token rejected: Signature has expired` once it ages past `exp` plus
+`auth.leeway_s` (default 60s).
+
+## Agents, and more than one issuer
+
+This guide is the **human** tier. Agents authenticate as workloads with the
+`client_credentials` grant from their own Keycloak client — see
+[Authentication → Agents sign in as themselves](#auth). Humans and agents are often
+separate realms; list each as its own `[[auth.issuers]]` block (a human root with
+`role = "user"`, an agent root with `role = "agent"`), matched by exact `iss` and
+never interchangeable.
+
+For the tightest, individually-attested agent identity on the SLIM channel itself,
+see [Attested Identity (SPIRE)](#spire-identity) — a different, heavier tier from
+this HTTP-API gate.
+
+## The honest ceiling
+
+The shipped overlay is **dev-grade**: Keycloak in `start-dev` (in-memory H2, HTTP,
+a demo user with a weak password). It is a real OIDC provider minting real RS256
+tokens against a real JWKS — enough to build and prove against — but it is **not** a
+hardened production Keycloak. For a real deployment, run your own Keycloak over TLS
+with a persistent datastore and real users, then point the same three config values
+(`issuer`, `jwks_url`, `login.issuer`) at it. Nothing else changes.
+
 
 ---
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -110,6 +110,7 @@
       <a href="#structured-memory" class="nav-link sub">Structured Memory</a>
       <a href="#hub-and-spoke" class="nav-link sub">Hub &amp; Spoke</a>
       <a href="#auth" class="nav-link sub">Authentication</a>
+      <a href="#keycloak-oidc" class="nav-link sub">Keycloak / OIDC Setup</a>
       <a href="#spire-identity" class="nav-link sub">Attested Identity (SPIRE)</a>
     </div>
     <div class="nav-section">
@@ -1392,6 +1393,116 @@ role   = &quot;agent&quot;</code></pre>
       <p>Only asymmetric signatures are accepted (<code>RS<em></code>, <code>PS</em></code>, <code>ES<em></code>). The <code>none</code> algorithm and the whole <code>HS</em></code> family are refused before verification, so a public JWKS key can never be replayed as an HMAC secret.</p>
       <h2 id="auth-trying-it-locally">Trying it locally</h2>
       <p>A dev OIDC issuer ships for exactly this, so you can exercise the gate without standing up Keycloak. See <code>docs/design/dev-auth-issuer.md</code>.</p>
+      <p>For the real thing — a Keycloak realm, client, and human <code>mycelium login</code>, wired end-to-end — follow the <a href="#keycloak-oidc">Keycloak / OIDC Setup</a> guide.</p>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="keycloak-oidc">
+      <p>&lt;!-- SPDX-License-Identifier: Apache-2.0 --&gt;</p>
+      <h1>Keycloak / OIDC setup</h1>
+      <p><a href="#auth">Authentication</a> explains the gate in the abstract: the backend trusts an OIDC issuer and validates a bearer token against its JWKS. This guide makes the <strong>human OIDC tier</strong> concrete against real <strong>Keycloak</strong> — realm, client, the claims the gate keys off, and a human <code>mycelium login</code>. Every command here was run against a live Keycloak; the wiring below is confirmed, not aspirational.</p>
+      <p>Keycloak is a <em>supported</em> issuer, not the default. The gate stays <strong>off by default</strong> (the try-it path never touches it) — you turn it on when a team shares a hub over a network. Dex, ZITADEL, Authentik, or your corporate SSO slot in exactly the same way; nothing here is Keycloak-specific except the URLs.</p>
+      <h2 id="keycloak-oidc-stand-up-keycloak">Stand up Keycloak</h2>
+      <p>A ready-to-run Keycloak ships as an <strong>opt-in compose overlay</strong> — off the default stack, added with an extra <code>-f</code> exactly like the dev issuer. It imports a <code>mycelium</code> realm with a public CLI client, an audience mapper, and a demo user, so there is nothing to click in the admin console.</p>
+      <pre><code>cd mycelium-cli/src/mycelium/docker
+docker compose <span class="flag">-f</span> compose.yml <span class="flag">-f</span> compose-dev.yml <span class="flag">-f</span> compose-keycloak.yml \
+  up <span class="flag">-d</span> keycloak</code></pre>
+      <p>The realm is ready when discovery answers:</p>
+      <pre><code>curl <span class="flag">-s</span> http://localhost:8080/realms/mycelium/.well-known/openid-configuration \
+  | python3 <span class="flag">-c</span> &#x27;import json,sys; print(json.load(sys.stdin)[<span class="str">&quot;issuer&quot;</span>])&#x27;
+<span class="comment"># → http://localhost:8080/realms/mycelium</span></code></pre>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Port already in use?</strong> Publish it elsewhere with <code>MYCELIUM_KEYCLOAK_PORT=8085 docker compose … up -d keycloak</code>. The overlay pins Keycloak&#x27;s advertised URL to the same port, so the issuer becomes <code>http://localhost:8085/realms/mycelium</code> — use that everywhere below. The admin console is at <code>/admin</code> (<code>admin</code> / <code>admin</code>, override with <code>MYCELIUM_KEYCLOAK_ADMIN[_PASSWORD]</code>).</div>
+      </div>
+      <h2 id="keycloak-oidc-what-the-realm-ships-and-what-the-gate-expects">What the realm ships (and what the gate expects)</h2>
+      <p>The imported realm (<code>docker/keycloak/mycelium-realm.json</code>) is the whole anatomy the gate needs. Point your own Keycloak at these same four things:</p>
+      <ul>
+        <li><strong>A public client <code>mycelium-cli</code></strong> — this is the client <code>mycelium login</code> uses.</li>
+      </ul>
+      <p>Public (no secret; it authenticates with PKCE), with the loopback redirect <code>http://127.0.0.1:*/callback</code> for the browser flow and the <strong>device grant</strong> enabled for headless login.</p>
+      <ul>
+        <li><strong>An audience mapper</strong> stamping <code>mycelium</code> into the access token&#x27;s <code>aud</code>. This is</li>
+      </ul>
+      <p>what makes <code>auth.audience = &quot;mycelium&quot;</code> meaningful — a token minted for some other app on the same Keycloak is refused.</p>
+      <ul>
+        <li><strong><code>sub</code> is a UUID, so the human handle comes from <code>preferred_username</code>.</strong> Set</li>
+      </ul>
+      <p><code>auth.handle_claim = &quot;preferred_username&quot;</code> for the human tier — otherwise every human arrives as an opaque UUID instead of <code>@demo</code>.</p>
+      <ul>
+        <li><strong>A demo user</strong> (<code>demo</code> / <code>demo</code>) so a human login has someone to sign in as.</li>
+      </ul>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>A gotcha worth knowing if you build your own client:</strong> the CLI&#x27;s <em>device</em> flow does not send PKCE parameters, so do <strong>not</strong> set the client to <em>require</em> PKCE (<code>pkce.code.challenge.method</code>) — that rejects the device grant with <code>Missing parameter: code_challenge_method</code>. Leave enforcement off; the CLI still uses PKCE on the browser flow, Keycloak just doesn&#x27;t mandate it on every grant.</div>
+      </div>
+      <h2 id="keycloak-oidc-wire-the-gate">Wire the gate</h2>
+      <p>The one subtlety worth understanding is <strong>which URL goes where</strong>, because the backend runs in a container and the browser/CLI run on the host:</p>
+      <ul>
+        <li>Keycloak stamps the token <code>iss</code> as <code>http://localhost:8080/realms/mycelium</code> for</li>
+      </ul>
+      <p>every caller (the overlay pins its advertised URL). That is what the browser and CLI reach it by, so it is the <code>issuer</code> the gate matches.</p>
+      <ul>
+        <li>The <strong>backend can&#x27;t use <code>localhost</code></strong> — inside the container that is the backend</li>
+      </ul>
+      <p>itself. On the compose network Keycloak is reachable as <code>keycloak:8080</code>, so that is where the backend fetches keys from.</p>
+      <p>The gate matches <code>iss</code> by <strong>exact string</strong> but fetches keys from a <strong>separately configured <code>jwks_url</code></strong>, so you point them at different hostnames on purpose. In <code>~/.mycelium/config.toml</code>:</p>
+      <pre><code>[auth]
+enabled      = true
+audience     = &quot;mycelium&quot;
+handle_claim = &quot;preferred_username&quot;
+
+[[auth.issuers]]
+issuer   = &quot;http://localhost:8080/realms/mycelium&quot;
+jwks_url = &quot;http://keycloak:8080/realms/mycelium/protocol/openid-connect/certs&quot;
+role     = &quot;user&quot;
+
+[login]
+issuer    = &quot;http://localhost:8080/realms/mycelium&quot;
+client_id = &quot;mycelium-cli&quot;
+audience  = &quot;mycelium&quot;</code></pre>
+      <p>Apply it and recreate the backend so it picks up the gate:</p>
+      <pre><code><span class="cmd">mycelium config apply</span>
+docker compose <span class="flag">-f</span> compose.yml <span class="flag">-f</span> compose-dev.yml <span class="flag">-f</span> compose-keycloak.yml \
+  up <span class="flag">-d</span> <span class="flag">--force-recreate</span> mycelium-backend</code></pre>
+      <p><code>/health</code> now reports the gate on and the issuer trusted:</p>
+      <pre><code>curl <span class="flag">-s</span> http://localhost:8000/health | python3 <span class="flag">-m</span> json.tool
+<span class="comment"># &quot;auth&quot;: { &quot;enabled&quot;: true, &quot;issuers&quot;: [&quot;http://localhost:8080/realms/mycelium&quot;],</span>
+<span class="comment">#           &quot;audience&quot;: &quot;mycelium&quot;, &quot;localhost_bypass&quot;: true }</span></code></pre>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>The localhost bypass does not save you here</strong> — and that is the point. Traffic from the CLI to the containerized backend arrives from the Docker bridge, not real loopback, so the gate genuinely enforces. See <a href="#auth">Authentication → The localhost bypass</a>.</div>
+      </div>
+      <h2 id="keycloak-oidc-sign-in-with-mycelium-login">Sign in with <code>mycelium login</code></h2>
+      <pre><code><span class="cmd">mycelium login</span>            # opens your browser to Keycloak
+<span class="cmd">mycelium login</span> <span class="flag">--device</span>   # headless: prints a URL + code to approve from any device</code></pre>
+      <p>Sign in as <code>demo</code> / <code>demo</code>. The CLI caches the token (<code>~/.mycelium/token.json</code>, mode <code>0600</code>) and every later command carries it:</p>
+      <pre><code><span class="cmd">mycelium whoami</span>
+<span class="comment"># acting as @demo</span>
+<span class="comment">#   signed in (http://localhost:8080/realms/mycelium, expires in 4 min)</span>
+
+<span class="cmd">mycelium room ls</span>          # now authorized through the Keycloak token</code></pre>
+      <p><code>mycelium logout</code> drops the session and the CLI goes back to sending no token.</p>
+      <h2 id="keycloak-oidc-prove-the-gate-what-validated-means">Prove the gate (what &quot;validated&quot; means)</h2>
+      <p>The same three checks that were run to confirm this guide, against the published backend port:</p>
+      <pre><code><span class="comment"># A real Keycloak token for the demo user</span>
+TOKEN=$(curl <span class="flag">-s</span> <span class="flag">-X</span> POST \
+  http://localhost:8080/realms/mycelium/protocol/openid-connect/token \
+  <span class="flag">-d</span> &#x27;grant_type=password&amp;client_id=mycelium-cli&amp;username=demo&amp;password=demo&amp;scope=openid profile&#x27; \
+  | python3 <span class="flag">-c</span> &#x27;import json,sys; print(json.load(sys.stdin)[<span class="str">&quot;access_token&quot;</span>])&#x27;)
+
+curl <span class="flag">-s</span> <span class="flag">-o</span> /dev/null <span class="flag">-w</span> &#x27;%{http_code}\n&#x27; http://localhost:8000/api/rooms              # 401  (no token)
+curl <span class="flag">-s</span> <span class="flag">-o</span> /dev/null <span class="flag">-w</span> &#x27;%{http_code}\n&#x27; <span class="flag">-H</span> <span class="str">&quot;Authorization: Bearer $TOKEN&quot;</span> \
+  http://localhost:8000/api/rooms                                                     # 200  (valid)
+curl <span class="flag">-s</span> <span class="flag">-o</span> /dev/null <span class="flag">-w</span> &#x27;%{http_code}\n&#x27; <span class="flag">-H</span> &#x27;Authorization: Bearer not.a.jwt&#x27; \
+  http://localhost:8000/api/rooms                                                     # 401  (garbage)</code></pre>
+      <p>An <strong>expired</strong> token is refused the same way — the response is <code>401</code> with <code>token rejected: Signature has expired</code> once it ages past <code>exp</code> plus <code>auth.leeway_s</code> (default 60s).</p>
+      <h2 id="keycloak-oidc-agents-and-more-than-one-issuer">Agents, and more than one issuer</h2>
+      <p>This guide is the <strong>human</strong> tier. Agents authenticate as workloads with the <code>client_credentials</code> grant from their own Keycloak client — see <a href="#auth">Authentication → Agents sign in as themselves</a>. Humans and agents are often separate realms; list each as its own <code>[[auth.issuers]]</code> block (a human root with <code>role = &quot;user&quot;</code>, an agent root with <code>role = &quot;agent&quot;</code>), matched by exact <code>iss</code> and never interchangeable.</p>
+      <p>For the tightest, individually-attested agent identity on the SLIM channel itself, see <a href="#spire-identity">Attested Identity (SPIRE)</a> — a different, heavier tier from this HTTP-API gate.</p>
+      <h2 id="keycloak-oidc-the-honest-ceiling">The honest ceiling</h2>
+      <p>The shipped overlay is <strong>dev-grade</strong>: Keycloak in <code>start-dev</code> (in-memory H2, HTTP, a demo user with a weak password). It is a real OIDC provider minting real RS256 tokens against a real JWKS — enough to build and prove against — but it is <strong>not</strong> a hardened production Keycloak. For a real deployment, run your own Keycloak over TLS with a persistent datastore and real users, then point the same three config values (<code>issuer</code>, <code>jwks_url</code>, <code>login.issuer</code>) at it. Nothing else changes.</p>
     </section>
 
     <hr class="divider">

--- a/mycelium-cli/src/mycelium/docker/compose-keycloak.yml
+++ b/mycelium-cli/src/mycelium/docker/compose-keycloak.yml
@@ -1,0 +1,45 @@
+# Real Keycloak issuer for the human OIDC tier (#565).
+#
+# Unlike compose-auth-dev.yml (the mock issuer, #566), this is a REAL OIDC
+# provider: it authenticates a real user and mints RS256 tokens against a real
+# JWKS. It is still an OPT-IN overlay, off the default try-it path — you add it
+# with an extra `-f` exactly like the dev issuer, and the base stack is
+# byte-for-byte unchanged without it.
+#
+# Bring it up alongside the running stack (from the docker/ dir, same project):
+#   docker compose \
+#     -f compose.yml -f compose-dev.yml -f compose-keycloak.yml \
+#     up -d keycloak
+#
+# The realm import (keycloak/mycelium-realm.json) ships a `mycelium` realm with:
+#   • a public PKCE client `mycelium-cli` (Authorization Code + Device Code,
+#     loopback redirect) — the client `mycelium login` uses,
+#   • an audience mapper stamping `mycelium` into the access token's `aud`, and
+#   • a demo user (demo / demo) so a human login has someone to sign in as.
+#
+# THE ISSUER/HOSTNAME SPLIT (this is the crux the guide documents):
+#   KC_HOSTNAME pins the token `iss` to http://localhost:8080/realms/mycelium
+#   regardless of which host reached Keycloak. The browser/CLI reach it at
+#   localhost:8080 (matches iss); the backend, on the compose network, cannot use
+#   `localhost` (that is the backend container itself) — so the gate is pointed at
+#   jwks_url http://keycloak:8080/realms/mycelium/protocol/openid-connect/certs
+#   for key fetch while still matching iss by exact string. See
+#   docs/guides/keycloak-oidc.md.
+
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.1
+    container_name: mycelium-keycloak
+    restart: unless-stopped
+    command: ["start-dev", "--import-realm"]
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${MYCELIUM_KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${MYCELIUM_KEYCLOAK_ADMIN_PASSWORD:-admin}
+      # Pin the advertised base URL so the minted `iss` is stable across callers.
+      KC_HOSTNAME: http://localhost:${MYCELIUM_KEYCLOAK_PORT:-8080}
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    volumes:
+      - ./keycloak/mycelium-realm.json:/opt/keycloak/data/import/mycelium-realm.json:ro
+    ports:
+      - "${MYCELIUM_KEYCLOAK_PORT:-8080}:8080"

--- a/mycelium-cli/src/mycelium/docker/keycloak/mycelium-realm.json
+++ b/mycelium-cli/src/mycelium/docker/keycloak/mycelium-realm.json
@@ -1,0 +1,65 @@
+{
+  "realm": "mycelium",
+  "enabled": true,
+  "displayName": "Mycelium",
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "accessTokenLifespan": 300,
+  "clients": [
+    {
+      "clientId": "mycelium-cli",
+      "name": "Mycelium CLI",
+      "description": "Public client for `mycelium login` (Authorization Code + PKCE and Device Code).",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "redirectUris": [
+        "http://127.0.0.1/*",
+        "http://127.0.0.1:*/callback",
+        "http://localhost:*/callback"
+      ],
+      "webOrigins": ["+"],
+      "attributes": {
+        "oauth2.device.authorization.grant.enabled": "true",
+        "standard.token.exchange.enabled": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "mycelium-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "mycelium",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "demo",
+      "enabled": true,
+      "emailVerified": true,
+      "email": "demo@mycelium.dev",
+      "firstName": "Demo",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "demo",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["default-roles-mycelium"]
+    }
+  ]
+}

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -364,3 +364,6 @@ JWKS key can never be replayed as an HMAC secret.
 
 A dev OIDC issuer ships for exactly this, so you can exercise the gate without
 standing up Keycloak. See `docs/design/dev-auth-issuer.md`.
+
+For the real thing — a Keycloak realm, client, and human `mycelium login`, wired
+end-to-end — follow the [Keycloak / OIDC Setup](#keycloak-oidc) guide.

--- a/mycelium-cli/src/mycelium/docs/guides/keycloak-oidc.md
+++ b/mycelium-cli/src/mycelium/docs/guides/keycloak-oidc.md
@@ -1,0 +1,183 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+# Keycloak / OIDC setup
+
+[Authentication](#auth) explains the gate in the abstract: the backend trusts an
+OIDC issuer and validates a bearer token against its JWKS. This guide makes the
+**human OIDC tier** concrete against real **Keycloak** — realm, client, the claims
+the gate keys off, and a human `mycelium login`. Every command here was run against
+a live Keycloak; the wiring below is confirmed, not aspirational.
+
+Keycloak is a *supported* issuer, not the default. The gate stays **off by default**
+(the try-it path never touches it) — you turn it on when a team shares a hub over a
+network. Dex, ZITADEL, Authentik, or your corporate SSO slot in exactly the same
+way; nothing here is Keycloak-specific except the URLs.
+
+## Stand up Keycloak
+
+A ready-to-run Keycloak ships as an **opt-in compose overlay** — off the default
+stack, added with an extra `-f` exactly like the dev issuer. It imports a `mycelium`
+realm with a public CLI client, an audience mapper, and a demo user, so there is
+nothing to click in the admin console.
+
+```bash
+cd mycelium-cli/src/mycelium/docker
+docker compose -f compose.yml -f compose-dev.yml -f compose-keycloak.yml \
+  up -d keycloak
+```
+
+The realm is ready when discovery answers:
+
+```bash
+curl -s http://localhost:8080/realms/mycelium/.well-known/openid-configuration \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["issuer"])'
+# → http://localhost:8080/realms/mycelium
+```
+
+> **Port already in use?** Publish it elsewhere with
+> `MYCELIUM_KEYCLOAK_PORT=8085 docker compose … up -d keycloak`. The overlay pins
+> Keycloak's advertised URL to the same port, so the issuer becomes
+> `http://localhost:8085/realms/mycelium` — use that everywhere below. The admin
+> console is at `/admin` (`admin` / `admin`, override with
+> `MYCELIUM_KEYCLOAK_ADMIN[_PASSWORD]`).
+
+## What the realm ships (and what the gate expects)
+
+The imported realm (`docker/keycloak/mycelium-realm.json`) is the whole anatomy the
+gate needs. Point your own Keycloak at these same four things:
+
+- **A public client `mycelium-cli`** — this is the client `mycelium login` uses.
+  Public (no secret; it authenticates with PKCE), with the loopback redirect
+  `http://127.0.0.1:*/callback` for the browser flow and the **device grant** enabled
+  for headless login.
+- **An audience mapper** stamping `mycelium` into the access token's `aud`. This is
+  what makes `auth.audience = "mycelium"` meaningful — a token minted for some other
+  app on the same Keycloak is refused.
+- **`sub` is a UUID, so the human handle comes from `preferred_username`.** Set
+  `auth.handle_claim = "preferred_username"` for the human tier — otherwise every
+  human arrives as an opaque UUID instead of `@demo`.
+- **A demo user** (`demo` / `demo`) so a human login has someone to sign in as.
+
+> **A gotcha worth knowing if you build your own client:** the CLI's *device* flow
+> does not send PKCE parameters, so do **not** set the client to *require* PKCE
+> (`pkce.code.challenge.method`) — that rejects the device grant with
+> `Missing parameter: code_challenge_method`. Leave enforcement off; the CLI still
+> uses PKCE on the browser flow, Keycloak just doesn't mandate it on every grant.
+
+## Wire the gate
+
+The one subtlety worth understanding is **which URL goes where**, because the
+backend runs in a container and the browser/CLI run on the host:
+
+- Keycloak stamps the token `iss` as `http://localhost:8080/realms/mycelium` for
+  every caller (the overlay pins its advertised URL). That is what the browser and
+  CLI reach it by, so it is the `issuer` the gate matches.
+- The **backend can't use `localhost`** — inside the container that is the backend
+  itself. On the compose network Keycloak is reachable as `keycloak:8080`, so that
+  is where the backend fetches keys from.
+
+The gate matches `iss` by **exact string** but fetches keys from a **separately
+configured `jwks_url`**, so you point them at different hostnames on purpose. In
+`~/.mycelium/config.toml`:
+
+```toml
+[auth]
+enabled      = true
+audience     = "mycelium"
+handle_claim = "preferred_username"
+
+[[auth.issuers]]
+issuer   = "http://localhost:8080/realms/mycelium"
+jwks_url = "http://keycloak:8080/realms/mycelium/protocol/openid-connect/certs"
+role     = "user"
+
+[login]
+issuer    = "http://localhost:8080/realms/mycelium"
+client_id = "mycelium-cli"
+audience  = "mycelium"
+```
+
+Apply it and recreate the backend so it picks up the gate:
+
+```bash
+mycelium config apply
+docker compose -f compose.yml -f compose-dev.yml -f compose-keycloak.yml \
+  up -d --force-recreate mycelium-backend
+```
+
+`/health` now reports the gate on and the issuer trusted:
+
+```bash
+curl -s http://localhost:8000/health | python3 -m json.tool
+# "auth": { "enabled": true, "issuers": ["http://localhost:8080/realms/mycelium"],
+#           "audience": "mycelium", "localhost_bypass": true }
+```
+
+> **The localhost bypass does not save you here** — and that is the point. Traffic
+> from the CLI to the containerized backend arrives from the Docker bridge, not real
+> loopback, so the gate genuinely enforces. See
+> [Authentication → The localhost bypass](#auth).
+
+## Sign in with `mycelium login`
+
+```bash
+mycelium login            # opens your browser to Keycloak
+mycelium login --device   # headless: prints a URL + code to approve from any device
+```
+
+Sign in as `demo` / `demo`. The CLI caches the token (`~/.mycelium/token.json`,
+mode `0600`) and every later command carries it:
+
+```bash
+mycelium whoami
+# acting as @demo
+#   signed in (http://localhost:8080/realms/mycelium, expires in 4 min)
+
+mycelium room ls          # now authorized through the Keycloak token
+```
+
+`mycelium logout` drops the session and the CLI goes back to sending no token.
+
+## Prove the gate (what "validated" means)
+
+The same three checks that were run to confirm this guide, against the published
+backend port:
+
+```bash
+# A real Keycloak token for the demo user
+TOKEN=$(curl -s -X POST \
+  http://localhost:8080/realms/mycelium/protocol/openid-connect/token \
+  -d 'grant_type=password&client_id=mycelium-cli&username=demo&password=demo&scope=openid profile' \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["access_token"])')
+
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8000/api/rooms              # 401  (no token)
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/api/rooms                                                     # 200  (valid)
+curl -s -o /dev/null -w '%{http_code}\n' -H 'Authorization: Bearer not.a.jwt' \
+  http://localhost:8000/api/rooms                                                     # 401  (garbage)
+```
+
+An **expired** token is refused the same way — the response is
+`401` with `token rejected: Signature has expired` once it ages past `exp` plus
+`auth.leeway_s` (default 60s).
+
+## Agents, and more than one issuer
+
+This guide is the **human** tier. Agents authenticate as workloads with the
+`client_credentials` grant from their own Keycloak client — see
+[Authentication → Agents sign in as themselves](#auth). Humans and agents are often
+separate realms; list each as its own `[[auth.issuers]]` block (a human root with
+`role = "user"`, an agent root with `role = "agent"`), matched by exact `iss` and
+never interchangeable.
+
+For the tightest, individually-attested agent identity on the SLIM channel itself,
+see [Attested Identity (SPIRE)](#spire-identity) — a different, heavier tier from
+this HTTP-API gate.
+
+## The honest ceiling
+
+The shipped overlay is **dev-grade**: Keycloak in `start-dev` (in-memory H2, HTTP,
+a demo user with a weak password). It is a real OIDC provider minting real RS256
+tokens against a real JWKS — enough to build and prove against — but it is **not** a
+hardened production Keycloak. For a real deployment, run your own Keycloak over TLS
+with a persistent datastore and real users, then point the same three config values
+(`issuer`, `jwks_url`, `login.issuer`) at it. Nothing else changes.


### PR DESCRIPTION
Closes #565 — the last open child of the identity epic (#560).

## What & why
The HTTP-API JWT gate, `mycelium login` (PKCE + device flow), and a generic
`guides/auth.md` already shipped, but they had only ever been exercised against
the **mock-oauth2 dev issuer** (#566) — never real Keycloak. This adds the
**human OIDC tier documented for Keycloak**, and — per the project's live-verify
discipline — **validated by actually running the stack against Keycloak.**

## What shipped
- **`compose-keycloak.yml` + `keycloak/mycelium-realm.json`** — an opt-in overlay
  (added with an extra `-f`, like the dev issuer; off the default try-it path).
  The realm import ships: a public PKCE client `mycelium-cli` (Authorization Code
  + Device grant, loopback redirect), an **audience mapper** stamping `mycelium`
  into `aud`, and a `demo`/`demo` user — zero admin-console clicks.
- **`docs/guides/keycloak-oidc.md`** — the operator guide, registered in
  `generate_docs.py` `SECTION_CONFIG` and rendered under **Reference → Guides**.
- Loose ends: `dev-auth-issuer.md` #565 line marked landed; `auth.md`
  "Trying it locally" now links the Keycloak guide.

## Validation (the point of the ticket)
Ran live against a real Keycloak:
- `mycelium login --device` minted a **real Keycloak** token; `mycelium whoami`
  reported *signed in as @demo*, and a gated `mycelium room ls` succeeded.
- Gate proofs against the published backend port: **no token → 401**,
  **valid Keycloak token → 200**, **garbage → 401**, **expired → 401**
  (`token rejected: Signature has expired`).
- `/health` showed the gate on with the Keycloak issuer trusted.
- Clean-room re-import of the shipped realm JSON reproduces it from scratch.

## Two gotchas found by running it (baked into the guide/realm)
1. **Issuer vs `jwks_url` decoupling** — the token `iss` is `localhost:8080`
   (what the browser/CLI mint), but the containerized backend can't use
   `localhost`, so `jwks_url` points at `keycloak:8080`. The gate matches `iss`
   by exact string yet fetches keys from a separate URL — so this split is the fix.
2. **Don't mandate PKCE on the client** — the CLI's *device* flow sends no PKCE
   params, so client-level enforcement rejects it with
   `Missing parameter: code_challenge_method`. The client uses PKCE on the browser
   flow without the server requiring it everywhere.

Human handle comes from `preferred_username` (Keycloak `sub` is a UUID) → the
guide sets `auth.handle_claim = "preferred_username"`.

## Out of scope
- Making Keycloak the default (non-goal; stays off, #567).
- **Frontend browser OIDC login flow** — the Next.js app has no OIDC support today
  and assumes an ungated backend; tracked in **#606**.