### PR TITLE
docs: use neutral placeholders instead of teammate names in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ That's also why you need at least one **agent runtime** (Claude Code): the agent
 
 ```bash
 # Agent 1 shares context in a persistent room
-mycelium memory set "position/julia" "I think we should use REST, not GraphQL" --handle julia-agent
+mycelium memory set "position/avery" "I think we should use REST, not GraphQL" --handle avery-agent
 
 # Agent 2 (hours later, different session) reads and adds their perspective
 mycelium memory search "API design decisions"
@@ -75,8 +75,8 @@ mycelium engine create aligner --kind aligner --room design
 mycelium engine invoke aligner "converge on API design"
 
 # Each participant loops: wait for its turn, then post a position
-mycelium await   --room design --handle julia-agent --json
-mycelium respond --room design --handle julia-agent "I can accept REST with pagination standards."
+mycelium await   --room design --handle avery-agent --json
+mycelium respond --room design --handle avery-agent "I can accept REST with pagination standards."
 
 # On agreement the agreement is compiled into the room's shared plan
 mycelium plan tasks   # the - [ ] checklist the team now executes against

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ mycelium memory set "position/avery" "I think we should use REST, not GraphQL" -
 
 # Agent 2 (hours later, different session) reads and adds their perspective
 mycelium memory search "API design decisions"
-mycelium memory set "position/selina" "Agree on REST, but we need pagination standards" --handle selina-agent
+mycelium memory set "position/rowan" "Agree on REST, but we need pagination standards" --handle rowan-agent
 ```
 
 When agents need to agree on something, one participant summons the aligner, and each agent takes turns responding until the team converges:

--- a/contracts/user-store.json
+++ b/contracts/user-store.json
@@ -24,18 +24,18 @@
   "normalize": {
     "_comment": "handle + team slugs are @-stripped, trimmed, lower-cased; blank teams dropped.",
     "input": {
-      "handle": "@Julia",
-      "display_name": "Julia Valenti",
+      "handle": "@Avery",
+      "display_name": "Avery Quinn",
       "teams": ["@Core", "Infra", "  "],
       "notify": null
     },
     "expected": {
-      "handle": "julia",
-      "display_name": "Julia Valenti",
+      "handle": "avery",
+      "display_name": "Avery Quinn",
       "teams": ["core", "infra"],
       "notify": null
     }
   },
 
-  "serialized_body": "display_name: Julia Valenti\nteams:\n- core\n- infra\nnotify: null"
+  "serialized_body": "display_name: Avery Quinn\nteams:\n- core\n- infra\nnotify: null"
 }

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -288,7 +288,7 @@
       <h2 id="cursor-create">Create an agent</h2>
       <pre><code><span class="cmd">mycelium agent create</span> design-agent <span class="flag">--adapter</span> <span class="arg">cursor</span> \
     <span class="flag">--cwd</span> ~/repos/my-frontend \
-    <span class="flag">--description</span> <span class="str">&quot;Owns the design system; pings @julia on ambiguity&quot;</span> \
+    <span class="flag">--description</span> <span class="str">&quot;Owns the design system; pings @avery on ambiguity&quot;</span> \
     <span class="flag">--room</span> my-project</code></pre>
 
       <p>This:</p>
@@ -362,7 +362,7 @@
       <pre><code><span class="comment"># Write a memory</span>
 curl -X POST http://localhost:8000/api/rooms/my-project/memory \
   -H "Content-Type: application/json" \
-  -d '{"items": [{"key": "work/api", "value": "REST with OpenAPI client", "created_by": "julia-agent"}]}'
+  -d '{"items": [{"key": "work/api", "value": "REST with OpenAPI client", "created_by": "avery-agent"}]}'
 
 <span class="comment"># Read it back</span>
 curl http://localhost:8000/api/rooms/my-project/memory/work/api

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -157,7 +157,7 @@ PATCH .../messages/{id}  {<span class="str">&quot;status&quot;</span>: <span cla
 
     <section class="doc-section" id="users">
       <h1>Users &amp; teams</h1>
-      <p>Mycelium models <em>whom an agent belongs to</em>. Without it, every agent on the fabric is anonymous: presence says &quot;agent-y is live,&quot; never &quot;julia&#x27;s agent-y is live.&quot; Ownership gives scoping (&quot;my agents&quot; vs another team&#x27;s), attribution (whose agent edited that?), and routing (escalate back to an agent&#x27;s owner).</p>
+      <p>Mycelium models <em>whom an agent belongs to</em>. Without it, every agent on the fabric is anonymous: presence says &quot;agent-y is live,&quot; never &quot;avery&#x27;s agent-y is live.&quot; Ownership gives scoping (&quot;my agents&quot; vs another team&#x27;s), attribution (whose agent edited that?), and routing (escalate back to an agent&#x27;s owner).</p>
       <p>Two entities, symmetric on disk:</p>
       <ul>
         <li><strong>Agents</strong> are room-scoped (<code>rooms/{room}/agents/{handle}</code>). A manifest can name</li>
@@ -168,21 +168,21 @@ PATCH .../messages/{id}  {<span class="str">&quot;status&quot;</span>: <span cla
       </ul>
       <p>what an <code>owner</code> points at.</p>
       <h2 id="users-self-asserted-for-now">Self-asserted, for now</h2>
-      <p>At this tier trust is exactly today&#x27;s handles: <strong>consistent, not cryptographic</strong>. <code>owner: julia</code> is a claim, not a verified identity; anyone can assert it. That&#x27;s deliberate: it shapes the model right so scoping, attribution, and routing have real slots to read, ahead of verified identity (per-member SLIM binding / JWT / SPIRE) filling those slots with signed claims. Don&#x27;t rely on it for access control.</p>
+      <p>At this tier trust is exactly today&#x27;s handles: <strong>consistent, not cryptographic</strong>. <code>owner: avery</code> is a claim, not a verified identity; anyone can assert it. That&#x27;s deliberate: it shapes the model right so scoping, attribution, and routing have real slots to read, ahead of verified identity (per-member SLIM binding / JWT / SPIRE) filling those slots with signed claims. Don&#x27;t rely on it for access control.</p>
       <p>Both fields default to empty, so nothing about existing agents changes: an agent with no owner is unowned.</p>
       <h2 id="users-commands">Commands</h2>
       <pre><code><span class="comment"># Register a human, once, globally</span>
-<span class="cmd">mycelium user create</span> julia <span class="flag">--name</span> <span class="str">&quot;Julia Valenti&quot;</span> <span class="flag">--team</span> core
+<span class="cmd">mycelium user create</span> avery <span class="flag">--name</span> <span class="str">&quot;Avery Quinn&quot;</span> <span class="flag">--team</span> core
 <span class="cmd">mycelium user ls</span>
-<span class="cmd">mycelium user show</span> julia          # record + the agents she owns
+<span class="cmd">mycelium user show</span> avery          # record + the agents she owns
 
 <span class="comment"># Bind an agent to its owner</span>
-<span class="cmd">mycelium agent create</span> release-agent <span class="flag">--cwd</span> ~/repo <span class="flag">--owner</span> julia <span class="flag">--team</span> core
-<span class="cmd">mycelium agent ls</span> <span class="flag">--owner</span> julia   # <span class="str">&quot;my agents&quot;</span>
+<span class="cmd">mycelium agent create</span> release-agent <span class="flag">--cwd</span> ~/repo <span class="flag">--owner</span> avery <span class="flag">--team</span> core
+<span class="cmd">mycelium agent ls</span> <span class="flag">--owner</span> avery   # <span class="str">&quot;my agents&quot;</span>
 <span class="cmd">mycelium agent ls</span> <span class="flag">--team</span> core     # <span class="str">&quot;my team&quot;</span>
 
 <span class="comment"># Declare who you are on this machine (sets identity + upserts the user record)</span>
-<span class="cmd">mycelium iam julia</span> <span class="flag">--name</span> <span class="str">&quot;Julia Valenti&quot;</span> <span class="flag">--team</span> core
+<span class="cmd">mycelium iam avery</span> <span class="flag">--name</span> <span class="str">&quot;Avery Quinn&quot;</span> <span class="flag">--team</span> core
 
 <span class="comment"># Who am I acting as?</span>
 <span class="cmd">mycelium whoami</span></code></pre>
@@ -405,7 +405,7 @@ PATCH .../messages/{id}  {<span class="str">&quot;status&quot;</span>: <span cla
 <span class="comment"># Accepting just to move on? Say so plainly in prose, and the aligner records</span>
 <span class="comment"># the deference:</span>
 <span class="cmd">mycelium respond</span> <span class="flag">--room</span> design <span class="flag">--handle</span> me \
-  &quot;I&#x27;m not persuaded, but I&#x27;ll defer to @julia-agent. [[mycelium: confidence=0.4 stance=accept]]&quot;</code></pre>
+  &quot;I&#x27;m not persuaded, but I&#x27;ll defer to @avery-agent. [[mycelium: confidence=0.4 stance=accept]]&quot;</code></pre>
       <p>The <code>[[mycelium: …]]</code> marker is lifted onto the L9 envelope and stripped from the prose. The aligner reads your reply and folds in the richer epistemic signals it can infer: the evidence you engaged, whether your position moved, and why:</p>
       <ul>
         <li><code>confidence</code> (0–1): how sure you are of your position</li>

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -53,13 +53,13 @@ cat .mycelium/rooms/design-review/decisions/scope.md
 # Ship the reduced-scope Q3 spec first
 ```
 
-### Agent 2: Selina shares research
+### Agent 2: Rowan shares research
 
 ```bash
 cat > .mycelium/rooms/design-review/context/staging.md << 'EOF'
 ---
 key: context/staging
-created_by: selina-agent
+created_by: rowan-agent
 version: 1
 ---
 Staging environment provisions in ~4 min from the base image; safe to stand up per-launch
@@ -146,9 +146,9 @@ mycelium respond --room design-review --handle avery-agent \
   "Prioritize the reduced-scope Q3 spec; we've slipped on big-bang launches before."
 ```
 
-**Terminal 2 (or Claude Code instance 2), selina-agent:**
+**Terminal 2 (or Claude Code instance 2), rowan-agent:**
 ```bash
-mycelium respond --room design-review --handle selina-agent \
+mycelium respond --room design-review --handle rowan-agent \
   "Focus on demo UX and frontend polish. Staging is cheap to stand up per-launch."
 ```
 
@@ -179,7 +179,7 @@ prose. The aligner interprets each reply against the NEGMAS negotiation:
 mycelium await --room design-review --handle avery-agent --json
 # → read the aligner's prompt, then reply with accept/reject/counter + one line why:
 mycelium respond --room design-review --handle avery-agent \
-  "I can accept if staging is owned by selina and the go/no-go review is scheduled."
+  "I can accept if staging is owned by rowan and the go/no-go review is scheduled."
 ```
 
 Repeat `await` → `respond` until the aligner reaches consensus. Agents never speak
@@ -206,24 +206,24 @@ mycelium plan task done <id>
 Give this to the second Claude Code instance:
 
 > You are participating in a Mycelium coordination room called `design-review`. You
-> are `selina-agent`. Your position: "Focus on demo UX and frontend polish; staging
+> are `rowan-agent`. Your position: "Focus on demo UX and frontend polish; staging
 > is cheap to stand up per-launch."
 >
 > ```bash
 > mycelium room use design-review
-> mycelium respond --room design-review --handle selina-agent \
+> mycelium respond --room design-review --handle rowan-agent \
 >   "Focus on demo UX and frontend polish. Staging is cheap to stand up per-launch."
 > ```
 >
 > Then loop until the aligner reaches consensus:
 > ```bash
-> mycelium await --room design-review --handle selina-agent --json
+> mycelium await --room design-review --handle rowan-agent --json
 > # read the aligner's prompt, then reply in prose (accept / reject / counter + why):
-> mycelium respond --room design-review --handle selina-agent "<your reply>"
+> mycelium respond --room design-review --handle rowan-agent "<your reply>"
 > ```
 >
 > When consensus is reached, the aligner has already compiled a shared plan, so run
-> `mycelium plan tasks --room design-review` and work the tasks tagged `@selina-agent`.
+> `mycelium plan tasks --room design-review` and work the tasks tagged `@rowan-agent`.
 
 ---
 

--- a/docs/demo-script.md
+++ b/docs/demo-script.md
@@ -35,19 +35,19 @@ ls .mycelium/rooms/design-review/
 # decisions/  failed/  status/  context/  work/  procedures/  log/  plan/
 ```
 
-### Agent 1: Julia shares architecture decisions
+### Agent 1: Avery shares architecture decisions
 
 ```bash
 # CLI syntax: mycelium memory set KEY VALUE [--handle AGENT]
-mycelium memory set decisions/scope "Ship the reduced-scope Q3 spec first" --handle julia-agent
-mycelium memory set decisions/llm-provider "litellm: provider/model format, one interface" --handle julia-agent
-mycelium memory set decisions/api-style "REST for now, generated OpenAPI client for type safety" --handle julia-agent
+mycelium memory set decisions/scope "Ship the reduced-scope Q3 spec first" --handle avery-agent
+mycelium memory set decisions/llm-provider "litellm: provider/model format, one interface" --handle avery-agent
+mycelium memory set decisions/api-style "REST for now, generated OpenAPI client for type safety" --handle avery-agent
 
 # These are just markdown files:
 cat .mycelium/rooms/design-review/decisions/scope.md
 # ---
 # key: decisions/scope
-# created_by: julia-agent
+# created_by: avery-agent
 # version: 1
 # ---
 # Ship the reduced-scope Q3 spec first
@@ -139,10 +139,10 @@ mycelium engine create aligner --kind aligner --room design-review
 
 ### Each participant posts an opening position
 
-**Terminal 1 (or Claude Code instance 1), julia-agent:**
+**Terminal 1 (or Claude Code instance 1), avery-agent:**
 ```bash
 mycelium room use design-review
-mycelium respond --room design-review --handle julia-agent \
+mycelium respond --room design-review --handle avery-agent \
   "Prioritize the reduced-scope Q3 spec; we've slipped on big-bang launches before."
 ```
 
@@ -176,9 +176,9 @@ prose. The aligner interprets each reply against the NEGMAS negotiation:
 
 ```bash
 # Blocks until a message is addressed to the handle:
-mycelium await --room design-review --handle julia-agent --json
+mycelium await --room design-review --handle avery-agent --json
 # → read the aligner's prompt, then reply with accept/reject/counter + one line why:
-mycelium respond --room design-review --handle julia-agent \
+mycelium respond --room design-review --handle avery-agent \
   "I can accept if staging is owned by selina and the go/no-go review is scheduled."
 ```
 

--- a/docs/l9-integration.html
+++ b/docs/l9-integration.html
@@ -249,7 +249,7 @@ sequenceDiagram
 
       <h2>Position &rarr; the episode opens</h2>
       <p>Each participant posts an opening position with <code>mycelium respond</code>. When a human summons the aligner (<code>mycelium engine invoke aligner …</code>), mycelium mints the episode and synthesizes the opening <code>intent:mission</code> envelope.</p>
-      <pre><code>mycelium respond --handle julia-agent --room api-design \
+      <pre><code>mycelium respond --handle avery-agent --room api-design \
   "REST primary; GraphQL internal only"</code></pre>
       <pre><code>// mycelium synthesizes (recorded into the episode):
 {
@@ -259,7 +259,7 @@ sequenceDiagram
     "participants": {
       "actors": [
         {"id": "aligner", "role": "coordinator"},
-        {"id": "julia-agent", "role": "agent"}
+        {"id": "avery-agent", "role": "agent"}
       ],
       "groups": {"room": "api-design"}
     },
@@ -268,12 +268,12 @@ sequenceDiagram
     "context": {"topic": "urn:concept:mycelium:api-design"}
   },
   "payload": {"type": "utterance",
-              "data": {"content": "- julia-agent: REST primary; GraphQL internal only"}}
+              "data": {"content": "- avery-agent: REST primary; GraphQL internal only"}}
 }</code></pre>
 
       <h2>Respond &rarr; a reply envelope (exchange)</h2>
       <p>On a tick, the agent answers with a prose reply and optional epistemic flags; mycelium parses it and folds it into a synthesized <code>exchange</code> envelope parented on the tick it answers.</p>
-      <pre><code>mycelium respond --handle julia-agent --room api-design \
+      <pre><code>mycelium respond --handle avery-agent --room api-design \
   "counter: transport=rest, meets the latency target" \
   --confidence 0.8 \
   --supporting-evidence "staging p99 data" \
@@ -290,7 +290,7 @@ sequenceDiagram
 {
   "header": {
     "kind": "exchange", "subprotocol": "mycelium",
-    "participants": {"actors": [{"id": "julia-agent", "role": "agent"},
+    "participants": {"actors": [{"id": "avery-agent", "role": "agent"},
                                 {"id": "aligner", "role": "agent"}],
                      "groups": null},
     "message": {"id": "9d2…", "parents": ["&lt;tick-id&gt;"],
@@ -305,7 +305,7 @@ sequenceDiagram
       <p><strong>What reaches the aligner from this:</strong> the parsed action + offer. The epistemic fields stay mycelium-side, folded into the episode for the metrics.</p>
 
       <h2>Grounding + revision_cause</h2>
-      <pre><code>mycelium respond --handle julia-agent --room api-design "accept" \
+      <pre><code>mycelium respond --handle avery-agent --room api-design "accept" \
   --confidence 0.9 --addresses "staging p99 data" --revision-cause grounded_argument</code></pre>
       <pre><code>// mycelium parses:
 {"action": "accept", "confidence": 0.9,

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -358,7 +358,7 @@ The kind vocabulary is open. Post your own (`note`, `decision`, `ci_result`, ...
 # Users & teams
 
 Mycelium models *whom an agent belongs to*. Without it, every agent on the fabric
-is anonymous: presence says "agent-y is live," never "julia's agent-y is live."
+is anonymous: presence says "agent-y is live," never "avery's agent-y is live."
 Ownership gives scoping ("my agents" vs another team's), attribution (whose agent
 edited that?), and routing (escalate back to an agent's owner).
 
@@ -372,7 +372,7 @@ Two entities, symmetric on disk:
 ## Self-asserted, for now
 
 At this tier trust is exactly today's handles: **consistent, not cryptographic**.
-`owner: julia` is a claim, not a verified identity; anyone can assert it. That's
+`owner: avery` is a claim, not a verified identity; anyone can assert it. That's
 deliberate: it shapes the model right so scoping, attribution, and routing have
 real slots to read, ahead of verified identity (per-member SLIM binding / JWT /
 SPIRE) filling those slots with signed claims. Don't rely on it for access control.
@@ -384,17 +384,17 @@ with no owner is unowned.
 
 ```bash
 # Register a human, once, globally
-mycelium user create julia --name "Julia Valenti" --team core
+mycelium user create avery --name "Avery Quinn" --team core
 mycelium user ls
-mycelium user show julia          # record + the agents she owns
+mycelium user show avery          # record + the agents she owns
 
 # Bind an agent to its owner
-mycelium agent create release-agent --cwd ~/repo --owner julia --team core
-mycelium agent ls --owner julia   # "my agents"
+mycelium agent create release-agent --cwd ~/repo --owner avery --team core
+mycelium agent ls --owner avery   # "my agents"
 mycelium agent ls --team core     # "my team"
 
 # Declare who you are on this machine (sets identity + upserts the user record)
-mycelium iam julia --name "Julia Valenti" --team core
+mycelium iam avery --name "Avery Quinn" --team core
 
 # Who am I acting as?
 mycelium whoami
@@ -701,7 +701,7 @@ mycelium respond --room design --handle me \
 # Accepting just to move on? Say so plainly in prose, and the aligner records
 # the deference:
 mycelium respond --room design --handle me \
-  "I'm not persuaded, but I'll defer to @julia-agent. [[mycelium: confidence=0.4 stance=accept]]"
+  "I'm not persuaded, but I'll defer to @avery-agent. [[mycelium: confidence=0.4 stance=accept]]"
 ```
 
 The `[[mycelium: …]]` marker is lifted onto the L9 envelope and stripped from
@@ -1616,7 +1616,7 @@ your **token** when you're signed in, and the self-asserted `identity.name` when
 you're not:
 
 ```
-acting as @julia  (julia#a8f3)
+acting as @avery  (avery#a8f3)
   signed in (https://sso.example.com/realms/mycelium, expires in 42 min)
 ```
 

--- a/docs/mycelium-dataflow.html
+++ b/docs/mycelium-dataflow.html
@@ -855,7 +855,7 @@
           <div style="display:grid; grid-template-columns:1fr 56px 1fr; gap:6px; margin-bottom:2px;">
             <div class="tick-col-label tcl-ce" style="text-align:center;">avery-agent</div>
             <div style="text-align:center; font-size:11px; color:var(--dim); font-family:'Geist Mono', 'SF Mono',monospace; padding-top:4px;">aligner</div>
-            <div class="tick-col-label tcl-ag" style="text-align:center;">selina-agent</div>
+            <div class="tick-col-label tcl-ag" style="text-align:center;">rowan-agent</div>
           </div>
 
           <!-- episode opens -->
@@ -881,14 +881,14 @@
             <div style="background:rgba(0,0,0,0.15); border:1px dashed rgba(143,184,232,0.12); border-radius:7px; padding:8px 10px; font-size:11px; color:var(--dim); font-family:'Geist Mono', 'SF Mono',monospace; text-align:center;">waiting…</div>
           </div>
 
-          <!-- CE → selina: respond (reject) -->
+          <!-- CE → rowan: respond (reject) -->
           <div style="display:grid; grid-template-columns:1fr 56px 1fr; gap:6px; align-items:center;">
             <div style="background:rgba(79,194,150,0.03); border:1px solid rgba(79,194,150,0.12); border-radius:7px; padding:6px 10px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); text-align:center;">offer sent</div>
             <div style="text-align:center; font-size:14.5px; color:var(--dim);">&#8594;</div>
             <div style="background:rgba(0,0,0,0.4); border:1px solid rgba(143,184,232,0.22); border-radius:7px; padding:8px 10px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11px; line-height:1.65;">
-              <div style="font-size:10px; color:var(--muted); margin-bottom:4px;">← await: tick addressed to selina-agent</div>
+              <div style="font-size:10px; color:var(--muted); margin-bottom:4px;">← await: tick addressed to rowan-agent</div>
               <span style="color:var(--green);">$</span> <span style="color:var(--text);">mycelium respond</span><br>
-              <span style="color:rgba(248,113,113,0.8);">"reject: too low"</span> <span style="color:var(--blue);">-r</span> <span style="color:var(--purple);">testing-thursday-10</span> <span style="color:var(--blue);">-H</span> <span style="color:var(--accent);">selina-agent</span>
+              <span style="color:rgba(248,113,113,0.8);">"reject: too low"</span> <span style="color:var(--blue);">-r</span> <span style="color:var(--purple);">testing-thursday-10</span> <span style="color:var(--blue);">-H</span> <span style="color:var(--accent);">rowan-agent</span>
             </div>
           </div>
 

--- a/docs/mycelium-dataflow.html
+++ b/docs/mycelium-dataflow.html
@@ -853,7 +853,7 @@
 
           <!-- header -->
           <div style="display:grid; grid-template-columns:1fr 56px 1fr; gap:6px; margin-bottom:2px;">
-            <div class="tick-col-label tcl-ce" style="text-align:center;">julia-agent</div>
+            <div class="tick-col-label tcl-ce" style="text-align:center;">avery-agent</div>
             <div style="text-align:center; font-size:11px; color:var(--dim); font-family:'Geist Mono', 'SF Mono',monospace; padding-top:4px;">aligner</div>
             <div class="tick-col-label tcl-ag" style="text-align:center;">selina-agent</div>
           </div>
@@ -866,11 +866,11 @@
           <!-- round label -->
           <div style="font-size:11px; letter-spacing:0.15em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--dim); text-align:center;">· round 1 ·</div>
 
-          <!-- CE → julia: propose -->
+          <!-- CE → avery: propose -->
           <div style="display:grid; grid-template-columns:1fr 56px 1fr; gap:6px; align-items:center;">
             <div style="background:rgba(0,0,0,0.4); border:1px solid rgba(92,199,210,0.22); border-radius:7px; padding:8px 10px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11px; line-height:1.7;">
-              <div style="font-size:10px; color:var(--muted); margin-bottom:5px;">← await: tick addressed to julia-agent</div>
-              <span style="color:var(--yellow);">the aligner</span> <span style="color:var(--dim);">→</span> <span style="color:var(--accent);">julia-agent</span> &nbsp;<span style="color:var(--blue);">round 1</span>, your offer on:<br>
+              <div style="font-size:10px; color:var(--muted); margin-bottom:5px;">← await: tick addressed to avery-agent</div>
+              <span style="color:var(--yellow);">the aligner</span> <span style="color:var(--dim);">→</span> <span style="color:var(--accent);">avery-agent</span> &nbsp;<span style="color:var(--blue);">round 1</span>, your offer on:<br>
               <span style="color:var(--text); padding-left:8px; display:inline-block; margin-top:3px;">price</span><br>
               <span style="color:var(--muted); padding-left:16px;">1. at listing &nbsp;2. 5–10% below &nbsp;3. comps-based</span><br>
               <span style="color:var(--text); padding-left:8px; display:inline-block;">deck with city views</span><br>
@@ -895,12 +895,12 @@
           <!-- ellipsis -->
           <div style="font-size:11px; letter-spacing:0.15em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--dim); text-align:center;">· rounds alternate (SAO) ·</div>
 
-          <!-- final: julia accepts -->
+          <!-- final: avery accepts -->
           <div style="display:grid; grid-template-columns:1fr 56px 1fr; gap:6px; align-items:center;">
             <div style="background:rgba(0,0,0,0.4); border:1px solid rgba(79,194,150,0.3); border-radius:7px; padding:8px 10px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11px; line-height:1.65;">
-              <div style="font-size:10px; color:var(--muted); margin-bottom:4px;">← await: tick addressed to julia-agent</div>
+              <div style="font-size:10px; color:var(--muted); margin-bottom:4px;">← await: tick addressed to avery-agent</div>
               <span style="color:var(--green);">$</span> <span style="color:var(--text);">mycelium respond</span><br>
-              <span style="color:var(--green);">"accept: fair comps"</span> <span style="color:var(--blue);">-r</span> <span style="color:var(--purple);">testing-thursday-10</span> <span style="color:var(--blue);">-H</span> <span style="color:var(--accent);">julia-agent</span>
+              <span style="color:var(--green);">"accept: fair comps"</span> <span style="color:var(--blue);">-r</span> <span style="color:var(--purple);">testing-thursday-10</span> <span style="color:var(--blue);">-H</span> <span style="color:var(--accent);">avery-agent</span>
             </div>
             <div style="text-align:center; font-size:14.5px; color:var(--green);">&#8592;</div>
             <div style="background:rgba(79,194,150,0.03); border:1px solid rgba(79,194,150,0.12); border-radius:7px; padding:6px 10px; font-size:11px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); text-align:center;">offer sent</div>
@@ -919,14 +919,14 @@
         <div style="width:100%; display:flex; flex-direction:column; gap:10px;">
           <div style="font-size:12px; font-weight:700; letter-spacing:0.15em; text-transform:uppercase; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); margin-bottom:4px;">Filesystem-Native Memory</div>
           <div class="term-block">
-            <span class="prompt">$</span> <span class="cmd">mycelium memory set</span> <span class="val">"decisions/api"</span> <span class="val">"REST chosen over GraphQL"</span> <span class="flag">--handle julia-agent</span><br>
+            <span class="prompt">$</span> <span class="cmd">mycelium memory set</span> <span class="val">"decisions/api"</span> <span class="val">"REST chosen over GraphQL"</span> <span class="flag">--handle avery-agent</span><br>
             <span class="output">Memory set: design-review/decisions/api (v1)  [rooms/design-review/decisions/api.md]</span>
           </div>
           <div class="term-block">
             <span class="prompt">$</span> <span class="cmd">cat</span> <span class="val">.mycelium/rooms/design-review/decisions/api.md</span><br>
             <span class="tdim">---</span><br>
             <span class="key">key:</span> <span class="output">decisions/api</span><br>
-            <span class="key">created_by:</span> <span class="output">julia-agent</span><br>
+            <span class="key">created_by:</span> <span class="output">avery-agent</span><br>
             <span class="key">version:</span> <span class="output">1</span><br>
             <span class="tdim">---</span><br>
             <span class="output">REST chosen over GraphQL</span>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1203,7 +1203,7 @@ role     = &quot;user&quot;</code></pre>
       <p>The access token is renewed automatically when it expires, using the refresh token, on the way into the next call that needs it — you don&#x27;t re-run <code>login</code> on a schedule. Renewal needs a refresh token, which most issuers grant only for the <code>offline_access</code> scope; it is in the default <code>login.scopes</code> for that reason. If renewal fails, the CLI drops the header and tells you to sign in again rather than sending a token the hub will reject.</p>
       <h3 id="auth-who-you-are">Who you are</h3>
       <p><code>mycelium whoami</code> (and <code>mycelium iam</code> with no arguments) reports the handle from your <strong>token</strong> when you&#x27;re signed in, and the self-asserted <code>identity.name</code> when you&#x27;re not:</p>
-      <pre><code>acting as @julia  (julia#a8f3)
+      <pre><code>acting as @avery  (avery#a8f3)
   signed in (https://sso.example.com/realms/mycelium, expires in 42 min)</code></pre>
       <p>Because a gated hub attributes writes to the token (see <em>The token is the author</em> below), a self-asserted handle that names someone else is a 403 in waiting — <code>login</code> and <code>iam</code> both say so when they disagree.</p>
       <h3 id="auth-configuration">Configuration</h3>

--- a/docs/stories.html
+++ b/docs/stories.html
@@ -510,7 +510,7 @@
             </div>
             <div style="display:flex; flex-direction:column; align-items:center; gap:6px; padding-top:10px; color:var(--muted); font-size:18px;">↓<br>↑</div>
             <div style="background:rgba(195,162,224,0.07); border:1px solid rgba(195,162,224,0.3); border-radius:8px; padding:10px 12px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11.5px;">
-              <div style="color:var(--purple); font-weight:700; margin-bottom:6px;">selina-agent</div>
+              <div style="color:var(--purple); font-weight:700; margin-bottom:6px;">rowan-agent</div>
               <div style="color:var(--muted); line-height:1.5;">"Frontend polish first: users churning on UX. Backend solid enough."</div>
             </div>
           </div>
@@ -524,7 +524,7 @@
             <span style="color:var(--green); font-weight:700; display:block; margin-bottom:4px;">consensus → compiled into plan/tasks.md</span>
             scope=migration-first · quality=high<br>
             <span style="color:var(--muted);">- [ ] lead the schema migration @avery-agent</span><br>
-            <span style="color:var(--muted);">- [ ] parallel frontend prep @selina-agent</span>
+            <span style="color:var(--muted);">- [ ] parallel frontend prep @rowan-agent</span>
           </div>
         </div>
       </div>

--- a/docs/stories.html
+++ b/docs/stories.html
@@ -505,7 +505,7 @@
         <div style="width:100%; display:flex; flex-direction:column; gap:10px;">
           <div style="display:grid; grid-template-columns:1fr auto 1fr; gap:8px; align-items:start;">
             <div style="background:rgba(143,184,232,0.07); border:1px solid rgba(143,184,232,0.3); border-radius:8px; padding:10px 12px; font-family:'Geist Mono', 'SF Mono',monospace; font-size:11.5px;">
-              <div style="color:var(--blue); font-weight:700; margin-bottom:6px;">julia-agent</div>
+              <div style="color:var(--blue); font-weight:700; margin-bottom:6px;">avery-agent</div>
               <div style="color:var(--muted); line-height:1.5;">"DB migration first: auth + frontend both depend on new schema."</div>
             </div>
             <div style="display:flex; flex-direction:column; align-items:center; gap:6px; padding-top:10px; color:var(--muted); font-size:18px;">↓<br>↑</div>
@@ -523,7 +523,7 @@
           <div style="background:rgba(79,194,150,0.06); border:1px solid rgba(79,194,150,0.2); border-radius:8px; padding:10px 14px; font-size:11.5px; font-family:'Geist Mono', 'SF Mono',monospace; color:var(--muted); line-height:1.6;">
             <span style="color:var(--green); font-weight:700; display:block; margin-bottom:4px;">consensus → compiled into plan/tasks.md</span>
             scope=migration-first · quality=high<br>
-            <span style="color:var(--muted);">- [ ] lead the schema migration @julia-agent</span><br>
+            <span style="color:var(--muted);">- [ ] lead the schema migration @avery-agent</span><br>
             <span style="color:var(--muted);">- [ ] parallel frontend prep @selina-agent</span>
           </div>
         </div>

--- a/fastapi-backend/tests/test_auth_gate.py
+++ b/fastapi-backend/tests/test_auth_gate.py
@@ -206,8 +206,8 @@ async def test_unsupported_role_claim_is_rejected(auth_on, signing_key):
 @pytest.mark.asyncio
 async def test_configured_handle_claim_is_honoured(monkeypatch, auth_on, signing_key):
     monkeypatch.setattr("app.config.settings.AUTH_HANDLE_CLAIM", "preferred_username")
-    principal = await auth_service.verify_token(_sign(signing_key, preferred_username="julia"))
-    assert principal.handle == "julia"
+    principal = await auth_service.verify_token(_sign(signing_key, preferred_username="avery"))
+    assert principal.handle == "avery"
 
 
 # ── enabled: everything else is 401 ───────────────────────────────────────────
@@ -473,8 +473,8 @@ async def test_each_issuer_carries_its_own_keys_and_role(two_issuers, signing_ke
     agent = await auth_service.verify_token(_sign(signing_key))
     assert agent.role == "agent"
 
-    human = await auth_service.verify_token(_sign(two_issuers, iss=HUMAN_ISSUER, sub="julia"))
-    assert (human.role, human.handle) == ("user", "julia")
+    human = await auth_service.verify_token(_sign(two_issuers, iss=HUMAN_ISSUER, sub="avery"))
+    assert (human.role, human.handle) == ("user", "avery")
 
 
 @pytest.mark.asyncio

--- a/fastapi-backend/tests/test_l9_history.py
+++ b/fastapi-backend/tests/test_l9_history.py
@@ -45,7 +45,7 @@ def _l9_record(message_id: str, sender: str, kind: str, text: str, data: dict) -
 @pytest.mark.asyncio
 async def test_l9_history_replays_frames_with_envelope(client) -> None:
     await _create_room(client, "wire")
-    append_transcript("wire", _l9_record("m1", "julia", "exchange", "cap at 30%", {"round": 1}))
+    append_transcript("wire", _l9_record("m1", "avery", "exchange", "cap at 30%", {"round": 1}))
 
     resp = await client.get("/api/rooms/wire/messages/l9")
     assert resp.status_code == 200
@@ -55,7 +55,7 @@ async def test_l9_history_replays_frames_with_envelope(client) -> None:
     frame = rows[0]
     # The bus frame shape the inspector reads: l9_<kind> + the full envelope in content.
     assert frame["message_type"] == "l9_exchange"
-    assert frame["sender_handle"] == "julia"
+    assert frame["sender_handle"] == "avery"
     content = json.loads(frame["content"])
     assert content["l9"]["header"]["kind"] == "exchange"
     assert content["l9"]["payload"]["data"] == {"round": 1}

--- a/fastapi-backend/tests/test_mentions_and_invites.py
+++ b/fastapi-backend/tests/test_mentions_and_invites.py
@@ -69,7 +69,7 @@ def _manager_with_channel(
 async def test_publish_human_maps_recipients_wakes_present_invites_absent():
     manager, managed = _manager_with_channel(members={"agent-x"})
 
-    result = await manager.publish_human(_ROOM, sender="julia", text="@agent-x @agent-y ship it")
+    result = await manager.publish_human(_ROOM, sender="avery", text="@agent-x @agent-y ship it")
 
     assert result is not None
     # Both mentions become L9 recipients (the semantic "to").
@@ -80,7 +80,7 @@ async def test_publish_human_maps_recipients_wakes_present_invites_absent():
     channel_send.assert_awaited_once()
     envelope = channel_send.await_args.args[0]
     actor_ids = [a.id for a in envelope.header.participants.actors]
-    assert actor_ids == ["julia", "agent-x", "agent-y"]
+    assert actor_ids == ["avery", "agent-x", "agent-y"]
     assert envelope.header.kind.value == "exchange"
 
     # Persister ingests the message locally exactly once (transcript + bus feed).
@@ -94,7 +94,7 @@ async def test_publish_human_maps_recipients_wakes_present_invites_absent():
 @pytest.mark.asyncio
 async def test_publish_human_returns_none_without_a_live_channel():
     manager = RoomChannelManager(endpoint="http://127.0.0.1:46357", default_workspace="mycelium")
-    assert await manager.publish_human("no-such-room", sender="julia", text="@x hi") is None
+    assert await manager.publish_human("no-such-room", sender="avery", text="@x hi") is None
 
 
 @pytest.mark.asyncio
@@ -105,7 +105,7 @@ async def test_publish_human_treats_await_lease_holder_as_present():
     manager, _managed = _manager_with_channel(members=set())
     manager.refresh_lease(_ROOM, "workpc")  # an active `await` long-poll
 
-    result = await manager.publish_human(_ROOM, sender="julia", text="@workpc ping")
+    result = await manager.publish_human(_ROOM, sender="avery", text="@workpc ping")
 
     assert result is not None
     assert result.invites == []  # present via lease → wake, no consent prompt
@@ -131,7 +131,7 @@ async def test_absent_invite_accept_joins():
     invite_mock = AsyncMock(return_value=True)
     manager.invite = invite_mock  # type: ignore[method-assign]
 
-    result = await manager.publish_human(_ROOM, sender="julia", text="@bob take a look")
+    result = await manager.publish_human(_ROOM, sender="avery", text="@bob take a look")
     assert result is not None
     invite = result.invites[0]
     assert manager.pending_invites(_ROOM) == [invite]
@@ -150,7 +150,7 @@ async def test_absent_invite_decline_does_not_join():
     invite_mock = AsyncMock(return_value=True)
     manager.invite = invite_mock  # type: ignore[method-assign]
 
-    result = await manager.publish_human(_ROOM, sender="julia", text="@carol ?")
+    result = await manager.publish_human(_ROOM, sender="avery", text="@carol ?")
     assert result is not None
     invite = result.invites[0]
 
@@ -170,7 +170,7 @@ async def test_mid_episode_invite_is_queued_then_flushed_on_close():
     manager.invite = invite_mock  # type: ignore[method-assign]
     manager.open_episode(_ROOM, "urn:ioc:mycelium:episode:step6-room:e1")
 
-    result = await manager.publish_human(_ROOM, sender="julia", text="@dave join us")
+    result = await manager.publish_human(_ROOM, sender="avery", text="@dave join us")
     assert result is not None
     invite = result.invites[0]
 
@@ -189,8 +189,8 @@ async def test_mid_episode_invite_is_queued_then_flushed_on_close():
 
 def test_request_invite_returns_none_for_present_member():
     manager, _managed = _manager_with_channel(members={"agent-x"})
-    assert manager.request_invite(_ROOM, "agent-x", requested_by="julia") is None
-    assert manager.request_invite(_ROOM, room_channels.BACKEND_AGENT, requested_by="julia") is None
+    assert manager.request_invite(_ROOM, "agent-x", requested_by="avery") is None
+    assert manager.request_invite(_ROOM, room_channels.BACKEND_AGENT, requested_by="avery") is None
 
 
 # ── cross-host consent: the invitee is addressed by identity, not by host ──────
@@ -218,7 +218,7 @@ async def test_accept_invites_remote_agent_by_identity_only(monkeypatch):
     cast(MagicMock, managed.client).invite = AsyncMock()  # the real manager.invite() path runs
     cast(MagicMock, managed.persister).note_join.return_value = False  # no re-serve
 
-    result = await manager.publish_human(_ROOM, sender="julia", text="@remote-bob join us")
+    result = await manager.publish_human(_ROOM, sender="avery", text="@remote-bob join us")
     assert result is not None
     invite = result.invites[0]
     assert invite.agent == "remote-bob"
@@ -245,7 +245,7 @@ async def test_own_agent_mention_outside_episode_invites_immediately(monkeypatch
     bg = MagicMock()
     manager.invite_in_background = bg  # type: ignore[method-assign]
 
-    result = await manager.publish_human(_ROOM, sender="julia", text="@mine hi")
+    result = await manager.publish_human(_ROOM, sender="avery", text="@mine hi")
 
     assert result is not None
     assert result.invites == []  # own agent → no consent prompt
@@ -266,7 +266,7 @@ async def test_own_agent_mention_mid_episode_is_queued_not_invited(monkeypatch):
     manager.invite_in_background = bg  # type: ignore[method-assign]
     manager.open_episode(_ROOM, "urn:ioc:mycelium:episode:step6-room:e1")
 
-    result = await manager.publish_human(_ROOM, sender="julia", text="@mine come help")
+    result = await manager.publish_human(_ROOM, sender="avery", text="@mine come help")
 
     assert result is not None
     assert result.invites == []  # own agent → no consent prompt surfaced
@@ -293,7 +293,7 @@ async def test_episode_abort_ingests_locally_and_flushes_queue():
     manager.open_episode(_ROOM, "urn:ioc:mycelium:episode:step6-room:e1")
 
     # A consent invite accepted mid-episode is deferred (queued).
-    result = await manager.publish_human(_ROOM, sender="julia", text="@dave join")
+    result = await manager.publish_human(_ROOM, sender="avery", text="@dave join")
     assert result is not None
     invite = result.invites[0]
     await manager.accept_invite(invite.id)

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -409,13 +409,13 @@ def test_list_store_human_and_agent_each_appear_once_in_order():
     #    with the envelope id), and ingested by the persister with list_write=False
     #    so it is NOT double-written to the list store.
     human_env, human_content = _msg_content(
-        "h-1", sender="julia", text="@smoke-agent hello", payload_type="message"
+        "h-1", sender="avery", text="@smoke-agent hello", payload_type="message"
     )
     local_state.add_message(
         room,
         local_state.StoredMessage(
             room_name=room,
-            sender_handle="julia",
+            sender_handle="avery",
             message_type="broadcast",
             content="hello",
             message_id="h-1",
@@ -434,7 +434,7 @@ def test_list_store_human_and_agent_each_appear_once_in_order():
 
     stored = local_state.list_messages(room)
     assert [(m.sender_handle, m.content) for m in stored] == [
-        ("julia", "hello"),
+        ("avery", "hello"),
         ("smoke-agent", "hi back"),
     ]
 
@@ -464,7 +464,7 @@ def test_conversational_messages_project_from_the_durable_transcript():
     get_room_dir(room)
 
     for mid, sender, ptype in [
-        ("h-1", "julia", "message"),
+        ("h-1", "avery", "message"),
         ("a-1", "growth", "reply"),
         ("p-1", "growth", "presence"),
     ]:
@@ -475,7 +475,7 @@ def test_conversational_messages_project_from_the_durable_transcript():
 
     projected = persister.conversational_messages(room)
     assert [(m.sender_handle, m.message_id) for m in projected] == [
-        ("julia", "h-1"),
+        ("avery", "h-1"),
         ("growth", "a-1"),
     ]
     assert projected[1].episode == "urn:ioc:mycelium:episode:r:s"
@@ -522,11 +522,11 @@ def test_addressed_absent_recipient_holds_the_triggering_message():
     """
     log = persister.DeliveryLog()
     # An @-mention broadcast while agent-x is absent (not present, not tracked).
-    log.record(_record("m1", sender="julia"), delivered_to=set(), recipients=["agent-x"])
+    log.record(_record("m1", sender="avery"), delivered_to=set(), recipients=["agent-x"])
     assert [r.message_id for r in log.undelivered("agent-x")] == ["m1"]
 
     # A later unrelated message it also misses stays in the tail, in order.
-    log.record(_record("m2", sender="julia"), delivered_to=set(), recipients=[])
+    log.record(_record("m2", sender="avery"), delivered_to=set(), recipients=[])
     assert [r.message_id for r in log.undelivered("agent-x")] == ["m1", "m2"]
 
     # A genuinely fresh join (not addressed) starts caught-up: nothing to replay.

--- a/fastapi-backend/tests/test_plan.py
+++ b/fastapi-backend/tests/test_plan.py
@@ -81,7 +81,7 @@ class TestSetTitleFromBody:
 
     def test_does_not_clobber_existing_title(self, tmp_path, monkeypatch):
         monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path))
-        plan_service.set_title("room-b", "Human Picked", updated_by="julia")
+        plan_service.set_title("room-b", "Human Picked", updated_by="avery")
         result = plan_service.set_title_from_body_if_absent("room-b", "# LLM Pick\n\n- [ ] x\n")
         assert result is None
         assert plan_service.get_title("room-b") == "Human Picked"
@@ -269,7 +269,7 @@ class TestPlanRoutes:
 
         # 3. set_title → plan_updated/title_set
         await client.put(
-            f"/api/rooms/{room}/plan/title", json={"text": "Q3 Sprint", "updated_by": "julia"}
+            f"/api/rooms/{room}/plan/title", json={"text": "Q3 Sprint", "updated_by": "avery"}
         )
 
         rows = [m for m in local_state.list_messages(room) if m.message_type == "plan_updated"]
@@ -286,7 +286,7 @@ class TestPlanRoutes:
         assert toggled["text"] == "wire up CI"
         title_set = json.loads(rows[2].content)
         assert title_set["title"] == "Q3 Sprint"
-        assert title_set["updated_by"] == "julia"
+        assert title_set["updated_by"] == "avery"
 
     async def test_room_creation_includes_plan_dir(self, client: AsyncClient):
         await client.post("/api/rooms", json={"name": "with-plan"})

--- a/fastapi-backend/tests/test_principal_enforcement.py
+++ b/fastapi-backend/tests/test_principal_enforcement.py
@@ -40,8 +40,8 @@ def test_classify_engine():
 
 
 def test_classify_user_normalized():
-    principals.write_user({"handle": "julia"})
-    assert principals.classify_sender("r", "@Julia") == "user"
+    principals.write_user({"handle": "avery"})
+    assert principals.classify_sender("r", "@Avery") == "user"
 
 
 def test_classify_unknown_is_phantom():
@@ -54,7 +54,7 @@ def test_classify_unknown_is_phantom():
 def test_agent_path_rejects_engine_and_phantom_allows_real():
     _seed_agent("r", "aligner", adapter="engine", kind="aligner")
     _seed_agent("r", "bot", adapter="claude_code", cwd="/tmp")
-    principals.write_user({"handle": "julia"})
+    principals.write_user({"handle": "avery"})
 
     # engine: never impersonable
     assert principals.post_rejection_reason("r", "aligner", allow_unregistered=False)
@@ -62,7 +62,7 @@ def test_agent_path_rejects_engine_and_phantom_allows_real():
     assert principals.post_rejection_reason("r", "foobar", allow_unregistered=False)
     # real agent + known user: allowed
     assert principals.post_rejection_reason("r", "bot", allow_unregistered=False) is None
-    assert principals.post_rejection_reason("r", "julia", allow_unregistered=False) is None
+    assert principals.post_rejection_reason("r", "avery", allow_unregistered=False) is None
 
 
 def test_human_path_tolerates_unregistered_but_not_engine():

--- a/fastapi-backend/tests/test_principals.py
+++ b/fastapi-backend/tests/test_principals.py
@@ -36,16 +36,16 @@ async def _register_agent(client: AsyncClient, room: str, handle: str, manifest:
 async def test_create_and_get_user(client: AsyncClient):
     resp = await client.post(
         "/api/users",
-        json={"handle": "julia", "display_name": "Julia Valenti", "teams": ["Core"]},
+        json={"handle": "avery", "display_name": "Avery Quinn", "teams": ["Core"]},
     )
     assert resp.status_code == 201
     body = resp.json()
-    assert body["handle"] == "julia"
+    assert body["handle"] == "avery"
     assert body["teams"] == ["core"]  # normalized
 
-    got = await client.get("/api/users/@Julia")
+    got = await client.get("/api/users/@Avery")
     assert got.status_code == 200
-    assert got.json()["display_name"] == "Julia Valenti"
+    assert got.json()["display_name"] == "Avery Quinn"
 
 
 @pytest.mark.asyncio
@@ -55,18 +55,18 @@ async def test_unknown_user_404(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_user_rollup_lists_owned_agents(client: AsyncClient):
-    await client.post("/api/users", json={"handle": "julia", "teams": ["core"]})
+    await client.post("/api/users", json={"handle": "avery", "teams": ["core"]})
     await _register_agent(
         client,
         "alpha",
         "a1",
-        {"adapter": "claude_code", "cwd": "/tmp", "owner": "julia"},
+        {"adapter": "claude_code", "cwd": "/tmp", "owner": "avery"},
     )
     await _register_agent(
         client,
         "beta",
         "a2",
-        {"adapter": "claude_code", "cwd": "/tmp", "owner": "julia", "team": "core"},
+        {"adapter": "claude_code", "cwd": "/tmp", "owner": "avery", "team": "core"},
     )
     await _register_agent(
         client,
@@ -75,21 +75,21 @@ async def test_user_rollup_lists_owned_agents(client: AsyncClient):
         {"adapter": "claude_code", "cwd": "/tmp", "owner": "sam"},
     )
 
-    user = (await client.get("/api/users/julia")).json()
+    user = (await client.get("/api/users/avery")).json()
     assert {o["handle"] for o in user["owns"]} == {"a1", "a2"}
 
 
 @pytest.mark.asyncio
 async def test_teams_rollup(client: AsyncClient):
-    await client.post("/api/users", json={"handle": "julia", "teams": ["core"]})
+    await client.post("/api/users", json={"handle": "avery", "teams": ["core"]})
     await _register_agent(
         client,
         "beta",
         "a2",
-        {"adapter": "claude_code", "cwd": "/tmp", "owner": "julia", "team": "core"},
+        {"adapter": "claude_code", "cwd": "/tmp", "owner": "avery", "team": "core"},
     )
 
     teams = {t["team"]: t for t in (await client.get("/api/teams")).json()["teams"]}
     assert "core" in teams
     assert teams["core"]["agent_count"] == 1
-    assert "julia" in teams["core"]["members"]
+    assert "avery" in teams["core"]["members"]

--- a/fastapi-backend/tests/test_user_store_contract.py
+++ b/fastapi-backend/tests/test_user_store_contract.py
@@ -58,14 +58,14 @@ def test_serialized_body_and_frontmatter_match_contract():
 
 def test_upsert_is_content_idempotent():
     g = _contract()
-    principals.write_user({"handle": "julia"})
+    principals.write_user({"handle": "avery"})
     # Same content: no version bump.
-    principals.write_user({"handle": "julia"})
-    record = read_memory_file(get_users_dir(), "julia")
+    principals.write_user({"handle": "avery"})
+    record = read_memory_file(get_users_dir(), "avery")
     assert record is not None
     assert record[0]["version"] == g["initial_version"]
     # A real change bumps it.
-    principals.write_user({"handle": "julia", "display_name": "Julia"})
-    record = read_memory_file(get_users_dir(), "julia")
+    principals.write_user({"handle": "avery", "display_name": "Avery"})
+    record = read_memory_file(get_users_dir(), "avery")
     assert record is not None
     assert record[0]["version"] == g["initial_version"] + 1

--- a/mycelium-cli/src/mycelium/collector.py
+++ b/mycelium-cli/src/mycelium/collector.py
@@ -935,7 +935,7 @@ class MetricsStore:
 
 
 def _agent_from_session_key(session_key: str) -> str:
-    """Extract agent name from a session key like 'agent:selina-agent:mycelium-room:...'."""
+    """Extract agent name from a session key like 'agent:rowan-agent:mycelium-room:...'."""
     if session_key.startswith("agent:"):
         parts = session_key.split(":", 3)
         if len(parts) >= 2:

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -687,7 +687,7 @@ def agent_create(
         "--allow-from",
         help=(
             "Comma-separated sender handles allowed to invoke this agent, and — under "
-            "an enabled auth gate — to act on its behalf (e.g. '@julia,@docs-agent')."
+            "an enabled auth gate — to act on its behalf (e.g. '@avery,@docs-agent')."
         ),
     ),
     owner: str | None = typer.Option(
@@ -714,7 +714,7 @@ def agent_create(
         # cursor (resident Cursor session; drops workspace rules)
         mycelium agent create design-agent --adapter cursor \\
             --cwd ~/repos/my-frontend \\
-            --description "Owns the design system; pings @julia on ambiguity"
+            --description "Owns the design system; pings @avery on ambiguity"
     """
     try:
         config = MyceliumConfig.load()

--- a/mycelium-cli/src/mycelium/commands/engine.py
+++ b/mycelium-cli/src/mycelium/commands/engine.py
@@ -58,7 +58,7 @@ def engine_create(
     allow_from: str | None = typer.Option(
         None,
         "--allow-from",
-        help="Comma-separated sender handles allowed to summon (e.g. '@julia').",
+        help="Comma-separated sender handles allowed to summon (e.g. '@avery').",
     ),
     handle_flag: str = typer.Option(
         "cli-user", "--as", "-H", help="Your own handle (recorded as created_by)."

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -778,7 +778,7 @@ def send(
     ctx: typer.Context,
     content: str = typer.Argument(
         ...,
-        help='Message content. Use @handle mentions to address specific agents, e.g. "@julia-agent ping".',
+        help='Message content. Use @handle mentions to address specific agents, e.g. "@avery-agent ping".',
     ),
     room: str | None = typer.Option(
         None, "--room", "-r", help="Room to post into (defaults to active room)"
@@ -806,9 +806,9 @@ def send(
     instead.
 
     Examples:
-        mycelium room send "@julia-agent please review the cache config"
+        mycelium room send "@avery-agent please review the cache config"
         mycelium room send --room design-review --handle arnold "@selina-agent thoughts on the API proposal?"
-        mycelium room send "@julia-agent @selina-agent sync at 3pm re: sprint priorities"
+        mycelium room send "@avery-agent @selina-agent sync at 3pm re: sprint priorities"
     """
     try:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -807,8 +807,8 @@ def send(
 
     Examples:
         mycelium room send "@avery-agent please review the cache config"
-        mycelium room send --room design-review --handle arnold "@selina-agent thoughts on the API proposal?"
-        mycelium room send "@avery-agent @selina-agent sync at 3pm re: sprint priorities"
+        mycelium room send --room design-review --handle arnold "@rowan-agent thoughts on the API proposal?"
+        mycelium room send "@avery-agent @rowan-agent sync at 3pm re: sprint priorities"
     """
     try:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841

--- a/mycelium-cli/src/mycelium/commands/user.py
+++ b/mycelium-cli/src/mycelium/commands/user.py
@@ -113,9 +113,9 @@ def _write_user(user: UserManifest, created_by: str) -> None:
 @app.command("create")
 def user_create(
     ctx: typer.Context,
-    handle: str = typer.Argument(..., help="User handle (lowercase slug, e.g. 'julia')."),
+    handle: str = typer.Argument(..., help="User handle (lowercase slug, e.g. 'avery')."),
     display_name: str = typer.Option(
-        "", "--name", "-n", help="Human-readable display name, e.g. 'Julia Valenti'."
+        "", "--name", "-n", help="Human-readable display name, e.g. 'Avery Quinn'."
     ),
     team: list[str] | None = typer.Option(
         None, "--team", help="Team slug this person belongs to (repeatable)."
@@ -130,7 +130,7 @@ def user_create(
     """Create (or upsert) a user in the global store.
 
     Examples:
-        mycelium user create julia --name "Julia Valenti" --team core
+        mycelium user create avery --name "Avery Quinn" --team core
     """
     try:
         try:
@@ -269,7 +269,7 @@ def whoami(ctx: typer.Context) -> None:
     """
     try:
         config = MyceliumConfig.load()
-        # The attribution handle can be session-qualified (``julia#a8f3``); the
+        # The attribution handle can be session-qualified (``avery#a8f3``); the
         # principal is the bare name it derives from.
         identity = config.get_current_identity()
         principal = (config.identity.name or identity).split("#", 1)[0].lower()
@@ -342,7 +342,7 @@ def whoami(ctx: typer.Context) -> None:
 def iam(
     ctx: typer.Context,
     handle: str | None = typer.Argument(
-        None, help="Your user handle (lowercase slug, e.g. 'julia'). Omit to report who you are."
+        None, help="Your user handle (lowercase slug, e.g. 'avery'). Omit to report who you are."
     ),
     name: str | None = typer.Option(None, "--name", "-n", help="Display name to set/update."),
     team: list[str] | None = typer.Option(None, "--team", help="Team slug to join (repeatable)."),
@@ -357,7 +357,7 @@ def iam(
     when signed in, the self-asserted one when not.
 
     Examples:
-        mycelium iam julia --name "Julia Valenti" --team core
+        mycelium iam avery --name "Avery Quinn" --team core
         mycelium iam
     """
     if handle is None:

--- a/mycelium-cli/src/mycelium/commands/wire.py
+++ b/mycelium-cli/src/mycelium/commands/wire.py
@@ -102,7 +102,7 @@ def l9_send(
     anything touches the wire.
 
     Example:
-        mycelium l9 send --room design --as @julia --kind commit --subkind resolved \\
+        mycelium l9 send --room design --as @avery --kind commit --subkind resolved \\
             --data '{"assignments": {"cap": "30"}}'
     """
     try:
@@ -167,7 +167,7 @@ def slim_send(
     how/whether it surfaces.
 
     Example:
-        mycelium slim send --room design --as @julia --text "hello channel"
+        mycelium slim send --room design --as @avery --text "hello channel"
     """
     if (text is None) == (json_payload is None):
         typer.secho("  ⟫  pass exactly one of --text or --json", fg=typer.colors.RED)

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -124,7 +124,7 @@ your **token** when you're signed in, and the self-asserted `identity.name` when
 you're not:
 
 ```
-acting as @julia  (julia#a8f3)
+acting as @avery  (avery#a8f3)
   signed in (https://sso.example.com/realms/mycelium, expires in 42 min)
 ```
 

--- a/mycelium-cli/src/mycelium/docs/l9-protocol.md
+++ b/mycelium-cli/src/mycelium/docs/l9-protocol.md
@@ -32,7 +32,7 @@ mycelium respond --room design --handle me \
 # Accepting just to move on? Say so plainly in prose, and the aligner records
 # the deference:
 mycelium respond --room design --handle me \
-  "I'm not persuaded, but I'll defer to @julia-agent. [[mycelium: confidence=0.4 stance=accept]]"
+  "I'm not persuaded, but I'll defer to @avery-agent. [[mycelium: confidence=0.4 stance=accept]]"
 ```
 
 The `[[mycelium: …]]` marker is lifted onto the L9 envelope and stripped from

--- a/mycelium-cli/src/mycelium/docs/principals.md
+++ b/mycelium-cli/src/mycelium/docs/principals.md
@@ -1,7 +1,7 @@
 # Users & teams
 
 Mycelium models *whom an agent belongs to*. Without it, every agent on the fabric
-is anonymous: presence says "agent-y is live," never "julia's agent-y is live."
+is anonymous: presence says "agent-y is live," never "avery's agent-y is live."
 Ownership gives scoping ("my agents" vs another team's), attribution (whose agent
 edited that?), and routing (escalate back to an agent's owner).
 
@@ -15,7 +15,7 @@ Two entities, symmetric on disk:
 ## Self-asserted, for now
 
 At this tier trust is exactly today's handles: **consistent, not cryptographic**.
-`owner: julia` is a claim, not a verified identity; anyone can assert it. That's
+`owner: avery` is a claim, not a verified identity; anyone can assert it. That's
 deliberate: it shapes the model right so scoping, attribution, and routing have
 real slots to read, ahead of verified identity (per-member SLIM binding / JWT /
 SPIRE) filling those slots with signed claims. Don't rely on it for access control.
@@ -27,17 +27,17 @@ with no owner is unowned.
 
 ```bash
 # Register a human, once, globally
-mycelium user create julia --name "Julia Valenti" --team core
+mycelium user create avery --name "Avery Quinn" --team core
 mycelium user ls
-mycelium user show julia          # record + the agents she owns
+mycelium user show avery          # record + the agents she owns
 
 # Bind an agent to its owner
-mycelium agent create release-agent --cwd ~/repo --owner julia --team core
-mycelium agent ls --owner julia   # "my agents"
+mycelium agent create release-agent --cwd ~/repo --owner avery --team core
+mycelium agent ls --owner avery   # "my agents"
 mycelium agent ls --team core     # "my team"
 
 # Declare who you are on this machine (sets identity + upserts the user record)
-mycelium iam julia --name "Julia Valenti" --team core
+mycelium iam avery --name "Avery Quinn" --team core
 
 # Who am I acting as?
 mycelium whoami

--- a/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
+++ b/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md
@@ -106,7 +106,7 @@ Structured negotiation is for "we have a multi-issue trade-off and need consensu
 
 ```bash
 mycelium room send --room <room-name> --handle claude-agent \
-  "@julia-agent heads up: redis eviction bug in staging"
+  "@avery-agent heads up: redis eviction bug in staging"
 ```
 
 Agents in that room receive your message addressed to them. One-way: no built-in reply loop. If the addressed agent replies in the room, you'll see it via `mycelium watch --room <room-name>` or by polling the room's messages, but they won't auto-deliver back into your terminal.

--- a/mycelium-cli/src/mycelium/integrations/cursor/assets/cursor_rules/mycelium.mdc
+++ b/mycelium-cli/src/mycelium/integrations/cursor/assets/cursor_rules/mycelium.mdc
@@ -93,7 +93,7 @@ For one-shot messages and durable notes (NOT negotiation; see below):
 
 ```bash
 mycelium room send --room <room-name> --handle cursor-agent \
-  "@julia-agent heads up: redis eviction bug in staging"
+  "@avery-agent heads up: redis eviction bug in staging"
 
 mycelium memory set "decision/cache" \
   '{"choice": "Redis", "rationale": "40ms p99 win, simpler ops"}' \

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -354,7 +354,7 @@ class AgentManifest(BaseModel):
     allow_from: list[str] = Field(
         default_factory=list,
         description=(
-            "Sender handles allowed to invoke this agent (e.g. ['@julia', '@docs-agent']). "
+            "Sender handles allowed to invoke this agent (e.g. ['@avery', '@docs-agent']). "
             "Empty list means anyone in the room can invoke. "
             "Also the 'act on behalf of' grant: with the hub's auth gate enabled, these "
             "handles (and the owner) may await or join as this agent; an empty list "
@@ -368,8 +368,8 @@ class AgentManifest(BaseModel):
         if not isinstance(data, dict):
             return data
         # Handle and the two principal pointers are all lowercase slugs — an
-        # owner/team is a `users/<handle>` / team slug, so `--owner Julia`
-        # binds to `users/julia`. The handle is required, so an empty result
+        # owner/team is a `users/<handle>` / team slug, so `--owner Avery`
+        # binds to `users/avery`. The handle is required, so an empty result
         # stays a string (and fails the pattern); owner/team collapse to None.
         for field in ("handle", "owner", "team"):
             value = data.get(field)
@@ -422,7 +422,7 @@ class UserManifest(BaseModel):
     """
 
     handle: str = Field(..., min_length=1, pattern=r"^[a-z0-9][a-z0-9._-]*$")
-    display_name: str = Field(default="", description="Human-readable name, e.g. 'Julia Valenti'.")
+    display_name: str = Field(default="", description="Human-readable name, e.g. 'Avery Quinn'.")
     teams: list[str] = Field(
         default_factory=list,
         description="Team slugs this person belongs to. Scopes 'my team' views.",

--- a/mycelium-cli/tests/test_cursor_dispatch.py
+++ b/mycelium-cli/tests/test_cursor_dispatch.py
@@ -49,12 +49,12 @@ def test_build_manifest_returns_cursor_adapter_with_cwd(tmp_path: Path) -> None:
         handle="design-agent",
         opts=AddOptions(room="r1"),
         description="d",
-        allow_from=["@julia"],
+        allow_from=["@avery"],
     )
     assert manifest.adapter == "cursor"
     assert manifest.handle == "design-agent"
     assert manifest.cwd == str(tmp_path)
-    assert manifest.allow_from == ["@julia"]
+    assert manifest.allow_from == ["@avery"]
 
 
 def test_build_manifest_allows_no_cwd_for_cursor() -> None:

--- a/mycelium-cli/tests/test_login.py
+++ b/mycelium-cli/tests/test_login.py
@@ -95,7 +95,7 @@ class _Resp:
 
 def _token(**overrides: Any) -> StoredToken:
     base = StoredToken(
-        access_token=_jwt({"sub": "julia", "exp": time.time() + 3600}),
+        access_token=_jwt({"sub": "avery", "exp": time.time() + 3600}),
         issuer=_META.issuer,
         client_id="mycelium-cli",
         refresh_token="refresh-1",
@@ -152,10 +152,10 @@ def test_expiry_uses_a_leeway_so_a_token_never_dies_in_flight() -> None:
 
 
 def test_handle_comes_from_the_configured_claim() -> None:
-    token = _token(access_token=_jwt({"sub": "@Julia", "email": "julia@example.com"}))
+    token = _token(access_token=_jwt({"sub": "@Avery", "email": "avery@example.com"}))
 
-    assert token.handle() == "julia"
-    assert token.handle("email") == "julia@example.com"
+    assert token.handle() == "avery"
+    assert token.handle("email") == "avery@example.com"
     # An opaque (non-JWT) access token has no readable claims, which is not an error.
     assert _token(access_token="opaque").handle() is None
 
@@ -395,7 +395,7 @@ def test_login_caches_the_session_and_remembers_the_issuer(
         login_cmd,
         "authorization_code_login",
         lambda *_a, **_k: oidc.TokenResponse(
-            access_token=_jwt({"sub": "julia"}),
+            access_token=_jwt({"sub": "avery"}),
             refresh_token="rt-1",
             expires_at=time.time() + 3600,
         ),
@@ -404,7 +404,7 @@ def test_login_caches_the_session_and_remembers_the_issuer(
     result = runner.invoke(app, ["login", "--issuer", "https://idp.test/realms/mycelium"])
 
     assert result.exit_code == 0
-    assert "Signed in as @julia" in _flat(result.stdout)
+    assert "Signed in as @avery" in _flat(result.stdout)
 
     cached = load_token()
     assert cached is not None
@@ -426,7 +426,7 @@ def test_login_device_flag_takes_the_device_path(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(
         login_cmd,
         "device_code_login",
-        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": "julia"})),
+        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": "avery"})),
     )
 
     result = runner.invoke(
@@ -453,7 +453,7 @@ def test_login_falls_back_to_device_code_when_there_is_no_browser(
     monkeypatch.setattr(
         login_cmd,
         "device_code_login",
-        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": "julia"})),
+        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": "avery"})),
     )
 
     result = runner.invoke(app, ["login", "--issuer", "https://idp.test/realms/mycelium"])
@@ -495,20 +495,20 @@ def test_logout_drops_the_session() -> None:
 
 
 def test_whoami_reports_the_token_identity_when_signed_in() -> None:
-    save_token(_token(access_token=_jwt({"sub": "julia", "exp": time.time() + 3600})))
+    save_token(_token(access_token=_jwt({"sub": "avery", "exp": time.time() + 3600})))
 
     result = runner.invoke(app, ["--json", "whoami"])
 
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["authenticated"] is True
-    assert payload["principal"] == "julia"
+    assert payload["principal"] == "avery"
     assert payload["token"]["issuer"] == _META.issuer
 
 
 def test_whoami_is_unchanged_when_logged_out() -> None:
     config = MyceliumConfig.load()
-    config.identity.name = "julia"
+    config.identity.name = "avery"
     config.save()
 
     result = runner.invoke(app, ["--json", "whoami"])
@@ -517,25 +517,25 @@ def test_whoami_is_unchanged_when_logged_out() -> None:
     payload = json.loads(result.stdout)
     assert payload["authenticated"] is False
     assert payload["token"] is None
-    assert payload["principal"] == "julia"
+    assert payload["principal"] == "avery"
 
 
 def test_iam_with_no_handle_reports_rather_than_asserting() -> None:
-    save_token(_token(access_token=_jwt({"sub": "julia", "exp": time.time() + 3600})))
+    save_token(_token(access_token=_jwt({"sub": "avery", "exp": time.time() + 3600})))
 
     result = runner.invoke(app, ["--json", "iam"])
 
     assert result.exit_code == 0
-    assert json.loads(result.stdout)["principal"] == "julia"
+    assert json.loads(result.stdout)["principal"] == "avery"
     # Reporting is read-only: nothing was written to identity.name.
     assert MyceliumConfig.load().identity.name is None
 
 
 def test_iam_flags_a_handle_the_token_will_not_back() -> None:
-    save_token(_token(access_token=_jwt({"sub": "julia", "exp": time.time() + 3600})))
+    save_token(_token(access_token=_jwt({"sub": "avery", "exp": time.time() + 3600})))
 
     result = runner.invoke(app, ["iam", "bob"])
 
     assert result.exit_code == 0
-    assert "you're signed in as @julia" in _flat(result.stdout)
+    assert "you're signed in as @avery" in _flat(result.stdout)
     assert "refuse writes claiming a different handle" in _flat(result.stdout)

--- a/mycelium-cli/tests/test_principal_layer.py
+++ b/mycelium-cli/tests/test_principal_layer.py
@@ -22,8 +22,8 @@ def test_manifest_owner_team_default_none() -> None:
 
 def test_manifest_normalizes_owner_and_team() -> None:
     """Owner/team are slug pointers — lowercased, @-stripped, like the handle."""
-    m = AgentManifest(handle="Bot", cwd="/tmp", owner="@Julia", team="Core")
-    assert m.owner == "julia"
+    m = AgentManifest(handle="Bot", cwd="/tmp", owner="@Avery", team="Core")
+    assert m.owner == "avery"
     assert m.team == "core"
 
 
@@ -33,22 +33,22 @@ def test_manifest_blank_owner_becomes_none() -> None:
 
 
 def test_user_manifest_normalizes() -> None:
-    u = UserManifest(handle="@Julia", display_name="Julia Valenti", teams=["@Core", "Infra"])
-    assert u.handle == "julia"
+    u = UserManifest(handle="@Avery", display_name="Avery Quinn", teams=["@Core", "Infra"])
+    assert u.handle == "avery"
     assert u.teams == ["core", "infra"]
 
 
 def test_user_store_roundtrip(isolated_home) -> None:  # noqa: ANN001
     """A user written to the global store loads back as a validated model."""
     user_cmd._write_user(
-        UserManifest(handle="julia", display_name="Julia", teams=["core"]),
+        UserManifest(handle="avery", display_name="Avery", teams=["core"]),
         created_by="tester",
     )
-    loaded = user_cmd.load_user("@Julia")  # normalization on read too
+    loaded = user_cmd.load_user("@Avery")  # normalization on read too
     assert loaded is not None
-    assert loaded.display_name == "Julia"
+    assert loaded.display_name == "Avery"
     assert loaded.teams == ["core"]
-    assert [u.handle for u in user_cmd.list_users()] == ["julia"]
+    assert [u.handle for u in user_cmd.list_users()] == ["avery"]
 
 
 def _seed_agent(room: str, handle: str, *, owner: str | None) -> None:
@@ -59,10 +59,10 @@ def _seed_agent(room: str, handle: str, *, owner: str | None) -> None:
 
 def test_load_owned_agents_collects_across_rooms(isolated_home) -> None:  # noqa: ANN001
     """Owned agents are collected across every local room."""
-    _seed_agent("alpha", "a1", owner="julia")
-    _seed_agent("beta", "a2", owner="julia")
+    _seed_agent("alpha", "a1", owner="avery")
+    _seed_agent("beta", "a2", owner="avery")
     _seed_agent("beta", "a3", owner="sam")
 
-    owned = load_owned_agents(owner="@Julia")
+    owned = load_owned_agents(owner="@Avery")
     handles = sorted(m.handle for _room, m in owned)
     assert handles == ["a1", "a2"]

--- a/mycelium-cli/tests/test_slim_l9.py
+++ b/mycelium-cli/tests/test_slim_l9.py
@@ -92,7 +92,7 @@ def test_build_envelope_content_sets_kind_and_subkind() -> None:
     content = l9.build_envelope_content(
         kind="commit",
         subkind="resolved",
-        sender="julia",
+        sender="avery",
         recipients=["bob"],
         episode="ep-1",
         parents=["p-1"],
@@ -105,14 +105,14 @@ def test_build_envelope_content_sets_kind_and_subkind() -> None:
 
 
 def test_build_envelope_content_omits_subkind_when_absent() -> None:
-    content = l9.build_envelope_content(kind="exchange", sender="julia", episode="ep-1")
+    content = l9.build_envelope_content(kind="exchange", sender="avery", episode="ep-1")
     assert "subkind" not in content["l9"]["header"]
 
 
 def test_build_envelope_content_rejects_invalid_subkind() -> None:
     with pytest.raises(l9.L9ValidationError):
         l9.build_envelope_content(
-            kind="exchange", subkind="not-a-real-subkind", sender="julia", episode="ep-1"
+            kind="exchange", subkind="not-a-real-subkind", sender="avery", episode="ep-1"
         )
 
 

--- a/mycelium-cli/tests/test_slim_member.py
+++ b/mycelium-cli/tests/test_slim_member.py
@@ -30,12 +30,12 @@ async def test_publish_once_announces_then_publishes(fake_httpx: FakeHTTPX) -> N
         api_url="http://localhost:8000",
         node_endpoint="http://127.0.0.1:46357",
         room="demo",
-        handle="julia",
+        handle="avery",
         payload=b"hello wire",
     )
 
     assert fake_httpx.calls == [
-        ("POST", "http://localhost:8000/api/rooms/demo/sessions", {"agent_handle": "julia"})
+        ("POST", "http://localhost:8000/api/rooms/demo/sessions", {"agent_handle": "avery"})
     ]
     assert FakeSlimClient.published == [b"hello wire"]
 
@@ -51,7 +51,7 @@ def test_publish_once_raises_when_node_unreachable(
                 api_url="http://localhost:8000",
                 node_endpoint="http://127.0.0.1:46357",
                 room="demo",
-                handle="julia",
+                handle="avery",
                 payload=b"x",
             )
         )
@@ -73,7 +73,7 @@ def test_publish_once_raises_on_join_timeout(
                 api_url="http://localhost:8000",
                 node_endpoint="http://127.0.0.1:46357",
                 room="demo",
-                handle="julia",
+                handle="avery",
                 payload=b"x",
                 join_timeout_s=0.05,
             )
@@ -83,4 +83,4 @@ def test_publish_once_raises_on_join_timeout(
 async def test_announce_presence_raises_on_http_error(fake_httpx: FakeHTTPX) -> None:
     fake_httpx.respond_with(lambda *_a: FakeResp(boom=True, status_code=500))
     with pytest.raises(RuntimeError):
-        await member.announce_presence("http://localhost:8000", "demo", "julia")
+        await member.announce_presence("http://localhost:8000", "demo", "avery")

--- a/mycelium-cli/tests/test_user_store_contract.py
+++ b/mycelium-cli/tests/test_user_store_contract.py
@@ -59,18 +59,18 @@ def test_serialized_body_matches_contract():
 
 def test_write_applies_tag_and_version(isolated_home):  # noqa: ANN001
     g = _contract()
-    user_cmd._write_user(UserManifest(handle="julia"), created_by="tester")
-    record = user_cmd.read_memory(get_users_dir(), "julia")
+    user_cmd._write_user(UserManifest(handle="avery"), created_by="tester")
+    record = user_cmd.read_memory(get_users_dir(), "avery")
     assert record is not None
     assert record[0]["tags"] == [g["manifest_tag"]]
     assert record[0]["version"] == g["initial_version"]
     # Content-idempotent: re-writing the same record does NOT bump the version.
-    user_cmd._write_user(UserManifest(handle="julia"), created_by="tester")
-    same = user_cmd.read_memory(get_users_dir(), "julia")
+    user_cmd._write_user(UserManifest(handle="avery"), created_by="tester")
+    same = user_cmd.read_memory(get_users_dir(), "avery")
     assert same is not None
     assert same[0]["version"] == g["initial_version"]
     # A real change bumps it.
-    user_cmd._write_user(UserManifest(handle="julia", display_name="Julia"), created_by="tester")
-    bumped = user_cmd.read_memory(get_users_dir(), "julia")
+    user_cmd._write_user(UserManifest(handle="avery", display_name="Avery"), created_by="tester")
+    bumped = user_cmd.read_memory(get_users_dir(), "avery")
     assert bumped is not None
     assert bumped[0]["version"] == g["initial_version"] + 1

--- a/mycelium-cli/tests/test_wire_cli.py
+++ b/mycelium-cli/tests/test_wire_cli.py
@@ -48,7 +48,7 @@ def test_l9_send_rejects_invalid_kind_before_publishing(monkeypatch: pytest.Monk
 
     monkeypatch.setattr(wire, "publish_once", _fake_publish)
 
-    result = runner.invoke(app, ["l9", "send", "--as", "julia", "--kind", "not-a-kind"])
+    result = runner.invoke(app, ["l9", "send", "--as", "avery", "--kind", "not-a-kind"])
     assert result.exit_code == 2
     assert not called
 
@@ -66,7 +66,7 @@ def test_l9_send_rejects_mismatched_subkind_before_publishing(
 
     result = runner.invoke(
         app,
-        ["l9", "send", "--as", "julia", "--kind", "exchange", "--subkind", "converged"],
+        ["l9", "send", "--as", "avery", "--kind", "exchange", "--subkind", "converged"],
     )
     assert result.exit_code == 2
     assert not called
@@ -86,7 +86,7 @@ def test_l9_send_builds_envelope_and_publishes(monkeypatch: pytest.MonkeyPatch) 
             "l9",
             "send",
             "--as",
-            "@julia",
+            "@avery",
             "--kind",
             "commit",
             "--subkind",
@@ -101,7 +101,7 @@ def test_l9_send_builds_envelope_and_publishes(monkeypatch: pytest.MonkeyPatch) 
     )
     assert result.exit_code == 0, result.output
     assert captured["room"] == "demo"
-    assert captured["handle"] == "julia"
+    assert captured["handle"] == "avery"
 
     content = l9.parse(captured["payload"])
     assert content is not None
@@ -116,7 +116,7 @@ def test_l9_send_rejects_non_object_data(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(wire, "publish_once", lambda **_k: None)
     result = runner.invoke(
         app,
-        ["l9", "send", "--as", "julia", "--kind", "exchange", "--data", "[1, 2, 3]"],
+        ["l9", "send", "--as", "avery", "--kind", "exchange", "--data", "[1, 2, 3]"],
     )
     assert result.exit_code == 2
 
@@ -126,16 +126,16 @@ def test_l9_send_surfaces_slim_send_error(monkeypatch: pytest.MonkeyPatch) -> No
         raise SlimSendError("SLIM node unreachable at http://x")
 
     monkeypatch.setattr(wire, "publish_once", _boom)
-    result = runner.invoke(app, ["l9", "send", "--as", "julia", "--kind", "exchange"])
+    result = runner.invoke(app, ["l9", "send", "--as", "avery", "--kind", "exchange"])
     assert result.exit_code == 1
     assert "unreachable" in result.output
 
 
 def test_slim_send_requires_exactly_one_of_text_or_json() -> None:
-    result = runner.invoke(app, ["slim", "send", "--as", "julia"])
+    result = runner.invoke(app, ["slim", "send", "--as", "avery"])
     assert result.exit_code == 2
 
-    result = runner.invoke(app, ["slim", "send", "--as", "julia", "--text", "hi", "--json", "{}"])
+    result = runner.invoke(app, ["slim", "send", "--as", "avery", "--text", "hi", "--json", "{}"])
     assert result.exit_code == 2
 
 
@@ -147,9 +147,9 @@ def test_slim_send_publishes_raw_text(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(wire, "publish_once", _fake_publish)
 
-    result = runner.invoke(app, ["slim", "send", "--as", "@julia", "--text", "hello channel"])
+    result = runner.invoke(app, ["slim", "send", "--as", "@avery", "--text", "hello channel"])
     assert result.exit_code == 0, result.output
-    assert captured["handle"] == "julia"
+    assert captured["handle"] == "avery"
     assert captured["room"] == "demo"
     assert captured["payload"] == b"hello channel"
 
@@ -162,11 +162,11 @@ def test_slim_send_publishes_raw_json(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(wire, "publish_once", _fake_publish)
 
-    result = runner.invoke(app, ["slim", "send", "--as", "julia", "--json", '{"anything": true}'])
+    result = runner.invoke(app, ["slim", "send", "--as", "avery", "--json", '{"anything": true}'])
     assert result.exit_code == 0, result.output
     assert json.loads(captured["payload"]) == {"anything": True}
 
 
 def test_slim_send_rejects_invalid_json() -> None:
-    result = runner.invoke(app, ["slim", "send", "--as", "julia", "--json", "{not json"])
+    result = runner.invoke(app, ["slim", "send", "--as", "avery", "--json", "{not json"])
     assert result.exit_code == 2

--- a/mycelium-cli/tests/test_wire_cli.py
+++ b/mycelium-cli/tests/test_wire_cli.py
@@ -92,7 +92,7 @@ def test_l9_send_builds_envelope_and_publishes(monkeypatch: pytest.MonkeyPatch) 
             "--subkind",
             "resolved",
             "--to",
-            "bob, @selina",
+            "bob, @rowan",
             "--parents",
             "p1,p2",
             "--data",
@@ -108,7 +108,7 @@ def test_l9_send_builds_envelope_and_publishes(monkeypatch: pytest.MonkeyPatch) 
     assert l9.kind_of(content) == "commit"
     assert content["l9"]["header"]["subkind"] == "resolved"
     assert content["l9"]["header"]["message"]["parents"] == ["p1", "p2"]
-    assert l9.recipients_of(content) == ["bob", "selina"]
+    assert l9.recipients_of(content) == ["bob", "rowan"]
     assert l9.payload_data_of(content) == {"assignments": {"cap": "30"}}
 
 

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -252,7 +252,7 @@ export function ActingAsPicker() {
               <label className="block space-y-1">
                 <span className="text-micro text-muted-foreground">Handle</span>
                 <Input
-                  placeholder="e.g. julia"
+                  placeholder="e.g. avery"
                   value={form.handle}
                   disabled={!form.isNew}
                   onChange={(e) => {
@@ -278,7 +278,7 @@ export function ActingAsPicker() {
               <label className="block space-y-1">
                 <span className="text-micro text-muted-foreground">Display name</span>
                 <Input
-                  placeholder="e.g. Julia Valenti"
+                  placeholder="e.g. Avery Quinn"
                   value={form.displayName}
                   onChange={(e) => setForm((f) => ({ ...f, displayName: e.target.value }))}
                 />

--- a/mycelium-frontend/src/mocks/handlers.ts
+++ b/mycelium-frontend/src/mocks/handlers.ts
@@ -62,7 +62,7 @@ export async function handleMock(req: Request): Promise<Response | null> {
             room: "atlas-migration",
             provisioned: true,
             persister_alive: true,
-            members: ["planner", "julia"],
+            members: ["planner", "avery"],
             pending_invites: 1,
             episode_active: true,
             reserves: 3,

--- a/mycelium-promo/index.html
+++ b/mycelium-promo/index.html
@@ -598,7 +598,7 @@
         color: var(--text);
       }
       .chat-avatar.avery  { background: linear-gradient(135deg, #5cc7d2 0%, #8fd6de 100%); color: #06181b; }
-      .chat-avatar.selina  { background: linear-gradient(135deg, #7f8a94 0%, #5b666f 100%); color: #e8ebee; }
+      .chat-avatar.rowan  { background: linear-gradient(135deg, #7f8a94 0%, #5b666f 100%); color: #e8ebee; }
       .chat-msg .body { flex: 1; min-width: 0; }
       .chat-msg .meta {
         display: flex; align-items: baseline; gap: 14px; margin-bottom: 6px;
@@ -632,7 +632,7 @@
       /* Typewriter: words start invisible, GSAP fades them in one by one */
       .word { opacity: 0; }
       .chat-msg .text .mention.avery { background: rgba(92, 199, 210,0.16); color: var(--accent); }
-      .chat-msg .text .mention.selina { background: rgba(192,132,252,0.18); color: var(--purple); }
+      .chat-msg .text .mention.rowan { background: rgba(192,132,252,0.18); color: var(--purple); }
       .chat-typing {
         display: inline-flex; gap: 7px; align-items: center;
         margin-top: 6px;
@@ -885,8 +885,8 @@
           <div class="term-body">
             <div id="s5-l1" class="term-line cmd"><span class="prompt">$ </span>mycelium agent create avery-agent --adapter claude_code</div>
             <div id="s5-l2" class="term-line ok">  ✓ Registered @avery-agent (claude_code)</div>
-            <div id="s5-l3" class="term-line cmd"><span class="prompt">$ </span>mycelium agent create selina-agent --adapter claude_code</div>
-            <div id="s5-l4" class="term-line ok">  ✓ Registered @selina-agent (claude_code)</div>
+            <div id="s5-l3" class="term-line cmd"><span class="prompt">$ </span>mycelium agent create rowan-agent --adapter claude_code</div>
+            <div id="s5-l4" class="term-line ok">  ✓ Registered @rowan-agent (claude_code)</div>
             <div id="s5-l5" class="term-line cmd"><span class="prompt">$ </span>mycelium engine create aligner --kind aligner</div>
             <div id="s5-l6" class="term-line ok">  ✓ Registered @aligner: Pi + NEGMAS mediator</div>
             <div id="s5-l7" class="term-line dim">  → address them by @handle from the mycelium room</div>
@@ -926,7 +926,7 @@
                 <div class="chat-avatar user">AL</div>
                 <div class="body">
                   <div class="meta"><span class="name">alex</span><span class="time">today at 12:08</span></div>
-                  <div class="text">hey <span class="mention avery">@avery-agent</span>, let's lock the Q3 launch plan with <span class="mention selina">@selina-agent</span></div>
+                  <div class="text">hey <span class="mention avery">@avery-agent</span>, let's lock the Q3 launch plan with <span class="mention rowan">@rowan-agent</span></div>
                 </div>
               </div>
               <div id="s5b-typing" class="chat-msg">
@@ -960,7 +960,7 @@
                 </div>
                 <div class="body">
                   <div class="meta"><span class="name">avery-agent</span><span class="agent-badge">AGENT</span><span class="time">12:08</span></div>
-                  <div class="text">On it. Posting my position and summoning <span class="mention selina">@aligner</span> to converge with <span class="mention selina">@selina-agent</span>. I'll report back with the plan.</div>
+                  <div class="text">On it. Posting my position and summoning <span class="mention rowan">@aligner</span> to converge with <span class="mention rowan">@rowan-agent</span>. I'll report back with the plan.</div>
                 </div>
               </div>
             </div>
@@ -975,7 +975,7 @@
               </div>
               <div class="mem-list">
                 <div class="mem-item"><span class="key">@avery-agent</span><div>claude_code</div></div>
-                <div class="mem-item"><span class="key">@selina-agent</span><div>claude_code</div></div>
+                <div class="mem-item"><span class="key">@rowan-agent</span><div>claude_code</div></div>
                 <div class="mem-item"><span class="key">@aligner</span><div>engine · aligner</div></div>
                 <div class="mem-item"><span class="key">@synthesizer</span><div>engine · synthesizer</div></div>
               </div>
@@ -1087,9 +1087,9 @@
                     <div class="cell" id="s6-j-7"></div>
                     <div class="cell" id="s6-j-8"></div>
                   </div>
-                  <!-- selina lane -->
+                  <!-- rowan lane -->
                   <div class="row">
-                    <div class="lane-label">selina</div>
+                    <div class="lane-label">rowan</div>
                     <div class="cell" id="s6-s-1">
                       <span id="s6-s-1-tick" class="glyph glyph-tick"></span>
                       <span id="s6-s-1-rej"  class="glyph" style="display:none;">
@@ -1193,7 +1193,7 @@
                 </div>
                 <div id="s6-ev-2" class="eventlog-row reject">
                   <span class="t">12:08:41</span><span class="r">R01</span>
-                  <span class="a">selina</span>
+                  <span class="a">rowan</span>
                   <span class="glyph"><svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--yellow); display:block;"><line x1="2" y1="2" x2="10" y2="10" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/><line x1="10" y1="2" x2="2" y2="10" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/></svg></span>
                   <span class="lab" style="color: var(--yellow);">reject</span>
                 </div>
@@ -1203,13 +1203,13 @@
                 </div>
                 <div id="s6-ev-4" class="eventlog-row reject">
                   <span class="t">12:08:55</span><span class="r">R02</span>
-                  <span class="a">selina</span>
+                  <span class="a">rowan</span>
                   <span class="glyph"><svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--yellow); display:block;"><line x1="2" y1="2" x2="10" y2="10" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/><line x1="10" y1="2" x2="2" y2="10" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/></svg></span>
                   <span class="lab" style="color: var(--yellow);">reject</span>
                 </div>
                 <div id="s6-ev-5" class="eventlog-row counter">
                   <span class="t">12:09:06</span><span class="r">R03</span>
-                  <span class="a">selina</span><span class="glyph glyph-diamond"></span><span class="lab">counter</span>
+                  <span class="a">rowan</span><span class="glyph glyph-diamond"></span><span class="lab">counter</span>
                 </div>
                 <div id="s6-ev-6" class="eventlog-row reject">
                   <span class="t">12:09:09</span><span class="r">R03</span>
@@ -1223,7 +1223,7 @@
                 </div>
                 <div id="s6-ev-8" class="eventlog-row counter">
                   <span class="t">12:09:24</span><span class="r">R04</span>
-                  <span class="a">selina</span><span class="glyph glyph-diamond"></span><span class="lab">counter</span>
+                  <span class="a">rowan</span><span class="glyph glyph-diamond"></span><span class="lab">counter</span>
                 </div>
                 <div id="s6-ev-9" class="eventlog-row accept">
                   <span class="t">12:09:36</span><span class="r">R05</span>
@@ -1231,7 +1231,7 @@
                 </div>
                 <div id="s6-ev-10" class="eventlog-row accept">
                   <span class="t">12:09:39</span><span class="r">R05</span>
-                  <span class="a">selina</span><span class="glyph glyph-accept"></span><span class="lab">accept</span>
+                  <span class="a">rowan</span><span class="glyph glyph-accept"></span><span class="lab">accept</span>
                 </div>
                 <div id="s6-ev-11" class="eventlog-row consensus">
                   <span class="t">12:09:39</span><span class="r">R05</span>
@@ -1287,7 +1287,7 @@
                   <div class="pl-head"># Q3 launch plan</div>
                   <div id="s6b-t1" class="task">
                     <span class="box">- [ ]</span>
-                    <span class="label">lock the reduced-scope spec <span class="handle">@selina-agent</span></span>
+                    <span class="label">lock the reduced-scope spec <span class="handle">@rowan-agent</span></span>
                   </div>
                   <div id="s6b-t2" class="task">
                     <span class="box">- [ ]</span>
@@ -1299,7 +1299,7 @@
                   </div>
                   <div id="s6b-t4" class="task">
                     <span class="box">- [ ]</span>
-                    <span class="label">schedule the go/no-go review <span class="handle">@selina-agent</span></span>
+                    <span class="label">schedule the go/no-go review <span class="handle">@rowan-agent</span></span>
                   </div>
                 </div>
               </div>
@@ -1363,7 +1363,7 @@
                     <div class="pl-head"># design-review — room briefing</div>
                     <div id="s6c-b1" class="task"><span class="box">—</span><span class="label">Goal · lock the Q3 launch plan with the team.</span></div>
                     <div id="s6c-b2" class="task"><span class="box">—</span><span class="label">Decision · ship the reduced-scope Q3 spec first.</span></div>
-                    <div id="s6c-b3" class="task"><span class="box">—</span><span class="label">Plan · 4 tasks compiled, owners <span class="handle">@selina-agent</span> / <span class="handle">@avery-agent</span>.</span></div>
+                    <div id="s6c-b3" class="task"><span class="box">—</span><span class="label">Plan · 4 tasks compiled, owners <span class="handle">@rowan-agent</span> / <span class="handle">@avery-agent</span>.</span></div>
                     <div id="s6c-b4" class="task"><span class="box">—</span><span class="label">Status · staging + go/no-go review scheduled.</span></div>
                   </div>
                 </div>
@@ -1402,7 +1402,7 @@
     <script src="./mycelium-bg.js"></script>
     <script>
       // Split agent-reply text into per-word spans so GSAP can typewriter them.
-      // Mentions (e.g. <span class="mention">@selina</span>) are wrapped as one word.
+      // Mentions (e.g. <span class="mention">@rowan</span>) are wrapped as one word.
       function splitWords(selector) {
         const el = document.querySelector(selector);
         if (!el) return;

--- a/mycelium-promo/index.html
+++ b/mycelium-promo/index.html
@@ -597,7 +597,7 @@
         border: 1.5px solid var(--border2);
         color: var(--text);
       }
-      .chat-avatar.julia  { background: linear-gradient(135deg, #5cc7d2 0%, #8fd6de 100%); color: #06181b; }
+      .chat-avatar.avery  { background: linear-gradient(135deg, #5cc7d2 0%, #8fd6de 100%); color: #06181b; }
       .chat-avatar.selina  { background: linear-gradient(135deg, #7f8a94 0%, #5b666f 100%); color: #e8ebee; }
       .chat-msg .body { flex: 1; min-width: 0; }
       .chat-msg .meta {
@@ -631,7 +631,7 @@
       }
       /* Typewriter: words start invisible, GSAP fades them in one by one */
       .word { opacity: 0; }
-      .chat-msg .text .mention.julia { background: rgba(92, 199, 210,0.16); color: var(--accent); }
+      .chat-msg .text .mention.avery { background: rgba(92, 199, 210,0.16); color: var(--accent); }
       .chat-msg .text .mention.selina { background: rgba(192,132,252,0.18); color: var(--purple); }
       .chat-typing {
         display: inline-flex; gap: 7px; align-items: center;
@@ -848,7 +848,7 @@
               </div>
               <div class="ui-pane">
                 <div class="event-stream">
-                  <div class="event-row"><span class="ts">12:04:17</span><span class="who">julia</span><span class="body"><span class="pill">memory.set</span>decisions/scope → "Ship the reduced-scope Q3 spec first"</span></div>
+                  <div class="event-row"><span class="ts">12:04:17</span><span class="who">avery</span><span class="body"><span class="pill">memory.set</span>decisions/scope → "Ship the reduced-scope Q3 spec first"</span></div>
                 </div>
                 <div class="ui-composer">message design-review · start with @handle to invoke an agent</div>
               </div>
@@ -883,8 +883,8 @@
             <span class="title">~ · mycelium agent</span>
           </div>
           <div class="term-body">
-            <div id="s5-l1" class="term-line cmd"><span class="prompt">$ </span>mycelium agent create julia-agent --adapter claude_code</div>
-            <div id="s5-l2" class="term-line ok">  ✓ Registered @julia-agent (claude_code)</div>
+            <div id="s5-l1" class="term-line cmd"><span class="prompt">$ </span>mycelium agent create avery-agent --adapter claude_code</div>
+            <div id="s5-l2" class="term-line ok">  ✓ Registered @avery-agent (claude_code)</div>
             <div id="s5-l3" class="term-line cmd"><span class="prompt">$ </span>mycelium agent create selina-agent --adapter claude_code</div>
             <div id="s5-l4" class="term-line ok">  ✓ Registered @selina-agent (claude_code)</div>
             <div id="s5-l5" class="term-line cmd"><span class="prompt">$ </span>mycelium engine create aligner --kind aligner</div>
@@ -926,11 +926,11 @@
                 <div class="chat-avatar user">AL</div>
                 <div class="body">
                   <div class="meta"><span class="name">alex</span><span class="time">today at 12:08</span></div>
-                  <div class="text">hey <span class="mention julia">@julia-agent</span>, let's lock the Q3 launch plan with <span class="mention selina">@selina-agent</span></div>
+                  <div class="text">hey <span class="mention avery">@avery-agent</span>, let's lock the Q3 launch plan with <span class="mention selina">@selina-agent</span></div>
                 </div>
               </div>
               <div id="s5b-typing" class="chat-msg">
-                <div class="chat-avatar julia">
+                <div class="chat-avatar avery">
                   <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <path d="M12 8V4H8"/>
                     <rect width="16" height="12" x="4" y="8" rx="2"/>
@@ -943,12 +943,12 @@
                 <div class="body">
                   <div class="chat-typing">
                     <span class="dots"><span class="dot"></span><span class="dot"></span><span class="dot"></span></span>
-                    julia-agent is thinking…
+                    avery-agent is thinking…
                   </div>
                 </div>
               </div>
               <div id="s5b-m2" class="chat-msg">
-                <div class="chat-avatar julia">
+                <div class="chat-avatar avery">
                   <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                     <path d="M12 8V4H8"/>
                     <rect width="16" height="12" x="4" y="8" rx="2"/>
@@ -959,7 +959,7 @@
                   </svg>
                 </div>
                 <div class="body">
-                  <div class="meta"><span class="name">julia-agent</span><span class="agent-badge">AGENT</span><span class="time">12:08</span></div>
+                  <div class="meta"><span class="name">avery-agent</span><span class="agent-badge">AGENT</span><span class="time">12:08</span></div>
                   <div class="text">On it. Posting my position and summoning <span class="mention selina">@aligner</span> to converge with <span class="mention selina">@selina-agent</span>. I'll report back with the plan.</div>
                 </div>
               </div>
@@ -974,7 +974,7 @@
                 <span class="it"><span class="ic"></span>Memory</span>
               </div>
               <div class="mem-list">
-                <div class="mem-item"><span class="key">@julia-agent</span><div>claude_code</div></div>
+                <div class="mem-item"><span class="key">@avery-agent</span><div>claude_code</div></div>
                 <div class="mem-item"><span class="key">@selina-agent</span><div>claude_code</div></div>
                 <div class="mem-item"><span class="key">@aligner</span><div>engine · aligner</div></div>
                 <div class="mem-item"><span class="key">@synthesizer</span><div>engine · synthesizer</div></div>
@@ -1055,9 +1055,9 @@
                     <div class="cell head" id="s6-rh-7">07</div>
                     <div class="cell head" id="s6-rh-8">08</div>
                   </div>
-                  <!-- julia lane -->
+                  <!-- avery lane -->
                   <div class="row">
-                    <div class="lane-label">julia</div>
+                    <div class="lane-label">avery</div>
                     <div class="cell" id="s6-j-1">
                       <span id="s6-j-1-tick" class="glyph glyph-tick"></span>
                       <span id="s6-j-1-prop" class="glyph glyph-square" style="display:none;"></span>
@@ -1189,7 +1189,7 @@
               <div class="eventlog-rows">
                 <div id="s6-ev-1" class="eventlog-row propose">
                   <span class="t">12:08:38</span><span class="r">R01</span>
-                  <span class="a">julia</span><span class="glyph glyph-square"></span><span class="lab">propose</span>
+                  <span class="a">avery</span><span class="glyph glyph-square"></span><span class="lab">propose</span>
                 </div>
                 <div id="s6-ev-2" class="eventlog-row reject">
                   <span class="t">12:08:41</span><span class="r">R01</span>
@@ -1199,7 +1199,7 @@
                 </div>
                 <div id="s6-ev-3" class="eventlog-row counter">
                   <span class="t">12:08:52</span><span class="r">R02</span>
-                  <span class="a">julia</span><span class="glyph glyph-diamond"></span><span class="lab">counter</span>
+                  <span class="a">avery</span><span class="glyph glyph-diamond"></span><span class="lab">counter</span>
                 </div>
                 <div id="s6-ev-4" class="eventlog-row reject">
                   <span class="t">12:08:55</span><span class="r">R02</span>
@@ -1213,13 +1213,13 @@
                 </div>
                 <div id="s6-ev-6" class="eventlog-row reject">
                   <span class="t">12:09:09</span><span class="r">R03</span>
-                  <span class="a">julia</span>
+                  <span class="a">avery</span>
                   <span class="glyph"><svg width="12" height="12" viewBox="0 0 12 12" style="color: var(--yellow); display:block;"><line x1="2" y1="2" x2="10" y2="10" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/><line x1="10" y1="2" x2="2" y2="10" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/></svg></span>
                   <span class="lab" style="color: var(--yellow);">reject</span>
                 </div>
                 <div id="s6-ev-7" class="eventlog-row counter">
                   <span class="t">12:09:21</span><span class="r">R04</span>
-                  <span class="a">julia</span><span class="glyph glyph-diamond"></span><span class="lab">counter</span>
+                  <span class="a">avery</span><span class="glyph glyph-diamond"></span><span class="lab">counter</span>
                 </div>
                 <div id="s6-ev-8" class="eventlog-row counter">
                   <span class="t">12:09:24</span><span class="r">R04</span>
@@ -1227,7 +1227,7 @@
                 </div>
                 <div id="s6-ev-9" class="eventlog-row accept">
                   <span class="t">12:09:36</span><span class="r">R05</span>
-                  <span class="a">julia</span><span class="glyph glyph-accept"></span><span class="lab">accept</span>
+                  <span class="a">avery</span><span class="glyph glyph-accept"></span><span class="lab">accept</span>
                 </div>
                 <div id="s6-ev-10" class="eventlog-row accept">
                   <span class="t">12:09:39</span><span class="r">R05</span>
@@ -1295,7 +1295,7 @@
                   </div>
                   <div id="s6b-t3" class="task">
                     <span class="box">- [ ]</span>
-                    <span class="label">wire the launch checklist into #engineering <span class="handle">@julia-agent</span></span>
+                    <span class="label">wire the launch checklist into #engineering <span class="handle">@avery-agent</span></span>
                   </div>
                   <div id="s6b-t4" class="task">
                     <span class="box">- [ ]</span>
@@ -1363,7 +1363,7 @@
                     <div class="pl-head"># design-review — room briefing</div>
                     <div id="s6c-b1" class="task"><span class="box">—</span><span class="label">Goal · lock the Q3 launch plan with the team.</span></div>
                     <div id="s6c-b2" class="task"><span class="box">—</span><span class="label">Decision · ship the reduced-scope Q3 spec first.</span></div>
-                    <div id="s6c-b3" class="task"><span class="box">—</span><span class="label">Plan · 4 tasks compiled, owners <span class="handle">@selina-agent</span> / <span class="handle">@julia-agent</span>.</span></div>
+                    <div id="s6c-b3" class="task"><span class="box">—</span><span class="label">Plan · 4 tasks compiled, owners <span class="handle">@selina-agent</span> / <span class="handle">@avery-agent</span>.</span></div>
                     <div id="s6c-b4" class="task"><span class="box">—</span><span class="label">Status · staging + go/no-go review scheduled.</span></div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

Two teammates' real names were being used as filler example values throughout the project — example handles (`julia`, `julia-agent`, `@Julia`, `selina`, `selina-agent`), sample display names (`"Julia Valenti"`), and sample output in docs, CLI `--help` text, test fixtures, the promo reel, and frontend input placeholders. This replaces all of that example-variable usage with neutral names:

| Was | Now |
|---|---|
| `julia` / `julia-agent` / `@Julia` | `avery` / `avery-agent` / `@Avery` |
| `"Julia Valenti"` | `"Avery Quinn"` |
| `selina` / `selina-agent` | `rowan` / `rowan-agent` |

**Attribution is deliberately left untouched.** This PR only changes placeholder/example values. The following still credit both teammates by name and were explicitly excluded:

- `LICENSE` (copyright holder)
- `MAINTAINERS.md`, `CONTRIBUTORS.md`
- `.github/CODEOWNERS` (functional — required-review plumbing)
- `SECURITY.md`, `CODE_OF_CONDUCT.md` (contact address)
- `.tome/wiki.md`, `.tome/pages/team.md` (both real names + GitHub handles intact)
- The real `clawhub.ai/juliarvalenti/mycelium-io` install URLs in `docs/site.js` and the troubleshooting skill

## Changes

- **Docs sources** — `mycelium-cli/src/mycelium/docs/{principals,l9-protocol,guides/auth}.md`, `docs/demo-script.md`, `README.md`
- **Generated docs** — `docs/{index,concepts,adapters,reference}.html` and `llms-full.txt` regenerated via `docs/generate_docs.py`; the hand-written `docs/{stories,l9-integration,mycelium-dataflow}.html` updated directly
- **CLI help text** — example strings in `commands/{agent,engine,room,user,wire}.py`, a docstring in `collector.py`, and `protocol.py` field descriptions
- **Adapter assets** — `claude_code` `SKILL.md` and the `cursor` rules file
- **Test fixtures** — 8 backend test modules, 7 CLI test modules
- **Contract** — `contracts/user-store.json` normalization fixture, updated in lockstep with both the backend and CLI contract tests that assert against it
- **Promo + frontend** — `mycelium-promo/index.html` (CSS classes, chat mockups, negotiation lanes), `acting-as-picker.tsx` placeholders, MSW mock handler

No behavioral change — every edit is a string literal, fixture value, CSS class name, or comment.

## Testing

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — **551 passed, 6 skipped** (backend); **445 passed** (CLI)
- [x] Linting passes (`uv run ruff check .`) — all checks passed
- [x] Format check passes (`uv run ruff format --check .`) — 257 files already formatted
- [x] `uv run ty check .` — all checks passed
- [x] `docs/generate_docs.py` re-run after editing the markdown and CLI-decorator sources; generated output is consistent with the sources (no drift)

Note: `ty` and `tests/test_engine_mediator.py` initially failed on an unresolved `negmas` import — reproduced with these changes stashed, so it was a pre-existing unsynced dep, not this diff. Resolved with `uv sync --group dev --extra engine`; `uv.lock` is unchanged.

## Related Issues

<!-- none -->