### PR TITLE
feat(identity): frontend OIDC login (browser tier) (#606)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2038,6 +2038,42 @@ For the tightest, individually-attested agent identity on the SLIM channel itsel
 see [Attested Identity (SPIRE)](#spire-identity) — a different, heavier tier from
 this HTTP-API gate.
 
+## Browser login (the frontend)
+
+The Next.js frontend does the same OIDC flow for humans in a browser. With the
+gate **off** it is unchanged — the localStorage handle-picker, no login. With the
+gate **on**, the app shows a **Sign in** screen and redirects to Keycloak; after
+you authenticate it carries your token on every `/api/*` call (sealed in an
+httpOnly cookie, injected server-side by the proxy — it never reaches browser JS).
+
+The realm import ships a second public client, **`mycelium-web`**, with the web
+redirect `http://localhost:3000/api/auth/callback` (the CLI's `mycelium-cli`
+client uses a loopback redirect instead — separate clients, separately revocable).
+
+Configure the frontend (server-side env) and bring the UI up:
+
+```bash
+export MYCELIUM_OIDC_ISSUER=http://localhost:8080/realms/mycelium
+export MYCELIUM_OIDC_INTERNAL_ISSUER=http://keycloak:8080/realms/mycelium
+export MYCELIUM_OIDC_CLIENT_ID=mycelium-web
+export MYCELIUM_OIDC_AUDIENCE=mycelium
+export AUTH_SESSION_SECRET=$(openssl rand -hex 32)
+
+docker compose -f compose.yml -f compose-dev.yml -f compose-keycloak.yml \
+  --profile ui up -d
+```
+
+The **issuer split is the same as the backend's**, for the same reason: the
+browser reaches Keycloak at `MYCELIUM_OIDC_ISSUER` (`localhost:8080`) and the
+token's `iss` matches it, but the containerized frontend server can't use
+`localhost`, so it runs discovery + token exchange against
+`MYCELIUM_OIDC_INTERNAL_ISSUER` (`keycloak:8080`). Running the frontend on the
+host with `pnpm dev` instead? Drop `INTERNAL_ISSUER` — the two coincide.
+
+> **Off by default here too.** With `MYCELIUM_OIDC_ISSUER` / `AUTH_SESSION_SECRET`
+> unset, the frontend never engages OIDC. And it only shows the sign-in screen
+> when the backend's `/health` reports the gate on — the try-it path is untouched.
+
 ## The honest ceiling
 
 The shipped overlay is **dev-grade**: Keycloak in `start-dev` (in-memory H2, HTTP,

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1501,6 +1501,23 @@ curl <span class="flag">-s</span> <span class="flag">-o</span> /dev/null <span c
       <h2 id="keycloak-oidc-agents-and-more-than-one-issuer">Agents, and more than one issuer</h2>
       <p>This guide is the <strong>human</strong> tier. Agents authenticate as workloads with the <code>client_credentials</code> grant from their own Keycloak client — see <a href="#auth">Authentication → Agents sign in as themselves</a>. Humans and agents are often separate realms; list each as its own <code>[[auth.issuers]]</code> block (a human root with <code>role = &quot;user&quot;</code>, an agent root with <code>role = &quot;agent&quot;</code>), matched by exact <code>iss</code> and never interchangeable.</p>
       <p>For the tightest, individually-attested agent identity on the SLIM channel itself, see <a href="#spire-identity">Attested Identity (SPIRE)</a> — a different, heavier tier from this HTTP-API gate.</p>
+      <h2 id="keycloak-oidc-browser-login-the-frontend">Browser login (the frontend)</h2>
+      <p>The Next.js frontend does the same OIDC flow for humans in a browser. With the gate <strong>off</strong> it is unchanged — the localStorage handle-picker, no login. With the gate <strong>on</strong>, the app shows a <strong>Sign in</strong> screen and redirects to Keycloak; after you authenticate it carries your token on every <code>/api/*</code> call (sealed in an httpOnly cookie, injected server-side by the proxy — it never reaches browser JS).</p>
+      <p>The realm import ships a second public client, <strong><code>mycelium-web</code></strong>, with the web redirect <code>http://localhost:3000/api/auth/callback</code> (the CLI&#x27;s <code>mycelium-cli</code> client uses a loopback redirect instead — separate clients, separately revocable).</p>
+      <p>Configure the frontend (server-side env) and bring the UI up:</p>
+      <pre><code>export MYCELIUM_OIDC_ISSUER=http://localhost:8080/realms/mycelium
+export MYCELIUM_OIDC_INTERNAL_ISSUER=http://keycloak:8080/realms/mycelium
+export MYCELIUM_OIDC_CLIENT_ID=mycelium-web
+export MYCELIUM_OIDC_AUDIENCE=mycelium
+export AUTH_SESSION_SECRET=$(openssl rand <span class="flag">-hex</span> 32)
+
+docker compose <span class="flag">-f</span> compose.yml <span class="flag">-f</span> compose-dev.yml <span class="flag">-f</span> compose-keycloak.yml \
+  <span class="flag">--profile</span> ui up <span class="flag">-d</span></code></pre>
+      <p>The <strong>issuer split is the same as the backend&#x27;s</strong>, for the same reason: the browser reaches Keycloak at <code>MYCELIUM_OIDC_ISSUER</code> (<code>localhost:8080</code>) and the token&#x27;s <code>iss</code> matches it, but the containerized frontend server can&#x27;t use <code>localhost</code>, so it runs discovery + token exchange against <code>MYCELIUM_OIDC_INTERNAL_ISSUER</code> (<code>keycloak:8080</code>). Running the frontend on the host with <code>pnpm dev</code> instead? Drop <code>INTERNAL_ISSUER</code> — the two coincide.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Off by default here too.</strong> With <code>MYCELIUM_OIDC_ISSUER</code> / <code>AUTH_SESSION_SECRET</code> unset, the frontend never engages OIDC. And it only shows the sign-in screen when the backend&#x27;s <code>/health</code> reports the gate on — the try-it path is untouched.</div>
+      </div>
       <h2 id="keycloak-oidc-the-honest-ceiling">The honest ceiling</h2>
       <p>The shipped overlay is <strong>dev-grade</strong>: Keycloak in <code>start-dev</code> (in-memory H2, HTTP, a demo user with a weak password). It is a real OIDC provider minting real RS256 tokens against a real JWKS — enough to build and prove against — but it is <strong>not</strong> a hardened production Keycloak. For a real deployment, run your own Keycloak over TLS with a persistent datastore and real users, then point the same three config values (<code>issuer</code>, <code>jwks_url</code>, <code>login.issuer</code>) at it. Nothing else changes.</p>
     </section>

--- a/mycelium-cli/src/mycelium/docker/compose-dev.yml
+++ b/mycelium-cli/src/mycelium/docker/compose-dev.yml
@@ -30,6 +30,16 @@ services:
       MYCELIUM_STUB_EMBEDDINGS: "1"
       LOG_LEVEL: DEBUG
 
+  # Build the frontend from local source instead of pulling the released image.
+  # compose.yml pins `pull_policy: always`, which would otherwise replace a local
+  # `--build` on the next `up` — so pin it to the dev tag and never pull here.
+  mycelium-frontend:
+    build:
+      context: ../../../../mycelium-frontend
+      dockerfile: Dockerfile
+    pull_policy: never
+    image: mycelium-frontend:dev
+
   mycelium-collector:
     build:
       context: ../../../

--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -179,6 +179,17 @@ services:
         required: false
     environment:
       MYCELIUM_INTERNAL_API_URL: http://mycelium-backend:8000
+      # Browser OIDC login (#606) — off by default. Empty issuer/secret leaves the
+      # frontend on the localStorage handle-picker tier, unchanged. Set these (and
+      # turn the backend gate on) to require a real sign-in. MYCELIUM_OIDC_ISSUER is
+      # the public issuer the browser reaches; MYCELIUM_OIDC_INTERNAL_ISSUER is the
+      # in-network base the frontend server uses for discovery/token exchange (e.g.
+      # http://keycloak:8080/realms/mycelium) — see docs/guides/keycloak-oidc.md.
+      MYCELIUM_OIDC_ISSUER: ${MYCELIUM_OIDC_ISSUER:-}
+      MYCELIUM_OIDC_INTERNAL_ISSUER: ${MYCELIUM_OIDC_INTERNAL_ISSUER:-}
+      MYCELIUM_OIDC_CLIENT_ID: ${MYCELIUM_OIDC_CLIENT_ID:-mycelium-web}
+      MYCELIUM_OIDC_AUDIENCE: ${MYCELIUM_OIDC_AUDIENCE:-}
+      AUTH_SESSION_SECRET: ${AUTH_SESSION_SECRET:-}
     depends_on:
       mycelium-backend:
         condition: service_healthy

--- a/mycelium-cli/src/mycelium/docker/keycloak/mycelium-realm.json
+++ b/mycelium-cli/src/mycelium/docker/keycloak/mycelium-realm.json
@@ -42,6 +42,39 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "mycelium-web",
+      "name": "Mycelium Web",
+      "description": "Public client for the Next.js frontend's browser OIDC login (Authorization Code + PKCE, web redirect).",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "fullScopeAllowed": true,
+      "redirectUris": [
+        "http://localhost:3000/api/auth/callback",
+        "http://127.0.0.1:3000/api/auth/callback"
+      ],
+      "webOrigins": ["+"],
+      "attributes": {
+        "post.logout.redirect.uris": "+"
+      },
+      "protocolMappers": [
+        {
+          "name": "mycelium-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "mycelium",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
     }
   ],
   "users": [

--- a/mycelium-cli/src/mycelium/docs/guides/keycloak-oidc.md
+++ b/mycelium-cli/src/mycelium/docs/guides/keycloak-oidc.md
@@ -173,6 +173,42 @@ For the tightest, individually-attested agent identity on the SLIM channel itsel
 see [Attested Identity (SPIRE)](#spire-identity) — a different, heavier tier from
 this HTTP-API gate.
 
+## Browser login (the frontend)
+
+The Next.js frontend does the same OIDC flow for humans in a browser. With the
+gate **off** it is unchanged — the localStorage handle-picker, no login. With the
+gate **on**, the app shows a **Sign in** screen and redirects to Keycloak; after
+you authenticate it carries your token on every `/api/*` call (sealed in an
+httpOnly cookie, injected server-side by the proxy — it never reaches browser JS).
+
+The realm import ships a second public client, **`mycelium-web`**, with the web
+redirect `http://localhost:3000/api/auth/callback` (the CLI's `mycelium-cli`
+client uses a loopback redirect instead — separate clients, separately revocable).
+
+Configure the frontend (server-side env) and bring the UI up:
+
+```bash
+export MYCELIUM_OIDC_ISSUER=http://localhost:8080/realms/mycelium
+export MYCELIUM_OIDC_INTERNAL_ISSUER=http://keycloak:8080/realms/mycelium
+export MYCELIUM_OIDC_CLIENT_ID=mycelium-web
+export MYCELIUM_OIDC_AUDIENCE=mycelium
+export AUTH_SESSION_SECRET=$(openssl rand -hex 32)
+
+docker compose -f compose.yml -f compose-dev.yml -f compose-keycloak.yml \
+  --profile ui up -d
+```
+
+The **issuer split is the same as the backend's**, for the same reason: the
+browser reaches Keycloak at `MYCELIUM_OIDC_ISSUER` (`localhost:8080`) and the
+token's `iss` matches it, but the containerized frontend server can't use
+`localhost`, so it runs discovery + token exchange against
+`MYCELIUM_OIDC_INTERNAL_ISSUER` (`keycloak:8080`). Running the frontend on the
+host with `pnpm dev` instead? Drop `INTERNAL_ISSUER` — the two coincide.
+
+> **Off by default here too.** With `MYCELIUM_OIDC_ISSUER` / `AUTH_SESSION_SECRET`
+> unset, the frontend never engages OIDC. And it only shows the sign-in screen
+> when the backend's `/health` reports the gate on — the try-it path is untouched.
+
 ## The honest ceiling
 
 The shipped overlay is **dev-grade**: Keycloak in `start-dev` (in-memory H2, HTTP,

--- a/mycelium-frontend/.env.example
+++ b/mycelium-frontend/.env.example
@@ -19,3 +19,26 @@
 #   The Docker production path does not need this.
 #
 # MYCELIUM_ALLOWED_DEV_ORIGINS=http://203.0.113.42:3000,http://my-dev-host:3000
+
+# ── Browser OIDC login (#606) — off by default ───────────────────────────────
+# Leave these unset and the frontend stays on the self-asserted handle-picker
+# tier (no login), exactly as before. Set them — and turn the backend gate on —
+# to require a real sign-in. The UI only shows a login screen when the backend's
+# /health advertises the gate as on. See docs/guides/keycloak-oidc.md.
+#
+# MYCELIUM_OIDC_ISSUER
+#   Public issuer the browser is redirected to (what the token's `iss` carries).
+#   e.g. http://localhost:8080/realms/mycelium
+# MYCELIUM_OIDC_INTERNAL_ISSUER
+#   In-network base the Next.js server uses for discovery + token exchange, when
+#   it can't reach the public issuer (containerized frontend). Defaults to
+#   MYCELIUM_OIDC_ISSUER. e.g. http://keycloak:8080/realms/mycelium
+# MYCELIUM_OIDC_CLIENT_ID    Public browser client id (default: mycelium-web).
+# MYCELIUM_OIDC_AUDIENCE     Audience to expect; match the hub's auth.audience.
+# AUTH_SESSION_SECRET        Random secret that seals the httpOnly session cookie.
+#
+# MYCELIUM_OIDC_ISSUER=http://localhost:8080/realms/mycelium
+# MYCELIUM_OIDC_INTERNAL_ISSUER=http://keycloak:8080/realms/mycelium
+# MYCELIUM_OIDC_CLIENT_ID=mycelium-web
+# MYCELIUM_OIDC_AUDIENCE=mycelium
+# AUTH_SESSION_SECRET=change-me-to-a-long-random-string

--- a/mycelium-frontend/package-lock.json
+++ b/mycelium-frontend/package-lock.json
@@ -12,6 +12,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",
         "driver.js": "^1.8.0",
+        "jose": "^6.2.9",
         "lucide-react": "^1.21.0",
         "next": "^16.2.6",
         "next-themes": "^0.4.6",
@@ -5248,9 +5249,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/mycelium-frontend/package.json
+++ b/mycelium-frontend/package.json
@@ -15,6 +15,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.0",
     "driver.js": "^1.8.0",
+    "jose": "^6.2.9",
     "lucide-react": "^1.21.0",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",

--- a/mycelium-frontend/src/app/api/[...path]/route.ts
+++ b/mycelium-frontend/src/app/api/[...path]/route.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 Mycelium Contributors
 
 import { getBackendUrl } from "@/lib/backend";
+import { bearer } from "@/lib/session";
 import { handleMock, isMockMode } from "@/mocks";
 
 /**
@@ -40,6 +41,11 @@ async function proxy(req: Request): Promise<Response> {
   // Ask upstream for plain bytes so we can stream the response straight through
   // without a content-encoding/content-length mismatch.
   headers.delete("accept-encoding");
+  // Attach the signed-in user's bearer (refreshing it if near expiry). Returns
+  // null when there's no session — gate off or signed out — so the header stays
+  // absent and the proxy behaves exactly as it did before OIDC existed.
+  const token = await bearer();
+  if (token) headers.set("authorization", `Bearer ${token}`);
 
   const init: RequestInit = {
     method: req.method,

--- a/mycelium-frontend/src/app/api/auth/callback/route.ts
+++ b/mycelium-frontend/src/app/api/auth/callback/route.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// Finish the flow: verify state, exchange the code for tokens, and seal them
+// into the session cookie. Then bounce back to where login started.
+
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { oidcConfig } from "@/lib/auth-config";
+import { claimsOf, endpoints, exchangeCode, handleFromClaims, requestOrigin } from "@/lib/oidc";
+import { TX_COOKIE, unseal, writeSession, type Session } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+interface Tx {
+  verifier: string;
+  state: string;
+  returnTo: string;
+}
+
+export async function GET(req: Request): Promise<Response> {
+  const cfg = oidcConfig();
+  if (!cfg) {
+    return NextResponse.json({ detail: "Browser OIDC login is not configured" }, { status: 400 });
+  }
+
+  const url = new URL(req.url);
+  const origin = requestOrigin(req);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const idpError = url.searchParams.get("error");
+
+  const jar = await cookies();
+  const txRaw = jar.get(TX_COOKIE)?.value;
+  // The transaction cookie is single-use — clear it regardless of outcome.
+  jar.set(TX_COOKIE, "", { path: "/", maxAge: 0 });
+
+  if (idpError) return loginError(origin, `identity provider returned: ${idpError}`);
+  if (!code || !state || !txRaw) return loginError(origin, "missing code or state");
+
+  const tx = await unseal<Tx>(txRaw, cfg.sessionSecret);
+  if (!tx || tx.state !== state) return loginError(origin, "state mismatch");
+
+  try {
+    const ep = await endpoints(cfg);
+    const redirectUri = `${origin}/api/auth/callback`;
+    const t = await exchangeCode(cfg, ep, code, redirectUri, tx.verifier);
+    const now = Math.floor(Date.now() / 1000);
+    const session: Session = {
+      access_token: t.access_token,
+      refresh_token: t.refresh_token,
+      expires_at: now + (t.expires_in ?? 300),
+      handle: handleFromClaims(claimsOf(t.access_token), cfg.handleClaim),
+    };
+    await writeSession(session);
+    return NextResponse.redirect(`${origin}${tx.returnTo || "/"}`);
+  } catch (e) {
+    return loginError(origin, e instanceof Error ? e.message : "token exchange failed");
+  }
+}
+
+function loginError(origin: string, msg: string): Response {
+  const to = new URL("/", origin);
+  to.searchParams.set("auth_error", msg);
+  return NextResponse.redirect(to.toString());
+}

--- a/mycelium-frontend/src/app/api/auth/login/route.ts
+++ b/mycelium-frontend/src/app/api/auth/login/route.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// Start the Authorization Code + PKCE flow: stash the verifier/state in a
+// short-lived httpOnly cookie and redirect the browser to the IdP.
+
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { oidcConfig } from "@/lib/auth-config";
+import { endpoints, pkce, randomState, requestOrigin } from "@/lib/oidc";
+import { seal, TX_COOKIE } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(req: Request): Promise<Response> {
+  const cfg = oidcConfig();
+  if (!cfg) {
+    return NextResponse.json({ detail: "Browser OIDC login is not configured" }, { status: 400 });
+  }
+
+  const url = new URL(req.url);
+  const origin = requestOrigin(req);
+  const returnTo = sanitizeReturn(url.searchParams.get("return_to"));
+  const redirectUri = `${origin}/api/auth/callback`;
+
+  let ep;
+  try {
+    ep = await endpoints(cfg);
+  } catch (e) {
+    return loginError(origin, e instanceof Error ? e.message : "discovery failed");
+  }
+
+  const { verifier, challenge } = pkce();
+  const state = randomState();
+  const tx = await seal({ verifier, state, returnTo }, cfg.sessionSecret, 600);
+  const jar = await cookies();
+  jar.set(TX_COOKIE, tx, {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 600,
+  });
+
+  const auth = new URL(ep.authorizationEndpoint);
+  auth.searchParams.set("response_type", "code");
+  auth.searchParams.set("client_id", cfg.clientId);
+  auth.searchParams.set("redirect_uri", redirectUri);
+  auth.searchParams.set("scope", cfg.scopes);
+  auth.searchParams.set("state", state);
+  auth.searchParams.set("code_challenge", challenge);
+  auth.searchParams.set("code_challenge_method", "S256");
+  return NextResponse.redirect(auth.toString());
+}
+
+/** Only ever return to a same-origin path — never an attacker-supplied URL. */
+function sanitizeReturn(v: string | null): string {
+  if (!v || !v.startsWith("/") || v.startsWith("//")) return "/";
+  return v;
+}
+
+function loginError(origin: string, msg: string): Response {
+  const to = new URL("/", origin);
+  to.searchParams.set("auth_error", msg);
+  return NextResponse.redirect(to.toString());
+}

--- a/mycelium-frontend/src/app/api/auth/logout/route.ts
+++ b/mycelium-frontend/src/app/api/auth/logout/route.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// Drop the session cookie. The client reloads afterward; with the cookie gone
+// the proxy forwards no token and the gate re-engages the sign-in screen.
+
+import { NextResponse } from "next/server";
+import { clearSession } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(): Promise<Response> {
+  await clearSession();
+  return NextResponse.json({ ok: true });
+}

--- a/mycelium-frontend/src/app/api/auth/session/route.ts
+++ b/mycelium-frontend/src/app/api/auth/session/route.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// What the browser needs to decide whether to show the app or the sign-in
+// screen: is the backend gate on, is OIDC configured here, and are we signed in.
+
+import { NextResponse } from "next/server";
+import { oidcConfig } from "@/lib/auth-config";
+import { getBackendUrl } from "@/lib/backend";
+import { getSession } from "@/lib/session";
+import { isMockMode } from "@/mocks";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<Response> {
+  const session = await getSession();
+  return NextResponse.json({
+    // `authRequired` comes from the backend's own /health auth block — the gate
+    // is the source of truth, so the UI can't disagree with it.
+    authRequired: await gateOn(),
+    oidcConfigured: oidcConfig() != null,
+    signedIn: session != null,
+    handle: session?.handle ?? null,
+  });
+}
+
+async function gateOn(): Promise<boolean> {
+  if (isMockMode()) return false;
+  try {
+    const res = await fetch(`${getBackendUrl()}/health`, { cache: "no-store" });
+    if (!res.ok) return false;
+    const health = (await res.json()) as { auth?: { enabled?: boolean } };
+    return Boolean(health.auth?.enabled);
+  } catch {
+    // If we can't reach the backend, don't trap the user behind a login screen.
+    return false;
+  }
+}

--- a/mycelium-frontend/src/app/api/events/stream/route.ts
+++ b/mycelium-frontend/src/app/api/events/stream/route.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 Mycelium Contributors
 
 import { getBackendUrl } from "@/lib/backend";
+import { upstreamSseHeaders } from "@/lib/session";
 import { isMockMode } from "@/mocks";
 
 const SSE_HEADERS = {
@@ -27,7 +28,7 @@ export async function GET() {
   let res: Response;
   try {
     res = await fetch(upstream, {
-      headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+      headers: await upstreamSseHeaders(),
       cache: "no-store",
     });
   } catch {

--- a/mycelium-frontend/src/app/api/notifications/stream/route.ts
+++ b/mycelium-frontend/src/app/api/notifications/stream/route.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 Mycelium Contributors
 
 import { getBackendUrl } from "@/lib/backend";
+import { upstreamSseHeaders } from "@/lib/session";
 import { isMockMode } from "@/mocks";
 
 const SSE_HEADERS = {
@@ -27,7 +28,7 @@ export async function GET() {
   let res: Response;
   try {
     res = await fetch(upstream, {
-      headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+      headers: await upstreamSseHeaders(),
       cache: "no-store",
     });
   } catch {

--- a/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
+++ b/mycelium-frontend/src/app/api/rooms/[name]/messages/stream/route.ts
@@ -2,6 +2,7 @@
 // Copyright 2026 Mycelium Contributors
 
 import { getBackendUrl } from "@/lib/backend";
+import { upstreamSseHeaders } from "@/lib/session";
 import { isMockMode, mockStream } from "@/mocks";
 
 export async function GET(
@@ -17,7 +18,7 @@ export async function GET(
   let res: Response;
   try {
     res = await fetch(upstream, {
-      headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+      headers: await upstreamSseHeaders(),
       // Prevent Next.js fetch cache from buffering the response
       cache: "no-store",
     });

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -5,6 +5,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { CurrentUserProvider } from "@/components/current-user";
+import { AuthSessionProvider } from "@/components/auth-session";
+import { LoginGate } from "@/components/login-gate";
 import { KeymapProvider } from "@/components/keymap-provider";
 import { NotificationsProvider } from "@/components/notifications-provider";
 
@@ -26,11 +28,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="min-h-screen bg-bg text-text antialiased">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           <CurrentUserProvider>
-            <NotificationsProvider>
-              {/* Above the pages, not inside a page's shell: a page registers
-                  its own bindings, so it has to sit under the provider. */}
-              <KeymapProvider>{children}</KeymapProvider>
-            </NotificationsProvider>
+            <AuthSessionProvider>
+              {/* Gate the whole app: when the backend requires auth and there's
+                  no session, this renders the sign-in screen instead of the
+                  shell (and its silently-empty room lists). Inert when the gate
+                  is off. */}
+              <LoginGate>
+                <NotificationsProvider>
+                  {/* Above the pages, not inside a page's shell: a page registers
+                      its own bindings, so it has to sit under the provider. */}
+                  <KeymapProvider>{children}</KeymapProvider>
+                </NotificationsProvider>
+              </LoginGate>
+            </AuthSessionProvider>
           </CurrentUserProvider>
         </ThemeProvider>
       </body>

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -14,6 +14,7 @@ import {
   type User,
 } from "@/lib/api";
 import { useCurrentUser } from "@/components/current-user";
+import { useAuthSession } from "@/components/auth-session";
 import { Monogram } from "@/components/ui/monogram";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -67,6 +68,7 @@ function iamCommand(u: BoundUser): string {
  */
 export function ActingAsPicker() {
   const { principal, setPrincipal } = useCurrentUser();
+  const { signedIn, handle: sessionHandle, logout } = useAuthSession();
   const [open, setOpen] = useState(false);
   const [users, setUsers] = useState<User[]>([]);
   const [teams, setTeams] = useState<Team[]>([]);
@@ -165,6 +167,21 @@ export function ActingAsPicker() {
             <DialogHeader>
               <DialogTitle className="text-ui font-semibold text-text">Acting as</DialogTitle>
             </DialogHeader>
+
+            {signedIn && (
+              // Signed in through the hub's identity provider: the handle is the
+              // token's, not a free choice — a gated hub attributes writes to the
+              // token, so switching here would only earn a 403. Offer sign-out.
+              <div className="mt-2 flex items-center justify-between gap-2 rounded-md border border-border bg-surface/40 px-3 py-2">
+                <span className="min-w-0 text-label">
+                  <span className="text-micro text-muted-foreground">Signed in as </span>
+                  <span className="font-mono text-text">@{sessionHandle}</span>
+                </span>
+                <Button variant="ghost" size="xs" onClick={logout}>
+                  Sign out
+                </Button>
+              </div>
+            )}
 
             <div className="mt-2 max-h-64 overflow-y-auto border border-border">
               <button

--- a/mycelium-frontend/src/components/auth-session.tsx
+++ b/mycelium-frontend/src/components/auth-session.tsx
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { useCurrentUser } from "./current-user";
+
+/**
+ * Browser session state for the OIDC tier. Polls `/api/auth/session` (which
+ * reads the backend's /health gate + our cookie), and — when signed in — syncs
+ * the self-asserted "acting as" handle to the token's handle, so a gated hub
+ * never sees a body handle that disagrees with the token (a 403 in waiting).
+ *
+ * When the gate is off this is inert: `authRequired` is false and the app
+ * renders exactly as before.
+ */
+interface AuthSessionState {
+  loading: boolean;
+  authRequired: boolean;
+  oidcConfigured: boolean;
+  signedIn: boolean;
+  handle: string | null;
+}
+
+interface AuthSession extends AuthSessionState {
+  login: () => void;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+const Ctx = createContext<AuthSession | null>(null);
+
+const INITIAL: AuthSessionState = {
+  loading: true,
+  authRequired: false,
+  oidcConfigured: false,
+  signedIn: false,
+  handle: null,
+};
+
+export function AuthSessionProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AuthSessionState>(INITIAL);
+  const { setPrincipal } = useCurrentUser();
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/auth/session", { cache: "no-store" });
+      const d = (await res.json()) as Partial<AuthSessionState>;
+      const next: AuthSessionState = {
+        loading: false,
+        authRequired: Boolean(d.authRequired),
+        oidcConfigured: Boolean(d.oidcConfigured),
+        signedIn: Boolean(d.signedIn),
+        handle: d.handle ?? null,
+      };
+      setState(next);
+      if (next.signedIn && next.handle) setPrincipal(next.handle);
+    } catch {
+      setState((s) => ({ ...s, loading: false }));
+    }
+  }, [setPrincipal]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // A 401 from any API call (e.g. an access token that expired mid-session)
+  // re-checks the session, so the gate re-engages instead of silently emptying.
+  useEffect(() => {
+    const onUnauthorized = () => refresh();
+    window.addEventListener("mycelium:auth-required", onUnauthorized);
+    return () => window.removeEventListener("mycelium:auth-required", onUnauthorized);
+  }, [refresh]);
+
+  const login = useCallback(() => {
+    const returnTo = window.location.pathname + window.location.search;
+    window.location.href = `/api/auth/login?return_to=${encodeURIComponent(returnTo)}`;
+  }, []);
+
+  const logout = useCallback(async () => {
+    await fetch("/api/auth/logout", { method: "POST" });
+    setPrincipal("");
+    window.location.href = "/";
+  }, [setPrincipal]);
+
+  return <Ctx.Provider value={{ ...state, login, logout, refresh }}>{children}</Ctx.Provider>;
+}
+
+export function useAuthSession(): AuthSession {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error("useAuthSession must be used within an AuthSessionProvider");
+  return ctx;
+}

--- a/mycelium-frontend/src/components/login-gate.tsx
+++ b/mycelium-frontend/src/components/login-gate.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { useAuthSession } from "./auth-session";
+
+/**
+ * Renders the app when the gate is off or the user is signed in; otherwise a
+ * sign-in screen. This is the fix for #606's silent-empty degrade: a gated hub
+ * with no session gets an explicit "sign in" prompt, not blank room lists.
+ */
+export function LoginGate({ children }: { children: ReactNode }) {
+  const { loading, authRequired, oidcConfigured, signedIn, login } = useAuthSession();
+
+  // Don't flash the sign-in screen on first paint while /api/auth/session
+  // resolves — for the common ungated hub it lands on "not required" instantly.
+  if (loading) return null;
+  if (!authRequired || signedIn) return <>{children}</>;
+
+  return <SignInScreen oidcConfigured={oidcConfigured} onLogin={login} />;
+}
+
+function SignInScreen({ oidcConfigured, onLogin }: { oidcConfigured: boolean; onLogin: () => void }) {
+  const authError = useAuthError();
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-bg px-6">
+      <div className="w-full max-w-sm rounded-lg border border-border bg-surface/40 p-8 text-center">
+        <p className="font-serif text-3xl italic text-text">mycelium</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This hub requires you to sign in.
+        </p>
+
+        {oidcConfigured ? (
+          <Button size="lg" className="mt-6 w-full" onClick={onLogin}>
+            Sign in with your identity provider
+          </Button>
+        ) : (
+          <p className="mt-6 rounded-md border border-border bg-bg/60 p-3 text-left text-xs text-muted-foreground">
+            The backend gate is on, but browser login isn&apos;t configured on this
+            server. Set <code className="text-accent">MYCELIUM_OIDC_ISSUER</code> and{" "}
+            <code className="text-accent">AUTH_SESSION_SECRET</code>, then reload.
+          </p>
+        )}
+
+        {authError && (
+          <p className="mt-4 text-left text-xs text-red">Sign-in failed: {authError}</p>
+        )}
+      </div>
+    </main>
+  );
+}
+
+/** Surface `?auth_error=…` from a failed callback, then strip it from the URL. */
+function useAuthError(): string | null {
+  const [err, setErr] = useState<string | null>(null);
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const e = url.searchParams.get("auth_error");
+    if (e) {
+      setErr(e);
+      url.searchParams.delete("auth_error");
+      window.history.replaceState({}, "", url.toString());
+    }
+  }, []);
+  return err;
+}

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -78,6 +78,12 @@ async function apiFetch<T = unknown>(path: string, opts: ApiFetchOptions<T> = {}
   }
 
   if (!res.ok) {
+    // A gated hub answering 401 means the session lapsed (or never existed).
+    // Signal the auth provider to re-check rather than letting a `fallback`
+    // caller degrade to a silently-empty view. See components/auth-session.tsx.
+    if (res.status === 401 && typeof window !== "undefined") {
+      window.dispatchEvent(new Event("mycelium:auth-required"));
+    }
     const message = await errorDetail(res);
     if (hasFallback) {
       logFetchError(path)(new Error(message));

--- a/mycelium-frontend/src/lib/auth-config.ts
+++ b/mycelium-frontend/src/lib/auth-config.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Browser-tier OIDC configuration — SERVER-SIDE only (route handlers).
+ *
+ * Off by default, exactly like the backend gate: with no `MYCELIUM_OIDC_ISSUER`
+ * and no `AUTH_SESSION_SECRET`, `oidcConfig()` returns null and the whole login
+ * path stays inert (the localStorage handle-picker tier is unchanged). The UI
+ * only engages OIDC when the backend advertises the gate is on *and* this is
+ * configured.
+ *
+ * The issuer split mirrors the backend's issuer/jwks_url decoupling: the browser
+ * reaches Keycloak at the public `issuer` (e.g. http://localhost:8080/realms/…),
+ * but the Next.js server — in a container — cannot use that `localhost`, so it
+ * makes discovery + token-exchange calls against `internalIssuer` (e.g.
+ * http://keycloak:8080/realms/…). For `pnpm dev` on the host the two coincide.
+ */
+export interface OidcConfig {
+  /** Public issuer the browser is redirected to and that stamps the token `iss`. */
+  issuer: string;
+  /** Base the Next.js server uses for discovery + token calls. Defaults to `issuer`. */
+  internalIssuer: string;
+  clientId: string;
+  audience?: string;
+  scopes: string;
+  handleClaim: string;
+  /** Secret used to seal the httpOnly session cookie (AES-256-GCM via a SHA-256 key). */
+  sessionSecret: string;
+}
+
+function trimSlash(s: string): string {
+  return s.replace(/\/+$/, "");
+}
+
+/** Resolved OIDC config, or null when browser login is not configured. */
+export function oidcConfig(): OidcConfig | null {
+  const issuer = process.env.MYCELIUM_OIDC_ISSUER?.trim();
+  const sessionSecret = process.env.AUTH_SESSION_SECRET?.trim();
+  // Both are required to engage OIDC. A gate-on backend with these unset is a
+  // real (if awkward) state — the sign-in screen says so rather than looping.
+  if (!issuer || !sessionSecret) return null;
+  const internal = process.env.MYCELIUM_OIDC_INTERNAL_ISSUER?.trim();
+  return {
+    issuer: trimSlash(issuer),
+    internalIssuer: trimSlash(internal || issuer),
+    clientId: process.env.MYCELIUM_OIDC_CLIENT_ID?.trim() || "mycelium-web",
+    audience: process.env.MYCELIUM_OIDC_AUDIENCE?.trim() || undefined,
+    scopes: process.env.MYCELIUM_OIDC_SCOPES?.trim() || "openid profile email",
+    handleClaim: process.env.MYCELIUM_OIDC_HANDLE_CLAIM?.trim() || "preferred_username",
+    sessionSecret,
+  };
+}
+
+/** Whether browser OIDC login is configured (issuer + session secret present). */
+export function oidcConfigured(): boolean {
+  return oidcConfig() != null;
+}

--- a/mycelium-frontend/src/lib/oidc.test.ts
+++ b/mycelium-frontend/src/lib/oidc.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it } from "vitest";
+import { base64url, handleFromClaims, pkce, requestOrigin } from "./oidc";
+import { oidcConfig } from "./auth-config";
+
+describe("base64url", () => {
+  it("is url-safe and unpadded", () => {
+    const out = base64url(Buffer.from([251, 255, 191, 0]));
+    expect(out).not.toMatch(/[+/=]/);
+  });
+});
+
+describe("pkce", () => {
+  it("derives the S256 challenge from the verifier", () => {
+    const { verifier, challenge } = pkce();
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    const expected = base64url(createHash("sha256").update(verifier).digest());
+    expect(challenge).toBe(expected);
+  });
+});
+
+describe("handleFromClaims", () => {
+  it("prefers the configured claim, normalized", () => {
+    expect(handleFromClaims({ preferred_username: "@Demo" }, "preferred_username")).toBe("demo");
+  });
+  it("falls back to preferred_username, then sub", () => {
+    expect(handleFromClaims({ sub: "uuid-1" }, "preferred_username")).toBe("uuid-1");
+    expect(handleFromClaims({ preferred_username: "alice", sub: "uuid" }, "email")).toBe("alice");
+  });
+  it("is empty for a missing claim", () => {
+    expect(handleFromClaims({}, "preferred_username")).toBe("");
+  });
+});
+
+describe("requestOrigin", () => {
+  const req = (headers: Record<string, string>) =>
+    new Request("http://0.0.0.0:3000/api/auth/login", { headers });
+
+  it("uses the Host header, not the bind address in req.url", () => {
+    expect(requestOrigin(req({ host: "localhost:3000" }))).toBe("http://localhost:3000");
+  });
+  it("honors forwarded proto/host behind a proxy", () => {
+    expect(
+      requestOrigin(req({ "x-forwarded-proto": "https", "x-forwarded-host": "app.example.com" })),
+    ).toBe("https://app.example.com");
+  });
+});
+
+describe("oidcConfig", () => {
+  const KEYS = [
+    "MYCELIUM_OIDC_ISSUER",
+    "MYCELIUM_OIDC_INTERNAL_ISSUER",
+    "MYCELIUM_OIDC_CLIENT_ID",
+    "MYCELIUM_OIDC_AUDIENCE",
+    "AUTH_SESSION_SECRET",
+  ];
+  afterEach(() => KEYS.forEach((k) => delete process.env[k]));
+
+  it("is null (off) until issuer + session secret are both set", () => {
+    expect(oidcConfig()).toBeNull();
+    process.env.MYCELIUM_OIDC_ISSUER = "http://localhost:8080/realms/mycelium";
+    expect(oidcConfig()).toBeNull(); // secret still missing
+  });
+
+  it("resolves, trims slashes, and defaults internalIssuer to issuer", () => {
+    process.env.MYCELIUM_OIDC_ISSUER = "http://localhost:8080/realms/mycelium/";
+    process.env.AUTH_SESSION_SECRET = "s3cret";
+    const cfg = oidcConfig();
+    expect(cfg?.issuer).toBe("http://localhost:8080/realms/mycelium");
+    expect(cfg?.internalIssuer).toBe("http://localhost:8080/realms/mycelium");
+    expect(cfg?.clientId).toBe("mycelium-web");
+    expect(cfg?.handleClaim).toBe("preferred_username");
+  });
+
+  it("keeps a distinct internal issuer for the containerized server", () => {
+    process.env.MYCELIUM_OIDC_ISSUER = "http://localhost:8080/realms/mycelium";
+    process.env.MYCELIUM_OIDC_INTERNAL_ISSUER = "http://keycloak:8080/realms/mycelium";
+    process.env.AUTH_SESSION_SECRET = "s3cret";
+    expect(oidcConfig()?.internalIssuer).toBe("http://keycloak:8080/realms/mycelium");
+  });
+});

--- a/mycelium-frontend/src/lib/oidc.ts
+++ b/mycelium-frontend/src/lib/oidc.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// A small, dependency-light OIDC client for the Authorization Code + PKCE flow,
+// mirroring the CLI's `oidc.py`. SERVER-SIDE only (route handlers): it fetches
+// discovery and exchanges codes/refresh tokens over the network.
+
+import { createHash, randomBytes } from "node:crypto";
+import type { OidcConfig } from "./auth-config";
+
+export function base64url(buf: Buffer | Uint8Array): string {
+  return Buffer.from(buf)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+interface DiscoveryDoc {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  end_session_endpoint?: string;
+}
+
+export interface Endpoints {
+  /** The public `iss` (what the browser reaches, what the token carries). */
+  issuer: string;
+  /** Browser-facing — the redirect target for login. */
+  authorizationEndpoint: string;
+  /** Server-facing — rewritten onto the internal host so the container can reach it. */
+  tokenEndpoint: string;
+  /** Browser-facing — optional RP-initiated logout. */
+  endSessionEndpoint?: string;
+}
+
+const discoCache = new Map<string, { at: number; ep: Endpoints }>();
+const DISCO_TTL_MS = 300_000;
+
+/**
+ * Discover endpoints from the internal issuer. Keycloak advertises PUBLIC URLs
+ * (pinned by KC_HOSTNAME), so the token endpoint comes back as `localhost:…`
+ * which the container can't reach — rewrite its base to the internal issuer.
+ * Browser-facing URLs (authorization, end-session) are left public.
+ */
+export async function endpoints(cfg: OidcConfig): Promise<Endpoints> {
+  const cached = discoCache.get(cfg.internalIssuer);
+  if (cached && Date.now() - cached.at < DISCO_TTL_MS) return cached.ep;
+
+  const url = `${cfg.internalIssuer}/.well-known/openid-configuration`;
+  const res = await fetch(url, { cache: "no-store" });
+  if (!res.ok) throw new Error(`OIDC discovery failed (${res.status}) at ${url}`);
+  const d = (await res.json()) as DiscoveryDoc;
+
+  const toInternal = (u: string): string =>
+    u.startsWith(d.issuer) ? cfg.internalIssuer + u.slice(d.issuer.length) : u;
+
+  const ep: Endpoints = {
+    issuer: d.issuer,
+    authorizationEndpoint: d.authorization_endpoint,
+    tokenEndpoint: toInternal(d.token_endpoint),
+    endSessionEndpoint: d.end_session_endpoint,
+  };
+  discoCache.set(cfg.internalIssuer, { at: Date.now(), ep });
+  return ep;
+}
+
+/**
+ * The browser-facing origin of a request. `new URL(req.url).origin` is unusable
+ * here: the Next standalone server reports its bind address (`0.0.0.0:3000`), not
+ * the host the browser actually used — which would send an unregistered
+ * `redirect_uri` to the IdP. Trust the `Host` header (and forwarded variants
+ * behind a proxy) instead.
+ */
+export function requestOrigin(req: Request): string {
+  const h = req.headers;
+  const proto = h.get("x-forwarded-proto") ?? new URL(req.url).protocol.replace(/:$/, "");
+  const host = h.get("x-forwarded-host") ?? h.get("host") ?? new URL(req.url).host;
+  return `${proto}://${host}`;
+}
+
+export function pkce(): { verifier: string; challenge: string } {
+  const verifier = base64url(randomBytes(32));
+  const challenge = base64url(createHash("sha256").update(verifier).digest());
+  return { verifier, challenge };
+}
+
+export function randomState(): string {
+  return base64url(randomBytes(16));
+}
+
+export interface TokenSet {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  id_token?: string;
+  scope?: string;
+}
+
+export function exchangeCode(
+  cfg: OidcConfig,
+  ep: Endpoints,
+  code: string,
+  redirectUri: string,
+  verifier: string,
+): Promise<TokenSet> {
+  return tokenRequest(ep.tokenEndpoint, {
+    grant_type: "authorization_code",
+    code,
+    client_id: cfg.clientId,
+    redirect_uri: redirectUri,
+    code_verifier: verifier,
+  });
+}
+
+export function refreshTokens(cfg: OidcConfig, ep: Endpoints, refreshToken: string): Promise<TokenSet> {
+  return tokenRequest(ep.tokenEndpoint, {
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: cfg.clientId,
+  });
+}
+
+async function tokenRequest(url: string, form: Record<string, string>): Promise<TokenSet> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(form).toString(),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`token endpoint ${res.status}: ${body.slice(0, 200)}`);
+  }
+  return (await res.json()) as TokenSet;
+}
+
+/** Decode a JWT's claims without verifying — the token is only used as a bearer
+ *  the backend re-validates; here we read `preferred_username`/`exp` locally. */
+export function claimsOf(jwt: string): Record<string, unknown> {
+  const part = jwt.split(".")[1];
+  if (!part) return {};
+  try {
+    const json = Buffer.from(part.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/** The `@handle` a token resolves to: the configured claim, falling back to
+ *  `preferred_username` then `sub`, normalized like stored handles. */
+export function handleFromClaims(claims: Record<string, unknown>, claim: string): string {
+  const raw = claims[claim] ?? claims["preferred_username"] ?? claims["sub"];
+  return typeof raw === "string" ? raw.trim().replace(/^@/, "").toLowerCase() : "";
+}

--- a/mycelium-frontend/src/lib/session.ts
+++ b/mycelium-frontend/src/lib/session.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// The browser session: OIDC tokens sealed in an httpOnly, AES-256-GCM cookie so
+// they never reach the browser bundle. SERVER-SIDE only (route handlers + the
+// proxy). The proxy calls `bearer()` to inject the access token; everything else
+// reads/writes the cookie through here.
+
+import { createHash } from "node:crypto";
+import { EncryptJWT, jwtDecrypt } from "jose";
+import { cookies } from "next/headers";
+import { oidcConfig } from "./auth-config";
+import { endpoints, refreshTokens, claimsOf, handleFromClaims } from "./oidc";
+
+export const SESSION_COOKIE = "myc_session";
+export const TX_COOKIE = "myc_oidc_tx";
+const SESSION_TTL_S = 60 * 60 * 12;
+/** Refresh a little before expiry so an in-flight call never rides a dead token. */
+const REFRESH_SKEW_S = 30;
+
+export interface Session {
+  access_token: string;
+  refresh_token?: string;
+  /** Access-token expiry, epoch seconds. */
+  expires_at: number;
+  handle: string;
+}
+
+function key(secret: string): Uint8Array {
+  return new Uint8Array(createHash("sha256").update(secret).digest());
+}
+
+const secure = process.env.NODE_ENV === "production";
+const cookieOpts = { httpOnly: true, sameSite: "lax" as const, secure, path: "/" };
+
+export async function seal(payload: Record<string, unknown>, secret: string, ttlSec: number): Promise<string> {
+  return new EncryptJWT(payload)
+    .setProtectedHeader({ alg: "dir", enc: "A256GCM" })
+    .setIssuedAt()
+    .setExpirationTime(`${ttlSec}s`)
+    .encrypt(key(secret));
+}
+
+export async function unseal<T = Record<string, unknown>>(token: string, secret: string): Promise<T | null> {
+  try {
+    const { payload } = await jwtDecrypt(token, key(secret));
+    return payload as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function getSession(): Promise<Session | null> {
+  const cfg = oidcConfig();
+  if (!cfg) return null;
+  const jar = await cookies();
+  const raw = jar.get(SESSION_COOKIE)?.value;
+  if (!raw) return null;
+  return unseal<Session>(raw, cfg.sessionSecret);
+}
+
+export async function writeSession(s: Session): Promise<void> {
+  const cfg = oidcConfig();
+  if (!cfg) return;
+  const sealed = await seal(s as unknown as Record<string, unknown>, cfg.sessionSecret, SESSION_TTL_S);
+  const jar = await cookies();
+  jar.set(SESSION_COOKIE, sealed, { ...cookieOpts, maxAge: SESSION_TTL_S });
+}
+
+export async function clearSession(): Promise<void> {
+  const jar = await cookies();
+  jar.set(SESSION_COOKIE, "", { ...cookieOpts, maxAge: 0 });
+}
+
+/**
+ * Upstream request headers for an SSE proxy leg (events / notifications / room
+ * stream). These routes don't go through the catch-all proxy, so they need the
+ * bearer attached here too — otherwise a gated backend 401s the stream and the
+ * UI silently stops updating. Adds nothing when there's no session.
+ */
+export async function upstreamSseHeaders(): Promise<Record<string, string>> {
+  const headers: Record<string, string> = {
+    Accept: "text/event-stream",
+    "Cache-Control": "no-cache",
+  };
+  const token = await bearer();
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * The bearer token to inject into a proxied `/api/*` call, refreshing it when
+ * it's within the skew window. Returns null when there is no session — gate off
+ * or signed out — so the proxy simply forwards no Authorization header, exactly
+ * as before this existed.
+ */
+export async function bearer(): Promise<string | null> {
+  const cfg = oidcConfig();
+  if (!cfg) return null;
+  const s = await getSession();
+  if (!s) return null;
+
+  const now = Math.floor(Date.now() / 1000);
+  if (s.expires_at - REFRESH_SKEW_S > now) return s.access_token;
+  // Expired (or nearly). Without a refresh token, send it and let the backend
+  // 401 — the client's session poll then re-engages the gate.
+  if (!s.refresh_token) return s.access_token;
+
+  try {
+    const ep = await endpoints(cfg);
+    const t = await refreshTokens(cfg, ep, s.refresh_token);
+    const next: Session = {
+      access_token: t.access_token,
+      refresh_token: t.refresh_token ?? s.refresh_token,
+      expires_at: now + (t.expires_in ?? 300),
+      handle: handleFromClaims(claimsOf(t.access_token), cfg.handleClaim) || s.handle,
+    };
+    await writeSession(next);
+    return next.access_token;
+  } catch {
+    // Refresh failed (revoked / IdP down): drop the session and forward nothing.
+    await clearSession();
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #606 — the browser counterpart to #565 (CLI/API Keycloak login, merged in #607).

## The gap
The HTTP JWT gate was built + validated for the CLI/API tier, but the frontend had **no auth path** — turning the gate on **silently emptied the GUI** (401s degraded to blank room lists, no login prompt).

## What shipped (hand-rolled OIDC, mirroring the CLI's `oidc.py`)
- **Server-side flow** (route handlers): `lib/oidc.ts` (discovery + PKCE + token exchange/refresh), `lib/session.ts` (tokens sealed in an **httpOnly AES-256-GCM cookie** via `jose`, never in browser JS), `lib/auth-config.ts`. Routes `/api/auth/{login,callback,logout,session}`.
- **Bearer injection** in the catch-all proxy **and the three SSE stream routes** (`events`, `notifications`, room `messages/stream`) — so live updates work under the gate, not just request/response calls.
- **`LoginGate`** replaces the silent-empty degrade with an explicit sign-in screen (and an honest "browser login isn't configured" state). A 401 from any call re-checks the session. The signed-in handle syncs to the acting-as identity, with a **Sign out** control.
- **Realm:** a public **`mycelium-web`** client (web redirect + audience mapper).
- **compose:** frontend OIDC env (off by default) + a dev build override so the local image isn't clobbered by `pull_policy: always`.
- **Docs:** a "Browser login" section in `keycloak-oidc.md`. Unit tests for the OIDC helpers.

## Off by default (#567)
With `MYCELIUM_OIDC_ISSUER` / `AUTH_SESSION_SECRET` unset, the frontend stays on the localStorage handle-picker tier, unchanged. The sign-in screen only appears when the backend's `/health` reports the gate on.

## The issuer split (same crux as #565)
Browser hits `MYCELIUM_OIDC_ISSUER` (`localhost:8080`, matching token `iss`); the containerized frontend runs discovery/token exchange against `MYCELIUM_OIDC_INTERNAL_ISSUER` (`keycloak:8080`). `redirect_uri` is derived from the `Host` header, not `req.url` (Next standalone reports its `0.0.0.0` bind address).

## Validated live (containerized frontend + Keycloak + gated backend)
```
login → Keycloak → callback → session cookie
/api/auth/session       → signedIn: true, handle: demo
/api/rooms   (signed in) → 200  (42 rooms)
/api/events/stream (signed in) → 200 text/event-stream   ← SSE authorized
/api/rooms   (anon)      → 401
```
Gate off: unchanged. `pnpm lint` + `pnpm test` (85) + `pnpm build` all green.

Shares the Keycloak realm/client added in #565/#607.