### PR TITLE
feat(cli): alias `mycelium ls` to `mycelium room ls`

### DIFF
--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -127,6 +127,10 @@ app.command(name="connect")(hub.connect)
 app.command(name="await")(participate.await_room)
 app.command(name="respond")(participate.respond)
 
+# Convenience alias: `mycelium ls` is `mycelium room ls` — rooms are the entry
+# point, so listing them shouldn't need the `room` prefix.
+app.command(name="ls")(room.list_rooms)
+
 # Command groups
 app.add_typer(room.app, name="room")
 app.add_typer(memory.app, name="memory")


### PR DESCRIPTION
`mycelium ls` now lists rooms — a top-level alias for `mycelium room ls`.

Rooms are the entry point to everything (memory, coordination, plans), so the most common list shouldn't need the `room` prefix. `ls` registers the existing `room.list_rooms` as a top-level command, so it inherits the same `--limit`/`--name` options and the global `--json`.

```
$ mycelium ls --limit 5
Rooms (5)
    pricing-model  (created 2026-08-16)
    …
```

Quality gate green (ruff / format / ty / 444 tests). The one failing `test_login::test_iam_…` is a pre-existing local test-isolation flake (reads a config with identity.name set), unrelated to this alias.