### PR TITLE
Unify SLIM + L9 into one "Network" pane

### DIFF
--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -130,9 +130,8 @@ function RoomWorkspace() {
   useKeyScope("room");
   useKeyAction("pane.channel", () => setEditorView("channel"));
   useKeyAction("pane.negotiate", () => setEditorView("negotiate"));
-  useKeyAction("pane.l9", () => setEditorView("l9"));
   useKeyAction("pane.plan", () => setEditorView("plan"));
-  useKeyAction("pane.slim", () => setEditorView("slim"));
+  useKeyAction("pane.network", () => setEditorView("network"));
   useKeyAction("rail.agents", () => openTab("agents"));
   useKeyAction("rail.episodes", () => openTab("episodes"));
   useKeyAction("rail.memory", () => openTab("memory"));

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -312,7 +312,7 @@ function renderWithMentions(text: string): React.ReactNode {
   );
 }
 
-export type View = "channel" | "negotiate" | "plan" | "l9" | "slim";
+export type View = "channel" | "negotiate" | "plan" | "network";
 export type NegotiationPhase = "idle" | "negotiating" | "converged" | "rejected";
 
 interface Props {
@@ -518,9 +518,8 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
           {([
             { id: "channel" as const,   label: "Channel",   count: channelCount as number | null, dot: false },
             { id: "negotiate" as const, label: "Negotiate", count: null,                          dot: negotiating },
-            { id: "l9" as const,        label: "L9",        count: null,                          dot: false },
             { id: "plan" as const,      label: "Plan",      count: null,                          dot: false },
-            { id: "slim" as const,      label: "SLIM",      count: null,                          dot: false },
+            { id: "network" as const,   label: "Network",   count: null,                          dot: false },
           ]).map(t => {
             // Hold the reveal modifier and each tab wears the key that selects it.
             const active = view === t.id;
@@ -548,18 +547,21 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
           })}
         </div>
       </div>
-      {view === "l9" ? (
-        <div className="flex-1 min-h-0">
-          <L9Inspector roomName={roomName} />
+      {view === "network" ? (
+        // Unified Network pane: SLIM channel diagnostics as a rail on top, the
+        // live L9 protocol feed filling the rest.
+        <div className="flex flex-1 min-h-0 flex-col">
+          <div className="shrink-0 border-b border-border bg-surface/40">
+            <RoomSlimView roomName={roomName} layout="rail" />
+          </div>
+          <div className="flex-1 min-h-0">
+            <L9Inspector roomName={roomName} />
+          </div>
         </div>
       ) : view === "negotiate" ? (
         <div className="flex-1 min-h-0">
           <NegotiationView events={events} />
         </div>
-      ) : view === "slim" ? (
-        <ScrollArea className="flex-1 min-h-0">
-          <RoomSlimView roomName={roomName} />
-        </ScrollArea>
       ) : (
       <ScrollArea className="flex-1 min-h-0" viewportRef={scrollRef}>
         {view === "plan" ? (

--- a/mycelium-frontend/src/components/keymap-provider.test.tsx
+++ b/mycelium-frontend/src/components/keymap-provider.test.tsx
@@ -12,7 +12,7 @@ function Room({ onPane }: { onPane: (id: string) => void }) {
   useKeyScope("room");
   useKeyAction("pane.channel", () => onPane("channel"));
   useKeyAction("pane.plan", () => onPane("plan"));
-  return <KeyBadge action="pane.l9" />;
+  return <KeyBadge action="pane.network" />;
 }
 
 function Composer() {
@@ -84,7 +84,7 @@ describe("<KeymapProvider />", () => {
 
     expect(document.querySelector("[data-key-badge]")).toBeNull();
     await user.keyboard("{Alt>}");
-    expect(document.querySelector("[data-key-badge]")).toHaveTextContent("L");
+    expect(document.querySelector("[data-key-badge]")).toHaveTextContent("W");
     await user.keyboard("{/Alt}");
     expect(document.querySelector("[data-key-badge]")).toBeNull();
   });

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -450,6 +450,8 @@ export function L9Inspector({ roomName }: Props) {
 
       {frames.length > 0 && (
         <div className="flex items-center gap-2 px-4 py-2 border-b border-border shrink-0 bg-paper">
+          <span className="caps-mono-sm text-muted-foreground">L9 PROTOCOL</span>
+          <span className="h-3 w-px bg-border" aria-hidden />
           <div className="flex flex-wrap items-center gap-1">
             {kindsPresent.map((kind) => {
               const active = !hiddenKinds.has(kind);

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -4,7 +4,18 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { ChevronRight, Radio } from "lucide-react";
+import {
+  ArrowLeftRight,
+  BookOpen,
+  ChevronRight,
+  Circle,
+  CircleCheck,
+  CircleX,
+  Radio,
+  Target,
+  TriangleAlert,
+  type LucideIcon,
+} from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
@@ -221,10 +232,39 @@ function kindTone(kind: string): string {
   return KIND_TONE[kind] ?? "var(--muted-foreground)";
 }
 
+/** Row tone, refined by subkind: a rejected commit reads red, not the green of a
+ *  converged one. Everything else follows its kind. */
+function frameTone(kind: string, subkind?: string | null): string {
+  if (kind === "commit") return subkind === "rejected" ? "var(--red)" : "var(--green)";
+  return kindTone(kind);
+}
+
+/** One glyph per kind — the scannable anchor at the start of every row. Commit
+ *  splits on outcome (✓ converged/resolved, ✕ rejected). */
+function frameIcon(kind: string, subkind?: string | null): LucideIcon {
+  switch (kind) {
+    case "exchange":
+      return ArrowLeftRight;
+    case "commit":
+      return subkind === "rejected" ? CircleX : CircleCheck;
+    case "knowledge":
+      return BookOpen;
+    case "contingency":
+      return TriangleAlert;
+    case "intent":
+      return Target;
+    default:
+      return Circle;
+  }
+}
+
 export function KindBadge({ kind, subkind }: { kind: string; subkind?: string | null }) {
-  const tone = kindTone(kind);
   return (
-    <span className="caps-mono-sm flex-shrink-0" style={{ color: tone }}>
+    <span
+      className="block min-w-0 truncate font-mono text-label font-semibold uppercase tracking-[0.02em]"
+      style={{ color: frameTone(kind, subkind) }}
+      title={`${kind}${subkind ? ":" + subkind : ""}`}
+    >
       {kind.toUpperCase()}
       {subkind ? <span className="text-muted-foreground">:{subkind}</span> : null}
     </span>
@@ -267,6 +307,9 @@ function FrameRow({
     return () => onExpandedChange(-1);
   }, [expanded, onExpandedChange]);
 
+  const Icon = frameIcon(frame.kind, frame.subkind);
+  const tone = frameTone(frame.kind, frame.subkind);
+
   return (
     <div className="border-b border-border last:border-b-0">
       <button
@@ -274,27 +317,32 @@ function FrameRow({
         aria-expanded={expanded}
         onClick={() => setExpanded((prev) => !prev)}
         title={expanded ? "Collapse envelope" : "Expand full envelope JSON"}
-        className="group flex items-baseline gap-2 px-4 py-2 w-full text-left cursor-pointer text-body transition-colors hover:bg-hairline"
+        // Fixed columns so kind / actor / summary line up down the feed, one text
+        // size throughout; timestamp + metrics ride a right-aligned meta cluster.
+        className="group grid w-full cursor-pointer grid-cols-[14px_16px_176px_120px_minmax(0,1fr)_auto] items-center gap-x-2.5 px-4 py-1.5 text-left text-label transition-colors hover:bg-hairline"
       >
         <ChevronRight
           aria-hidden
-          className={`size-3.5 flex-shrink-0 self-center text-faint transition-transform group-hover:text-muted-foreground ${expanded ? "rotate-90" : ""}`}
+          className={`size-3.5 text-faint transition-transform group-hover:text-muted-foreground ${expanded ? "rotate-90" : ""}`}
         />
+        <Icon aria-hidden className="size-3.5" style={{ color: tone }} />
         <KindBadge kind={frame.kind} subkind={frame.subkind} />
-        {frame.episode ? (
-          <span className="font-mono text-micro text-accent" title={frame.episode}>
-            {shortEpisode(frame.episode)}
-          </span>
-        ) : null}
-        <span className="font-mono text-label text-muted-foreground truncate">{frame.sender}</span>
-        <span className="text-muted-foreground truncate">{frame.summary}</span>
-        {frame.metrics ? <MetricsRow metrics={frame.metrics} /> : null}
-        {frame.parents.length > 0 ? (
-          <span className="text-micro text-muted-foreground font-mono" title={frame.parents.join("\n")}>
-            ←{frame.parents.length}
-          </span>
-        ) : null}
-        <span className="ml-auto text-micro text-muted-foreground font-mono tabular flex-shrink-0">{frame.time}</span>
+        <span className="truncate font-mono text-muted-foreground">{frame.sender}</span>
+        <span className="min-w-0 truncate text-text">{frame.summary}</span>
+        <span className="flex items-center justify-end gap-2.5 text-micro text-muted-foreground">
+          {frame.metrics ? <MetricsRow metrics={frame.metrics} /> : null}
+          {frame.parents.length > 0 ? (
+            <span className="font-mono tabular" title={frame.parents.join("\n")}>
+              ←{frame.parents.length}
+            </span>
+          ) : null}
+          {frame.episode ? (
+            <span className="font-mono text-accent" title={frame.episode}>
+              {shortEpisode(frame.episode)}
+            </span>
+          ) : null}
+          <span className="font-mono tabular">{frame.time}</span>
+        </span>
       </button>
       {expanded ? (
         <ScrollArea className="mx-4 mb-2 h-64 border border-border bg-surface">

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -438,15 +438,15 @@ export function L9Inspector({ roomName }: Props) {
 
   return (
     <div className="flex flex-col h-full" data-testid="l9-inspector">
-      <div className="flex items-center gap-2 px-4 border-b border-border shrink-0 h-[48px] bg-paper">
-        <span className="caps-mono-sm text-muted-foreground">L9 PROTOCOL</span>
-        {!connected && (
-          <span className="caps-mono-sm text-yellow flex items-center gap-1.5">
-            <span aria-hidden className="inline-block size-1.5 rounded-full bg-yellow" />
-            RECONNECTING
-          </span>
-        )}
-      </div>
+      {/* No "L9 PROTOCOL" title bar: the pane tab already reads "Network" and the
+          SLIM diagnostics rail sits right above. Only the transient reconnecting
+          state needs a strip of its own. */}
+      {!connected && (
+        <div className="flex items-center gap-1.5 px-4 shrink-0 h-[28px] border-b border-border bg-paper caps-mono-sm text-yellow">
+          <span aria-hidden className="inline-block size-1.5 rounded-full bg-yellow" />
+          RECONNECTING
+        </div>
+      )}
 
       {frames.length > 0 && (
         <div className="flex items-center gap-2 px-4 py-2 border-b border-border shrink-0 bg-paper">

--- a/mycelium-frontend/src/components/room-slim.tsx
+++ b/mycelium-frontend/src/components/room-slim.tsx
@@ -12,11 +12,21 @@ import {
 } from "@/lib/api";
 import { Skeleton } from "@/components/ui/skeleton";
 
-/** The "SLIM" room view: this room's SLIM channel status — the node it rides,
- *  who is present (SLIM members plus server-held `await` participants), episode
- *  state, and durable-inbox counters. Scoped to the current room (the fabric-wide
- *  fleet view is the CLI's `mycelium network`). Read-only, polled, fail-soft. */
-export function RoomSlimView({ roomName }: { roomName: string }) {
+/** This room's SLIM channel status — the node it rides, who is present (SLIM
+ *  members plus server-held `await` participants), episode state, and
+ *  durable-inbox counters. Scoped to the current room (the fabric-wide fleet view
+ *  is the CLI's `mycelium network`). Read-only, polled, fail-soft.
+ *
+ *  `layout="rail"` renders a compact single-strip diagnostics bar — the top of
+ *  the unified Network pane, above the L9 feed. `layout="full"` (default) is the
+ *  stacked card view. */
+export function RoomSlimView({
+  roomName,
+  layout = "full",
+}: {
+  roomName: string;
+  layout?: "full" | "rail";
+}) {
   const [coord, setCoord] = useState<CoordinationStatus | null>(null);
   const [loaded, setLoaded] = useState(false);
 
@@ -43,6 +53,53 @@ export function RoomSlimView({ roomName }: { roomName: string }) {
 
   const room: CoordinationRoom | null = coord?.rooms.find((r) => r.room === roomName) ?? null;
   const enabled = coord?.slim_enabled ?? false;
+
+  if (layout === "rail") {
+    if (loaded && !coord) {
+      return (
+        <div className="flex items-center gap-1.5 px-4 py-2 text-micro text-muted-foreground">
+          <span style={{ color: "var(--red)" }}>●</span> SLIM · backend unreachable
+        </div>
+      );
+    }
+    return (
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-2 text-micro">
+        <RailStat
+          dot={coord ? (enabled ? "var(--green)" : "var(--red)") : "var(--yellow)"}
+          label="SLIM"
+        >
+          <span className="font-mono text-text">{coord?.endpoint ?? "…"}</span>
+        </RailStat>
+        <RailStat label="channels">{coord?.channels_live ?? "—"}</RailStat>
+        <RailStat label="provisions">
+          {coord ? `${coord.provisions_ok}✓ / ${coord.provisions_failed}✗` : "—"}
+        </RailStat>
+        <span className="h-3 w-px bg-border" aria-hidden />
+        <RailStat
+          dot={room?.provisioned ? "var(--green)" : "var(--yellow)"}
+          label={`channel · ${roomName}`}
+        >
+          {room ? (room.provisioned ? "live" : "pending") : loaded ? "none" : "…"}
+        </RailStat>
+        <RailStat label="members">{room?.members.length ?? 0}</RailStat>
+        <RailStat label="episode">
+          <span style={{ color: room?.episode_active ? "var(--accent)" : undefined }}>
+            {room?.episode_active ? "active" : "idle"}
+          </span>
+        </RailStat>
+        <RailStat label="invites">
+          <span style={{ color: (room?.pending_invites ?? 0) > 0 ? "var(--yellow)" : undefined }}>
+            {room?.pending_invites ?? 0}
+          </span>
+        </RailStat>
+        {(room?.receive_errors ?? 0) > 0 && (
+          <RailStat label="recv-err">
+            <span style={{ color: "var(--red)" }}>{room?.receive_errors}</span>
+          </RailStat>
+        )}
+      </div>
+    );
+  }
 
   if (loaded && !coord) {
     return <div className="p-6 text-label text-muted-foreground">Backend unreachable.</div>;
@@ -145,6 +202,28 @@ function SectionHeader({ title, dot, dotLabel }: { title: string; dot: string; d
         {dotLabel}
       </span>
     </div>
+  );
+}
+
+function RailStat({
+  label,
+  dot,
+  children,
+}: {
+  label: string;
+  dot?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <span className="flex items-center gap-1.5">
+      {dot && (
+        <span style={{ color: dot }} aria-hidden>
+          ●
+        </span>
+      )}
+      <span className="text-muted-foreground">{label}</span>
+      <span className="tabular text-text">{children}</span>
+    </span>
   );
 }
 

--- a/mycelium-frontend/src/lib/commands.test.ts
+++ b/mycelium-frontend/src/lib/commands.test.ts
@@ -25,7 +25,7 @@ const COMMANDS = [
   command("room:pricing", "pricing-model", "Rooms"),
   command("room:ops", "ops", "Rooms"),
   command("pane.plan", "Plan", "Panes"),
-  command("pane.l9", "L9", "Panes"),
+  command("pane.network", "Network", "Panes"),
 ];
 
 describe("recent commands", () => {
@@ -62,9 +62,9 @@ describe("paletteFilter", () => {
   });
 
   it("does not let recency outrank a decisively better match", () => {
-    const filter = paletteFilter(["pane.l9"]);
+    const filter = paletteFilter(["pane.network"]);
     expect(filter("room:pricing", "pricing", ["pricing-model"])).toBeGreaterThan(
-      filter("pane.l9", "pricing", ["L9"]),
+      filter("pane.network", "pricing", ["Network"]),
     );
   });
 });

--- a/mycelium-frontend/src/lib/keymap.test.ts
+++ b/mycelium-frontend/src/lib/keymap.test.ts
@@ -75,7 +75,7 @@ describe("keymap", () => {
   });
 
   it("resolves an action to the chord its badge draws", () => {
-    expect(chordFor("pane.l9")).toBe("alt+l");
+    expect(chordFor("pane.network")).toBe("alt+w");
     expect(chordFor("nope")).toBeUndefined();
   });
 

--- a/mycelium-frontend/src/lib/keymap.ts
+++ b/mycelium-frontend/src/lib/keymap.ts
@@ -90,9 +90,10 @@ export const KEYMAP: Binding[] = [
 
   { id: "pane.channel", keys: ["alt+c"], label: "Channel", group: "Panes", scope: "room" },
   { id: "pane.negotiate", keys: ["alt+n"], label: "Negotiate", group: "Panes", scope: "room" },
-  { id: "pane.l9", keys: ["alt+l"], label: "L9", group: "Panes", scope: "room" },
   { id: "pane.plan", keys: ["alt+p"], label: "Plan", group: "Panes", scope: "room" },
-  { id: "pane.slim", keys: ["alt+s"], label: "SLIM", group: "Panes", scope: "room" },
+  // Network = the merged SLIM diagnostics rail + L9 protocol feed. ⌥W (netWork);
+  // ⌥N is taken by Negotiate.
+  { id: "pane.network", keys: ["alt+w"], label: "Network", group: "Panes", scope: "room" },
 
   { id: "rail.agents", keys: ["alt+a"], label: "Members", group: "Inspector", scope: "room" },
   // Not ⌥E: Alt+E opens the browser menu on Windows and Linux.


### PR DESCRIPTION
## What
SLIM and L9 were two separate panes onto the same thing — the room's messaging fabric. This merges them into a single **Network** tab:

- **SLIM channel status → a compact diagnostics rail across the top** (SLIM node, channels live, provisions · this channel's members, episode state, pending invites, recv-errors).
- **The live L9 protocol feed fills the rest below it** (unchanged — frames, kind/episode filters, auto-scroll, row expansion).

Also dropped the now-redundant **"L9 PROTOCOL"** title bar inside the L9 inspector: the tab already reads "Network" and the SLIM rail sits right above it, so it was just chrome eating 48px. A thin **RECONNECTING** strip still appears when the SSE drops.

## How
- `event-stream.tsx`: `View` `"l9" | "slim"` → `"network"`; the one branch stacks `RoomSlimView layout="rail"` (`shrink-0`) over `L9Inspector` (`flex-1 min-h-0`, scrollable).
- `room-slim.tsx`: new compact `layout="rail"` variant (a single strip of stat chips); the full stacked-card view is retained behind the default.
- `l9-inspector.tsx`: title bar removed; reconnecting-only strip kept.
- `keymap.ts`: `pane.l9` (⌥L) + `pane.slim` (⌥S) collapse to `pane.network` (⌥W, "netWork"). The command palette derives from the keymap, so it follows automatically.

## Tests & gates
- Updated the three tests that referenced the old pane ids (`keymap.test.ts`, `commands.test.ts`, `keymap-provider.test.tsx`). The `findConflicts`-is-empty keymap test confirms ⌥W doesn't collide.
- `pnpm lint`, full `vitest` (147 passed — incl. the 16 L9-inspector tests, which don't depend on the removed title), and `pnpm build` all green.

## Note
Verified via typecheck/tests/build. I didn't run the full stack (needs a SLIM node + backend) to eyeball the rail live — happy to if you want a screenshot pass.