### PR TITLE
Rooms sidebar: activity signal (unread badges + recency order)

### DIFF
--- a/mycelium-frontend/src/components/rooms-sidebar.test.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.test.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026 Mycelium Contributors
 
 import { act } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeEventSource } from "@/test/fake-event-source";
@@ -149,5 +149,39 @@ describe("<RoomsSidebar /> keyboard navigation", () => {
     await user.keyboard("{Escape}");
     await user.keyboard("{Alt>}2{/Alt}");
     expect(push).toHaveBeenCalledWith("/room/bravo");
+  });
+});
+
+describe("<RoomsSidebar /> unread badges", () => {
+  beforeEach(() => {
+    FakeEventSource.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    window.localStorage.clear();
+  });
+
+  const seed = (list: { room: string; read: boolean }[]) =>
+    window.localStorage.setItem("mycelium.notifications", JSON.stringify(list));
+
+  it("badges a room that has unread activity, and leaves others clean", async () => {
+    seed([
+      { room: "beta", read: false },
+      { room: "beta", read: false },
+      { room: "alpha", read: true },
+    ]);
+    await renderSidebar(["alpha", "beta"]);
+
+    const beta = screen.getByRole("link", { name: /beta/ });
+    expect(within(beta).getByLabelText("2 unread")).toBeInTheDocument();
+    const alpha = screen.getByRole("link", { name: /alpha/ });
+    expect(within(alpha).queryByLabelText(/unread/)).toBeNull();
+  });
+
+  it("does not badge the room you're already viewing", async () => {
+    seed([{ room: "beta", read: false }]);
+    await renderSidebar(["alpha", "beta"], "beta");
+    // Scoped to the row: beta's unread still counts globally (the footer bell),
+    // it just shouldn't badge the room you're currently reading.
+    const beta = screen.getByRole("link", { name: /beta/ });
+    expect(within(beta).queryByLabelText(/unread/)).toBeNull();
   });
 });

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -12,6 +12,7 @@ import { fetchRooms, getAppEventsSSEUrl, type Room } from "@/lib/api";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { NotificationBell } from "@/components/notification-bell";
+import { useNotifications } from "@/components/notifications-provider";
 import { EmptyState } from "@/components/empty-state";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { KeyBadge } from "@/components/key-badge";
@@ -78,9 +79,25 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
     return () => { clearInterval(t); es?.close(); clearTimeout(retry); };
   }, []);
 
+  // Unread activity per room, from the same client-side notification store the
+  // bell reads — muted rooms don't count, so a muted room never wears a badge.
+  const { notifications, settings } = useNotifications();
+  const unreadByRoom = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const n of notifications) {
+      if (n.read || settings.mutedRooms.includes(n.room)) continue;
+      m.set(n.room, (m.get(n.room) ?? 0) + 1);
+    }
+    return m;
+  }, [notifications, settings.mutedRooms]);
+
+  // Filter by the query, then order by recency (last active first) so rooms with
+  // fresh activity float up — the same ordering the command palette uses.
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return q ? rooms.filter(r => r.name.toLowerCase().includes(q)) : rooms;
+    const base = q ? rooms.filter(r => r.name.toLowerCase().includes(q)) : rooms;
+    const recency = (r: Room) => r.last_activity ?? r.created_at ?? "";
+    return [...base].sort((a, b) => recency(b).localeCompare(recency(a)));
   }, [rooms, query]);
 
   // ---- Keyboard navigation -------------------------------------------------
@@ -251,7 +268,7 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
       {/* Rooms header + search */}
       <div className="flex items-center gap-2 px-3 pt-3 pb-2">
         <span className="text-micro font-semibold uppercase tracking-wide text-muted-foreground">Rooms</span>
-        <span className="text-micro tabular text-faint">{rooms.length}</span>
+        <span className="text-micro tabular text-muted-foreground">{rooms.length}</span>
         <button
           onClick={() => setShowCreate(true)}
           aria-label="New room"
@@ -300,6 +317,9 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
           filtered.map((room, i) => {
             const active = room.name === activeRoom;
             const label = hints?.labels[i];
+            // Don't badge the room you're already looking at — being here is
+            // reading it. Elsewhere, unread activity draws the name brighter too.
+            const unread = active ? 0 : unreadByRoom.get(room.name) ?? 0;
             return (
               <Link
                 key={room.name}
@@ -329,9 +349,23 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
                     </span>
                   )}
                 </span>
-                <span className={`truncate text-label ${active ? "font-medium text-text" : "text-muted-foreground group-hover:text-text"}`}>
+                <span
+                  className={`min-w-0 flex-1 truncate text-label ${
+                    active || unread > 0
+                      ? "font-medium text-text"
+                      : "text-muted-foreground group-hover:text-text"
+                  }`}
+                >
                   {room.name}
                 </span>
+                {unread > 0 && (
+                  <span
+                    aria-label={`${unread} unread`}
+                    className="flex h-4 min-w-4 flex-shrink-0 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold tabular leading-none text-accent-fg"
+                  >
+                    {unread > 9 ? "9+" : unread}
+                  </span>
+                )}
               </Link>
             );
           })


### PR DESCRIPTION
The sidebar was the most polished of the three rails already — so this isn't a restyle, it's **signal**. It looked clean but told you nothing: every room identical, ordered alphabetically regardless of where anything was happening.

## Changes
- **Per-room unread badge.** Derived from the same client-side notification store the footer bell reads (`useNotifications()`), so it's basically free. A small accent count (9+ capped); unread also draws the room name brighter. Respects mutes (a muted room never badges) and **doesn't badge the room you're currently viewing** (being there is reading it).
- **Recency ordering.** Rooms sort by `last_activity` (falling back to `created_at`) so fresh ones float to the top — the same ordering the command palette already uses. Stable sort, so nothing reshuffles when timestamps tie.
- **Nit:** aligned the "Rooms" header count color with the members header (`muted`, was `faint`).

Avatars, hint/digit keyboard nav, search, and the footer are untouched.

## Tests
Added: a badge appears and counts on a room with unread activity while clean rooms stay bare; the badge stays off the room you're actively viewing (scoped to the row — global unread still reaches the bell). Existing keyboard-nav tests confirm the recency sort leaves their order intact.

`pnpm lint`, full `vitest` (149), and `pnpm build` all green.