### PR TITLE
Tiered per-room notifications (Discord-style)

### DIFF
--- a/mycelium-frontend/src/components/notification-bell.tsx
+++ b/mycelium-frontend/src/components/notification-bell.tsx
@@ -18,6 +18,8 @@ const KIND_LABEL: Record<NotificationKind, string> = {
   consensus: "Consensus",
   knowledge: "Knowledge",
   join: "Join",
+  // Badge-only, filtered out of the bell — present for exhaustiveness.
+  message: "Message",
 };
 
 const KIND_TONE: Record<NotificationKind, string> = {
@@ -26,6 +28,7 @@ const KIND_TONE: Record<NotificationKind, string> = {
   consensus: "var(--green)",
   knowledge: "var(--yellow)",
   join: "var(--muted-foreground)",
+  message: "var(--muted-foreground)",
 };
 
 function timeAgo(iso: string): string {
@@ -46,7 +49,10 @@ export function NotificationBell() {
   const [open, setOpen] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
 
-  const items = [...notifications].reverse();
+  // The bell is the "loud" inbox: only alert items (mentions, directs, consensus,
+  // knowledge). Badge-only room activity badges the sidebar, never lands here.
+  const loud = notifications.filter((n) => n.alert !== false);
+  const items = [...loud].reverse();
 
   return (
     <>
@@ -73,9 +79,9 @@ export function NotificationBell() {
         <PopoverContent className="flex max-h-[28rem] w-80 flex-col p-0">
           <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
             <span className="text-label font-semibold text-text">Notifications</span>
-            <span className="text-micro tabular text-faint">{notifications.length}</span>
+            <span className="text-micro tabular text-faint">{loud.length}</span>
             <div className="ml-auto flex items-center gap-1">
-              {notifications.length > 0 && (
+              {loud.length > 0 && (
                 <button
                   onClick={markAllRead}
                   title="Mark all read"
@@ -161,7 +167,7 @@ export function NotificationBell() {
               ))
             )}
           </div>
-          {notifications.length > 0 && (
+          {loud.length > 0 && (
             <div className="border-t border-border px-3 py-1.5">
               <button onClick={clearAll} className="text-micro text-muted-foreground hover:text-text">
                 Clear all

--- a/mycelium-frontend/src/components/notifications-provider.tsx
+++ b/mycelium-frontend/src/components/notifications-provider.tsx
@@ -20,13 +20,15 @@ import {
   classify,
   DEFAULT_SETTINGS,
   electLeader,
-  isAdmitted,
+  isAlert,
   loadNotifications,
   loadSettings,
   openCrossTabChannel,
+  roomLevel,
   saveNotifications,
   saveSettings,
   type NotificationSettings,
+  type RoomLevel,
   type StoredNotification,
 } from "@/lib/notifications";
 
@@ -38,10 +40,12 @@ interface NotificationsContextValue {
   setSettings: (settings: NotificationSettings) => void;
   markRead: (id: string) => void;
   markAllRead: () => void;
+  markRoomRead: (room: string) => void;
   dismiss: (id: string) => void;
   clearAll: () => void;
   muteRoom: (room: string) => void;
   unmuteRoom: (room: string) => void;
+  setRoomLevel: (room: string, level: RoomLevel) => void;
   desktopPermission: NotificationPermission | "unsupported";
   requestDesktopPermission: () => void;
 }
@@ -109,6 +113,11 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
         case "read-all":
           setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
           break;
+        case "room-read":
+          setNotifications((prev) =>
+            prev.map((n) => (n.room === msg.room ? { ...n, read: true } : n)),
+          );
+          break;
         case "dismiss":
           setNotifications((prev) => prev.filter((n) => n.id !== msg.id));
           break;
@@ -129,9 +138,10 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     saveNotifications(notifications);
   }, [notifications]);
 
-  // Tab-title unread badge.
+  // Tab-title unread badge — loud items only, matching the bell (badge-only room
+  // activity stays in the sidebar, not the tab title).
   useEffect(() => {
-    const unread = notifications.filter((n) => !n.read).length;
+    const unread = notifications.filter((n) => n.alert !== false && !n.read).length;
     document.title = unread > 0 ? `(${unread}) ${BASE_TITLE}` : BASE_TITLE;
   }, [notifications]);
 
@@ -152,14 +162,18 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
           if (!n) return;
           if (seenIds.current.has(n.id)) return;
           seenIds.current.add(n.id);
-          if (!isAdmitted(n, settingsRef.current)) return;
-          setNotifications((prev) => [...prev, { ...n, read: false }]);
-          // Notify when this tab isn't the one you're looking at. `hasFocus()`
-          // (not visibilityState) is the right signal: it's false when you've
-          // switched to another tab, minimized, OR alt-tabbed to another app —
-          // whereas visibilityState stays "visible" for a window that's merely
-          // behind another app, so those pings would be silently dropped.
-          if (isLeader.current && !document.hasFocus()) {
+          // Muted rooms are dropped outright. Everything else is stored so it can
+          // badge the room; `alert` records whether it's also "loud" (bell inbox
+          // + sound/desktop) or badge-only.
+          if (roomLevel(settingsRef.current, n.room) === "muted") return;
+          const loud = isAlert(n, settingsRef.current);
+          setNotifications((prev) => [...prev, { ...n, read: false, alert: loud }]);
+          // Sound/desktop only for loud items, and only when this tab isn't the
+          // one you're looking at. `hasFocus()` (not visibilityState) is the right
+          // signal: it's false when you've switched to another tab, minimized, OR
+          // alt-tabbed to another app — whereas visibilityState stays "visible"
+          // for a window merely behind another app, so those pings would be lost.
+          if (loud && !settingsRef.current.dnd && isLeader.current && !document.hasFocus()) {
             if (settingsRef.current.soundEnabled) ping(settingsRef.current.soundVolume);
             if (settingsRef.current.desktopEnabled && "Notification" in window && window.Notification.permission === "granted") {
               try {
@@ -213,27 +227,54 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
     channelRef.current?.post({ type: "clear" });
   }, []);
 
-  const muteRoom = useCallback(
-    (room: string) => {
-      if (settingsRef.current.mutedRooms.includes(room)) return;
-      setSettings({ ...settingsRef.current, mutedRooms: [...settingsRef.current.mutedRooms, room] });
+  // Set a room's Discord-style level. `mutedRooms` is kept in sync with the
+  // override so the settings panel's muted-rooms list keeps working unchanged.
+  const setRoomLevel = useCallback(
+    (room: string, level: RoomLevel) => {
+      const s = settingsRef.current;
+      const roomLevels = { ...s.roomLevels, [room]: level };
+      const mutedRooms =
+        level === "muted"
+          ? [...new Set([...s.mutedRooms, room])]
+          : s.mutedRooms.filter((r) => r !== room);
+      setSettings({ ...s, roomLevels, mutedRooms });
     },
     [setSettings],
   );
 
+  const muteRoom = useCallback((room: string) => setRoomLevel(room, "muted"), [setRoomLevel]);
+
+  // Unmute clears the override entirely, restoring the global default.
   const unmuteRoom = useCallback(
     (room: string) => {
-      setSettings({ ...settingsRef.current, mutedRooms: settingsRef.current.mutedRooms.filter((r) => r !== room) });
+      const s = settingsRef.current;
+      const roomLevels = { ...s.roomLevels };
+      delete roomLevels[room];
+      setSettings({ ...s, roomLevels, mutedRooms: s.mutedRooms.filter((r) => r !== room) });
     },
     [setSettings],
   );
+
+  // Opening a room reads it: clears its unread badge and marks its bell entries
+  // read, on every tab.
+  const markRoomRead = useCallback((room: string) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.room === room && !n.read ? { ...n, read: true } : n)),
+    );
+    channelRef.current?.post({ type: "room-read", room });
+  }, []);
 
   const requestDesktopPermission = useCallback(() => {
     if (typeof window === "undefined" || !("Notification" in window)) return;
     window.Notification.requestPermission().then((perm) => setDesktopPermission(perm));
   }, []);
 
-  const unreadCount = useMemo(() => notifications.filter((n) => !n.read).length, [notifications]);
+  // The bell's badge + tab title count only "loud" unread — mentions, directs,
+  // consensus, knowledge. Badge-only room activity lives in the sidebar, not here.
+  const unreadCount = useMemo(
+    () => notifications.filter((n) => n.alert !== false && !n.read).length,
+    [notifications],
+  );
 
   const value = useMemo<NotificationsContextValue>(
     () => ({
@@ -244,10 +285,12 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
       setSettings,
       markRead,
       markAllRead,
+      markRoomRead,
       dismiss,
       clearAll,
       muteRoom,
       unmuteRoom,
+      setRoomLevel,
       desktopPermission,
       requestDesktopPermission,
     }),
@@ -259,10 +302,12 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
       setSettings,
       markRead,
       markAllRead,
+      markRoomRead,
       dismiss,
       clearAll,
       muteRoom,
       unmuteRoom,
+      setRoomLevel,
       desktopPermission,
       requestDesktopPermission,
     ],

--- a/mycelium-frontend/src/components/rooms-sidebar.test.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.test.tsx
@@ -184,4 +184,16 @@ describe("<RoomsSidebar /> unread badges", () => {
     const beta = screen.getByRole("link", { name: /beta/ });
     expect(within(beta).queryByLabelText(/unread/)).toBeNull();
   });
+
+  it("does not badge a muted room, and marks it as muted", async () => {
+    window.localStorage.setItem(
+      "mycelium.notification-settings",
+      JSON.stringify({ roomLevels: { beta: "muted" } }),
+    );
+    seed([{ room: "beta", read: false }]);
+    await renderSidebar(["alpha", "beta"]);
+    const beta = screen.getByRole("link", { name: /beta/ });
+    expect(within(beta).queryByLabelText(/unread/)).toBeNull();
+    expect(within(beta).getByLabelText("muted")).toBeInTheDocument();
+  });
 });

--- a/mycelium-frontend/src/components/rooms-sidebar.test.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.test.tsx
@@ -2,7 +2,7 @@
 // Copyright 2026 Mycelium Contributors
 
 import { act } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeEventSource } from "@/test/fake-event-source";
@@ -149,5 +149,39 @@ describe("<RoomsSidebar /> keyboard navigation", () => {
     await user.keyboard("{Escape}");
     await user.keyboard("{Alt>}2{/Alt}");
     expect(push).toHaveBeenCalledWith("/room/bravo");
+  });
+});
+
+describe("<RoomsSidebar /> unread badges", () => {
+  beforeEach(() => {
+    FakeEventSource.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    window.localStorage.clear();
+  });
+
+  const seed = (list: { room: string; read: boolean }[]) =>
+    window.localStorage.setItem("mycelium.notifications", JSON.stringify(list));
+
+  it("badges a room that has unread activity, and leaves others clean", async () => {
+    seed([
+      { room: "beta", read: false },
+      { room: "beta", read: false },
+      { room: "alpha", read: true },
+    ]);
+    await renderSidebar(["alpha", "beta"]);
+
+    const beta = screen.getByRole("link", { name: /beta/ });
+    expect(within(beta).getByLabelText("2 unread")).toBeInTheDocument();
+    const alpha = screen.getByRole("link", { name: /alpha/ });
+    expect(within(alpha).queryByLabelText(/unread/)).toBeNull();
+  });
+
+  it("does not badge the room you're already viewing", async () => {
+    seed([{ room: "beta", read: false }]);
+    await renderSidebar(["alpha", "beta"], "beta");
+    // Scoped to the row: beta's unread still counts globally (the footer bell),
+    // it just shouldn't badge the room you're currently reading.
+    const beta = screen.getByRole("link", { name: /beta/ });
+    expect(within(beta).queryByLabelText(/unread/)).toBeNull();
   });
 });

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -7,8 +7,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { BarChart3, Boxes, Plus, Search, SearchX } from "lucide-react";
+import { AtSign, BarChart3, Bell, BellOff, Boxes, Check, Plus, Search, SearchX, type LucideIcon } from "lucide-react";
 import { fetchRooms, getAppEventsSSEUrl, type Room } from "@/lib/api";
+import { roomLevel, type RoomLevel } from "@/lib/notifications";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { NotificationBell } from "@/components/notification-bell";
@@ -80,16 +82,22 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   }, []);
 
   // Unread activity per room, from the same client-side notification store the
-  // bell reads — muted rooms don't count, so a muted room never wears a badge.
-  const { notifications, settings } = useNotifications();
+  // bell reads. Any non-muted message counts (broadcasts badge here even though
+  // they never ring the bell); a muted room never wears a badge.
+  const { notifications, settings, setRoomLevel, markRoomRead } = useNotifications();
   const unreadByRoom = useMemo(() => {
     const m = new Map<string, number>();
     for (const n of notifications) {
-      if (n.read || settings.mutedRooms.includes(n.room)) continue;
+      if (n.read || roomLevel(settings, n.room) === "muted") continue;
       m.set(n.room, (m.get(n.room) ?? 0) + 1);
     }
     return m;
-  }, [notifications, settings.mutedRooms]);
+  }, [notifications, settings]);
+
+  // Opening a room reads it — clear its badge (and its bell entries) on arrival.
+  useEffect(() => {
+    if (activeRoom) markRoomRead(activeRoom);
+  }, [activeRoom, markRoomRead]);
 
   // Filter by the query, then order by recency (last active first) so rooms with
   // fresh activity float up — the same ordering the command palette uses.
@@ -320,9 +328,10 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
             // Don't badge the room you're already looking at — being here is
             // reading it. Elsewhere, unread activity draws the name brighter too.
             const unread = active ? 0 : unreadByRoom.get(room.name) ?? 0;
+            const level = roomLevel(settings, room.name);
             return (
+              <div key={room.name} className="group/room relative">
               <Link
-                key={room.name}
                 href={`/room/${encodeURIComponent(room.name)}`}
                 className={`group flex items-center gap-2.5 rounded-lg px-2 py-1.5 transition-colors ${
                   active ? "bg-elevated ring-1 ring-border" : "hover:bg-hairline"
@@ -361,12 +370,21 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
                 {unread > 0 && (
                   <span
                     aria-label={`${unread} unread`}
-                    className="flex h-4 min-w-4 flex-shrink-0 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold tabular leading-none text-accent-fg"
+                    className="flex h-4 min-w-4 flex-shrink-0 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold tabular leading-none text-accent-fg transition-opacity group-hover/room:opacity-0"
                   >
                     {unread > 9 ? "9+" : unread}
                   </span>
                 )}
+                {unread === 0 && level === "muted" && (
+                  <BellOff aria-label="muted" className="size-3 flex-shrink-0 text-faint transition-opacity group-hover/room:opacity-0" />
+                )}
               </Link>
+              {/* Discord-style per-room control, revealed on hover, overlaying the
+                  badge slot. Outside the Link so it never navigates. */}
+              <div className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover/room:pointer-events-auto group-hover/room:opacity-100">
+                <RoomLevelMenu room={room.name} level={level} onSet={setRoomLevel} />
+              </div>
+              </div>
             );
           })
         )}
@@ -390,5 +408,57 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
 
       <CreateRoomDialog open={showCreate} onClose={() => setShowCreate(false)} onCreated={load} />
     </aside>
+  );
+}
+
+const LEVEL_OPTIONS: { level: RoomLevel; label: string; hint: string; Icon: LucideIcon }[] = [
+  { level: "all", label: "All messages", hint: "badge + bell + sound", Icon: Bell },
+  { level: "mentions", label: "Only mentions", hint: "badge; bell on @you", Icon: AtSign },
+  { level: "muted", label: "Muted", hint: "nothing", Icon: BellOff },
+];
+
+/** Discord-style notification level picker for one room. The trigger wears the
+ *  current level's glyph; the menu sets it. */
+function RoomLevelMenu({
+  room,
+  level,
+  onSet,
+}: {
+  room: string;
+  level: RoomLevel;
+  onSet: (room: string, level: RoomLevel) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const Current = LEVEL_OPTIONS.find((o) => o.level === level)?.Icon ?? Bell;
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        aria-label={`Notifications for ${room}: ${level}`}
+        onClick={(e) => e.preventDefault()}
+        className="flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+      >
+        <Current className="size-3.5" />
+      </PopoverTrigger>
+      <PopoverContent className="w-48 p-1">
+        {LEVEL_OPTIONS.map(({ level: l, label, hint, Icon }) => (
+          <button
+            key={l}
+            type="button"
+            onClick={() => {
+              onSet(room, l);
+              setOpen(false);
+            }}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-hairline"
+          >
+            <Icon className="size-3.5 flex-shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1">
+              <span className="block text-label text-text">{label}</span>
+              <span className="block text-micro text-muted-foreground">{hint}</span>
+            </span>
+            {level === l && <Check className="size-3.5 flex-shrink-0 text-accent" />}
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -12,6 +12,7 @@ import { fetchRooms, getAppEventsSSEUrl, type Room } from "@/lib/api";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { NotificationBell } from "@/components/notification-bell";
+import { useNotifications } from "@/components/notifications-provider";
 import { EmptyState } from "@/components/empty-state";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { KeyBadge } from "@/components/key-badge";
@@ -78,9 +79,25 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
     return () => { clearInterval(t); es?.close(); clearTimeout(retry); };
   }, []);
 
+  // Unread activity per room, from the same client-side notification store the
+  // bell reads — muted rooms don't count, so a muted room never wears a badge.
+  const { notifications, settings } = useNotifications();
+  const unreadByRoom = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const n of notifications) {
+      if (n.read || settings.mutedRooms.includes(n.room)) continue;
+      m.set(n.room, (m.get(n.room) ?? 0) + 1);
+    }
+    return m;
+  }, [notifications, settings.mutedRooms]);
+
+  // Filter by the query, then order by recency (last active first) so rooms with
+  // fresh activity float up — the same ordering the command palette uses.
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    return q ? rooms.filter(r => r.name.toLowerCase().includes(q)) : rooms;
+    const base = q ? rooms.filter(r => r.name.toLowerCase().includes(q)) : rooms;
+    const recency = (r: Room) => r.last_activity ?? r.created_at ?? "";
+    return [...base].sort((a, b) => recency(b).localeCompare(recency(a)));
   }, [rooms, query]);
 
   // ---- Keyboard navigation -------------------------------------------------
@@ -251,7 +268,7 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
       {/* Rooms header + search */}
       <div className="flex items-center gap-2 px-3 pt-3 pb-2">
         <span className="text-micro font-semibold uppercase tracking-wide text-muted-foreground">Rooms</span>
-        <span className="text-micro tabular text-faint">{rooms.length}</span>
+        <span className="text-micro tabular text-muted-foreground">{rooms.length}</span>
         <button
           onClick={() => setShowCreate(true)}
           aria-label="New room"
@@ -300,6 +317,9 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
           filtered.map((room, i) => {
             const active = room.name === activeRoom;
             const label = hints?.labels[i];
+            // Don't badge the room you're already looking at — being here is
+            // reading it. Elsewhere, unread activity draws the name brighter too.
+            const unread = active ? 0 : unreadByRoom.get(room.name) ?? 0;
             return (
               <Link
                 key={room.name}
@@ -329,9 +349,23 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
                     </span>
                   )}
                 </span>
-                <span className={`truncate text-label ${active ? "font-medium text-text" : "text-muted-foreground group-hover:text-text"}`}>
+                <span
+                  className={`min-w-0 flex-1 truncate text-label ${
+                    active || unread > 0
+                      ? "font-medium text-text"
+                      : "text-muted-foreground group-hover:text-text"
+                  }`}
+                >
                   {room.name}
                 </span>
+                {unread > 0 && (
+                  <span
+                    aria-label={`${unread} unread`}
+                    className="flex h-4 min-w-4 flex-shrink-0 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold tabular leading-none text-accent-fg"
+                  >
+                    {unread > 9 ? "9+" : unread}
+                  </span>
+                )}
               </Link>
             );
           })

--- a/mycelium-frontend/src/lib/notifications.test.ts
+++ b/mycelium-frontend/src/lib/notifications.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 Mycelium Contributors
 
 import { describe, expect, it } from "vitest";
-import { classify, DEFAULT_SETTINGS, isAdmitted } from "@/lib/notifications";
+import { classify, DEFAULT_SETTINGS, isAdmitted, isAlert, roomLevel } from "@/lib/notifications";
 
 const CREATED = "2026-08-15T10:00:00.000000+00:00";
 
@@ -24,8 +24,13 @@ describe("classify", () => {
     expect(n).toMatchObject({ room: "sprint", kind: "mention", needsMe: true });
   });
 
-  it("ignores a mention of someone else", () => {
+  it("classifies a message that doesn't mention you as ambient (badge-only)", () => {
     const n = classify(l9Exchange("hey @carol can you take a look?"), "bob");
+    expect(n).toMatchObject({ kind: "message", needsMe: false });
+  });
+
+  it("ignores your own post", () => {
+    const n = classify(l9Exchange("just thinking out loud"), "alice");
     expect(n).toBeNull();
   });
 
@@ -118,5 +123,44 @@ describe("isAdmitted", () => {
 
   it("rejects a notification from a muted room", () => {
     expect(isAdmitted(mention, { ...DEFAULT_SETTINGS, mutedRooms: ["sprint"] })).toBe(false);
+  });
+});
+
+describe("roomLevel", () => {
+  it("defaults to mentions under needs-me scope, all under everything", () => {
+    expect(roomLevel(DEFAULT_SETTINGS, "sprint")).toBe("mentions");
+    expect(roomLevel({ ...DEFAULT_SETTINGS, scope: "everything" }, "sprint")).toBe("all");
+  });
+
+  it("lets a per-room override win over the scope default and legacy mute", () => {
+    const s = { ...DEFAULT_SETTINGS, mutedRooms: ["sprint"], roomLevels: { sprint: "all" as const } };
+    expect(roomLevel(s, "sprint")).toBe("all");
+  });
+
+  it("reads a legacy muted room as muted", () => {
+    expect(roomLevel({ ...DEFAULT_SETTINGS, mutedRooms: ["sprint"] }, "sprint")).toBe("muted");
+  });
+});
+
+describe("isAlert", () => {
+  const mention = classify(l9Exchange("hey @bob"), "bob")!;
+  const message = classify(l9Exchange("morning all"), "bob")!;
+
+  it("is loud for a mention under the default (mentions) level", () => {
+    expect(isAlert(mention, DEFAULT_SETTINGS)).toBe(true);
+  });
+
+  it("is quiet (badge-only) for ambient chatter under mentions", () => {
+    expect(isAlert(message, DEFAULT_SETTINGS)).toBe(false);
+  });
+
+  it("is loud for ambient chatter when the room is on all", () => {
+    const s = { ...DEFAULT_SETTINGS, roomLevels: { sprint: "all" as const } };
+    expect(isAlert(message, s)).toBe(true);
+  });
+
+  it("is silent for anything in a muted room", () => {
+    const s = { ...DEFAULT_SETTINGS, roomLevels: { sprint: "muted" as const } };
+    expect(isAlert(mention, s)).toBe(false);
   });
 });

--- a/mycelium-frontend/src/lib/notifications.ts
+++ b/mycelium-frontend/src/lib/notifications.ts
@@ -235,11 +235,26 @@ export function openCrossTabChannel(onMessage: (msg: CrossTabMessage) => void): 
   if (typeof window === "undefined" || typeof window.BroadcastChannel === "undefined") {
     return { post: () => {}, close: () => {} };
   }
+  let closed = false;
   const bc = new BroadcastChannel(CHANNEL_NAME);
   bc.onmessage = (e) => onMessage(e.data as CrossTabMessage);
   return {
-    post: (msg) => bc.postMessage(msg),
-    close: () => bc.close(),
+    // Posting on a closed channel throws InvalidStateError. React Strict Mode
+    // double-mounts the provider (close → reopen), and an effect can fire a post
+    // against the just-closed channel in that window — so a post after close is a
+    // no-op, not a crash.
+    post: (msg) => {
+      if (closed) return;
+      try {
+        bc.postMessage(msg);
+      } catch {
+        // Channel closed between the guard and the post — ignore.
+      }
+    },
+    close: () => {
+      closed = true;
+      bc.close();
+    },
   };
 }
 

--- a/mycelium-frontend/src/lib/notifications.ts
+++ b/mycelium-frontend/src/lib/notifications.ts
@@ -7,7 +7,7 @@
 // Framework-agnostic on purpose — `notifications-provider.tsx` is the only
 // React-aware consumer, so this stays unit-testable without rendering.
 
-export type NotificationKind = "mention" | "direct" | "consensus" | "knowledge" | "join";
+export type NotificationKind = "mention" | "direct" | "consensus" | "knowledge" | "join" | "message";
 
 export interface ClassifiedNotification {
   id: string;
@@ -16,17 +16,25 @@ export interface ClassifiedNotification {
   summary: string;
   sender: string;
   time: string;
-  /** True for the kinds "Needs me" scope includes (mention/direct/consensus/
-   *  knowledge); false for ambient activity ("everything" scope only, e.g. a
-   *  plain join). */
+  /** True for the kinds that ring the bell (mention/direct/consensus/knowledge);
+   *  false for ambient activity that only badges (a plain broadcast or a join). */
   needsMe: boolean;
 }
 
 export interface StoredNotification extends ClassifiedNotification {
   read: boolean;
+  /** True when this reached the bell inbox + sound/desktop ("loud"); false when
+   *  it only bumps the room's unread badge ("quiet"). Missing on legacy entries,
+   *  which were all loud — treat `!== false` as loud. */
+  alert?: boolean;
 }
 
 export type NotificationScope = "needs-me" | "everything";
+
+/** Per-room notification level (Discord-style), overriding the global default.
+ *  all = every message is loud; mentions = only @you/consensus is loud, the rest
+ *  just badges; muted = nothing (no badge, no bell). */
+export type RoomLevel = "all" | "mentions" | "muted";
 
 export interface NotificationSettings {
   scope: NotificationScope;
@@ -35,6 +43,8 @@ export interface NotificationSettings {
   desktopEnabled: boolean;
   dnd: boolean;
   mutedRooms: string[];
+  /** Per-room overrides of the scope-derived default. */
+  roomLevels: Record<string, RoomLevel>;
 }
 
 export const DEFAULT_SETTINGS: NotificationSettings = {
@@ -44,7 +54,26 @@ export const DEFAULT_SETTINGS: NotificationSettings = {
   desktopEnabled: false,
   dnd: false,
   mutedRooms: [],
+  roomLevels: {},
 };
+
+/** The effective level for a room: an explicit per-room override wins, else a
+ *  legacy mute reads as "muted", else the global scope's default ("everything" →
+ *  all, "needs-me" → mentions). */
+export function roomLevel(settings: NotificationSettings, room: string): RoomLevel {
+  const override = settings.roomLevels?.[room];
+  if (override) return override;
+  if (settings.mutedRooms.includes(room)) return "muted";
+  return settings.scope === "everything" ? "all" : "mentions";
+}
+
+/** Is this notification "loud" — bell inbox + sound/desktop — vs badge-only?
+ *  Loud when the room is on "all", or the item needs you and the room isn't muted. */
+export function isAlert(n: ClassifiedNotification, settings: NotificationSettings): boolean {
+  const level = roomLevel(settings, n.room);
+  if (level === "muted") return false;
+  return level === "all" || n.needsMe;
+}
 
 const MENTION_RE = /@([\w-]+)/g;
 
@@ -87,17 +116,21 @@ export function classify(raw: Record<string, unknown>, principal: string): Class
   switch (mtype) {
     case "l9_exchange": {
       const text = (content.content as string) || "";
+      // Your own post is never a notification to yourself.
+      if (sender.toLowerCase() === handle) return null;
       const directed = recipient !== null && recipient.toLowerCase() === handle;
       const mentioned = mentionsHandle(text, handle);
-      if (!directed && !mentioned) return null;
+      // A message that neither addresses nor mentions you is ambient room
+      // activity: it badges the room (quiet) but doesn't ring the bell.
+      const kind = directed ? "direct" : mentioned ? "mention" : "message";
       return {
         id,
         room,
         sender,
         time,
-        kind: directed ? "direct" : "mention",
+        kind,
         summary: text.slice(0, 160),
-        needsMe: true,
+        needsMe: directed || mentioned,
       };
     }
     case "l9_commit": {
@@ -121,14 +154,12 @@ export function classify(raw: Record<string, unknown>, principal: string): Class
   }
 }
 
-/** Does ``settings`` admit this classified notification (scope, per-room
- *  mute, global do-not-disturb)? Pure predicate — the caller decides what to
- *  do with an admitted notification (store it, ping, badge it). */
+/** Should this notification ring the bell right now — i.e. it's "loud" for the
+ *  room's level and global do-not-disturb is off. (A badge-only item is stored
+ *  but never admitted here.) Pure predicate; the caller decides what to do. */
 export function isAdmitted(n: ClassifiedNotification, settings: NotificationSettings): boolean {
   if (settings.dnd) return false;
-  if (settings.mutedRooms.includes(n.room)) return false;
-  if (settings.scope === "needs-me" && !n.needsMe) return false;
-  return true;
+  return isAlert(n, settings);
 }
 
 const NOTIFICATIONS_KEY = "mycelium.notifications";
@@ -187,6 +218,7 @@ export function saveSettings(settings: NotificationSettings): void {
 export type CrossTabMessage =
   | { type: "read"; id: string }
   | { type: "read-all" }
+  | { type: "room-read"; room: string }
   | { type: "dismiss"; id: string }
   | { type: "clear" }
   | { type: "settings"; settings: NotificationSettings };


### PR DESCRIPTION
Fixes the thing that subverted expectations: a plain room broadcast used to be dropped entirely — no notif, and (since #624) not even a badge. Now there are **three outcomes** and a **per-room control** to choose between them.

## The three tiers
| Per-room level | Sidebar badge | Bell + sound/desktop |
|---|---|---|
| **All messages** | any message | any message |
| **Only mentions** (default) | any message | only @you / directs / consensus / knowledge |
| **Muted** | — | — |

Default is **Mentions** (from the existing global `needs-me` scope). The global scope still sets the default; per-room levels override it.

## How it works
- **`classify()`** now emits ambient room activity as a low-priority **`message`** (`needsMe=false`) instead of `null`, and skips your own posts. So broadcasts **badge** the room but stay quiet.
- **`roomLevel()` / `isAlert()`** decide badge-vs-loud from the per-room level; muted drops everything.
- **One store, an `alert` flag per entry.** The bell inbox, its count, and the tab title show **loud** only; the **sidebar badge** counts any non-muted unread (broadcasts included). No broadcast spam in the bell.
- **Sidebar row menu** (hover-revealed, Discord-style): All / Only mentions / Muted, with a check on the current level and a persistent muted glyph on muted rooms. Outside the `<Link>` so it never navigates.
- **Opening a room marks it read** (clears its badge + its bell entries), synced across tabs via a new `room-read` cross-tab message.
- `muteRoom`/`unmuteRoom` reimplemented over the new level; `mutedRooms` kept in sync so the existing settings panel needs no changes.

## Tests (+13)
classify ambient vs mention vs your-own-post; `roomLevel` defaults + override precedence + legacy mute; `isAlert` badge-vs-loud across levels; sidebar doesn't badge a muted room and shows the muted glyph. Existing `isAdmitted` tests still pass (reimplemented in terms of the new model).

`pnpm lint`, full `vitest` (158), and `pnpm build` all green.

## Verify against the running stack
Post to a room you're *not* viewing: a plain broadcast should badge it (Mentions default) without ringing the bell; an `@you` should badge **and** ring; set the room to Muted from the row menu and both should go silent; open the room and its badge clears.