### PR TITLE
@ mentions people too, not just agents

### DIFF
--- a/mycelium-frontend/src/components/room-chat-box.test.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.test.tsx
@@ -13,6 +13,10 @@ vi.mock("@/lib/api", () => ({
   fetchRoomAgents: vi.fn().mockResolvedValue([
     { handle: "aligner", adapter: "engine", kind: "aligner", description: "mediator", cwd: null, owner: null, team: null, allow_from: [] },
   ]),
+  fetchRoomMembers: vi.fn().mockResolvedValue([
+    { handle: "watcher", kind: "lease", last_seen: null },
+    { handle: "aligner", kind: "slim", last_seen: null },
+  ]),
   fetchMemories: vi.fn().mockResolvedValue([
     { key: "decisions/db", value: "", version: 2, created_by: "julia", updated_at: "" },
     { key: "context/goals", value: "", version: 1, created_by: "sam", updated_at: "" },
@@ -76,6 +80,18 @@ describe("<RoomChatBox /> composer triggers", () => {
     await userEvent.click(option);
 
     expect((box as HTMLTextAreaElement).value).toContain("@aligner ");
+  });
+
+  it("also autocompletes a person (present member), not just agents", async () => {
+    render(<RoomChatBox roomName="demo" />);
+    const box = await textarea();
+    await userEvent.click(box);
+    await userEvent.type(box, "@wat");
+
+    const option = await screen.findByRole("button", { name: /@watcher/ });
+    await userEvent.click(option);
+
+    expect((box as HTMLTextAreaElement).value).toContain("@watcher ");
   });
 
   it("does not open a skill popover for a slash inside a word (e.g. a path)", async () => {

--- a/mycelium-frontend/src/components/room-chat-box.test.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.test.tsx
@@ -17,6 +17,12 @@ vi.mock("@/lib/api", () => ({
     { handle: "watcher", kind: "lease", last_seen: null },
     { handle: "aligner", kind: "slim", last_seen: null },
   ]),
+  fetchMessages: vi.fn().mockResolvedValue({
+    messages: [
+      { message_type: "broadcast", sender_handle: "sam" },
+      { message_type: "broadcast", sender_handle: "aligner" },
+    ],
+  }),
   fetchMemories: vi.fn().mockResolvedValue([
     { key: "decisions/db", value: "", version: 2, created_by: "julia", updated_at: "" },
     { key: "context/goals", value: "", version: 1, created_by: "sam", updated_at: "" },
@@ -92,6 +98,18 @@ describe("<RoomChatBox /> composer triggers", () => {
     await userEvent.click(option);
 
     expect((box as HTMLTextAreaElement).value).toContain("@watcher ");
+  });
+
+  it("autocompletes a poster who isn't currently present (Members-panel parity)", async () => {
+    render(<RoomChatBox roomName="demo" />);
+    const box = await textarea();
+    await userEvent.click(box);
+    await userEvent.type(box, "@sam");
+
+    const option = await screen.findByRole("button", { name: /@sam/ });
+    await userEvent.click(option);
+
+    expect((box as HTMLTextAreaElement).value).toContain("@sam ");
   });
 
   it("does not open a skill popover for a slash inside a word (e.g. a path)", async () => {

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -9,11 +9,13 @@ import { ArrowUp } from "lucide-react";
 import {
   fetchMemories,
   fetchRoomAgents,
+  fetchRoomMembers,
   fetchSkills,
   logFetchError,
   sendRoomMessage,
   type AgentSummary,
   type Memory,
+  type PresenceMember,
   type Skill,
 } from "@/lib/api";
 import { useCurrentUser } from "@/components/current-user";
@@ -88,6 +90,7 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [agents, setAgents] = useState<AgentSummary[]>([]);
+  const [members, setMembers] = useState<PresenceMember[]>([]);
   const [memories, setMemories] = useState<Memory[]>([]);
   const [skills, setSkills] = useState<Skill[]>([]);
   const [trigger, setTrigger] = useState<Trigger | null>(null);
@@ -95,10 +98,12 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
   const refreshSources = useCallback(() => {
+    // `@` mentions anyone in the room — agents plus the present people (and you).
     fetchRoomAgents(roomName).then(setAgents).catch((err) => {
       logFetchError("fetchRoomAgents")(err);
       setAgents([]);
     });
+    fetchRoomMembers(roomName).then(setMembers).catch(logFetchError("fetchRoomMembers"));
     // Memory keys drive `[[` autocomplete; skills drive `/`. Both degrade to [].
     fetchMemories(roomName).then(setMemories).catch(logFetchError("fetchMemories"));
     fetchSkills(roomName).then(setSkills).catch(logFetchError("fetchSkills"));
@@ -126,18 +131,40 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
     if (found) setHighlight(0);
   };
 
+  // Everyone `@` can address: agents first, then the present people (SLIM/lease
+  // members that aren't agents), then you — deduped by handle.
+  const mentionRoster = useMemo(() => {
+    const seen = new Set(agents.map((a) => a.handle.toLowerCase()));
+    const agentItems = agents.map((a) => ({
+      handle: a.handle,
+      secondary: a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter,
+      tertiary: a.description || undefined,
+    }));
+    const people: { handle: string; secondary: string; tertiary?: string }[] = [];
+    for (const m of members) {
+      const key = m.handle.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      people.push({ handle: m.handle, secondary: m.kind === "slim" ? "person · here" : "person" });
+    }
+    const me = principal.trim();
+    if (me && !seen.has(me.toLowerCase())) people.push({ handle: me, secondary: "you" });
+    people.sort((a, b) => a.handle.localeCompare(b.handle));
+    return [...agentItems, ...people];
+  }, [agents, members, principal]);
+
   const candidates = useMemo<Candidate[]>(() => {
     if (trigger === null) return [];
     if (trigger.kind === "agent") {
       const pool = trigger.query
-        ? agents.filter((a) => a.handle.toLowerCase().startsWith(trigger.query))
-        : agents;
-      return pool.slice(0, 6).map((a) => ({
-        id: a.handle,
-        insert: `@${a.handle}`,
-        primary: `@${a.handle}`,
-        secondary: a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter,
-        tertiary: a.description || undefined,
+        ? mentionRoster.filter((r) => r.handle.toLowerCase().startsWith(trigger.query))
+        : mentionRoster;
+      return pool.slice(0, 8).map((r) => ({
+        id: r.handle,
+        insert: `@${r.handle}`,
+        primary: `@${r.handle}`,
+        secondary: r.secondary,
+        tertiary: r.tertiary,
       }));
     }
     if (trigger.kind === "memory") {
@@ -163,7 +190,7 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
       secondary: "skill",
       tertiary: s.description || undefined,
     }));
-  }, [agents, memories, skills, trigger]);
+  }, [mentionRoster, memories, skills, trigger]);
 
   const accept = useCallback(
     (candidate: Candidate) => {
@@ -277,7 +304,7 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
             value={content}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
-            placeholder="Message the room…  @ agent · [[ memory · / skill"
+            placeholder="Message the room…  @ mention · [[ memory · / skill"
             minRows={1}
             maxRows={10}
             className="w-full resize-none bg-transparent px-4 pt-3 pb-1.5 text-body text-text leading-relaxed focus:outline-none placeholder:text-muted-foreground"

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -8,6 +8,7 @@ import TextareaAutosize from "react-textarea-autosize";
 import { ArrowUp } from "lucide-react";
 import {
   fetchMemories,
+  fetchMessages,
   fetchRoomAgents,
   fetchRoomMembers,
   fetchSkills,
@@ -91,6 +92,7 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [agents, setAgents] = useState<AgentSummary[]>([]);
   const [members, setMembers] = useState<PresenceMember[]>([]);
+  const [posters, setPosters] = useState<string[]>([]);
   const [memories, setMemories] = useState<Memory[]>([]);
   const [skills, setSkills] = useState<Skill[]>([]);
   const [trigger, setTrigger] = useState<Trigger | null>(null);
@@ -104,6 +106,18 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
       setAgents([]);
     });
     fetchRoomMembers(roomName).then(setMembers).catch(logFetchError("fetchRoomMembers"));
+    // Human posters from the transcript — a broadcast from a non-agent handle —
+    // so `@` reaches people who've spoken even if they aren't present right now.
+    fetchMessages(roomName, 200)
+      .then(({ messages }) =>
+        setPosters(
+          messages
+            .filter((m) => m.message_type === "broadcast")
+            .map((m) => m.sender_handle ?? "")
+            .filter(Boolean),
+        ),
+      )
+      .catch(logFetchError("fetchMessages"));
     // Memory keys drive `[[` autocomplete; skills drive `/`. Both degrade to [].
     fetchMemories(roomName).then(setMemories).catch(logFetchError("fetchMemories"));
     fetchSkills(roomName).then(setSkills).catch(logFetchError("fetchSkills"));
@@ -131,27 +145,41 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
     if (found) setHighlight(0);
   };
 
-  // Everyone `@` can address: agents first, then the present people (SLIM/lease
-  // members that aren't agents), then you — deduped by handle.
+  // Everyone `@` can address, at parity with the Members panel: agents first,
+  // then people — agent owners ∪ posters ∪ present members ∪ you (minus agents),
+  // deduped by handle. `present` marks a live SLIM member.
   const mentionRoster = useMemo(() => {
-    const seen = new Set(agents.map((a) => a.handle.toLowerCase()));
+    const agentHandles = new Set(agents.map((a) => a.handle.toLowerCase()));
     const agentItems = agents.map((a) => ({
       handle: a.handle,
       secondary: a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter,
-      tertiary: a.description || undefined,
+      tertiary: a.description as string | undefined,
     }));
-    const people: { handle: string; secondary: string; tertiary?: string }[] = [];
-    for (const m of members) {
-      const key = m.handle.toLowerCase();
-      if (seen.has(key)) continue;
-      seen.add(key);
-      people.push({ handle: m.handle, secondary: m.kind === "slim" ? "person · here" : "person" });
-    }
-    const me = principal.trim();
-    if (me && !seen.has(me.toLowerCase())) people.push({ handle: me, secondary: "you" });
-    people.sort((a, b) => a.handle.localeCompare(b.handle));
-    return [...agentItems, ...people];
-  }, [agents, members, principal]);
+
+    const me = principal.trim().toLowerCase();
+    const peopleByHandle = new Map<string, { handle: string; present: boolean }>();
+    const addPerson = (raw: string, present: boolean) => {
+      const h = raw.replace(/^@/, "").toLowerCase();
+      if (!h || agentHandles.has(h)) return;
+      const existing = peopleByHandle.get(h);
+      if (existing) existing.present = existing.present || present;
+      else peopleByHandle.set(h, { handle: h, present });
+    };
+    for (const a of agents) if (a.owner) addPerson(a.owner, false);
+    for (const p of posters) addPerson(p, false);
+    for (const m of members) addPerson(m.handle, m.kind === "slim");
+    if (me) addPerson(me, false);
+
+    const peopleItems = [...peopleByHandle.values()]
+      .sort((a, b) => a.handle.localeCompare(b.handle))
+      .map((p) => ({
+        handle: p.handle,
+        secondary: p.handle === me ? "you" : p.present ? "person · here" : "person",
+        tertiary: undefined as string | undefined,
+      }));
+
+    return [...agentItems, ...peopleItems];
+  }, [agents, members, posters, principal]);
 
   const candidates = useMemo<Candidate[]>(() => {
     if (trigger === null) return [];


### PR DESCRIPTION
The chat composer's `@` autocomplete only listed **agents**. Now it lists everyone you can address in the room.

## What
- Merge the room's **present people** (SLIM / lease members who aren't agents) and **you** (the acting-as handle) into the `@` roster, alongside agents.
- Order: agents first (with adapter/kind), then people (sorted), deduped by handle. A present human shows `person · here` (SLIM) or `person`; you show `you`.
- Sourced from `fetchRoomMembers` — the same presence the Members panel uses. Placeholder updated to `@ mention`.

## Notes
- Covers agents + currently-present people + you. A human who posted and then left (not currently present) isn't included yet — if you want that, it's one more source (`fetchMessages` posters), same as the Members panel merges.

## Tests
Added: `@` surfaces a present person (`watcher`), not just the agent. Existing `@agent`, `[[`, `/`, and path-slash cases still pass.

`pnpm lint`, full `vitest`, and `pnpm build` all green.