### PR TITLE
Remove the confusing rooms 'f to label them all' hint

### DIFF
--- a/mycelium-frontend/src/components/rooms-sidebar.test.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.test.tsx
@@ -43,64 +43,10 @@ async function renderSidebar(names: string[], activeRoom: string | null = null) 
 }
 
 describe("<RoomsSidebar /> keyboard navigation", () => {
-  // The hint overlay tells a tap from a hold by wall clock, so the tests drive
-  // it: unchanged means "tapped" (latched open), advanced means "held".
-  let now = 0;
-
   beforeEach(() => {
     push.mockClear();
-    now = 1_000;
-    vi.spyOn(Date, "now").mockImplementation(() => now);
     FakeEventSource.reset();
     vi.stubGlobal("EventSource", FakeEventSource);
-  });
-
-  it("reveals a hint label per room and jumps to the one pressed", async () => {
-    const user = await renderSidebar(["alpha", "beta", "gamma"]);
-
-    await user.keyboard("{f>}");
-    expect(screen.getByText("Press a hint label to jump")).toBeInTheDocument();
-    expect(document.querySelectorAll("[data-hint]")).toHaveLength(3);
-
-    await user.keyboard("d{/f}");
-    expect(push).toHaveBeenCalledWith("/room/gamma");
-    expect(screen.queryByText("Press a hint label to jump")).not.toBeInTheDocument();
-  });
-
-  it("expands to 2-char labels once the rooms outgrow the home row", async () => {
-    const names = Array.from({ length: 12 }, (_, i) => `room-${i}`);
-    const user = await renderSidebar(names);
-
-    await user.keyboard("{f>}{/f}");
-    const labels = [...document.querySelectorAll("[data-hint]")].map(el => el.getAttribute("data-hint"));
-    expect(labels).toHaveLength(12);
-    expect(labels.every(l => l?.length === 2)).toBe(true);
-
-    // A partial label narrows without jumping; the second char commits.
-    await user.keyboard("a");
-    expect(push).not.toHaveBeenCalled();
-    await user.keyboard("d");
-    expect(push).toHaveBeenCalledWith("/room/room-2");
-  });
-
-  it("holds to peek: releasing the hint key closes an untouched overlay", async () => {
-    const user = await renderSidebar(["alpha", "beta"]);
-
-    await user.keyboard("{f>}");
-    expect(document.querySelectorAll("[data-hint]")).toHaveLength(2);
-    now += 400;
-    await user.keyboard("{/f}");
-    expect(document.querySelectorAll("[data-hint]")).toHaveLength(0);
-    expect(push).not.toHaveBeenCalled();
-  });
-
-  it("escapes hint mode without navigating", async () => {
-    const user = await renderSidebar(["alpha", "beta"]);
-
-    await user.keyboard("{f>}{/f}");
-    await user.keyboard("{Escape}");
-    expect(document.querySelectorAll("[data-hint]")).toHaveLength(0);
-    expect(push).not.toHaveBeenCalled();
   });
 
   it("cycles to the next and previous room", async () => {
@@ -129,13 +75,10 @@ describe("<RoomsSidebar /> keyboard navigation", () => {
     expect(badges).toEqual(["1", "2", "3", "4", "5", "6", "7", "8", "9"]);
     // The brand wears its own key in the same hold.
     expect(document.querySelector("a[href='/'] [data-key-badge]")).toHaveTextContent("H");
-    // Nine digits don't cover eleven rooms, so the overlay says where the rest are.
-    expect(screen.getByText(/to label them all/)).toBeInTheDocument();
 
     await user.keyboard("2{/Alt}");
     expect(push).toHaveBeenCalledWith("/room/room-1");
     expect(document.querySelector("[data-key-badge]")).toBeNull();
-    expect(screen.queryByText(/to label them all/)).not.toBeInTheDocument();
   });
 
   it("switches among the rooms the filter leaves on screen", async () => {

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -18,8 +18,7 @@ import { useNotifications } from "@/components/notifications-provider";
 import { EmptyState } from "@/components/empty-state";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { KeyBadge } from "@/components/key-badge";
-import { useCommands, useKeyAction, useKeyCapture, useKeyReveal } from "@/components/keymap-provider";
-import { chordFor, hintLabels } from "@/lib/keymap";
+import { useCommands, useKeyAction } from "@/components/keymap-provider";
 import type { PaletteCommand } from "@/lib/commands";
 
 // The sidebar lives inside each page's AppShell, so navigation remounts it. A
@@ -34,19 +33,9 @@ function monogram(name: string): string {
   return s.toUpperCase();
 }
 
-/** Below this, a hint keypress reads as a tap that latches the overlay open;
- *  above it, as a hold that peeks and closes on release. */
-const HOLD_TO_PEEK_MS = 250;
-
 interface Props {
   /** The room currently open, so its row is highlighted. Null on the home view. */
   activeRoom?: string | null;
-}
-
-/** Hint mode: labels for the rooms on screen, plus what's been typed so far. */
-interface Hints {
-  labels: string[];
-  typed: string;
 }
 
 export function RoomsSidebar({ activeRoom = null }: Props) {
@@ -109,21 +98,11 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   }, [rooms, query]);
 
   // ---- Keyboard navigation -------------------------------------------------
-  // The rooms on screen are the switchable set, in the order they're listed: a
-  // filtered sidebar switches among what it shows, so hint labels, the digit
-  // fast path and next/prev all agree with what the user is looking at.
+  // The rooms on screen are the switchable set, in the order they're listed, so
+  // the digit fast path and next/prev agree with what the user is looking at.
   const router = useRouter();
-  const captureKeys = useKeyCapture();
-  const [hints, setHints] = useState<Hints | null>(null);
-  const hintsRef = useRef<Hints | null>(null);
   const roomsRef = useRef(filtered);
-  const releaseKeys = useRef<(() => void) | null>(null);
-  const hintKey = useRef<string>("");
-  const hintOpenedAt = useRef(0);
-  // The capture handler is installed once but reads live state; mirror it so it
-  // never acts on the list or the typed prefix from an earlier render.
   useEffect(() => {
-    hintsRef.current = hints;
     roomsRef.current = filtered;
   });
 
@@ -133,72 +112,6 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
     },
     [router],
   );
-
-  const exitHints = useCallback(() => {
-    releaseKeys.current?.();
-    releaseKeys.current = null;
-    setHints(null);
-  }, []);
-
-  // Hint mode owns the keyboard while it's up, so a label char is read as a
-  // label and never as the binding it would otherwise fire.
-  const onHintKey = useCallback(
-    (e: KeyboardEvent) => {
-      const current = hintsRef.current;
-      if (!current) return;
-      e.preventDefault();
-      if (e.key === "Escape") {
-        exitHints();
-        return;
-      }
-      if (e.key === "Backspace") {
-        setHints({ ...current, typed: current.typed.slice(0, -1) });
-        return;
-      }
-      if (/^[1-9]$/.test(e.key)) {
-        const room = roomsRef.current[Number(e.key) - 1];
-        exitHints();
-        go(room);
-        return;
-      }
-      if (e.key.length !== 1) return;
-      const typed = (current.typed + e.key).toLowerCase();
-      const exact = current.labels.indexOf(typed);
-      if (exact >= 0) {
-        exitHints();
-        go(roomsRef.current[exact]);
-        return;
-      }
-      // A char that starts no label is a typo, not a jump: swallow it and
-      // leave the overlay as it was.
-      if (current.labels.some(l => l.startsWith(typed))) setHints({ ...current, typed });
-    },
-    [exitHints, go],
-  );
-
-  useKeyAction("rooms.hints", (sequence) => {
-    if (filtered.length === 0) return;
-    hintKey.current = sequence;
-    hintOpenedAt.current = Date.now();
-    setHints({ labels: hintLabels(filtered.length), typed: "" });
-    releaseKeys.current = captureKeys(onHintKey);
-  });
-
-  // Hold-to-peek: releasing the hint key closes the overlay again, unless it
-  // was a quick tap (latched open) or a label is already part-typed.
-  useEffect(() => {
-    if (!hints) return;
-    const onKeyUp = (e: KeyboardEvent) => {
-      if (e.key !== hintKey.current) return;
-      if (Date.now() - hintOpenedAt.current < HOLD_TO_PEEK_MS) return;
-      if (hintsRef.current?.typed) return;
-      exitHints();
-    };
-    window.addEventListener("keyup", onKeyUp);
-    return () => window.removeEventListener("keyup", onKeyUp);
-  }, [hints, exitHints]);
-
-  useEffect(() => () => releaseKeys.current?.(), []);
 
   const cycle = useCallback(
     (delta: number) => {
@@ -247,11 +160,6 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   );
   useCommands(commands);
 
-  // While the reveal modifier is held the first nine rooms wear their own digit;
-  // `f` labels the whole list, which is the answer past nine.
-  const revealed = useKeyReveal();
-  const hintsChord = chordFor("rooms.hints");
-
   return (
     <aside data-tour="rooms" className="flex w-[236px] flex-shrink-0 flex-col border-r border-border bg-surface/50">
       {/* Brand */}
@@ -298,20 +206,6 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
         </div>
       </div>
 
-      {hints ? (
-        <div role="status" aria-live="polite" className="px-3 pb-2 text-micro text-muted-foreground">
-          Press a hint label to jump{hints.typed ? ` · ${hints.typed}…` : ""}
-        </div>
-      ) : (
-        // Nine digits only go so far; say where the rest are while the badges
-        // are on screen and the question is being asked.
-        revealed && filtered.length > 9 && (
-          <div className="px-3 pb-2 text-micro text-muted-foreground">
-            <kbd className="font-sans">{hintsChord}</kbd> to label them all
-          </div>
-        )
-      )}
-
       {/* Rooms list */}
       <ScrollArea className="min-h-0 flex-1">
         <nav className="px-2 pb-2">
@@ -324,7 +218,6 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
         ) : (
           filtered.map((room, i) => {
             const active = room.name === activeRoom;
-            const label = hints?.labels[i];
             // Don't badge the room you're already looking at — being here is
             // reading it. Elsewhere, unread activity draws the name brighter too.
             const unread = active ? 0 : unreadByRoom.get(room.name) ?? 0;
@@ -345,18 +238,6 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
                 >
                   {monogram(room.name)}
                   {i < 9 && <KeyBadge chord={`alt+${i + 1}`} overlay />}
-                  {label && (
-                    <span
-                      data-hint={label}
-                      className="absolute inset-0 flex items-center justify-center rounded-md bg-yellow font-mono text-micro font-bold text-bg motion-safe:animate-in motion-safe:fade-in-0"
-                    >
-                      {[...label].map((c, ci) => (
-                        <span key={ci} className={ci < (hints?.typed.length ?? 0) ? "opacity-40" : undefined}>
-                          {c}
-                        </span>
-                      ))}
-                    </span>
-                  )}
                 </span>
                 <span
                   className={`min-w-0 flex-1 truncate text-label ${

--- a/mycelium-frontend/src/lib/keymap.ts
+++ b/mycelium-frontend/src/lib/keymap.ts
@@ -75,15 +75,6 @@ export const KEYMAP: Binding[] = [
     // The palette lists the rooms themselves, by name and past the ninth.
     palette: false,
   },
-  {
-    id: "rooms.hints",
-    keys: ["f"],
-    label: "Label every room — press a label to jump (past the first nine)",
-    group: "Rooms",
-    scope: "global",
-    // A hold-to-read overlay: there's nothing for a list row to invoke.
-    palette: false,
-  },
   { id: "rooms.next", keys: ["]", "J"], label: "Next room", group: "Rooms", scope: "global" },
   { id: "rooms.prev", keys: ["[", "K"], label: "Previous room", group: "Rooms", scope: "global" },
   { id: "nav.home", keys: ["alt+h"], label: "Command center", group: "Navigate", scope: "global" },


### PR DESCRIPTION
## What
That reveal hint — the `⌥F to label them all` line that appeared while holding ⌥ with >9 rooms — was an **in-flow** element between the search box and the room list, so it **pushed the whole list down** every time it showed. It was also undiscoverable and unclear (what does "label them all" mean?). Gone.

Removed the whole `f` label-jump feature:
- The two in-flow hint lines (`⌥F to label them all`, `Press a hint label to jump`).
- The per-room 2-char **label overlay** on avatars.
- The keyboard-capture / hold-to-peek machinery in the sidebar.
- The `rooms.hints` (`f`) keybind and its 4 tests.

## Kept
- **⌥1–9 quick-jump** for the first nine rooms (unchanged).
- **next/prev** cycling (`]` / `[`, `J` / `K`).
- The pure `hintLabels` util + its unit tests stay — it's generic and could back a future hint system; nothing renders it now.

## Gates
`pnpm lint`, full `vitest` (143), and `pnpm build` all green.