### PR TITLE
feat(frontend): focus the chat with Enter as well as i

### DIFF
--- a/mycelium-frontend/src/lib/keymap.ts
+++ b/mycelium-frontend/src/lib/keymap.ts
@@ -92,7 +92,7 @@ export const KEYMAP: Binding[] = [
   { id: "rail.memory", keys: ["alt+m"], label: "Memory", group: "Inspector", scope: "room" },
   { id: "rail.toggle", keys: ["\\"], label: "Collapse / expand the rail", group: "Inspector", scope: "room" },
 
-  { id: "focus.chat", keys: ["i"], label: "Write a message", group: "Focus", scope: "room" },
+  { id: "focus.chat", keys: ["i", "Enter"], label: "Write a message", group: "Focus", scope: "room" },
   {
     id: "mode.command",
     keys: ["Escape"],


### PR DESCRIPTION
The chat-focus shortcut (`focus.chat`) now answers to **Enter** in addition to **i**.

`keys[0]` stays `"i"`, so the badge and cheatsheet still show **I** as the primary hint. Enter only fires in command mode — while an input holds focus it's treated as typing and passes through untouched (`keymap-provider.tsx` editable guard).

Keymap tests pass (25/25).