### PR TITLE
fix(backend): promote L9 knowledge/commit into the chat cold read

### DIFF
--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -346,6 +346,17 @@ def write_transcript(room: str, records: list[TranscriptRecord]) -> None:
         logger.exception("transcript write failed for room %s", room)
 
 
+# L9 record kinds promoted into the room chat view on a cold read, mirroring the
+# frontend's ``L9_RAISE_UP_TYPES`` (contracts/l9-surface.json): ``knowledge`` (a
+# memory push, e.g. a distilled extraction or the synced plan) and ``commit`` (an
+# aligner consensus). Chat itself (an ``exchange`` with a ``message``/``reply``
+# payload) is projected as a plain broadcast above; these ride as their
+# ``l9_<kind>`` frame instead — the exact shape the live SSE bus pushes
+# (:func:`l9_bus_frame`), so the frontend decodes a refresh identically to the
+# live stream instead of dropping the row (the "temporary" raise-up rows bug).
+_RAISE_UP_KINDS = frozenset({"knowledge", "commit"})
+
+
 def _conversational_text(content: dict[str, Any]) -> str | None:
     """The human-facing chat text of a record, or None if it isn't chat.
 
@@ -362,22 +373,33 @@ def _conversational_text(content: dict[str, Any]) -> str | None:
 def stored_message_from_record(room: str, record: TranscriptRecord) -> StoredMessage | None:
     """Project a transcript record into the ``StoredMessage`` the list/UI reads.
 
-    Returns None for a non-conversational record. The synthetic id is derived from
-    the envelope id so it's stable across reads, and ``message_id`` carries that
-    envelope id as the cross-store correlation key (dedup against ``local_state``).
+    Returns None for a non-conversational, non-raise-up record. The synthetic id is
+    derived from the envelope id so it's stable across reads, and ``message_id``
+    carries that envelope id as the cross-store correlation key (dedup against
+    ``local_state``).
     """
     from app.services.local_state import StoredMessage
 
     text = _conversational_text(record.content)
-    if text is None:
+    if text is not None:
+        # Chat: a plain broadcast row carrying the prose.
+        message_type: str = MessageType.BROADCAST
+        content = text
+    elif record.kind in _RAISE_UP_KINDS:
+        # A promoted L9 system frame (memory push / consensus): carry the whole
+        # envelope as the ``l9_<kind>`` frame the live stream uses, so the cold
+        # read reproduces the live view instead of dropping it on refresh.
+        message_type = f"l9_{record.kind}"
+        content = json.dumps(record.content)
+    else:
         return None
     episode = record.content.get("l9", {}).get("header", {}).get("message", {}).get("episode")
     seed = record.message_id or f"{record.recorded_at}:{record.sender}"
     msg = StoredMessage(
         room_name=room,
-        sender_handle=record.sender,
-        message_type=MessageType.BROADCAST,
-        content=text,
+        sender_handle=record.sender or l9.SYSTEM_ACTOR_ID,
+        message_type=message_type,
+        content=content,
         episode=episode if isinstance(episode, str) else None,
         message_id=record.message_id or None,
         id=uuid.uuid5(_MESSAGE_ID_NS, seed),

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -515,6 +515,60 @@ def test_conversational_projection_is_stable_and_dedups_against_the_list_store()
     assert disk[0].message_id == mem[0].message_id == "a-1"  # one correlation key, dedupable
 
 
+def test_raise_up_l9_frames_project_into_the_conversational_view():
+    """A ``knowledge`` push and a ``commit`` consensus are promoted into the chat
+    feed on the cold read, carrying the whole envelope as their ``l9_<kind>`` frame
+    — the exact shape the live SSE bus pushes. Without this the frontend promotes
+    them live but a refresh drops them (the "temporary" raise-up rows bug).
+    """
+    import json
+
+    from app.services.l9_slim import serialize_content
+
+    room = "raise-up-room"
+    get_room_dir(room)
+
+    know_env = l9.build_envelope(
+        kind=Kind.knowledge,
+        subkind="extraction",
+        episode="urn:ioc:mycelium:episode:raise-up-room:knowledge",
+        topic="urn:concept:mycelium:raise-up-room",
+        message_id="k-1",
+        payload_type="extraction",
+        payload_data={"key": "agents/x", "version": 1},
+    )
+    know_content = serialize_content(know_env, extra={"content": "memory updated → agents/x"})
+    persister.append_transcript(room, persister.record_from(know_env, know_content))
+
+    commit_env = l9.build_envelope(
+        kind=Kind.commit,
+        subkind="converged",
+        episode="urn:ioc:mycelium:episode:raise-up-room:neg",
+        topic="urn:concept:mycelium:raise-up-room",
+        message_id="c-1",
+        payload_type="data",
+        payload_data={"assignments": {"alice": "build"}},
+    )
+    commit_content = serialize_content(commit_env, extra={"content": "CONSENSUS"})
+    persister.append_transcript(room, persister.record_from(commit_env, commit_content))
+
+    # A control frame (presence) still stays out — only the raise-up kinds promote.
+    pres_env, pres_content = _msg_content(
+        "p-1", sender="alice", text="here", payload_type="presence"
+    )
+    persister.append_transcript(room, persister.record_from(pres_env, pres_content))
+
+    projected = persister.conversational_messages(room)
+    assert [(m.message_type, m.message_id) for m in projected] == [
+        ("l9_knowledge", "k-1"),
+        ("l9_commit", "c-1"),
+    ]
+    # The content is the full envelope JSON, so the frontend decodes a refresh
+    # identically to the live frame it pushes over SSE.
+    assert json.loads(projected[0].content)["l9"]["header"]["kind"] == "knowledge"
+    assert projected[0].episode == "urn:ioc:mycelium:episode:raise-up-room:knowledge"
+
+
 def test_addressed_absent_recipient_holds_the_triggering_message():
     """§E: a message @-addressed to an absent, untracked agent is held in its
     undelivered tail, so its first wake replays the mention that invited it —


### PR DESCRIPTION
## Problem

A subset of L9 frames are promoted into the room chat surface (the frontend's `L9_RAISE_UP_TYPES`): memory pushes (`l9_knowledge`) and aligner consensus (`l9_commit` → `coordination_consensus`). They render live over SSE, but **vanish on refresh** — surviving only in the `/l9` inspector.

### Root cause

The chat feed has two sources that disagreed:

- **Live (SSE):** `persister._publish_to_bus` pushes every transcript record as `l9_<kind>`; the frontend promotes `l9_knowledge`/`l9_commit`.
- **Cold read (`GET /messages` → `room_conversation` → `conversational_messages`):** `_conversational_text` kept only `message`/`reply` payloads, so `knowledge`/`commit` records were dropped. On refresh the chat rebuilds purely from this snapshot → the rows disappear.

The `/l9` endpoint (`l9_wire_history`) has no payload filter, which is why the frames survived there.

## Fix

Extend `stored_message_from_record` to also project the raise-up L9 kinds (`knowledge`, `commit`) as their `l9_<kind>` frame carrying the full envelope JSON — **byte-identical to `l9_bus_frame`**, the shape the live bus pushes. So `parseEvent` decodes a refresh exactly like the live frame; the cold read reproduces the live view.

- No frontend change: SSE carries no history, so the REST snapshot and live stream never overlap (no double rows).
- No double-render: `knowledge`/`commit` are transcript-only; the local_state-only kinds (`coordination_join`, `plan_updated`) are untouched.

## Test

Added `test_raise_up_l9_frames_project_into_the_conversational_view` — a `knowledge` + `commit` record promote (as `l9_knowledge`/`l9_commit` with full-envelope content and episode) while a control `presence` frame stays out.

## Verified against the running dev backend

Rebuilt the backend, pushed 3 fresh `memory set` calls to the `handshake` room; all three `l9_knowledge` rows now appear at the top of `GET /messages` (and the room's whole prior knowledge/commit backlog now shows inline) — where before they were absent from chat on refresh.

Gate: `ruff check` + `format` + `ty check` clean; 167 passed across message/persister/l9/stream/plan suites.