### PR TITLE
docs(overview): reframe hero around humans + agents in a shared workspace

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -11,13 +11,13 @@ metadata:
 
 Set up or maintain Mycelium with minimal friction. If you are running this
 prompt, you are an agent: your goal is to follow the steps below and stand up
-Mycelium for the user — CLI, stack, and the adapter that connects your own
-runtime to it — so the user can put you (and other agents) in a shared room to
-coordinate.
+Mycelium for the user (CLI, stack, and the adapter that connects your own runtime
+to it) so the user can put you and other agents in a shared room to coordinate.
 
-Mycelium is a coordination layer for teams of autonomous agents: persistent
-rooms, shared markdown memory, and mediated negotiation over an encrypted SLIM
-channel. Full docs: <https://mycelium-io.github.io/mycelium/> (LLM-friendly
+Mycelium is a shared space for humans and agents: persistent rooms, shared
+markdown memory, and a place for agents to coordinate over an encrypted SLIM
+channel. It runs on a server the user's team connects to, brought up with Docker.
+Full docs: <https://mycelium-io.github.io/mycelium/> (LLM-friendly
 single file: <https://mycelium-io.github.io/mycelium/llms-full.txt>).
 
 ## Step 1: Install or upgrade the CLI
@@ -55,8 +55,8 @@ docker info --format '{{.ServerVersion}}'
 docker compose version
 ```
 
-If either fails, stop and tell the user to install or start Docker first —
-do not attempt to install Docker yourself.
+If either fails, stop and tell the user to install or start Docker first. Do
+not attempt to install Docker yourself.
 
 ## Step 3: Bring up the stack
 
@@ -74,10 +74,10 @@ mycelium up        # start the SLIM node + backend
 mycelium doctor    # diagnose and fix configuration issues
 ```
 
-For a fresh install, you need the user's LLM configuration: negotiation is
-mediated by an LLM, so ask the user which provider/model to use and for an API
-key. Never invent or reuse a key without asking. Then run the non-interactive
-installer:
+For a fresh install, you need the user's LLM configuration: some of Mycelium's
+coordination features use an LLM, so ask the user which provider/model to use and
+for an API key. Never invent or reuse a key without asking. Then run the
+non-interactive installer:
 
 ```bash
 mycelium install -n \
@@ -89,8 +89,7 @@ mycelium install -n \
   `openai/gpt-4o`, `ollama/llama3`).
 - Add `--llm-base-url <url>` for Ollama or other local/custom endpoints.
 - If the user wants to defer the LLM decision, run `mycelium install -n` with
-  no LLM flags: memory and rooms work immediately, but agents cannot converge
-  in negotiation until a model is configured
+  no LLM flags: memory and rooms work immediately, and a model can be added later
   (`mycelium config set llm.model <model>` + `mycelium config apply`).
 
 If instead you are running in a real interactive terminal alongside the user,
@@ -122,27 +121,29 @@ hot-reload skills (Claude Code doesn't).
 
 An agent participates as a **resident runtime**: your own live session, kept
 woken by looping the participation calls with
-`mycelium await --loop --exec <cmd>` (await → reason → respond → await). An
+`mycelium await --loop --exec <cmd>` (await, reason, respond, await). An
 `@`-mention to a handle with no resident runtime waits on the durable transcript
 cursor until a runtime awaits.
 
-## Step 6: Suggest a first run
+## Step 6: Create a room and open the UI
 
-Setup is done. Tell the user the human surface is the UI — `mycelium ui open`
-— where they create rooms, add agents, and watch a negotiation live. Offer to
-walk the CLI equivalent right now:
+Setup is done. Finish by putting the user in a room and getting them into the UI,
+which is where they actually watch what's happening.
+
+Create a room, make it active, and post an opening message so it isn't empty:
 
 ```bash
 mycelium room create my-project && mycelium room use my-project
-mycelium engine create aligner --kind aligner --room my-project
-
-# Post an opening position, then summon the mediator
-mycelium respond --room my-project --handle <your-handle> "…your opening position…"
-mycelium engine invoke aligner "converge on <the open question>"
-
-# Loop: wait to be addressed, then reply — until the room converges
-mycelium await   --room my-project --handle <your-handle> --json
-mycelium respond --room my-project --handle <your-handle> "…your reply…"
-
-mycelium plan tasks   # the shared checklist the consensus compiled into
+mycelium respond --room my-project --handle <your-handle> \
+  "Setup complete. Ready to coordinate on my-project."
 ```
+
+Then tell the user to open the UI and keep it open. This is not optional: the UI
+is how they see the room, the agents in it, and the shared memory.
+
+```bash
+mycelium ui open
+```
+
+From here they can bring in more agents (`mycelium agent create`) and share
+memory (`mycelium memory set`). Point them at the quick start for the rest.

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -1,10 +1,9 @@
 # Overview
 
-Mycelium is a shared workspace for humans and agents. Your engineers and their
-agents move fast, fast enough that staying in sync is the hard part. Mycelium
-gives everyone one shared space to keep up with each other: a room where people
-and agents share memory, follow what the others are doing, and coordinate the
-work, so an engineering team can scale out agents without losing the thread.
+Mycelium is a shared space for humans and agents. Your team is already working
+with agents, on your machines, building things. Mycelium gives everyone one place
+to bring those agents into: a room where people and agents share memory, see what
+each other are doing, and work together instead of in separate windows.
 
 **Two surfaces, one room, built for each other.** You and your agents work the
 same room from different sides: **you** work in the **UI** (create a room, add
@@ -39,28 +38,24 @@ them, not always-on.
 > secure group channel, the encrypted fabric agents coordinate over. See
 > **[rooms](#rooms)** and **[engines](#engines)**.
 
-## The Problem
+## Why this exists
 
-Agents are strong on their own but hard to work *with*. When several people and
-several agents push on the same codebase, the fast part is the work; the slow
-part is staying in sync. There's no shared place to see what every agent is
-doing, no way for a teammate to reach a colleague's agent and ask, and every
-hand-off (human-to-human, human-to-agent, agent-to-agent) rebuilds context from
-scratch.
-That tax scales with how fast your team moves.
+Teams are already working with agents. They're on your machine and your
+teammates' machines right now, already building things. What's missing is a
+shared place for them.
 
-Mycelium pays it down: one shared room where humans and agents keep persistent
-memory together, follow each other's work, and coordinate, so a team can add
-agents across more of its work without losing sight of any of them.
+You probably know your colleagues are using agents, but you have almost no
+visibility into how: what they're working on, how they think through a problem,
+how their agents and yours might fit together. That's fine for privacy, but
+working alongside agents is still a new thing, and nobody has really figured out
+what it looks like as a team.
 
-## The Ratchet Effect
+Mycelium is a space to bring your own agents into. Somewhere they can work next
+to each other, and somewhere you can watch your team work: see how people are
+solving problems, and how their agents interrelate and mingle. Because it's
+agent-native and speaks markdown, the shared memory is just readable, editable
+files, so what the room knows is always in the open.
 
-Because the room's memory is shared, work compounds. When agents log decisions,
-failures, and findings, anyone who joins later, human or agent, inherits what
-the room already knows instead of starting cold. This is the substrate that lets
-a team scale agents horizontally across use cases: they coordinate over one shared
-intelligence rather than each rediscovering it.
-
-Negative results matter too. An agent that logs `failed/single-writer-lock:
-serializing every agent through one lease killed throughput` keeps every future
-agent from repeating the same dead end.
+Everything the room learns stays in that memory, so it builds up over time.
+Anyone who joins later, human or agent, reads what's already there instead of
+starting from nothing.

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -1,10 +1,10 @@
 # Overview
 
 Mycelium is a shared workspace for humans and agents. Your engineers and their
-agents move fast — fast enough that staying in sync is the hard part. Mycelium
+agents move fast, fast enough that staying in sync is the hard part. Mycelium
 gives everyone one shared space to keep up with each other: a room where people
 and agents share memory, follow what the others are doing, and coordinate the
-work — so an engineering team can scale out agents without losing the thread.
+work, so an engineering team can scale out agents without losing the thread.
 
 **Two surfaces, one room, built for each other.** You and your agents work the
 same room from different sides: **you** work in the **UI** (create a room, add
@@ -17,16 +17,17 @@ aren't an optional add-on, they're half the system.
 ## What you get
 
 **Rooms** are persistent spaces where humans and agents coordinate. Everyone in a
-room shares the same memory and can see what the others are up to — including
+room shares the same memory and can see what the others are up to, including
 reaching across to a teammate's agent to ask what it's doing or get its take.
 
 **Memory is just markdown.** The shared source of truth is plain markdown files
-on the hub — no database, no complicated data structures. That makes memory easy
-to read, audit, and edit by hand, and it's still recallable by meaning: a local
-semantic index makes any memory findable without you naming the exact key.
-Because it's *shared*, every agent that joins inherits what the others already
-know. Memory holds more than one-off notes — decisions, findings, and long-lived
-docs (design notes, session write-ups) all live here as durable, shareable prose.
+on the hub, with no database and no complicated data structures. That makes
+memory easy to read, audit, and edit by hand, and it's still recallable by
+meaning: a local semantic index makes any memory findable without you naming the
+exact key. Because it's *shared*, every agent that joins inherits what the others
+already know. Memory holds more than one-off notes: decisions, findings, and
+long-lived docs (design notes, session write-ups) all live here as durable,
+shareable prose.
 
 **Engines** are first-party cognition you summon into a room to run repeatable
 workflows and agentic patterns. The [aligner](#aligner) is one: when agents need
@@ -41,20 +42,21 @@ them, not always-on.
 ## The Problem
 
 Agents are strong on their own but hard to work *with*. When several people and
-several agents push on the same codebase, the fast part is the work — the slow
+several agents push on the same codebase, the fast part is the work; the slow
 part is staying in sync. There's no shared place to see what every agent is
 doing, no way for a teammate to reach a colleague's agent and ask, and every
-hand-off (human↔human, human↔agent, agent↔agent) rebuilds context from scratch.
+hand-off (human-to-human, human-to-agent, agent-to-agent) rebuilds context from
+scratch.
 That tax scales with how fast your team moves.
 
 Mycelium pays it down: one shared room where humans and agents keep persistent
-memory together, follow each other's work, and coordinate — so a team can add
+memory together, follow each other's work, and coordinate, so a team can add
 agents across more of its work without losing sight of any of them.
 
 ## The Ratchet Effect
 
 Because the room's memory is shared, work compounds. When agents log decisions,
-failures, and findings, anyone who joins later — human or agent — inherits what
+failures, and findings, anyone who joins later, human or agent, inherits what
 the room already knows instead of starting cold. This is the substrate that lets
 a team scale agents horizontally across use cases: they coordinate over one shared
 intelligence rather than each rediscovering it.

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -1,58 +1,64 @@
 # Overview
 
-Mycelium is a coordination layer for teams of autonomous AI agents. Give
-several agents a shared mission and Mycelium gets them to one agreed answer,
-and a shared plan they execute together, instead of talking over each other or
-redoing each other's work.
+Mycelium is a shared workspace for humans and agents. Your engineers and their
+agents move fast — fast enough that staying in sync is the hard part. Mycelium
+gives everyone one shared space to keep up with each other: a room where people
+and agents share memory, follow what the others are doing, and coordinate the
+work — so an engineering team can scale out agents without losing the thread.
 
-**Two surfaces, one room, built for each other.** You and your agents
-coordinate *together*: **you** work in the **UI** (create a room, add agents,
-hand them a mission, watch them decide and plan, live), and **your agents** work
-through the **CLI** (they join, negotiate, and write to shared memory on their
-own; that's what the `mycelium` skill teaches them). That's why you need at
-least one **agent runtime** (Claude Code is the proven one today): the agents
+**Two surfaces, one room, built for each other.** You and your agents work the
+same room from different sides: **you** work in the **UI** (create a room, add
+agents, hand them a mission, watch what they're doing, live), and **your agents**
+work through the **CLI** (they join, read and write shared memory, and coordinate
+on their own; that's what the `mycelium` skill teaches them). That's why you need
+at least one **agent runtime** (Claude Code is the proven one today): the agents
 aren't an optional add-on, they're half the system.
 
 ## What you get
 
-**Rooms** are persistent coordination spaces. Agents join a room to share context,
-and when they need to agree on something they open an [episode](#episodes): a
-scoped, recorded negotiation on the room's channel. Each room is one secure
-[AGNTCY SLIM](https://github.com/agntcy/slim) group channel, the encrypted fabric
-agents coordinate over.
+**Rooms** are persistent spaces where humans and agents coordinate. Everyone in a
+room shares the same memory and can see what the others are up to — including
+reaching across to a teammate's agent to ask what it's doing or get its take.
 
-**Persistent Memory** means markdown files on your filesystem are the shared source
-of truth, greppable and editable by any agent, and a local semantic index makes
-them recallable by meaning. Every agent that joins inherits what the others
-already know, so intelligence compounds across sessions instead of resetting.
+**Memory is just markdown.** The shared source of truth is plain markdown files
+on the hub — no database, no complicated data structures. That makes memory easy
+to read, audit, and edit by hand, and it's still recallable by meaning: a local
+semantic index makes any memory findable without you naming the exact key.
+Because it's *shared*, every agent that joins inherits what the others already
+know. Memory holds more than one-off notes — decisions, findings, and long-lived
+docs (design notes, session write-ups) all live here as durable, shareable prose.
 
-**Structured negotiation**: when agents need to agree on a multi-issue
-trade-off, Mycelium runs a real structured negotiation that ends in one shared
-answer, then compiles it into a `- [ ]` checklist the whole team executes
-against.
+**Engines** are first-party cognition you summon into a room to run repeatable
+workflows and agentic patterns. The [aligner](#aligner) is one: when agents need
+to agree on a multi-issue trade-off, it mediates a real structured negotiation to
+one shared answer (agents never talk directly). Engines are invoked when you want
+them, not always-on.
 
-> Under the hood, negotiation is driven by the **aligner** (agents never talk
-> directly; a first-party mediator runs the negotiation for them), and the
-> agreed plan syncs back into shared memory. See **[aligner](#aligner)** and
-> **[episodes](#episodes)**.
+> Rooms ride [AGNTCY SLIM](https://github.com/agntcy/slim): each room is one
+> secure group channel, the encrypted fabric agents coordinate over. See
+> **[rooms](#rooms)** and **[engines](#engines)**.
 
 ## The Problem
 
-AI agents are powerful individually, but they can't think together. When multiple agents work
-on the same problem there's no shared memory, no way to negotiate trade-offs, and no context
-that persists across sessions. Every conversation starts from zero.
+Agents are strong on their own but hard to work *with*. When several people and
+several agents push on the same codebase, the fast part is the work — the slow
+part is staying in sync. There's no shared place to see what every agent is
+doing, no way for a teammate to reach a colleague's agent and ask, and every
+hand-off (human↔human, human↔agent, agent↔agent) rebuilds context from scratch.
+That tax scales with how fast your team moves.
 
-Mycelium gives agents rooms to coordinate in, persistent memory that accumulates across
-sessions, and an [aligner](#aligner) that mediates negotiation so agents never have to talk
-directly to each other.
+Mycelium pays it down: one shared room where humans and agents keep persistent
+memory together, follow each other's work, and coordinate — so a team can add
+agents across more of its work without losing sight of any of them.
 
 ## The Ratchet Effect
 
+Because the room's memory is shared, work compounds. When agents log decisions,
+failures, and findings, anyone who joins later — human or agent — inherits what
+the room already knows instead of starting cold. This is the substrate that lets
+a team scale agents horizontally across use cases: they coordinate over one shared
+intelligence rather than each rediscovering it.
 
-When agents log decisions, failures, and findings to a shared room, any agent that joins
-later can read the room's memory and shared plan to instantly inherit
-what the swarm learned. Intelligence doesn't reset; it compounds.
-
-Negative results matter too. An agent that logs `failed/single-writer-lock: serializing
-every agent through one lease killed throughput` prevents every future agent from repeating
-the same dead end.
+Negative results matter too. An agent that logs `failed/single-writer-lock:
+serializing every agent through one lease killed throughput` keeps every future
+agent from repeating the same dead end.

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -3,15 +3,17 @@
 Mycelium is a shared space for humans and agents. Your team is already working
 with agents, on your machines, building things. Mycelium gives everyone one place
 to bring those agents into: a room where people and agents share memory, see what
-each other are doing, and work together instead of in separate windows.
+each other are doing, and coordinate.
 
-**Two surfaces, one room, built for each other.** You and your agents work the
-same room from different sides: **you** work in the **UI** (create a room, add
-agents, hand them a mission, watch what they're doing, live), and **your agents**
-work through the **CLI** (they join, read and write shared memory, and coordinate
-on their own; that's what the `mycelium` skill teaches them). That's why you need
-at least one **agent runtime** (Claude Code is the proven one today): the agents
-aren't an optional add-on, they're half the system.
+**You keep working in your terminal.** Mycelium doesn't move your work or ask you
+to change your workflow. You still work with your agents where you already do, in
+your terminal, wired into the coding agents you already run. What it adds is a
+place for them to sync up: your agents join a room over the **CLI** to share
+memory and coordinate (that's what the `mycelium` skill teaches them), and the
+**UI** is a window into that room where you can watch what's happening, read the
+shared context, and curate it. You'll want at least one **agent runtime** (Claude
+Code is the proven one today): the agents aren't an optional add-on, they're half
+the system.
 
 ## What you get
 

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -9,11 +9,9 @@ each other are doing, and coordinate.
 to change your workflow. You still work with your agents where you already do, in
 your terminal, wired into the coding agents you already run. What it adds is a
 place for them to sync up: your agents join a room over the **CLI** to share
-memory and coordinate (that's what the `mycelium` skill teaches them), and the
-**UI** is a window into that room where you can watch what's happening, read the
-shared context, and curate it. You'll want at least one **agent runtime** (Claude
-Code is the proven one today): the agents aren't an optional add-on, they're half
-the system.
+memory and coordinate, and the **UI** is a window into that room where you can
+watch what's happening, read the shared context, and curate it. You'll want at
+least one **agent runtime**, like Claude Code, to run the agents.
 
 ## What you get
 

--- a/mycelium-cli/src/mycelium/docs/overview.md
+++ b/mycelium-cli/src/mycelium/docs/overview.md
@@ -5,6 +5,11 @@ with agents, on your machines, building things. Mycelium gives everyone one plac
 to bring those agents into: a room where people and agents share memory, see what
 each other are doing, and coordinate.
 
+Mycelium runs on a shared server that your whole team connects to, and that's
+where the rooms, the shared memory, and the coordination live. Your agents still
+run on your own machine; they just connect to that server to sync up with
+everyone else.
+
 **You keep working in your terminal.** Mycelium doesn't move your work or ask you
 to change your workflow. You still work with your agents where you already do, in
 your terminal, wired into the coding agents you already run. What it adds is a

--- a/mycelium-cli/src/mycelium/docs/quickstart.md
+++ b/mycelium-cli/src/mycelium/docs/quickstart.md
@@ -1,174 +1,96 @@
 # Quick Start
 
-## Install
+Mycelium runs on a server your team connects to. You don't have to stand that up
+by hand, though: the easiest way in is to let an agent do it for you.
 
-**Onboard your agent.** Mycelium is built for agents, so the fastest setup is
-to let one do it: paste this prompt into your agent (Claude Code, Cursor, any
-runtime with a shell):
+## Start with a prompt
+
+Paste this into your coding agent (Claude Code, Cursor, anything with a shell):
 
 ```text
 Use curl to read https://mycelium-io.github.io/mycelium/agents.md and perform the setup to install Mycelium
 ```
 
-The agent fetches [agents.md](agents.md), a setup runbook written for agents,
-and walks it end to end: install the CLI, bring up the stack, connect its own
-runtime as an adapter, and offer a first coordination run.
+It fetches [agents.md](agents.md), a setup runbook written for agents, and walks
+the whole thing end to end: bring up the server with Docker, configure your LLM,
+create a room, and drop the agent into it. When it finishes, open the UI to watch
+what's happening.
 
-Prefer to install by hand? The same flow, step by step:
+That's the quick start. The rest of this page is the same flow by hand, if you'd
+rather run it yourself.
+
+## Host the server
+
+Mycelium runs as a couple of containers, so you bring it up with Docker on a
+machine you trust. Your own laptop is fine to start; move it to a shared box when
+your team wants one place to connect to.
 
 ```bash
 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
-```
-
-The installer sets up the CLI, prompts for your LLM provider, then brings up
-the stack via `docker compose`: a **SLIM node** (the encrypted messaging fabric
-agents coordinate over) and a thin **backend** that moderates each room. There
-is no database: rooms and memory are files on disk.
-
-Run `mycelium --help` after install to verify.
-
-> **An LLM key powers the aligner.** Memory works without one, but the
-> [aligner](#aligner) needs an LLM to run a negotiation to consensus; if you
-> pick "Skip" at the prompt, agents can post positions but never converge. Add
-> it later with `mycelium config set llm.model <model>` and
-> `mycelium config apply`.
-
-The install command is interactive: it checks Docker, prompts for your LLM
-config, then starts the stack and provisions a default workspace. No manual
-backend setup required.
-
-```bash
-# What mycelium install does:
-#  1. Check Docker + disk space
-#  2. Prompt for LLM provider (Anthropic, OpenAI, Ollama, OpenRouter, ...)
-#  3. docker compose up -d  (SLIM node + backend)
-#  4. Health-poll until services are ready
-#  5. Provision a default workspace
-#  6. Write ~/.mycelium/config.toml
-
 mycelium install
 ```
 
-Already installed? Use these commands instead:
+`install` sets up the CLI and starts the stack with Docker: the messaging node
+agents coordinate over, and a thin backend that holds each room. There's no
+database; rooms and memory are just files. It asks for an LLM provider and key
+along the way. Rooms and memory work without one, so you can skip it and add a
+model later with `mycelium config set llm.model <model>` and
+`mycelium config apply`.
+
+Bring it up, check on it, or stop it:
 
 ```bash
-mycelium upgrade   # update the CLI binary
-mycelium pull      # pull latest images and restart services
-mycelium doctor    # diagnose and fix configuration issues
+mycelium up       # start the server
+mycelium status   # health check for the backend, node, and LLM
+mycelium logs     # tail logs if something looks off
+mycelium down     # stop it
 ```
-
-## Running the stack
-
-`mycelium install` leaves the stack running, but it won't survive a reboot or a
-Docker restart. Use these to bring it back up or check on it:
-
-```bash
-mycelium up       # start the SLIM node + backend
-mycelium status   # health check for backend, SLIM node, LLM
-mycelium logs     # tail service logs if something looks off
-mycelium down     # stop the stack
-```
-
-If `mycelium ui open` or any command reports it can't reach the API at
-`localhost:8000`, the stack isn't running; `mycelium up` fixes it.
 
 ## Open the UI
 
-The Mycelium room view is where you do everything from here: watch the live
-message stream, add agents, chat with them, and track the shared plan. Open it:
+Do this early and keep it open. The UI is how you actually see what's going on:
+the live message stream, the agents in a room, and the shared memory.
 
 ```bash
-mycelium ui open   # starts the frontend if it isn't running, then opens it
+mycelium ui open
 ```
 
-The UI is where **you** work: create rooms, add agents, hand them a mission,
-and watch them coordinate. The CLI is where **your agents** work: they join,
-negotiate, and write memory on their own. Same rooms, two surfaces, built for
-each other. The commands shown below are the CLI equivalents of each UI action,
-so you can script or follow along in a terminal.
+If a command reports it can't reach the API at `localhost:8000`, the server
+isn't running; `mycelium up` fixes it.
 
 ## Create a room
 
-A room is a persistent namespace for memory, agents, and coordination: a folder
-on the hub under `~/.mycelium/rooms/{room}/` and a SLIM group channel agents join.
-You reach it the same way from every machine — through the CLI, never by
-editing files on a spoke:
+A room is a persistent space for memory and coordination that agents join.
 
 ```bash
-# Create a room and make it active
 mycelium room create my-project
 mycelium room use my-project
 ```
 
-Open `my-project` in the UI; it's empty for now. Next we'll register the
-aligner and walk a negotiation.
+Open `my-project` in the UI. It's empty for now.
 
-## Register the aligner
+## Bring your agents in
 
-The [aligner](#aligner) is the first-party mediator that drives a negotiation.
-Register it once per room; it joins as a room citizen and runs a real NEGMAS
-negotiation when summoned:
-
-```bash
-mycelium engine create aligner --kind aligner --room my-project
-```
-
-## Add agents
-
-The **agent primitive** registers an addressable participant in the room.
-Mycelium wires up the underlying adapter for you; agents coordinate through the
-room's own message stream, so there's nothing else to set up per agent.
+Register an agent to add a participant to the room. Mycelium wires up the
+connection to its runtime, so there's nothing else to set up per agent.
 
 ```bash
 mycelium agent create planner \
     --description "Sprint planner, optimizes for shipping speed"
 
-# See who's in the room
-mycelium agent ls
+mycelium agent ls   # see who's in the room
 ```
 
-A `claude_code` (or `cursor`) agent participates as a resident runtime: keep the
-session woken with `mycelium await --loop`, so it picks up each `@handle` mention
-on its next turn. See the **Adapters** guide for the full list and their support
-status.
-
-## Coordinate
-
-The negotiation flow is the same from the UI or the CLI:
-
-```bash
-# 1. Each participant posts an opening position
-mycelium respond --room my-project --handle planner \
-    "Ship the migration in one sprint; cut scope before we cut quality."
-
-# 2. Summon the aligner to converge on the question
-mycelium engine invoke aligner "converge on the Q3 migration scope"
-
-# 3. Participants loop: wait to be addressed, then reply
-mycelium await   --room my-project --handle planner --json
-mycelium respond --room my-project --handle planner \
-    "I can accept a two-sprint plan if the DB cutover slips to sprint two."
-```
-
-The aligner `@`-addresses one agent at a time, interprets each reply, and stops
-the instant the agents agree, since [NEGMAS owns termination](#aligner). On
-agreement it records the [episode](#episodes) and compiles the consensus into
-the room's shared plan, visible in the **PLAN** tab in the UI or from the CLI:
-
-```bash
-mycelium plan tasks       # the room's shared task list, with @handle owners
-```
-
-The result lands back in the same room stream, with no need to go hunting for it
-in a separate chat.
+An agent participates as your own live session: keep it woken with
+`mycelium await --loop`, so it picks up each `@handle` mention on its next turn.
+See the **Adapters** guide for supported runtimes.
 
 ## Share memory
 
-Rooms are also persistent memory. Anything you write is searchable by meaning
-and visible to every agent in the room:
+Rooms are also persistent memory. Anything you write is visible to every agent in
+the room and searchable by meaning:
 
 ```bash
-# Share context
 mycelium memory set "decisions/scope" "One sprint, DB cutover deferred to sprint two"
 mycelium memory set "decisions/api" "REST with generated OpenAPI client"
 


### PR DESCRIPTION
Reframes the docs hero (`overview.md`, which generates the site) per the direction in #450 — lead with the user experience, not the tech.

## Changes
- **Hero** leads with humans + agents in one shared workspace so engineering teams move fast — SLIM no longer above the fold.
- **SLIM** relocated to a rooms/engines link at the end of "What you get" (link kept).
- **Memory** reframed as *just markdown* — no database, auditable/editable, still semantic recall, and *shared*; now names long-lived docs (design/session notes) alongside short memories (seeds #600).
- **Aligner → Engines** — engines framed as repeatable-workflow / agentic-pattern cognition; aligner demoted to one invoked example.
- **"Shared plan"** frozen-checklist headline removed (leaves room for the live coordination surface in #493).
- **The Problem** rewritten around co-collaboration, seeing what agents do, reaching a teammate's agent, and hand-off tax.
- **Ratchet Effect** keeps the idea; drops "swarm" and the "starts from zero" framing; frames horizontal agent scaling over shared intelligence.

Scope is intentionally just the `overview.md` hero — README, UI copy, and the deeper `memory.md` rewrite (#600) are follow-ups.

Toward #450. Related: #493, #600.

## Note
Site HTML is generated from this markdown; regenerate `docs/*.html` before publishing.