### PR TITLE
fix(frontend): stop tying auth cookie Secure flag to NODE_ENV

### DIFF
--- a/mycelium-cli/src/mycelium/docker/compose.yml
+++ b/mycelium-cli/src/mycelium/docker/compose.yml
@@ -190,6 +190,11 @@ services:
       MYCELIUM_OIDC_CLIENT_ID: ${MYCELIUM_OIDC_CLIENT_ID:-mycelium-web}
       MYCELIUM_OIDC_AUDIENCE: ${MYCELIUM_OIDC_AUDIENCE:-}
       AUTH_SESSION_SECRET: ${AUTH_SESSION_SECRET:-}
+      # Auth cookies default to Secure. Set to "false" for a plain-HTTP appliance
+      # deployment with no TLS termination in front (e.g. a bare public IP) —
+      # otherwise the browser silently drops them and login fails with "missing
+      # code or state". Leave unset/true whenever TLS actually terminates.
+      MYCELIUM_COOKIE_SECURE: ${MYCELIUM_COOKIE_SECURE:-}
     depends_on:
       mycelium-backend:
         condition: service_healthy

--- a/mycelium-frontend/src/app/api/auth/login/route.ts
+++ b/mycelium-frontend/src/app/api/auth/login/route.ts
@@ -37,7 +37,7 @@ export async function GET(req: Request): Promise<Response> {
   jar.set(TX_COOKIE, tx, {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: process.env.MYCELIUM_COOKIE_SECURE !== "false",
     path: "/",
     maxAge: 600,
   });

--- a/mycelium-frontend/src/lib/session.ts
+++ b/mycelium-frontend/src/lib/session.ts
@@ -30,7 +30,12 @@ function key(secret: string): Uint8Array {
   return new Uint8Array(createHash("sha256").update(secret).digest());
 }
 
-const secure = process.env.NODE_ENV === "production";
+// Secure by default; self-hosted deployments with no TLS in front (the
+// appliance path — see docs/guides/keycloak-oidc.md) opt out explicitly. Tying
+// this to NODE_ENV instead would break every non-TLS deployment, since the
+// built Docker image always runs with NODE_ENV=production regardless of
+// whether the operator terminates TLS.
+const secure = process.env.MYCELIUM_COOKIE_SECURE !== "false";
 const cookieOpts = { httpOnly: true, sameSite: "lax" as const, secure, path: "/" };
 
 export async function seal(payload: Record<string, unknown>, secret: string, ttlSec: number): Promise<string> {


### PR DESCRIPTION
## Summary
- The OIDC transaction/session cookies hardcoded `secure: process.env.NODE_ENV === "production"`, but the built Docker image always sets `NODE_ENV=production` regardless of whether the deployment actually terminates TLS.
- Any appliance-style deployment served over plain HTTP (bare public IP, no reverse proxy — a real, documented deployment shape) had the browser silently drop the Secure cookie, failing login with "missing code or state".
- Adds `MYCELIUM_COOKIE_SECURE` (default unset = secure) so operators without TLS in front can opt out explicitly.

Found while standing up Keycloak+SPIRE on a plain-HTTP test box (oclw1).

## Test plan
- [ ] Deploy behind TLS (secure unset/true) — cookies still Secure, login works
- [ ] Deploy on plain HTTP with `MYCELIUM_COOKIE_SECURE=false` — login completes end to end
- [ ] Deploy on plain HTTP with the var unset — cookie silently dropped (confirms it's opt-in, not a default weakening)