### PR TITLE
fix(cli): default agent create --owner to the --as handle (#650)

### DIFF
--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -213,6 +213,20 @@ def load_owned_agents(*, owner: str) -> list[tuple[str, AgentManifest]]:
     return owned
 
 
+def _default_owner(owner: str | None, handle_flag: str) -> str | None:
+    """Owner to persist: explicit --owner wins, else the caller's own --as handle.
+
+    The creator owns what they create unless told otherwise, so the handle that
+    just ran ``agent create`` can immediately act on the agent it made (#650).
+    The ``cli-user`` sentinel names no real principal, so it stamps no ownership.
+    """
+    if owner is not None:
+        return owner
+    if handle_flag and handle_flag != "cli-user":
+        return handle_flag
+    return None
+
+
 def _warn_unknown_principal(manifest: AgentManifest) -> None:
     """Warn (never fail) when an agent's owner has no user record.
 
@@ -621,6 +635,7 @@ def _create_wizard(
     description = questionary.text("Description (what does this agent do?):").ask() or ""
 
     owner = (questionary.text("Owner (a users/<handle>, optional):").ask() or "").strip() or None
+    owner = _default_owner(owner, handle_flag)  # creator owns what they create (#650)
     team = (questionary.text("Team slug (optional):").ask() or "").strip() or None
 
     room_name = room_opt or _pick_room(config)
@@ -702,7 +717,13 @@ def agent_create(
         None, "--team", help="Team slug this agent is fielded by. Self-asserted."
     ),
     handle_flag: str = typer.Option(
-        "cli-user", "--as", "-H", help="Your own handle (recorded as created_by)."
+        "cli-user",
+        "--as",
+        "-H",
+        help=(
+            "Your own handle (recorded as created_by, and made --owner by default "
+            "so you can act on the agent you just created; pass --owner to override)."
+        ),
     ),
 ) -> None:
     """Create a new, Mycelium-controlled agent in a room.
@@ -749,6 +770,8 @@ def agent_create(
             allow_list = [a.strip() for a in allow_from.split(",") if a.strip()]
 
         room_name = _resolve_room(config, room)
+
+        owner = _default_owner(owner, handle_flag)
 
         impl = get_adapter(adapter, cwd=cwd)
 

--- a/mycelium-cli/tests/test_agent_owner_default.py
+++ b/mycelium-cli/tests/test_agent_owner_default.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""`agent create` defaults --owner to the caller's --as handle (#650)."""
+
+from __future__ import annotations
+
+from mycelium.commands.agent import _default_owner
+
+
+def test_explicit_owner_wins_over_as() -> None:
+    assert _default_owner("bob", "julia") == "bob"
+
+
+def test_owner_defaults_to_as_handle() -> None:
+    assert _default_owner(None, "julia") == "julia"
+
+
+def test_cli_user_sentinel_stamps_no_owner() -> None:
+    # The default --as sentinel names no real principal, so nothing is owned.
+    assert _default_owner(None, "cli-user") is None
+
+
+def test_explicit_owner_wins_even_over_sentinel_as() -> None:
+    assert _default_owner("bob", "cli-user") == "bob"


### PR DESCRIPTION
## What

`mycelium agent create <handle> --as julia` created an agent whose `created_by` was `julia` but which `julia` had **no access to** — the next `mycelium await --handle <handle>` failed with:

> handle '…' is not the authenticated principal '@julia' and has granted it no access; add 'julia' to that handle's owner or allow_from to act on its behalf.

You had to *also* pass `--owner julia` to drive the agent you just created. `--as` reads like "I am creating this, as me", but it was purely an audit-trail field.

## Fix

Per the issue's recommended option: **default `--owner` to `--as` when `--owner` is omitted** — the creator owns what they create. Explicit `--owner` still wins (so you can create an agent owned by someone else), and the `cli-user` sentinel default names no real principal so it stamps no ownership (no spurious "owner has no user record" warning in the no-auth path).

- `_default_owner(owner, handle_flag)` — pure helper, shared by the flag path and the interactive wizard.
- `--as` help text now says it becomes `--owner` by default.
- Unit test covering all four cases.

Closes #650.

## Test
`uv run pytest tests/test_agent_owner_default.py -q` → 4 passed; ruff + ty clean.