### PR TITLE
fix(backend): route await through the durable per-handle delivery cursor (#649)

### DIFF
--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import asyncio
 import re
-from dataclasses import dataclass
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -40,20 +39,13 @@ from app.services.l9_slim import serialize_content
 router = APIRouter(prefix="/rooms/{room_name}", tags=["participate"])
 
 
-@dataclass
-class _AwaitState:
-    """Per-(room, handle) long-poll cursor over the durable transcript.
-
-    ``cursor`` is how far the handle has consumed; ``last_tick`` is the content of
-    the last tick it was served, so a following reply parents onto it.
-    """
-
-    cursor: int
-    last_tick: dict[str, Any] | None = None
-
-
-# Process-local — a fresh backend starts every handle at the current transcript end.
-_await_state: dict[tuple[str, str], _AwaitState] = {}
+# The delivery cursor itself lives on the durable inbox (``persister.log``), so it
+# survives a restart and starts a brand-new handle at its ``agent create`` /
+# first-mention anchor rather than "now". Only the last served tick is kept
+# process-local here: it's a best-effort convenience so a following ``reply``
+# parents onto the tick that woke the caller, and losing it on restart just drops
+# that one parent edge — never a message.
+_last_tick: dict[tuple[str, str], dict[str, Any]] = {}
 
 _POLL_INTERVAL_S = 0.4
 _MAX_WAIT_S = 3600.0
@@ -157,27 +149,27 @@ async def await_message(room_name: str, request: Request, handle: str, timeout: 
         return {"room": room_name, "handle": handle, "message": None}
     persister = managed.persister
     key = (room_name, handle)
-    state = _await_state.get(key)
-    if state is None:
-        # First await for this handle: start at the current end so it only sees
-        # turns addressed to it from when it began participating.
-        state = _AwaitState(cursor=len(persister.log.records))
-        _await_state[key] = state
-
+    # The cursor rides the durable inbox: its first read is the handle's persisted
+    # delivery position — anchored at the mention that summoned it (``record()``
+    # holds an @-addressed turn for an untracked recipient) and preserved across a
+    # backend restart. So a message sitting in the transcript before this handle's
+    # first ``await`` is delivered, not skipped.
     loop = asyncio.get_event_loop()
     deadline = loop.time() + (timeout if timeout > 0 else _MAX_WAIT_S)
     while True:
         records = persister.log.records
-        i = state.cursor
+        i = persister.log.position(handle)
         while i < len(records):
             record = records[i]
             i += 1
             if _addressed_to(record.content, handle):
-                state.cursor = i
-                state.last_tick = record.content
+                persister.advance_cursor(handle, i)
+                _last_tick[key] = record.content
                 room_channels.manager.refresh_lease(room_name, handle)
                 return _describe(room_name, handle, record)
-        state.cursor = len(records)
+        # Nothing addressed in the scanned range: consume it (advance past the
+        # observer/broadcast turns this handle doesn't await) and keep polling.
+        persister.advance_cursor(handle, len(records))
         if loop.time() >= deadline:
             return {"room": room_name, "handle": handle, "message": None}
         room_channels.manager.refresh_lease(room_name, handle)
@@ -210,8 +202,7 @@ async def post_reply(room_name: str, body: ReplyBody, request: Request):
         raise HTTPException(status_code=503, detail="No live channel for room")
 
     payload_data, clean = _parse_marker(body.text)
-    st = _await_state.get((room_name, handle))
-    woke = (st.last_tick if st else None) or {}
+    woke = _last_tick.get((room_name, handle)) or {}
     woke_header = (woke.get("l9") or {}).get("header") or {}
     woke_msg = woke_header.get("message") or {}
     woke_actors = (woke_header.get("participants") or {}).get("actors") or []

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -265,6 +265,29 @@ class DeliveryLog:
         pos = self._cursors.get(handle, len(self._records))
         return self._records[pos:]
 
+    def position(self, handle: str) -> int:
+        """``handle``'s delivery cursor — the transcript end if never tracked.
+
+        The same cursor the durable inbox re-serves from, so server-held
+        ``await`` (a pull) and reconnect re-serve (a push) share one persisted
+        delivery position instead of the process-local one ``await`` used to keep.
+        """
+        return self._cursors.get(handle, len(self._records))
+
+    def advance(self, handle: str, pos: int) -> None:
+        """Move ``handle``'s cursor forward to ``pos`` (clamped, never backward).
+
+        Registers the handle if new, so a first ``await`` that consumes to the
+        transcript end is remembered across a restart instead of re-initializing
+        to "now" each process. Never rewinds: a lower ``pos`` is ignored, so a
+        drain can't un-deliver a tail an earlier live send already advanced past.
+        """
+        end = len(self._records)
+        clamped = max(0, min(int(pos), end))
+        current = self._cursors.get(handle)
+        if current is None or clamped > current:
+            self._cursors[handle] = clamped
+
     def mark_caught_up(self, handle: str) -> None:
         """Advance ``handle`` to the transcript end (after a re-serve)."""
         self._cursors[handle] = len(self._records)
@@ -674,6 +697,17 @@ class RoomPersister:
     def _persist_cursors(self) -> None:
         """Snapshot the delivery cursors to disk (best-effort, per mutation)."""
         write_cursors(self.room, self.log.cursors)
+
+    def advance_cursor(self, handle: str, pos: int) -> None:
+        """Advance ``handle``'s durable delivery cursor to ``pos`` and persist it.
+
+        The consume side of the durable inbox for a server-held ``await`` caller:
+        as ``await`` drains the transcript it commits the new position here so it
+        survives a backend restart, rather than the process-local cursor that
+        silently reset every handle to "now" on restart.
+        """
+        self.log.advance(handle, pos)
+        self._persist_cursors()
 
     # -- membership signals (driven by RoomChannelManager) --
 

--- a/fastapi-backend/tests/test_participate_await.py
+++ b/fastapi-backend/tests/test_participate_await.py
@@ -12,11 +12,16 @@ cursor is the durable inbox's, not a process-local one.
 from __future__ import annotations
 
 import pytest
+from starlette.requests import Request
 
 from app.routes import participate
 from app.services import l9, persister
 from app.services.l9_models import Kind
 from app.services.l9_slim import serialize_content
+
+# A bare ASGI request — ``authorize_handle`` is stubbed out, so the route never
+# reads it; it exists only to satisfy the ``Request`` parameter type.
+_REQUEST = Request({"type": "http", "method": "GET", "path": "/await", "headers": []})
 
 
 def _addressed_record(message_id: str, *, to: str, sender: str = "avery"):
@@ -87,7 +92,7 @@ async def test_first_await_replays_a_mention_sent_before_it(wired):
     )
 
     wired(log)
-    result = await participate.await_message("r", object(), handle="claude-code-agent", timeout=0)
+    result = await participate.await_message("r", _REQUEST, handle="claude-code-agent", timeout=0)
     assert result["message_id"] == "m1"
     assert result["prompt"] == "@claude-code-agent hello"
 
@@ -103,10 +108,10 @@ async def test_await_consumes_the_message_it_serves(wired):
     )
 
     wired(log)
-    first = await participate.await_message("r", object(), handle="claude-code-agent", timeout=0)
+    first = await participate.await_message("r", _REQUEST, handle="claude-code-agent", timeout=0)
     assert first["message_id"] == "m1"
 
-    second = await participate.await_message("r", object(), handle="claude-code-agent", timeout=1)
+    second = await participate.await_message("r", _REQUEST, handle="claude-code-agent", timeout=1)
     assert second["message"] is None  # consumed, nothing left
 
 
@@ -122,5 +127,5 @@ async def test_await_ignores_turns_addressed_to_others(wired):
     )
 
     wired(log)
-    result = await participate.await_message("r", object(), handle="claude-code-agent", timeout=1)
+    result = await participate.await_message("r", _REQUEST, handle="claude-code-agent", timeout=1)
     assert result["message"] is None

--- a/fastapi-backend/tests/test_participate_await.py
+++ b/fastapi-backend/tests/test_participate_await.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""``await`` delivers off the durable per-handle cursor (#649).
+
+Node-free: the SLIM channel is faked so the test exercises only the delivery
+logic — that a first ``await`` replays a message already sitting in the
+transcript addressed to the handle (the reported bug), consumes it, and that the
+cursor is the durable inbox's, not a process-local one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.routes import participate
+from app.services import l9, persister
+from app.services.l9_models import Kind
+from app.services.l9_slim import serialize_content
+
+
+def _addressed_record(message_id: str, *, to: str, sender: str = "avery"):
+    """A human exchange @-addressed to ``to`` (an L9 recipient, as the send path
+    builds it), recorded as a transcript record."""
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=l9.episode_urn("r", "live"),
+        sender=sender,
+        sender_role="human",
+        recipients=[to],
+        topic=l9.topic_urn("r"),
+        message_id=message_id,
+        payload_type="message",
+    )
+    content = serialize_content(env, extra={"content": f"@{to} hello"})
+    return persister.record_from(env, content)
+
+
+class _FakePersister:
+    """Just enough of RoomPersister for the await loop: a durable log + the
+    consume-side cursor advance (no disk write needed in the unit test)."""
+
+    def __init__(self, log: persister.DeliveryLog) -> None:
+        self.log = log
+
+    def advance_cursor(self, handle: str, pos: int) -> None:
+        self.log.advance(handle, pos)
+
+
+class _Managed:
+    def __init__(self, persister_: _FakePersister) -> None:
+        self.persister = persister_
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Wire the await route to a fake room whose transcript we control."""
+
+    def _wire(log: persister.DeliveryLog) -> None:
+        managed = _Managed(_FakePersister(log))
+
+        async def _provision(_room):
+            return managed
+
+        monkeypatch.setattr(participate, "room_exists", lambda _r: True)
+        monkeypatch.setattr(participate.actor, "authorize_handle", lambda *a, **k: None)
+        monkeypatch.setattr(participate.room_channels.manager, "provision", _provision)
+        monkeypatch.setattr(
+            participate.room_channels.manager, "refresh_lease", lambda *a, **k: None
+        )
+        # Keep the empty-poll cases from spinning the full long-poll window.
+        monkeypatch.setattr(participate, "_POLL_INTERVAL_S", 0.01)
+
+    return _wire
+
+
+@pytest.mark.asyncio
+async def test_first_await_replays_a_mention_sent_before_it(wired):
+    """The repro: a message addressed to a fresh handle *before* its first await
+    is delivered, not skipped at "now"."""
+    # A mention broadcast anchors an untracked recipient's cursor at itself.
+    log = persister.DeliveryLog()
+    log.record(
+        _addressed_record("m1", to="claude-code-agent"),
+        delivered_to=set(),
+        recipients=["claude-code-agent"],
+    )
+
+    wired(log)
+    result = await participate.await_message("r", object(), handle="claude-code-agent", timeout=0)
+    assert result["message_id"] == "m1"
+    assert result["prompt"] == "@claude-code-agent hello"
+
+
+@pytest.mark.asyncio
+async def test_await_consumes_the_message_it_serves(wired):
+    """A served turn is not served again: the durable cursor advanced past it."""
+    log = persister.DeliveryLog()
+    log.record(
+        _addressed_record("m1", to="claude-code-agent"),
+        delivered_to=set(),
+        recipients=["claude-code-agent"],
+    )
+
+    wired(log)
+    first = await participate.await_message("r", object(), handle="claude-code-agent", timeout=0)
+    assert first["message_id"] == "m1"
+
+    second = await participate.await_message("r", object(), handle="claude-code-agent", timeout=1)
+    assert second["message"] is None  # consumed, nothing left
+
+
+@pytest.mark.asyncio
+async def test_await_ignores_turns_addressed_to_others(wired):
+    """A handle only wakes on turns addressed to it — an observer broadcast to a
+    peer is consumed silently, never returned."""
+    log = persister.DeliveryLog()
+    log.record(
+        _addressed_record("m1", to="someone-else"),
+        delivered_to=set(),
+        recipients=["someone-else"],
+    )
+
+    wired(log)
+    result = await participate.await_message("r", object(), handle="claude-code-agent", timeout=1)
+    assert result["message"] is None

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -177,6 +177,62 @@ def test_loaded_cursors_are_clamped_to_the_transcript_length():
     assert [r.message_id for r in log.undelivered("behind")] == ["m1"]  # clamped to 0
 
 
+def test_position_of_an_untracked_handle_is_the_transcript_end():
+    """A handle no one has addressed sits at "now": nothing prior is its business."""
+    log = persister.DeliveryLog([_record("m1"), _record("m2")])
+    assert log.position("stranger") == 2
+
+
+def test_position_of_an_addressed_untracked_handle_is_its_anchor():
+    """The mention that summoned an absent handle anchors its cursor at itself, so
+    ``position`` reports the mention — not the end — for its first await."""
+    log = persister.DeliveryLog()
+    log.record(_record("m0", sender="avery"), delivered_to=set(), recipients=[])
+    log.record(_record("m1", sender="avery"), delivered_to=set(), recipients=["agent-x"])
+    assert log.position("agent-x") == 1  # anchored at the mention, not the end (2)
+
+
+def test_advance_moves_the_cursor_forward_and_registers_a_new_handle():
+    log = persister.DeliveryLog([_record("m1"), _record("m2"), _record("m3")])
+    log.advance("agent-x", 2)
+    assert log.knows("agent-x")
+    assert [r.message_id for r in log.undelivered("agent-x")] == ["m3"]
+
+
+def test_advance_never_rewinds_a_cursor():
+    """A drain can't un-deliver a tail an earlier live send already advanced past."""
+    log = persister.DeliveryLog([_record("m1"), _record("m2"), _record("m3")])
+    log.advance("agent-x", 3)
+    log.advance("agent-x", 1)  # a stale/lower position is ignored
+    assert log.position("agent-x") == 3
+
+
+def test_advance_clamps_beyond_the_transcript_end():
+    log = persister.DeliveryLog([_record("m1")])
+    log.advance("agent-x", 99)
+    assert log.position("agent-x") == 1
+
+
+def test_an_await_advanced_cursor_survives_a_restart(tmp_path, monkeypatch):
+    """The consume side of the durable inbox persists: a message drained by an
+    ``await`` on one process is not re-served after a restart (#649)."""
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    room = "await-restart"
+    records = [_record("m1"), _record("m2")]
+    for r in records:
+        persister.append_transcript(room, r)
+
+    log = persister.DeliveryLog(records, cursors=persister.load_cursors(room))
+    log.advance("agent-x", 2)  # await drained both
+    persister.write_cursors(room, log.cursors)
+
+    resumed = persister.DeliveryLog(
+        persister.load_transcript(room), cursors=persister.load_cursors(room)
+    )
+    assert resumed.undelivered("agent-x") == []  # not re-served after the "restart"
+    assert resumed.position("agent-x") == 2
+
+
 def test_transcript_does_not_clobber_episode_records():
     """The transcript is a distinct file from log/episodes/*."""
     room = "coexist-room"


### PR DESCRIPTION
## The bug

`mycelium await` returned `{"message": null}` for a handle even though `mycelium room messages` clearly showed messages addressed to it — the messages were sent in the gap between `agent create` and that handle's *first* `await`. The same drop happens across every backend restart.

Root cause (`app/routes/participate.py`): `await` kept its own **process-local, in-memory** cursor (`_await_state`) that:
- initialized to the **current transcript end** on a handle's first call — so anything already sitting there addressed to it was permanently skipped, and
- was wiped on every backend restart/redeploy, silently resetting every handle's delivery point to "now".

This directly contradicted the module's own docstring ("a tick is *never missed*").

## The fix

The durable inbox (`app/services/persister.py`) **already** maintains exactly the right thing — a **persisted per-handle delivery position** (`DeliveryLog` + `.delivery-cursors.json`) that:
- anchors an untracked, `@`-addressed recipient **at the mention that summoned it** (`record()` already does this — the send path maps `@`-mentions to L9 recipients), and
- **resumes from disk** on restart.

`await` had reinvented that cursor in-memory and got it wrong. This PR routes `await` through the existing durable cursor instead of a new mechanism:

- `DeliveryLog.position()` / `.advance()` — read/advance the persisted cursor (monotonic, clamped).
- `RoomPersister.advance_cursor()` — the consume side: persists each drain.
- `await` reads `persister.log.position(handle)` and commits via `advance_cursor` as it drains.
- The process-local map now holds **only the last-served tick** — a best-effort convenience so a following `reply` parents onto the tick that woke the caller; losing it on restart drops one parent edge, never a message.

This also means `await` (pull) and reconnect re-serve (push) now share **one** delivery position, so a message consumed by `await` is never double-served on a later SLIM rejoin.

### Scope note
This closes the reported `await` correctness bug — the participation primitive the whole coordination model depends on. The issue's broader-audit siblings (presence leases → mediator roster, and the `local_state` UI shim, #497) are **separate in-memory-state surfaces** and are intentionally left for their own PRs; this one is anchored on the delivery cursor.

## Tests
- `tests/test_persister.py`: `position`/`advance` semantics + an `await`-advanced cursor surviving a simulated restart.
- `tests/test_participate_await.py` (new, node-free): the repro — a first `await` replays a mention sent before it, consumes it, and ignores turns addressed to peers.

`ruff` + `ty` clean; `test_persister`, `test_sessions_rejoin`, `test_handle_authorization`, `test_memory_write_broadcast` green.

Closes #649.