### PR TITLE
test(cli): isolate project-config/token leaks; whoami/iam echo hub + refresh status

### DIFF
--- a/mycelium-cli/src/mycelium/commands/user.py
+++ b/mycelium-cli/src/mycelium/commands/user.py
@@ -289,11 +289,13 @@ def whoami(ctx: typer.Context) -> None:
                     {
                         "identity": identity,
                         "principal": principal,
+                        "api_url": config.server.api_url,
                         "authenticated": token is not None,
                         "token": {
                             "handle": token_handle,
                             "issuer": token.issuer,
                             "expires_at": token.expires_at,
+                            "refreshable": token.refresh_token is not None,
                         }
                         if token
                         else None,
@@ -308,11 +310,18 @@ def whoami(ctx: typer.Context) -> None:
             return
 
         console.print(f"[bold]acting as[/bold] [cyan]@{principal}[/cyan]  [dim]({identity})[/dim]")
+        console.print(f"  [dim]hub: {config.server.api_url}[/dim]")
         if token is not None:
             remaining = token.expires_in()
             expiry = f", expires in {int(remaining // 60)} min" if remaining is not None else ""
             source = "signed in" if token_handle else "signed in, no handle claim"
             console.print(f"  [green]{source}[/green] [dim]({token.issuer}{expiry})[/dim]")
+            # No issuer-side expiry for the refresh token itself (it's opaque),
+            # so this reports whether one exists at all, not a countdown.
+            if token.refresh_token:
+                console.print("  [dim]refreshes automatically on expiry[/dim]")
+            else:
+                console.print("  [dim]no refresh token — re-login required after expiry[/dim]")
         if user is None:
             console.print(
                 f'[dim]Not registered. Claim it with: mycelium iam {principal} --name "…"[/dim]'
@@ -390,6 +399,7 @@ def iam(
             f"[green]You are[/green] [cyan]@{manifest.handle}[/cyan]"
             f"{f' ({manifest.display_name})' if manifest.display_name else ''}{team_line}"
         )
+        console.print(f"[dim]hub: {config.server.api_url}[/dim]")
         console.print("[dim]Set as this machine's identity. Check with: mycelium whoami[/dim]")
 
         # A gated hub attributes writes to the token, and refuses a body that

--- a/mycelium-cli/tests/conftest.py
+++ b/mycelium-cli/tests/conftest.py
@@ -285,8 +285,14 @@ def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point ``Path.home()`` (and thus ``get_mycelium_dir``) at a temp dir.
 
     ``filesystem.get_mycelium_dir`` resolves to ``~/.mycelium``; setting ``HOME``
-    keeps a test from ever touching the developer's real data dir. Returns the
+    keeps a test from ever touching the developer's real data dir. Also chdirs
+    into the temp dir: ``MyceliumConfig.load()`` additionally discovers a
+    *project-local* ``./.mycelium/config.toml`` by walking up from the cwd
+    (independent of ``$HOME``), so a contributor with local scratch state in
+    their checkout (e.g. from manual e2e testing) would otherwise leak into
+    "isolated" tests just by running them from within the repo. Returns the
     temp home so a test can seed ``.mycelium`` under it.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
     return tmp_path

--- a/mycelium-cli/tests/test_login.py
+++ b/mycelium-cli/tests/test_login.py
@@ -55,8 +55,16 @@ _META = ProviderMetadata(
 
 @pytest.fixture(autouse=True)
 def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep every test off the developer's real ``~/.mycelium`` and token cache."""
+    """Keep every test off the developer's real ``~/.mycelium`` and token cache.
+
+    Also chdirs into ``tmp_path``: ``MyceliumConfig.load()`` additionally
+    discovers a project-local ``./.mycelium/config.toml`` by walking up from
+    the cwd (independent of ``$HOME``), so a contributor with local scratch
+    state in their checkout (e.g. from manual e2e testing) would otherwise leak
+    into these "isolated" tests just by running them from within the repo.
+    """
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
     monkeypatch.delenv(tokens.TOKEN_FILE_ENV, raising=False)
     # The "session expired" notice fires once per process; reset the latch so
     # each test observes its own behavior.

--- a/mycelium-cli/tests/test_plan_commands.py
+++ b/mycelium-cli/tests/test_plan_commands.py
@@ -10,6 +10,8 @@ to pin the HTTP wiring. No backend server.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 from typer.testing import CliRunner
 
@@ -85,9 +87,18 @@ def test_plan_tasks_all_includes_done(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_fetch_plan_hits_room_scoped_endpoint(
-    fake_httpx: FakeHTTPX, monkeypatch: pytest.MonkeyPatch
+    fake_httpx: FakeHTTPX, monkeypatch: pytest.MonkeyPatch, isolated_home: Path
 ) -> None:
-    """The real ``_fetch_plan`` GETs the room-scoped plan endpoint."""
+    """The real ``_fetch_plan`` GETs the room-scoped plan endpoint.
+
+    Needs ``isolated_home``: without it, ``current_token()`` picks up whatever
+    real session happens to be cached at the developer's actual
+    ``~/.mycelium/token.json`` and tries to refresh it against the bare
+    ``SimpleNamespace`` config stubbed below (which has no ``login`` section),
+    crashing with an unrelated ``AttributeError`` instead of exercising what
+    this test actually checks: the HTTP wiring.
+    """
+    del isolated_home  # only needed for its patching side effect
     from types import SimpleNamespace
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
Two test-isolation gaps found while hand-testing #648 (config save's auth-section fix), plus a small CLI UX drive-by found via live confusion mid-session about which hub a command was hitting. These commits were originally pushed to #648's branch but landed after that PR had already squash-merged, so they never made it into `main` — this PR carries them over cleanly.

**Test isolation:**
- `MyceliumConfig.load()` also discovers a project-local `./.mycelium/config.toml` by walking up from the cwd, independent of `$HOME`. The shared `isolated_home` fixture and `test_login.py`'s own `_isolate` only patched `HOME`, so running the suite from a checkout with local e2e-testing scratch state leaked that project's identity/room config into supposedly-isolated tests. Both now also `chdir` into the temp dir.
- `test_fetch_plan_hits_room_scoped_endpoint` never isolated `$HOME` at all, so it picked up whatever real session was cached at the developer's actual `~/.mycelium/token.json` and crashed refreshing it against the test's bare stub config instead of testing the HTTP wiring it's meant to pin. Now uses `isolated_home` like its siblings.

**CLI UX:** `whoami`/`iam` now echo which hub they're talking to and whether the cached session can auto-refresh (has a refresh token) or will need a fresh `mycelium login` once it lapses.

## Test plan
- [x] `uv run pytest tests/ -q` against current `main` (462 passed, run with a real `~/.mycelium` and actual cached state — confirms the isolation fixes hold up outside a clean CI environment)
- [x] `uv run ruff check` / `ruff format --check` on all touched files