### PR TITLE
fix(backend): let respond (/reply) honor owner/allow_from delegation

### DIFF
--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -196,8 +196,10 @@ async def post_reply(room_name: str, body: ReplyBody, request: Request):
         raise HTTPException(status_code=404, detail="Room not found")
     # A verified token names the replier; unauthenticated, the body's handle does.
     # Either way it is resolved here, so the transcript sender and the L9 actor
-    # below are the same handle the room-membership guard passed.
-    handle = actor.bind_actor(request, body.handle, field="handle")
+    # below are the same handle the room-membership guard passed. Delegation-aware
+    # (owner/allow_from), matching await_message's authorize_handle just below —
+    # an agent's owner can reply on its behalf, not just watch for its turns.
+    handle = actor.bind_delegated_actor(request, room_name, body.handle, field="handle")
     # The reply rides as sender_role="agent", so the handle must be a real
     # principal — a registered agent or a known user — and never an engine
     # (engines aren't impersonable). Guard before provisioning a channel.

--- a/fastapi-backend/app/services/actor.py
+++ b/fastapi-backend/app/services/actor.py
@@ -91,6 +91,26 @@ def bind_optional_actor(
     return _authoritative(principal, claimed, field)
 
 
+def bind_delegated_actor(
+    request: Request | None, room: str, claimed: str | None, *, field: str = "handle"
+) -> str:
+    """Like :func:`bind_actor`, but also honors owner/allow_from delegation.
+
+    Use this for a write that is a *documented* delegation surface (an agent's
+    owner replying on its behalf, per ``mycelium agent create --owner``) — unlike
+    ``bind_actor``/``_authoritative``, which requires the claimed handle to be the
+    token's own and is right for writes that must always be the caller's own.
+    """
+    principal = current_principal(request)
+    if principal is None:
+        return claimed or ""
+    authorize_handle(request, room, claimed, field=field)
+    base, sep, session = (claimed or "").partition("#")
+    normalized = normalize_handle(base)
+    resolved = normalized if normalized is not None else principal.handle
+    return f"{resolved}#{session}" if sep and session else resolved
+
+
 def may_act_as(principal: Principal, room: str, handle: str | None) -> bool:
     """Whether ``principal`` may act as ``handle`` in ``room``.
 

--- a/fastapi-backend/tests/test_handle_binding.py
+++ b/fastapi-backend/tests/test_handle_binding.py
@@ -39,11 +39,16 @@ async def _write(client: AsyncClient, *, key: str, created_by: str, room: str = 
     )
 
 
-def _seed_agent(room: str, handle: str, *, adapter: str = "claude_code") -> None:
+def _seed_agent(
+    room: str, handle: str, *, adapter: str = "claude_code", owner: str | None = None
+) -> None:
+    manifest: dict[str, Any] = {"adapter": adapter}
+    if owner is not None:
+        manifest["owner"] = owner
     write_memory_file(
         get_room_dir(room),
         f"agents/{handle}",
-        yaml.safe_dump({"adapter": adapter}, sort_keys=False),
+        yaml.safe_dump(manifest, sort_keys=False),
         created_by="tester",
     )
 
@@ -208,6 +213,54 @@ async def test_reply_claiming_another_handle_is_refused(client: AsyncClient, as_
     as_principal("alice")
     resp = await client.post(f"/api/rooms/{ROOM}/reply", json={"handle": "mallory", "text": "hi"})
     assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reply_as_an_owned_agent_is_allowed(client: AsyncClient, as_principal, monkeypatch):
+    """Regression (#657): await_message already honored owner/allow_from
+    delegation via authorize_handle; post_reply used the stricter, delegation-
+    blind bind_actor instead, so an agent's owner could watch for its turns but
+    never actually post the reply as it. mallory owns the agent here, so replying
+    as it must succeed even though mallory isn't the agent's own literal handle.
+    """
+    from app.services import room_channels
+
+    class _Persister:
+        def __init__(self) -> None:
+            self.log = DeliveryLog([])
+            self.ingested: list[Any] = []
+
+        def ingest_local(self, envelope: Any, content: dict, list_write: bool = False) -> None:
+            self.ingested.append(envelope)
+
+    class _Channel:
+        async def send(self, envelope: Any, *, extra: dict | None = None) -> None:
+            return None
+
+    class _Managed:
+        def __init__(self) -> None:
+            self.channel = _Channel()
+            self.persister = _Persister()
+
+    managed = _Managed()
+
+    class _Manager:
+        async def provision(self, room: str, **_kw: Any) -> _Managed:
+            return managed
+
+        def refresh_lease(self, room: str, handle: str) -> None:
+            return None
+
+    monkeypatch.setattr(room_channels, "manager", _Manager())
+
+    await _make_room(client)
+    _seed_agent(ROOM, "owned-agent", owner="mallory")
+    as_principal("mallory")
+    resp = await client.post(
+        f"/api/rooms/{ROOM}/reply", json={"handle": "owned-agent", "text": "hi"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["handle"] == "owned-agent"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `await_message` (`participate.py`) already used the delegation-aware `authorize_handle` (owner/allow_from), but `post_reply` used the strict, delegation-blind `bind_actor` instead — so an agent's owner could `await` on its behalf but never actually `respond` as it. The two halves of the same participation protocol disagreed.
- Adds `actor.bind_delegated_actor`, which mirrors `bind_actor`'s session-qualifier handling (`alice#a8f3`) but authorizes via `may_act_as` (owner/allow_from) instead of requiring strict token-handle equality. Switches `post_reply` to use it.

Found live while validating a real Cisco SSO deployment (mycelium.outshift.io): created an agent, granted myself ownership via `--owner`, could `await` on its behalf, then got a 403 trying to actually post the reply.

## Test plan
- [x] `test_reply_as_an_owned_agent_is_allowed` — verified it fails with the original `bind_actor` (exact reported 403) and passes with the fix
- [x] `test_reply_claiming_another_handle_is_refused` still passes (agent with no owner grant stays refused)
- [x] `uv run pytest tests/ -x -q` — 633 passed, 2 skipped
- [x] `uv run ruff check` / `ruff format --check` / `ty check` on touched files

Closes #657.