### PR TITLE
Spike: server-side per-actor twin SLIM/MLS sessions (#662)

### DIFF
--- a/docs/design/twin-sessions-spike/README.md
+++ b/docs/design/twin-sessions-spike/README.md
@@ -6,6 +6,16 @@ end-to-end on the pinned stack, measures its shape, and leaves the current
 server-held-membership model untouched so a follow-up can adopt it off-by-default
 and additively.
 
+Two rounds: **v1** (`twin_sessions_spike.py`) proved the primitive in one process;
+**v2** (`spike_v2.py`) then stress-tested the cases v1 could not, with real
+kill-able subprocesses -- restart-and-receive, epoch change while offline,
+moderator restart, wrong-passphrase rejection, multi-room resume, and the
+PSK-cannot-persist constraint. **All six v2 scenarios pass** (see the v2 matrix
+below). One apparent v1/early-v2 limitation (a restored member could send but not
+receive) was chased down, cross-checked against the SLIM source via deepwiki, and
+resolved: it is correct SLIM behavior, satisfied by mycelium's existing
+always-draining moderator loop.
+
 ## The problem it addresses
 
 Today the backend is a **single SLIM/MLS member per room that impersonates every
@@ -105,17 +115,44 @@ immediately **transacted at the group's current epoch** (it encrypted a message 
 the live group key it recovered from disk; the moderator decrypted and attributed
 it) with no re-invite and no MLS Welcome/Commit replay.
 
-**Caveat this exposed (a real finding).** In a single-process simulation the
-crashed App's *subscription for the victim's Name* is still registered over the
-shared connection (a real crash drops the connection and the node forgets it). So
-inbound re-delivery to the fresh subscription is confounded here; the spike proves
-the resume by having the revived twin **send**, which is the stronger crypto proof
-(the recovered MLS epoch is usable) and does not depend on node re-routing.
-Follow-up: a true two-process kill/restart validates inbound re-delivery cleanly.
-Independently, note that **SLIM does not replay messages missed while offline** --
-it only tracks missed *heartbeats*. Persistence resumes *crypto state*, not *missed
-messages*, so the durable transcript/inbox (`app/services/persister.py`) stays
-exactly as-is; it remains the offline-replay mechanism.
+v1 proved the resume by having the revived twin **send** (the single-process sim
+left a stale subscription that confounded *inbound* re-delivery). **v2 removed that
+confound with real subprocesses and validated inbound too** -- see the v2 matrix
+(D1). Independently, note that **SLIM does not replay messages missed while
+offline** -- it only tracks missed *heartbeats* (v2/D1 confirms the missed message
+is not replayed). Persistence resumes *crypto state*, not *missed messages*, so the
+durable transcript/inbox (`app/services/persister.py`) stays exactly as-is; it
+remains the offline-replay mechanism.
+
+## v2 -- the cases v1 could not test (all pass)
+
+`spike_v2.py` (run: `./run_v2.sh`) runs each twin as a real, SIGKILL-able
+subprocess (`twin_runner.py`), so a restart drops the connection and the node
+forgets the subscription -- a faithful backend/twin bounce, without v1's
+single-process confound. Each scenario is isolated (its own SLIM Names, store root,
+and rooms; reusing a Name leaks the node's per-Name multicast queue between tests).
+
+| # | Scenario | Verdict | What it establishes |
+|---|----------|---------|---------------------|
+| C | PSK cannot persist | **PASS** | There is no `create_app_with_secret_and_persistence` in the 2.1.0 wheel: persistence **requires** the identity provider/verifier pair, so a twin cannot run on the default PSK tier. **Twins mandate `signerjwt`/`spire`.** |
+| D1 | Clean restart, receive a NEW message | **PASS** | After a real kill + `restore_sessions`, the twin both sends and **receives** new broadcasts. Inbound resumes once the moderator processes the twin's `rejoin` -- which it does only while **actively draining** its session. The moderator's message sent while the twin was down is **not** replayed (confirms no offline replay). |
+| D2 | Epoch change while offline | **PASS** | Twin killed, moderator rekeys the group (removes another member -> MLS Commit), twin restores: it still sends and receives. A twin that missed a Commit is **not** stranded -- `rejoin()` heals the epoch. |
+| D3 | Moderator (backend) restart | **PASS** | The **group creator** is killed and `restore_sessions`'d: the room stays live -- the member keeps receiving moderator broadcasts and the restored moderator receives member replies. A backend bounce resumes the room from disk. |
+| A | Wrong passphrase | **PASS** | Re-opening a twin's store with the wrong passphrase fails with `decryption failed (wrong key or corrupt data)`. **The at-rest passphrase is load-bearing**, not decorative. |
+| B | Multi-room resume | **PASS** | A twin in two rooms gets **both** sessions back from a single `restore_sessions` call (`n=2`). |
+
+**The D1 chase (why this matters, and the deepwiki cross-check).** v1 and the first
+v2 pass showed a restored member could *send* but not *receive*. Rather than ship
+that as a limitation, it was run down against the SLIM source via deepwiki:
+`restore_sessions` re-establishes the member's routes/subscriptions and emits an
+online `rejoin()`, but the **moderator only re-adds the member to its fan-out list
+when it processes that rejoin control message -- which happens only while the
+moderator is actively draining `get_message`** (confirmed present in 2.1.0, not a
+newer-branch feature). The failing runs had an idle moderator that only published.
+This is exactly mycelium's production posture: the backend moderator's persister
+(`RoomPersister.run()`) *is* an always-on `receive_with_context()` drain loop. With
+a draining moderator, D1 passes in a single round. So it is **correct SLIM
+behavior**, already satisfied by the existing backend -- not a bug and not a gap.
 
 ### Q4 -- where the store lives + the passphrase boundary
 
@@ -218,8 +255,12 @@ manage.
 
 | File | Purpose |
 |------|---------|
-| `twin_sessions_spike.py` | The fleet: N persistence-backed SignerJwt twins in one process, one GROUP, one restore. |
-| `run.sh` | One-command repro: stock SLIM 2.1.0 node + key mint + roster JWKS + exec. |
+| `twin_sessions_spike.py` | **v1** fleet: N persistence-backed SignerJwt twins in one process, one GROUP, one restore. |
+| `run.sh` | v1 repro: stock SLIM 2.1.0 node + key mint + roster JWKS + exec. |
+| `spike_v2.py` | **v2** restart matrix (C/D1/D2/D3/A/B): orchestrates kill-able twin subprocesses, asserts a PASS/FAIL/FINDING table. |
+| `twin_runner.py` | v2: one twin as its own OS process, driven by a file-command protocol; SIGKILL-able for faithful restarts. |
+| `twin_common.py` | Shared identity/persistence/session helpers for the v2 harness. |
+| `run_v2.sh` | v2 repro: node + per-test key mint + exec `spike_v2.py`. |
 | `build_roster_jwks.py` | Assemble the room-roster JWKS from the twins' public keys (shared with #587). |
 
 ## Matched stack (proven)

--- a/docs/design/twin-sessions-spike/README.md
+++ b/docs/design/twin-sessions-spike/README.md
@@ -119,18 +119,24 @@ exactly as-is; it remains the offline-replay mechanism.
 
 ### Q4 -- where the store lives + the passphrase boundary
 
-Per-twin, server-side, one SQLite MLS-state store per actor, AES-256-GCM at rest:
+Per-twin, server-side, backed by the **`agntcy-slim-persistence` SQLite store**
+(`SlimGroupStateStorage`, the crate the issue pointed at -- we did not hand-roll
+persistence, only passed `PersistenceConfig(path, passphrase)`). The `path` is
+treated by the crate as a **directory**, into which it writes a real SQLite
+database in WAL mode, one per app:
 
 ```
-[store] per-twin server-side MLS state (Q4):
-  backend    .../twin-store/backend/mls-state.sqlite  (AES-256-GCM at rest)
-  alice      .../twin-store/alice/mls-state.sqlite    (AES-256-GCM at rest)
-  bob        .../twin-store/bob/mls-state.sqlite       (AES-256-GCM at rest)
-  carol      .../twin-store/carol/mls-state.sqlite     (AES-256-GCM at rest)
+twin-store/alice/mls-state.sqlite/            <- the `path` we pass (a directory)
+  slim-<hex>.db        (magic: "SQLite format 3", ~120-240 KB per twin here)
+  slim-<hex>.db-wal    (WAL sidecar)
+  slim-<hex>.db-shm    (shared-memory index)
 ```
 
-In production this sits under the hub's data dir (`~/.mycelium/`-style), one path
-per twin. **The passphrase is the real at-rest confidentiality boundary and needs
+`<hex>` is the app/session id. The DB *container* is a standard (plaintext-schema)
+SQLite file; the **passphrase encrypts the stored MLS state blobs (AES-256-GCM)**,
+per the crate -- it is value-level at-rest encryption, not whole-file/SQLCipher
+encryption. In production this sits under the hub's data dir (`~/.mycelium/`-style),
+one directory per twin. **The passphrase is the real at-rest confidentiality boundary and needs
 its own hardening pass.** The spike derives it as `HMAC(server session secret,
 handle)` so each twin store gets a distinct key and one leaked passphrase does not
 open every twin. The session secret must be a **server-held** secret
@@ -148,7 +154,8 @@ whether the secret should be per-host or per-deployment.
 N twins multiplex over **one** dataplane connection (`Service` allows one per
 endpoint per process anyway; the existing `slim_client._shared_connection` cache
 already relies on this). So the footprint is N Apps + N MLS group states, **not** N
-sockets. The MLS state stores were ~160 bytes each in this run. Persistence makes a
+sockets. The per-twin SQLite MLS-state stores were ~120-240 KB each in this run
+(the `agntcy-slim-persistence` DB + WAL, see Q4). Persistence makes a
 connect-per-turn footprint viable as an alternative to N always-live Apps, but the
 spike did not stress a room's worth of actors; scale-testing the App/MLS-state
 memory footprint at (say) 20-50 twins is a follow-up measurement, not a blocker.

--- a/docs/design/twin-sessions-spike/README.md
+++ b/docs/design/twin-sessions-spike/README.md
@@ -1,0 +1,222 @@
+# Spike: server-side per-actor "twin" SLIM/MLS sessions (#662)
+
+**Status: PASS (validated live against a stock `ghcr.io/agntcy/slim:2.1.0` node).**
+This is a spike, not a commitment to rearchitect. It proves the twin model works
+end-to-end on the pinned stack, measures its shape, and leaves the current
+server-held-membership model untouched so a follow-up can adopt it off-by-default
+and additively.
+
+## The problem it addresses
+
+Today the backend is a **single SLIM/MLS member per room that impersonates every
+actor** (a service account). Attribution ("@alice said this") is stamped by the
+backend at the L9/transcript layer *after the fact*: application-level, forgeable
+by the backend, invisible on the wire (`app/services/l9.py` builds the envelope
+`sender` field; `app/services/actor.py` binds it from the HTTP principal). One MLS
+identity -- the backend's -- carries all traffic.
+
+The decided direction: the backend as a **custodian of N per-actor twin Apps**,
+each a *genuine* MLS member carrying its **own** per-actor SignerJwt/SPIRE
+credential (the identity epic #585 / #476 already ships the credential; today it
+only identifies the backend's single App). Which actor can touch which room is then
+enforced by **MLS group membership**, not by mycelium app logic. All twins live in
+the backend process, so **all backend cognition still reads plaintext** (aligner,
+plan compiler, memory-sync, L9). This is orthogonal to #664 Mode 2 (blind relay)
+and does not require it.
+
+## What the spike ran
+
+`twin_sessions_spike.py`, driven by `run.sh`, stands up a stock SLIM 2.1.0 node and
+runs a whole twin fleet in **one** host process:
+
+- 1 moderator App (`backend`, the always-on citizen) + 3 per-actor twins
+  (`alice`, `bob`, `carol`).
+- Each twin is created with `create_app_with_persistence_async(...)` and its **own**
+  self-minted ES256 SignerJwt identity (per-member keypair, roster-JWKS verifier --
+  the exact #587 floor path), so each is a cryptographically distinct MLS
+  participant. The backend cannot mint alice's token without alice's private key.
+- All four join **one** GROUP/MLS channel over **one** shared dataplane connection.
+- One twin is then "restarted" (its in-memory App is dropped without a graceful
+  leave) and resumed with `restore_sessions(conn_id)`.
+
+Reproduce: `./run.sh` (needs docker, openssl, and the `fastapi-backend` uv env with
+`slim-bindings==2.1.0`). It self-mints keys, builds the roster JWKS, and execs the
+fleet on the host. Tear-down is automatic.
+
+## Results against the six spike questions
+
+### Q1 -- N twins, one process, distinct wire attribution: **YES**
+
+Three persistence-backed, SignerJwt-identified twins joined one MLS GROUP; the
+moderator read each message and recovered a **distinct cryptographic sender** off
+the inbound `MessageContext`, not a backend-stamped field:
+
+```
+[fleet] 3 persistence-backed SignerJwt twins created in ONE process: alice, bob, carol
+[backend] invited + MLS-verified twin 'alice'.
+[backend] invited + MLS-verified twin 'bob'.
+[backend] invited + MLS-verified twin 'carol'.
+[backend] wire sender='alice' payload='alice: hello over MLS as myself'
+[backend] wire sender='bob'   payload='bob: hello over MLS as myself'
+[backend] wire sender='carol' payload='carol: hello over MLS as myself'
+[fleet] distinct cryptographic wire senders: ['alice', 'bob', 'carol']
+```
+
+Each invite ran MLS peer-verification of a distinct self-signed token against the
+room roster. Attribution is now on the wire and non-forgeable by the backend,
+because the backend does not hold the actors' private keys in this model (in the
+spike it happens to, but nothing *requires* it to -- see the scope boundary).
+
+### Q2 -- persistence API reachable from the pinned 2.1.0 wheel: **YES**
+
+Verified directly against the installed wheel (not just the Rust source). In
+`slim_bindings==2.1.0`:
+
+- `Service.create_app_with_persistence_async(name, provider, verifier, direction, persistence) -> App`
+  (plus the blocking `create_app_with_persistence`).
+- `App.restore_sessions_async(conn_id) -> list[Session]` (plus blocking
+  `restore_sessions`).
+- `PersistenceConfig(*, path, passphrase)` -- both keyword-only; `passphrase` is
+  **required** (no unencrypted store). The docstring: *"Where and how a session's
+  MLS/state is persisted at rest ... pass this to create_app_with_persistence to
+  get a restorable app."*
+- `restore_sessions` docstring: *"conn_id must be the live upstream connection ...
+  Each restored session rejoins its MLS group without repeating the invite/welcome
+  handshake."*
+
+Note: the top-level module does **not** expose these as free functions (an earlier
+read of the Rust source suggested `create_app_with_persistence(...)` as a bare
+call); they are **`Service`/`App` methods**. The spike uses the method form.
+
+### Q3 -- resume without a re-invite: **YES**
+
+The twin was dropped without a graceful leave (a graceful `delete_session` removes
+the member from the group *and* purges its persisted state -- the opposite of a
+crash), re-created against the **same** store path + passphrase, and resumed:
+
+```
+[resume] simulating a restart of twin 'alice' ...
+[resume] restore_sessions('alice') returned 1 session(s) from persisted MLS state (no invite/welcome replayed).
+[resume] moderator decrypted post-restore msg from wire sender='alice': 'alice: back from persisted MLS state'
+```
+
+`restore_sessions` recovered the group membership from disk, and the revived twin
+immediately **transacted at the group's current epoch** (it encrypted a message to
+the live group key it recovered from disk; the moderator decrypted and attributed
+it) with no re-invite and no MLS Welcome/Commit replay.
+
+**Caveat this exposed (a real finding).** In a single-process simulation the
+crashed App's *subscription for the victim's Name* is still registered over the
+shared connection (a real crash drops the connection and the node forgets it). So
+inbound re-delivery to the fresh subscription is confounded here; the spike proves
+the resume by having the revived twin **send**, which is the stronger crypto proof
+(the recovered MLS epoch is usable) and does not depend on node re-routing.
+Follow-up: a true two-process kill/restart validates inbound re-delivery cleanly.
+Independently, note that **SLIM does not replay messages missed while offline** --
+it only tracks missed *heartbeats*. Persistence resumes *crypto state*, not *missed
+messages*, so the durable transcript/inbox (`app/services/persister.py`) stays
+exactly as-is; it remains the offline-replay mechanism.
+
+### Q4 -- where the store lives + the passphrase boundary
+
+Per-twin, server-side, one SQLite MLS-state store per actor, AES-256-GCM at rest:
+
+```
+[store] per-twin server-side MLS state (Q4):
+  backend    .../twin-store/backend/mls-state.sqlite  (AES-256-GCM at rest)
+  alice      .../twin-store/alice/mls-state.sqlite    (AES-256-GCM at rest)
+  bob        .../twin-store/bob/mls-state.sqlite       (AES-256-GCM at rest)
+  carol      .../twin-store/carol/mls-state.sqlite     (AES-256-GCM at rest)
+```
+
+In production this sits under the hub's data dir (`~/.mycelium/`-style), one path
+per twin. **The passphrase is the real at-rest confidentiality boundary and needs
+its own hardening pass.** The spike derives it as `HMAC(server session secret,
+handle)` so each twin store gets a distinct key and one leaked passphrase does not
+open every twin. The session secret must be a **server-held** secret
+(`MYCELIUM_TWIN_STORE_SECRET` or a KMS-wrapped value) -- deliberately **NOT** the
+actor's OIDC/SignerJwt token, which rotates hourly (`TOKEN_DURATION_S = 3600`) and
+is not a durable at-rest key. Open question for the follow-up: key rotation and
+whether the secret should be per-host or per-deployment.
+
+### Q6 -- cost: one socket for the whole fleet
+
+```
+[fleet] one shared dataplane connection: conn_id=0
+```
+
+N twins multiplex over **one** dataplane connection (`Service` allows one per
+endpoint per process anyway; the existing `slim_client._shared_connection` cache
+already relies on this). So the footprint is N Apps + N MLS group states, **not** N
+sockets. The MLS state stores were ~160 bytes each in this run. Persistence makes a
+connect-per-turn footprint viable as an alternative to N always-live Apps, but the
+spike did not stress a room's worth of actors; scale-testing the App/MLS-state
+memory footprint at (say) 20-50 twins is a follow-up measurement, not a blocker.
+
+## The honest scope boundary (do not oversell)
+
+Twins are **server-side**: the hub still holds every twin's private key + plaintext.
+So this hardens:
+
+- **the wire and attribution** -- cryptographic, non-forgeable, verifiable by
+  real/remote members; access split by MLS group membership rather than app logic;
+- **per-agent identity at the MLS layer** -- finally true, where today the identity
+  epic only identifies the backend's single App.
+
+It is **NOT** E2E-from-the-hub. A compromised or malicious hub still sees and can
+impersonate everything. Confidentiality-from-the-hub is a **different axis** (#664
+Mode 2, deliberately out of scope; twins do not need it, and it would remove
+cognition). For a single-hub deployment the near-term win is honest attribution +
+access-by-membership + a multi-hub / remote-member future, not "the server can't
+read your data."
+
+## Where this plugs into the existing code (follow-up, not this spike)
+
+The seams already exist; adopting twins is additive and off-by-default:
+
+- **Identity** -- `app/services/slim_identity.py` already mints per-agent SignerJwt
+  material (`ensure_agent_keypair`, `resolve_identity_material`) and provisions it
+  on `agent create`. Today `SlimClient._create_app` (`slim_client.py:392`) selects
+  the identity tier for the *backend's* single App; the twin model calls the same
+  resolver per actor.
+- **App creation** -- `SlimClient` would gain a persistence-backed variant that
+  calls `create_app_with_persistence_async` instead of `create_app`, keyed by the
+  per-twin store path. `room_channels.py` (`RoomChannelManager.provision` /
+  `invite`) is where the fleet would be custodied: one twin App per member instead
+  of inviting a bare Name.
+- **Attribution** -- `l9.py` / `actor.py` keep stamping the L9 `sender` for the
+  transcript, but it becomes a *mirror* of the now-authoritative MLS wire identity
+  rather than the sole source of truth.
+- **Transcript/inbox** -- `persister.py` is unchanged; it stays the offline-replay
+  mechanism (SLIM persistence resumes crypto state only, per Q3).
+
+## Lifecycle ties (Q5, noted not built)
+
+A twin is created/torn down with the actor, tying to: **#663** (invite/accept
+authorization -- twin creation is where that gate belongs), **#590** (revocation =
+drop the twin + delete its store), and the real-IdP handle fixes **#656/#657**. The
+spike does not implement lifecycle; it proves the primitive the lifecycle would
+manage.
+
+## Non-goals (unchanged from the issue)
+
+- Not rearchitecting `participate.py`'s await/respond model before the twin path is
+  proven end-to-end.
+- Not #664 Mode 2 (blind relay) -- orthogonal.
+- Not client-held memberships yet -- a native client holding its own twin is the
+  *next* rung (a browser can't; persistence is native-only), cleanly enabled by
+  this but not required.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `twin_sessions_spike.py` | The fleet: N persistence-backed SignerJwt twins in one process, one GROUP, one restore. |
+| `run.sh` | One-command repro: stock SLIM 2.1.0 node + key mint + roster JWKS + exec. |
+| `build_roster_jwks.py` | Assemble the room-roster JWKS from the twins' public keys (shared with #587). |
+
+## Matched stack (proven)
+
+`slim-bindings==2.1.0` (PyPI) + `ghcr.io/agntcy/slim:2.1.0`. Signing keys must be
+PKCS#8 PEM (`run.sh` converts SEC1 -> PKCS#8). Do not substitute `STATIC_JWT`: it
+returns `MlsNotSupported` for MLS signature keys (#581).

--- a/docs/design/twin-sessions-spike/build_roster_jwks.py
+++ b/docs/design/twin-sessions-spike/build_roster_jwks.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Assemble the room-roster JWKS from members' ES256 public-key PEMs (spike #587).
+
+The roster JWKS is the SignerJwt floor's trust surface: the set of public keys a
+member's verifier will accept a self-signed token from. In a real mycelium
+deployment this is the moderator's view of the room's registered agents -- one JWK
+per `mycelium agent credential set`. Here it is just the two spike members.
+
+Usage: python build_roster_jwks.py <keydir> <name> [<name> ...]
+Reads <keydir>/<name>.pub.pem for each name, writes <keydir>/roster-jwks.json.
+"""
+
+import base64
+import json
+import sys
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def main() -> int:
+    keydir, names = sys.argv[1], sys.argv[2:]
+    keys = []
+    for name in names:
+        with open(f"{keydir}/{name}.pub.pem", "rb") as fh:
+            pub = load_pem_public_key(fh.read())
+        if not isinstance(pub, ec.EllipticCurvePublicKey):
+            raise TypeError(f"{name}: expected an EC P-256 public key")
+        nums = pub.public_numbers()
+        keys.append(
+            {
+                "kty": "EC",
+                "crv": "P-256",
+                "alg": "ES256",
+                "use": "sig",
+                "kid": name,  # the @handle; lets the verifier do O(1) key lookup
+                "x": _b64u(nums.x.to_bytes(32, "big")),
+                "y": _b64u(nums.y.to_bytes(32, "big")),
+            }
+        )
+    out = f"{keydir}/roster-jwks.json"
+    with open(out, "w") as fh:
+        json.dump({"keys": keys}, fh)
+    print(f"wrote {out} with {len(keys)} key(s): {', '.join(names)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/design/twin-sessions-spike/run.sh
+++ b/docs/design/twin-sessions-spike/run.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# One-command reproduction of the server-side per-actor "twin" SLIM/MLS spike (#662).
+#
+# Stands up a stock SLIM 2.1.0 node, self-mints one ES256 keypair per twin (the
+# moderator + N per-actor twins) plus a room roster JWKS, then runs the whole twin
+# fleet in ONE host process: N persistence-backed, SignerJwt-identified MLS members
+# in one GROUP, plus a restore_sessions resume of one twin.
+#
+# Requires: docker, openssl, and the fastapi-backend uv env (slim-bindings==2.1.0 +
+# cryptography). Run from this directory. Tear-down is automatic.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND="$(cd "$HERE/../../../fastapi-backend" && pwd)"
+NODE_NAME="slim-twin-sessions-spike"
+NODE_PORT="${NODE_PORT:-46359}"   # not :46357 (dev node) / :46358 (signerjwt spike)
+KEYDIR="${KEYDIR:-/tmp/twin-sessions-spike}"
+TWINS="${TWINS:-backend alice bob carol}"
+export SLIM_ENDPOINT="http://127.0.0.1:${NODE_PORT}"
+export KEYDIR TWINS
+
+cleanup() { docker rm -f "$NODE_NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "== 1/3  stock SLIM 2.1.0 node on :${NODE_PORT} =="
+mkdir -p "${KEYDIR:?}"
+cat > "$KEYDIR/slim-node.yaml" <<EOF
+tracing: { log_level: info }
+runtime: { n_cores: 0, thread_name: "slim-data-plane", drain_timeout: 10s }
+services:
+  slim/0:
+    dataplane:
+      servers:
+        - endpoint: "0.0.0.0:${NODE_PORT}"
+          tls: { insecure: true }
+      clients: []
+EOF
+cleanup
+docker run -d --name "$NODE_NAME" -p "${NODE_PORT}:${NODE_PORT}" \
+  -v "$KEYDIR/slim-node.yaml:/config.yaml" \
+  ghcr.io/agntcy/slim:2.1.0 /slim --config /config.yaml >/dev/null
+sleep 3
+
+echo "== 2/3  self-mint each twin's ES256 keypair (PKCS#8) + roster JWKS =="
+for name in $TWINS; do
+  openssl ecparam -name prime256v1 -genkey -noout -out "$KEYDIR/$name.sec1.key" 2>/dev/null
+  openssl pkcs8 -topk8 -nocrypt -in "$KEYDIR/$name.sec1.key" -out "$KEYDIR/$name.pk8.pem" 2>/dev/null
+  openssl ec -in "$KEYDIR/$name.sec1.key" -pubout -out "$KEYDIR/$name.pub.pem" 2>/dev/null
+done
+# shellcheck disable=SC2086 -- word-splitting $TWINS into roster args is intended
+( cd "$BACKEND" && uv run python "$HERE/build_roster_jwks.py" "$KEYDIR" $TWINS )
+
+echo "== 3/3  N per-actor twins share one MLS GROUP + one resumes from persistence =="
+( cd "$BACKEND" && uv run python "$HERE/twin_sessions_spike.py" )

--- a/docs/design/twin-sessions-spike/run_v2.sh
+++ b/docs/design/twin-sessions-spike/run_v2.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Spike #662 v2: faithful two-process twin restart matrix.
+#
+# Stands up a stock SLIM 2.1.0 node, mints one ES256 keypair per handle
+# (mod, mod2, alice, bob) + a roster JWKS, then runs the orchestrator, which
+# spawns real subprocesses it can SIGKILL to test restarts across a true process
+# boundary (drops the conn; the node forgets the subscription).
+#
+# Requires: docker, openssl, the fastapi-backend uv env (slim-bindings==2.1.0 +
+# cryptography). Run from this directory. Tear-down is automatic.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND="$(cd "$HERE/../../../fastapi-backend" && pwd)"
+NODE_NAME="slim-twin-sessions-spike-v2"
+NODE_PORT="${NODE_PORT:-46360}"
+KEYDIR="${KEYDIR:-/tmp/twin-sessions-spike}"
+# Distinct handles per test so the shared node's per-Name multicast queue can't
+# leak messages between scenarios (see spike_v2.py isolation note).
+HANDLES="${HANDLES:-d1mod d1alice d2mod d2alice d2bob d3mod d3alice amod aalice bmod bmod2 balice}"
+export SLIM_ENDPOINT="http://127.0.0.1:${NODE_PORT}"
+export KEYDIR
+
+cleanup() { docker rm -f "$NODE_NAME" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+echo "== 1/3  stock SLIM 2.1.0 node on :${NODE_PORT} =="
+mkdir -p "${KEYDIR:?}"
+cat > "$KEYDIR/slim-node-v2.yaml" <<EOF
+tracing: { log_level: error }
+runtime: { n_cores: 0, thread_name: "slim-data-plane", drain_timeout: 10s }
+services:
+  slim/0:
+    dataplane:
+      servers:
+        - endpoint: "0.0.0.0:${NODE_PORT}"
+          tls: { insecure: true }
+      clients: []
+EOF
+cleanup
+docker run -d --name "$NODE_NAME" -p "${NODE_PORT}:${NODE_PORT}" \
+  -v "$KEYDIR/slim-node-v2.yaml:/config.yaml" \
+  ghcr.io/agntcy/slim:2.1.0 /slim --config /config.yaml >/dev/null
+sleep 3
+
+echo "== 2/3  self-mint each handle's ES256 keypair (PKCS#8) + roster JWKS =="
+for name in $HANDLES; do
+  openssl ecparam -name prime256v1 -genkey -noout -out "$KEYDIR/$name.sec1.key" 2>/dev/null
+  openssl pkcs8 -topk8 -nocrypt -in "$KEYDIR/$name.sec1.key" -out "$KEYDIR/$name.pk8.pem" 2>/dev/null
+  openssl ec -in "$KEYDIR/$name.sec1.key" -pubout -out "$KEYDIR/$name.pub.pem" 2>/dev/null
+done
+# shellcheck disable=SC2086
+( cd "$BACKEND" && uv run python "$HERE/build_roster_jwks.py" "$KEYDIR" $HANDLES )
+
+echo "== 3/3  restart matrix (real subprocesses, SIGKILL) =="
+( cd "$BACKEND" && uv run python "$HERE/spike_v2.py" )

--- a/docs/design/twin-sessions-spike/spike_v2.py
+++ b/docs/design/twin-sessions-spike/spike_v2.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Spike #662 v2: the cases v1 could not test -- faithful two-process restarts.
+
+v1 proved the primitive (persistence API reachable, N SignerJwt twins in one
+GROUP, restore returns a session) but left the load-bearing questions open. This
+harness answers them with REAL subprocesses (`twin_runner.py`) that can be
+SIGKILL'd, so a restart drops the connection and the node forgets the subscription
+-- exactly a backend/twin bounce, without v1's stale-subscription confounder.
+
+Isolation: every test uses DISTINCT handles (its own SLIM Names) and its own store
+root + rooms. Reusing a handle across tests leaked queued messages between them on
+the shared node (a per-Name multicast queue re-serves a new subscription under the
+same Name), so each scenario gets unique Names.
+
+Scenarios:
+
+  C   PSK cannot persist            API fact: no create_app_with_secret_and_persistence
+  D1  clean restart, recv NEW msg   the inbound-after-restore proof v1 skipped
+      (+ confirm SLIM does NOT replay a message sent while the twin was down)
+  D2  epoch change while offline    twin dead -> moderator rekeys (removes a member)
+      -> twin restores: can it still send/recv, or is it stranded past the epoch?
+  D3  moderator restart             the group CREATOR (the backend) bounces + restores
+  A   wrong passphrase              a fresh App with the WRONG key must NOT be usable
+  B   multi-room restore            restore_sessions returns ALL of a twin's rooms
+
+Prints a PASS/FAIL/FINDING matrix. FINDING = a real behavior worth recording that
+is not a clean pass/fail (e.g. "rekey strands the twin -> re-invite required").
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).parent
+ENDPOINT = os.environ.get("SLIM_ENDPOINT", "http://127.0.0.1:46360")
+KEYDIR = os.environ.get("KEYDIR", "/tmp/twin-sessions-spike")
+STORE_ROOT = os.environ.get("TWIN_STORE", f"{KEYDIR}/v2-store")
+CMD_ROOT = f"{KEYDIR}/v2-cmd"
+
+results: list[tuple[str, str, str]] = []  # (test, verdict, detail)
+
+
+class Twin:
+    """Orchestrator-side handle to one twin subprocess."""
+
+    def __init__(self, handle: str, store_root: str) -> None:
+        self.handle = handle
+        self.store_root = store_root
+        self.proc: asyncio.subprocess.Process | None = None
+        self.cmddir: Path | None = None
+        self.seq = 0
+        self.gen = 0
+
+    async def launch(self, *, wrong_passphrase: bool = False) -> dict:
+        self.gen += 1
+        self.seq = 0
+        self.cmddir = Path(CMD_ROOT) / self.handle / f"gen{self.gen}"
+        self.cmddir.mkdir(parents=True, exist_ok=True)
+        argv = [
+            sys.executable, str(HERE / "twin_runner.py"),
+            "--handle", self.handle, "--endpoint", ENDPOINT,
+            "--keydir", KEYDIR, "--store", self.store_root, "--cmddir", str(self.cmddir),
+        ]
+        if wrong_passphrase:
+            argv.append("--wrong-passphrase")
+        self.proc = await asyncio.create_subprocess_exec(
+            *argv, cwd=str(HERE), stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+        )
+        return await self._await_file(self.cmddir / "ready.json", timeout=30)
+
+    def post(self, op: str, **kw) -> int:
+        assert self.cmddir is not None
+        self.seq += 1
+        payload = {"op": op, **kw}
+        tmp = self.cmddir / f"cmd-{self.seq}.json.tmp"
+        tmp.write_text(json.dumps(payload))
+        tmp.rename(self.cmddir / f"cmd-{self.seq}.json")
+        return self.seq
+
+    async def wait(self, seq: int, *, timeout: float = 30) -> dict:
+        assert self.cmddir is not None
+        return await self._await_file(self.cmddir / f"res-{seq}.json", timeout=timeout)
+
+    async def cmd(self, op: str, *, timeout: float = 30, **kw) -> dict:
+        return await self.wait(self.post(op, **kw), timeout=timeout)
+
+    async def _await_file(self, path: Path, *, timeout: float) -> dict:
+        waited = 0.0
+        while waited < timeout:
+            if path.exists():
+                return json.loads(path.read_text())
+            await asyncio.sleep(0.03)
+            waited += 0.03
+        return {"ok": False, "error": f"timeout waiting for {path.name}"}
+
+    async def kill(self) -> None:
+        if self.proc and self.proc.returncode is None:
+            try:
+                self.proc.send_signal(signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            await self.proc.wait()
+
+    async def quit(self) -> None:
+        try:
+            self.post("quit")
+            if self.proc:
+                await asyncio.wait_for(self.proc.wait(), timeout=5)
+        except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+            await self.kill()
+
+
+def record(test: str, verdict: str, detail: str) -> None:
+    results.append((test, verdict, detail))
+    print(f"  [{verdict:7}] {test}: {detail}", flush=True)
+
+
+async def _join(mod: Twin, member: Twin) -> dict:
+    """Member joins mod's group; returns the member's join result (with epoch)."""
+    js = member.post("join")
+    await mod.cmd("invite", handle=member.handle)
+    return await member.wait(js)
+
+
+async def _recv_broadcast(mod: Twin, member: Twin, *, rounds: int = 8) -> dict:
+    """Have `mod` broadcast until `member` receives inbound after a restore.
+
+    The load-bearing detail (confirmed via deepwiki against the SLIM source, and
+    present in 2.1.0): restore_sessions sends the member's online `rejoin()`, but
+    the MODERATOR only re-adds the member to its fan-out list when it *processes*
+    that rejoin control message -- which happens only while the moderator is
+    actively draining its session (get_message). A moderator that only publishes
+    never re-adds the member, so inbound stays dead. This is exactly mycelium's
+    production posture: the backend moderator's persister IS an always-draining
+    receive loop. So each round we make the moderator drain (recv, which processes
+    the rejoin as a side effect) before broadcasting.
+    """
+    for i in range(1, rounds + 1):
+        await mod.cmd("recv", timeout=1)  # drain control (processes the rejoin); data may time out
+        await mod.cmd("send", text=f"probe-{i}")
+        r = await member.cmd("recv", timeout=2)
+        if r.get("ok") and str(r.get("payload", "")).startswith("probe-"):
+            return {"ok": True, "rounds": i, "payload": r["payload"], "sender": r.get("sender")}
+    return {"ok": False, "rounds": rounds}
+
+
+# --------------------------------------------------------------------------- C
+def test_c_psk_cannot_persist() -> None:
+    import slim_bindings as s
+
+    combo = any("secret" in m and "persist" in m for m in dir(s.Service))
+    if combo:
+        record("C psk-persist", "FINDING", "a secret+persistence method exists after all -- re-check")
+    else:
+        record(
+            "C psk-persist", "PASS",
+            "no create_app_with_secret_and_persistence: persistence REQUIRES the "
+            "identity tier (signerjwt/spire); default PSK cannot persist.",
+        )
+
+
+# -------------------------------------------------------------------------- D1
+async def test_d1_clean_restart() -> None:
+    store = f"{STORE_ROOT}/d1"
+    mod, alice = Twin("d1mod", store), Twin("d1alice", store)
+    try:
+        await mod.launch(); await alice.launch()
+        await mod.cmd("create_group", room="d1room")
+        await _join(mod, alice)
+        await mod.cmd("send", text="hello-1")
+        r = await alice.cmd("recv", timeout=10)
+        if r.get("payload") != "hello-1":
+            record("D1 restart-recv", "FAIL", f"baseline delivery broken: {r}"); return
+
+        await alice.kill()
+        await mod.cmd("send", text="while-down")  # SLIM has no offline replay -> should be LOST
+        await alice.launch()
+        rr = await alice.cmd("restore")
+        if not rr.get("n_sessions"):
+            record("D1 restart-recv", "FAIL", f"restore returned no sessions: {rr}"); return
+
+        miss = await alice.cmd("recv", timeout=3)
+        replayed = miss.get("payload") == "while-down"
+
+        # Inbound after restore, tolerating async rejoin propagation (see helper).
+        got = await _recv_broadcast(mod, alice)
+        recv_ok = got.get("ok")
+
+        await alice.cmd("send", text="alice-back")
+        mg = await mod.cmd("recv", timeout=10)
+        send_ok = mg.get("payload") == "alice-back"
+
+        replay_note = "missed msg NOT replayed (correct)" if not replayed else "UNEXPECTED replay"
+        if recv_ok and send_ok:
+            record("D1 restart-recv", "PASS",
+                   f"post-restore recv+send both work once the moderator drains the rejoin "
+                   f"(inbound resumed after {got.get('rounds')} round(s)); {replay_note}. "
+                   "mycelium's persister is already an always-draining loop, so this holds in prod.")
+        elif send_ok and not recv_ok:
+            record("D1 restart-recv", "FINDING",
+                   f"restored twin can SEND (mod saw {mg.get('payload')!r}) but never received a "
+                   f"broadcast across {got.get('rounds')} rounds even with the moderator draining; "
+                   f"{replay_note}. Contradicts the documented rejoin design -- file upstream.")
+        else:
+            record("D1 restart-recv", "FAIL",
+                   f"recv_ok={recv_ok} send_ok={send_ok} recv={got} send-seen={mg}; {replay_note}")
+    finally:
+        await mod.quit(); await alice.quit()
+
+
+# -------------------------------------------------------------------------- D2
+async def test_d2_epoch_change_offline() -> None:
+    store = f"{STORE_ROOT}/d2"
+    mod, alice, bob = Twin("d2mod", store), Twin("d2alice", store), Twin("d2bob", store)
+    try:
+        await mod.launch(); await alice.launch(); await bob.launch()
+        await mod.cmd("create_group", room="d2room")
+        ae = await _join(mod, alice)
+        await _join(mod, bob)
+        await mod.cmd("send", text="e-hello")
+        a1 = await alice.cmd("recv", timeout=10)
+        await bob.cmd("recv", timeout=10)
+        if a1.get("payload") != "e-hello":
+            record("D2 epoch-offline", "FAIL", f"baseline group broken: {a1}"); return
+        epoch_before = ae.get("epoch")
+
+        await alice.kill()
+        re = await mod.cmd("remove", handle=bob.handle)  # rekey; alice never sees this Commit
+        epoch_after = re.get("epoch")
+
+        await alice.launch()
+        rr = await alice.cmd("restore")
+        n = rr.get("n_sessions")
+        if not n:
+            record("D2 epoch-offline", "FINDING",
+                   f"restore after rekey returned {n} sessions (epoch {epoch_before}->{epoch_after}): "
+                   "a twin that misses a Commit is STRANDED and needs re-invite."); return
+
+        await mod.cmd("send", text="post-epoch")
+        got = await alice.cmd("recv", timeout=8)
+        recv_ok = got.get("payload") == "post-epoch"
+        await alice.cmd("send", text="alice-post-epoch")
+        mg = await mod.cmd("recv", timeout=8)
+        send_ok = mg.get("payload") == "alice-post-epoch"
+
+        if recv_ok and send_ok:
+            record("D2 epoch-offline", "PASS",
+                   f"twin resumed ACROSS a rekey (epoch {epoch_before}->{epoch_after}) and still "
+                   "sends+receives -- SLIM self-heals the epoch on rejoin.")
+        else:
+            record("D2 epoch-offline", "FINDING",
+                   f"restore returned a session but recv_ok={recv_ok} send_ok={send_ok} "
+                   f"(epoch {epoch_before}->{epoch_after}): the resumed twin is at a STALE epoch "
+                   "and cannot transact -- re-invite required after a rekey.")
+    finally:
+        await mod.quit(); await alice.quit(); await bob.quit()
+
+
+# -------------------------------------------------------------------------- D3
+async def test_d3_moderator_restart() -> None:
+    store = f"{STORE_ROOT}/d3"
+    mod, alice = Twin("d3mod", store), Twin("d3alice", store)
+    try:
+        await mod.launch(); await alice.launch()
+        await mod.cmd("create_group", room="d3room")
+        await _join(mod, alice)
+        await mod.cmd("send", text="m1")
+        if (await alice.cmd("recv", timeout=10)).get("payload") != "m1":
+            record("D3 moderator-restart", "FAIL", "baseline moderator->member broken"); return
+
+        await mod.kill()  # the backend / group creator dies
+        await mod.launch()
+        rr = await mod.cmd("restore")
+        n = rr.get("n_sessions")
+        if not n:
+            record("D3 moderator-restart", "FINDING",
+                   f"the group CREATOR restored {n} sessions: a backend bounce cannot resume the "
+                   "moderator role from persistence -- the room must be re-created/re-invited."); return
+
+        await mod.cmd("send", text="m2")
+        recv_ok = (await alice.cmd("recv", timeout=10)).get("payload") == "m2"
+        await alice.cmd("send", text="a1")
+        mg = await mod.cmd("recv", timeout=10)
+        send_ok = mg.get("payload") == "a1"
+        if recv_ok and send_ok:
+            record("D3 moderator-restart", "PASS",
+                   "restored moderator keeps the room live: member still receives moderator "
+                   "broadcasts and the moderator receives member replies.")
+        else:
+            record("D3 moderator-restart", "FINDING",
+                   f"moderator restored a session but recv_ok={recv_ok} send_ok={send_ok}: "
+                   "the room is not fully live after a moderator bounce.")
+    finally:
+        await mod.quit(); await alice.quit()
+
+
+# --------------------------------------------------------------------------- A
+async def test_a_wrong_passphrase() -> None:
+    store = f"{STORE_ROOT}/a"
+    mod, alice = Twin("amod", store), Twin("aalice", store)
+    try:
+        await mod.launch(); await alice.launch()
+        await mod.cmd("create_group", room="aroom")
+        await _join(mod, alice)
+        await mod.cmd("send", text="persist-me")
+        await alice.cmd("recv", timeout=10)  # establish + persist state
+        await alice.kill()
+
+        # Relaunch alice pointed at her EXISTING store but with the WRONG passphrase.
+        ready = await alice.launch(wrong_passphrase=True)
+        if ready.get("error"):
+            record("A wrong-passphrase", "PASS",
+                   f"App refused to open the store with a wrong key at startup: {ready.get('error')}")
+            return
+        rr = await alice.cmd("restore")
+        if rr.get("error") or not rr.get("n_sessions"):
+            record("A wrong-passphrase", "PASS",
+                   f"restore with wrong passphrase yielded no usable session: {rr}")
+            return
+        # restore enumerated a session ROW -- that alone does not prove the key
+        # worked (the MLS secrets may decrypt lazily). Prove USABILITY: can the
+        # wrong-key twin actually receive a group message? If yes, the at-rest key
+        # is NOT load-bearing (a real hole). If no, the key IS load-bearing.
+        await mod.cmd("send", text="after-wrong")
+        got = await alice.cmd("recv", timeout=6)
+        if got.get("ok") and got.get("payload") == "after-wrong":
+            record("A wrong-passphrase", "FAIL",
+                   f"wrong-passphrase twin RECEIVED group traffic ({got}) -- at-rest key is NOT load-bearing!")
+        else:
+            record("A wrong-passphrase", "PASS",
+                   f"restore returned a row (n={rr.get('n_sessions')}) but the wrong-key twin cannot "
+                   f"transact ({got.get('error')}) -- the passphrase IS load-bearing for MLS state.")
+    finally:
+        await mod.quit(); await alice.quit()
+
+
+# --------------------------------------------------------------------------- B
+async def test_b_multi_room_restore() -> None:
+    store = f"{STORE_ROOT}/b"
+    moda, modb, alice = Twin("bmod", store), Twin("bmod2", store), Twin("balice", store)
+    try:
+        await moda.launch(); await modb.launch(); await alice.launch()
+        await moda.cmd("create_group", room="broomA")
+        await modb.cmd("create_group", room="broomB")
+        await _join(moda, alice)
+        await _join(modb, alice)  # same twin, second room -> second persisted session
+        await alice.kill()
+        await alice.launch()
+        rr = await alice.cmd("restore")
+        n = rr.get("n_sessions")
+        if n == 2:
+            record("B multi-room", "PASS", "restore_sessions returned BOTH of the twin's rooms (n=2).")
+        else:
+            record("B multi-room", "FINDING",
+                   f"restore_sessions returned n={n} for a twin in 2 rooms -- multi-room resume "
+                   "does not restore every session in one call.")
+    finally:
+        await moda.quit(); await modb.quit(); await alice.quit()
+
+
+async def main() -> int:
+    import shutil
+
+    shutil.rmtree(STORE_ROOT, ignore_errors=True)
+    shutil.rmtree(CMD_ROOT, ignore_errors=True)
+
+    print("== spike v2: faithful two-process twin restart matrix ==", flush=True)
+    test_c_psk_cannot_persist()
+    for name, coro in [
+        ("D1", test_d1_clean_restart()),
+        ("D2", test_d2_epoch_change_offline()),
+        ("D3", test_d3_moderator_restart()),
+        ("A", test_a_wrong_passphrase()),
+        ("B", test_b_multi_room_restore()),
+    ]:
+        try:
+            await coro
+        except Exception as exc:  # noqa: BLE001
+            record(name, "ERROR", f"{type(exc).__name__}: {exc}")
+
+    print("\n== summary ==", flush=True)
+    for test, verdict, detail in results:
+        print(f"  {verdict:7} {test:22} {detail}", flush=True)
+    failed = [r for r in results if r[1] in ("FAIL", "ERROR")]
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/docs/design/twin-sessions-spike/twin_common.py
+++ b/docs/design/twin-sessions-spike/twin_common.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared SLIM/twin helpers for the #662 spike v2 harness.
+
+Factored out of `twin_sessions_spike.py` (v1) so the two-process harness
+(`twin_runner.py` + `spike_v2.py`) builds identical twins: same SignerJwt
+identity path, same persistence config, same MLS group session config.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import hmac
+import os
+from pathlib import Path
+
+import slim_bindings
+
+ISSUER = os.environ.get("SIGNERJWT_ISSUER", "mycelium-resident")
+AUDIENCE = [os.environ.get("SIGNERJWT_AUDIENCE", "mycelium-slim")]
+ORG, NS = "mycelium", "default"
+
+# The at-rest passphrase boundary (Q4): HMAC(server session secret, handle) so
+# each twin store gets a distinct key. Deliberately NOT the OIDC/SignerJwt token.
+_SESSION_SECRET = os.environ.get("MYCELIUM_TWIN_STORE_SECRET", "dev-twin-store-secret-do-not-ship")
+
+
+def store_passphrase(handle: str) -> str:
+    return hmac.new(_SESSION_SECRET.encode(), handle.encode(), hashlib.sha256).hexdigest()
+
+
+def store_path(store_root: str, handle: str) -> str:
+    p = Path(store_root) / handle
+    p.mkdir(parents=True, exist_ok=True)
+    return str(p / "mls-state.sqlite")
+
+
+def _read(path: str) -> str:
+    with open(path) as fh:
+        return fh.read()
+
+
+def signerjwt_identity(keydir: str, name: str):
+    """Per-actor SignerJwt provider + roster-JWKS verifier (mirrors #587)."""
+    encoding_key = slim_bindings.JwtKeyConfig(
+        algorithm=slim_bindings.JwtAlgorithm.ES256,
+        format=slim_bindings.JwtKeyFormat.PEM,
+        key=slim_bindings.JwtKeyData.DATA(value=_read(f"{keydir}/{name}.pk8.pem")),  # type: ignore[call-arg]
+    )
+    provider = slim_bindings.IdentityProviderConfig.JWT(
+        config=slim_bindings.ClientJwtAuth(
+            key=slim_bindings.JwtKeyType.ENCODING(key=encoding_key),  # type: ignore[call-arg]
+            audience=AUDIENCE,
+            issuer=ISSUER,
+            subject=name,
+            duration=datetime.timedelta(seconds=3600),
+        )
+    )
+    decoding_key = slim_bindings.JwtKeyConfig(
+        algorithm=slim_bindings.JwtAlgorithm.ES256,
+        format=slim_bindings.JwtKeyFormat.JWKS,
+        key=slim_bindings.JwtKeyData.DATA(value=_read(f"{keydir}/roster-jwks.json")),  # type: ignore[call-arg]
+    )
+    verifier = slim_bindings.IdentityVerifierConfig.JWT(
+        config=slim_bindings.JwtAuth(
+            key=slim_bindings.JwtKeyType.DECODING(key=decoding_key),  # type: ignore[call-arg]
+            audience=AUDIENCE,
+            issuer=ISSUER,
+            subject=None,
+            duration=datetime.timedelta(seconds=3600),
+        )
+    )
+    return provider, verifier
+
+
+def group_session_config():
+    return slim_bindings.SessionConfig(
+        session_type=slim_bindings.SessionType.GROUP,
+        max_retries=5,
+        interval=datetime.timedelta(seconds=5),
+        metadata={},
+        mls_settings=slim_bindings.MlsSettings(
+            header_integrity_validation_percent=100,
+            max_seen_control_message_ids_size=None,
+        ),
+    )
+
+
+def persistence_config(store_root: str, handle: str, *, passphrase: str | None = None):
+    """PersistenceConfig for a twin. `passphrase` override lets the wrong-key test
+    point a fresh App at an existing store with the WRONG key."""
+    return slim_bindings.PersistenceConfig(
+        path=store_path(store_root, handle),
+        passphrase=passphrase if passphrase is not None else store_passphrase(handle),
+    )
+
+
+async def make_twin_app(svc, conn, keydir, store_root, handle, *, passphrase=None):
+    """Create ONE persistence-backed, SignerJwt-identified twin App + subscribe.
+
+    Note (finding C): there is no `create_app_with_secret_and_persistence` in the
+    2.1.0 wheel -- persistence REQUIRES the identity provider/verifier pair, so a
+    twin cannot run on the default PSK tier. Persistence mandates signerjwt/spire.
+    """
+    provider, verifier = signerjwt_identity(keydir, handle)
+    name = slim_bindings.Name(ORG, NS, handle)
+    app = await svc.create_app_with_persistence_async(
+        name,
+        provider,
+        verifier,
+        slim_bindings.Direction.BIDIRECTIONAL,
+        persistence_config(store_root, handle, passphrase=passphrase),
+    )
+    await app.subscribe_async(name, conn)
+    return app, name
+
+
+def sender_leaf(ctx) -> str:
+    """Best-effort recover the sender's Name leaf from a MessageContext."""
+    for attr in ("source_name", "source", "name"):
+        val = getattr(ctx, attr, None)
+        if val is None:
+            continue
+        for meth in ("components", "as_tuple"):
+            fn = getattr(val, meth, None)
+            if callable(fn):
+                try:
+                    return fn()[-1]
+                except Exception:  # noqa: BLE001
+                    pass
+        return str(val)
+    return repr(ctx)

--- a/docs/design/twin-sessions-spike/twin_runner.py
+++ b/docs/design/twin-sessions-spike/twin_runner.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A single SLIM twin as its OWN OS process, driven by a file-command protocol.
+
+This is what v1 could not do: a *faithful* restart. v1 simulated a twin restart by
+dropping an in-memory App inside one process, which left the crashed App's
+subscription registered over the shared connection (the confounder documented in
+the v1 README). Here each twin is a real subprocess: SIGKILL drops its connection,
+the node forgets its subscription, and a fresh subprocess resumes from the on-disk
+MLS state with `restore_sessions(new_conn_id)` -- exactly a backend/twin bounce.
+
+The orchestrator (`spike_v2.py`) drives this process by dropping JSON command files
+into `--cmddir` and reading JSON result files back. One command at a time; the
+runner blocks on each until done, so the event loop keeps servicing SLIM control
+traffic (invites, MLS Commits) between commands.
+
+Commands (JSON on stdin-less file protocol):
+  {"op":"create_group","room":R}   moderator: create the MLS GROUP
+  {"op":"join"}                    member: listen_for_session (await invite)
+  {"op":"invite","handle":H}       moderator: route + invite H into the group
+  {"op":"remove","handle":H}       moderator: remove H (advances the MLS epoch)
+  {"op":"restore"}                 resume sessions from persisted state; -> n
+  {"op":"send","text":T}           publish T to the group
+  {"op":"recv","timeout":S}        get one message (-> payload+sender or timeout)
+  {"op":"quit"}                    exit 0
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import json
+import os
+from pathlib import Path
+
+import slim_bindings
+
+import twin_common as tc
+
+
+def _atomic_write(path: Path, obj) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(obj))
+    tmp.rename(path)
+
+
+def _epoch(session) -> int | None:
+    for attr in ("epoch", "mls_epoch", "current_epoch"):
+        val = getattr(session, attr, None)
+        if isinstance(val, int):
+            return val
+    return None
+
+
+class Runner:
+    def __init__(self, args) -> None:
+        self.args = args
+        self.conn: int | None = None
+        self.app = None
+        self.session = None
+
+    async def start(self) -> None:
+        slim_bindings.initialize_with_defaults()
+        svc = slim_bindings.get_global_service()
+        self.conn = await svc.connect_async(
+            slim_bindings.new_insecure_client_config(self.args.endpoint)
+        )
+        wrong = self.args.wrong_passphrase
+        self.app, self.name = await tc.make_twin_app(
+            svc,
+            self.conn,
+            self.args.keydir,
+            self.args.store,
+            self.args.handle,
+            passphrase=("WRONG-" + tc.store_passphrase(self.args.handle)) if wrong else None,
+        )
+        _atomic_write(Path(self.args.cmddir) / "ready.json", {"handle": self.args.handle, "conn": self.conn})
+
+    async def _exec(self, cmd: dict) -> dict:  # noqa: PLR0911, PLR0912 -- flat dispatch
+        op = cmd["op"]
+        try:
+            if op == "create_group":
+                room = slim_bindings.Name(tc.ORG, tc.NS, cmd["room"])
+                created = self.app.create_session(tc.group_session_config(), room)
+                await created.completion.wait_async()
+                self.session = created.session
+                return {"ok": True, "epoch": _epoch(self.session)}
+            if op == "join":
+                self.session = await self.app.listen_for_session_async(None)
+                return {"ok": True, "epoch": _epoch(self.session)}
+            if op == "invite":
+                target = slim_bindings.Name(tc.ORG, tc.NS, cmd["handle"])
+                await self.app.set_route_async(target, self.conn)
+                handle = await self.session.invite_async(target)
+                await handle.wait_async()
+                return {"ok": True, "epoch": _epoch(self.session)}
+            if op == "remove":
+                target = slim_bindings.Name(tc.ORG, tc.NS, cmd["handle"])
+                handle = await self.session.remove_async(target)
+                await handle.wait_async()
+                return {"ok": True, "epoch": _epoch(self.session)}
+            if op == "restore":
+                sessions = await self.app.restore_sessions_async(self.conn)
+                self.session = sessions[0] if sessions else None
+                return {"ok": True, "n_sessions": len(sessions), "epoch": _epoch(self.session)}
+            if op == "send":
+                if self.session is None:
+                    return {"ok": False, "error": "no session"}
+                await self.session.publish_async(cmd["text"].encode(), None, None)
+                return {"ok": True}
+            if op == "recv":
+                if self.session is None:
+                    return {"ok": False, "error": "no session"}
+                timeout = datetime.timedelta(seconds=cmd.get("timeout", 10))
+                msg = await self.session.get_message_async(timeout=timeout)
+                return {"ok": True, "payload": msg.payload.decode(errors="replace"),
+                        "sender": tc.sender_leaf(msg.context)}
+            if op == "quit":
+                return {"ok": True, "quit": True}
+        except Exception as exc:  # noqa: BLE001 -- spike: report the exact failure
+            return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+        return {"ok": False, "error": f"unknown op {op!r}"}
+
+    async def loop(self) -> int:
+        cmddir = Path(self.args.cmddir)
+        seq = 1
+        while True:
+            cmd_path = cmddir / f"cmd-{seq}.json"
+            if not cmd_path.exists():
+                await asyncio.sleep(0.03)
+                continue
+            cmd = json.loads(cmd_path.read_text())
+            res = await self._exec(cmd)
+            _atomic_write(cmddir / f"res-{seq}.json", res)
+            if cmd["op"] == "quit":
+                return 0
+            seq += 1
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--handle", required=True)
+    ap.add_argument("--endpoint", required=True)
+    ap.add_argument("--keydir", required=True)
+    ap.add_argument("--store", required=True)
+    ap.add_argument("--cmddir", required=True)
+    ap.add_argument("--wrong-passphrase", action="store_true")
+    args = ap.parse_args()
+    Path(args.cmddir).mkdir(parents=True, exist_ok=True)
+    runner = Runner(args)
+    try:
+        await runner.start()
+    except Exception as exc:  # noqa: BLE001
+        _atomic_write(Path(args.cmddir) / "ready.json", {"handle": args.handle, "error": f"{type(exc).__name__}: {exc}"})
+        return 2
+    return await runner.loop()
+
+
+if __name__ == "__main__":
+    os.chdir(Path(__file__).parent)  # so `import twin_common` resolves
+    raise SystemExit(asyncio.run(main()))

--- a/docs/design/twin-sessions-spike/twin_sessions_spike.py
+++ b/docs/design/twin-sessions-spike/twin_sessions_spike.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Server-side per-actor "twin" SLIM/MLS sessions spike (issue #662).
+
+Today the mycelium backend is a **single SLIM/MLS member per room that
+impersonates every actor** (a service account). Attribution ("@alice said this")
+is stamped by the backend at the L9/transcript layer *after the fact* --
+application-level, forgeable by the backend, invisible on the wire.
+
+This spike proves the decided direction: the backend as a **custodian of N
+per-actor twin Apps**, each a *genuine* MLS member carrying its **own per-actor
+SignerJwt identity** (the #476/#585 credential), all hosted **server-side** in one
+process. Which actor can touch which room is then enforced by **MLS group
+membership**, not by mycelium app logic.
+
+It answers the six spike questions from the issue:
+
+  Q1  Stand up N twins (>=2 per-actor Apps) in one backend process, each with its
+      own SignerJwt identity, all joined to ONE room GROUP -- confirm distinct,
+      cryptographically-attributable membership on the wire.
+  Q2  Confirm PersistenceConfig / create_app_with_persistence / restore_sessions
+      are reachable from the pinned slim-bindings==2.1.0 wheel (not just Rust).
+  Q3  Resume: tear a twin down (simulated restart) and restore_sessions its
+      persisted state -- confirm it rejoins its MLS group with NO re-invite.
+  Q4  Where the per-twin store lives (server-side) and what the passphrase derives
+      from (the real at-rest confidentiality boundary -- NOT the OIDC token).
+  Q6  Cost: N Apps multiplexed over ONE shared dataplane connection (one socket),
+      not N sockets.
+
+The honest scope boundary (stated plainly, not oversold): twins are
+**server-side**, so the hub still holds every twin's private key + plaintext. This
+hardens **the wire and attribution** and finally makes per-agent identity true at
+the MLS layer -- but it is **NOT** E2E-from-the-hub. A malicious hub still sees and
+can impersonate everything. Confidentiality-from-the-hub is a different axis
+(#664 Mode 2, deliberately out of scope).
+
+Run: `./run.sh` (stands up a stock SLIM 2.1.0 node on :46359, mints one ES256
+keypair per twin + a roster JWKS, execs this on the host). Env:
+SLIM_ENDPOINT=http://127.0.0.1:46359, KEYDIR=/tmp/twin-sessions-spike,
+TWINS="backend alice bob carol".
+
+Matched stack (proven by #587/#583): slim-bindings==2.1.0 (PyPI) +
+ghcr.io/agntcy/slim:2.1.0. Signing keys must be PKCS#8 PEM (run.sh converts).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import hashlib
+import hmac
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import slim_bindings
+
+SLIM = os.environ.get("SLIM_ENDPOINT", "http://127.0.0.1:46359")
+KEYDIR = os.environ.get("KEYDIR", "/tmp/twin-sessions-spike")
+STORE = os.environ.get("TWIN_STORE", f"{KEYDIR}/twin-store")
+
+ISSUER = os.environ.get("SIGNERJWT_ISSUER", "mycelium-resident")
+AUDIENCE = [os.environ.get("SIGNERJWT_AUDIENCE", "mycelium-slim")]
+
+ORG, NS, ROOM = "mycelium", "default", "twin-room"
+# First twin is the moderator (the always-on backend citizen); the rest are the
+# per-actor twins the backend custodies. The point of the spike is that the
+# backend does NOT speak for alice/bob/carol -- each has its own App + identity.
+TWINS = os.environ.get("TWINS", "backend alice bob carol").split()
+MODERATOR = TWINS[0]
+ACTORS = TWINS[1:]
+
+# The at-rest passphrase boundary (Q4). Derived here from a per-host session
+# secret HMAC'd with the actor handle so each twin store gets a DISTINCT key and
+# one leaked passphrase does not open every twin. In production this session
+# secret is a server-held secret (e.g. MYCELIUM_TWIN_STORE_SECRET / a KMS-wrapped
+# value) -- deliberately NOT the actor's OIDC/SignerJwt token, which rotates
+# hourly and is not a durable at-rest key. This is the real confidentiality
+# boundary for the twin store and wants its own hardening pass (see README Q4).
+_SESSION_SECRET = os.environ.get("MYCELIUM_TWIN_STORE_SECRET", "dev-twin-store-secret-do-not-ship")
+
+
+def _store_passphrase(handle: str) -> str:
+    return hmac.new(_SESSION_SECRET.encode(), handle.encode(), hashlib.sha256).hexdigest()
+
+
+def _store_path(handle: str) -> str:
+    # Server-side, per-twin, under the hub's data dir (~/.mycelium/-style). One
+    # SQLite MLS state store per actor; AES-256-GCM at rest under the passphrase.
+    p = Path(STORE) / handle
+    p.mkdir(parents=True, exist_ok=True)
+    return str(p / "mls-state.sqlite")
+
+
+def _read(path: str) -> str:
+    with open(path) as fh:
+        return fh.read()
+
+
+def signerjwt_identity(name: str):
+    """Per-actor SignerJwt provider + roster-JWKS verifier (mirrors #587).
+
+    Provider: sign this twin's own JWT with its local PKCS#8 ES256 key. Verifier:
+    trust the room roster's public keys (static multi-key JWKS). This is what
+    makes each twin a cryptographically distinct MLS participant -- the backend
+    cannot mint alice's token without alice's private key.
+    """
+    encoding_key = slim_bindings.JwtKeyConfig(
+        algorithm=slim_bindings.JwtAlgorithm.ES256,
+        format=slim_bindings.JwtKeyFormat.PEM,
+        key=slim_bindings.JwtKeyData.DATA(value=_read(f"{KEYDIR}/{name}.pk8.pem")),  # type: ignore[call-arg]
+    )
+    provider = slim_bindings.IdentityProviderConfig.JWT(
+        config=slim_bindings.ClientJwtAuth(
+            key=slim_bindings.JwtKeyType.ENCODING(key=encoding_key),  # type: ignore[call-arg]
+            audience=AUDIENCE,
+            issuer=ISSUER,
+            subject=name,  # the mycelium @handle -- the SLIM Name leaf
+            duration=datetime.timedelta(seconds=3600),
+        )
+    )
+    decoding_key = slim_bindings.JwtKeyConfig(
+        algorithm=slim_bindings.JwtAlgorithm.ES256,
+        format=slim_bindings.JwtKeyFormat.JWKS,
+        key=slim_bindings.JwtKeyData.DATA(value=_read(f"{KEYDIR}/roster-jwks.json")),  # type: ignore[call-arg]
+    )
+    verifier = slim_bindings.IdentityVerifierConfig.JWT(
+        config=slim_bindings.JwtAuth(
+            key=slim_bindings.JwtKeyType.DECODING(key=decoding_key),  # type: ignore[call-arg]
+            audience=AUDIENCE,
+            issuer=ISSUER,
+            subject=None,
+            duration=datetime.timedelta(seconds=3600),
+        )
+    )
+    return provider, verifier
+
+
+def group_session_config():
+    return slim_bindings.SessionConfig(
+        session_type=slim_bindings.SessionType.GROUP,
+        max_retries=5,
+        interval=datetime.timedelta(seconds=5),
+        metadata={},
+        mls_settings=slim_bindings.MlsSettings(
+            header_integrity_validation_percent=100,
+            max_seen_control_message_ids_size=None,
+        ),
+    )
+
+
+def persistence_config(handle: str):
+    # Q2 + Q4: the persistence seam. `path` is the server-side per-twin store;
+    # `passphrase` is the at-rest key. Both keyword-only in the 2.1.0 wheel.
+    return slim_bindings.PersistenceConfig(
+        path=_store_path(handle),
+        passphrase=_store_passphrase(handle),
+    )
+
+
+async def make_twin(svc, conn, name: str):
+    """Create ONE persistence-backed, SignerJwt-identified twin App + subscribe.
+
+    This is the load-bearing call for the spike: `create_app_with_persistence_async`
+    with a per-actor identity. N of these in one process == a twin fleet.
+    """
+    provider, verifier = signerjwt_identity(name)
+    slim_name = slim_bindings.Name(ORG, NS, name)
+    app = await svc.create_app_with_persistence_async(
+        slim_name,
+        provider,
+        verifier,
+        slim_bindings.Direction.BIDIRECTIONAL,
+        persistence_config(name),
+    )
+    await app.subscribe_async(slim_name, conn)
+    return app, slim_name
+
+
+def _sender_leaf(ctx) -> str:
+    """Best-effort recover the sender's Name leaf from a MessageContext.
+
+    The whole point of twins: the on-the-wire source of alice's message is
+    alice's App, not the backend. We surface whatever the binding exposes so the
+    attribution is visibly cryptographic, not a backend-stamped field.
+    """
+    for attr in ("source_name", "source", "name"):
+        val = getattr(ctx, attr, None)
+        if val is None:
+            continue
+        for meth in ("components", "as_tuple"):
+            fn = getattr(val, meth, None)
+            if callable(fn):
+                try:
+                    return fn()[-1]
+                except Exception:  # noqa: BLE001
+                    pass
+        return str(val)
+    return repr(ctx)
+
+
+async def main() -> int:  # noqa: PLR0915 -- spike: linear narrative is the point
+    # Fresh store each run so Q3's "restore" is unambiguous.
+    shutil.rmtree(STORE, ignore_errors=True)
+
+    slim_bindings.initialize_with_defaults()
+    svc = slim_bindings.get_global_service()
+
+    # Q6: ONE dataplane connection for the whole fleet. Every twin App multiplexes
+    # over this single conn_id -- N twins, one socket, not N sockets.
+    conn = await svc.connect_async(slim_bindings.new_insecure_client_config(SLIM))
+    print(f"[fleet] one shared dataplane connection: conn_id={conn}", flush=True)
+
+    # ---- Q1: stand up the twin fleet, all in this one process ----
+    mod_app, _ = await make_twin(svc, conn, MODERATOR)
+    twins: dict[str, object] = {}
+    twin_names: dict[str, object] = {}
+    for name in ACTORS:
+        app, slim_name = await make_twin(svc, conn, name)
+        twins[name] = app
+        twin_names[name] = slim_name
+    print(
+        f"[fleet] {len(ACTORS)} persistence-backed SignerJwt twins created "
+        f"in ONE process: {', '.join(ACTORS)}",
+        flush=True,
+    )
+
+    room = slim_bindings.Name(ORG, NS, ROOM)
+    created = mod_app.create_session(group_session_config(), room)
+    await created.completion.wait_async()
+    session = created.session
+    print(f"[{MODERATOR}] MLS GROUP session established (moderator).", flush=True)
+
+    # Each twin waits for its invite, then speaks once so the moderator can read
+    # the on-the-wire sender identity.
+    ready: dict[str, asyncio.Event] = {n: asyncio.Event() for n in ACTORS}
+    joined_sessions: dict[str, object] = {}
+
+    async def twin_wait(name: str):
+        s = await twins[name].listen_for_session_async(None)
+        joined_sessions[name] = s
+        ready[name].set()
+        await s.publish_async(f"{name}: hello over MLS as myself".encode(), None, None)
+
+    waiters = [asyncio.create_task(twin_wait(n)) for n in ACTORS]
+
+    for name in ACTORS:
+        await mod_app.set_route_async(twin_names[name], conn)
+        handle = await session.invite_async(twin_names[name])
+        await handle.wait_async()
+        await asyncio.wait_for(ready[name].wait(), timeout=30)
+        print(f"[{MODERATOR}] invited + MLS-verified twin '{name}'.", flush=True)
+
+    # ---- Q1 (cont.): read each twin's message; prove distinct wire attribution ----
+    seen: dict[str, str] = {}
+    for _ in ACTORS:
+        msg = await session.get_message_async(timeout=datetime.timedelta(seconds=30))
+        leaf = _sender_leaf(msg.context)
+        seen[leaf] = msg.payload.decode()
+        print(f"[{MODERATOR}] wire sender={leaf!r} payload={msg.payload.decode()!r}", flush=True)
+
+    await asyncio.gather(*waiters)
+    distinct = {k for k in seen if k in ACTORS}
+    if len(distinct) != len(ACTORS):
+        # Surface, don't hide: if the binding does not expose per-twin source on
+        # the moderator's inbound context, the attribution claim is unproven.
+        print(
+            f"\nWARN: distinct wire senders={sorted(distinct)} but expected {ACTORS}. "
+            "Twin membership is real (each invite ran MLS peer-verification of a "
+            "DISTINCT SignerJwt), but this binding did not surface per-sender "
+            "source on the moderator's inbound MessageContext.",
+            flush=True,
+        )
+    else:
+        print(f"[fleet] distinct cryptographic wire senders: {sorted(distinct)}", flush=True)
+
+    # ---- Q3: resume one twin from its persisted MLS state, NO re-invite ----
+    victim = ACTORS[0]
+    print(f"\n[resume] simulating a restart of twin '{victim}' ...", flush=True)
+    # Drop every in-memory handle to the victim's App + its joined session WITHOUT
+    # a graceful leave. A graceful `delete_session` removes the member from the
+    # MLS group AND purges its persisted state -- the opposite of a crash. A real
+    # restart just loses the process: the on-disk MLS state is all that survives,
+    # so we only drop references and let GC reclaim the App. `restore_sessions`
+    # then recovers the group membership from disk (see the returned session
+    # count below). One caveat this single-process sim exposes: the crashed App's
+    # subscription for the victim's Name is still registered over the SHARED conn
+    # (a real crash drops the conn and the node forgets it), so we verify the
+    # resume by having the revived twin SEND rather than depending on the node
+    # re-routing inbound to the fresh subscription.
+    twins.pop(victim)
+    joined_sessions.pop(victim, None)
+    import gc
+
+    gc.collect()
+
+    # Re-create the App against the SAME store path + passphrase, then restore.
+    revived, revived_name = await make_twin(svc, conn, victim)
+    restored = await revived.restore_sessions_async(conn)
+    print(
+        f"[resume] restore_sessions('{victim}') returned {len(restored)} session(s) "
+        "from persisted MLS state (no invite/welcome replayed).",
+        flush=True,
+    )
+    if not restored:
+        print(
+            "\nFAIL: restore_sessions returned no sessions -- the twin did not "
+            "rejoin its MLS group from persisted state.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+
+    # Prove the restored MLS state is USABLE: the revived twin transacts on the
+    # restored session at the group's current epoch, with no re-invite. It SENDS
+    # (encrypts to the live group key it recovered from disk) and the moderator
+    # decrypts + attributes it -- a direct proof the crypto epoch survived, and
+    # one that does not depend on the node re-routing to the fresh subscription.
+    revived_session = restored[0]
+    proof = f"{victim}: back from persisted MLS state".encode()
+    await revived_session.publish_async(proof, None, None)
+    got = await session.get_message_async(timeout=datetime.timedelta(seconds=30))
+    leaf = _sender_leaf(got.context)
+    print(
+        f"[resume] moderator decrypted post-restore msg from wire sender={leaf!r}: "
+        f"{got.payload.decode()!r}",
+        flush=True,
+    )
+    if got.payload != proof:
+        print("\nFAIL: revived twin's post-restore message did not round-trip.", file=sys.stderr, flush=True)
+        return 1
+
+    # ---- Q4: report where the store lives + the passphrase boundary ----
+    print("\n[store] per-twin server-side MLS state (Q4):", flush=True)
+    for name in TWINS:
+        path = _store_path(name)
+        size = Path(path).stat().st_size if Path(path).exists() else 0
+        print(f"  {name:10} {path}  ({size} bytes, AES-256-GCM at rest)", flush=True)
+    print(
+        "  passphrase = HMAC(server session secret, handle) -- distinct per twin, "
+        "NOT the OIDC/SignerJwt token.",
+        flush=True,
+    )
+
+    print(
+        f"\nPASS: {len(ACTORS)} per-actor SignerJwt twins (persistence-backed) shared "
+        f"one MLS GROUP over one socket; twin '{victim}' resumed from persisted "
+        "state with no re-invite.",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(asyncio.run(main()))
+    except Exception as exc:  # noqa: BLE001 -- spike: surface the exact failure
+        print(f"\nFAIL: {type(exc).__name__}: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/docs/design/twin-sessions-spike/twin_sessions_spike.py
+++ b/docs/design/twin-sessions-spike/twin_sessions_spike.py
@@ -331,11 +331,24 @@ async def main() -> int:  # noqa: PLR0915 -- spike: linear narrative is the poin
         return 1
 
     # ---- Q4: report where the store lives + the passphrase boundary ----
-    print("\n[store] per-twin server-side MLS state (Q4):", flush=True)
+    # `path` is treated by agntcy-slim-persistence as a DIRECTORY; it writes a real
+    # SQLite DB (WAL mode) inside, so we sum the files it created, not stat the dir.
+    print("\n[store] per-twin server-side agntcy-slim-persistence SQLite store (Q4):", flush=True)
     for name in TWINS:
-        path = _store_path(name)
-        size = Path(path).stat().st_size if Path(path).exists() else 0
-        print(f"  {name:10} {path}  ({size} bytes, AES-256-GCM at rest)", flush=True)
+        store_dir = Path(_store_path(name))
+        files = list(store_dir.glob("*")) if store_dir.is_dir() else []
+        total = sum(f.stat().st_size for f in files if f.is_file())
+        dbs = [f.name for f in files if f.suffix == ".db"]
+        print(
+            f"  {name:10} {store_dir}/  ({total} bytes across {len(files)} file(s); "
+            f"db={dbs[0] if dbs else '?'})",
+            flush=True,
+        )
+    print(
+        "  DB container is standard SQLite (WAL); the passphrase encrypts the MLS "
+        "state blobs (AES-256-GCM), not the whole file.",
+        flush=True,
+    )
     print(
         "  passphrase = HMAC(server session secret, handle) -- distinct per twin, "
         "NOT the OIDC/SignerJwt token.",


### PR DESCRIPTION
Closes the spike ask in #662 (spike, not a rearchitecture commitment).

## What this is
Proves the decided direction end-to-end: the backend as a **custodian of N per-actor "twin" SLIM Apps**, each a genuine MLS member with its **own** SignerJwt identity, all hosted server-side in one process and joined to one room GROUP. Access becomes MLS-group-membership-enforced instead of app-logic-enforced; attribution moves onto the wire instead of being backend-stamped after the fact. All backend cognition still reads plaintext.

Additive and off-by-default. Leaves the current server-held-membership model and `persister.py` untouched.

## Validated live (stock `ghcr.io/agntcy/slim:2.1.0` node, `slim-bindings==2.1.0`)

| Q | Question | Result |
|---|----------|--------|
| Q1 | N twins in one process, distinct wire attribution | **YES** -- 3 twins, one GROUP, `distinct cryptographic wire senders: ['alice','bob','carol']` |
| Q2 | persistence API reachable from the 2.1.0 wheel | **YES** -- `Service.create_app_with_persistence_async`, `App.restore_sessions_async`, `PersistenceConfig(path, passphrase)` (methods, not free functions) |
| Q3 | resume without a re-invite | **YES** -- `restore_sessions` recovers the group from disk; revived twin transacts at the current MLS epoch, no welcome/commit replay |
| Q4 | store location + passphrase boundary | per-twin server-side SQLite, AES-256-GCM; passphrase = `HMAC(server session secret, handle)`, **not** the OIDC token |
| Q6 | cost | whole fleet multiplexes **one** dataplane connection (one socket) |

Q5 (lifecycle: ties to #663 / #590 / #656 / #657) is noted, not built.

## Honest scope boundary
Twins are **server-side**, so the hub still holds every twin's key + plaintext. This hardens the **wire + attribution** and makes **per-agent identity true at the MLS layer** (today the identity epic only identifies the backend's single App). It is **NOT** E2E-from-the-hub -- that is a different axis (#664 Mode 2), deliberately out of scope and not required by twins.

## Findings worth reading
- `create_app_with_persistence` is a **`Service` method**, not the free function the Rust source reading suggested.
- SLIM persistence resumes **crypto state only**, never missed messages -- so the durable transcript/inbox stays as the offline-replay mechanism.
- A graceful `delete_session` purges persisted state (it is a real leave, not a crash); the faithful crash sim just drops the App and lets `restore_sessions` recover from disk.
- Single-process resume has a stale-subscription confounder on inbound routing; the spike proves resume via the revived twin **sending**. A true two-process kill/restart is the clean follow-up.

## Contents
`docs/design/twin-sessions-spike/`: `README.md` (full report), `twin_sessions_spike.py`, `run.sh` (one-command repro), `build_roster_jwks.py`.

Run: `cd docs/design/twin-sessions-spike && ./run.sh` (needs docker + openssl + the `fastapi-backend` uv env).