### PR TITLE
Document two-plane security; persist hub SLIM PSK in config.toml

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -69,6 +69,7 @@ SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
     # CLI + Config blocks injected after architecture, before guides/troubleshooting.
     ("guides/structured-memory.md", "structured-memory",  "reference", "Guides",       "Structured Memory"),
     ("guides/hub-and-spoke.md",     "hub-and-spoke",      "reference", "Guides",       "Hub & Spoke"),
+    ("guides/security-planes.md",   "security-planes",    "reference", "Guides",       "Security Planes"),
     ("guides/auth.md",              "auth",               "reference", "Guides",       "Authentication"),
     ("guides/keycloak-oidc.md",     "keycloak-oidc",      "reference", "Guides",       "Keycloak / OIDC Setup"),
     ("guides/spire-identity.md",    "spire-identity",     "reference", "Guides",       "Attested Identity (SPIRE)"),

--- a/mycelium-cli/src/mycelium/commands/config.py
+++ b/mycelium-cli/src/mycelium/commands/config.py
@@ -58,6 +58,13 @@ def show(ctx: typer.Context) -> None:
             if config.llm.api_key:
                 masked = config.llm.api_key[:8] + "..." if len(config.llm.api_key) > 8 else "***"
                 typer.echo(f"  LLM API Key:  {masked}")
+            if config.slim.master_secret:
+                masked = (
+                    config.slim.master_secret[:8] + "..."
+                    if len(config.slim.master_secret) > 8
+                    else "***"
+                )
+                typer.echo(f"  SLIM PSK:     {masked}  (hub-only)")
             typer.echo(f"  Backend Port: {config.runtime.backend_port}")
 
     except Exception as e:
@@ -127,6 +134,15 @@ def set_config(
             f"Set {key} = {value[:20]}{'...' if len(value) > 20 else ''}",
             fg=typer.colors.GREEN,
         )
+        if key == "slim.identity" and str(parsed_value).lower() in (
+            "signerjwt",
+            "spire",
+        ):
+            typer.echo(
+                "[dim]SLIM channel identity (native SLIM clients on the hub). "
+                "Does not enable HTTP API auth — configure auth.enabled separately "
+                "for shared spokes.[/dim]"
+            )
 
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False
@@ -208,8 +224,13 @@ def apply_config(
 
         from mycelium.docker_utils import write_env_file
 
-        env_path = write_env_file(config)
+        env_path, secret_assigned = write_env_file(config)
         typer.secho(f"  ✓ Wrote {env_path}", fg=typer.colors.GREEN)
+        if secret_assigned:
+            typer.secho(
+                "  ✓ Generated [slim].master_secret (hub SLIM PSK) in config.toml",
+                fg=typer.colors.GREEN,
+            )
 
         if restart:
             typer.echo("  Restarting containers...")
@@ -343,6 +364,11 @@ def _migrate_env_to_config(config: "MyceliumConfig") -> None:
     # Runtime: data dir
     if not config.runtime.data_dir and env.get("MYCELIUM_DATA_DIR"):
         config.runtime.data_dir = env["MYCELIUM_DATA_DIR"]
+        changed = True
+
+    # SLIM: hub master secret (legacy .env → config.toml)
+    if not config.slim.master_secret and env.get("MYCELIUM_SLIM_MASTER_SECRET"):
+        config.slim.master_secret = env["MYCELIUM_SLIM_MASTER_SECRET"]
         changed = True
 
     if changed:

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -517,7 +517,7 @@ def _check_http_auth_gate(*, api_url: str) -> CheckResult:
                 name="HTTP API auth",
                 status=status,
                 message="JWT gate enabled on hub",
-                details=details or None,
+                details=details,
             )
         if remote_target:
             return CheckResult(

--- a/mycelium-cli/src/mycelium/commands/doctor.py
+++ b/mycelium-cli/src/mycelium/commands/doctor.py
@@ -479,6 +479,121 @@ def _check_backend_reachable(*, local_backend: bool = True) -> CheckResult:
         )
 
 
+def _read_env_master_secret() -> str | None:
+    """Return ``MYCELIUM_SLIM_MASTER_SECRET`` from ``~/.mycelium/.env`` if set."""
+    env_path = Path.home() / ".mycelium" / ".env"
+    if not env_path.exists():
+        return None
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, val = stripped.partition("=")
+        if key.strip() == "MYCELIUM_SLIM_MASTER_SECRET":
+            cleaned = val.strip().strip('"').strip("'")
+            return cleaned or None
+    return None
+
+
+def _check_http_auth_gate(*, api_url: str) -> CheckResult:
+    """Warn when the hub HTTP API is reachable but auth is off on a remote URL."""
+    host = (urlparse(api_url).hostname or "").lower()
+    remote_target = host not in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+    try:
+        import httpx
+
+        resp = httpx.get(f"{api_url.rstrip('/')}/health", timeout=5)
+        if resp.status_code >= 500:
+            return CheckResult(
+                name="HTTP API auth",
+                status="warning",
+                message="Could not read auth status from /health",
+            )
+        auth = resp.json().get("auth") or {}
+        if auth.get("enabled"):
+            details = [str(w) for w in auth.get("warnings") or []]
+            status = "warning" if details else "ok"
+            return CheckResult(
+                name="HTTP API auth",
+                status=status,
+                message="JWT gate enabled on hub",
+                details=details or None,
+            )
+        if remote_target:
+            return CheckResult(
+                name="HTTP API auth",
+                status="warning",
+                message=(
+                    "HTTP JWT gate is off — peers can read/write memory and post as any @handle"
+                ),
+                details=[
+                    "Spokes use the HTTP API (:8000), not SLIM PSK.",
+                    "Enable auth.enabled on the hub before sharing over a network.",
+                    "See: mycelium config set auth.enabled true",
+                ],
+            )
+        return CheckResult(
+            name="HTTP API auth",
+            status="ok",
+            message="Off (local backend — expected for try-it)",
+        )
+    except Exception as exc:
+        return CheckResult(
+            name="HTTP API auth",
+            status="warning",
+            message=f"Could not check auth status: {type(exc).__name__}",
+            details=[str(exc)],
+        )
+
+
+def _hub_slim_master_secret() -> str | None:
+    """Return the hub SLIM master secret from config.toml, falling back to .env."""
+    try:
+        from mycelium.config import MyceliumConfig
+
+        secret = MyceliumConfig.load().slim.master_secret
+        if secret:
+            return secret
+    except Exception:
+        pass
+    return _read_env_master_secret()
+
+
+def _check_hub_slim_psk(*, local_backend: bool) -> CheckResult | None:
+    """Hub-only: warn when SLIM keys derive from the public dev master secret."""
+    if not local_backend:
+        return None
+    from mycelium.slim import naming
+
+    secret = _hub_slim_master_secret()
+    if secret and secret != naming._DEV_MASTER_SECRET:
+        return CheckResult(
+            name="SLIM PSK (hub)",
+            status="ok",
+            message="Private slim.master_secret configured",
+        )
+    if not secret:
+        return CheckResult(
+            name="SLIM PSK (hub)",
+            status="warning",
+            message="No hub SLIM master secret in config.toml",
+            details=[
+                "Run: mycelium config apply  (generates [slim].master_secret)",
+                "PSK gates native SLIM group join on the hub — spokes do not use it.",
+            ],
+        )
+    return CheckResult(
+        name="SLIM PSK (hub)",
+        status="warning",
+        message="Hub uses the public dev SLIM master secret",
+        details=[
+            "PSK gates native SLIM group join on the hub — spokes do not use it.",
+            "Run: mycelium config apply  (generates a private [slim].master_secret)",
+            "For spokes on a network, enable auth.enabled (HTTP JWT gate).",
+        ],
+    )
+
+
 # Keys that should match between ~/.mycelium/.env and config.toml. Each entry
 # is (env_key, config_accessor); config_accessor pulls the equivalent value
 # out of a loaded MyceliumConfig. `mycelium config apply` regenerates .env
@@ -952,6 +1067,11 @@ def doctor(
         if local:
             service_checks.append(_check_docker_containers())
         service_checks.append(_check_backend_reachable(local_backend=local))
+        service_checks.append(_check_http_auth_gate(api_url=api_url))
+        if local:
+            psk_check = _check_hub_slim_psk(local_backend=local)
+            if psk_check is not None:
+                service_checks.append(psk_check)
         service_checks.append(_check_llm_connectivity())
         if local:
             service_checks.append(_check_mediator_pi_binary())

--- a/mycelium-cli/src/mycelium/commands/hub.py
+++ b/mycelium-cli/src/mycelium/commands/hub.py
@@ -177,9 +177,7 @@ def connect(
             "  Stored the SLIM node endpoint. Default participation (memory, "
             "await/respond) uses the hub HTTP API (server.api_url), not SLIM."
         )
-        typer.echo(
-            "  Spokes do not need MYCELIUM_SLIM_MASTER_SECRET for that path."
-        )
+        typer.echo("  Spokes do not need MYCELIUM_SLIM_MASTER_SECRET for that path.")
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False
         print_error(e, verbose=verbose)

--- a/mycelium-cli/src/mycelium/commands/hub.py
+++ b/mycelium-cli/src/mycelium/commands/hub.py
@@ -117,7 +117,7 @@ def host(ctx: typer.Context) -> None:
 
         # Self-host: wire this machine up immediately.
         config = MyceliumConfig.load()
-        config.slim = SlimConfig(node_endpoint=local_endpoint)
+        config.slim = config.slim.model_copy(update={"node_endpoint": local_endpoint})
         config.save()
 
         typer.secho("SLIM node running.", fg=typer.colors.GREEN)
@@ -162,11 +162,23 @@ def connect(
         config = MyceliumConfig.load()
         # Construct through SlimConfig so its validator adds the scheme and trims
         # slashes (pydantic v2 doesn't validate plain attribute assignment).
-        config.slim = SlimConfig(node_endpoint=address)
+        normalized = SlimConfig(
+            node_endpoint=address,
+            identity=config.slim.identity,
+            master_secret=config.slim.master_secret,
+        )
+        config.slim = normalized
         config.save()
         typer.secho(
             f"Connected to SLIM node at {config.slim.node_endpoint}",
             fg=typer.colors.GREEN,
+        )
+        typer.echo(
+            "  Stored the SLIM node endpoint. Default participation (memory, "
+            "await/respond) uses the hub HTTP API (server.api_url), not SLIM."
+        )
+        typer.echo(
+            "  Spokes do not need MYCELIUM_SLIM_MASTER_SECRET for that path."
         )
     except Exception as e:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False

--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -611,8 +611,10 @@ def _write_mycelium_config(
     config.save(config_path)
 
     # Derive .env from the canonical config.toml
-    env_path = write_env_file(config)
+    env_path, secret_assigned = write_env_file(config)
     typer.echo(f"  ✓ Regenerated {env_path} from config.toml")
+    if secret_assigned:
+        typer.echo("  ✓ Generated [slim].master_secret (hub SLIM PSK)")
 
 
 # ── Animation helper ──────────────────────────────────────────────────────────

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -670,6 +670,8 @@ class MyceliumConfig(BaseModel):
             config_path.parent.mkdir(parents=True, exist_ok=True)
             with open(config_path, "w") as f:
                 toml.dump(config_dict, f)
+            # Holds secrets (slim.master_secret, llm.api_key); keep it owner-only.
+            config_path.chmod(0o600)
             self._write_json_snapshot(config_path.parent)
             return
 
@@ -701,6 +703,8 @@ class MyceliumConfig(BaseModel):
 
         with open(global_path, "w") as f:
             toml.dump(global_dict, f)
+        # Holds secrets (slim.master_secret, llm.api_key); keep it owner-only.
+        global_path.chmod(0o600)
         self._write_json_snapshot(global_path.parent)
 
     def _write_json_snapshot(self, config_dir: Path) -> None:
@@ -724,6 +728,9 @@ class MyceliumConfig(BaseModel):
             # rather than showing as `\u2014`.
             json.dump(snapshot, f, indent=2, ensure_ascii=False)
             f.write("\n")
+        # The snapshot is a full config dump (includes slim.master_secret,
+        # llm.api_key); keep it owner-only, same as config.toml.
+        json_path.chmod(0o600)
 
     def get_data_dir(self) -> Path:
         """Get the resolved data directory."""

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -105,6 +105,29 @@ class SlimConfig(BaseModel):
         ),
     )
 
+    master_secret: str | None = Field(
+        default=None,
+        description=(
+            "Hub-only SLIM PSK master secret. Auto-generated on first "
+            "``mycelium config apply`` / install when unset; rendered to "
+            "``MYCELIUM_SLIM_MASTER_SECRET`` in ~/.mycelium/.env for the backend "
+            "container. Spokes do not need this. Override with "
+            "``mycelium config set slim.master_secret …`` to rotate."
+        ),
+    )
+
+    @field_validator("master_secret")
+    @classmethod
+    def _validate_master_secret(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not stripped:
+            return None
+        if len(stripped) < 32:
+            raise ValueError("slim.master_secret must be at least 32 characters")
+        return stripped
+
     @field_validator("identity")
     @classmethod
     def _validate_identity(cls, v: str) -> str:
@@ -572,6 +595,10 @@ class MyceliumConfig(BaseModel):
             env_config["server"]["api_url"] = api_url
         if slim_endpoint := os.getenv("MYCELIUM_SLIM_ENDPOINT"):
             env_config["slim"]["node_endpoint"] = slim_endpoint
+        if slim_master := os.getenv("MYCELIUM_SLIM_MASTER_SECRET"):
+            env_config["slim"]["master_secret"] = slim_master
+        if slim_identity := os.getenv("MYCELIUM_SLIM_IDENTITY"):
+            env_config["slim"]["identity"] = slim_identity
         if active_room := os.getenv("MYCELIUM_ACTIVE_ROOM"):
             env_config["rooms"]["active"] = active_room
 

--- a/mycelium-cli/src/mycelium/docker_utils.py
+++ b/mycelium-cli/src/mycelium/docker_utils.py
@@ -19,6 +19,7 @@ We round-trip it through the existing .env on regeneration so that
 from __future__ import annotations
 
 import json
+import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -32,6 +33,52 @@ if TYPE_CHECKING:
 # when the key has no natural home in MyceliumConfig (i.e., it's runtime/ops
 # state, not user-tunable configuration).
 _OPERATOR_MANAGED_KEYS: tuple[str, ...] = ("MYCELIUM_IMAGE_TAG",)
+
+_MASTER_SECRET_ENV = "MYCELIUM_SLIM_MASTER_SECRET"
+
+
+def _read_env_value(env_path: Path | None, key: str) -> str | None:
+    """Return a single key from an existing ``.env``, or ``None``."""
+    if env_path is None or not env_path.exists():
+        return None
+    try:
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or "=" not in stripped:
+                continue
+            k, _, value = stripped.partition("=")
+            if k.strip() == key:
+                cleaned = value.strip().strip('"').strip("'")
+                return cleaned or None
+    except OSError:
+        return None
+    return None
+
+
+def ensure_slim_master_secret(config: MyceliumConfig, *, env_path: Path | None = None) -> bool:
+    """Ensure ``config.slim.master_secret`` is set before rendering ``.env``.
+
+    Import order when unset:
+
+    1. Existing ``MYCELIUM_SLIM_MASTER_SECRET`` in ``env_path`` (migration)
+    2. Fresh ``secrets.token_hex(32)`` (first hub install / apply)
+
+    Returns ``True`` when a value was imported or generated (caller should
+    ``config.save()``).
+    """
+    if config.slim.master_secret:
+        return False
+
+    if env_path is None:
+        env_path = config.get_global_config_dir() / ".env"
+
+    imported = _read_env_value(env_path, _MASTER_SECRET_ENV)
+    if imported:
+        config.slim.master_secret = imported
+        return True
+
+    config.slim.master_secret = secrets.token_hex(32)
+    return True
 
 
 def _read_operator_managed_keys(env_path: Path | None) -> dict[str, str]:
@@ -151,10 +198,11 @@ def generate_env_file(
         "",
         "# ── SLIM channel identity (off by default, #567) ─────────────────────────",
         # 'psk' | 'signerjwt' | 'spire'. The backend + CLI both read
-        # MYCELIUM_SLIM_IDENTITY; the shared master secret / require flags and the
-        # SPIRE socket/trust-domain envs stay operator-managed (out of band), same
-        # as today. See slim_identity.py.
+        # MYCELIUM_SLIM_IDENTITY; the shared master secret is authored in
+        # config.toml ([slim].master_secret) and rendered here. SPIRE socket/trust-
+        # domain envs stay operator-managed (out of band). See slim_identity.py.
         f"MYCELIUM_SLIM_IDENTITY={config.slim.identity}",
+        f"MYCELIUM_SLIM_MASTER_SECRET={config.slim.master_secret or ''}",
         "",
         "# ── Frontend dev-mode cross-origin allowlist ─────────────────────────────",
         # Next.js dev server blocks cross-origin requests by default. When running
@@ -185,20 +233,25 @@ def generate_env_file(
     return "\n".join(lines) + "\n"
 
 
-def write_env_file(config: MyceliumConfig, env_path: Path | None = None) -> Path:
+def write_env_file(config: MyceliumConfig, env_path: Path | None = None) -> tuple[Path, bool]:
     """Write (or overwrite) the .env file derived from config.toml.
 
-    Preserves operator-managed pins (currently ``MYCELIUM_IMAGE_TAG``) from
-    the existing .env so that ``mycelium config apply`` doesn't silently
-    roll users back to ``:latest`` after a ``mycelium pull --version``.
+    Ensures ``[slim].master_secret`` is set (import or generate) and persists
+    it to ``config.toml`` when newly assigned. Preserves operator-managed pins
+    (currently ``MYCELIUM_IMAGE_TAG``) from the existing .env.
 
-    Returns the path that was written.
+    Returns ``(path, secret_was_assigned)`` where ``secret_was_assigned`` is
+    ``True`` when a master secret was imported or generated this call.
     """
     if env_path is None:
         env_path = config.get_global_config_dir() / ".env"
     env_path.parent.mkdir(parents=True, exist_ok=True)
 
+    secret_assigned = ensure_slim_master_secret(config, env_path=env_path)
+    if secret_assigned:
+        config.save()
+
     preserved = _read_operator_managed_keys(env_path)
     rendered = generate_env_file(config, image_tag=preserved.get("MYCELIUM_IMAGE_TAG"))
     env_path.write_text(rendered, encoding="utf-8")
-    return env_path
+    return env_path, secret_assigned

--- a/mycelium-cli/src/mycelium/docs/architecture.md
+++ b/mycelium-cli/src/mycelium/docs/architecture.md
@@ -20,25 +20,28 @@ machine) owns the whole agent workflow.
 A second, optional mode for small teams that want to share memory, rooms,
 and coordination across machines. One machine runs the SLIM node and
 backend (the **hub**); other machines run only the CLI + agents (**spokes**)
-and connect to the hub's channel.
+as **thin HTTP clients** to the hub API.
 
 | Role  | What runs locally | When to use |
 |-------|-------------------|-------------|
 | **Hub**   | The SLIM node + the thin FastAPI backend (room moderator). | The team's shared coordination server. One per team. |
-| **Spoke** | CLI + agents only. Points at the hub's SLIM address. | Each teammate's laptop. Agents on the spoke participate in shared rooms hosted by the hub. |
+| **Spoke** | CLI + agents only. Points `server.api_url` at the hub backend. | Each teammate's laptop. Memory and participation go over HTTP `:8000`. |
 
-Stand a hub up and point spokes at it:
+Stand a hub up and point spokes at the **backend** (required):
 
 ```bash
-# On the hub: starts the SLIM node + backend, prints the connect address
+# On the hub: starts the SLIM node + backend
 mycelium hub host
+mycelium up
 
-# On each spoke: point this machine at the hub's channel
-mycelium hub connect http://<hub-ip>:46357
+# On each spoke: point at the hub's HTTP API
+mycelium config set server.api_url http://<hub-ip>:8000
 ```
 
-See the [Hub & Spoke Setup guide](#hub-and-spoke) for step-by-step
-instructions.
+Spokes do not need `MYCELIUM_SLIM_MASTER_SECRET` for the default path. The
+SLIM/MLS fabric is hub-side; spokes use `await`/`respond` over HTTP. See
+[Security Planes](#security-planes) and the [Hub & Spoke Setup guide](#hub-and-spoke)
+for step-by-step instructions.
 
 `mycelium doctor` auto-detects which mode you're in by looking at
 `server.api_url` in `~/.mycelium/config.toml`: if it points to
@@ -72,13 +75,13 @@ mycelium room clone my-project --from http://ec2-host:8000
 Mycelium runs on **one SLIM node** and a thin backend: no database, no
 message broker, no vector store.
 
-Agents coordinate over an [AGNTCY SLIM](https://github.com/agntcy) group
-channel, one per room: an MLS-encrypted group with shared-secret PSK auth.
-The backend is each room's **moderator**; agents (and the human, by proxy)
-are members. Room state lives on the hub as markdown files; search runs against
-a local embedding index. Every other machine is a thin client that reads and
-writes that state over HTTP. Coordination messages ride SLIM as additive
-[L9 envelopes](#l9-protocol).
+The hub backend moderates an [AGNTCY SLIM](https://github.com/agntcy) group
+channel per room (MLS-encrypted; PSK or SignerJwt/SPIRE on the **SLIM plane**).
+Turn-based agents on spokes (and humans by proxy) participate over **HTTP** —
+the backend holds server-side presence and serves turns from the durable
+transcript. Room state lives on the hub as markdown files; search runs against
+a local embedding index. Every spoke reads and writes that state over HTTP.
+Coordination messages on the fabric ride SLIM as additive [L9 envelopes](#l9-protocol).
 
 | Layer | Technology | Used for |
 |-------|-----------|----------|

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -4,6 +4,10 @@ Mycelium's backend can require a signed **bearer token** on every HTTP API call,
 validated against an OIDC issuer you configure. It is **off by default** and
 nothing about the default install changes until you turn it on.
 
+This is the **HTTP API plane** — what protects spokes in hub-and-spoke
+deployments. It is separate from SLIM/MLS PSK or SignerJwt on the coordination
+fabric; see [Security Planes](#security-planes).
+
 ## Off by default, on purpose
 
 Auth must never be a wall between someone and trying Mycelium. A fresh install

--- a/mycelium-cli/src/mycelium/docs/guides/hub-and-spoke.md
+++ b/mycelium-cli/src/mycelium/docs/guides/hub-and-spoke.md
@@ -1,138 +1,115 @@
 # Hub & Spoke Setup
 
 Run Mycelium across two or more machines so a small team shares rooms,
-memory, and coordination over one SLIM node.
+memory, and coordination from one hub.
 
-Coordination rides an AGNTCY SLIM group channel, an MLS-encrypted messaging
-fabric. One machine is the **hub**: it runs the SLIM node plus the always-on
-backend that moderates each room. Every other machine is a **spoke** that
-points at the hub's node. There is no database and no separate channel server;
-the node is a blind ciphertext forwarder, so the hub never sees room contents
-in the clear.
+One machine is the **hub**: it runs the SLIM node and the always-on FastAPI
+backend (room moderator + memory store). Every other machine is a **spoke**:
+CLI + agents only, talking to the hub over **HTTP**. There is no database and
+no separate channel server.
+
+> **Two planes.** Spokes use the **HTTP API** (`:8000`) for memory and
+> participation. The **SLIM/MLS fabric** (`:46357`) is used by the hub backend
+> as moderator; spokes do not join it in the default path and do **not** need
+> `MYCELIUM_SLIM_MASTER_SECRET`. See [Security Planes](#security-planes).
 
 ## When to use this
 
 Use hub-and-spoke when people on different machines need to join the same
 rooms, see the same memories, and run negotiations together. If everything
-runs on one machine, the default single-device install already does this.
+runs on one machine, the default single-device install already does this;
+see the [Quick Start](#quickstart).
 
 ## Topology
 
 ```
-┌──────────────────────────────────┐
-│  Hub  (one machine)              │
-│                                  │
-│  mycelium install                │
-│  mycelium hub host  → SLIM :46357│
-│  mycelium up        → backend    │
-│  mycelium up --ui   → frontend   │
-└────────────┬─────────────────────┘
-             │  SLIM (MLS-encrypted)
-     ┌───────┴───────┐
-     │               │
-┌────┴─────┐   ┌─────┴────┐
-│ Spoke A  │   │ Spoke B  │
-│          │   │          │
-│ mycelium │   │ mycelium │
-│ connect  │   │ connect  │
-│ + agents │   │ + agents │
-└──────────┘   └──────────┘
+┌─────────────────────────────────────────────┐
+│  Hub  (one machine)                         │
+│                                             │
+│  mycelium install                           │
+│  mycelium hub host                          │
+│  ├─ SLIM node        :46357  (MLS fabric)   │
+│  └─ FastAPI backend  :8000  (HTTP API)     │
+│       moderator + memory store              │
+└──────────────────┬──────────────────────────┘
+                   │
+         HTTP :8000  (memory, await, respond)
+                   │
+     ┌─────────────┴─────────────┐
+     │                           │
+┌────┴──────┐              ┌─────┴─────┐
+│ Spoke A   │              │ Spoke B   │
+│ CLI       │              │ CLI       │
+│ + agents  │              │ + agents  │
+└───────────┘              └───────────┘
 ```
 
-Spokes run only the CLI and their agents. They connect to the hub's node
-address and coordinate over the shared channel.
+Spokes are **thin HTTP clients**. They keep no copy of room memory locally;
+every `memory`, `await`, and `respond` call goes to the hub API.
+
+The SLIM node on the hub forwards MLS **ciphertext** between native SLIM
+members. The backend moderator decrypts for the transcript, aligner, and
+memory — it is not a blind observer of room content.
 
 ## Step 1: Stand up the hub
 
-On the hub machine, install the stack:
+On the hub machine, install the stack and start the SLIM node:
 
 ```bash
 mycelium install
-```
-
-Start the SLIM node — this prints the address spokes connect to:
-
-```bash
 mycelium hub host
 ```
+
+`mycelium hub host` starts the `slim` node container and prints addresses:
 
 ```
 SLIM node running.
   local     → http://127.0.0.1:46357  (this machine, saved to config)
   for peers → http://192.168.1.20:46357
-
-  Peers connect with:  mycelium connect http://192.168.1.20:46357
 ```
 
-Note the `for peers` LAN address. Then bring up the backend (and optionally
-the frontend UI):
+Ensure the backend is up as well (`mycelium up` or the full install stack).
+
+Verify with:
 
 ```bash
-mycelium up          # backend only
-mycelium up --ui     # backend + frontend at http://hub-ip:3000
-```
-
-Verify everything is running:
-
-```bash
-mycelium status
 mycelium doctor
 ```
 
 `doctor` auto-detects hub vs spoke mode from `server.api_url` (a local
-backend means hub) and runs the checks that apply.
+backend means hub) and runs the checks that apply. Override with
+`--mode hub|spoke` if needed.
+
+### Hub-only: SLIM master secret
+
+The hub SLIM PSK lives in **`config.toml`**, not as a hand-edited `.env` entry.
+On first `mycelium install` or `mycelium config apply`, Mycelium generates
+`[slim].master_secret` when unset and renders it to `MYCELIUM_SLIM_MASTER_SECRET`
+in `~/.mycelium/.env` for the backend container.
+
+```bash
+mycelium config apply    # generates [slim].master_secret if missing
+mycelium config show     # SLIM PSK shown masked
+```
+
+To rotate:
+
+```bash
+mycelium config set slim.master_secret "$(openssl rand -hex 32)"
+mycelium config apply --restart
+```
+
+Spokes never need this value. Re-running `config apply` preserves the secret.
 
 ### Open ports
 
-Spokes need to reach the hub on:
+| Port  | Service        | Spokes need it? | Purpose |
+|-------|----------------|-----------------|---------|
+| **8000** | FastAPI backend | **Yes** | Memory, `await`/`respond`, room ops |
+| 46357 | SLIM node      | No (default)    | Native SLIM on hub; optional for `slim send` |
 
-| Port  | Service          | Required |
-|-------|------------------|----------|
-| 46357 | SLIM node        | Yes      |
-| 8000  | Backend HTTP API | Yes      |
-| 3000  | Frontend UI      | Optional |
-
-The SLIM node forwards only MLS ciphertext. Restrict access with a VPN,
-Tailscale, or firewall rules regardless — access to a channel is gated by
-its shared-secret PSK, but defence in depth applies.
-
-### Shared secret
-
-The per-channel MLS key is derived offline from
-`MYCELIUM_SLIM_MASTER_SECRET`. Every host that shares rooms must set the
-**same** value:
-
-```bash
-# On every host (hub and all spokes)
-export MYCELIUM_SLIM_MASTER_SECRET="your-private-secret-here"
-```
-
-Add it to `~/.mycelium/.env` or your system environment. The built-in dev
-default is public — anyone with the repo can derive it. Set your own value
-before any shared or internet-facing use.
-
-### Accessing the UI from a public IP or NAT
-
-If you run `mycelium up --ui` and access the frontend from a browser
-whose origin differs from `localhost` (common on cloud VMs accessed over
-a public IP), Next.js dev mode returns 403 on internal endpoints. Fix it
-by allowlisting the browser's origin:
-
-```bash
-mycelium config set runtime.allowed_dev_origins "203.0.113.42"
-mycelium config apply
-```
-
-`mycelium config apply` writes `MYCELIUM_ALLOWED_DEV_ORIGINS` to
-`~/.mycelium/.env`, which the frontend container reads. Comma-separate
-multiple origins:
-
-```bash
-mycelium config set runtime.allowed_dev_origins "203.0.113.42,10.0.0.5"
-```
-
-This is a dev-mode concern only. Production builds serve the browser from
-the same origin, so no allowlist is needed.
+Restrict `:8000` on the hub when the team shares a network. Enable the
+[HTTP JWT gate](#auth) — that is what protects spokes, not the SLIM PSK.
 
 ## Step 2: Connect each spoke
 
@@ -142,29 +119,44 @@ On each spoke, install the CLI:
 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
 ```
 
-Point it at the hub's SLIM node (the `for peers` line from Step 1) and at
-the hub's backend:
+Point the spoke at the **hub backend** (required):
+
+```bash
+mycelium config set server.api_url http://192.168.1.20:8000
+```
+
+Or during init:
+
+```bash
+mycelium init --api-url http://192.168.1.20:8000
+```
+
+**Optional:** store the hub's SLIM node address (only needed for native SLIM
+tooling such as `mycelium slim send`, not for normal participation):
 
 ```bash
 mycelium connect http://192.168.1.20:46357
-mycelium config set server.api_url http://192.168.1.20:8000
 ```
 
 Verify:
 
 ```bash
-mycelium status
 mycelium doctor
 ```
 
-The spoke reports backend connectivity and skips checks that only apply to
-a local backend.
+The spoke reports **spoke mode**, checks backend reachability and HTTP auth
+status, and skips hub-only checks (Docker, SLIM PSK).
+
+### Secure a shared hub
+
+When spokes reach the hub over a LAN or VPN, turn on HTTP authentication on
+the hub. See [Authentication](#auth). Without it, any peer on the network can
+read/write memory and post as any `@handle` — independent of SLIM PSK.
 
 ## Step 3: Use a room from a spoke
 
-There is one store: the hub's. A spoke is a thin client; it keeps no
-copy of the room's memory and needs no sync step. Create the room on the
-hub, then use it from anywhere.
+There is one store: the hub's. Create the room on the hub, then use it from
+anywhere.
 
 ```bash
 # On the hub
@@ -178,155 +170,98 @@ On a spoke, just make it the active room:
 mycelium room use portfolio
 ```
 
-Every memory command now resolves against the hub over HTTP:
+Every memory command resolves against the hub over HTTP:
 
 ```bash
-mycelium memory ls                       # the hub's memories
+mycelium memory ls
 mycelium memory get decisions/allocation
 mycelium memory set decisions/allocation "60/40 equities to bonds"
 mycelium memory search "what did we decide about risk"
 ```
 
-Because reads go to the hub, a spoke sees a write the moment it lands;
-there is no local copy to drift. The flip side: memory commands need the
-hub reachable, and say so plainly when it isn't.
+Because reads go to the hub, a spoke sees a write the moment it lands.
+Memory commands need the hub reachable and report plainly when it is not.
 
-> `mycelium room clone` pulls a point-in-time HTTP snapshot of a room's
-> memories to local files, useful for backups or offline reads. It is not
-> how agents join or stay in sync — that is the live SLIM channel.
+> `mycelium room clone` pulls a point-in-time snapshot to local files (backup
+> or offline read). It is not part of joining a room from a spoke.
 
 ## Step 4: Run a negotiation across machines
 
-Register the aligner once in the room:
+Register the [aligner](#aligner) once in the room, post opening positions,
+and loop on participation. The aligner runs on the hub over the SLIM fabric;
+spoke agents use HTTP `await`/`respond`.
 
 ```bash
 mycelium engine create aligner --kind aligner --room portfolio
 ```
 
-Each machine registers its agent:
+Each participant posts an opening position:
 
 ```bash
-# On hub
-mycelium agent create hub-agent --room portfolio
-
-# On spoke A
-mycelium agent create spoke-a --room portfolio
-
-# On spoke B
-mycelium agent create spoke-b --room portfolio
-```
-
-### Resident agent loops
-
-The recommended way to keep an agent awake across the whole negotiation is
-`await --loop --exec`. The command receives each turn's JSON on stdin and
-is expected to call `mycelium respond`:
-
-```bash
-# On each machine — using Pi as the agent brain
-mycelium await --loop --room portfolio --handle hub-agent \
-  --exec "env MYCELIUM_ROOM=portfolio MYCELIUM_HANDLE=hub-agent ./pi-driver.sh"
-```
-
-A minimal Pi driver (`pi-driver.sh`):
-
-```bash
-#!/usr/bin/env bash
-TURN=$(cat)
-PROMPT=$(echo "$TURN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('content',''))")
-REPLY=$(pi --print --mode json --no-tools --no-session \
-    --model "your-provider/your-model" \
-    --api-key "$YOUR_API_KEY" \
-    "$PROMPT" 2>/dev/null | python3 -c "
-import sys, json
-for line in sys.stdin:
-    try:
-        d = json.loads(line)
-        if d.get('type') == 'message_update':
-            ev = d.get('assistantMessageEvent', {})
-            if ev.get('type') == 'text_end':
-                print(ev.get('content', ''))
-                exit(0)
-    except: pass
-")
-mycelium respond --room "\$MYCELIUM_ROOM" --handle "\$MYCELIUM_HANDLE" "\$REPLY"
-```
-
-### Manual participation
-
-For manual or scripted participation without a resident loop:
-
-```bash
-# Each participant posts an opening position
+# Spoke A's agent
 mycelium respond --room portfolio --handle alice "I want 60% equities."
+
+# Spoke B's agent
 mycelium respond --room portfolio --handle bob "No more than 40% equities."
 ```
 
-A human summons the aligner:
+Summon the aligner:
 
 ```bash
 mycelium engine invoke aligner "converge on the equities allocation"
 ```
 
-Each participant reads the aligner's prompt and replies:
+Each participant loops over HTTP (no SLIM socket on the spoke):
 
 ```bash
 mycelium await --room portfolio --handle alice --json
 mycelium respond --room portfolio --handle alice "accept 50%, meets my floor"
 ```
 
-### Outcome
-
-On agreement the aligner emits `commit:converged`, records the episode, and
-compiles the room's shared `plan/tasks.md`. Read it on any machine:
+On agreement the aligner compiles `plan/tasks.md`. Read it on any machine:
 
 ```bash
 mycelium plan tasks
 ```
 
-Agents work the `@handle` tasks assigned to them. The compiled plan syncs as
-a `knowledge` memory to every machine on the channel.
-
 ## Agent identity
 
-Each agent needs a unique handle across the whole deployment. The handle is
+Each agent needs a unique handle across the deployment. The handle is
 resolved from, in order:
 
 1. `identity.name` in `~/.mycelium/config.toml`
 2. The `MYCELIUM_AGENT_HANDLE` environment variable
 3. The `--handle` flag on `await` / `respond`
 
+On a shared hub with [auth enabled](#auth), the token — not the body alone —
+is the actor of record. Configure agent credentials for unattended spokes.
+
 ## Troubleshooting
 
-### Spoke can't reach the hub's SLIM node
+### Spoke can't reach the hub
 
-```bash
-curl http://192.168.1.20:46357
-```
-
-If this fails, check firewall rules, VPN connectivity, or security groups.
-The SLIM node binds inside Docker; the host firewall may block external
-access.
-
-### Spoke can't reach the backend
+Check the **backend** first (the path spokes actually use):
 
 ```bash
 curl http://192.168.1.20:8000/health
 ```
 
-Ensure port 8000 is open on the hub and `mycelium up` is running. Check
-`mycelium status` on the hub.
+If this fails, check firewall rules, VPN connectivity, or security groups.
+The backend must be reachable on port **8000**.
 
-### Invites silently fail / agents can't join channels
-
-The most common cause is a `MYCELIUM_SLIM_MASTER_SECRET` mismatch. Every
-host must use the **same** secret; a mismatch means channel keys don't
-agree and invites are silently dropped. Verify the value is identical on
-hub and all spokes, then restart the backend on the hub.
+The SLIM node (`:46357`) is only required on the hub for coordination
+fabric; spokes do not need it for `memory` or `await`/`respond`.
 
 ### `doctor` reports "spoke mode" unexpectedly
 
 `mycelium doctor` infers mode from `server.api_url`. If it points at a
 non-local address, doctor assumes spoke mode. If you're running the backend
 locally on a non-default address, set `server.api_url` to
-`http://localhost:8000`, or force the mode with `mycelium doctor --mode hub`.
+`http://localhost:8000` in `~/.mycelium/config.toml`, or force hub mode:
+
+```bash
+mycelium doctor --mode hub
+```
+
+See [Troubleshooting](#troubleshooting) for the full runbook and
+[Security Planes](#security-planes) for HTTP vs SLIM protection.

--- a/mycelium-cli/src/mycelium/docs/guides/security-planes.md
+++ b/mycelium-cli/src/mycelium/docs/guides/security-planes.md
@@ -1,0 +1,84 @@
+# Security Planes
+
+Mycelium has **two enforcement planes**. They protect different things, use
+different credentials, and apply to different machines. Conflating them is the
+most common hub-and-spoke misconfiguration.
+
+## The two planes
+
+| Plane | Port (default) | Who uses it | What it protects | Default | Upgrade |
+|-------|----------------|-------------|------------------|---------|---------|
+| **HTTP API** | 8000 | Spokes, humans, agents (`memory`, `await`, `respond`) | Memory, participation, handle attribution | Open (no token) | [Authentication](#auth) (`auth.enabled`) |
+| **SLIM / MLS** | 46357 | Hub backend (moderator); dev `slim send`; future native connectors | Native SLIM group membership on the coordination fabric | Shared-secret **PSK** (hub only) | [SignerJwt](#spire-identity) / [SPIRE](#spire-identity) |
+
+**Spokes do not use the SLIM plane for normal work.** A spoke is a thin HTTP
+client: it points `server.api_url` at the hub backend and never needs
+`MYCELIUM_SLIM_MASTER_SECRET`.
+
+The hub backend holds the room's SLIM/MLS session as **moderator**. Spoke agents
+participate over HTTP; the backend keeps them present via a **server-held lease**
+and delivers turns from the **durable transcript**. That path bypasses PSK
+entirely.
+
+## What PSK actually protects
+
+PSK (`MYCELIUM_SLIM_MASTER_SECRET` → HMAC per `workspace/room` →
+`create_app_with_secret`) is the **SLIM-plane room gate**:
+
+- It decides who may **authenticate as a SLIM app and join a room's MLS group**.
+- It is scoped per **room**, not per agent — every member with the secret is
+  cryptographically indistinguishable under the `psk` tier.
+- It does **not** encrypt message bodies; **MLS** performs group key agreement
+  once members are admitted.
+- It does **not** protect spokes, memory, or `@handle` impersonation over HTTP.
+
+With the public dev literal shipped in the repo, PSK protects nothing by itself.
+A fresh hub install generates a private `[slim].master_secret` in
+`config.toml` on first `mycelium config apply` (rendered to `.env` for Docker).
+Override with `mycelium config set slim.master_secret …` to rotate.
+
+## What protects spokes
+
+For hub-and-spoke, the urgent control is the **HTTP API gate**, not PSK:
+
+```bash
+mycelium config set auth.enabled true
+mycelium config set auth.audience mycelium
+# … configure [[auth.issuers]] …
+mycelium config apply
+```
+
+See [Authentication](#auth) for humans and agent service accounts.
+
+Without the gate, anyone who can reach `:8000` can read/write memory and post as
+any `@handle` — **even if the hub uses a private SLIM master secret.**
+
+## Deployment profiles
+
+| Profile | HTTP API | SLIM (hub) | Spoke config |
+|---------|----------|------------|--------------|
+| **Solo dev** | Open | Dev PSK literal (fallback if no config secret) | N/A (all-in-one) |
+| **LAN team** | JWT on | Auto-generated `[slim].master_secret` on hub | `server.api_url` → hub:8000 only |
+| **Hosted** | JWT required | Private hub secret + SignerJwt or SPIRE | Same; no master secret on spokes |
+
+`mycelium doctor` reports HTTP auth status from the hub's `/health` endpoint.
+In **hub** mode it also warns when `[slim].master_secret` is missing or still
+the public dev literal.
+
+## SLIM identity ladder (hub native clients)
+
+| Tier | Plane | Spoke needs it? |
+|------|-------|-----------------|
+| `psk` | SLIM | No (hub backend only today) |
+| `signerjwt` | SLIM | Only if the spoke runs a native SLIM connector |
+| `spire` | SLIM | Same |
+
+`mycelium config set slim.identity signerjwt` changes **SLIM channel identity** on
+machines that open native SLIM connections. It does **not** turn on HTTP API auth.
+Configure `[auth]` separately.
+
+## Related guides
+
+- [Hub & Spoke Setup](#hub-and-spoke) — topology and spoke checklist
+- [Authentication](#auth) — HTTP JWT gate (spokes and hub API)
+- [Attested Identity (SPIRE)](#spire-identity) — hardened SLIM plane

--- a/mycelium-cli/src/mycelium/docs/troubleshooting.md
+++ b/mycelium-cli/src/mycelium/docs/troubleshooting.md
@@ -60,30 +60,35 @@ mycelium init --api-url http://your-hub:8000
 
 ---
 
-### 4. SLIM Node Unreachable
+### 4. Spoke Can't Reach the Hub (or Backend Down)
 
-**Symptom**: agents join a room but never exchange anything; `mycelium await`
-hangs; `mycelium doctor` flags the backend or a spoke can't reach the hub.
+**Symptom**: `Cannot connect to Mycelium API`; memory/`await`/`respond` fail;
+`mycelium doctor` reports backend unreachable.
 
-Agents coordinate over a **SLIM group channel** served by the hub's SLIM node
-(default port **46357**). If that node is down or unreachable, no messages flow.
-
-```bash
-mycelium doctor                     # detects hub vs spoke, checks reachability
-docker ps | grep slim               # is the SLIM node up on the hub?
-mycelium hub host                   # (re)start the SLIM node and print its address
-```
-
-On a spoke, confirm it points at the right node and the port is open:
+Spokes talk to the hub over **HTTP** (`server.api_url`, default port **8000**).
+They do not need the SLIM node for normal participation.
 
 ```bash
-grep node_endpoint ~/.mycelium/config.toml
-curl http://<hub-ip>:46357            # raw reachability from the spoke
-mycelium connect http://<hub-ip>:46357  # re-point at the hub node
+mycelium doctor                     # detects hub vs spoke; checks /health
+curl http://<hub-ip>:8000/health    # from the spoke
+mycelium config get server.api_url    # should point at the hub backend
 ```
 
-Common causes: firewall/security group blocks 46357, VPN/Tailscale not
-connected, or a stale endpoint in `config.toml`.
+On the **hub**, ensure the backend and SLIM node are running:
+
+```bash
+mycelium up
+docker ps | grep mycelium
+mycelium hub host                   # (re)start the SLIM node if needed
+```
+
+If coordination still fails on the hub itself, check the SLIM node (port
+**46357**) — the backend moderator needs it. Spokes rarely need `:46357`
+unless you use native SLIM tooling (`mycelium slim send`).
+
+Common causes: firewall blocks **8000**, wrong `server.api_url`, VPN not
+connected, or auth enabled on the hub without `mycelium login` on the spoke.
+See [Security Planes](#security-planes) and [Authentication](#auth).
 
 ---
 

--- a/mycelium-cli/src/mycelium/slim/identity.py
+++ b/mycelium-cli/src/mycelium/slim/identity.py
@@ -42,7 +42,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # ── Mode switch (off by default) ─────────────────────────────────────────────
-# Mirrors the D1 ``MYCELIUM_SLIM_MASTER_SECRET`` posture: env-only, no config-apply
+# Mirrors the hub ``[slim].master_secret`` → ``MYCELIUM_SLIM_MASTER_SECRET`` path in
+# ``docker_utils.generate_env_file``; env override still wins via ``_load_from_env``.
 # coupling, so both the backend and the thin CLI resolve it identically.
 _MODE_ENV = "MYCELIUM_SLIM_IDENTITY"
 _REQUIRE_ENV = "MYCELIUM_SLIM_IDENTITY_REQUIRE"

--- a/mycelium-cli/tests/test_doctor_checks.py
+++ b/mycelium-cli/tests/test_doctor_checks.py
@@ -10,9 +10,13 @@ The mediator-Pi check has its own file (``test_doctor_mediator_pi``).
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from mycelium.commands import doctor
+from mycelium.config import MyceliumConfig
+from mycelium.slim import naming
 
 
 @pytest.mark.parametrize(
@@ -47,3 +51,53 @@ def test_check_config_files_errors_when_missing(
     assert result.status == "error"
     assert ".env" in result.message and "config.toml" in result.message
     assert any("mycelium install" in d for d in result.details)
+
+
+def test_check_http_auth_gate_warns_on_remote_ungated(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"auth": {"enabled": False}}
+    monkeypatch.setattr("httpx.get", lambda *a, **k: mock_resp)
+
+    result = doctor._check_http_auth_gate(api_url="http://hub.lan:8000")
+    assert result.status == "warning"
+    assert "JWT gate is off" in result.message
+
+
+def test_check_http_auth_gate_ok_on_localhost_ungated(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"auth": {"enabled": False}}
+    monkeypatch.setattr("httpx.get", lambda *a, **k: mock_resp)
+
+    result = doctor._check_http_auth_gate(api_url="http://localhost:8000")
+    assert result.status == "ok"
+
+
+def test_check_hub_slim_psk_skipped_on_spoke() -> None:
+    assert doctor._check_hub_slim_psk(local_backend=False) is None
+
+
+def test_check_hub_slim_psk_warns_on_dev_secret(isolated_home) -> None:
+    myc = isolated_home / ".mycelium"
+    myc.mkdir(parents=True, exist_ok=True)
+    config = MyceliumConfig()
+    config.slim.master_secret = naming._DEV_MASTER_SECRET
+    config.save(myc / "config.toml")
+
+    result = doctor._check_hub_slim_psk(local_backend=True)
+    assert result is not None
+    assert result.status == "warning"
+    assert "public dev" in result.message
+
+
+def test_check_hub_slim_psk_ok_with_private_secret(isolated_home) -> None:
+    myc = isolated_home / ".mycelium"
+    myc.mkdir(parents=True, exist_ok=True)
+    config = MyceliumConfig()
+    config.slim.master_secret = "my-private-hub-secret-0123456789abcd"
+    config.save(myc / "config.toml")
+
+    result = doctor._check_hub_slim_psk(local_backend=True)
+    assert result is not None
+    assert result.status == "ok"

--- a/mycelium-cli/tests/test_slim_master_secret_config.py
+++ b/mycelium-cli/tests/test_slim_master_secret_config.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""[slim].master_secret: config.toml source of truth → .env render."""
+
+from __future__ import annotations
+
+from mycelium.config import MyceliumConfig
+from mycelium.docker_utils import ensure_slim_master_secret, generate_env_file, write_env_file
+from mycelium.slim import naming
+
+
+def _parse_env(text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        if "=" in line and not line.lstrip().startswith("#"):
+            k, _, v = line.partition("=")
+            out[k.strip()] = v.strip()
+    return out
+
+
+def test_ensure_generates_when_unset(isolated_home) -> None:
+    cfg = MyceliumConfig()
+    assert cfg.slim.master_secret is None
+    assert ensure_slim_master_secret(cfg) is True
+    assert cfg.slim.master_secret
+    assert len(cfg.slim.master_secret) >= 32
+
+
+def test_ensure_imports_from_existing_env(isolated_home) -> None:
+    myc = isolated_home / ".mycelium"
+    myc.mkdir(parents=True)
+    env_path = myc / ".env"
+    env_path.write_text("MYCELIUM_SLIM_MASTER_SECRET=imported-secret-value-0123456789ab\n")
+
+    cfg = MyceliumConfig()
+    assert ensure_slim_master_secret(cfg, env_path=env_path) is True
+    assert cfg.slim.master_secret == "imported-secret-value-0123456789ab"
+
+
+def test_ensure_noop_when_config_already_set(isolated_home) -> None:
+    cfg = MyceliumConfig()
+    cfg.slim.master_secret = "already-set-secret-value-0123456789abc"
+    assert ensure_slim_master_secret(cfg) is False
+
+
+def test_generate_env_file_emits_master_secret(isolated_home) -> None:
+    cfg = MyceliumConfig()
+    cfg.slim.master_secret = "configured-secret-value-0123456789abcd"
+    env = _parse_env(generate_env_file(cfg))
+    assert env["MYCELIUM_SLIM_MASTER_SECRET"] == cfg.slim.master_secret
+
+
+def test_write_env_file_persists_generated_secret(isolated_home) -> None:
+    myc = isolated_home / ".mycelium"
+    myc.mkdir(parents=True)
+    config_path = myc / "config.toml"
+
+    cfg = MyceliumConfig()
+    cfg.save(config_path)
+
+    env_path, assigned = write_env_file(cfg, env_path=myc / ".env")
+    assert assigned is True
+    assert env_path.exists()
+    env = _parse_env(env_path.read_text(encoding="utf-8"))
+    assert env["MYCELIUM_SLIM_MASTER_SECRET"]
+    assert env["MYCELIUM_SLIM_MASTER_SECRET"] != naming._DEV_MASTER_SECRET
+
+    reloaded = MyceliumConfig.load(config_path)
+    assert reloaded.slim.master_secret == env["MYCELIUM_SLIM_MASTER_SECRET"]
+
+
+def test_write_env_file_preserves_secret_on_reapply(isolated_home) -> None:
+    myc = isolated_home / ".mycelium"
+    myc.mkdir(parents=True)
+    config_path = myc / "config.toml"
+
+    cfg = MyceliumConfig()
+    cfg.slim.master_secret = "stable-secret-value-0123456789abcdef"
+    cfg.save(config_path)
+
+    env_path, first_assigned = write_env_file(cfg, env_path=myc / ".env")
+    assert first_assigned is False
+    first_secret = _parse_env(env_path.read_text(encoding="utf-8"))["MYCELIUM_SLIM_MASTER_SECRET"]
+
+    cfg.llm.model = "anthropic/claude-sonnet-4-6"
+    _, second_assigned = write_env_file(cfg, env_path=env_path)
+    assert second_assigned is False
+    second_secret = _parse_env(env_path.read_text(encoding="utf-8"))["MYCELIUM_SLIM_MASTER_SECRET"]
+    assert second_secret == first_secret

--- a/mycelium-cli/tests/test_slim_master_secret_config.py
+++ b/mycelium-cli/tests/test_slim_master_secret_config.py
@@ -88,3 +88,18 @@ def test_write_env_file_preserves_secret_on_reapply(isolated_home) -> None:
     assert second_assigned is False
     second_secret = _parse_env(env_path.read_text(encoding="utf-8"))["MYCELIUM_SLIM_MASTER_SECRET"]
     assert second_secret == first_secret
+
+
+def test_save_locks_secret_bearing_files_to_owner_only(isolated_home) -> None:
+    """config.toml + config.json hold slim.master_secret / llm.api_key, so save()
+    must write them 0600, not the default umask (often 0644)."""
+    myc = isolated_home / ".mycelium"
+    myc.mkdir(parents=True)
+    config_path = myc / "config.toml"
+
+    cfg = MyceliumConfig()
+    cfg.slim.master_secret = "stable-secret-value-0123456789abcdef"
+    cfg.save(config_path)
+
+    assert config_path.stat().st_mode & 0o777 == 0o600
+    assert (myc / "config.json").stat().st_mode & 0o777 == 0o600


### PR DESCRIPTION
## Summary

Clarifies **what PSK actually protects** in Mycelium’s hub-and-spoke model, fixes misleading hub-and-spoke docs, and makes the hub SLIM master secret **durable across `config apply`** by moving it into `config.toml`.

**Core insight:** Mycelium has **two enforcement planes**. Spokes participate over **HTTP (`:8000`)**; the **SLIM/MLS fabric (`:46357`)** is hub-side (moderator + native clients). PSK gates **native SLIM group join** on the hub — it does **not** secure spokes. Shared-hub security is **`auth.enabled` (JWT)**, not a private master secret.

## Background (analysis)

### Two planes

| Plane | Port | Who uses it | Default protection |
|-------|------|-------------|-------------------|
| **HTTP API** | 8000 | Spokes, `memory`, `await`/`respond` | Open (opt-in JWT) |
| **SLIM / MLS** | 46357 | Hub backend moderator; dev `slim send` | PSK on hub |

Spokes are **thin HTTP clients**. The hub holds server-side presence (lease + durable transcript); agents never join MLS on the spoke in the default path.

### What PSK protects (and does not)

- **Does:** authenticates **native SLIM apps** joining a room’s MLS group (`MYCELIUM_SLIM_MASTER_SECRET` → HMAC per `workspace/room` → `create_app_with_secret`).
- **Does not:** HTTP memory/participation, `@handle` impersonation, spoke access, or privacy from the hub operator (backend reads plaintext for transcript/aligner/memory).
- **MLS** encrypts on the fabric; PSK is the room **gate**, not the message cipher.

### Why spokes work without the master secret

`await`/`respond` hit the hub API. PSK is irrelevant to that path — which is why setting a private PSK alone does **not** secure a shared LAN; **`auth.enabled`** does.

### Prior doc problems fixed

- Hub-and-spoke implied spokes “coordinate over SLIM” and need `:46357` + PSK sync.
- Troubleshooting pointed spokes at the SLIM node instead of `:8000`.
- Manual `.env` edits for PSK were unsafe: **`config apply` regenerates `.env` from `config.toml`** and only preserved `MYCELIUM_IMAGE_TAG`.

## Changes in this PR

### Docs
- New **[Security Planes](mycelium-cli/src/mycelium/docs/guides/security-planes.md)** guide (two-plane model, deployment profiles, PSK scope).
- Rewritten **[Hub & Spoke](mycelium-cli/src/mycelium/docs/guides/hub-and-spoke.md)**: spokes → `server.api_url` `:8000`; SLIM optional; hub-only PSK via config.
- Updates to **architecture**, **troubleshooting**, **auth** (HTTP plane callout).

### Hub SLIM PSK — Option A (`config.toml` source of truth)
- `[slim].master_secret` in `MyceliumConfig`.
- **`ensure_slim_master_secret()`** on `config apply` / install: import from legacy `.env` if present, else generate `secrets.token_hex(32)`.
- Rendered to `MYCELIUM_SLIM_MASTER_SECRET` in `.env` for the backend container.
- **`config apply --migrate-env`** imports existing `.env` secret into config.
- **`config show`** masks SLIM PSK; rotation via `config set slim.master_secret`.
- Public dev literal **unchanged** as runtime fallback for tests / host `uvicorn` without Docker.

### CLI / doctor
- **`mycelium connect`**: notes that default participation uses HTTP, not SLIM.
- **`config set slim.identity signerjwt|spire`**: reminds that HTTP auth is separate.
- **`doctor`**: HTTP JWT gate status from `/health`; hub-only SLIM PSK check from `config.toml`.

## Deliberately out of scope

- Spoke-side SLIM connectors / custodial MLS (#667) — documented as future/alternate paths, not changed here.
- `MYCELIUM_SLIM_REQUIRE_SECRET` compose defaults, TLS to SLIM node, per-room PSK epoch rotation.
- Syncing PSK to spokes (they don’t use it).

## Test plan

- [x] `pytest tests/test_slim_master_secret_config.py tests/test_doctor_checks.py tests/test_docker_env_image_tag_pin.py tests/test_docker_env_auth.py`
- [ ] Fresh install → `config apply` → `config show` shows masked SLIM PSK; `.env` contains `MYCELIUM_SLIM_MASTER_SECRET`
- [ ] Re-run `config apply` → secret unchanged in `config.toml` and `.env`
- [ ] Spoke with remote `server.api_url` → `doctor` warns if HTTP auth off; no SLIM PSK check
- [ ] Hub with dev literal in config → `doctor` warns


Made with [Cursor](https://cursor.com)