### PR TITLE
fix: allow email-shaped handles from real IdPs (#656)

### DIFF
--- a/fastapi-backend/app/routes/engines.py
+++ b/fastapi-backend/app/routes/engines.py
@@ -20,7 +20,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from app.routes.memory import upsert_memories
-from app.schemas import AgentRead, MemoryBatchCreate, MemoryCreate
+from app.schemas import HANDLE_PATTERN, AgentRead, MemoryBatchCreate, MemoryCreate
 from app.services import actor
 from app.services.filesystem import get_room_dir, read_memory_file, room_exists
 
@@ -32,7 +32,7 @@ router = APIRouter(prefix="/rooms/{room_name}/engines", tags=["engines"])
 # ``mycelium.protocol.ENGINE_KINDS``; the summon seam self-selects by ``kind``.
 ENGINE_KINDS = frozenset({"aligner", "synthesizer"})
 
-_HANDLE_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_HANDLE_RE = re.compile(HANDLE_PATTERN)
 
 
 class EngineCreate(BaseModel):

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -12,6 +12,15 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
 
+# Two shape rules, deliberately distinct. A *handle* is an identity and can be
+# minted by a real IdP, so it allows the `@` a corporate SSO `preferred_username`
+# carries (e.g. `user@example.com`). A *slug* is a filename / composer trigger
+# token (skill names) and stays clean. The CLI (`mycelium/protocol.py`) and the
+# frontend (`acting-as-picker.tsx`) keep matching copies; the thin CLI can't
+# import this package.
+HANDLE_PATTERN = r"^[a-z0-9][a-z0-9._@-]*$"
+SLUG_PATTERN = r"^[a-z0-9][a-z0-9._-]*$"
+
 # ── Room ──────────────────────────────────────────────────────────────────────
 
 
@@ -375,7 +384,7 @@ class SkillCreate(BaseModel):
         ...,
         min_length=1,
         max_length=128,
-        pattern=r"^[a-z0-9][a-z0-9._-]*$",
+        pattern=SLUG_PATTERN,
         description="Skill slug (kebab-case); the filename and the composer's /trigger token",
     )
     description: str = Field("", max_length=512, description="One-line summary shown in listings")
@@ -417,7 +426,7 @@ class SkillListResponse(BaseModel):
 
 
 class UserCreate(BaseModel):
-    handle: str = Field(..., min_length=1, pattern=r"^[a-z0-9][a-z0-9._-]*$")
+    handle: str = Field(..., min_length=1, pattern=HANDLE_PATTERN)
     display_name: str = ""
     teams: list[str] = Field(default_factory=list)
     notify: str | None = None

--- a/fastapi-backend/tests/test_handle_pattern.py
+++ b/fastapi-backend/tests/test_handle_pattern.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Handle vs. slug shape rules (backend side).
+
+A *handle* is an identity and can be minted by a real IdP, so an email-shaped
+``preferred_username`` (Cisco SSO / Keycloak) must validate. A *slug* is a
+filename / composer trigger token and stays clean. These are deliberately two
+patterns; regressing either back to a single slug rule reintroduces #656.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.routes.engines import _HANDLE_RE
+from app.schemas import SkillCreate, UserCreate
+
+
+def test_user_handle_accepts_email_shaped_identity() -> None:
+    """An IdP-minted email handle registers, not just validates on login (#656)."""
+    assert UserCreate(handle="user@example.com").handle == "user@example.com"
+
+
+def test_engine_handle_regex_accepts_email_shaped_identity() -> None:
+    assert _HANDLE_RE.match("user@example.com")
+    assert not _HANDLE_RE.match("has space")
+
+
+def test_skill_name_stays_clean() -> None:
+    """A skill name is a `/trigger token / filename, not an identity — no `@`."""
+    SkillCreate(name="deploy-runbook", created_by="tester")
+    with pytest.raises(ValidationError):
+        SkillCreate(name="user@example.com", created_by="tester")

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -53,6 +53,15 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+# Two shape rules, deliberately distinct. A *handle* is an identity and can be
+# minted by a real IdP, so it allows the `@` a corporate SSO `preferred_username`
+# carries (e.g. `user@example.com`). A *slug* is a filename / composer trigger
+# token (memory keys, skill names) and stays clean. Keep this backend-side copy
+# (`app/schemas.py`, `app/routes/engines.py`) and the frontend copy
+# (`acting-as-picker.tsx`) in agreement; the thin CLI can't import the backend.
+HANDLE_PATTERN = r"^[a-z0-9][a-z0-9._@-]*$"
+SLUG_PATTERN = r"^[a-z0-9][a-z0-9._-]*$"
+
 # Why an agent's stated belief moved this turn (SIEP `belief.revision_cause`).
 # ``social_compliance`` is the one that drives SCR down; the rest are genuine.
 RevisionCause = Literal[
@@ -266,7 +275,7 @@ class MemoryLogEntry(BaseModel):
     """
 
     category: Literal["work", "decisions", "context", "status", "procedures", "plan"]
-    slug: str = Field(..., min_length=1, pattern=r"^[a-z0-9][a-z0-9._-]*$")
+    slug: str = Field(..., min_length=1, pattern=SLUG_PATTERN)
     content: str = Field(..., min_length=1)
     tags: list[str] | None = None
 
@@ -316,11 +325,12 @@ class AgentManifest(BaseModel):
     - ``engine``: a first-party cognition engine (e.g. ``aligner``), run by the
       backend. Requires ``kind``.
 
-    The handle slug doubles as the mention target (``@release-agent``), so it
-    must match the same lowercase pattern other memory slugs use.
+    The handle doubles as the mention target (``@release-agent``). It follows the
+    lowercase ``HANDLE_PATTERN`` — like a memory slug but also allowing ``@``, so
+    an IdP-minted email identity (``user@example.com``) is a valid handle.
     """
 
-    handle: str = Field(..., min_length=1, pattern=r"^[a-z0-9][a-z0-9._-]*$")
+    handle: str = Field(..., min_length=1, pattern=HANDLE_PATTERN)
     adapter: Literal["claude_code", "cursor", "engine"] = "claude_code"
     kind: str | None = Field(
         default=None,
@@ -421,7 +431,7 @@ class UserManifest(BaseModel):
     cryptographic.
     """
 
-    handle: str = Field(..., min_length=1, pattern=r"^[a-z0-9][a-z0-9._-]*$")
+    handle: str = Field(..., min_length=1, pattern=HANDLE_PATTERN)
     display_name: str = Field(default="", description="Human-readable name, e.g. 'Avery Quinn'.")
     teams: list[str] = Field(
         default_factory=list,

--- a/mycelium-cli/tests/test_handle_pattern.py
+++ b/mycelium-cli/tests/test_handle_pattern.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Handle vs. slug shape rules (CLI side).
+
+A *handle* is an identity and can be minted by a real IdP, so an email-shaped
+``preferred_username`` (Cisco SSO / Keycloak) must validate. A *slug* is a
+filename / composer trigger token and stays clean. These are deliberately two
+patterns; regressing either back to a single slug rule reintroduces #656.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from mycelium.protocol import AgentManifest, MemoryLogEntry, UserManifest
+
+
+@pytest.mark.parametrize("model", [AgentManifest, UserManifest])
+def test_handle_accepts_email_shaped_identity(model: type) -> None:
+    """An IdP-minted email handle registers, not just validates on login (#656)."""
+    m = model(handle="user@example.com")
+    assert m.handle == "user@example.com"
+
+
+@pytest.mark.parametrize("model", [AgentManifest, UserManifest])
+def test_handle_still_rejects_spaces_and_bad_leading_char(model: type) -> None:
+    # A bare leading `@` is normalized away (lstrip), so it isn't the guard —
+    # inner whitespace and a non-alphanumeric first char still are.
+    with pytest.raises(ValidationError):
+        model(handle="has space")
+    with pytest.raises(ValidationError):
+        model(handle="!bad")
+
+
+def test_memory_slug_stays_clean() -> None:
+    """A slug is a filename, not an identity — `@` is not allowed."""
+    MemoryLogEntry(category="work", slug="cron-setup", content="ok")
+    with pytest.raises(ValidationError):
+        MemoryLogEntry(category="work", slug="user@example.com", content="ok")

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -30,7 +30,10 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 
-const SLUG = /^[a-z0-9][a-z0-9._-]*$/;
+// A handle is an identity and can be minted by a real IdP, so it allows the `@`
+// a corporate SSO `preferred_username` carries (e.g. `user@example.com`). Keep
+// in sync with the backend (`app/schemas.py`) and CLI (`protocol.py`) copies.
+const HANDLE = /^[a-z0-9][a-z0-9._@-]*$/;
 const normHandle = (s: string) => s.trim().replace(/^@/, "").toLowerCase();
 
 interface Form {
@@ -128,8 +131,8 @@ export function ActingAsPicker() {
       setError("Enter a handle.");
       return;
     }
-    if (!SLUG.test(handle)) {
-      setError("Handle must be lowercase letters, digits, . _ or -, with no spaces.");
+    if (!HANDLE.test(handle)) {
+      setError("Handle must be lowercase letters, digits, . _ - or @, with no spaces.");
       return;
     }
     try {

--- a/openapi.json
+++ b/openapi.json
@@ -2320,7 +2320,7 @@
           },
           "handle": {
             "minLength": 1,
-            "pattern": "^[a-z0-9][a-z0-9._-]*$",
+            "pattern": "^[a-z0-9][a-z0-9._@-]*$",
             "title": "Handle",
             "type": "string"
           },


### PR DESCRIPTION
Closes #656.

## Problem

Under a real corporate OIDC issuer (Cisco SSO / Keycloak) whose `preferred_username` is a full email address, `mycelium login` resolves the token handle fine (`@user@example.com`) but every handle-taking command (`iam`, `agent create --owner/--allow-from`, acting-as picker) rejects it: the handle regex `^[a-z0-9][a-z0-9._-]*$` has no `@`. You could be authenticated as a handle the system refused to let you register.

## Fix

The single slug regex was copy-pasted across ~7 field definitions in two languages. Rather than widen all copies, this splits it by intent:

- **`HANDLE_PATTERN`** = `^[a-z0-9][a-z0-9._@-]*$` — identities (user / agent / engine handles). Allows the `@` an email-shaped IdP username carries.
- **`SLUG_PATTERN`** = `^[a-z0-9][a-z0-9._-]*$` — filenames / composer trigger tokens (memory slugs, skill names). Unchanged; these are not identities and stay clean.

Handles and slugs were only ever *accidentally* the same regex; they're now named, deliberate, and centralized once per package (backend `app/schemas.py`, CLI `mycelium/protocol.py`, frontend `acting-as-picker.tsx` — the thin CLI can't import the backend, so a shared import isn't possible across the two Python packages).

Also fixes a second latent inconsistency the issue flagged: `engines.py`'s handle regex was additionally missing `.`.

## Out of scope (follow-up)

The chat composer's `@`-mention autocomplete (`room-chat-box.tsx`) still stops its capture at the first `@`, so *mentioning* an email-shaped handle in chat isn't fully wired. This PR is the registration/validation fix #656 describes; mention autocomplete for email handles is a separate UX change.

## Tests

- `mycelium-cli/tests/test_handle_pattern.py` — email handles register on `AgentManifest`/`UserManifest`; memory slugs still reject `@`.
- `fastapi-backend/tests/test_handle_pattern.py` — `UserCreate` + engine handle regex accept email handles; `SkillCreate` still rejects `@`.

Full lint/format/type gates pass in both Python packages; frontend `tsc --noEmit` passes. Existing principals/engines/skills/user-store suites green.