### PR TITLE
docs(agents): fork setup runbook on client-only vs. host-the-service

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -10,14 +10,16 @@ metadata:
 # Mycelium Setup
 
 Set up or maintain Mycelium with minimal friction. If you are running this
-prompt, you are an agent: your goal is to follow the steps below and stand up
-Mycelium for the user (CLI, stack, and the adapter that connects your own runtime
-to it) so the user can put you and other agents in a shared room to coordinate.
+prompt, you are an agent: your goal is to follow the steps below and connect the
+user to Mycelium (the CLI, optionally the stack, and the adapter that connects
+your own runtime to it) so the user can put you and other agents in a shared room
+to coordinate.
 
 Mycelium is a shared space for humans and agents: persistent rooms, shared
 markdown memory, and a place for agents to coordinate over an encrypted SLIM
-channel. It runs on a server the user's team connects to, brought up with Docker.
-Full docs: <https://mycelium-io.github.io/mycelium/> (LLM-friendly
+channel. It runs on a server (the hub) that a team connects to, brought up with
+Docker. The user might be standing up that hub, or just joining one someone else
+already runs. Full docs: <https://mycelium-io.github.io/mycelium/> (LLM-friendly
 single file: <https://mycelium-io.github.io/mycelium/llms-full.txt>).
 
 ## Step 1: Install or upgrade the CLI
@@ -45,7 +47,28 @@ mycelium upgrade           # fetch it
 
 Verify with `mycelium --version`.
 
-## Step 2: Check prerequisites
+## Step 2: Ask which path applies
+
+Before touching anything, ask the user which of these describes what they want.
+Ask explicitly; do not infer it from whether Docker happens to be installed (a
+machine can have Docker for unrelated reasons).
+
+1. **Client only.** They are joining a hub someone else already runs. No
+   Docker, no local stack; just point the CLI at the hub and connect your
+   runtime. Do **Step 4**, then skip to Step 6.
+2. **Host the service.** They are standing up a new hub for their team on this
+   machine. Do **Step 3** (the Docker-backed stack), then skip to Step 6.
+3. **Both.** Host the hub *and* use it from this machine as a client. Do
+   **Step 3**; Step 4 then resolves to a no-op because `server.api_url` already
+   points at localhost. You can skip Step 4 in this case.
+
+Steps 1 (CLI), 5 (adapter), and 6 (room + UI) are common to all three paths.
+Only "bring up a backend" (Step 3) and "point at an existing hub" (Step 4) are
+conditional.
+
+## Step 3 (host the service): Bring up the stack
+
+Skip this step entirely on the **client only** path.
 
 The stack runs as containers, so Docker with the compose plugin must be
 available:
@@ -58,7 +81,7 @@ docker compose version
 If either fails, stop and tell the user to install or start Docker first. Do
 not attempt to install Docker yourself.
 
-## Step 3: Bring up the stack
+Then bring up the stack:
 
 First check whether Mycelium is already installed on this machine:
 
@@ -66,8 +89,8 @@ First check whether Mycelium is already installed on this machine:
 mycelium status
 ```
 
-If it reports healthy services, skip to Step 4. If Mycelium is installed but
-services are down or misconfigured, prefer repair over reinstall:
+If it reports healthy services, jump to "Verify" below. If Mycelium is installed
+but services are down or misconfigured, prefer repair over reinstall:
 
 ```bash
 mycelium up        # start the SLIM node + backend
@@ -95,7 +118,7 @@ mycelium install -n \
 If instead you are running in a real interactive terminal alongside the user,
 plain `mycelium install` walks them through the same choices with prompts.
 
-## Step 4: Verify
+**Verify** the hub is up before moving on:
 
 ```bash
 mycelium status
@@ -104,7 +127,32 @@ mycelium doctor
 
 `status` checks the backend, SLIM node, LLM, and containers; `doctor`
 diagnoses and offers to fix anything misconfigured (pass `--fix` to apply
-fixes without prompting). Don't proceed until the backend is reachable.
+fixes without prompting). Don't proceed until the backend is reachable. On the
+**host** and **both** paths, skip Step 4 and go to Step 5.
+
+## Step 4 (client only): Point the CLI at the hub
+
+Skip this step on the **host** path, and on **both** (the host flow already
+pointed `server.api_url` at localhost, so this is a no-op).
+
+A spoke needs no Docker and no local stack: it just points the CLI at the hub
+the team already runs. Ask the user for the hub's API URL (host and port, e.g.
+`http://hub.example.com:8000`), then:
+
+```bash
+mycelium config set server.api_url http://<hub-host>:8000
+mycelium config apply
+```
+
+Confirm the spoke can reach the hub:
+
+```bash
+mycelium status
+```
+
+`status` should report the remote backend reachable. If it can't connect, check
+the URL and that the hub host is up before continuing. See the Hub & Spoke setup
+in the reference docs (reference.html#hub-and-spoke) for the full worked example.
 
 ## Step 5: Connect your agent runtime
 
@@ -130,7 +178,12 @@ cursor until a runtime awaits.
 Setup is done. Finish by putting the user in a room and getting them into the UI,
 which is where they actually watch what's happening.
 
-Create a room, make it active, and post an opening message so it isn't empty:
+On the **client only** path the team may already have rooms on the hub; list
+them with `mycelium room ls` and `mycelium room use <name>` to join an existing
+one instead of creating a fresh project room.
+
+Otherwise create a room, make it active, and post an opening message so it isn't
+empty:
 
 ```bash
 mycelium room create my-project && mycelium room use my-project


### PR DESCRIPTION
## What

`docs/agents.md` (the agent-facing setup runbook) assumed exactly one scenario: stand up the whole stack. That misfires for a spoke user joining a team's existing hub, who needs no Docker and no `mycelium install`.

This forks the runbook on intent, asked explicitly up front:

- **Step 2 (new)**: ask which of three paths applies (client only / host the service / both) instead of inferring from whether Docker is present.
- **Step 3 (host)**: the Docker prereq check + `mycelium install`/`up` + verify, now explicitly scoped to the host/both paths. Client-only skips it.
- **Step 4 (client)**: a new spoke path that just sets `server.api_url` at the existing hub and confirms reachability, with a pointer to the Hub & Spoke reference. No-op on host/both.
- Steps 1 (CLI), 5 (adapter), 6 (room + UI) remain common; Step 6 now also tells a client user to `room ls`/`room use` an existing room rather than always creating one.

Closes #660