### PR TITLE
feat(frontend): full-page memory view at /room/{room}/memory/{key}

### DIFF
--- a/docs/plans/614-full-page-memory-view.md
+++ b/docs/plans/614-full-page-memory-view.md
@@ -30,12 +30,15 @@ slashes allowed). Rail stays as **quick peek**; full-page is the reading surface
 | ----- | --------------------------------------------------------------------------- |
 | #600  | Epic — #614 is the dedicated-route track                                    |
 | #611  | Merged — wikilinks, backlinks, relations in rail; transclusion markers only |
-| #599  | Graph viz + global inline transclusion in `markdown-content` (later)        |
+| #599  | Graph viz (later); rail integrity banner + inline transclusion moved here  |
 | #596  | Frontmatter schemas (out of scope)                                          |
 
 
 #599's open question (*rail vs full-page*) is answered here: **full-page for reading**;
-graph stays in Memory area (#599).
+graph stays in Memory area (#599). The rail integrity banner and inline transclusion
+(originally scoped to #599) shipped in this branch too, since #614 already built the
+`fetchMemoryIntegrity`/`fetchMemoryExpanded` plumbing and `MemoryDetail` accepts both
+props regardless of variant — see Phase 3.
 
 ---
 
@@ -86,11 +89,17 @@ tests when the slice needs a later phase.
 
 - "Open full page" link in `DetailDrawer` header (memory panel)
 - `navigateToKey`: if key not in loaded list → `router.push(memoryHref(...))`
+- Rail drawer fetches the room's `fetchMemoryIntegrity` report and the selected
+  memory's `fetchMemoryExpanded` body, passing both into `MemoryDetail` — the
+  integrity banner and inline transclusion (#599) are no longer page-only
 
 **Tests**
 
 - `memory-detail.test.tsx`: "Open full page" href correct when `showOpenFullPage`
 - `memory-routes.test.ts` already covers href generation (panel uses same helper)
+- `memory-detail.test.tsx`: integrity banner renders on the default (rail) variant
+- `memory-panel.test.tsx`: drawer's `MemoryDetail` receives the integrity report and
+  the selected memory's expanded `renderedBody`
 
 ---
 
@@ -189,6 +198,14 @@ Demo pages (seeded in `demo`):
 - [x] Memory tab → select a memory in the rail
 - [x] Drawer header **Full page** link (title: "Open full page") is visible
 - [x] Click → navigates to `/room/demo/memory/{key}` with same content
+
+### 5b. Rail integrity banner + inline transclusion (#599)
+
+- [ ] Select `context/integrity-orphan` (or similar) in the rail → banner shows in the
+      drawer, matching the full-page wording
+- [ ] Select a memory with `![[key]]` in the rail → **Rendered** mode (default) shows
+      the expanded content, not a raw `![[…]]` marker
+- [ ] **Raw** toggle in the rail still shows the original markdown with the marker intact
 
 ### 6. Memory tree vs off-tree navigation
 

--- a/docs/plans/614-full-page-memory-view.md
+++ b/docs/plans/614-full-page-memory-view.md
@@ -201,11 +201,11 @@ Demo pages (seeded in `demo`):
 
 ### 5b. Rail integrity banner + inline transclusion (#599)
 
-- [ ] Select `context/integrity-orphan` (or similar) in the rail → banner shows in the
+- [x] Select `context/integrity-orphan` (or similar) in the rail → banner shows in the
       drawer, matching the full-page wording
-- [ ] Select a memory with `![[key]]` in the rail → **Rendered** mode (default) shows
+- [x] Select a memory with `![[key]]` in the rail → **Rendered** mode (default) shows
       the expanded content, not a raw `![[…]]` marker
-- [ ] **Raw** toggle in the rail still shows the original markdown with the marker intact
+- [x] **Raw** toggle in the rail still shows the original markdown with the marker intact
 
 ### 6. Memory tree vs off-tree navigation
 

--- a/docs/plans/614-full-page-memory-view.md
+++ b/docs/plans/614-full-page-memory-view.md
@@ -1,0 +1,231 @@
+# #614 — Full-page memory view
+
+Branch: `614-full-page-memory-view`  
+Issue: [https://github.com/mycelium-io/mycelium/issues/614](https://github.com/mycelium-io/mycelium/issues/614)  
+Epic: #600 (interlinked wiki). Complements #599 (graph UI). Builds on #611 (linking, merged).
+
+## Problem
+
+Memory content lives in the right-rail inspector (~340px drawer). For an interlinked
+wiki (#600), reading a page, walking wikilinks, expanding transclusions, and scanning
+backlinks all fight for that width. Chat wikilinks (#611) land in the rail; the content
+deserves a real page.
+
+## Goal
+
+Dedicated, deep-linkable wiki page at `/room/{room}/memory/{key}` (URL-encoded key,
+slashes allowed). Rail stays as **quick peek**; full-page is the reading surface.
+
+## Non-goals
+
+- Graph **visualization** (#599) — force-directed graph, link autocomplete in editor
+- Frontmatter schema editing (#596)
+- Cross-room link resolution (surface `cross_room` errors as-is)
+- Mandatory chat wikilink → full page (#614 says that promotion is **optional**)
+
+## Related issues
+
+
+| Issue | Role                                                                        |
+| ----- | --------------------------------------------------------------------------- |
+| #600  | Epic — #614 is the dedicated-route track                                    |
+| #611  | Merged — wikilinks, backlinks, relations in rail; transclusion markers only |
+| #599  | Graph viz + global inline transclusion in `markdown-content` (later)        |
+| #596  | Frontmatter schemas (out of scope)                                          |
+
+
+#599's open question (*rail vs full-page*) is answered here: **full-page for reading**;
+graph stays in Memory area (#599).
+
+---
+
+## Implementation phases (with tests)
+
+Each phase ships with unit tests that prove the intended behavior, or documents deferred
+tests when the slice needs a later phase.
+
+### Phase 1 — Routing & URL helpers
+
+**Deliverables**
+
+- `src/lib/memory-routes.ts` — `encodeMemoryKeyPath`, `parseMemoryKeyParam`, `memoryHref`
+- `src/app/room/[name]/memory/[...key]/page.tsx` — catch-all route
+- `fetchMemory` uses shared encode helper
+
+**Tests (**`memory-routes.test.ts`**)**
+
+- Round-trip keys with slashes and special chars
+- `memoryHref("demo", "decisions/db")` → `/room/demo/memory/decisions/db`
+- Room names with spaces are encoded
+
+**Deferred until Phase 2**
+
+- Page integration test (needs `MemoryPageView`)
+
+---
+
+### Phase 2 — Full-page view component
+
+**Deliverables**
+
+- `src/components/memory-page-view.tsx` — loads memory, expand, integrity; renders layout
+- Reuse `MemoryDetail` with `variant="page"`
+
+**Tests (**`memory-page-view.test.tsx` **or** `memory-detail.test.tsx`**)**
+
+- Renders memory key and body when props/data provided
+- Shows neighbors section (1-hop from links API)
+- Shows integrity note when memory has broken outbound or is orphan
+- Rendered mode uses expanded body when expand API returns content
+
+---
+
+### Phase 3 — Rail affordances
+
+**Deliverables**
+
+- "Open full page" link in `DetailDrawer` header (memory panel)
+- `navigateToKey`: if key not in loaded list → `router.push(memoryHref(...))`
+
+**Tests**
+
+- `memory-detail.test.tsx`: "Open full page" href correct when `showOpenFullPage`
+- `memory-routes.test.ts` already covers href generation (panel uses same helper)
+
+---
+
+### Phase 4 — Navigation & search
+
+**Deliverables**
+
+- `resultHref` for `memory` hits → direct memory URL (not `?focus=`)
+- Room page: legacy `?focus=memory:…` redirects to memory URL
+- Chat wikilink → rail unchanged (#614 optional); document as follow-up
+
+**Tests (**`search.test.ts`**)**
+
+- Memory hit href is `/room/{room}/memory/{encoded-key}`
+- Room hits unchanged
+- Legacy focus parse still works for non-memory types
+
+---
+
+### Phase 5 — API clients & link surfaces
+
+**Deliverables**
+
+- `fetchMemoryExpanded`, `fetchMemoryIntegrity` in `api.ts`
+- `src/lib/memory-links.ts` — `neighborKeys()`, `integrityNotesForMemory()` (pure)
+
+**Tests (**`memory-links.test.ts`**)**
+
+- Neighbors = unique outbound targets + backlink sources (excluding self)
+- Integrity notes for broken outbound from this key and orphan status
+
+---
+
+## File checklist
+
+
+| Action | File                                                   |
+| ------ | ------------------------------------------------------ |
+| Add    | `src/lib/memory-routes.ts`, `memory-routes.test.ts`    |
+| Add    | `src/lib/memory-links.ts`, `memory-links.test.ts`      |
+| Add    | `src/app/room/[name]/memory/[...key]/page.tsx`         |
+| Add    | `src/components/memory-page-view.tsx`                  |
+| Add    | `src/components/memory-detail.test.tsx`                |
+| Edit   | `src/lib/api.ts`                                       |
+| Edit   | `src/components/memory-detail.tsx`                     |
+| Edit   | `src/components/memory-panel.tsx`                      |
+| Edit   | `src/lib/search.ts`, `search.test.ts`                  |
+| Edit   | `src/app/room/[name]/page.tsx` (legacy focus redirect) |
+
+
+---
+
+## Manual test checklist (demo room)
+
+Open this file in the editor and click the boxes as you go (`- [ ]` → `- [x]`).
+
+### Prerequisites
+
+- [x] Backend healthy: `curl http://localhost:8000/health` returns `"status":"ok"`
+- [x] Frontend at [http://localhost:3000](http://localhost:3000) (`pnpm dev` in `mycelium-frontend`, or dev container)
+- [x] Demo room has interlinked memories (`context/overview`, `decisions/db`, etc.)
+
+### 1. Direct URL — full-page load
+
+- [x] Open [http://localhost:3000/room/demo/memory/context/overview](http://localhost:3000/room/demo/memory/context/overview)
+- [x] Page uses full width (not the ~340px rail drawer)
+- [x] Header shows room back link and memory key title
+- [x] Memory body renders (markdown, wikilinks clickable)
+- [x] **Related** section lists 1-hop neighbors
+
+### 2. Wikilink navigation on full page
+
+- [x] Click a `[[wikilink]]` in the body (e.g. `decisions/db`)
+- [x] URL updates to `/room/demo/memory/decisions/db`
+- [x] New memory content loads correctly
+
+### 3. Transclusion (Rendered mode)
+
+- [x] On a memory with `![[key]]`, **Rendered** mode is default
+- [x] Expanded content appears (not raw `![[…]]` markers)
+- [x] **Raw** toggle shows original markdown
+- [x] Back to **Rendered** restores expanded view
+
+### 4. Integrity banner
+
+Demo pages (seeded in `demo`):
+
+- [x] **Orphan only:** [http://localhost:3000/room/demo/memory/context/integrity-orphan](http://localhost:3000/room/demo/memory/context/integrity-orphan) → `nothing links here yet (orphan)`
+- [x] **Broken outbound only:** [http://localhost:3000/room/demo/memory/context/integrity-broken](http://localhost:3000/room/demo/memory/context/integrity-broken) → `2 broken outbound links`
+- [x] **Both:** [http://localhost:3000/room/demo/memory/context/integrity-both](http://localhost:3000/room/demo/memory/context/integrity-both) → broken outbound · orphan
+- [x] Clean memory (e.g. overview) shows no spurious warnings
+
+### 5. Rail → full page
+
+- [x] Open [http://localhost:3000/room/demo](http://localhost:3000/room/demo)
+- [x] Memory tab → select a memory in the rail
+- [x] Drawer header **Full page** link (title: "Open full page") is visible
+- [x] Click → navigates to `/room/demo/memory/{key}` with same content
+
+### 6. Memory tree vs off-tree navigation
+
+- [x] Memory **in tree** → opens in rail (peek unchanged)
+- [x] Key **not in tree** (search or direct URL) → full-page URL *(direct URL path covered by §4 orphan/both pages; search palette is §7)*
+
+### 7. Search → direct memory URL
+
+- [x] Search palette finds a memory (e.g. `overview` or `memory:context`) — open with `**/**` or `**/ search**` in the status bar (not ⌘K)
+- [x] After clicking a **memory** row, address bar is `/room/demo/memory/...` (not `?focus=memory:…`) — no copyable link on rows; watch the URL change on click
+
+### 8. Legacy focus redirect
+
+- [x] Open [http://localhost:3000/room/demo?focus=memory:context/overview](http://localhost:3000/room/demo?focus=memory:context/overview)
+- [x] URL replaces with `/room/demo/memory/context/overview`
+- [x] Full-page view loads
+
+### 9. Missing key
+
+- [x] Open [http://localhost:3000/room/demo/memory/does/not/exist](http://localhost:3000/room/demo/memory/does/not/exist)
+- [x] **Memory not found.** with **Back to room** link
+- [x] Back link returns to `/room/demo`
+
+### 10. Chat wikilink (unchanged — optional follow-up)
+
+- [x] Click `[[wikilink]]` in chat → memory **rail** opens (not full page)
+
+### 11. Edge cases
+
+- [x] Slashed key loads: `/room/demo/memory/decisions/storage-model`
+- [x] Browser back/forward between memory pages works
+
+### Ship (after manual QA)
+
+- [ ] Critical items 1–9 pass
+- [ ] Unit tests green: `pnpm exec vitest run src/lib/memory-routes.test.ts src/lib/memory-links.test.ts src/lib/search.test.ts src/components/memory-detail.test.tsx`
+- [ ] Commit on `614-full-page-memory-view`
+- [ ] Open PR referencing #614
+
+**Quick smoke (~2 min):** 1 → 2 → 5 → 7 → 9

--- a/fastapi-backend/app/services/links.py
+++ b/fastapi-backend/app/services/links.py
@@ -206,6 +206,23 @@ def _strip_code(body: str) -> str:
     return _INLINE_CODE_RE.sub(lambda m: " " * len(m.group(0)), body)
 
 
+def _code_span_ranges(body: str) -> list[tuple[int, int]]:
+    """Start/end offsets of fenced code blocks and inline code spans.
+
+    A ``![[…]]`` example quoted in backticks (documentation about the syntax,
+    not a live link) must not be treated as a real marker — same rule
+    ``parse_body_links`` applies via ``_strip_code``, restated here as ranges
+    since ``expand`` needs to preserve the surrounding text verbatim.
+    """
+    ranges = [m.span() for m in _FENCE_RE.finditer(body)]
+    ranges += [m.span() for m in _INLINE_CODE_RE.finditer(body)]
+    return ranges
+
+
+def _in_code_span(pos: int, ranges: list[tuple[int, int]]) -> bool:
+    return any(start <= pos < end for start, end in ranges)
+
+
 def parse_body_links(body: str) -> list[Link]:
     """Extract every link in a markdown body, in document order."""
     scannable = _strip_code(body)
@@ -547,8 +564,11 @@ def expand(room_name: str, key: str) -> dict[str, Any]:
     body = source[1]
     targets = {e.key: e for e in load_index(room_name)}
     expansions: list[Expansion] = []
+    code_ranges = _code_span_ranges(body)
 
     def replace(match: re.Match[str]) -> str:
+        if _in_code_span(match.start(), code_ranges):
+            return match.group(0)
         link = _make_link(match.group(1), kind=KIND_TRANSCLUSION, raw=match.group(0))
         if link is None:
             return match.group(0)

--- a/fastapi-backend/tests/test_handle_binding.py
+++ b/fastapi-backend/tests/test_handle_binding.py
@@ -251,6 +251,10 @@ async def test_reply_as_an_owned_agent_is_allowed(client: AsyncClient, as_princi
         def refresh_lease(self, room: str, handle: str) -> None:
             return None
 
+        async def send_as_custodian(self, room: str, handle: str, data: bytes) -> bool:
+            # PSK default: no custodial session, so the reply falls back to a moderator send.
+            return False
+
     monkeypatch.setattr(room_channels, "manager", _Manager())
 
     await _make_room(client)

--- a/fastapi-backend/tests/test_links.py
+++ b/fastapi-backend/tests/test_links.py
@@ -231,6 +231,33 @@ def test_expand_reports_a_missing_memory():
     assert links.expand("r", "nope")["found"] is False
 
 
+def test_expansion_skips_a_marker_quoted_as_a_code_example():
+    """A backtick-quoted `![[…]]` is documentation about the syntax, not a live
+    link — same rule ``parse_body_links`` already applies via ``_strip_code``,
+    but ``expand`` runs its own substitution and must honor it too."""
+    _write(
+        "r",
+        "glossary/self",
+        "Definition. Other pages embed this with `![[glossary/self]]`.",
+        expandable=True,
+    )
+    _write("r", "reader", "![[glossary/self]]")
+
+    result = links.expand("r", "reader")
+
+    assert result["rendered"].count("Definition.") == 1
+    assert "`![[glossary/self]]`" in result["rendered"]
+    assert result["expansions"] == [
+        {
+            "target": "glossary/self",
+            "anchor": None,
+            "raw": "![[glossary/self]]",
+            "expanded": True,
+            "error": None,
+        }
+    ]
+
+
 # ── Backward compatibility ───────────────────────────────────────────────────
 
 

--- a/mycelium-frontend/src/app/room/[name]/memory/[...key]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/memory/[...key]/page.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { Suspense } from "react";
+import { useParams } from "next/navigation";
+import { AppShell } from "@/components/app-shell";
+import { MemoryPageView } from "@/components/memory-page-view";
+import { GlobalStatusItems } from "@/components/status-items";
+import { ActingAsPicker } from "@/components/acting-as-picker";
+import { parseMemoryKeyParam } from "@/lib/memory-routes";
+
+function MemoryPageBody() {
+  const params = useParams();
+  const roomName = params.name as string;
+  const keySegments = params.key;
+  const memoryKey = parseMemoryKeyParam(
+    Array.isArray(keySegments) ? keySegments : keySegments ? [keySegments] : [],
+  );
+
+  return <MemoryPageView roomName={roomName} memoryKey={memoryKey} />;
+}
+
+/** Dedicated full-page memory route: `/room/{room}/memory/{key}` (#614). */
+export default function MemoryPage() {
+  const params = useParams();
+  const roomName = params.name as string;
+
+  return (
+    <AppShell
+      activeRoom={roomName}
+      statusLeft={<span className="text-micro text-muted-foreground">Memory</span>}
+      statusRight={
+        <>
+          <ActingAsPicker />
+          <GlobalStatusItems />
+        </>
+      }
+    >
+      <Suspense fallback={null}>
+        <MemoryPageBody />
+      </Suspense>
+    </AppShell>
+  );
+}

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -7,6 +7,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchRoom, logFetchError, type EpisodeSummary, type Room } from "@/lib/api";
 import { parseFocus, type FocusTarget } from "@/lib/search";
+import { memoryHref } from "@/lib/memory-routes";
 import { AppShell } from "@/components/app-shell";
 import { EventStream, type View, type NegotiationPhase } from "@/components/event-stream";
 import { RoomChatBox } from "@/components/room-chat-box";
@@ -116,9 +117,12 @@ function RoomWorkspace() {
     applied.current = focusParam;
     const target = parseFocus(focusParam);
     if (!target) return;
+    if (target.type === "memory") {
+      router.replace(memoryHref(roomName, target.id));
+      return;
+    }
     setFocus(target);
-    if (target.type === "memory") openTab("memory");
-    else if (target.type === "episode") openTab("episodes");
+    if (target.type === "episode") openTab("episodes");
     else if (target.type === "agent") openTab("agents");
     else if (target.type === "message") setEditorView("channel");
     router.replace(`/room/${encodeURIComponent(roomName)}`, { scroll: false });

--- a/mycelium-frontend/src/components/markdown-content.test.tsx
+++ b/mycelium-frontend/src/components/markdown-content.test.tsx
@@ -110,4 +110,18 @@ describe("<MarkdownContent /> memory links", () => {
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
+
+  it("leaves a wikilink/transclusion syntax example inside a code span inert", () => {
+    // A glossary row like `` `![[key]]` embeds the target `` is prose *about*
+    // the syntax, not a live link — it must not become a chip that navigates
+    // to a literal memory named "key".
+    render(
+      <MarkdownContent onLinkClick={vi.fn()}>
+        {"Transclusion: `![[key]]` embeds the target body, and `[[key]]` is a wikilink."}
+      </MarkdownContent>,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByText(/!\[\[key\]\]/)).toBeInTheDocument();
+  });
 });

--- a/mycelium-frontend/src/components/markdown-content.tsx
+++ b/mycelium-frontend/src/components/markdown-content.tsx
@@ -175,6 +175,10 @@ export function MarkdownContent({ children, className, onLinkClick, brokenLinks 
       if (Array.isArray(node))
         return node.map((n, i) => <React.Fragment key={i}>{walk(n)}</React.Fragment>);
       if (React.isValidElement(node)) {
+        // A code span/block is prose *about* syntax, not a link — e.g. a
+        // glossary row showing `![[key]]` as an example must stay inert text,
+        // not become a chip that navigates to a literal memory named "key".
+        if (node.type === "code" || node.type === "pre") return node;
         const props = node.props as { children?: React.ReactNode };
         return React.cloneElement(
           node as React.ReactElement<{ children?: React.ReactNode }>,

--- a/mycelium-frontend/src/components/memory-detail-json.test.ts
+++ b/mycelium-frontend/src/components/memory-detail-json.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import {
+  isJsonRawText,
+  parseJsonRawText,
+  prettyPrintJsonRawText,
+} from "@/lib/json-text";
+
+describe("memory raw JSON helpers", () => {
+  it("accepts object and array literals", () => {
+    expect(isJsonRawText('{"a":1}')).toBe(true);
+    expect(isJsonRawText("[1,2]")).toBe(true);
+    expect(parseJsonRawText(' {"x": true} ')).toEqual({ x: true });
+  });
+
+  it("rejects markdown and partial JSON", () => {
+    expect(isJsonRawText("See [[link]]")).toBe(false);
+    expect(isJsonRawText("{not json}")).toBe(false);
+    expect(isJsonRawText("")).toBe(false);
+  });
+
+  it("pretty-prints without adding API fields", () => {
+    expect(prettyPrintJsonRawText('{"b":2,"a":1}')).toBe(
+      '{\n  "b": 2,\n  "a": 1\n}',
+    );
+  });
+});

--- a/mycelium-frontend/src/components/memory-detail.test.tsx
+++ b/mycelium-frontend/src/components/memory-detail.test.tsx
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryDetail, type MemoryLike } from "@/components/memory-detail";
+
+vi.mock("@/lib/api", () => ({
+  fetchMemoryLinks: vi.fn(),
+}));
+
+import { fetchMemoryLinks } from "@/lib/api";
+
+const memory: MemoryLike = {
+  key: "context/overview",
+  value: { text: "See [[decisions/db]]" },
+  content_text: "See [[decisions/db]]",
+  version: 1,
+  created_by: "alice",
+};
+
+describe("MemoryDetail", () => {
+  beforeEach(() => {
+    vi.mocked(fetchMemoryLinks).mockResolvedValue({
+      key: memory.key,
+      outbound: [
+        {
+          target: "decisions/db",
+          kind: "wikilink",
+          raw: "[[decisions/db]]",
+          resolved: true,
+        },
+      ],
+      backlinks: [
+        {
+          target: memory.key,
+          source: "plan/title",
+          kind: "wikilink",
+          raw: "[[context/overview]]",
+          resolved: true,
+        },
+      ],
+    });
+  });
+
+  it("renders neighbors on the page variant", async () => {
+    const onNavigate = vi.fn();
+    render(<MemoryDetail memory={memory} roomName="demo" variant="page" onNavigate={onNavigate} />);
+    const relatedSection = (await screen.findByText("Related")).closest("div")?.parentElement;
+    expect(relatedSection).toBeTruthy();
+    const related = within(relatedSection!);
+    expect(related.getByRole("button", { name: "decisions/db" })).toBeInTheDocument();
+    expect(related.getByRole("button", { name: "plan/title" })).toBeInTheDocument();
+  });
+
+  it("shows integrity banner when this memory has broken outbound links", async () => {
+    render(
+      <MemoryDetail
+        memory={memory}
+        roomName="demo"
+        variant="page"
+        integrity={{
+          broken: [
+            {
+              source: memory.key,
+              target: "gone",
+              kind: "wikilink",
+              raw: "[[gone]]",
+              resolved: false,
+            },
+          ],
+          orphans: [],
+          total_memories: 1,
+          total_links: 1,
+        }}
+      />,
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent(/broken outbound link/i);
+  });
+
+  it("uses renderedBody in Rendered mode", async () => {
+    render(
+      <MemoryDetail
+        memory={{ ...memory, content_text: "Original body" }}
+        variant="page"
+        renderedBody="Expanded body with inlined glossary."
+      />,
+    );
+    expect(await screen.findByText(/Expanded body with inlined glossary/)).toBeInTheDocument();
+    expect(screen.queryByText("Original body")).not.toBeInTheDocument();
+  });
+
+  it("does not show Format JSON for markdown raw body", async () => {
+    const user = userEvent.setup();
+    render(<MemoryDetail memory={memory} roomName="demo" />);
+    await user.click(screen.getByRole("button", { name: "Raw" }));
+    expect(screen.queryByRole("button", { name: /format json/i })).not.toBeInTheDocument();
+  });
+
+  it("pretty-prints JSON already in the raw body", async () => {
+    const user = userEvent.setup();
+    const jsonMemory: MemoryLike = {
+      key: "data/config",
+      value: { text: '{"enabled":true,"ports":[8080]}' },
+      content_text: '{"enabled":true,"ports":[8080]}',
+      version: 1,
+      created_by: "alice",
+    };
+    render(<MemoryDetail memory={jsonMemory} roomName="demo" />);
+    await user.click(screen.getByRole("button", { name: "Raw" }));
+    await user.click(screen.getByRole("button", { name: /pretty-print json/i }));
+    const pre = document.querySelector("pre");
+    expect(pre?.textContent).toContain('"enabled": true');
+    expect(pre?.textContent).toContain('"ports"');
+    expect(pre?.textContent).not.toContain('"key":');
+    expect(pre?.textContent).not.toContain('"version":');
+  });
+});

--- a/mycelium-frontend/src/components/memory-detail.test.tsx
+++ b/mycelium-frontend/src/components/memory-detail.test.tsx
@@ -79,6 +79,22 @@ describe("MemoryDetail", () => {
     expect(await screen.findByRole("status")).toHaveTextContent(/broken outbound link/i);
   });
 
+  it("shows the integrity banner on the rail (default) variant too (#599)", async () => {
+    render(
+      <MemoryDetail
+        memory={memory}
+        roomName="demo"
+        integrity={{
+          broken: [],
+          orphans: [memory.key],
+          total_memories: 1,
+          total_links: 0,
+        }}
+      />,
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent(/orphan/i);
+  });
+
   it("uses renderedBody in Rendered mode", async () => {
     render(
       <MemoryDetail

--- a/mycelium-frontend/src/components/memory-detail.tsx
+++ b/mycelium-frontend/src/components/memory-detail.tsx
@@ -4,9 +4,12 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { ArrowUpRight, CornerDownLeft } from "lucide-react";
+import { ArrowUpRight, CornerDownLeft, Share2 } from "lucide-react";
+import { highlightJson } from "@/components/l9-inspector";
 import { MarkdownContent } from "@/components/markdown-content";
-import { fetchMemoryLinks, type MemoryLink } from "@/lib/api";
+import { fetchMemoryLinks, type MemoryLink, type MemoryLinksIntegrity } from "@/lib/api";
+import { isJsonRawText, prettyPrintJsonRawText } from "@/lib/json-text";
+import { integrityNotesForMemory, neighborKeys, type MemoryIntegrityNotes } from "@/lib/memory-links";
 
 export interface MemoryLike {
   key: string;
@@ -138,14 +141,97 @@ interface Props {
   roomName?: string;
   /** Opens another memory by key — supplied by whatever owns the selection. */
   onNavigate?: (key: string) => void;
+  /** Rail peek vs full-page wiki layout. */
+  variant?: "rail" | "page";
+  /** When set, Rendered mode shows expanded transclusions (#614 full page). */
+  renderedBody?: string | null;
+  /** Room integrity report; page variant surfaces per-memory notes. */
+  integrity?: MemoryLinksIntegrity | null;
+}
+
+function IntegrityBanner({ notes }: { notes: MemoryIntegrityNotes }) {
+  const parts: string[] = [];
+  if (notes.brokenOutbound > 0) {
+    parts.push(
+      `${notes.brokenOutbound} broken outbound link${notes.brokenOutbound === 1 ? "" : "s"}`,
+    );
+  }
+  if (notes.isOrphan) parts.push("nothing links here yet (orphan)");
+  return (
+    <div
+      role="status"
+      className="mx-5 mt-4 rounded-lg border border-yellow/30 bg-yellow/10 px-3 py-2 text-label text-yellow"
+    >
+      {parts.join(" · ")}
+    </div>
+  );
+}
+
+function NeighborChips({
+  keys,
+  onNavigate,
+  className,
+}: {
+  keys: string[];
+  onNavigate?: (key: string) => void;
+  className?: string;
+}) {
+  if (keys.length === 0) return null;
+  return (
+    <div className={`border-t border-border py-4 ${className ?? "px-5"}`}>
+      <div className="mb-2 flex items-center gap-1.5 text-micro uppercase tracking-wide text-faint">
+        <Share2 className="size-3" />
+        Related
+        <span className="tabular">({keys.length})</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {keys.map(key => (
+          onNavigate ? (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onNavigate(key)}
+              className="rounded-md border border-border bg-surface px-2 py-1 font-mono text-micro text-accent transition-colors hover:bg-hairline"
+            >
+              {key}
+            </button>
+          ) : (
+            <span
+              key={key}
+              className="rounded-md border border-border bg-surface px-2 py-1 font-mono text-micro text-muted-foreground"
+            >
+              {key}
+            </span>
+          )
+        ))}
+      </div>
+    </div>
+  );
 }
 
 /** Read-only review/audit of one memory: metadata, its markdown body, its links. */
-export function MemoryDetail({ memory, roomName, onNavigate }: Props) {
+export function MemoryDetail({
+  memory,
+  roomName,
+  onNavigate,
+  variant = "rail",
+  renderedBody = null,
+  integrity = null,
+}: Props) {
+  const pad = variant === "page" ? "px-6 md:px-8" : "px-5";
   const [raw, setRaw] = useState(false);
+  const [jsonView, setJsonView] = useState(false);
   const [outbound, setOutbound] = useState<MemoryLink[]>([]);
   const [backlinks, setBacklinks] = useState<MemoryLink[]>([]);
   const text = memory.content_text ?? formatValue(memory.value);
+  const displayText = !raw && renderedBody ? renderedBody : text;
+  const rawIsJson = useMemo(() => isJsonRawText(text), [text]);
+  const rawDisplay =
+    jsonView && rawIsJson ? (prettyPrintJsonRawText(text) ?? text) : text;
+
+  useEffect(() => {
+    if (!raw) setJsonView(false);
+  }, [raw]);
 
   useEffect(() => {
     if (!roomName) return;
@@ -187,18 +273,27 @@ export function MemoryDetail({ memory, roomName, onNavigate }: Props) {
   );
 
   const hasLinks = outbound.length > 0 || backlinks.length > 0;
+  const neighbors = useMemo(
+    () => (variant === "page" ? neighborKeys(memory.key, outbound, backlinks) : []),
+    [variant, memory.key, outbound, backlinks],
+  );
+  const integrityNotes = useMemo(
+    () => (variant === "page" ? integrityNotesForMemory(memory.key, integrity) : null),
+    [variant, memory.key, integrity],
+  );
 
   return (
     <div>
+      {integrityNotes && <IntegrityBanner notes={integrityNotes} />}
       {/* A skill is just a `skills/…` memory — no special pane, just a tag. */}
       {memory.key.startsWith("skills/") && (
-        <div className="px-5 pt-4">
+        <div className={`${pad} pt-4`}>
           <span className="inline-flex items-center rounded-md border border-accent/30 bg-accent-soft/40 px-2 py-0.5 text-micro font-medium text-accent">
             skill
           </span>
         </div>
       )}
-      <div className="grid grid-cols-2 gap-x-6 gap-y-4 border-b border-border px-5 py-4">
+      <div className={`grid grid-cols-2 gap-x-6 gap-y-4 border-b border-border ${pad} py-4`}>
         <Meta label="Version"><span className="tabular">v{memory.version}</span></Meta>
         <Meta label="Author">{memory.updated_by || memory.created_by}</Meta>
         {memory.updated_at && (
@@ -213,7 +308,7 @@ export function MemoryDetail({ memory, roomName, onNavigate }: Props) {
         )}
       </div>
 
-      <div className="flex items-center gap-2 px-5 pt-4">
+      <div className={`flex flex-wrap items-center gap-2 ${pad} pt-4`}>
         <div className="flex items-center gap-0.5 rounded-lg border border-border bg-surface p-0.5">
           {([["Rendered", false], ["Raw", true]] as const).map(([label, on]) => (
             <button
@@ -227,28 +322,45 @@ export function MemoryDetail({ memory, roomName, onNavigate }: Props) {
             </button>
           ))}
         </div>
+        {raw && rawIsJson && (
+          <button
+            type="button"
+            aria-pressed={jsonView}
+            aria-label="Pretty-print JSON"
+            onClick={() => setJsonView(on => !on)}
+            className={`rounded-lg border px-2.5 py-1 text-micro font-medium transition-colors ${
+              jsonView
+                ? "border-accent/40 bg-accent-soft/40 text-accent"
+                : "border-border bg-surface text-muted-foreground hover:text-text"
+            }`}
+          >
+            Format JSON
+          </button>
+        )}
       </div>
 
-      <div className="px-5 py-4">
+      <div className={`${pad} py-4`}>
         {raw ? (
           <pre className="overflow-x-auto rounded-lg border border-border bg-surface p-3 font-mono text-micro leading-relaxed text-text whitespace-pre-wrap break-words">
-            {text}
+            {jsonView ? highlightJson(rawDisplay) : rawDisplay}
           </pre>
         ) : (
           <MarkdownContent
-            className="contrast text-body leading-relaxed"
+            className={`contrast leading-relaxed ${variant === "page" ? "text-body max-w-prose" : "text-body"}`}
             onLinkClick={onNavigate}
             brokenLinks={broken}
           >
-            {text}
+            {displayText}
           </MarkdownContent>
         )}
       </div>
 
-      {/* Backlinks are the point: before changing this memory, they show
-          exactly which others depend on what it says. */}
+      {variant === "page" && (
+        <NeighborChips keys={neighbors} onNavigate={onNavigate} className={pad} />
+      )}
+
       {hasLinks && (
-        <div className="grid gap-4 border-t border-border px-5 py-4">
+        <div className={`grid gap-4 border-t border-border ${pad} py-4`}>
           <LinkGroup
             title="Links to"
             icon={ArrowUpRight}

--- a/mycelium-frontend/src/components/memory-detail.tsx
+++ b/mycelium-frontend/src/components/memory-detail.tsx
@@ -143,9 +143,11 @@ interface Props {
   onNavigate?: (key: string) => void;
   /** Rail peek vs full-page wiki layout. */
   variant?: "rail" | "page";
-  /** When set, Rendered mode shows expanded transclusions (#614 full page). */
+  /** When set, Rendered mode shows expanded transclusions instead of raw
+   *  `![[…]]` markers (#614 full page, #599 rail drawer). */
   renderedBody?: string | null;
-  /** Room integrity report; page variant surfaces per-memory notes. */
+  /** Room integrity report; surfaces this memory's broken-link/orphan notes
+   *  in either variant when supplied. */
   integrity?: MemoryLinksIntegrity | null;
 }
 
@@ -277,9 +279,12 @@ export function MemoryDetail({
     () => (variant === "page" ? neighborKeys(memory.key, outbound, backlinks) : []),
     [variant, memory.key, outbound, backlinks],
   );
+  // Integrity banner shows in both variants when a report is supplied — the
+  // rail drawer is a valid place to notice a broken link before opening the
+  // full page (#599).
   const integrityNotes = useMemo(
-    () => (variant === "page" ? integrityNotesForMemory(memory.key, integrity) : null),
-    [variant, memory.key, integrity],
+    () => integrityNotesForMemory(memory.key, integrity),
+    [memory.key, integrity],
   );
 
   return (

--- a/mycelium-frontend/src/components/memory-page-view.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.tsx
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { ChevronLeft } from "lucide-react";
+import {
+  fetchMemory,
+  fetchMemoryExpanded,
+  fetchMemoryIntegrity,
+  type Memory,
+  type MemoryLinksIntegrity,
+} from "@/lib/api";
+import { memoryHref } from "@/lib/memory-routes";
+import { MemoryDetail } from "@/components/memory-detail";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  roomName: string;
+  memoryKey: string;
+}
+
+/** Full-page wiki view for one memory (#614). */
+export function MemoryPageView({ roomName, memoryKey }: Props) {
+  const router = useRouter();
+  const [memory, setMemory] = useState<Memory | null | undefined>(undefined);
+  const [renderedBody, setRenderedBody] = useState<string | null>(null);
+  const [integrity, setIntegrity] = useState<MemoryLinksIntegrity | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    setMemory(undefined);
+    setRenderedBody(null);
+    fetchMemory(roomName, memoryKey).then(m => {
+      if (!live) return;
+      setMemory(m);
+    });
+    fetchMemoryExpanded(roomName, memoryKey).then(exp => {
+      if (!live || !exp.found || !exp.rendered) return;
+      setRenderedBody(exp.rendered);
+    });
+    fetchMemoryIntegrity(roomName).then(report => {
+      if (live) setIntegrity(report);
+    });
+    return () => {
+      live = false;
+    };
+  }, [roomName, memoryKey]);
+
+  const onNavigate = useCallback(
+    (key: string) => router.push(memoryHref(roomName, key)),
+    [router, roomName],
+  );
+
+  if (memory === undefined) {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-10 space-y-4">
+        <Skeleton className="h-6 w-48" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+      </div>
+    );
+  }
+
+  if (memory === null) {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <p className="text-body text-muted-foreground">Memory not found.</p>
+        <Link
+          href={`/room/${encodeURIComponent(roomName)}`}
+          className="mt-4 inline-flex items-center gap-1 text-label text-accent"
+        >
+          <ChevronLeft className="size-4" />
+          Back to room
+        </Link>
+      </div>
+    );
+  }
+
+  const crumbs = memoryKey.split("/");
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+      <header className="sticky top-0 z-10 border-b border-border bg-surface/90 px-6 py-3 backdrop-blur-sm md:px-8">
+        <Link
+          href={`/room/${encodeURIComponent(roomName)}`}
+          className="mb-2 inline-flex items-center gap-1 text-micro text-muted-foreground transition-colors hover:text-accent"
+        >
+          <ChevronLeft className="size-3.5" />
+          {roomName}
+        </Link>
+        <h1 className="font-mono text-ui font-semibold text-text break-all">
+          {crumbs.map((part, i) => (
+            <span key={i}>
+              {i > 0 && <span className="text-faint">/</span>}
+              {part}
+            </span>
+          ))}
+        </h1>
+      </header>
+
+      <div className="mx-auto w-full max-w-3xl pb-12">
+        <MemoryDetail
+          memory={memory}
+          roomName={roomName}
+          onNavigate={onNavigate}
+          variant="page"
+          renderedBody={renderedBody}
+          integrity={integrity}
+        />
+      </div>
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/memory-panel.test.tsx
+++ b/mycelium-frontend/src/components/memory-panel.test.tsx
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryPanel } from "@/components/memory-panel";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/memory-detail", () => ({
+  MemoryDetail: () => <div data-testid="memory-detail" />,
+}));
+
+vi.mock("@/components/detail-drawer", () => ({
+  DetailDrawer: ({
+    open,
+    children,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div data-testid="memory-drawer">{children}</div> : null),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchMemories: vi.fn(),
+  fetchMemory: vi.fn(),
+  searchMemories: vi.fn(),
+  fetchMemoryLinks: vi.fn(),
+}));
+
+import { fetchMemories, fetchMemory, fetchMemoryLinks } from "@/lib/api";
+
+const offTree = {
+  key: "context/off-tree",
+  value: { text: "not in the first page" },
+  content_text: "not in the first page",
+  version: 1,
+  created_by: "alice",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("<MemoryPanel /> peek navigation", () => {
+  beforeEach(() => {
+    push.mockClear();
+    vi.mocked(fetchMemories).mockResolvedValue([]);
+    vi.mocked(fetchMemory).mockReset();
+    vi.mocked(fetchMemoryLinks).mockResolvedValue({
+      key: offTree.key,
+      outbound: [],
+      backlinks: [],
+    });
+  });
+
+  it("routes to full page when focusMemory targets a missing key", async () => {
+    vi.mocked(fetchMemory).mockResolvedValue(null);
+
+    render(
+      <MemoryPanel
+        roomName="demo"
+        refreshTrigger={0}
+        focusMemory={{ key: "missing/key", nonce: 1 }}
+      />,
+    );
+
+    await act(async () => {});
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith("/room/demo/memory/missing/key"),
+    );
+  });
+
+  it("opens the drawer via fetch when focusMemory targets a key outside the loaded list", async () => {
+    vi.mocked(fetchMemory).mockImplementation(async (room, key) => {
+      expect(room).toBe("demo");
+      expect(key).toBe(offTree.key);
+      return offTree;
+    });
+
+    render(
+      <MemoryPanel
+        roomName="demo"
+        refreshTrigger={0}
+        focusMemory={{ key: offTree.key, nonce: 1 }}
+      />,
+    );
+
+    await waitFor(() => expect(fetchMemory).toHaveBeenCalled());
+    expect(await screen.findByTestId("memory-drawer")).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/mycelium-frontend/src/components/memory-panel.test.tsx
+++ b/mycelium-frontend/src/components/memory-panel.test.tsx
@@ -25,7 +25,13 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("@/components/memory-detail", () => ({
-  MemoryDetail: () => <div data-testid="memory-detail" />,
+  MemoryDetail: (props: { integrity?: unknown; renderedBody?: string | null }) => (
+    <div
+      data-testid="memory-detail"
+      data-has-integrity={props.integrity ? "yes" : "no"}
+      data-rendered-body={props.renderedBody ?? ""}
+    />
+  ),
 }));
 
 vi.mock("@/components/detail-drawer", () => ({
@@ -41,11 +47,22 @@ vi.mock("@/components/detail-drawer", () => ({
 vi.mock("@/lib/api", () => ({
   fetchMemories: vi.fn(),
   fetchMemory: vi.fn(),
+  fetchMemoryExpanded: vi.fn(),
+  fetchMemoryIntegrity: vi.fn(),
   searchMemories: vi.fn(),
   fetchMemoryLinks: vi.fn(),
 }));
 
-import { fetchMemories, fetchMemory, fetchMemoryLinks } from "@/lib/api";
+import {
+  fetchMemories,
+  fetchMemory,
+  fetchMemoryExpanded,
+  fetchMemoryIntegrity,
+  fetchMemoryLinks,
+} from "@/lib/api";
+
+const EMPTY_INTEGRITY = { broken: [], orphans: [], total_memories: 0, total_links: 0 };
+const EMPTY_EXPAND = { key: "", rendered: "", expansions: [], found: false };
 
 const offTree = {
   key: "context/off-tree",
@@ -66,6 +83,8 @@ describe("<MemoryPanel /> peek navigation", () => {
       outbound: [],
       backlinks: [],
     });
+    vi.mocked(fetchMemoryIntegrity).mockResolvedValue(EMPTY_INTEGRITY);
+    vi.mocked(fetchMemoryExpanded).mockResolvedValue(EMPTY_EXPAND);
   });
 
   it("routes to full page when focusMemory targets a missing key", async () => {
@@ -103,5 +122,42 @@ describe("<MemoryPanel /> peek navigation", () => {
     await waitFor(() => expect(fetchMemory).toHaveBeenCalled());
     expect(await screen.findByTestId("memory-drawer")).toBeInTheDocument();
     expect(push).not.toHaveBeenCalled();
+  });
+
+  it("passes the room integrity report and expanded body into the drawer's MemoryDetail (#599)", async () => {
+    vi.mocked(fetchMemory).mockResolvedValue(offTree);
+    vi.mocked(fetchMemoryIntegrity).mockResolvedValue({
+      broken: [
+        {
+          source: offTree.key,
+          target: "gone",
+          kind: "wikilink",
+          raw: "[[gone]]",
+          resolved: false,
+        },
+      ],
+      orphans: [],
+      total_memories: 1,
+      total_links: 1,
+    });
+    vi.mocked(fetchMemoryExpanded).mockResolvedValue({
+      key: offTree.key,
+      rendered: "expanded transclusion body",
+      expansions: [],
+      found: true,
+    });
+
+    render(
+      <MemoryPanel
+        roomName="demo"
+        refreshTrigger={0}
+        focusMemory={{ key: offTree.key, nonce: 1 }}
+      />,
+    );
+
+    const detail = await screen.findByTestId("memory-detail");
+    await waitFor(() => expect(fetchMemoryExpanded).toHaveBeenCalledWith("demo", offTree.key));
+    await waitFor(() => expect(detail).toHaveAttribute("data-has-integrity", "yes"));
+    expect(detail).toHaveAttribute("data-rendered-body", "expanded transclusion body");
   });
 });

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -3,8 +3,10 @@
 
 "use client";
 
-import { useEffect, useMemo, useState, useCallback } from "react";
-import { Brain, ChevronRight, Folder, FolderOpen, FileText, AlertCircle } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Brain, ChevronRight, ExternalLink, Folder, FolderOpen, FileText, AlertCircle } from "lucide-react";
 import {
   fetchMemories,
   fetchMemory,
@@ -12,6 +14,8 @@ import {
   type Memory,
   type MemorySearchResult,
 } from "@/lib/api";
+import { memoryHref } from "@/lib/memory-routes";
+import { expandedPathsForKey, resolveMemoryPeekNavigation } from "@/lib/memory-panel-nav";
 import { DetailDrawer } from "@/components/detail-drawer";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -188,6 +192,7 @@ function TreeRows({ nodes, depth, collapsed, onToggle, onSelect, selected }: Tre
 }
 
 export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocusConsumed, focusMemory }: Props) {
+  const router = useRouter();
   const [memories, setMemories] = useState<Memory[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
@@ -196,6 +201,8 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
   const [searchError, setSearchError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Memory | null>(null);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const memoriesRef = useRef(memories);
+  memoriesRef.current = memories;
 
   // fetchMemories degrades to [] on failure (fire-and-forget list), so no
   // try/catch is needed here — a failed load just shows the empty state.
@@ -211,6 +218,33 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
 
   useEffect(() => { loadData(); }, [loadData, refreshTrigger]);
 
+  const revealKeyInTree = useCallback((key: string, clearSearch = false) => {
+    if (clearSearch) setSearchResults(null);
+    setCollapsed(prev => {
+      const next = new Set(prev);
+      for (const path of expandedPathsForKey(key)) next.delete(path);
+      return next;
+    });
+  }, []);
+
+  const openMemoryByKey = useCallback(
+    async (key: string) => {
+      const nav = await resolveMemoryPeekNavigation(
+        roomName,
+        key,
+        memoriesRef.current,
+        fetchMemory,
+      );
+      if (nav.action === "drawer") {
+        setSelected(nav.memory);
+        revealKeyInTree(key, true);
+        return;
+      }
+      router.push(nav.href);
+    },
+    [roomName, revealKeyInTree, router],
+  );
+
   // Arriving from search: open the named memory and reveal its folder. The tree
   // only holds the first page of keys, so the memory is fetched by key rather
   // than looked up in what happens to be loaded.
@@ -218,20 +252,8 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
     if (!focusKey) return;
     // Consumed only once the memory is in hand: clearing the request first would
     // unmount the effect that is still fetching what it asked for.
-    fetchMemory(roomName, focusKey).then(memory => {
-      if (memory) {
-        setSearchResults(null);
-        setSelected(memory);
-        setCollapsed(prev => {
-          const next = new Set(prev);
-          const parts = focusKey.split("/");
-          for (let i = 1; i < parts.length; i++) next.delete(parts.slice(0, i).join("/"));
-          return next;
-        });
-      }
-      onFocusConsumed?.();
-    });
-  }, [roomName, focusKey, onFocusConsumed]);
+    void openMemoryByKey(focusKey).finally(() => onFocusConsumed?.());
+  }, [roomName, focusKey, onFocusConsumed, openMemoryByKey]);
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) { setSearchResults(null); setSearchError(null); return; }
@@ -249,22 +271,11 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
 
   const tree = useMemo(() => buildTree(memories), [memories]);
 
-  // Following a link keeps the drawer open on the target, so a reader can walk
-  // the graph without going back through the tree.
-  const navigateToKey = useCallback(
-    (key: string) => {
-      const target = memories.find(m => m.key === key);
-      if (target) setSelected(target);
-    },
-    [memories],
-  );
-
   // A chat `[[wikilink]]` (or any external focus request) selects that memory.
-  // navigateToKey changes with `memories`, so a focus set before the list loads
-  // resolves once it arrives; the nonce re-fires the same key on a repeat click.
+  // The nonce re-fires the same key on a repeat click.
   useEffect(() => {
-    if (focusMemory?.key) navigateToKey(focusMemory.key);
-  }, [focusMemory, navigateToKey]);
+    if (focusMemory?.key) void openMemoryByKey(focusMemory.key);
+  }, [focusMemory, openMemoryByKey]);
 
   const toggleNs = useCallback((path: string) =>
     setCollapsed(prev => {
@@ -395,9 +406,21 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
         onClose={() => setSelected(null)}
         title={selected?.key}
         subtitle={selected ? `v${selected.version} · ${selected.created_by}` : undefined}
+        actions={
+          selected ? (
+            <Link
+              href={memoryHref(roomName, selected.key)}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+              title="Open full page"
+            >
+              <ExternalLink className="size-3.5" />
+              Full page
+            </Link>
+          ) : undefined
+        }
       >
         {selected && (
-          <MemoryDetail memory={selected} roomName={roomName} onNavigate={navigateToKey} />
+          <MemoryDetail memory={selected} roomName={roomName} onNavigate={openMemoryByKey} />
         )}
       </DetailDrawer>
     </div>

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -10,8 +10,11 @@ import { Brain, ChevronRight, ExternalLink, Folder, FolderOpen, FileText, AlertC
 import {
   fetchMemories,
   fetchMemory,
+  fetchMemoryExpanded,
+  fetchMemoryIntegrity,
   searchMemories,
   type Memory,
+  type MemoryLinksIntegrity,
   type MemorySearchResult,
 } from "@/lib/api";
 import { memoryHref } from "@/lib/memory-routes";
@@ -201,6 +204,8 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
   const [searchError, setSearchError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Memory | null>(null);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [integrity, setIntegrity] = useState<MemoryLinksIntegrity | null>(null);
+  const [renderedBody, setRenderedBody] = useState<string | null>(null);
   const memoriesRef = useRef(memories);
   memoriesRef.current = memories;
 
@@ -210,6 +215,37 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
     setMemories(await fetchMemories(roomName));
     setLoaded(true);
   }, [roomName]);
+
+  // Room-wide integrity report, refreshed alongside the tree — cheap enough
+  // to fetch unconditionally so the drawer can flag a broken/orphaned memory
+  // without a per-open round trip (#599).
+  useEffect(() => {
+    let live = true;
+    fetchMemoryIntegrity(roomName).then(report => {
+      if (live) setIntegrity(report);
+    });
+    return () => {
+      live = false;
+    };
+  }, [roomName, refreshTrigger]);
+
+  // Expanded transclusions for whichever memory is open in the drawer, so the
+  // rail peek matches the full page instead of leaving `![[…]]` markers as
+  // unexpanded chips (#599).
+  useEffect(() => {
+    if (!selected) {
+      setRenderedBody(null);
+      return;
+    }
+    let live = true;
+    setRenderedBody(null);
+    fetchMemoryExpanded(roomName, selected.key).then(exp => {
+      if (live && exp.found && exp.rendered) setRenderedBody(exp.rendered);
+    });
+    return () => {
+      live = false;
+    };
+  }, [roomName, selected]);
 
   const contributors = useMemo(
     () => Array.from(new Set(memories.map(m => m.created_by).filter(Boolean))),
@@ -420,7 +456,13 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
         }
       >
         {selected && (
-          <MemoryDetail memory={selected} roomName={roomName} onNavigate={openMemoryByKey} />
+          <MemoryDetail
+            memory={selected}
+            roomName={roomName}
+            onNavigate={openMemoryByKey}
+            renderedBody={renderedBody}
+            integrity={integrity}
+          />
         )}
       </DetailDrawer>
     </div>

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -7,6 +7,7 @@
 // URL baking. The internal backend URL is a server-side concern.
 
 import type { SearchResponse } from "@/lib/search";
+import { encodeMemoryKeyPath } from "@/lib/memory-routes";
 
 /**
  * Attach to a fetch `.catch` to surface network failures in the browser
@@ -176,7 +177,7 @@ export async function fetchMemories(roomName: string, prefix?: string): Promise<
  *  a caller jumping to a since-deleted key lands on the room rather than an
  *  error. */
 export async function fetchMemory(roomName: string, key: string): Promise<Memory | null> {
-  const path = key.split("/").map(encodeURIComponent).join("/");
+  const path = encodeMemoryKeyPath(key);
   return apiFetch<Memory | null>(`/api/rooms/${roomName}/memory/${path}`, {
     cache: "no-store",
     fallback: null,
@@ -244,6 +245,51 @@ export async function fetchMemoryLinks(roomName: string, key: string): Promise<M
     { cache: "no-store", fallback: EMPTY_LINKS },
   );
   return { key, outbound: data.outbound ?? [], backlinks: data.backlinks ?? [] };
+}
+
+export interface BrokenLink extends MemoryLink {
+  source: string;
+}
+
+export interface MemoryLinksIntegrity {
+  broken: BrokenLink[];
+  orphans: string[];
+  total_memories: number;
+  total_links: number;
+}
+
+const EMPTY_INTEGRITY: MemoryLinksIntegrity = {
+  broken: [],
+  orphans: [],
+  total_memories: 0,
+  total_links: 0,
+};
+
+/** Room-wide link integrity — broken edges and orphans. Degrades to empty. */
+export async function fetchMemoryIntegrity(roomName: string): Promise<MemoryLinksIntegrity> {
+  return apiFetch<MemoryLinksIntegrity>(`/api/rooms/${roomName}/links/integrity`, {
+    cache: "no-store",
+    fallback: EMPTY_INTEGRITY,
+  });
+}
+
+export interface MemoryExpanded {
+  key: string;
+  rendered: string;
+  expansions: Array<{ raw: string; target: string; resolved: boolean; error?: string | null }>;
+  found: boolean;
+}
+
+const EMPTY_EXPAND: MemoryExpanded = { key: "", rendered: "", expansions: [], found: false };
+
+/** Body with `![[…]]` transclusions expanded (depth 1). Returns empty when missing. */
+export async function fetchMemoryExpanded(roomName: string, key: string): Promise<MemoryExpanded> {
+  const params = new URLSearchParams({ key });
+  const data = await apiFetch<MemoryExpanded>(
+    `/api/rooms/${roomName}/links/expand?${params}`,
+    { cache: "no-store", fallback: { ...EMPTY_EXPAND, key } },
+  );
+  return { ...EMPTY_EXPAND, ...data, key };
 }
 
 // ── Skills ───────────────────────────────────────────────────────────────────

--- a/mycelium-frontend/src/lib/json-text.ts
+++ b/mycelium-frontend/src/lib/json-text.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/** True when `text` is a single JSON object/array (for Raw → format toggle). */
+export function isJsonRawText(text: string): boolean {
+  return parseJsonRawText(text) !== null;
+}
+
+export function parseJsonRawText(text: string): unknown | null {
+  const trimmed = text.trim();
+  if (!trimmed || !(trimmed.startsWith("{") || trimmed.startsWith("["))) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+export function prettyPrintJsonRawText(text: string): string | null {
+  const parsed = parseJsonRawText(text);
+  return parsed === null ? null : JSON.stringify(parsed, null, 2);
+}

--- a/mycelium-frontend/src/lib/memory-links.test.ts
+++ b/mycelium-frontend/src/lib/memory-links.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import { integrityNotesForMemory, neighborKeys } from "@/lib/memory-links";
+import type { MemoryLink, MemoryLinksIntegrity } from "@/lib/api";
+
+const link = (over: Partial<MemoryLink>): MemoryLink => ({
+  target: "b",
+  kind: "wikilink",
+  raw: "[[b]]",
+  resolved: true,
+  ...over,
+});
+
+describe("neighborKeys", () => {
+  it("collects outbound targets and backlink sources, excluding self", () => {
+    const outbound = [link({ target: "decisions/a" }), link({ target: "context/b" })];
+    const backlinks = [link({ source: "context/c", target: "here" })];
+    expect(neighborKeys("here", outbound, backlinks)).toEqual(["context/b", "context/c", "decisions/a"]);
+  });
+
+  it("dedupes when the same key appears twice", () => {
+    const outbound = [link({ target: "a" }), link({ target: "a" })];
+    expect(neighborKeys("here", outbound, [])).toEqual(["a"]);
+  });
+});
+
+describe("integrityNotesForMemory", () => {
+  const integrity: MemoryLinksIntegrity = {
+    broken: [{ source: "here", target: "gone", kind: "wikilink", raw: "[[gone]]", resolved: false }],
+    orphans: ["lonely"],
+    total_memories: 2,
+    total_links: 1,
+  };
+
+  it("returns null when the memory has no integrity issues", () => {
+    expect(integrityNotesForMemory("ok", integrity)).toBeNull();
+  });
+
+  it("counts broken outbound from this key", () => {
+    expect(integrityNotesForMemory("here", integrity)).toEqual({
+      brokenOutbound: 1,
+      isOrphan: false,
+    });
+  });
+
+  it("flags orphans", () => {
+    expect(integrityNotesForMemory("lonely", integrity)).toEqual({
+      brokenOutbound: 0,
+      isOrphan: true,
+    });
+  });
+});

--- a/mycelium-frontend/src/lib/memory-links.ts
+++ b/mycelium-frontend/src/lib/memory-links.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import type { MemoryLink, MemoryLinksIntegrity } from "@/lib/api";
+
+/** One-hop neighbors for the full-page "Related" section (#614).
+ *
+ * Union of outbound targets and backlink sources, deduped, excluding self. */
+export function neighborKeys(key: string, outbound: MemoryLink[], backlinks: MemoryLink[]): string[] {
+  const neighbors = new Set<string>();
+  for (const link of outbound) {
+    if (link.target && link.target !== key) neighbors.add(link.target);
+  }
+  for (const link of backlinks) {
+    const source = link.source ?? link.target;
+    if (source && source !== key) neighbors.add(source);
+  }
+  return [...neighbors].sort((a, b) => a.localeCompare(b));
+}
+
+export interface MemoryIntegrityNotes {
+  brokenOutbound: number;
+  isOrphan: boolean;
+}
+
+/** Per-memory slice of a room integrity report for inline banners. */
+export function integrityNotesForMemory(
+  key: string,
+  integrity: MemoryLinksIntegrity | null,
+): MemoryIntegrityNotes | null {
+  if (!integrity) return null;
+  const brokenOutbound = integrity.broken.filter(b => b.source === key).length;
+  const isOrphan = integrity.orphans.includes(key);
+  if (brokenOutbound === 0 && !isOrphan) return null;
+  return { brokenOutbound, isOrphan };
+}

--- a/mycelium-frontend/src/lib/memory-panel-nav.test.ts
+++ b/mycelium-frontend/src/lib/memory-panel-nav.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it, vi } from "vitest";
+import { expandedPathsForKey, resolveMemoryPeekNavigation } from "@/lib/memory-panel-nav";
+import type { Memory } from "@/lib/api";
+
+const mem = (key: string): Memory => ({
+  key,
+  value: { text: "body" },
+  content_text: "body",
+  version: 1,
+  created_by: "alice",
+  updated_at: "2026-01-01T00:00:00Z",
+});
+
+describe("resolveMemoryPeekNavigation", () => {
+  it("opens the drawer from the loaded list without fetching", async () => {
+    const fetchByKey = vi.fn();
+    const result = await resolveMemoryPeekNavigation(
+      "demo",
+      "context/overview",
+      [mem("context/overview")],
+      fetchByKey,
+    );
+    expect(result).toEqual({ action: "drawer", memory: mem("context/overview") });
+    expect(fetchByKey).not.toHaveBeenCalled();
+  });
+
+  it("fetches by key when missing from the loaded list (limit-50 / empty tree)", async () => {
+    const offTree = mem("context/off-tree");
+    const fetchByKey = vi.fn().mockResolvedValue(offTree);
+    const result = await resolveMemoryPeekNavigation("demo", "context/off-tree", [], fetchByKey);
+    expect(fetchByKey).toHaveBeenCalledWith("demo", "context/off-tree");
+    expect(result).toEqual({ action: "drawer", memory: offTree });
+  });
+
+  it("routes to full page only when the memory does not exist", async () => {
+    const fetchByKey = vi.fn().mockResolvedValue(null);
+    const result = await resolveMemoryPeekNavigation("demo", "missing/key", [], fetchByKey);
+    expect(result).toEqual({
+      action: "full-page",
+      href: "/room/demo/memory/missing/key",
+    });
+  });
+});
+
+describe("expandedPathsForKey", () => {
+  it("returns namespace prefixes to uncollapse", () => {
+    expect(expandedPathsForKey("context/overview")).toEqual(["context"]);
+    expect(expandedPathsForKey("a/b/c")).toEqual(["a", "a/b"]);
+  });
+});

--- a/mycelium-frontend/src/lib/memory-panel-nav.ts
+++ b/mycelium-frontend/src/lib/memory-panel-nav.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import type { Memory } from "@/lib/api";
+import { memoryHref } from "@/lib/memory-routes";
+
+export type MemoryPeekNavigation =
+  | { action: "drawer"; memory: Memory }
+  | { action: "full-page"; href: string };
+
+/** Rail/chat navigation: peek in the drawer when the memory exists on the hub;
+ *  otherwise open the dedicated full-page route (404 UI lives there). */
+export async function resolveMemoryPeekNavigation(
+  roomName: string,
+  key: string,
+  memories: Memory[],
+  fetchByKey: (room: string, key: string) => Promise<Memory | null>,
+): Promise<MemoryPeekNavigation> {
+  const cached = memories.find(m => m.key === key);
+  if (cached) return { action: "drawer", memory: cached };
+  const fetched = await fetchByKey(roomName, key);
+  if (fetched) return { action: "drawer", memory: fetched };
+  return { action: "full-page", href: memoryHref(roomName, key) };
+}
+
+/** Expand ancestor folders in the tree so `key` is visible. */
+export function expandedPathsForKey(key: string): string[] {
+  const parts = key.split("/");
+  const paths: string[] = [];
+  for (let i = 1; i < parts.length; i++) {
+    paths.push(parts.slice(0, i).join("/"));
+  }
+  return paths;
+}

--- a/mycelium-frontend/src/lib/memory-routes.test.ts
+++ b/mycelium-frontend/src/lib/memory-routes.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import { encodeMemoryKeyPath, memoryHref, parseMemoryKeyParam } from "@/lib/memory-routes";
+
+describe("encodeMemoryKeyPath", () => {
+  it("encodes each slash segment separately", () => {
+    expect(encodeMemoryKeyPath("decisions/db choice")).toBe(
+      "decisions/db%20choice",
+    );
+  });
+
+  it("round-trips through parseMemoryKeyParam", () => {
+    const key = "log/episodes/a1:b2";
+    const segments = encodeMemoryKeyPath(key).split("/");
+    expect(parseMemoryKeyParam(segments)).toBe(key);
+  });
+});
+
+describe("memoryHref", () => {
+  it("builds a catch-all path for slash keys", () => {
+    expect(memoryHref("demo", "context/overview")).toBe("/room/demo/memory/context/overview");
+  });
+
+  it("encodes room names with spaces", () => {
+    expect(memoryHref("atlas migration", "plan/title")).toBe(
+      "/room/atlas%20migration/memory/plan/title",
+    );
+  });
+});

--- a/mycelium-frontend/src/lib/memory-routes.ts
+++ b/mycelium-frontend/src/lib/memory-routes.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/** URL helpers for the full-page memory view (#614).
+ *
+ * Keys may contain slashes (`decisions/db`). We encode each path segment separately
+ * so the catch-all route `[...key]` round-trips cleanly — same contract as the
+ * backend memory API path. */
+
+/** Encode a memory key for use in a URL path (one segment per slash). */
+export function encodeMemoryKeyPath(key: string): string {
+  return key.split("/").map(encodeURIComponent).join("/");
+}
+
+/** Decode a catch-all `[...key]` param back to a memory key. */
+export function parseMemoryKeyParam(segments: string[]): string {
+  return segments.map(decodeURIComponent).join("/");
+}
+
+/** Canonical in-app URL for a room memory page. */
+export function memoryHref(room: string, key: string): string {
+  return `/room/${encodeURIComponent(room)}/memory/${encodeMemoryKeyPath(key)}`;
+}

--- a/mycelium-frontend/src/lib/search.test.ts
+++ b/mycelium-frontend/src/lib/search.test.ts
@@ -22,14 +22,19 @@ describe("result links", () => {
     expect(resultHref(hit({ type: "room", id: "atlas", room: "atlas" }))).toBe("/room/atlas");
   });
 
-  it("carries the item as one focus parameter, round-tripping through the URL", () => {
+  it("opens memory hits on the full-page route (#614)", () => {
     const href = resultHref(hit());
+    expect(href).toBe("/room/atlas%20migration/memory/decisions/db%20choice");
+  });
+
+  it("carries non-memory items as one focus parameter, round-tripping through the URL", () => {
+    const href = resultHref(hit({ type: "episode", id: "ep-1" }));
     const focus = new URL(href, "http://x").searchParams.get("focus");
-    expect(parseFocus(focus)).toEqual({ type: "memory", id: "decisions/db choice" });
+    expect(parseFocus(focus)).toEqual({ type: "episode", id: "ep-1" });
   });
 
   it("escapes a room name so a space can't end the path", () => {
-    expect(resultHref(hit())).toContain("/room/atlas%20migration?");
+    expect(resultHref(hit({ type: "episode", id: "ep-1" }))).toContain("/room/atlas%20migration?");
   });
 
   it("keeps the colons inside a memory key out of the type split", () => {

--- a/mycelium-frontend/src/lib/search.ts
+++ b/mycelium-frontend/src/lib/search.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Mycelium Contributors
 
+import { memoryHref } from "@/lib/memory-routes";
+
 /** Command-style search: the content counterpart to the command palette.
  *
  *  ⌘K runs *actions*; this finds *things* — memories, episodes, messages, rooms
@@ -110,9 +112,11 @@ export function parseFocus(raw: string | null | undefined): FocusTarget | null {
 }
 
 /** Where picking `hit` navigates to. A room is its own target and needs no
- *  focus; everything else opens its room with the item selected. */
+ *  focus; memory hits open the dedicated full-page route (#614); everything
+ *  else opens its room with the item selected. */
 export function resultHref(hit: SearchHit): string {
-  const room = `/room/${encodeURIComponent(hit.room)}`;
   if (hit.type === "room") return `/room/${encodeURIComponent(hit.id)}`;
+  if (hit.type === "memory") return memoryHref(hit.room, hit.id);
+  const room = `/room/${encodeURIComponent(hit.room)}`;
   return `${room}?focus=${encodeURIComponent(focusParam(hit))}`;
 }


### PR DESCRIPTION
## Summary

Adds a dedicated, linkable full-page view for a single memory, alongside the existing rail drawer peek. Closes #614.

- New route `/room/{room}/memory/{...key}` (`MemoryPageView`) rendering the memory's expanded markdown body, one-hop related links, and an integrity banner (broken outbound links / orphan status) via the room's link-integrity report.
- `MemoryDetail` gains a `page` variant (wider prose layout, neighbor chips, integrity banner) alongside the existing `rail` variant used by the drawer.
- Raw mode gets a **Format JSON** toggle that only appears when the raw body is itself JSON, and pretty-prints that body in place — it no longer swaps in a synthetic `{key, value, version, ...}` API record.
- Fixed a navigation race in `memory-panel.tsx`: chat `[[wikilinks]]` and rail navigation now fetch a memory by key before falling back to the full-page route, instead of bouncing to the full page whenever the memory wasn't in the first loaded page (limit 50) or the tree hadn't finished loading yet.
- Semantic search hits for memories now open the full-page route directly instead of `?focus=memory:…`; the legacy focus param still redirects there for old links.
- Extracted reusable helpers: `lib/memory-routes.ts` (URL encode/decode/href), `lib/memory-links.ts` (neighbor keys, integrity notes), `lib/memory-panel-nav.ts` (drawer-vs-full-page resolution), `lib/json-text.ts` (raw-body JSON detection/pretty-print).

## Test plan

- [x] `pnpm exec vitest run` for the touched suites (31/31 passing): `memory-routes`, `memory-links`, `memory-panel-nav`, `memory-detail`, `memory-detail-json`, `memory-panel`, `search`
- [x] Manual QA against a demo room with seeded long-content + integrity-demo memories (orphan / broken-link / both) — see `docs/plans/614-full-page-memory-view.md` checklist
- [x] Reviewer: click a memory search hit and a chat `[[wikilink]]` to a memory outside the rail's first page and confirm it opens the drawer/full page as expected rather than always bouncing to the full page

Made with [Cursor](https://cursor.com)