### PR TITLE
feat(aligner): closed move vocabulary for coordination exchanges (#681)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ pnpm-lock.yaml
 
 # Claude Code harness state (per-session worktrees, transcripts)
 .claude/worktrees/
+
+# portman per-worktree dev-server port leases (machine-local)
+.ports.lock
+.ports.toml

--- a/contracts/slim-l9-wire.json
+++ b/contracts/slim-l9-wire.json
@@ -45,11 +45,11 @@
   },
 
   "valid_subkinds": {
-    "_comment": "Kind -> allowed subkinds. Backend: app.services.l9.VALID_SUBKINDS (keyed by the Kind enum). CLI: mycelium.slim.l9.VALID_SUBKINDS (keyed by the plain string, since the hidden `l9 send`/`slim send` plumbing takes a raw --kind string). An empty/None subkind is always valid for any kind.",
+    "_comment": "Kind -> allowed subkinds. Backend: app.services.l9.VALID_SUBKINDS (keyed by the Kind enum). CLI: mycelium.slim.l9.VALID_SUBKINDS (keyed by the plain string, since the hidden `l9 send`/`slim send` plumbing takes a raw --kind string). An empty/None subkind is always valid for any kind. The exchange move subkinds counter/accept/reject are the closed negotiation-move vocabulary a coordination reply carries on the wire (counter = any offer incl. the opening one; accept/reject respond to the standing offer); team-formation predates them.",
     "knowledge": ["distillation", "extraction", "feedback", "query"],
     "commit": ["converged", "rejected", "resolved"],
     "intent": ["coordinator-assignment", "mission"],
-    "exchange": ["team-formation"],
+    "exchange": ["accept", "counter", "reject", "team-formation"],
     "contingency": ["negotiation"]
   },
 

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -580,6 +580,13 @@ class AlignerEngine:
         if isinstance(offer, dict):
             reply["offer"] = offer
             reply.setdefault("action", "accept" if proposing else "reject")
+        # The wire move type, kept distinct from the collapsed metric ``action``
+        # above: the mediator's raw verb when it's one of the closed vocabulary,
+        # else a bare offer is a ``counter`` (the opening position included).
+        if isinstance(action, str) and action in l9.EXCHANGE_MOVE_SUBKINDS:
+            reply["move"] = action
+        elif isinstance(offer, dict):
+            reply["move"] = "counter"
         l9_episode.record_reply(ep, handle=handle, reply=reply, round_n=None)
 
     def _mediator_text(

--- a/fastapi-backend/app/services/l9.py
+++ b/fastapi-backend/app/services/l9.py
@@ -50,13 +50,21 @@ SUBPROTOCOL_MYCELIUM = "mycelium"
 SYSTEM_ACTOR_ID = "system"
 SYSTEM_ACTOR_ROLE = "coordinator"
 
+# ``exchange`` move subkinds: the closed vocabulary a coordination reply carries
+# so a negotiation move is explicit on the wire (countable, replayable) instead
+# of inferred from prose. ``counter`` is any offer (the opening one included);
+# ``accept``/``reject`` respond to the standing offer. The mediator emits exactly
+# these (``mediator.interpret``). A reply with no subkind stays valid, so replies
+# predating this vocabulary round-trip unchanged.
+EXCHANGE_MOVE_SUBKINDS = frozenset({"counter", "accept", "reject"})
+
 # Kind -> allowed subkinds. An empty/None subkind is always valid. A failed
 # negotiation commits as ``rejected`` (was ``abort`` under the now-removed Go CFN).
 VALID_SUBKINDS: dict[Kind, frozenset[str]] = {
     Kind.knowledge: frozenset({"query", "distillation", "extraction", "feedback"}),
     Kind.commit: frozenset({"converged", "resolved", "rejected"}),
     Kind.intent: frozenset({"coordinator-assignment", "mission"}),
-    Kind.exchange: frozenset({"team-formation"}),
+    Kind.exchange: frozenset({"team-formation"}) | EXCHANGE_MOVE_SUBKINDS,
     Kind.contingency: frozenset({"negotiation"}),
 }
 

--- a/fastapi-backend/app/services/l9_episode.py
+++ b/fastapi-backend/app/services/l9_episode.py
@@ -193,6 +193,13 @@ def record_reply(
     prior/posterior/deference tracking used by the consensus metrics.
     """
     action = str(reply.get("action") or "reject")
+    # The wire move type (l9.EXCHANGE_MOVE_SUBKINDS) is distinct from ``action``:
+    # ``action`` keeps its accept/hold semantics for the belief-move metrics
+    # below, while ``move`` records what the agent actually did (a proposer's
+    # offer folds to action=accept for the metrics but is a ``counter`` on the
+    # wire). Absent or unrecognized -> no subkind, so the reply stays valid.
+    move = reply.get("move")
+    subkind = move if move in l9.EXCHANGE_MOVE_SUBKINDS else None
     payload_data: dict[str, Any] = {"round": round_n, "action": action}
     if synthesised:
         payload_data["synthesised"] = True
@@ -214,6 +221,7 @@ def record_reply(
     parent = ep.last_tick_ids.get(handle) or ep.intent_id
     env = l9.build_envelope(
         kind=Kind.exchange,
+        subkind=subkind,
         episode=ep.episode,
         parents=[parent] if parent else [],
         sender=handle,

--- a/fastapi-backend/tests/test_aligner.py
+++ b/fastapi-backend/tests/test_aligner.py
@@ -211,3 +211,52 @@ def test_at_mention_neutralized_in_mediator_prompt() -> None:
     assert "@growth" not in out and "@risk" not in out
     assert "growth holds tech" in out and "risk wants" in out
     assert "@ home" in out  # a lone @ (not before a word char) is untouched
+
+
+# ── move type reaches the wire (#681) ─────────────────────────────────────────
+
+
+def _fold_episode() -> Any:
+    from app.services import l9_episode
+
+    return l9_episode.open_episode(
+        parent_room=_ROOM,
+        short_id="abc123",
+        workspace_id="ws-1",
+        mas_id="mas-1",
+        agents=["a1", "a2"],
+        joined_intents="- a1: ship\n- a2: test",
+        engine_handle="aligner",
+    )
+
+
+def _last_subkind(ep: Any) -> str | None:
+    return ep.messages[-1]["header"].get("subkind")
+
+
+def test_fold_reading_stamps_move_subkind() -> None:
+    """The mediator's interpreted move survives to the reply envelope's subkind
+    instead of being collapsed away — a proposer's offer is a ``counter``, a
+    responder's verdict is ``accept``/``reject``."""
+    engine = _engine(
+        FakeManager(FakeManaged(_ROOM, "mycelium", FakeChannel(), FakePersister()), [])
+    )
+
+    # Responder accept / reject map straight through.
+    ep = _fold_episode()
+    engine._fold_reading(ep, "a1", {"action": "accept"}, proposing=False)
+    assert _last_subkind(ep) == "accept"
+    engine._fold_reading(ep, "a1", {"action": "reject"}, proposing=False)
+    assert _last_subkind(ep) == "reject"
+
+    # A proposer's offer is a counter even though the metric action folds to accept.
+    ep = _fold_episode()
+    engine._fold_reading(
+        ep, "a1", {"action": "counter", "offer": {"budget": "high"}}, proposing=True
+    )
+    assert _last_subkind(ep) == "counter"
+
+    # A bare offer with no explicit verb still reads as a counter.
+    ep = _fold_episode()
+    engine._fold_reading(ep, "a1", {"offer": {"budget": "low"}}, proposing=True)
+    assert _last_subkind(ep) == "counter"

--- a/fastapi-backend/tests/test_l9_episode.py
+++ b/fastapi-backend/tests/test_l9_episode.py
@@ -390,3 +390,38 @@ def test_read_team_prior_local_absent_returns_none(tmp_path, monkeypatch):
 
     monkeypatch.setattr(settings, "MYCELIUM_DATA_DIR", str(tmp_path))
     assert l9_episode.read_team_prior_local("never-negotiated") is None
+
+
+# ── move subkind on the wire (#681) ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("move", "expected"),
+    [("counter", "counter"), ("accept", "accept"), ("reject", "reject")],
+)
+def test_reply_stamps_move_subkind(move: str, expected: str):
+    """A recognized move rides the exchange reply's header.subkind, so a
+    negotiation move is explicit on the wire instead of inferred from prose."""
+    ep = _open()
+    l9_episode.record_reply(ep, handle="a1", reply={"action": "accept", "move": move}, round_n=1)
+    reply = ep.messages[-1]
+    assert reply["header"]["kind"] == "exchange"
+    assert reply["header"]["subkind"] == expected
+
+
+def test_reply_without_move_has_no_subkind():
+    """Replies predating the move vocabulary carry no subkind and round-trip
+    unchanged (an absent subkind is always valid)."""
+    ep = _open()
+    l9_episode.record_reply(ep, handle="a1", reply={"action": "accept"}, round_n=1)
+    reply = ep.messages[-1]
+    assert reply["header"]["kind"] == "exchange"
+    assert "subkind" not in reply["header"]
+
+
+def test_reply_ignores_unknown_move():
+    """A move outside the closed vocabulary is dropped, never stamped as an
+    invalid subkind (faithful, never fabricated)."""
+    ep = _open()
+    l9_episode.record_reply(ep, handle="a1", reply={"action": "accept", "move": "bogus"}, round_n=1)
+    assert "subkind" not in ep.messages[-1]["header"]

--- a/mycelium-cli/src/mycelium/slim/l9.py
+++ b/mycelium-cli/src/mycelium/slim/l9.py
@@ -63,7 +63,10 @@ VALID_SUBKINDS: dict[str, frozenset[str]] = {
     "knowledge": frozenset({"query", "distillation", "extraction", "feedback"}),
     "commit": frozenset({"converged", "resolved", "rejected"}),
     "intent": frozenset({"coordinator-assignment", "mission"}),
-    "exchange": frozenset({"team-formation"}),
+    # ``counter``/``accept``/``reject`` are the negotiation-move subkinds a
+    # coordination reply carries (see the backend's ``EXCHANGE_MOVE_SUBKINDS``);
+    # ``team-formation`` predates them. An empty/None subkind stays valid.
+    "exchange": frozenset({"team-formation", "counter", "accept", "reject"}),
     "contingency": frozenset({"negotiation"}),
 }
 


### PR DESCRIPTION
Closes #681. Part of #684 (sharpen aligner negotiation quality).

## What

Coordination replies carried the move type only as an unvalidated free string in `payload.data`, and `aligner._fold_reading` collapsed `counter` → `reject` before the envelope was built. So a negotiation move could not be counted or replayed without re-parsing prose.

This promotes the move type the mediator already emits (`counter` / `accept` / `reject`) to a closed vocabulary that rides the `exchange` reply envelope's `header.subkind`.

## How

- **`l9.py`** — new `EXCHANGE_MOVE_SUBKINDS = {counter, accept, reject}`, folded into `VALID_SUBKINDS[Kind.exchange]` alongside the pre-existing `team-formation`.
- **`l9_episode.record_reply`** — reads `reply["move"]` and stamps it as the envelope subkind (only when recognized; unknown/absent → no subkind).
- **`aligner._fold_reading`** — derives the real move (a proposer's offer is a `counter`, a responder's verdict is `accept`/`reject`) **without touching** the metric-folding `action`, so MPC/GAR/SCR stay byte-identical.
- **`contracts/slim-l9-wire.json`** + **CLI `slim/l9.py`** — the frozen wire contract and its byte-for-byte CLI mirror both gain the three move subkinds; both contract suites re-lock to the JSON.

Ticks are left unchanged — a tick is the mediator prompting an agent, not an agent move.

## Acceptance (from #681)

- [x] Shared wire contract gets the new move types
- [x] Both CLI and backend tests pass
- [x] Existing negotiations round-trip unchanged (subkind is optional; the metric binary is untouched)

## Design notes

- Move type lives on `header.subkind`, reusing the existing `validate_subkind` mechanism rather than a new validated payload field.
- The wire `move` is deliberately separate from the metric `action`: a proposer's offer folds to `action=accept` for the belief metrics but is a `counter` on the wire. Overloading one field would have shifted the metrics.

## Tests

7 new tests (move stamping, move derivation, unknown-move dropped, no-move round-trip). Full L9/aligner/episode/contract surface: `108 passed, 3 skipped` (backend), `10 passed` (CLI). ruff + ty clean on both sides.