### PR TITLE
feat(aligner): log opening positions snapshot before negotiation (#679)

### DIFF
--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -333,6 +333,7 @@ class AlignerEngine:
         topic = l9.topic_urn(room)
 
         self._manager.open_episode(room, episode)
+        positions = self._opening_positions(persister, participants)
         ep = l9_episode.open_episode(
             parent_room=room,
             short_id=episode_id,
@@ -341,10 +342,10 @@ class AlignerEngine:
             agents=participants,
             joined_intents="aligner mediate: converge on the open question via SAO",
             engine_handle=me,
+            opening_positions=positions,
         )
         try:
             brain = self._make_brain(episode)
-            positions = self._opening_positions(persister, participants)
             issues = await asyncio.to_thread(
                 mediator.discover_issues,
                 "Converge on the room's open question — agree one value per issue.",

--- a/fastapi-backend/app/services/l9_episode.py
+++ b/fastapi-backend/app/services/l9_episode.py
@@ -86,6 +86,10 @@ class EpisodeState:
     # back to the system actor (an episode opened outside an engine context).
     engine_handle: str = ""
     intent_id: str = ""
+    # Each participant's opening prose, captured before mediation runs — the
+    # structured snapshot the episode record renders as "Opening Positions" so a
+    # negotiation can be audited against what the room believed going in (#679).
+    opening_positions: dict[str, str] = field(default_factory=dict)
     # Ordered record of every envelope in the episode (dicts, wire shape).
     messages: list[dict[str, Any]] = field(default_factory=list)
     # handle -> l9 message id of the last tick sent to that agent.
@@ -114,12 +118,17 @@ def open_episode(
     agents: list[str],
     joined_intents: str,
     engine_handle: str = "",
+    opening_positions: dict[str, str] | None = None,
 ) -> EpisodeState:
     """Open the episode: mint URNs and record the ``intent`` envelope.
 
     ``engine_handle`` is the registered engine mediating the episode; it signs
     the intent/tick/consensus envelopes so the wire carries the engine's real
     identity. Empty falls back to the system actor.
+
+    ``opening_positions`` is each participant's stated prose at the start,
+    captured before mediation runs; it is rendered into the episode record's
+    "Opening Positions" section for audit (#679).
     """
     ep = EpisodeState(
         episode=l9.episode_urn(parent_room, short_id),
@@ -130,6 +139,7 @@ def open_episode(
         mas_id=mas_id,
         agents=agents[:],
         engine_handle=engine_handle,
+        opening_positions=dict(opening_positions or {}),
     )
     intent = l9.build_envelope(
         kind=Kind.intent,
@@ -386,6 +396,19 @@ def write_episode_record(
             )
         if plan_file:
             lines.append(f"- plan: `{plan_file}`")
+        if ep.opening_positions:
+            lines += [
+                "",
+                "## Opening Positions",
+                "",
+                "Each participant's stated position at the start, before mediation:",
+                "",
+                *(
+                    f"- **@{handle}**: {ep.opening_positions[handle]}"
+                    for handle in ep.agents
+                    if handle in ep.opening_positions
+                ),
+            ]
         lines += [
             "",
             "## Messages",

--- a/fastapi-backend/scripts/aligner_driver.py
+++ b/fastapi-backend/scripts/aligner_driver.py
@@ -110,6 +110,7 @@ def main() -> None:
         agents=participants,
         joined_intents="\n".join(f"- {h}: {p}" for h, p in positions.items()),
         engine_handle="aligner",
+        opening_positions=positions,
     )
 
     print(f"[driver] model={llm_env['LLM_MODEL']}  participants={participants}", flush=True)
@@ -176,6 +177,7 @@ def main() -> None:
             "steps": mech.current_step,
             "metrics": metrics,
             "issues": issues,
+            "opening_positions": ep.opening_positions,
             "episode_messages": ep.messages,
         }
         result_file.write_text(json.dumps(result, indent=2))

--- a/fastapi-backend/tests/test_l9_episode.py
+++ b/fastapi-backend/tests/test_l9_episode.py
@@ -425,3 +425,58 @@ def test_reply_ignores_unknown_move():
     ep = _open()
     l9_episode.record_reply(ep, handle="a1", reply={"action": "accept", "move": "bogus"}, round_n=1)
     assert "subkind" not in ep.messages[-1]["header"]
+
+
+# ── opening positions snapshot (#679) ─────────────────────────────────────────
+
+
+def test_open_episode_stores_opening_positions():
+    """The snapshot is captured on the episode at open, before mediation."""
+    ep = l9_episode.open_episode(
+        parent_room="sprint",
+        short_id="abc123",
+        workspace_id="ws-1",
+        mas_id="mas-1",
+        agents=["a1", "a2"],
+        joined_intents="- a1: ship\n- a2: test",
+        opening_positions={"a1": "ship it in Q3", "a2": "test first, Q4"},
+    )
+    assert ep.opening_positions == {"a1": "ship it in Q3", "a2": "test first, Q4"}
+
+
+def test_open_episode_opening_positions_default_empty():
+    """Absent snapshot → empty dict (older callers are unaffected)."""
+    assert _open().opening_positions == {}
+
+
+def test_episode_record_renders_opening_positions(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "MYCELIUM_DATA_DIR", str(tmp_path))
+    ep = l9_episode.open_episode(
+        parent_room="sprint",
+        short_id="abc123",
+        workspace_id="ws-1",
+        mas_id="mas-1",
+        agents=["a1", "a2"],
+        joined_intents="- a1: ship\n- a2: test",
+        opening_positions={"a1": "ship it in Q3", "a2": "test first, Q4"},
+    )
+    l9_episode.write_episode_record(ep, outcome="converged", metrics=None, plan_file=None)
+    body = (tmp_path / "rooms" / "sprint" / "log" / "episodes" / "abc123.md").read_text()
+    assert "## Opening Positions" in body
+    assert "- **@a1**: ship it in Q3" in body
+    assert "- **@a2**: test first, Q4" in body
+    # Renders in roster order, above the message log.
+    assert body.index("## Opening Positions") < body.index("## Messages")
+
+
+def test_episode_record_omits_opening_positions_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "MYCELIUM_DATA_DIR", str(tmp_path))
+    l9_episode.write_episode_record(_open(), outcome="rejected", metrics=None, plan_file=None)
+    body = (tmp_path / "rooms" / "sprint" / "log" / "episodes" / "abc123.md").read_text()
+    assert "## Opening Positions" not in body


### PR DESCRIPTION
Closes #679. Part of #684 (sharpen aligner negotiation quality).

## What

Records each participant's stated opening prose as a structured **Opening Positions** snapshot on the episode — captured *before* mediation runs — and renders it into the episode record (`log/episodes/{id}.md`). So when a negotiation goes sideways, or a plan's provenance is unclear, you can see what the room believed going in, not just the final consensus.

## How

- `EpisodeState` gains an optional `opening_positions: dict[str, str]`.
- `open_episode(..., opening_positions=None)` stores it (default empty → existing callers unchanged).
- `aligner.mediate` now computes `_opening_positions(...)` **before** opening the episode and passes the snapshot in, so it's captured at open time.
- `write_episode_record` renders a `## Opening Positions` section (per-agent, roster order, above the message log) when a snapshot is present; omitted entirely when absent.

Pure observability — no change to negotiation behavior. The snapshot is deterministic prose derived from the existing position text: no extra LLM call, nothing fabricated (consistent with the aligner's "faithful, never fabricated" principle).

## Validated on the in-process driver

Threaded `opening_positions` through `scripts/aligner_driver.py` + its `result.json` so the rig exercises the new capability. Ran a full negotiation against `claude-haiku-4-5`: the snapshot correctly recorded growth's `60%/Q3` and risk's `30%/Q4` opening stances even though the negotiation converged to `45%/Q4` — the exact before/after audit trail this is for.

## Tests

4 new tests: snapshot storage, default-empty (back-compat), rendered section + ordering, and the absent-snapshot omission. Full episode/aligner/mediator suites green; `ruff` + `ty` clean.