### PR TITLE
feat(aligner): catch term mismatch before the negotiation starts (#680)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,10 +107,11 @@ see issue #446.)
 engine, the **aligner** (`app/services/aligner.py`), summoned by `@`-mention. It
 runs a real **NEGMAS Stacked Alternating Offers** mechanism (`mediator.py`); its
 brain is a persistent **Pi** coding-agent session (`pi_brain.py`) so it keeps memory
-across rounds. It discovers issues from the agents' opening positions, brokers each
-round, `@`-addresses one agent at a time over SLIM, interprets each reply into an
-SAO move (`offer_snap.py` snaps near-misses / nearest numeric grid point), and
-**NEGMAS owns termination**: it stops the instant the agents agree.
+across rounds. It checks the opening positions for a term the agents are using in
+different senses (one clarifying round if so, none otherwise), discovers issues from
+those positions, brokers each round, `@`-addresses one agent at a time over SLIM,
+interprets each reply into an SAO move (`offer_snap.py` snaps near-misses / nearest
+numeric grid point), and **NEGMAS owns termination**: it stops the instant the agents agree.
 
 **Episodes.** A summon opens an **episode**, a tagged, membership-scoped negotiation
 on the room's channel (a tag over the existing channel, not a separate one), 1:1 with

--- a/docs/index.html
+++ b/docs/index.html
@@ -678,6 +678,7 @@ We chose Postgres because of myc://context/stack.</code></pre>
       <h2 id="aligner-how-it-negotiates">How it negotiates</h2>
       <p>The aligner drives a real <strong>NEGMAS Stacked Alternating Offers</strong> negotiation, so consensus comes out of the mechanism rather than an LLM improvising one. The mechanism owns proposer rotation and the unanimity stop; the aligner only supplies each agent&#x27;s move when NEGMAS asks for one.</p>
       <ol class="steps">
+        <li><strong>Align vocabulary.</strong> Before any offer exists, it reads the opening positions for a term the participants are using in <em>different senses</em> — &quot;done&quot;, &quot;priority&quot;, &quot;blocked&quot;. A word two agents read differently is a disagreement an agreement would hide rather than settle, so when it finds one the aligner runs a single clarifying round: one <code>@</code>-addressed turn each, asking only for a definition, folded into the prose the next step reads. Most rooms share their vocabulary — no mismatch means no round, and the check itself is one cheap call. <code>ALIGNER_TERM_CHECK=0</code> skips it.</li>
         <li><strong>Discover.</strong> It reads the participants&#x27; opening positions (posted with <code>mycelium respond</code>) and derives the negotiable issues and their options.</li>
         <li><strong>Broker.</strong> Each round it <code>@</code>-addresses one agent at a time over SLIM with the standing offer, waits for that agent&#x27;s <code>mycelium respond</code> reply, and interprets the natural-language reply into an SAO move (accept / reject / counter). Agents answer in prose; they never speak the protocol.</li>
         <li><strong>Terminate.</strong> NEGMAS stops the instant everyone accepts the same offer; it never loops to the step cap. A negotiation that can&#x27;t reach agreement commits as <code>rejected</code>.</li>
@@ -702,6 +703,11 @@ We chose Postgres because of myc://context/stack.</code></pre>
               <td><code>ALIGNER_HANDLE</code></td>
               <td><code>aligner</code></td>
               <td>Reserved handle that a summon is recognised by</td>
+            </tr>
+            <tr>
+              <td><code>ALIGNER_TERM_CHECK</code></td>
+              <td><code>true</code></td>
+              <td>Run the pre-negotiation term check, and one clarifying round when it finds a mismatch</td>
             </tr>
             <tr>
               <td><code>ALIGNER_ROUND_TIMEOUT_S</code></td>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -917,16 +917,24 @@ mechanism owns proposer rotation and the
 unanimity stop; the aligner only supplies each agent's move when NEGMAS asks for
 one.
 
-1. **Discover.** It reads the participants' opening positions (posted with
+1. **Align vocabulary.** Before any offer exists, it reads the opening positions
+   for a term the participants are using in *different senses* — "done",
+   "priority", "blocked". A word two agents read differently is a disagreement an
+   agreement would hide rather than settle, so when it finds one the aligner runs
+   a single clarifying round: one `@`-addressed turn each, asking only for a
+   definition, folded into the prose the next step reads. Most rooms share their
+   vocabulary — no mismatch means no round, and the check itself is one cheap
+   call. `ALIGNER_TERM_CHECK=0` skips it.
+2. **Discover.** It reads the participants' opening positions (posted with
    `mycelium respond`) and derives the negotiable issues and their options.
-2. **Broker.** Each round it `@`-addresses one agent at a time over SLIM with the
+3. **Broker.** Each round it `@`-addresses one agent at a time over SLIM with the
    standing offer, waits for that agent's `mycelium respond` reply, and interprets
    the natural-language reply into an SAO move (accept / reject / counter). Agents
    answer in prose; they never speak the protocol.
-3. **Terminate.** NEGMAS stops the instant everyone accepts the same offer; it
+4. **Terminate.** NEGMAS stops the instant everyone accepts the same offer; it
    never loops to the step cap. A negotiation that can't reach agreement commits
    as `rejected`.
-4. **Compile.** On agreement the aligner emits `commit:converged` carrying the
+5. **Compile.** On agreement the aligner emits `commit:converged` carrying the
    agreed `{issue: value}` map, and `plan_compiler` (a separate LLM stage that
    *consumes* the outcome, distinct from the negotiation engine) turns it into the
    room's [shared plan](#plan), `plan/tasks.md`: a `- [ ]` checklist with
@@ -953,6 +961,7 @@ The aligner is dormant by default and configured through `~/.mycelium/.env`
 | Env var | Default | Purpose |
 |---|---|---|
 | `ALIGNER_HANDLE` | `aligner` | Reserved handle that a summon is recognised by |
+| `ALIGNER_TERM_CHECK` | `true` | Run the pre-negotiation term check, and one clarifying round when it finds a mismatch |
 | `ALIGNER_ROUND_TIMEOUT_S` | `30.0` | How long one addressed agent has to reply before the mediator moves on |
 | `ALIGNER_MEDIATOR_MAX_STEPS` | `20` | Hard cap on NEGMAS SAO steps, a safety bound; NEGMAS normally stops at agreement well before it |
 | `ALIGNER_PI_TIMEOUT_S` | `120.0` | Per-turn wall-clock bound on one Pi brain call |

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -125,6 +125,11 @@ class Settings(BaseSettings):
     # well above the participant count so several proposer rotations can happen
     # (spike used 20).
     ALIGNER_MEDIATOR_MAX_STEPS: int = 20
+    # Pre-negotiation term check — one cheap brain call over the opening positions
+    # looking for a word two agents use in different senses, and one clarifying
+    # round when it finds any. On by default: a room that shares its vocabulary
+    # pays a single call and negotiates exactly as before. Off skips the check.
+    ALIGNER_TERM_CHECK: bool = True
     # Mediator brain runtime — the cognitive engine behind the SAO
     # mediator, an *internal* agent — always a persistent, optionally
     # OpenShell-sandboxed `pi -p --session <id> --mode json` session that gives the

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -79,6 +79,11 @@ _NON_PARTICIPANTS = frozenset({BACKEND_AGENT, l9.SYSTEM_ACTOR_ID})
 # L9-addressed agent wakes; the names stay readable.
 _AT_MENTION = re.compile(r"@(?=\w)")
 
+# Round number stamped on the pre-negotiation clarifying tick. SAO steps are
+# NEGMAS's own, counted from 1, so round 0 marks the turn that ran before the
+# mechanism existed.
+_CLARIFY_ROUND = 0
+
 
 def _registered_engine_kind(room: str, handle: str) -> str | None:
     """The CE kind if ``handle`` is a registered ``engine`` agent in ``room``.
@@ -346,6 +351,9 @@ class AlignerEngine:
         )
         try:
             brain = self._make_brain(episode)
+            positions = await self._clarify_terms(
+                managed, persister, ep, me, episode, topic, positions, brain
+            )
             issues = await asyncio.to_thread(
                 mediator.discover_issues,
                 "Converge on the room's open question — agree one value per issue.",
@@ -454,6 +462,76 @@ class AlignerEngine:
             latest.setdefault(handle, f"(no opening position stated by @{handle})")
         return latest
 
+    async def _clarify_terms(
+        self,
+        managed: ManagedRoomChannel,
+        persister: RoomPersister,
+        ep: EpisodeState,
+        sender: str,
+        episode: str,
+        topic: str,
+        positions: dict[str, str],
+        brain: Callable[..., str],
+    ) -> dict[str, str]:
+        """Stage 0 — one clarifying round when agents share a term but not its meaning.
+
+        Agents can converge on words they read differently ("priority", "done",
+        "blocked"), and an agreement built on those words settles nothing. So
+        before any offer exists, the brain reads the opening prose for terms two
+        participants are using in different senses; when it finds any, each
+        participant is ``@``-addressed once — the same one-agent-at-a-time seam the
+        SAO rounds use — and its answer is folded into the prose that issue
+        discovery then reads.
+
+        Exactly one round, never a loop: the point is to make the vocabulary
+        visible to the mediator and the room, not to negotiate the definitions.
+        No mismatch (the common case) means no prompt and no reply wait, so a room
+        that speaks the same language runs exactly as it did before.
+
+        The returned positions are what the negotiation proceeds on; the episode
+        keeps the untouched opening snapshot, so the record still shows what each
+        agent said before it was asked to define anything.
+        """
+        from app.services import mediator
+
+        if not settings.ALIGNER_TERM_CHECK:
+            return positions
+        try:
+            mismatches = await asyncio.to_thread(
+                mediator.detect_term_mismatch, positions, llm=brain
+            )
+        except Exception:
+            logger.warning("aligner term check failed on room %s", managed.room, exc_info=True)
+            return positions
+        if not mismatches:
+            return positions
+        logger.info(
+            "aligner (mediator) room %s: term mismatch on %s — one clarifying round",
+            managed.room,
+            [m["term"] for m in mismatches],
+        )
+        clarified = dict(positions)
+        clarifications: dict[str, str] = {}
+        for handle in positions:
+            reply = await self._slim_turn(
+                managed,
+                persister,
+                sender,
+                handle,
+                episode,
+                topic,
+                mediator.clarification_prompt(handle, mismatches),
+                _CLARIFY_ROUND,
+                action="clarify",
+            )
+            text = reply.strip()
+            if not text:
+                continue  # silence leaves that agent's opening prose as stated
+            clarifications[handle] = text
+            clarified[handle] = f"{positions[handle]}\n\n(clarified by @{handle}: {text})"
+        l9_episode.record_term_check(ep, mismatches=mismatches, clarifications=clarifications)
+        return clarified
+
     async def _slim_turn(
         self,
         managed: ManagedRoomChannel,
@@ -464,11 +542,14 @@ class AlignerEngine:
         topic: str,
         prompt: str,
         round_n: int,
+        action: str = "position",
     ) -> str:
         """Publish one ``@handle`` prompt, wait for the reply, return its prose.
 
         Bounded by ``round_timeout_s`` (a silent agent yields ``""``, read as a
-        reject) so the mechanism can never hang on one participant.
+        reject) so the mechanism can never hang on one participant. ``action`` is
+        what the tick asks for: an SAO ``position``, or a ``clarify`` definition on
+        the pre-negotiation round.
         """
         before = len(persister.log.records)
         env = l9.build_envelope(
@@ -478,7 +559,7 @@ class AlignerEngine:
             recipients=[handle],
             topic=topic,
             payload_type="tick",
-            payload_data={"round": round_n, "action": "position"},
+            payload_data={"round": round_n, "action": action},
         )
         # Neutralise ``@`` tokens so the broker's summary (which names the other
         # agents) doesn't spuriously wake them — only the L9 ``recipients=[handle]``

--- a/fastapi-backend/app/services/l9_episode.py
+++ b/fastapi-backend/app/services/l9_episode.py
@@ -90,6 +90,11 @@ class EpisodeState:
     # structured snapshot the episode record renders as "Opening Positions" so a
     # negotiation can be audited against what the room believed going in (#679).
     opening_positions: dict[str, str] = field(default_factory=dict)
+    # Terms the pre-negotiation check found the participants using in different
+    # senses, and what each answered in the clarifying round that followed. Empty
+    # on the common path (no mismatch, no clarifying round).
+    term_mismatches: list[dict[str, Any]] = field(default_factory=list)
+    clarifications: dict[str, str] = field(default_factory=dict)
     # Ordered record of every envelope in the episode (dicts, wire shape).
     messages: list[dict[str, Any]] = field(default_factory=list)
     # handle -> l9 message id of the last tick sent to that agent.
@@ -186,6 +191,23 @@ def record_tick(
     ep.last_tick_ids[handle] = env.header.message.id  # type: ignore[union-attr]
     ep.messages.append(env_dict)
     return env_dict
+
+
+def record_term_check(
+    ep: EpisodeState,
+    *,
+    mismatches: list[dict[str, Any]],
+    clarifications: dict[str, str],
+) -> None:
+    """Record the pre-negotiation term check and the clarifying round it drove.
+
+    Kept off the quality metrics on purpose: the clarifying round is vocabulary
+    repair, not a negotiation move, so folding it into MPC/GAR/SCR would score a
+    definition as a concession. It lands in the episode record instead, where an
+    audit can see which words the room had to agree on before it could agree.
+    """
+    ep.term_mismatches = [dict(m) for m in mismatches]
+    ep.clarifications = {h: t for h, t in clarifications.items() if t.strip()}
 
 
 def record_reply(
@@ -409,6 +431,31 @@ def write_episode_record(
                     if handle in ep.opening_positions
                 ),
             ]
+        if ep.term_mismatches:
+            lines += [
+                "",
+                "## Term Clarifications",
+                "",
+                "Terms the participants were using differently, caught before the first "
+                "offer, and what each said they meant:",
+                "",
+            ]
+            for mismatch in ep.term_mismatches:
+                lines.append(f"- **{mismatch.get('term', '')}**")
+                readings = mismatch.get("readings")
+                if isinstance(readings, dict):
+                    lines += [f"  - read by @{handle} as: {r}" for handle, r in readings.items()]
+            if ep.clarifications:
+                lines += [
+                    "",
+                    "Clarifying round:",
+                    "",
+                    *(
+                        f"- **@{handle}**: {ep.clarifications[handle]}"
+                        for handle in ep.agents
+                        if handle in ep.clarifications
+                    ),
+                ]
         lines += [
             "",
             "## Messages",

--- a/fastapi-backend/app/services/mediator.py
+++ b/fastapi-backend/app/services/mediator.py
@@ -52,6 +52,11 @@ logger = logging.getLogger(__name__)
 # The mediator's issue-discovery runs at temperature 0 for stable JSON parsing.
 _DISCOVER_TEMPERATURE = 0.0
 
+# Terms the pre-negotiation check will ask about in one clarifying round. A
+# mismatch list longer than this is a signal the check is over-reading the prose,
+# not that the room shares five broken words; the clarifying prompt stays short.
+MAX_TERM_MISMATCHES = 3
+
 # Negotiation stance appended to every agent-facing prompt. Deliberately neutral:
 # the earlier "no agreement is the worst outcome … concede everything secondary"
 # framing coerced agents into capitulating below their stated floor in a single
@@ -83,6 +88,98 @@ def _extract_json(text: str) -> dict[str, Any]:
         if isinstance(parsed, dict):
             return parsed
     return {}
+
+
+def detect_term_mismatch(
+    positions: dict[str, str], *, llm: Callable[..., str]
+) -> list[dict[str, Any]]:
+    """Mediator stage 0 — do two agents use the same word to mean different things?
+
+    Reads the opening prose *before* any offers and returns the terms two or more
+    participants use in materially different senses, as
+    ``[{"term": str, "readings": {handle: meaning}}]``. An empty list — the
+    common case — means the negotiation proceeds exactly as it would have.
+
+    A term mismatch is not a disagreement: two agents wanting a different *value*
+    for the same word is the negotiation itself. What this catches is the case
+    that survives it — an agreement whose words each side reads differently, so
+    the room converges on prose while still talking past each other.
+
+    Faithful, never fabricated (the aligner's standing rule): a reported mismatch
+    must name a real participant on both sides and quote a reading per agent, and
+    anything that fails those checks is dropped rather than repaired. Fail-soft on
+    an LLM error or garbage output — no mismatch, no clarifying round.
+    """
+    roster = {handle.strip().lower(): handle for handle in positions}
+    opening = "\n".join(f"@{handle}: {prose}" for handle, prose in positions.items())
+    try:
+        out = _extract_json(
+            llm(
+                "You are a negotiation mediator reading the opening positions BEFORE any "
+                "offers are made. Find TERM MISMATCHES: a word or phrase that two or more "
+                "agents both use but MEAN DIFFERENTLY, so an agreement written with that word "
+                "would hide a disagreement instead of settling it.\n"
+                "Report a mismatch ONLY when you can quote each agent's own sense of the term "
+                "from their text. Wanting a different VALUE for the same term is NOT a "
+                "mismatch — that is the negotiation. An empty list is the normal answer; do "
+                "not invent one.\n\n"
+                f"POSITIONS:\n{opening}\n\n"
+                'Return ONLY JSON: {"mismatches":[{"term":"the word",'
+                '"readings":{"handle":"what that agent means by it"}}]}',
+                system="Strict JSON. Report only genuine same-word-different-meaning clashes; "
+                'prefer {"mismatches":[]} over a speculative one.',
+                temperature=_DISCOVER_TEMPERATURE,
+            )
+        )
+    except Exception:
+        logger.warning("mediator term check failed; continuing without a clarifying round")
+        return []
+    raw = out.get("mismatches")
+    if not isinstance(raw, list):
+        return []
+    clean: list[dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        term = item.get("term")
+        readings = item.get("readings")
+        if not isinstance(term, str) or not term.strip() or not isinstance(readings, dict):
+            continue
+        # Keep only readings attributed to a real participant, and only a term at
+        # least two of them are on: a one-sided "mismatch" is just one agent's
+        # definition, and an unknown handle is a fabrication.
+        named = {
+            roster[str(h).strip().lower()]: str(v).strip()
+            for h, v in readings.items()
+            if str(h).strip().lower() in roster and str(v).strip()
+        }
+        if len(named) < 2:
+            continue
+        clean.append({"term": term.strip(), "readings": named})
+        if len(clean) == MAX_TERM_MISMATCHES:
+            break
+    return clean
+
+
+def clarification_prompt(handle: str, mismatches: list[dict[str, Any]]) -> str:
+    """The one clarifying turn's prompt — deterministic prose, no offer requested.
+
+    Shows the agent how the room is reading each contested term (including its own
+    reading, so a misread is correctable in-band, the same way the mediator
+    restates its SAO readings) and asks only for a definition.
+    """
+    terms = "\n".join(
+        f'- "{m["term"]}" — '
+        + "; ".join(f"@{h} seems to mean {reading}" for h, reading in m["readings"].items())
+        for m in mismatches
+    )
+    return (
+        f"@{handle} — clarifying round, before any offers. The opening positions use the same "
+        f"term in what look like different senses:\n\n{terms}\n\n"
+        "State plainly what YOU mean by each term (one sentence each), and correct the reading "
+        "above if it has you wrong. Do not make or accept an offer yet — this round only fixes "
+        "the vocabulary so the agreement means the same thing to everyone."
+    )
 
 
 def discover_issues(

--- a/fastapi-backend/scripts/aligner_driver.py
+++ b/fastapi-backend/scripts/aligner_driver.py
@@ -238,6 +238,15 @@ def main() -> None:
     ap.add_argument("--cap", type=int, default=30, help="max SAO steps")
     ap.add_argument("--turn-timeout", type=float, default=3600.0, help="seconds to wait per reply")
     args = ap.parse_args()
+    # The data dir is fixed at import time (settings reads it once), so a --workdir
+    # that disagrees would run the turn bridge in one place and read the episode
+    # record from another. Point people at the env var rather than half-honour it.
+    if Path(args.workdir).resolve() != _WORKDIR.resolve():
+        raise SystemExit(
+            f"--workdir {args.workdir} disagrees with the data dir under {_WORKDIR}; "
+            f"set ALIGNER_DRIVER_WORKDIR={args.workdir} instead (it must be read "
+            "before app.config is imported)."
+        )
     if not settings.ALIGNER_TERM_CHECK:
         print("[driver] note: ALIGNER_TERM_CHECK is off — stage 0 will be skipped", flush=True)
     asyncio.run(_drive(args))

--- a/fastapi-backend/scripts/aligner_driver.py
+++ b/fastapi-backend/scripts/aligner_driver.py
@@ -114,15 +114,12 @@ def main() -> None:
     )
 
     print(f"[driver] model={llm_env['LLM_MODEL']}  participants={participants}", flush=True)
-    print("[driver] discovering issues from opening positions (real LLM)...", flush=True)
-    issues = mediator.discover_issues(args.task, positions, llm=brain)
-    print(f"[driver] issues = {json.dumps(issues)}", flush=True)
-    if not issues:
-        result_file.write_text(json.dumps({"converged": False, "reason": "no issues discovered"}))
-        print("[driver] no issues discovered; done.", flush=True)
-        return
 
     seq = {"n": 0}
+
+    def ask(handle: str, prompt: str, round_n: int) -> str:
+        """Blocking form of the file bridge, for turns outside the async run."""
+        return asyncio.run(fetch_prose(handle, prompt, round_n))
 
     async def fetch_prose(handle: str, prompt: str, round_n: int) -> str:
         """Interactive agent-reply seam: publish the turn, block on reply.txt."""
@@ -151,6 +148,31 @@ def main() -> None:
         print(f"[driver] @{handle} timed out (no reply) — treating as silence.", flush=True)
         return ""
 
+    print("[driver] checking the opening positions for term mismatch (real LLM)...", flush=True)
+    mismatches = mediator.detect_term_mismatch(positions, llm=brain)
+    clarifications: dict[str, str] = {}
+    if mismatches:
+        print(
+            f"[driver] term mismatch = {json.dumps(mismatches)} — one clarifying round", flush=True
+        )
+        for handle in list(positions):
+            reply = ask(handle, mediator.clarification_prompt(handle, mismatches), 0).strip()
+            if not reply:
+                continue
+            clarifications[handle] = reply
+            positions[handle] = f"{positions[handle]}\n\n(clarified by @{handle}: {reply})"
+        l9_episode.record_term_check(ep, mismatches=mismatches, clarifications=clarifications)
+    else:
+        print("[driver] no term mismatch — negotiating on the opening positions", flush=True)
+
+    print("[driver] discovering issues from opening positions (real LLM)...", flush=True)
+    issues = mediator.discover_issues(args.task, positions, llm=brain)
+    print(f"[driver] issues = {json.dumps(issues)}", flush=True)
+    if not issues:
+        result_file.write_text(json.dumps({"converged": False, "reason": "no issues discovered"}))
+        print("[driver] no issues discovered; done.", flush=True)
+        return
+
     async def run() -> None:
         loop = asyncio.get_running_loop()
         negotiation = mediator.MediatedNegotiation(
@@ -178,6 +200,8 @@ def main() -> None:
             "metrics": metrics,
             "issues": issues,
             "opening_positions": ep.opening_positions,
+            "term_mismatches": ep.term_mismatches,
+            "clarifications": ep.clarifications,
             "episode_messages": ep.messages,
         }
         result_file.write_text(json.dumps(result, indent=2))

--- a/fastapi-backend/scripts/aligner_driver.py
+++ b/fastapi-backend/scripts/aligner_driver.py
@@ -1,27 +1,29 @@
-"""Interactive in-process aligner driver — real Pi brain, no SLIM, no node.
+"""Interactive driver for the *real* aligner — a thin wrapper, no re-implementation.
 
-Runs the *real* mediator cognition (``discover_issues`` -> ``MediatedNegotiation``
--> ``build_mechanism`` -> ``mech.run``) with a real per-session ``PiBrain``, but
-replaces only the agent-reply seam (``fetch_prose``) with a file bridge so a human
-(or Claude) can answer as each agent, turn by turn. The episode is recorded via the
-real ``l9_episode`` folding, so afterwards you can inspect exactly what the aligner
-understood and what the wire envelopes look like.
-
-This isolates the aligner's *cognition* from the SLIM transport (which needs live
-subscriber connectors). It's the rig for gut-checking mediator-logic changes
-(#679/#680/#682/#683) against a real model.
+Runs the actual ``AlignerEngine.mediate()`` end to end against a real per-session
+``PiBrain``, using the same in-repo fakes the test suite uses for the coordination
+stack (``FakePersister``/``FakeManaged``/``FakeManager``). The only thing swapped is
+the agent-reply seam: instead of ``FakeChannel``'s canned auto-reply, an
+``InteractiveChannel`` surfaces each ``@handle`` prompt to a file and injects the
+human's reply back into the transcript the mediator polls. So every stage the real
+engine runs — term-mismatch check + clarifying round, opening-positions snapshot,
+issue discovery, the SAO loop, verdict + episode-record write — is exercised as
+shipped. Nothing about the negotiation flow is duplicated here; this file is a
+wrapper with a run function and the file bridge, and it stays that way as the
+engine grows.
 
 Protocol (all under --workdir, default /tmp/aligner-lab):
-  * The driver writes the current turn to ``turn.json`` and blocks.
+  * The engine addresses one agent; the driver writes that turn to ``turn.json``.
   * You read ``turn.json``, then write the agent's reply prose to ``reply.txt``.
-  * The driver consumes ``reply.txt`` (deletes it) and continues.
-  * On termination it writes ``result.json`` (assignments + metrics + transcript).
+  * The driver injects it as that agent's transcript reply and the engine continues.
+  * On termination the real episode record is copied to ``episode.md`` and a
+    ``result.json`` summarises the verdict.
 
-Positions are seeded from ``positions.json`` in the workdir ({handle: prose}); if
-absent, a default two-agent budget scenario is used.
+Positions seed from ``positions.json`` in the workdir ({handle: prose}); if absent,
+a default two-agent budget scenario is used. LLM config is read from
+``~/.mycelium/.env``. Run from fastapi-backend/:
 
-Run from fastapi-backend/:
-  uv run python scripts/aligner_driver.py --workdir /tmp/aligner-lab
+  PYTHONPATH=. uv run python scripts/aligner_driver.py --workdir /tmp/aligner-lab
 """
 
 from __future__ import annotations
@@ -32,29 +34,27 @@ import json
 import os
 import time
 from pathlib import Path
+from typing import Any
 
-from app.services import l9_episode, mediator
-from app.services.pi_brain import PiBrain
+# The episode record is written through the memory filesystem, which is rooted at
+# MYCELIUM_DATA_DIR — set it to the workdir before app.config/settings is imported.
+_WORKDIR = Path(os.environ.get("ALIGNER_DRIVER_WORKDIR", "/tmp/aligner-lab"))
+_DATA_DIR = _WORKDIR / "data"
+_DATA_DIR.mkdir(parents=True, exist_ok=True)
+os.environ.setdefault("MYCELIUM_DATA_DIR", str(_DATA_DIR))
+os.environ.setdefault("MYCELIUM_STUB_EMBEDDINGS", "1")
 
+from app.config import settings  # noqa: E402
+from app.services import aligner, l9  # noqa: E402
+from app.services.l9_models import Kind  # noqa: E402
+from app.services.l9_slim import serialize_content  # noqa: E402
+from app.services.persister import record_from  # noqa: E402
+from app.services.pi_brain import PiBrain  # noqa: E402
+from tests.fakes import FakeManaged, FakeManager, FakePersister  # noqa: E402
 
-def _load_llm_env() -> dict[str, str]:
-    """Read LLM_MODEL/API_KEY/BASE_URL from ~/.mycelium/.env (never printed)."""
-    env_path = Path.home() / ".mycelium" / ".env"
-    out: dict[str, str] = {}
-    if env_path.is_file():
-        for line in env_path.read_text().splitlines():
-            line = line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            k, v = line.split("=", 1)
-            if k in {"LLM_MODEL", "LLM_API_KEY", "LLM_BASE_URL"}:
-                out[k] = v.strip()
-    # Env vars win over the file if the caller exported them.
-    for k in ("LLM_MODEL", "LLM_API_KEY", "LLM_BASE_URL"):
-        if os.environ.get(k):
-            out[k] = os.environ[k]
-    return out
-
+_ROOM = "aligner-lab"
+_EPISODE = l9.episode_urn(_ROOM, "live")
+_TOPIC = l9.topic_urn(_ROOM)
 
 _DEFAULT_POSITIONS = {
     "growth": "Allocate 60% of the budget to the tech platform rebuild; growth depends on it. Ship in Q3.",
@@ -62,25 +62,112 @@ _DEFAULT_POSITIONS = {
 }
 
 
-def main() -> None:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--workdir", default="/tmp/aligner-lab")
-    ap.add_argument(
-        "--task", default="Converge on the tech budget percentage and the ship timeline."
-    )
-    ap.add_argument("--cap", type=int, default=30, help="max SAO steps")
-    ap.add_argument(
-        "--turn-timeout", type=float, default=3600.0, help="seconds to wait for a reply"
-    )
-    args = ap.parse_args()
+def _load_llm_env() -> dict[str, str]:
+    """Read LLM_MODEL/API_KEY/BASE_URL from ~/.mycelium/.env (never printed)."""
+    env_path = Path.home() / ".mycelium" / ".env"
+    out: dict[str, str] = {}
+    if env_path.is_file():
+        for raw in env_path.read_text().splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            if k in {"LLM_MODEL", "LLM_API_KEY", "LLM_BASE_URL"}:
+                out[k] = v.strip()
+    for k in ("LLM_MODEL", "LLM_API_KEY", "LLM_BASE_URL"):
+        if os.environ.get(k):
+            out[k] = os.environ[k]
+    return out
 
+
+def _position_record(handle: str, text: str, seq: int) -> Any:
+    """A transcript reply record from ``handle`` carrying ``text`` — the shape the
+    mediator's ``_is_position`` accepts and ``_slim_turn`` / ``_opening_positions``
+    read (an agent-role ``exchange`` reply whose content is the prose)."""
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=_EPISODE,
+        sender=handle,
+        sender_role="agent",
+        recipients=[l9.SYSTEM_ACTOR_ID],
+        topic=_TOPIC,
+        payload_type="reply",
+        payload_data={"action": "position"},
+        message_id=f"drv-{seq}",
+    )
+    return record_from(env, serialize_content(env, extra={"content": text}))
+
+
+class InteractiveChannel:
+    """An ``L9SlimChannel`` stand-in whose agent turns are answered by a human.
+
+    On every ``exchange`` prompt the engine sends, surfaces the addressed agent's
+    turn to ``turn.json`` and blocks until ``reply.txt`` appears, then injects the
+    reply into the persister's log as that agent's transcript reply — exactly what
+    a real agent's SLIM/HTTP reply would land as, which is what ``_slim_turn``
+    polls for. The ``commit`` envelope is recorded but never prompts.
+    """
+
+    def __init__(self, persister: FakePersister, workdir: Path, timeout_s: float) -> None:
+        self._persister = persister
+        self._turn_file = workdir / "turn.json"
+        self._reply_file = workdir / "reply.txt"
+        self._timeout_s = timeout_s
+        self.sent: list[tuple[Any, dict[str, Any] | None]] = []
+        self._seq = 0
+
+    async def send(self, envelope: Any, *, extra: dict[str, Any] | None = None) -> None:
+        self.sent.append((envelope, extra))
+        if envelope.header.kind != Kind.exchange:
+            return
+        data = envelope.payload.data
+        prompt = (extra or {}).get("content", "")
+        for actor in envelope.header.participants.actors[1:]:
+            self._seq += 1
+            handle = actor.id
+            self._turn_file.write_text(
+                json.dumps(
+                    {
+                        "seq": self._seq,
+                        "handle": handle,
+                        "round": data.get("round"),
+                        "action": data.get("action"),
+                        "prompt": prompt,
+                    },
+                    indent=2,
+                )
+            )
+            print(
+                f"\n[driver] === TURN {self._seq} — @{handle} "
+                f"(round {data.get('round')}, {data.get('action')}) ===\n"
+                f"[driver] aligner asks:\n{prompt}\n"
+                f"[driver] >>> write @{handle}'s reply to {self._reply_file} <<<",
+                flush=True,
+            )
+            reply = await self._await_reply(handle)
+            self._persister.log.record(
+                _position_record(handle, reply, self._seq), delivered_to=set()
+            )
+
+    async def _await_reply(self, handle: str) -> str:
+        deadline = time.monotonic() + self._timeout_s
+        while time.monotonic() < deadline:
+            if self._reply_file.exists():
+                text = self._reply_file.read_text().strip()
+                self._reply_file.unlink(missing_ok=True)
+                self._turn_file.unlink(missing_ok=True)
+                print(f"[driver] @{handle} replied: {text}", flush=True)
+                return text
+            await asyncio.sleep(0.5)
+        print(f"[driver] @{handle} timed out — treating as silence.", flush=True)
+        return ""
+
+
+async def _drive(args: argparse.Namespace) -> None:
     work = Path(args.workdir)
     work.mkdir(parents=True, exist_ok=True)
-    turn_file = work / "turn.json"
-    reply_file = work / "reply.txt"
-    result_file = work / "result.json"
-    for stale in (turn_file, reply_file, result_file):
-        stale.unlink(missing_ok=True)
+    for stale in ("turn.json", "reply.txt", "result.json", "episode.md"):
+        (work / stale).unlink(missing_ok=True)
 
     pos_file = work / "positions.json"
     positions = json.loads(pos_file.read_text()) if pos_file.is_file() else dict(_DEFAULT_POSITIONS)
@@ -88,150 +175,72 @@ def main() -> None:
 
     llm_env = _load_llm_env()
     if not llm_env.get("LLM_MODEL"):
-        raise SystemExit("no LLM_MODEL found in ~/.mycelium/.env or environment")
+        raise SystemExit("no LLM_MODEL in ~/.mycelium/.env or environment")
+
+    # Pre-seed each agent's opening position into the transcript, the way agents
+    # post positions before the aligner is summoned; _opening_positions reads these.
+    persister = FakePersister()
+    for i, (handle, prose) in enumerate(positions.items()):
+        persister.log.record(
+            _position_record(handle, prose, i - len(positions)), delivered_to=set()
+        )
+
+    channel = InteractiveChannel(persister, work, args.turn_timeout)
+    managed = FakeManaged(room=_ROOM, workspace="mycelium", channel=channel, persister=persister)
+    manager = FakeManager(managed, participants)
 
     session_dir = work / "pi-session"
     session_dir.mkdir(exist_ok=True)
-    brain = PiBrain(
-        session_path=session_dir / "brain.jsonl",
-        model=llm_env["LLM_MODEL"],
-        api_key=llm_env.get("LLM_API_KEY"),
-        base_url=llm_env.get("LLM_BASE_URL"),
-        binary="pi",
-        timeout_s=180.0,
-        openshell=False,
-    )
 
-    ep = l9_episode.open_episode(
-        parent_room="aligner-lab",
-        short_id="drv00001",
-        workspace_id="mycelium",
-        mas_id="",
-        agents=participants,
-        joined_intents="\n".join(f"- {h}: {p}" for h, p in positions.items()),
-        engine_handle="aligner",
-        opening_positions=positions,
+    def brain_factory(episode: str) -> Any:
+        return PiBrain(
+            session_path=session_dir / "brain.jsonl",
+            model=llm_env["LLM_MODEL"],
+            api_key=llm_env.get("LLM_API_KEY"),
+            base_url=llm_env.get("LLM_BASE_URL"),
+            binary="pi",
+            timeout_s=180.0,
+            openshell=False,
+        )
+
+    engine = aligner.AlignerEngine(
+        manager,  # type: ignore[arg-type]
+        handle="aligner",
+        round_timeout_s=args.turn_timeout,
+        poll_interval_s=0.5,
+        max_steps=args.cap,
+        brain_factory=brain_factory,
     )
 
     print(f"[driver] model={llm_env['LLM_MODEL']}  participants={participants}", flush=True)
+    print("[driver] running the real AlignerEngine.mediate() ...", flush=True)
+    verdict = await engine.mediate(_ROOM, engine_handle="aligner")
 
-    seq = {"n": 0}
-
-    def ask(handle: str, prompt: str, round_n: int) -> str:
-        """Blocking form of the file bridge, for turns outside the async run."""
-        return asyncio.run(fetch_prose(handle, prompt, round_n))
-
-    async def fetch_prose(handle: str, prompt: str, round_n: int) -> str:
-        """Interactive agent-reply seam: publish the turn, block on reply.txt."""
-        seq["n"] += 1
-        turn_file.write_text(
-            json.dumps(
-                {"seq": seq["n"], "handle": handle, "round": round_n, "prompt": prompt},
-                indent=2,
-            )
-        )
-        print(
-            f"\n[driver] === TURN {seq['n']} — @{handle} (round {round_n}) ===\n"
-            f"[driver] aligner asks:\n{prompt}\n"
-            f"[driver] >>> write @{handle}'s reply to {reply_file} <<<",
-            flush=True,
-        )
-        deadline = time.monotonic() + args.turn_timeout
-        while time.monotonic() < deadline:
-            if reply_file.exists():
-                text = reply_file.read_text().strip()
-                reply_file.unlink(missing_ok=True)
-                turn_file.unlink(missing_ok=True)
-                print(f"[driver] @{handle} replied: {text}", flush=True)
-                return text
-            await asyncio.sleep(0.5)
-        print(f"[driver] @{handle} timed out (no reply) — treating as silence.", flush=True)
-        return ""
-
-    print("[driver] checking the opening positions for term mismatch (real LLM)...", flush=True)
-    mismatches = mediator.detect_term_mismatch(positions, llm=brain)
-    clarifications: dict[str, str] = {}
-    if mismatches:
-        print(
-            f"[driver] term mismatch = {json.dumps(mismatches)} — one clarifying round", flush=True
-        )
-        for handle in list(positions):
-            reply = ask(handle, mediator.clarification_prompt(handle, mismatches), 0).strip()
-            if not reply:
-                continue
-            clarifications[handle] = reply
-            positions[handle] = f"{positions[handle]}\n\n(clarified by @{handle}: {reply})"
-        l9_episode.record_term_check(ep, mismatches=mismatches, clarifications=clarifications)
-    else:
-        print("[driver] no term mismatch — negotiating on the opening positions", flush=True)
-
-    print("[driver] discovering issues from opening positions (real LLM)...", flush=True)
-    issues = mediator.discover_issues(args.task, positions, llm=brain)
-    print(f"[driver] issues = {json.dumps(issues)}", flush=True)
-    if not issues:
-        result_file.write_text(json.dumps({"converged": False, "reason": "no issues discovered"}))
-        print("[driver] no issues discovered; done.", flush=True)
-        return
-
-    async def run() -> None:
-        loop = asyncio.get_running_loop()
-        negotiation = mediator.MediatedNegotiation(
-            issues=issues,
-            cap=args.cap,
-            loop=loop,
-            fetch_prose=fetch_prose,
-            turn_timeout_s=args.turn_timeout,
-            llm=brain,
-            on_reading=lambda handle, reading, proposing: l9_episode.record_reply(
-                ep,
-                handle=handle,
-                reply=_reading_to_reply(reading, proposing),
-                round_n=None,
-            ),
-        )
-        mech = mediator.build_mechanism(issues, participants, negotiation, cap=args.cap)
-        await asyncio.to_thread(mech.run)
-        assignments = mediator.agreement_assignments(mech, negotiation.names)
-        metrics = l9_episode.compute_metrics(ep)
-        result = {
-            "converged": assignments is not None,
-            "assignments": assignments,
-            "steps": mech.current_step,
-            "metrics": metrics,
-            "issues": issues,
-            "opening_positions": ep.opening_positions,
-            "term_mismatches": ep.term_mismatches,
-            "clarifications": ep.clarifications,
-            "episode_messages": ep.messages,
-        }
-        result_file.write_text(json.dumps(result, indent=2))
-        print(
-            f"\n[driver] === DONE — {'AGREEMENT' if assignments else 'no agreement'} "
-            f"in {mech.current_step} steps ===\n[driver] assignments={assignments}\n"
-            f"[driver] metrics={metrics}\n[driver] full result + episode transcript -> {result_file}",
-            flush=True,
-        )
-
-    asyncio.run(run())
+    # The real episode record the engine just wrote — copy it out and summarise.
+    episodes = sorted((_DATA_DIR / "rooms" / _ROOM / "log" / "episodes").glob("*.md"))
+    record = episodes[-1].read_text() if episodes else "(no episode record written)"
+    (work / "episode.md").write_text(record)
+    (work / "result.json").write_text(json.dumps({"verdict": verdict}, indent=2, default=str))
+    # The verdict is the commit envelope; convergence is its subkind.
+    subkind = (verdict or {}).get("header", {}).get("subkind")
+    converged = subkind == "converged"
+    print(
+        f"\n[driver] === DONE — {'AGREEMENT' if converged else 'no agreement'} ===\n"
+        f"[driver] verdict={verdict}\n"
+        f"[driver] real episode record -> {work / 'episode.md'}",
+        flush=True,
+    )
 
 
-def _reading_to_reply(reading: dict, proposing: bool) -> dict:
-    """Mirror aligner._fold_reading: derive the metric action + wire move (#681)."""
-    reply: dict = {}
-    action = reading.get("action") if isinstance(reading, dict) else None
-    if isinstance(action, str) and action:
-        reply["action"] = "accept" if action == "accept" else "reject"
-    offer = reading.get("offer") if isinstance(reading, dict) else None
-    if isinstance(offer, dict):
-        reply["offer"] = offer
-        reply.setdefault("action", "accept" if proposing else "reject")
-    from app.services import l9
-
-    if isinstance(action, str) and action in l9.EXCHANGE_MOVE_SUBKINDS:
-        reply["move"] = action
-    elif isinstance(offer, dict):
-        reply["move"] = "counter"
-    return reply
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workdir", default=str(_WORKDIR))
+    ap.add_argument("--cap", type=int, default=30, help="max SAO steps")
+    ap.add_argument("--turn-timeout", type=float, default=3600.0, help="seconds to wait per reply")
+    args = ap.parse_args()
+    if not settings.ALIGNER_TERM_CHECK:
+        print("[driver] note: ALIGNER_TERM_CHECK is off — stage 0 will be skipped", flush=True)
+    asyncio.run(_drive(args))
 
 
 if __name__ == "__main__":

--- a/fastapi-backend/tests/fakes.py
+++ b/fastapi-backend/tests/fakes.py
@@ -284,6 +284,7 @@ class FakeSlimClient:
 def make_fake_llm() -> Any:
     """A deterministic stand-in for the mediator's Pi brain, keyed on the prompt.
 
+    * the term check → no mismatch (so no clarifying round);
     * discovery → one issue ``cap`` with three options;
     * a propose interpretation → counter to ``cap = 30``;
     * a respond interpretation → accept;
@@ -294,6 +295,8 @@ def make_fake_llm() -> Any:
     """
 
     def _fake_llm(prompt: str, *, system: str = "", temperature: float = 0.3) -> str:
+        if "TERM MISMATCHES" in prompt:
+            return json.dumps({"mismatches": []})  # the shared-vocabulary default
         if "identify the negotiable ISSUES" in prompt:
             return json.dumps({"issues": [{"name": "cap", "options": ["25", "30", "35"]}]})
         if "Interpret @" in prompt:

--- a/fastapi-backend/tests/test_l9_episode.py
+++ b/fastapi-backend/tests/test_l9_episode.py
@@ -480,3 +480,66 @@ def test_episode_record_omits_opening_positions_when_absent(tmp_path, monkeypatc
     l9_episode.write_episode_record(_open(), outcome="rejected", metrics=None, plan_file=None)
     body = (tmp_path / "rooms" / "sprint" / "log" / "episodes" / "abc123.md").read_text()
     assert "## Opening Positions" not in body
+
+
+# ── term check + clarifying round (#680) ──────────────────────────────────────
+
+_MISMATCH = [{"term": "done", "readings": {"a1": "shipped", "a2": "merged"}}]
+
+
+def test_record_term_check_stores_mismatches_and_clarifications():
+    ep = _open()
+    assert ep.term_mismatches == [] and ep.clarifications == {}
+    l9_episode.record_term_check(
+        ep, mismatches=_MISMATCH, clarifications={"a1": "done means live", "a2": "   "}
+    )
+    assert ep.term_mismatches == _MISMATCH
+    assert ep.clarifications == {"a1": "done means live"}  # a blank answer isn't one
+
+
+def test_record_term_check_leaves_quality_metrics_alone():
+    """The clarifying round is vocabulary repair, not a negotiation move: it must
+    not read as a concession in MPC/GAR/SCR."""
+    ep = _open()
+    l9_episode.record_reply(
+        ep, handle="a1", reply={"action": "accept", "confidence": 0.9}, round_n=1
+    )
+    l9_episode.record_reply(
+        ep, handle="a2", reply={"action": "accept", "confidence": 0.8}, round_n=1
+    )
+    before = l9_episode.compute_metrics(ep)
+    messages = len(ep.messages)
+    l9_episode.record_term_check(ep, mismatches=_MISMATCH, clarifications={"a1": "live"})
+    assert l9_episode.compute_metrics(ep) == before
+    assert len(ep.messages) == messages
+
+
+def test_episode_record_renders_term_clarifications(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "MYCELIUM_DATA_DIR", str(tmp_path))
+    ep = _open()
+    l9_episode.record_term_check(
+        ep,
+        mismatches=_MISMATCH,
+        clarifications={"a1": "done means live", "a2": "done means merged"},
+    )
+    l9_episode.write_episode_record(ep, outcome="converged", metrics=None, plan_file=None)
+    body = (tmp_path / "rooms" / "sprint" / "log" / "episodes" / "abc123.md").read_text()
+    assert "## Term Clarifications" in body
+    assert "- **done**" in body
+    assert "read by @a1 as: shipped" in body
+    assert "- **@a1**: done means live" in body
+    assert body.index("## Term Clarifications") < body.index("## Messages")
+
+
+def test_episode_record_omits_term_clarifications_when_absent(tmp_path, monkeypatch):
+    """The common path — a room that shares its vocabulary — records nothing."""
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "MYCELIUM_DATA_DIR", str(tmp_path))
+    l9_episode.write_episode_record(_open(), outcome="converged", metrics=None, plan_file=None)
+    body = (tmp_path / "rooms" / "sprint" / "log" / "episodes" / "abc123.md").read_text()
+    assert "## Term Clarifications" not in body

--- a/fastapi-backend/tests/test_mediator.py
+++ b/fastapi-backend/tests/test_mediator.py
@@ -27,6 +27,7 @@ from tests.fakes import (
     FakeManager,
     FakePersister,
     fake_brain_factory,
+    make_fake_llm,
 )
 
 _ROOM = "mediate-room"
@@ -267,3 +268,217 @@ async def test_mediate_rejects_when_no_issues_discovered(
     assert verdict is not None
     assert verdict["header"]["subkind"] == "rejected"
     assert manager.closed == [_ROOM]
+
+
+# ── stage 0: the pre-negotiation term check (#680) ────────────────────────────
+
+
+def _mismatch_llm(*, term: str = "done") -> Any:
+    """A fake brain that reports one term mismatch, then behaves like the default."""
+    base = make_fake_llm()
+
+    def _llm(prompt: str, *, system: str = "", temperature: float = 0.3) -> str:
+        if "TERM MISMATCHES" in prompt:
+            return json.dumps(
+                {
+                    "mismatches": [
+                        {
+                            "term": term,
+                            "readings": {
+                                "growth": "shipped to users",
+                                "risk": "code merged, review pending",
+                            },
+                        }
+                    ]
+                }
+            )
+        return base(prompt, system=system, temperature=temperature)
+
+    return _llm
+
+
+def test_detect_term_mismatch_keeps_real_clashes_and_drops_the_rest() -> None:
+    """A term two named participants read differently survives; a one-sided
+    reading, an unknown handle, and a malformed entry are dropped rather than
+    repaired — a fabricated mismatch would cost the room a whole round."""
+
+    def llm(prompt: str, *, system: str = "", temperature: float = 0.0) -> str:
+        return json.dumps(
+            {
+                "mismatches": [
+                    {"term": "done", "readings": {"growth": "shipped", "risk": "merged"}},
+                    {"term": "priority", "readings": {"growth": "urgent"}},  # one-sided
+                    {"term": "blocked", "readings": {"growth": "waiting", "ghost": "stuck"}},
+                    {"term": "", "readings": {"growth": "x", "risk": "y"}},
+                    "not a dict",
+                ]
+            }
+        )
+
+    found = mediator.detect_term_mismatch({"growth": "a", "risk": "b"}, llm=llm)
+    assert found == [{"term": "done", "readings": {"growth": "shipped", "risk": "merged"}}]
+
+
+def test_detect_term_mismatch_empty_on_garbage_or_failure() -> None:
+    """No mismatch is the safe answer: unparseable output and a brain that raises
+    both mean the negotiation runs exactly as it would have."""
+    positions = {"growth": "a", "risk": "b"}
+    assert mediator.detect_term_mismatch(positions, llm=lambda *a, **k: "not json") == []
+    assert mediator.detect_term_mismatch(positions, llm=lambda *a, **k: '{"mismatches":{}}') == []
+
+    def boom(*_a: Any, **_k: Any) -> str:
+        raise RuntimeError("brain down")
+
+    assert mediator.detect_term_mismatch(positions, llm=boom) == []
+
+
+def test_detect_term_mismatch_caps_the_clarifying_prompt() -> None:
+    """More reported terms than the cap reads as over-reading, not a broken room."""
+
+    def llm(*_a: Any, **_k: Any) -> str:
+        return json.dumps(
+            {
+                "mismatches": [
+                    {"term": f"t{i}", "readings": {"growth": "x", "risk": "y"}} for i in range(6)
+                ]
+            }
+        )
+
+    found = mediator.detect_term_mismatch({"growth": "a", "risk": "b"}, llm=llm)
+    assert len(found) == mediator.MAX_TERM_MISMATCHES
+
+
+def test_clarification_prompt_asks_for_a_definition_not_an_offer() -> None:
+    prompt = mediator.clarification_prompt(
+        "growth", [{"term": "done", "readings": {"growth": "shipped", "risk": "merged"}}]
+    )
+    assert "done" in prompt
+    assert "shipped" in prompt and "merged" in prompt  # both readings shown, correctable
+    assert "before any offers" in prompt
+
+
+@pytest.mark.asyncio
+async def test_mediate_injects_one_clarifying_round_on_term_mismatch() -> None:
+    """A mismatch buys exactly ONE clarifying round — one turn per participant,
+    before the first SAO step — and its answers reach issue discovery."""
+    from app.services.l9_models import Kind as _Kind
+    from app.services.persister import envelope_recipients
+
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "aligner"])
+
+    seen: list[dict[str, str]] = []
+    real_discover = mediator.discover_issues
+
+    def spy_discover(task: str, positions: dict[str, str], **kw: Any) -> Any:
+        seen.append(dict(positions))
+        return real_discover(task, positions, **kw)
+
+    engine = _engine(manager, brain_factory=lambda _ep: _mismatch_llm())
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(mediator, "discover_issues", spy_discover)
+        verdict = await engine.mediate(_ROOM)
+
+    assert verdict is not None
+    ticks = [s for s, _ in channel.sent if s.header.kind == _Kind.exchange]
+    clarify = [t for t in ticks if t.payload.data.get("action") == "clarify"]
+    # One clarifying turn per participant, and one only — never a loop.
+    assert [envelope_recipients(t)[0] for t in clarify] == ["growth", "risk"]
+    assert all(t.payload.data["round"] == 0 for t in clarify)
+    # It ran BEFORE the mechanism: the clarifying ticks precede every SAO tick.
+    assert ticks[: len(clarify)] == clarify
+    # And the answers are what discovery reads — the whole point of the round.
+    assert seen and all("(clarified by @" in prose for prose in seen[0].values())
+
+
+@pytest.mark.asyncio
+async def test_mediate_records_the_term_check_on_the_episode() -> None:
+    """The mismatch and each agent's answer land in the episode record, so an
+    audit can see which words the room had to agree on before it could agree."""
+    from app.services.filesystem import ensure_room_structure, get_room_dir
+
+    room_dir = get_room_dir("term-record-room")
+    ensure_room_structure(room_dir)
+
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged("term-record-room", "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "aligner"])
+
+    await _engine(manager, brain_factory=lambda _ep: _mismatch_llm()).mediate("term-record-room")
+
+    records = list((room_dir / "log" / "episodes").glob("*.md"))
+    assert len(records) == 1
+    body = records[0].read_text()
+    assert "## Term Clarifications" in body
+    assert "**done**" in body
+    assert "read by @growth as: shipped to users" in body
+    # The opening snapshot stays the prose the agents actually posted (#679) —
+    # the clarification is recorded beside it, never folded back into it.
+    assert "(clarified by @" not in body.split("## Term Clarifications")[0]
+
+
+@pytest.mark.asyncio
+async def test_mediate_without_term_mismatch_adds_no_round() -> None:
+    """A room that shares its vocabulary negotiates exactly as before: no
+    clarifying tick, no extra reply wait."""
+    from app.services.l9_models import Kind as _Kind
+
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "aligner"])
+
+    verdict = await _engine(manager).mediate(_ROOM)
+
+    assert verdict is not None
+    ticks = [s for s, _ in channel.sent if s.header.kind == _Kind.exchange]
+    assert ticks  # the negotiation itself still ran
+    assert all(t.payload.data.get("action") == "position" for t in ticks)
+
+
+@pytest.mark.asyncio
+async def test_term_check_can_be_switched_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``ALIGNER_TERM_CHECK=0`` skips the check entirely — not even the one call."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "ALIGNER_TERM_CHECK", False)
+    calls: list[str] = []
+
+    def spy_detect(*a: Any, **k: Any) -> list[dict[str, Any]]:
+        calls.append("called")
+        return []
+
+    monkeypatch.setattr(mediator, "detect_term_mismatch", spy_detect)
+
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "aligner"])
+
+    await _engine(manager, brain_factory=lambda _ep: _mismatch_llm()).mediate(_ROOM)
+
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_mediate_survives_a_failing_term_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A broken check costs the room nothing: the negotiation runs as if the
+    vocabulary were shared, rather than failing the whole summon."""
+
+    def boom(*_a: Any, **_k: Any) -> list[dict[str, Any]]:
+        raise RuntimeError("brain down")
+
+    monkeypatch.setattr(mediator, "detect_term_mismatch", boom)
+
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "aligner"])
+
+    verdict = await _engine(manager).mediate(_ROOM)
+
+    assert verdict is not None
+    assert verdict["header"]["subkind"] == "converged"

--- a/mycelium-cli/src/mycelium/docs/aligner.md
+++ b/mycelium-cli/src/mycelium/docs/aligner.md
@@ -24,16 +24,24 @@ mechanism owns proposer rotation and the
 unanimity stop; the aligner only supplies each agent's move when NEGMAS asks for
 one.
 
-1. **Discover.** It reads the participants' opening positions (posted with
+1. **Align vocabulary.** Before any offer exists, it reads the opening positions
+   for a term the participants are using in *different senses* — "done",
+   "priority", "blocked". A word two agents read differently is a disagreement an
+   agreement would hide rather than settle, so when it finds one the aligner runs
+   a single clarifying round: one `@`-addressed turn each, asking only for a
+   definition, folded into the prose the next step reads. Most rooms share their
+   vocabulary — no mismatch means no round, and the check itself is one cheap
+   call. `ALIGNER_TERM_CHECK=0` skips it.
+2. **Discover.** It reads the participants' opening positions (posted with
    `mycelium respond`) and derives the negotiable issues and their options.
-2. **Broker.** Each round it `@`-addresses one agent at a time over SLIM with the
+3. **Broker.** Each round it `@`-addresses one agent at a time over SLIM with the
    standing offer, waits for that agent's `mycelium respond` reply, and interprets
    the natural-language reply into an SAO move (accept / reject / counter). Agents
    answer in prose; they never speak the protocol.
-3. **Terminate.** NEGMAS stops the instant everyone accepts the same offer; it
+4. **Terminate.** NEGMAS stops the instant everyone accepts the same offer; it
    never loops to the step cap. A negotiation that can't reach agreement commits
    as `rejected`.
-4. **Compile.** On agreement the aligner emits `commit:converged` carrying the
+5. **Compile.** On agreement the aligner emits `commit:converged` carrying the
    agreed `{issue: value}` map, and `plan_compiler` (a separate LLM stage that
    *consumes* the outcome, distinct from the negotiation engine) turns it into the
    room's [shared plan](#plan), `plan/tasks.md`: a `- [ ]` checklist with
@@ -60,6 +68,7 @@ The aligner is dormant by default and configured through `~/.mycelium/.env`
 | Env var | Default | Purpose |
 |---|---|---|
 | `ALIGNER_HANDLE` | `aligner` | Reserved handle that a summon is recognised by |
+| `ALIGNER_TERM_CHECK` | `true` | Run the pre-negotiation term check, and one clarifying round when it finds a mismatch |
 | `ALIGNER_ROUND_TIMEOUT_S` | `30.0` | How long one addressed agent has to reply before the mediator moves on |
 | `ALIGNER_MEDIATOR_MAX_STEPS` | `20` | Hard cap on NEGMAS SAO steps, a safety bound; NEGMAS normally stops at agreement well before it |
 | `ALIGNER_PI_TIMEOUT_S` | `120.0` | Per-turn wall-clock bound on one Pi brain call |


### PR DESCRIPTION
## Summary

Agents use the same word for different things — "done", "priority", "blocked" — and nothing caught it until the mismatch was already shaping offers. A negotiation could converge on prose each side read differently, which is worse than not converging: the plan compiles and the disagreement surfaces later.

This adds a **stage 0** to the mediator: one cheap brain call over the opening positions, before any offer exists, asking whether two participants are using a shared term in materially different senses. When it finds one, the aligner runs **exactly one** clarifying round through the existing `@`-mention seam — one turn per participant, asking only for a definition — and folds the answers into the prose issue discovery then reads. When it finds nothing (the common case) the negotiation is what it was before: no prompt, no reply wait, no extra round.

Builds directly on the opening-positions snapshot from #688: that captured what the room believed going in, this checks whether the room *means* the same thing by it.

## Changes

- **`mediator.detect_term_mismatch(positions, llm)`** — stage 0. Returns `[{"term", "readings": {handle: meaning}}]`. The prompt draws the line explicitly: wanting a different *value* for a term is the negotiation, not a mismatch, and an empty list is the expected answer. Faithful, never fabricated — a reported mismatch must name a real participant on both sides with a quoted reading each, or it is dropped rather than repaired; unknown handles, one-sided readings and malformed entries never reach the room. Capped at `MAX_TERM_MISMATCHES = 3` (a longer list reads as over-reading, not a room with five broken words) and fail-soft on an LLM error or garbage output.
- **`mediator.clarification_prompt(handle, mismatches)`** — deterministic prose, no LLM. Shows the agent every reading including its own, so a misread is correctable in-band the way the mediator already restates its SAO readings, and says plainly not to make or accept an offer yet.
- **`aligner._clarify_terms`** — runs the check after the episode opens and before `discover_issues`, then the one round via `_slim_turn` (`round=0`, `action="clarify"` on the tick payload, so a clarifying turn is distinguishable on the wire from an SAO position). A silent agent keeps its opening prose as stated. One round, never a loop: the point is to make the vocabulary visible, not to negotiate definitions.
- **`l9_episode.record_term_check`** + a `## Term Clarifications` section in `log/episodes/{id}.md`. Deliberately kept **out** of MPC/GAR/SCR — a definition is not a concession, and folding it in would score it as one. The opening-positions snapshot keeps the untouched prose, so the record still shows what each agent said before it was asked to define anything.
- **`ALIGNER_TERM_CHECK`** (default on) — an operator kill switch that skips the stage entirely, not even the one call.
- Threaded through `scripts/aligner_driver.py` (+ `result.json`) so the in-process rig from #687 exercises stage 0, and documented in the aligner docs (`How it negotiates` gains an "Align vocabulary" step; new tunable row).

## Testing

Acceptance from the issue is covered directly: a scenario with an injected mismatch triggers **one** extra clarifying round (asserted per-participant, ordered before every SAO tick, with the answers reaching discovery); a scenario without one is unchanged (every tick is a `position`).

12 new tests — mismatch parsing/filtering (real clash kept, one-sided/unknown-handle/malformed dropped), the cap, fail-soft on garbage and on a raising brain, the prompt contract, the injected round, the episode record, the no-mismatch path, the kill switch, and a broken check not costing the room its negotiation.

Backend suite: **681 passed, 9 skipped**. `ruff check`, `ruff format --check` and `ty check` all clean.

Not validated against a live model this round — no `pi` binary or LLM credentials in this environment, so the driver rig change is threaded but unexercised. Worth one live run through `scripts/aligner_driver.py` with a deliberately mismatched pair of positions before relying on the detector's precision in the wild.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)

## Related Issues

Closes #680. Part of #684.

---
_Generated by [Claude Code](https://claude.ai/code/session_019rU1wFabXpfJBMumsnSB2t)_