### PR TITLE
feat(frontend): dedupe room data fetching behind an SWR cache (#627)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,16 @@ is no litellm dependency.
   code + the user-facing SPIRE identity guide):** custodial means the hub still holds
   every key + plaintext; this hardens the wire + attribution + access-by-membership,
   and it is **NOT** E2E-from-the-hub.
+- **GUI server state is one SWR cache; client state stays local.** Every room
+  read in the frontend goes through `mycelium-frontend/src/lib/room-data.ts` —
+  typed SWR hooks keyed `["room", name, resource]`, so N panels reading the same
+  resource make one request and share one cache entry (the composer's `@`
+  popover and the Members rail are two views of one `useRoomRoster`). SWR owns
+  polling, refocus and dedup, so components hold no `setInterval` and no
+  fetched-data `useState`; a pushed SSE event calls `useRoomRevalidate(room)`
+  rather than threading a refresh counter down as a prop. A store (Zustand) is
+  reserved for genuine client state — which rail is open, what's selected — not
+  for anything the hub owns.
 - **Adapter capability (be honest).** `claude_code` is proven; `cursor` is untested.
   `openclaw` and `hermes` are **gone**, not deprecated — they rode the removed
   SSE/coordination-tick model and their packages were deleted (#503). Don't

--- a/mycelium-frontend/package-lock.json
+++ b/mycelium-frontend/package-lock.json
@@ -24,6 +24,7 @@
         "react-textarea-autosize": "^8.5.9",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.16.2",
+        "swr": "^2.5.1",
         "tailwind-merge": "^3.6.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -3034,9 +3035,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3054,9 +3052,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3074,9 +3069,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3094,9 +3086,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8665,6 +8654,19 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.5.1.tgz",
+      "integrity": "sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/mycelium-frontend/package.json
+++ b/mycelium-frontend/package.json
@@ -27,6 +27,7 @@
     "react-textarea-autosize": "^8.5.9",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.16.2",
+    "swr": "^2.5.1",
     "tailwind-merge": "^3.6.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { AuthSessionProvider } from "@/components/auth-session";
 import { LoginGate } from "@/components/login-gate";
 import { KeymapProvider } from "@/components/keymap-provider";
 import { NotificationsProvider } from "@/components/notifications-provider";
+import { SWRProvider } from "@/components/swr-provider";
 
 export const metadata: Metadata = {
   title: "mycelium",
@@ -27,21 +28,26 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className="min-h-screen bg-bg text-text antialiased">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
-          <CurrentUserProvider>
-            <AuthSessionProvider>
-              {/* Gate the whole app: when the backend requires auth and there's
-                  no session, this renders the sign-in screen instead of the
-                  shell (and its silently-empty room lists). Inert when the gate
-                  is off. */}
-              <LoginGate>
-                <NotificationsProvider>
-                  {/* Above the pages, not inside a page's shell: a page registers
-                      its own bindings, so it has to sit under the provider. */}
-                  <KeymapProvider>{children}</KeymapProvider>
-                </NotificationsProvider>
-              </LoginGate>
-            </AuthSessionProvider>
-          </CurrentUserProvider>
+          {/* One cache for every room read below, above the router so it
+              survives navigation between rooms. */}
+          <SWRProvider>
+            <CurrentUserProvider>
+              <AuthSessionProvider>
+                {/* Gate the whole app: when the backend requires auth and
+                    there's no session, this renders the sign-in screen instead
+                    of the shell (and its silently-empty room lists). Inert when
+                    the gate is off. */}
+                <LoginGate>
+                  <NotificationsProvider>
+                    {/* Above the pages, not inside a page's shell: a page
+                        registers its own bindings, so it has to sit under the
+                        provider. */}
+                    <KeymapProvider>{children}</KeymapProvider>
+                  </NotificationsProvider>
+                </LoginGate>
+              </AuthSessionProvider>
+            </CurrentUserProvider>
+          </SWRProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -5,7 +5,8 @@
 
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { fetchRoom, logFetchError, type EpisodeSummary, type Room } from "@/lib/api";
+import { type EpisodeSummary } from "@/lib/api";
+import { useRoom, useRoomRevalidate } from "@/lib/room-data";
 import { parseFocus, type FocusTarget } from "@/lib/search";
 import { memoryHref } from "@/lib/memory-routes";
 import { AppShell } from "@/components/app-shell";
@@ -46,8 +47,6 @@ export default function RoomPage() {
 function RoomWorkspace() {
   const params = useParams();
   const roomName = params.name as string;
-  const [room, setRoom] = useState<Room | null>(null);
-  const [memoryRefresh, setMemoryRefresh] = useState(0);
   const [connected, setConnected] = useState(false);
   const [inspectorTab, setInspectorTab] = useState<Tab>("agents");
   const [inspectorOpen, setInspectorOpen] = useState(true);
@@ -69,20 +68,12 @@ function RoomWorkspace() {
     if (typeof window !== "undefined") window.history.replaceState(null, "", window.location.pathname);
   }, []);
 
-  const { agents, episodes, openTasks } = useRoomStatus(roomName, memoryRefresh);
+  const { agents, episodes, openTasks } = useRoomStatus(roomName);
+  const { room } = useRoom(roomName);
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetchRoom(roomName).then((r: Room) => { if (!cancelled) setRoom(r); }).catch(logFetchError("fetchRoom"));
-    load();
-    const t = setInterval(load, 8000);
-    return () => { cancelled = true; clearInterval(t); };
-  }, [roomName]);
-
-  const handleMemoryChanged = useCallback(() => {
-    setMemoryRefresh(n => n + 1);
-  }, []);
+  // A pushed memory/presence event refreshes every reader of this room's data
+  // at once — the panels no longer take a refresh counter to find out.
+  const handleMemoryChanged = useRoomRevalidate(roomName);
 
   const openTab = useCallback((tab: Tab) => {
     setInspectorTab(tab);
@@ -220,7 +211,6 @@ function RoomWorkspace() {
               onMemoryChanged={handleMemoryChanged}
               onConnectionChange={setConnected}
               onNegotiationPhaseChange={setNegPhase}
-              planRefreshTrigger={memoryRefresh}
               onOpenMemory={openMemory}
               view={editorView}
               onViewChange={setEditorView}
@@ -235,7 +225,6 @@ function RoomWorkspace() {
         <RoomInspector
           roomName={roomName}
           masId={room?.mas_id ?? null}
-          memoryRefresh={memoryRefresh}
           tab={inspectorTab}
           onTabChange={setInspectorTab}
           open={inspectorOpen}

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -3,17 +3,10 @@
 
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Users } from "lucide-react";
-import {
-  createEngine,
-  fetchMessages,
-  fetchRoomAgents,
-  fetchRoomMembers,
-  type AgentSummary,
-  type EngineKind,
-  type PresenceMember,
-} from "@/lib/api";
+import { createEngine, type EngineKind, type PresenceMember } from "@/lib/api";
+import { useRoomRoster } from "@/lib/room-data";
 import { Button } from "@/components/ui/button";
 import { Chip } from "@/components/ui/chip";
 import { Input } from "@/components/ui/input";
@@ -32,8 +25,6 @@ import {
 
 interface Props {
   roomName: string;
-  /** Bumped by the room page on pushed presence/memory events to refetch now. */
-  refreshKey?: number;
   /** One-shot request to open the Add dialog on its engines tab — how the
    *  command palette reaches the invite form from anywhere in the room. */
   engineInvite?: boolean;
@@ -42,16 +33,6 @@ interface Props {
    *  so the row scrolls into sight and marks itself instead of opening. */
   focusHandle?: string | null;
   onFocusConsumed?: () => void;
-}
-
-interface Person {
-  handle: string;
-  /** Team slugs, unioned from the agents this person owns. */
-  teams: string[];
-  /** True when this is the handle the browser is acting as. */
-  you: boolean;
-  /** True when they own ≥1 agent here (vs. only having posted). */
-  owns: boolean;
 }
 
 /** Minute-granular relative age; null under a minute (an actively-polling lease
@@ -92,50 +73,20 @@ function subtext(...parts: (string | null | undefined | false)[]): string {
  */
 export function AgentsPanel({
   roomName,
-  refreshKey = 0,
   engineInvite = false,
   onEngineInviteShown,
   focusHandle = null,
   onFocusConsumed,
 }: Props) {
-  const [agents, setAgents] = useState<AgentSummary[]>([]);
-  const [posters, setPosters] = useState<string[]>([]);
-  const [liveMembers, setLiveMembers] = useState<PresenceMember[]>([]);
-  const [loaded, setLoaded] = useState(false);
   const [mineOnly, setMineOnly] = useState(false);
   const [addTab, setAddTab] = useState<"agents" | "engines">("agents");
   const [addOpen, setAddOpen] = useState(false);
   const { principal } = useCurrentUser();
 
-  const refresh = useCallback(() => {
-    // fetchRoomAgents degrades to [] on failure, so no .catch is needed —
-    // `loaded` still flips so the skeleton clears either way.
-    fetchRoomAgents(roomName).then((a) => {
-      setAgents(a);
-      setLoaded(true);
-    });
-    // Human posters come from the transcript: a room chat post is a broadcast
-    // from a handle that isn't a registered agent. fetchMessages degrades to
-    // { messages: [] } on failure, so no .catch is needed.
-    fetchMessages(roomName, 200).then(({ messages }) => {
-      setPosters(
-        messages
-          .filter((m) => m.message_type === "broadcast")
-          .map((m) => m.sender_handle ?? "")
-          .filter(Boolean),
-      );
-    });
-    // Live presence: SLIM-connected + server-held lease members. Catches handles
-    // that joined via `mycelium await` without registering an agent manifest.
-    // fetchRoomMembers degrades to [] on failure, so no .catch is needed.
-    fetchRoomMembers(roomName).then(setLiveMembers);
-  }, [roomName]);
-
-  useEffect(() => {
-    refresh();
-    const t = setInterval(refresh, 30_000);
-    return () => clearInterval(t);
-  }, [refresh, refreshKey]);
+  // Who's here, shared with the composer's `@` popover: agents from the room's
+  // manifests, people from agent owners ∪ posters ∪ live presence ∪ you, and a
+  // presence entry for whoever holds a SLIM socket or an `await` lease.
+  const { agents, people, presence, loading, refresh } = useRoomRoster(roomName);
 
   useEffect(() => {
     if (!engineInvite) return;
@@ -157,15 +108,7 @@ export function AgentsPanel({
   useEffect(() => {
     if (!highlight) return;
     highlightRow.current?.scrollIntoView({ block: "center" });
-  }, [highlight, loaded]);
-
-  const agentHandles = useMemo(() => new Set(agents.map((a) => a.handle)), [agents]);
-
-  // presence map: handle → full presence member (kind + last_seen) for each live one.
-  const presenceMap = useMemo(
-    () => new Map(liveMembers.map((m) => [m.handle, m])),
-    [liveMembers],
-  );
+  }, [highlight, loading]);
 
   // Re-tick once a minute so the minute-granular "seen Xm ago" labels advance
   // without a refetch (matches the label resolution — no sub-minute churn).
@@ -174,35 +117,6 @@ export function AgentsPanel({
     const t = setInterval(() => setNow((n) => n + 1), 60_000);
     return () => clearInterval(t);
   }, []);
-
-  // People = owners of the room's agents ∪ human posters ∪ live presence members
-  // ∪ the acting-as handle. Teams roll up from each person's owned agents.
-  const people = useMemo(() => {
-    const byHandle = new Map<string, Person>();
-    const add = (handle: string, owns: boolean) => {
-      const h = handle.replace(/^@/, "").toLowerCase();
-      if (!h) return;
-      const existing = byHandle.get(h);
-      if (existing) {
-        existing.owns = existing.owns || owns;
-        return;
-      }
-      byHandle.set(h, { handle: h, teams: [], you: h === principal, owns });
-    };
-    for (const a of agents) if (a.owner) add(a.owner, true);
-    for (const p of posters) if (!agentHandles.has(p)) add(p, false);
-    // Include handles present via SLIM or lease that aren't registered agents.
-    for (const m of liveMembers) if (!agentHandles.has(m.handle)) add(m.handle, false);
-    if (principal) add(principal, false);
-    for (const person of byHandle.values()) {
-      person.teams = [
-        ...new Set(
-          agents.filter((a) => a.owner === person.handle && a.team).map((a) => a.team as string),
-        ),
-      ];
-    }
-    return [...byHandle.values()].sort((x, y) => x.handle.localeCompare(y.handle));
-  }, [agents, posters, liveMembers, agentHandles, principal]);
 
   // "Mine" scopes the agent list to the acting-as user: agents they own, plus
   // any agent fielded by a team their own agents claim.
@@ -324,7 +238,7 @@ export function AgentsPanel({
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        {!loaded &&
+        {loading &&
           ["w-20", "w-28", "w-16"].map((w, i) => (
             <div key={i} className="flex items-center gap-2.5 px-3 py-2.5">
               <Skeleton className="size-8 flex-shrink-0 rounded-full" />
@@ -334,7 +248,7 @@ export function AgentsPanel({
               </div>
             </div>
           ))}
-        {loaded && agents.length === 0 && people.length === 0 && (
+        {!loading && agents.length === 0 && people.length === 0 && (
           <EmptyState
             size="sm"
             icon={Users}
@@ -352,7 +266,7 @@ export function AgentsPanel({
           <>
             <SectionLabel count={people.length}>People</SectionLabel>
             {people.map((p) => {
-              const presence = presenceMap.get(p.handle);
+              const memberPresence = presence.get(p.handle);
               const marked = highlight === p.handle;
               return (
                 <div
@@ -362,7 +276,7 @@ export function AgentsPanel({
                     marked ? "bg-accent/15" : ""
                   }`}
                 >
-                  <Monogram handle={p.handle} color="var(--muted-foreground)" presence={presence?.kind} />
+                  <Monogram handle={p.handle} color="var(--muted-foreground)" presence={memberPresence?.kind} />
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
                       <span className="truncate font-mono text-label font-semibold text-text">
@@ -373,7 +287,7 @@ export function AgentsPanel({
                     <div className="mt-0.5 truncate text-micro text-muted-foreground">
                       {subtext(
                         p.owns ? "owner" : "posted here",
-                        presenceNote(presence),
+                        presenceNote(memberPresence),
                         p.teams.length > 0 && p.teams.join(", "),
                       )}
                     </div>
@@ -387,7 +301,7 @@ export function AgentsPanel({
         {agents.length > 0 && <SectionLabel count={visibleAgents.length}>Agents</SectionLabel>}
         {visibleAgents.map((a) => {
           const mine = principal !== "" && a.owner === principal;
-          const presence = presenceMap.get(a.handle);
+          const memberPresence = presence.get(a.handle.toLowerCase());
           const marked = highlight === a.handle;
           return (
             <div
@@ -397,7 +311,7 @@ export function AgentsPanel({
                 marked ? "bg-accent/15" : ""
               }`}
             >
-              <Monogram handle={a.handle} presence={presence?.kind} />
+              <Monogram handle={a.handle} presence={memberPresence?.kind} />
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-1.5">
                   <span className="truncate font-mono text-label font-semibold text-text">
@@ -421,7 +335,7 @@ export function AgentsPanel({
                 <div className="mt-0.5 truncate text-micro text-muted-foreground">
                   {subtext(
                     a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter,
-                    presenceNote(presence),
+                    presenceNote(memberPresence),
                     a.description,
                   )}
                 </div>

--- a/mycelium-frontend/src/components/episodes-rail.tsx
+++ b/mycelium-frontend/src/components/episodes-rail.tsx
@@ -5,7 +5,8 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Activity } from "lucide-react";
-import { fetchEpisode, fetchEpisodes, logFetchError, type EpisodeSummary } from "@/lib/api";
+import { fetchEpisode, type EpisodeSummary } from "@/lib/api";
+import { useRoomEpisodes } from "@/lib/room-data";
 import { DetailDrawer } from "@/components/detail-drawer";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -35,31 +36,8 @@ interface EpisodesRailProps {
 }
 
 export function EpisodesRail({ roomName, focusShortId = null, onFocusConsumed }: EpisodesRailProps) {
-  const [episodes, setEpisodes] = useState<EpisodeSummary[]>([]);
-  const [loaded, setLoaded] = useState(false);
   const [selected, setSelected] = useState<EpisodeSummary | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetchEpisodes(roomName)
-        .then((data) => {
-          if (!cancelled) {
-            setEpisodes(data);
-            setLoaded(true);
-          }
-        })
-        .catch((err) => {
-          logFetchError("fetchEpisodes")(err);
-          if (!cancelled) setLoaded(true);
-        });
-    load();
-    const t = setInterval(load, 5000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
-  }, [roomName]);
+  const { episodes, loading } = useRoomEpisodes(roomName);
 
   // Arriving from search: open the named episode's drawer. The list is the
   // primary source because an episode still *running* has no `log/episodes/*`
@@ -74,14 +52,14 @@ export function EpisodesRail({ roomName, focusShortId = null, onFocusConsumed }:
       onFocusConsumed?.();
       return;
     }
-    if (!loaded) return;
+    if (loading) return;
     fetchEpisode(roomName, focusShortId).then((detail) => {
       if (detail) setSelected(detail);
       // Answered either way: a since-deleted episode leaves you in the room
       // rather than leaving the request pending forever.
       onFocusConsumed?.();
     });
-  }, [roomName, focusShortId, episodes, loaded, onFocusConsumed]);
+  }, [roomName, focusShortId, episodes, loading, onFocusConsumed]);
 
   const counts = useMemo(() => {
     const live = episodes.filter(isLive).length;
@@ -99,7 +77,7 @@ export function EpisodesRail({ roomName, focusShortId = null, onFocusConsumed }:
       </div>
 
       <div className="flex-1 overflow-y-auto py-1">
-        {!loaded ? (
+        {loading ? (
           Array.from({ length: 3 }, (_, i) => (
             <div key={i} className="flex flex-col gap-1.5 px-4 py-2.5">
               <div className="flex items-center gap-2">

--- a/mycelium-frontend/src/components/event-stream.consent.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.consent.test.tsx
@@ -2,7 +2,8 @@
 // Copyright 2026 Mycelium Contributors
 
 import { act } from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithSWR } from "@/test/swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeEventSource } from "@/test/fake-event-source";
 
@@ -45,7 +46,7 @@ describe("<EventStream /> consent prompt", () => {
   });
 
   it("surfaces a consent_request bus event as an accept/decline prompt", async () => {
-    render(<EventStream roomName="sprint" />);
+    renderWithSWR(<EventStream roomName="sprint" />);
     // Let the initial fetchPendingInvites effect settle so its empty result
     // can't overwrite the invite the bus event adds below.
     await act(async () => {});
@@ -62,7 +63,7 @@ describe("<EventStream /> consent prompt", () => {
   });
 
   it("accept wiring calls the invites endpoint with the accept decision", async () => {
-    render(<EventStream roomName="sprint" />);
+    renderWithSWR(<EventStream roomName="sprint" />);
     // Let the initial fetchPendingInvites effect settle so its empty result
     // can't overwrite the invite the bus event adds below.
     await act(async () => {});
@@ -78,7 +79,7 @@ describe("<EventStream /> consent prompt", () => {
   });
 
   it("decline wiring calls the invites endpoint with the decline decision", async () => {
-    render(<EventStream roomName="sprint" />);
+    renderWithSWR(<EventStream roomName="sprint" />);
     // Let the initial fetchPendingInvites effect settle so its empty result
     // can't overwrite the invite the bus event adds below.
     await act(async () => {});

--- a/mycelium-frontend/src/components/event-stream.render.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.render.test.tsx
@@ -2,7 +2,8 @@
 // Copyright 2026 Mycelium Contributors
 
 import { act } from "react";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import { renderWithSWR } from "@/test/swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeEventSource } from "@/test/fake-event-source";
 
@@ -43,7 +44,7 @@ describe("<EventStream /> live message rendering", () => {
   });
 
   it("renders an l9_exchange streamed over SSE as a chat message", async () => {
-    render(<EventStream roomName="sprint" />);
+    renderWithSWR(<EventStream roomName="sprint" />);
     await act(async () => {});
     const es = FakeEventSource.latest();
 
@@ -59,7 +60,7 @@ describe("<EventStream /> live message rendering", () => {
 
   it("auto-scrolls the ScrollArea viewport, not the outer wrapper, on new messages", async () => {
     const scrollTo = vi.spyOn(Element.prototype, "scrollTo");
-    render(<EventStream roomName="sprint" />);
+    renderWithSWR(<EventStream roomName="sprint" />);
     await act(async () => {});
     const es = FakeEventSource.latest();
 
@@ -77,7 +78,7 @@ describe("<EventStream /> live message rendering", () => {
 
   it("renders an l9_commit streamed over SSE as a consensus notice, not the unhandled fallback", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    render(<EventStream roomName="sprint" />);
+    renderWithSWR(<EventStream roomName="sprint" />);
     await act(async () => {});
     const es = FakeEventSource.latest();
 
@@ -110,7 +111,7 @@ describe("<EventStream /> live message rendering", () => {
 
   it("renders an l9_knowledge streamed over SSE as a knowledge notice, not the unhandled fallback", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    render(<EventStream roomName="sprint" />);
+    renderWithSWR(<EventStream roomName="sprint" />);
     await act(async () => {});
     const es = FakeEventSource.latest();
 
@@ -139,7 +140,7 @@ describe("<EventStream /> live message rendering", () => {
 
   it("warns loudly on an unhandled message_type instead of dropping it silently", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    render(<EventStream roomName="sprint" />);
+    renderWithSWR(<EventStream roomName="sprint" />);
     await act(async () => {});
     const es = FakeEventSource.latest();
 

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -7,12 +7,12 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   getSSEUrl,
   fetchMessages,
-  fetchRoomAgents,
   fetchPendingInvites,
   respondToInvite,
   logFetchError,
   type PendingInvite,
 } from "@/lib/api";
+import { useRoomAgents } from "@/lib/room-data";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomPlanHeader } from "@/components/room-plan-header";
 import { ConsentDialog } from "@/components/consent-dialog";
@@ -322,7 +322,6 @@ interface Props {
   onMemoryChanged?: () => void;
   onConnectionChange?: (connected: boolean) => void;
   onNegotiationPhaseChange?: (phase: NegotiationPhase) => void;
-  planRefreshTrigger?: number;
   /** Open a memory by key — wired to `[[wikilinks]]` in chat so a message can
    *  link a room's memory and a reader (or agent author) can jump straight to it. */
   onOpenMemory?: (key: string) => void;
@@ -337,7 +336,7 @@ interface Props {
   onFocusConsumed?: () => void;
 }
 
-export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onNegotiationPhaseChange, planRefreshTrigger = 0, onOpenMemory, view: viewProp, onViewChange, suppressInvites = false, focusMessageId = null, onFocusConsumed }: Props) {
+export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onNegotiationPhaseChange, onOpenMemory, view: viewProp, onViewChange, suppressInvites = false, focusMessageId = null, onFocusConsumed }: Props) {
   const [events, setEvents] = useState<Event[]>([]);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const [connected, setConnected] = useState(false);
@@ -350,34 +349,19 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   const [viewInternal, setViewInternal] = useState<View>("channel");
   const view = viewProp ?? viewInternal;
   const setView = (v: View) => { if (viewProp === undefined) setViewInternal(v); onViewChange?.(v); };
-  const [agentHandles, setAgentHandles] = useState<Set<string>>(new Set());
-  const [agentOwners, setAgentOwners] = useState<Map<string, string>>(new Map());
   const [invites, setInvites] = useState<PendingInvite[]>([]);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   // Know which senders are registered agents (to badge their replies) and whom
-  // each belongs to (to attribute them inline). Self-fetched (mirrors the chat
-  // box) so the page doesn't have to thread it; owner is resolved at render time
+  // each belongs to (to attribute them inline). Off the room's shared agent
+  // read, so this costs no request of its own; owner is resolved at render time
   // so it always reflects the current manifest, never a stale stamp.
-  useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetchRoomAgents(roomName)
-        .then((a) => {
-          if (cancelled) return;
-          setAgentHandles(new Set(a.map((x) => x.handle)));
-          setAgentOwners(
-            new Map(a.filter((x) => x.owner).map((x) => [x.handle, x.owner as string])),
-          );
-        })
-        .catch(logFetchError("fetchRoomAgents"));
-    load();
-    const t = setInterval(load, 30_000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
-  }, [roomName]);
+  const { agents } = useRoomAgents(roomName);
+  const agentHandles = useMemo(() => new Set(agents.map((a) => a.handle)), [agents]);
+  const agentOwners = useMemo(
+    () => new Map(agents.filter((a) => a.owner).map((a) => [a.handle, a.owner as string])),
+    [agents],
+  );
 
   // Load initial messages
   useEffect(() => {
@@ -567,7 +551,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
       ) : (
       <ScrollArea className="flex-1 min-h-0" viewportRef={scrollRef}>
         {view === "plan" ? (
-          <RoomPlanHeader roomName={roomName} refreshTrigger={planRefreshTrigger} />
+          <RoomPlanHeader roomName={roomName} />
         ) : !historyLoaded ? (
           <ChannelSkeleton />
         ) : visible.length === 0 ? (

--- a/mycelium-frontend/src/components/home-dashboard.tsx
+++ b/mycelium-frontend/src/components/home-dashboard.tsx
@@ -3,20 +3,19 @@
 
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { Boxes, Plus, Sparkles } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
-import {
-  fetchRooms,
-  fetchRoomAgents,
-  fetchEpisodes,
-  type EpisodeSummary,
-  type Room,
-} from "@/lib/api";
+import { type EpisodeSummary, type Room } from "@/lib/api";
+import { useRoomAgents, useRoomEpisodes, useRooms, type RoomQueryOptions } from "@/lib/room-data";
+
+/** The cards read the shared caches but don't drive them: a grid of rooms is a
+ *  glance, not a watch. */
+const NO_POLL: RoomQueryOptions = { refreshInterval: 0 };
 
 // The seeded sample room the "Run a sample coordination" onboarding routes into.
 const SAMPLE_TOUR_HREF = "/room/pricing-model?tour=1";
@@ -66,22 +65,8 @@ function episodeState(ep: EpisodeSummary): { label: string; color: string; live:
  *  heading it wears — "command palette" and "command center" are two different
  *  things, and only one of them is a command surface. */
 export function HomeDashboard() {
-  const [rooms, setRooms] = useState<Room[]>([]);
-  const [loaded, setLoaded] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
-
-  // fetchRooms degrades to [] on failure (fire-and-forget list), so no
-  // .catch is needed — `loaded` still flips so the skeleton clears either way.
-  const load = useCallback(
-    () => fetchRooms().then((data) => { setRooms(data); setLoaded(true); }),
-    [],
-  );
-
-  useEffect(() => {
-    load();
-    const t = setInterval(load, 10_000);
-    return () => clearInterval(t);
-  }, [load]);
+  const { rooms, loading, refresh } = useRooms();
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -102,7 +87,7 @@ export function HomeDashboard() {
           </div>
         </header>
 
-        {!loaded ? (
+        {loading ? (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {Array.from({ length: 4 }, (_, i) => (
               <RoomCardSkeleton key={i} />
@@ -134,7 +119,7 @@ export function HomeDashboard() {
         )}
       </div>
 
-      <CreateRoomDialog open={showCreate} onClose={() => setShowCreate(false)} onCreated={load} />
+      <CreateRoomDialog open={showCreate} onClose={() => setShowCreate(false)} onCreated={refresh} />
     </div>
   );
 }
@@ -159,22 +144,14 @@ function RoomCardSkeleton() {
 }
 
 function RoomCard({ room }: { room: Room }) {
-  const [agentCount, setAgentCount] = useState<number | null>(null);
-  const [episodes, setEpisodes] = useState<EpisodeSummary[] | null>(null);
+  // A card per room, so these read once and don't poll: the grid is a glance,
+  // and opening a room is what starts watching it.
+  const { agents, loading: agentsLoading } = useRoomAgents(room.name, NO_POLL);
+  const { episodes } = useRoomEpisodes(room.name, NO_POLL);
 
-  useEffect(() => {
-    let cancelled = false;
-    fetchRoomAgents(room.name)
-      .then(a => { if (!cancelled) setAgentCount(a.length); })
-      .catch(() => { if (!cancelled) setAgentCount(0); });
-    fetchEpisodes(room.name)
-      .then(e => { if (!cancelled) setEpisodes(e); })
-      .catch(() => { if (!cancelled) setEpisodes([]); });
-    return () => { cancelled = true; };
-  }, [room.name]);
-
-  const live = (episodes ?? []).map(episodeState).filter(s => s.live).length;
-  const latest = (episodes ?? [])[0];
+  const agentCount = agentsLoading ? null : agents.length;
+  const live = episodes.map(episodeState).filter(s => s.live).length;
+  const latest = episodes[0];
   const latestState = latest ? episodeState(latest) : null;
 
   return (

--- a/mycelium-frontend/src/components/memory-panel.test.tsx
+++ b/mycelium-frontend/src/components/memory-panel.test.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Mycelium Contributors
 
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
+import { renderWithSWR } from "@/test/swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryPanel } from "@/components/memory-panel";
 
@@ -90,10 +91,9 @@ describe("<MemoryPanel /> peek navigation", () => {
   it("routes to full page when focusMemory targets a missing key", async () => {
     vi.mocked(fetchMemory).mockResolvedValue(null);
 
-    render(
+    renderWithSWR(
       <MemoryPanel
         roomName="demo"
-        refreshTrigger={0}
         focusMemory={{ key: "missing/key", nonce: 1 }}
       />,
     );
@@ -111,10 +111,9 @@ describe("<MemoryPanel /> peek navigation", () => {
       return offTree;
     });
 
-    render(
+    renderWithSWR(
       <MemoryPanel
         roomName="demo"
-        refreshTrigger={0}
         focusMemory={{ key: offTree.key, nonce: 1 }}
       />,
     );
@@ -147,10 +146,9 @@ describe("<MemoryPanel /> peek navigation", () => {
       found: true,
     });
 
-    render(
+    renderWithSWR(
       <MemoryPanel
         roomName="demo"
-        refreshTrigger={0}
         focusMemory={{ key: offTree.key, nonce: 1 }}
       />,
     );

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -8,15 +8,13 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Brain, ChevronRight, ExternalLink, Folder, FolderOpen, FileText, AlertCircle } from "lucide-react";
 import {
-  fetchMemories,
   fetchMemory,
   fetchMemoryExpanded,
-  fetchMemoryIntegrity,
   searchMemories,
   type Memory,
-  type MemoryLinksIntegrity,
   type MemorySearchResult,
 } from "@/lib/api";
+import { useRoomMemories, useRoomMemoryIntegrity } from "@/lib/room-data";
 import { memoryHref } from "@/lib/memory-routes";
 import { expandedPathsForKey, resolveMemoryPeekNavigation } from "@/lib/memory-panel-nav";
 import { DetailDrawer } from "@/components/detail-drawer";
@@ -34,7 +32,6 @@ interface TreeNode {
 interface Props {
   roomName: string;
   masId?: string | null;
-  refreshTrigger: number;
   /** A memory key to open, arrived at from search. */
   focusKey?: string | null;
   onFocusConsumed?: () => void;
@@ -194,40 +191,23 @@ function TreeRows({ nodes, depth, collapsed, onToggle, onSelect, selected }: Tre
   );
 }
 
-export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocusConsumed, focusMemory }: Props) {
+export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusMemory }: Props) {
   const router = useRouter();
-  const [memories, setMemories] = useState<Memory[]>([]);
-  const [loaded, setLoaded] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<MemorySearchResult[] | null>(null);
   const [searching, setSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
   const [selected, setSelected] = useState<Memory | null>(null);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
-  const [integrity, setIntegrity] = useState<MemoryLinksIntegrity | null>(null);
   const [renderedBody, setRenderedBody] = useState<string | null>(null);
+
+  // The tree, plus the room-wide integrity report the drawer reads to flag a
+  // broken or orphaned memory without a per-open round trip. Both revalidate
+  // when a memory write reaches the room, so neither needs a refresh prop.
+  const { memories, loading } = useRoomMemories(roomName);
+  const { integrity } = useRoomMemoryIntegrity(roomName);
   const memoriesRef = useRef(memories);
   memoriesRef.current = memories;
-
-  // fetchMemories degrades to [] on failure (fire-and-forget list), so no
-  // try/catch is needed here — a failed load just shows the empty state.
-  const loadData = useCallback(async () => {
-    setMemories(await fetchMemories(roomName));
-    setLoaded(true);
-  }, [roomName]);
-
-  // Room-wide integrity report, refreshed alongside the tree — cheap enough
-  // to fetch unconditionally so the drawer can flag a broken/orphaned memory
-  // without a per-open round trip (#599).
-  useEffect(() => {
-    let live = true;
-    fetchMemoryIntegrity(roomName).then(report => {
-      if (live) setIntegrity(report);
-    });
-    return () => {
-      live = false;
-    };
-  }, [roomName, refreshTrigger]);
 
   // Expanded transclusions for whichever memory is open in the drawer, so the
   // rail peek matches the full page instead of leaving `![[…]]` markers as
@@ -251,8 +231,6 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
     () => Array.from(new Set(memories.map(m => m.created_by).filter(Boolean))),
     [memories],
   );
-
-  useEffect(() => { loadData(); }, [loadData, refreshTrigger]);
 
   const revealKeyInTree = useCallback((key: string, clearSearch = false) => {
     if (clearSearch) setSearchResults(null);
@@ -409,7 +387,7 @@ export function MemoryPanel({ roomName, refreshTrigger, focusKey = null, onFocus
         {/* File tree */}
         {!searchResults && (
           <div className="py-1">
-            {!loaded ? (
+            {loading ? (
               ["w-24", "w-32", "w-20", "w-28"].map((w, i) => (
                 <div key={i} className="flex items-center gap-1.5 pr-3" style={{ height: ROW_H, paddingLeft: 8 }}>
                   <Skeleton className="size-3 rounded-sm" />

--- a/mycelium-frontend/src/components/room-chat-box.test.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.test.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Mycelium Contributors
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithSWR } from "@/test/swr";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -52,7 +53,7 @@ describe("<RoomChatBox /> composer triggers", () => {
   });
 
   it("autocompletes a memory on [[ and inserts [[key]]", async () => {
-    render(<RoomChatBox roomName="demo" />);
+    renderWithSWR(<RoomChatBox roomName="demo" />);
     const box = await textarea();
     await userEvent.click(box);
     // `[` is a special char in userEvent.type — double it to type a literal `[[`.
@@ -65,7 +66,7 @@ describe("<RoomChatBox /> composer triggers", () => {
   });
 
   it("autocompletes a skill on / and inserts /name", async () => {
-    render(<RoomChatBox roomName="demo" />);
+    renderWithSWR(<RoomChatBox roomName="demo" />);
     const box = await textarea();
     await userEvent.click(box);
     await userEvent.type(box, "/sum");
@@ -77,7 +78,7 @@ describe("<RoomChatBox /> composer triggers", () => {
   });
 
   it("still autocompletes an @agent mention", async () => {
-    render(<RoomChatBox roomName="demo" />);
+    renderWithSWR(<RoomChatBox roomName="demo" />);
     const box = await textarea();
     await userEvent.click(box);
     await userEvent.type(box, "@ali");
@@ -89,7 +90,7 @@ describe("<RoomChatBox /> composer triggers", () => {
   });
 
   it("also autocompletes a person (present member), not just agents", async () => {
-    render(<RoomChatBox roomName="demo" />);
+    renderWithSWR(<RoomChatBox roomName="demo" />);
     const box = await textarea();
     await userEvent.click(box);
     await userEvent.type(box, "@wat");
@@ -101,7 +102,7 @@ describe("<RoomChatBox /> composer triggers", () => {
   });
 
   it("autocompletes a poster who isn't currently present (Members-panel parity)", async () => {
-    render(<RoomChatBox roomName="demo" />);
+    renderWithSWR(<RoomChatBox roomName="demo" />);
     const box = await textarea();
     await userEvent.click(box);
     await userEvent.type(box, "@sam");
@@ -113,7 +114,7 @@ describe("<RoomChatBox /> composer triggers", () => {
   });
 
   it("does not open a skill popover for a slash inside a word (e.g. a path)", async () => {
-    render(<RoomChatBox roomName="demo" />);
+    renderWithSWR(<RoomChatBox roomName="demo" />);
     const box = await textarea();
     await userEvent.click(box);
     await userEvent.type(box, "path/sum");

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -3,24 +3,13 @@
 
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
 import { ArrowUp } from "lucide-react";
-import {
-  fetchMemories,
-  fetchMessages,
-  fetchRoomAgents,
-  fetchRoomMembers,
-  fetchSkills,
-  logFetchError,
-  sendRoomMessage,
-  type AgentSummary,
-  type Memory,
-  type PresenceMember,
-  type Skill,
-} from "@/lib/api";
-import { useCurrentUser } from "@/components/current-user";
+import { sendRoomMessage, type Memory } from "@/lib/api";
+import { useRoomMemories, useRoomRoster, useRoomSkills } from "@/lib/room-data";
 import { useKeyAction } from "@/components/keymap-provider";
+import { useCurrentUser } from "@/components/current-user";
 
 interface Props {
   roomName: string;
@@ -90,44 +79,17 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
   const { principal } = useCurrentUser();
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [agents, setAgents] = useState<AgentSummary[]>([]);
-  const [members, setMembers] = useState<PresenceMember[]>([]);
-  const [posters, setPosters] = useState<string[]>([]);
-  const [memories, setMemories] = useState<Memory[]>([]);
-  const [skills, setSkills] = useState<Skill[]>([]);
   const [trigger, setTrigger] = useState<Trigger | null>(null);
   const [highlight, setHighlight] = useState(0);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
 
-  const refreshSources = useCallback(() => {
-    // `@` mentions anyone in the room — agents plus the present people (and you).
-    fetchRoomAgents(roomName).then(setAgents).catch((err) => {
-      logFetchError("fetchRoomAgents")(err);
-      setAgents([]);
-    });
-    fetchRoomMembers(roomName).then(setMembers).catch(logFetchError("fetchRoomMembers"));
-    // Human posters from the transcript — a broadcast from a non-agent handle —
-    // so `@` reaches people who've spoken even if they aren't present right now.
-    fetchMessages(roomName, 200)
-      .then(({ messages }) =>
-        setPosters(
-          messages
-            .filter((m) => m.message_type === "broadcast")
-            .map((m) => m.sender_handle ?? "")
-            .filter(Boolean),
-        ),
-      )
-      .catch(logFetchError("fetchMessages"));
-    // Memory keys drive `[[` autocomplete; skills drive `/`. Both degrade to [].
-    fetchMemories(roomName).then(setMemories).catch(logFetchError("fetchMemories"));
-    fetchSkills(roomName).then(setSkills).catch(logFetchError("fetchSkills"));
-  }, [roomName]);
-
-  useEffect(() => {
-    refreshSources();
-    const t = setInterval(refreshSources, 30_000);
-    return () => clearInterval(t);
-  }, [refreshSources]);
+  // `@` reaches everyone in the room, off the same roster the Members rail
+  // renders; `[[` reads the room's memory keys and `/` its skills. All three
+  // are shared reads — opening a room fetches each of them once, however many
+  // panels are looking.
+  const { agents, people } = useRoomRoster(roomName);
+  const { memories } = useRoomMemories(roomName);
+  const { skills } = useRoomSkills(roomName);
 
   // The composer is a keybind target. Focus lands on the next frame because the
   // same keypress may be switching the channel pane back into view, and a
@@ -145,41 +107,22 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
     if (found) setHighlight(0);
   };
 
-  // Everyone `@` can address, at parity with the Members panel: agents first,
-  // then people — agent owners ∪ posters ∪ present members ∪ you (minus agents),
-  // deduped by handle. `present` marks a live SLIM member.
-  const mentionRoster = useMemo(() => {
-    const agentHandles = new Set(agents.map((a) => a.handle.toLowerCase()));
-    const agentItems = agents.map((a) => ({
-      handle: a.handle,
-      secondary: a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter,
-      tertiary: a.description as string | undefined,
-    }));
-
-    const me = principal.trim().toLowerCase();
-    const peopleByHandle = new Map<string, { handle: string; present: boolean }>();
-    const addPerson = (raw: string, present: boolean) => {
-      const h = raw.replace(/^@/, "").toLowerCase();
-      if (!h || agentHandles.has(h)) return;
-      const existing = peopleByHandle.get(h);
-      if (existing) existing.present = existing.present || present;
-      else peopleByHandle.set(h, { handle: h, present });
-    };
-    for (const a of agents) if (a.owner) addPerson(a.owner, false);
-    for (const p of posters) addPerson(p, false);
-    for (const m of members) addPerson(m.handle, m.kind === "slim");
-    if (me) addPerson(me, false);
-
-    const peopleItems = [...peopleByHandle.values()]
-      .sort((a, b) => a.handle.localeCompare(b.handle))
-      .map((p) => ({
+  // Agents first, then people — the roster's order, labelled for the popover.
+  const mentionRoster = useMemo(
+    () => [
+      ...agents.map((a) => ({
+        handle: a.handle,
+        secondary: a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter,
+        tertiary: a.description as string | undefined,
+      })),
+      ...people.map((p) => ({
         handle: p.handle,
-        secondary: p.handle === me ? "you" : p.present ? "person · here" : "person",
+        secondary: p.you ? "you" : p.presence?.kind === "slim" ? "person · here" : "person",
         tertiary: undefined as string | undefined,
-      }));
-
-    return [...agentItems, ...peopleItems];
-  }, [agents, members, posters, principal]);
+      })),
+    ],
+    [agents, people],
+  );
 
   const candidates = useMemo<Candidate[]>(() => {
     if (trigger === null) return [];

--- a/mycelium-frontend/src/components/room-inspector.tsx
+++ b/mycelium-frontend/src/components/room-inspector.tsx
@@ -24,7 +24,6 @@ const TABS: { id: Tab; label: string; icon: LucideIcon }[] = [
 interface Props {
   roomName: string;
   masId?: string | null;
-  memoryRefresh: number;
   /** Optional controlled tab + open state (e.g. driven from the status bar). */
   tab?: Tab;
   onTabChange?: (tab: Tab) => void;
@@ -46,7 +45,6 @@ interface Props {
 export function RoomInspector({
   roomName,
   masId,
-  memoryRefresh,
   tab: tabProp,
   onTabChange,
   open: openProp,
@@ -130,7 +128,6 @@ export function RoomInspector({
         {tab === "agents" && (
           <AgentsPanel
             roomName={roomName}
-            refreshKey={memoryRefresh}
             engineInvite={engineInvite}
             onEngineInviteShown={onEngineInviteShown}
             focusHandle={focused("agent")}
@@ -148,7 +145,6 @@ export function RoomInspector({
           <MemoryPanel
             roomName={roomName}
             masId={masId ?? null}
-            refreshTrigger={memoryRefresh}
             focusKey={focused("memory")}
             onFocusConsumed={onFocusConsumed}
             focusMemory={focusMemory}

--- a/mycelium-frontend/src/components/room-plan-header.tsx
+++ b/mycelium-frontend/src/components/room-plan-header.tsx
@@ -3,15 +3,9 @@
 
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import {
-  fetchPlan,
-  togglePlanTask,
-  addPlanTask,
-  setPlanTitle,
-  type PlanResponse,
-  type PlanFile,
-} from "@/lib/api";
+import { useState } from "react";
+import { togglePlanTask, addPlanTask, setPlanTitle, type PlanFile, type PlanResponse } from "@/lib/api";
+import { useRoomPlan } from "@/lib/room-data";
 import { ListChecks, AlertCircle } from "lucide-react";
 import { MarkdownContent } from "./markdown-content";
 import { EmptyState } from "@/components/empty-state";
@@ -22,7 +16,6 @@ import { Input } from "@/components/ui/input";
 
 interface Props {
   roomName: string;
-  refreshTrigger: number;
 }
 
 // Filter the "title" file out of file chips; its content is the headline above.
@@ -33,29 +26,18 @@ type Open =
   | { kind: "tasks" }
   | { kind: "file"; slug: string };
 
-export function RoomPlanHeader({ roomName, refreshTrigger }: Props) {
-  const [plan, setPlan] = useState<PlanResponse | null>(null);
+export function RoomPlanHeader({ roomName }: Props) {
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState("");
   const [open, setOpen] = useState<Open>({ kind: "tasks" });
   const [newTaskText, setNewTaskText] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
 
-  // fetchPlan degrades to an empty plan on failure, so no try/catch is
-  // needed here — a failed load just shows the "no tasks yet" empty state.
-  const load = useCallback(async () => {
-    setPlan(await fetchPlan(roomName));
-  }, [roomName]);
-
-  // Reload on mount, on refreshTrigger bumps, and on a slow poll. A
-  // negotiation consensus compiles plan/tasks.md on the backend; that write
-  // lands on the parent room without a memory_changed event this page sees,
-  // so polling guarantees the materialized plan surfaces after consensus.
-  useEffect(() => {
-    load();
-    const t = setInterval(load, 8000);
-    return () => clearInterval(t);
-  }, [load, refreshTrigger]);
+  // A negotiation consensus compiles plan/tasks.md on the backend, and that
+  // write lands without a memory_changed event this page sees — so the plan is
+  // the one room resource still worth polling closely, and `refresh` is what an
+  // edit made here calls to see its own result.
+  const { plan, refresh: load } = useRoomPlan(roomName);
 
   const startEditTitle = () => {
     setTitleDraft(plan?.title ?? "");

--- a/mycelium-frontend/src/components/room-slim.tsx
+++ b/mycelium-frontend/src/components/room-slim.tsx
@@ -3,13 +3,8 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
-import {
-  fetchCoordination,
-  logFetchError,
-  type CoordinationRoom,
-  type CoordinationStatus,
-} from "@/lib/api";
+import { type CoordinationRoom } from "@/lib/api";
+import { useCoordination } from "@/lib/room-data";
 import { Skeleton } from "@/components/ui/skeleton";
 
 /** This room's SLIM channel status — the node it rides, who is present (SLIM
@@ -27,29 +22,8 @@ export function RoomSlimView({
   roomName: string;
   layout?: "full" | "rail";
 }) {
-  const [coord, setCoord] = useState<CoordinationStatus | null>(null);
-  const [loaded, setLoaded] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    const load = () =>
-      fetchCoordination()
-        .then((c) => {
-          if (cancelled) return;
-          setCoord(c);
-          setLoaded(true);
-        })
-        .catch((err) => {
-          logFetchError("fetchCoordination")(err);
-          if (!cancelled) setLoaded(true);
-        });
-    load();
-    const t = setInterval(load, 20_000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
-  }, []);
+  const { coordination: coord, loading } = useCoordination();
+  const loaded = !loading;
 
   const room: CoordinationRoom | null = coord?.rooms.find((r) => r.room === roomName) ?? null;
   const enabled = coord?.slim_enabled ?? false;

--- a/mycelium-frontend/src/components/rooms-sidebar.test.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.test.tsx
@@ -2,7 +2,8 @@
 // Copyright 2026 Mycelium Contributors
 
 import { act } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
+import { renderWithSWR } from "@/test/swr";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeEventSource } from "@/test/fake-event-source";
@@ -29,7 +30,7 @@ function rooms(...names: string[]) {
 
 async function renderSidebar(names: string[], activeRoom: string | null = null) {
   vi.mocked(fetchRooms).mockResolvedValue(rooms(...names) as never);
-  render(
+  renderWithSWR(
     <CurrentUserProvider>
       <NotificationsProvider>
         <KeymapProvider>

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -8,7 +8,8 @@ import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { AtSign, BarChart3, Bell, BellOff, Boxes, Check, Plus, Search, SearchX, type LucideIcon } from "lucide-react";
-import { fetchRooms, getAppEventsSSEUrl, type Room } from "@/lib/api";
+import { getAppEventsSSEUrl, type Room } from "@/lib/api";
+import { useRooms } from "@/lib/room-data";
 import { roomLevel, type RoomLevel } from "@/lib/notifications";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
@@ -20,11 +21,6 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { KeyBadge } from "@/components/key-badge";
 import { useCommands, useKeyAction } from "@/components/keymap-provider";
 import type { PaletteCommand } from "@/lib/commands";
-
-// The sidebar lives inside each page's AppShell, so navigation remounts it. A
-// module-level cache lets a fresh mount paint the last-known rooms immediately
-// (no count flashing 100 → 0 → 100 while the refetch is in flight).
-let roomsCache: Room[] = [];
 
 /** Two-letter monogram from a room name (mirrors the agent avatars). */
 function monogram(name: string): string {
@@ -39,20 +35,17 @@ interface Props {
 }
 
 export function RoomsSidebar({ activeRoom = null }: Props) {
-  const [rooms, setRooms] = useState<Room[]>(roomsCache);
   const [query, setQuery] = useState("");
   const [showCreate, setShowCreate] = useState(false);
 
-  // fetchRooms degrades to [] on failure (fire-and-forget list), so no
-  // .catch is needed — a failed poll just leaves the last-known rooms in place.
-  const load = () => fetchRooms().then((data) => { roomsCache = data; setRooms(roomsCache); });
+  // The rooms list is a shared cache entry that outlives this mount — the
+  // sidebar sits inside each page's AppShell, so navigation remounts it, and a
+  // warm cache paints the last-known rooms instead of flashing an empty rail.
+  const { rooms, refresh } = useRooms();
 
+  // Push keeps the list instant; the hook's slow poll is the fail-soft fallback
+  // for a dropped SSE connection.
   useEffect(() => {
-    load();
-    // Push keeps the list instant; the slow poll is a fail-soft fallback for a
-    // dropped SSE connection.
-    const t = setInterval(load, 30_000);
-
     let es: EventSource | undefined;
     let retry: ReturnType<typeof setTimeout>;
     function connect() {
@@ -60,15 +53,15 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
       es.onmessage = (e) => {
         try {
           const msg = JSON.parse(e.data);
-          if (msg.type === "room_created" || msg.type === "room_deleted") load();
+          if (msg.type === "room_created" || msg.type === "room_deleted") refresh();
         } catch {}
       };
       es.onerror = () => { es?.close(); retry = setTimeout(connect, 5000); };
     }
     connect();
 
-    return () => { clearInterval(t); es?.close(); clearTimeout(retry); };
-  }, []);
+    return () => { es?.close(); clearTimeout(retry); };
+  }, [refresh]);
 
   // Unread activity per room, from the same client-side notification store the
   // bell reads. Any non-muted message counts (broadcasts badge here even though
@@ -287,7 +280,7 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
         </div>
       </div>
 
-      <CreateRoomDialog open={showCreate} onClose={() => setShowCreate(false)} onCreated={load} />
+      <CreateRoomDialog open={showCreate} onClose={() => setShowCreate(false)} onCreated={refresh} />
     </aside>
   );
 }

--- a/mycelium-frontend/src/components/swr-provider.tsx
+++ b/mycelium-frontend/src/components/swr-provider.tsx
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { SWRConfig } from "swr";
+
+/**
+ * App-wide defaults for the room data hooks (`@/lib/room-data`).
+ *
+ * The cache is SWR's default one, which lives above the router: navigating
+ * between rooms re-mounts every panel but keeps what was already fetched, so a
+ * room you have opened before paints from cache and revalidates behind the
+ * paint instead of flashing empty.
+ *
+ * Per-resource polling is set by the hooks themselves; these are the cross-
+ * cutting choices. `focusThrottleInterval` is the one worth naming: refocusing
+ * the tab should refresh a stale room, but tabbing back and forth shouldn't
+ * replay every read in the tree.
+ */
+export function SWRProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <SWRConfig
+      value={{
+        revalidateOnFocus: true,
+        revalidateOnReconnect: true,
+        focusThrottleInterval: 30_000,
+        errorRetryCount: 3,
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+}

--- a/mycelium-frontend/src/lib/room-data.test.tsx
+++ b/mycelium-frontend/src/lib/room-data.test.tsx
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { act, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithSWR } from "@/test/swr";
+
+vi.mock("@/lib/api", () => ({
+  fetchRoomAgents: vi.fn(),
+  fetchRoomMembers: vi.fn(),
+  fetchMessages: vi.fn(),
+  fetchMemories: vi.fn(),
+  fetchMemoryIntegrity: vi.fn(),
+  fetchSkills: vi.fn(),
+  fetchPlan: vi.fn(),
+  fetchEpisodes: vi.fn(),
+  fetchRoom: vi.fn(),
+  fetchRooms: vi.fn(),
+  fetchCoordination: vi.fn(),
+  logFetchError: () => () => undefined,
+}));
+
+import { fetchMessages, fetchRoomAgents, fetchRoomMembers } from "@/lib/api";
+import { CurrentUserProvider } from "@/components/current-user";
+import { useRoomRevalidate, useRoomRoster } from "@/lib/room-data";
+
+const agent = (handle: string, extra: Record<string, unknown> = {}) => ({
+  handle,
+  adapter: "claude_code",
+  kind: null,
+  description: "",
+  cwd: null,
+  owner: null,
+  team: null,
+  allow_from: [],
+  ...extra,
+});
+
+/** One consumer of the roster, rendered as a flat list so a second copy of the
+ *  same component is indistinguishable from the first in the DOM. */
+function Roster({ room, testId }: { room: string; testId: string }) {
+  const { agents, people } = useRoomRoster(room);
+  return (
+    <ul data-testid={testId}>
+      {agents.map((a) => (
+        <li key={`agent-${a.handle}`}>{`agent:${a.handle}`}</li>
+      ))}
+      {people.map((p) => (
+        <li key={`person-${p.handle}`}>
+          {`person:${p.handle}${p.you ? ":you" : ""}${p.owns ? ":owns" : ""}` +
+            `${p.presence ? `:${p.presence.kind}` : ""}${p.teams.length ? `:${p.teams.join("+")}` : ""}`}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Revalidator({ room }: { room: string }) {
+  const revalidate = useRoomRevalidate(room);
+  return (
+    <button type="button" onClick={revalidate}>
+      refresh
+    </button>
+  );
+}
+
+function renderRoster(ui: React.ReactElement) {
+  return renderWithSWR(<CurrentUserProvider>{ui}</CurrentUserProvider>);
+}
+
+describe("useRoomRoster", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.mocked(fetchRoomAgents).mockReset().mockResolvedValue([
+      agent("aligner", { adapter: "engine", kind: "aligner" }),
+      agent("bob-code", { owner: "Bob", team: "platform" }),
+    ]);
+    vi.mocked(fetchRoomMembers).mockReset().mockResolvedValue([
+      { handle: "aligner", kind: "slim", last_seen: null },
+      { handle: "watcher", kind: "lease", last_seen: "2026-08-20T00:00:00Z" },
+    ]);
+    vi.mocked(fetchMessages).mockReset().mockResolvedValue({
+      messages: [
+        { message_type: "broadcast", sender_handle: "sam" },
+        { message_type: "broadcast", sender_handle: "aligner" },
+        { message_type: "l9_exchange", sender_handle: "ignored" },
+      ],
+    });
+  });
+
+  it("serves two consumers of the same room from one request per resource", async () => {
+    renderRoster(
+      <>
+        <Roster room="demo" testId="composer" />
+        <Roster room="demo" testId="rail" />
+      </>,
+    );
+
+    await waitFor(() => expect(screen.getAllByText("agent:aligner")).toHaveLength(2));
+    expect(fetchRoomAgents).toHaveBeenCalledTimes(1);
+    expect(fetchRoomMembers).toHaveBeenCalledTimes(1);
+    expect(fetchMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("unions people from owners, posters, presence and the acting-as handle", async () => {
+    window.localStorage.setItem("mycelium.principal", "julia");
+    renderRoster(<Roster room="demo" testId="rail" />);
+
+    // An owner is a person even when they've never posted, and their teams roll
+    // up from the agents they own.
+    expect(await screen.findByText("person:bob:owns:platform")).toBeInTheDocument();
+    // A poster, and someone present only through an `await` lease.
+    expect(screen.getByText("person:sam")).toBeInTheDocument();
+    expect(screen.getByText("person:watcher:lease")).toBeInTheDocument();
+    expect(screen.getByText("person:julia:you")).toBeInTheDocument();
+    // An agent that posted or is present is listed as an agent, never twice.
+    expect(screen.queryByText(/^person:aligner/)).not.toBeInTheDocument();
+  });
+
+  it("refetches every consumer of a room when the room is revalidated", async () => {
+    renderRoster(
+      <>
+        <Roster room="demo" testId="rail" />
+        <Revalidator room="demo" />
+      </>,
+    );
+    await waitFor(() => expect(fetchRoomAgents).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      screen.getByRole("button", { name: "refresh" }).click();
+    });
+
+    await waitFor(() => expect(fetchRoomAgents).toHaveBeenCalledTimes(2));
+    expect(fetchRoomMembers).toHaveBeenCalledTimes(2);
+    expect(fetchMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps rooms apart: a second room is its own set of requests", async () => {
+    renderRoster(
+      <>
+        <Roster room="demo" testId="rail" />
+        <Roster room="other" testId="other" />
+      </>,
+    );
+
+    await waitFor(() => expect(fetchRoomAgents).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(fetchRoomAgents).mock.calls.map(([room]) => room)).toEqual(["demo", "other"]);
+  });
+});

--- a/mycelium-frontend/src/lib/room-data.ts
+++ b/mycelium-frontend/src/lib/room-data.ts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+/**
+ * Room server state, fetched once per resource.
+ *
+ * Every read here is an SWR hook keyed by `["room", <name>, <resource>]`, so N
+ * components asking for the same thing make one request and share one cache
+ * entry: the composer and the Members rail read the same roster, the status bar
+ * and the plan header read the same plan. SWR owns revalidation — polling,
+ * refocus, reconnect, and request dedup — so components hold no `setInterval`
+ * and no fetched-data `useState`, and a pushed event refreshes every reader
+ * through `useRoomRevalidate` instead of a counter threaded down as a prop.
+ *
+ * Client state (which rail is open, what's selected) stays where it is: this
+ * module is only for what the hub owns.
+ */
+
+import { useCallback, useMemo } from "react";
+import useSWR, { useSWRConfig, type SWRConfiguration } from "swr";
+import {
+  fetchCoordination,
+  fetchEpisodes,
+  fetchMemories,
+  fetchMemoryIntegrity,
+  fetchMessages,
+  fetchPlan,
+  fetchRoom,
+  fetchRoomAgents,
+  fetchRoomMembers,
+  fetchRooms,
+  fetchSkills,
+  logFetchError,
+  type AgentSummary,
+  type CoordinationStatus,
+  type EpisodeSummary,
+  type Memory,
+  type MemoryLinksIntegrity,
+  type PlanResponse,
+  type PresenceMember,
+  type Room,
+  type Skill,
+} from "@/lib/api";
+import { useCurrentUser } from "@/components/current-user";
+
+/**
+ * One cadence per resource rather than one per component, picked from how fast
+ * the thing actually moves: a live negotiation and a compiled plan are worth
+ * watching closely; manifests, memories and skills change when someone changes
+ * them, and a pushed event revalidates those the moment they do.
+ */
+const POLL = {
+  rooms: 30_000,
+  room: 30_000,
+  agents: 30_000,
+  members: 30_000,
+  messages: 30_000,
+  memories: 30_000,
+  skills: 30_000,
+  plan: 8_000,
+  episodes: 5_000,
+  coordination: 20_000,
+} as const;
+
+/** Messages are read here only to find who has posted; one page is plenty. */
+const POSTER_LIMIT = 200;
+
+// Stable empties: a fresh `[]` per render would break every downstream memo.
+const NO_ROOMS: Room[] = [];
+const NO_AGENTS: AgentSummary[] = [];
+const NO_MEMBERS: PresenceMember[] = [];
+const NO_POSTERS: string[] = [];
+const NO_MEMORIES: Memory[] = [];
+const NO_SKILLS: Skill[] = [];
+const NO_EPISODES: EpisodeSummary[] = [];
+
+type RoomResource =
+  | "room"
+  | "agents"
+  | "members"
+  | "messages"
+  | "memories"
+  | "skills"
+  | "plan"
+  | "episodes"
+  | "integrity";
+
+/** A null key parks the hook: a room-less render fetches nothing. */
+function roomKey(room: string, resource: RoomResource, ...rest: (string | number)[]) {
+  return room ? (["room", room, resource, ...rest] as const) : null;
+}
+
+/** Per-call-site overrides. The one that earns its keep is `refreshInterval: 0`
+ *  — a card in a grid of rooms wants the shared cache, not N more timers. */
+export interface RoomQueryOptions {
+  refreshInterval?: number;
+}
+
+interface Query<T> {
+  data: T;
+  loading: boolean;
+  error: unknown;
+  refresh: () => void;
+}
+
+function useRoomQuery<T>(
+  room: string,
+  resource: RoomResource,
+  load: (room: string) => Promise<T>,
+  empty: T,
+  fallbackInterval: number,
+  opts: RoomQueryOptions = {},
+  config: SWRConfiguration = {},
+): Query<T> {
+  const { data, isLoading, error, mutate } = useSWR(roomKey(room, resource), () => load(room), {
+    refreshInterval: opts.refreshInterval ?? fallbackInterval,
+    ...config,
+  });
+  const refresh = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+  return { data: data ?? empty, loading: isLoading, error, refresh };
+}
+
+// ── Rooms ────────────────────────────────────────────────────────────────────
+
+export function useRooms(opts: RoomQueryOptions = {}) {
+  const { data, isLoading, mutate } = useSWR("rooms", fetchRooms, {
+    refreshInterval: opts.refreshInterval ?? POLL.rooms,
+  });
+  const refresh = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+  return { rooms: data ?? NO_ROOMS, loading: isLoading, refresh };
+}
+
+/** One room's metadata. `fetchRoom` throws rather than falling back, so a
+ *  failure is logged here and left as `null` for the caller to render around. */
+export function useRoom(room: string, opts: RoomQueryOptions = {}) {
+  const { data, loading, error, refresh } = useRoomQuery(
+    room,
+    "room",
+    fetchRoom,
+    null as Room | null,
+    POLL.room,
+    opts,
+    { onError: logFetchError(`fetchRoom(${room})`) },
+  );
+  return { room: data, loading, error, refresh };
+}
+
+// ── Room resources ───────────────────────────────────────────────────────────
+
+export function useRoomAgents(room: string, opts: RoomQueryOptions = {}) {
+  const { data, loading, refresh } = useRoomQuery(
+    room, "agents", fetchRoomAgents, NO_AGENTS, POLL.agents, opts,
+  );
+  return { agents: data, loading, refresh };
+}
+
+/** Live presence: SLIM-connected members plus server-held `await` leases. */
+export function useRoomMembers(room: string, opts: RoomQueryOptions = {}) {
+  const { data, loading, refresh } = useRoomQuery(
+    room, "members", fetchRoomMembers, NO_MEMBERS, POLL.members, opts,
+  );
+  return { members: data, loading, refresh };
+}
+
+/** Handles that have broadcast into the room — people reachable by `@` even
+ *  when they aren't present right now. */
+export function useRoomPosters(room: string, opts: RoomQueryOptions = {}) {
+  const { data, isLoading, mutate } = useSWR(
+    room ? (["room", room, "messages", POSTER_LIMIT] as const) : null,
+    () => fetchMessages(room, POSTER_LIMIT),
+    { refreshInterval: opts.refreshInterval ?? POLL.messages },
+  );
+  const posters = useMemo(() => {
+    if (!data) return NO_POSTERS;
+    return data.messages
+      .filter((m) => m.message_type === "broadcast")
+      .map((m) => m.sender_handle ?? "")
+      .filter(Boolean);
+  }, [data]);
+  const refresh = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+  return { posters, loading: isLoading, refresh };
+}
+
+export function useRoomMemories(room: string, opts: RoomQueryOptions = {}) {
+  const { data, loading, refresh } = useRoomQuery(
+    room, "memories", fetchMemories, NO_MEMORIES, POLL.memories, opts,
+  );
+  return { memories: data, loading, refresh };
+}
+
+/** Room-wide link integrity. Not polled: it moves only when a memory does, and
+ *  a memory write already revalidates the room. */
+export function useRoomMemoryIntegrity(room: string, opts: RoomQueryOptions = {}) {
+  const { data, loading, refresh } = useRoomQuery(
+    room, "integrity", fetchMemoryIntegrity, null as MemoryLinksIntegrity | null, 0, opts,
+  );
+  return { integrity: data, loading, refresh };
+}
+
+export function useRoomSkills(room: string, opts: RoomQueryOptions = {}) {
+  const { data, loading, refresh } = useRoomQuery(
+    room, "skills", fetchSkills, NO_SKILLS, POLL.skills, opts,
+  );
+  return { skills: data, loading, refresh };
+}
+
+export function useRoomPlan(room: string, opts: RoomQueryOptions = {}) {
+  const { data, loading, refresh } = useRoomQuery(
+    room, "plan", fetchPlan, null as PlanResponse | null, POLL.plan, opts,
+  );
+  return { plan: data, loading, refresh };
+}
+
+export function useRoomEpisodes(room: string, opts: RoomQueryOptions = {}) {
+  const { data, loading, refresh } = useRoomQuery(
+    room, "episodes", fetchEpisodes, NO_EPISODES, POLL.episodes, opts,
+  );
+  return { episodes: data, loading, refresh };
+}
+
+/** Fabric-wide SLIM telemetry — one `/health` read shared by every reader. */
+export function useCoordination(opts: RoomQueryOptions = {}) {
+  const { data, isLoading } = useSWR<CoordinationStatus | null>("coordination", fetchCoordination, {
+    refreshInterval: opts.refreshInterval ?? POLL.coordination,
+  });
+  return { coordination: data ?? null, loading: isLoading };
+}
+
+// ── Revalidation ─────────────────────────────────────────────────────────────
+
+/** Refetch everything this room owns. This is what a pushed SSE event calls:
+ *  one trigger reaches every reader of every room resource, wherever it sits in
+ *  the tree, so nothing has to thread a refresh counter down as a prop. */
+export function useRoomRevalidate(room: string): () => void {
+  const { mutate } = useSWRConfig();
+  return useCallback(() => {
+    void mutate((key) => Array.isArray(key) && key[0] === "room" && key[1] === room);
+  }, [mutate, room]);
+}
+
+// ── Roster ───────────────────────────────────────────────────────────────────
+
+/** A person in the room: an agent's owner, someone who has posted, someone
+ *  present, or you. Never an agent — those are listed as agents. */
+export interface RosterPerson {
+  handle: string;
+  /** Team slugs, unioned from the agents this person owns. */
+  teams: string[];
+  /** True when this is the handle the browser is acting as. */
+  you: boolean;
+  /** True when they own ≥1 agent here (vs. only having posted). */
+  owns: boolean;
+  presence?: PresenceMember;
+}
+
+export interface RoomRoster {
+  agents: AgentSummary[];
+  people: RosterPerson[];
+  /** handle (lowercased) → presence, for badging a row live or awaiting. */
+  presence: Map<string, PresenceMember>;
+  loading: boolean;
+  refresh: () => void;
+}
+
+/**
+ * Everyone in a room, computed once: agents from the manifests, people from
+ * agent owners ∪ posters ∪ present members ∪ you. The Members rail and the
+ * composer's `@` popover are two views of this one answer — they used to derive
+ * it separately, from the same three endpoints, on two timers.
+ */
+export function useRoomRoster(room: string, opts: RoomQueryOptions = {}): RoomRoster {
+  const { agents, loading, refresh: refreshAgents } = useRoomAgents(room, opts);
+  const { members, refresh: refreshMembers } = useRoomMembers(room, opts);
+  const { posters, refresh: refreshPosters } = useRoomPosters(room, opts);
+  const { principal } = useCurrentUser();
+  const me = principal.trim().toLowerCase();
+
+  const presence = useMemo(
+    () => new Map(members.map((m) => [m.handle.toLowerCase(), m])),
+    [members],
+  );
+
+  const people = useMemo(() => {
+    const agentHandles = new Set(agents.map((a) => a.handle.toLowerCase()));
+    const byHandle = new Map<string, RosterPerson>();
+    const add = (raw: string, owns: boolean) => {
+      const handle = raw.trim().replace(/^@/, "").toLowerCase();
+      if (!handle || agentHandles.has(handle)) return;
+      const existing = byHandle.get(handle);
+      if (existing) {
+        existing.owns = existing.owns || owns;
+        return;
+      }
+      byHandle.set(handle, {
+        handle,
+        teams: [],
+        you: handle === me,
+        owns,
+        presence: presence.get(handle),
+      });
+    };
+    for (const a of agents) if (a.owner) add(a.owner, true);
+    for (const p of posters) add(p, false);
+    for (const m of members) add(m.handle, false);
+    if (me) add(me, false);
+
+    for (const person of byHandle.values()) {
+      person.teams = [
+        ...new Set(
+          agents
+            .filter((a) => (a.owner ?? "").toLowerCase() === person.handle && a.team)
+            .map((a) => a.team as string),
+        ),
+      ];
+    }
+    return [...byHandle.values()].sort((x, y) => x.handle.localeCompare(y.handle));
+  }, [agents, members, posters, presence, me]);
+
+  const refresh = useCallback(() => {
+    refreshAgents();
+    refreshMembers();
+    refreshPosters();
+  }, [refreshAgents, refreshMembers, refreshPosters]);
+
+  return { agents, people, presence, loading, refresh };
+}

--- a/mycelium-frontend/src/lib/use-status.ts
+++ b/mycelium-frontend/src/lib/use-status.ts
@@ -3,14 +3,9 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
-import {
-  fetchRoomAgents,
-  fetchEpisodes,
-  fetchPlan,
-  fetchCollectorMetrics,
-  type EpisodeSummary,
-} from "@/lib/api";
+import useSWR from "swr";
+import { fetchCollectorMetrics, type EpisodeSummary } from "@/lib/api";
+import { useRoomAgents, useRoomEpisodes, useRoomPlan } from "@/lib/room-data";
 
 /** The slice of the collector's metrics payload the status bar reads: total
  *  spend and per-model token totals (to find the primary model). */
@@ -27,29 +22,20 @@ export interface RoomStatus {
   openTasks: number | null;
 }
 
-/** Lightweight per-room counts for the status bar (polled, fail-soft).
- *
- *  ``refreshKey`` triggers an immediate reload when it changes — the room page
- *  bumps it on pushed presence/memory events so counts update without waiting
- *  on the poll. */
-export function useRoomStatus(roomName: string, refreshKey = 0): RoomStatus {
-  const [agents, setAgents] = useState<number | null>(null);
-  const [episodes, setEpisodes] = useState<EpisodeSummary[] | null>(null);
-  const [openTasks, setOpenTasks] = useState<number | null>(null);
+/** Lightweight per-room counts for the status bar. Reads the room's shared
+ *  agent / episode / plan caches, so the bar costs no requests of its own and
+ *  never disagrees with the rails showing the same numbers. `null` until the
+ *  first read lands, so a count renders only once it means something. */
+export function useRoomStatus(roomName: string): RoomStatus {
+  const { agents, loading: agentsLoading } = useRoomAgents(roomName);
+  const { episodes, loading: episodesLoading } = useRoomEpisodes(roomName);
+  const { plan } = useRoomPlan(roomName);
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = () => {
-      fetchRoomAgents(roomName).then(a => { if (!cancelled) setAgents(a.length); }).catch(() => {});
-      fetchEpisodes(roomName).then(e => { if (!cancelled) setEpisodes(e); }).catch(() => {});
-      fetchPlan(roomName).then(p => { if (!cancelled) setOpenTasks(p.open_count ?? 0); }).catch(() => {});
-    };
-    load();
-    const t = setInterval(load, 8000);
-    return () => { cancelled = true; clearInterval(t); };
-  }, [roomName, refreshKey]);
-
-  return { agents, episodes, openTasks };
+  return {
+    agents: agentsLoading ? null : agents.length,
+    episodes: episodesLoading ? null : episodes,
+    openTasks: plan ? plan.open_count ?? 0 : null,
+  };
 }
 
 export interface GlobalStatus {
@@ -58,41 +44,42 @@ export interface GlobalStatus {
   healthy: boolean | null;
 }
 
+/** Primary model = the one that burned the most tokens. */
+function primaryModel(col: CollectorSpendShape | null): string | null {
+  const byModel: Record<string, { total?: number }> = col?.counters?.tokens?.by_model ?? {};
+  let top: string | null = null;
+  let max = -1;
+  for (const [m, v] of Object.entries(byModel)) {
+    const total = v?.total ?? 0;
+    if (total > max) { max = total; top = m; }
+  }
+  return top;
+}
+
+async function probeHealth(): Promise<boolean> {
+  try {
+    const res = await fetch("/api/health", { cache: "no-store" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 /** Global workspace status for the status bar: primary LLM model, spend, and
- *  backend health (polled slowly, fail-soft). */
+ *  backend health (polled slowly, fail-soft). The status bar renders on every
+ *  page, so both reads are shared cache entries like the room ones. */
 export function useGlobalStatus(): GlobalStatus {
-  const [model, setModel] = useState<string | null>(null);
-  const [spend, setSpend] = useState<number | null>(null);
-  const [healthy, setHealthy] = useState<boolean | null>(null);
+  const { data: collector } = useSWR<CollectorSpendShape | null>(
+    "collector-metrics",
+    () => fetchCollectorMetrics<CollectorSpendShape>(),
+    { refreshInterval: 20_000 },
+  );
+  const { data: healthy } = useSWR("health", probeHealth, { refreshInterval: 20_000 });
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const col = await fetchCollectorMetrics<CollectorSpendShape>();
-        if (!cancelled && col) {
-          const cost = col.counters?.cost_usd;
-          setSpend(typeof cost?.total === "number" ? cost.total : null);
-          // Primary model = the one that burned the most tokens.
-          const byModel: Record<string, { total?: number }> = col.counters?.tokens?.by_model ?? {};
-          let top: string | null = null;
-          let max = -1;
-          for (const [m, v] of Object.entries(byModel)) {
-            const tot = v?.total ?? 0;
-            if (tot > max) { max = tot; top = m; }
-          }
-          setModel(top);
-        }
-      } catch { /* fail-soft */ }
-      try {
-        const res = await fetch("/api/health", { cache: "no-store" });
-        if (!cancelled) setHealthy(res.ok);
-      } catch { if (!cancelled) setHealthy(false); }
-    };
-    load();
-    const t = setInterval(load, 20_000);
-    return () => { cancelled = true; clearInterval(t); };
-  }, []);
-
-  return { model, spend, healthy };
+  const cost = collector?.counters?.cost_usd;
+  return {
+    model: primaryModel(collector ?? null),
+    spend: typeof cost?.total === "number" ? cost.total : null,
+    healthy: healthy ?? null,
+  };
 }

--- a/mycelium-frontend/src/test/swr.tsx
+++ b/mycelium-frontend/src/test/swr.tsx
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { render, type RenderOptions } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import type { ReactElement, ReactNode } from "react";
+
+/**
+ * A fresh SWR cache per render.
+ *
+ * The room data hooks (`@/lib/room-data`) share one cache in the app — that's
+ * the point of them. In tests that sharing would leak across cases: the second
+ * render of a component would paint the first case's fixtures. Mounting a
+ * provider with its own `Map` scopes the cache — and SWR's in-flight dedup,
+ * which hangs off it — to one render.
+ */
+export function SWRTestCache({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig value={{ provider: () => new Map(), revalidateOnFocus: false }}>
+      {children}
+    </SWRConfig>
+  );
+}
+
+export function renderWithSWR(ui: ReactElement, options?: Omit<RenderOptions, "wrapper">) {
+  return render(ui, { wrapper: SWRTestCache, ...options });
+}


### PR DESCRIPTION
## Summary

Opening a room used to fire the same reads several times over. The composer and the Members rail each derived the roster from `agents` + `sessions/members` + `messages` on their own 30s timers; memory, plan and episodes were fetched once per panel; and a pushed SSE event refreshed them by threading a counter down as a prop.

This adds `mycelium-frontend/src/lib/room-data.ts` — typed SWR hooks keyed `["room", name, resource]` — so N components reading a resource make **one** request and share **one** cache entry. Per the decision on #627: SWR for server state, a store reserved for genuine client state (which rail is open, what's selected), which stays where it is.

Verified in a browser against the mock backend (`MYCELIUM_UI_MOCK=1`): a room page now issues exactly one request per resource, and the `@` popover lists the same roster the Members rail renders.

## Changes

- **`lib/room-data.ts`** — `useRooms`, `useRoom`, `useRoomAgents`, `useRoomMembers`, `useRoomPosters`, `useRoomMemories`, `useRoomMemoryIntegrity`, `useRoomSkills`, `useRoomPlan`, `useRoomEpisodes`, `useCoordination`, plus `useRoomRevalidate(room)`. One polling cadence per resource, picked from how fast the thing actually moves (plan 8s, episodes 5s, manifests/memories/skills 30s, integrity not polled), overridable per call site.
- **`useRoomRoster(room)`** — agents ∪ owners ∪ posters ∪ present members ∪ you, computed once. The composer's `@` popover and the Members rail are now two views of the same answer instead of two derivations from the same three endpoints. Handle matching is normalized to lowercase throughout, so an agent whose manifest handle differs in case from its presence entry no longer shows up twice.
- **Refresh-counter props deleted** — `AgentsPanel.refreshKey`, `MemoryPanel.refreshTrigger`, `RoomPlanHeader.refreshTrigger`, `EventStream.planRefreshTrigger`, `RoomInspector.memoryRefresh`, `useRoomStatus(refreshKey)`. A pushed memory/presence event calls `useRoomRevalidate(roomName)`, which reaches every reader of that room wherever it sits in the tree.
- **Migrated** `room-chat-box`, `agents-panel`, `memory-panel`, `room-plan-header`, `episodes-rail`, `event-stream` (agents read only — messages/invites stay SSE-driven), `rooms-sidebar` (drops its module-level `roomsCache`; the SWR cache above the router does that job now), `home-dashboard`, `room-slim`, and both hooks in `lib/use-status.ts`. Every hand-rolled `setInterval` fetch loop in these is gone; the only remaining one is the metrics screen, which has a user-facing interval control.
- **`components/swr-provider.tsx`** in the root layout for the cross-cutting defaults (refocus/reconnect revalidation, focus throttle, retry count).
- **`test/swr.tsx`** — `renderWithSWR`, a fresh cache per render so a shared cache can't leak fixtures between test cases.
- Notes the decision in `CLAUDE.md`; adds `swr` to `package.json` / `package-lock.json`.

### Behaviour notes (deliberate)

- `fetchRoom` polled at 8s and now shares the 30s room cadence — it supplies the header's name/`mas_id`, which don't move.
- The home grid's per-room cards read the shared caches with `refreshInterval: 0`: a grid of rooms is a glance, and one card per room shouldn't add two timers each.
- Polling now pauses while the tab is hidden (SWR's default), and resumes on refocus.

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run` — 24 files, 187 tests pass (4 new in `lib/room-data.test.tsx`: one request per resource across two consumers, the people union, room-scoped revalidation, and per-room key isolation)
- `npx next build` — clean
- Manual, in Chromium against `MYCELIUM_UI_MOCK=1`: room page request log shows one call per resource; `@` popover, Members rail, Memory rail, plan header and status bar all render as before

The repo checkboxes below are the backend gate; this PR touches no Python.

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Format check passes (`uv run ruff format --check .`)

## Related Issues

Closes #627


---
_Generated by [Claude Code](https://claude.ai/code/session_01AjWS6aXfCXEGxjPktoBzhH)_