### PR TITLE
feat: page every list by keyset cursor; reverse-scroll room history (#654)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,16 @@ is no litellm dependency.
   (version increments). Frontmatter the store doesn't manage is user data: it
   survives a rewrite rather than being dropped, and `MemoryCreate.meta` (CLI:
   `--meta k=v`, `--expandable`) writes it.
+- **Lists page by keyset cursor, not offset.** One primitive
+  (`app/services/pagination.py`) pages every list: ask with `cursor`, get back
+  `next_cursor` + `has_more`, and a null cursor means the end. The token carries the
+  sort key of the row a page ended on, so a page boundary survives rows arriving at
+  the head — the reason a reader can scroll back through a live room without
+  duplicating or skipping messages, which offset cannot do. Envelope responses carry
+  the two fields in the body; the one bare-list response (memory) carries them as
+  `X-Next-Cursor` / `X-Has-More`. `offset` still works where it already did.
+  Client-side the same contract has one walker each: `mycelium/pagination.py`
+  (`--all` / `--cursor`) and `use-cursor-pagination.ts` + `use-reverse-scroll.ts`.
 - **Memories interlink; the link index is derived.** `myc://key` (canonical) and
   `[[key]]` (shorthand) are the same edge, plus `![[key]]` transclusions and typed
   frontmatter relations (`supersedes`, `depends-on`, `part-of`, `relates-to`).

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -455,9 +455,9 @@
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">messages</span> [<span class="arg">&lt;room&gt;</span>] [<span class="flag">--limit</span> N] [<span class="flag">--sender</span> <span class="arg">&lt;handle&gt;</span>] [<span class="flag">--type</span> <span class="arg">&lt;type&gt;</span>]</code>
+          <code><span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">messages</span> [<span class="arg">&lt;room&gt;</span>] [<span class="flag">--limit</span> N] [<span class="flag">--all</span>] [<span class="flag">--cursor</span> <span class="arg">&lt;cursor&gt;</span>] [<span class="flag">--sender</span> <span class="arg">&lt;handle&gt;</span>] [<span class="flag">--type</span> <span class="arg">&lt;type&gt;</span>]</code>
         </div>
-        <div class="cmd-ref-body">Read recent messages in a room (point-in-time, newest first). Filter with <code>--sender</code> / <code>--type</code>.</div>
+        <div class="cmd-ref-body">Read messages in a room, newest first. <code>--all</code> walks the full history; <code>--cursor</code> resumes from a previous page. Filter with <code>--sender</code> / <code>--type</code>.</div>
       </div>
 
       <div class="cmd-ref">
@@ -557,9 +557,9 @@
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">ls</span> [prefix/]</code>
+          <code><span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">ls</span> [prefix/] [<span class="flag">--all</span>]</code>
         </div>
-        <div class="cmd-ref-body">List memories from the hub. Optional prefix filters by namespace.</div>
+        <div class="cmd-ref-body">List memories from the hub. Optional prefix filters by namespace; <code>--all</code> walks past the first page.</div>
       </div>
 
       <div class="cmd-ref">

--- a/fastapi-backend/app/routes/episodes.py
+++ b/fastapi-backend/app/routes/episodes.py
@@ -14,10 +14,12 @@ GET /rooms/{room}/episodes/{short_id} — one episode + its envelope chain
 from __future__ import annotations
 
 import logging
+from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
 from app.schemas import EpisodeDetailRead, EpisodeListResponse
+from app.services import pagination
 from app.services.episode_records import (
     EPISODES_PREFIX,
     episode_summary,
@@ -36,11 +38,42 @@ def _require_room(room_name: str) -> None:
         raise HTTPException(status_code=404, detail="Room not found")
 
 
+def _episode_sort_key(episode: dict[str, Any]) -> tuple[str, str, str]:
+    """An episode's keyset sort key: pinned-live first, then newest, then id.
+
+    The leading rank is how "an in-progress episode sorts first" survives
+    pagination — it is part of the order rather than a post-sort insert, so a
+    cursor into page two still agrees with page one about where the live one sits.
+    """
+    live = "1" if episode.get("outcome") == "open" else "0"
+    return (live, str(episode.get("updated_at") or ""), str(episode.get("short_id") or ""))
+
+
 @router.get("", response_model=EpisodeListResponse)
-async def list_episodes(room_name: str, limit: int = 50):
+async def list_episodes(
+    room_name: str,
+    limit: int = Query(50, ge=1, le=500),
+    cursor: str | None = Query(
+        None, description="Opaque cursor from a previous page's next_cursor"
+    ),
+):
     """List episode summaries for a room, newest first (an in-progress one first)."""
     _require_room(room_name)
-    return {"episodes": room_episodes(room_name, limit=limit)}
+    try:
+        page = pagination.paginate(
+            room_episodes(room_name, limit=None),
+            key=_episode_sort_key,
+            limit=limit,
+            cursor=cursor,
+        )
+    except pagination.InvalidCursor as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "episodes": page.items,
+        "total": page.total,
+        "next_cursor": page.next_cursor,
+        "has_more": page.has_more,
+    }
 
 
 @router.get("/{short_id}", response_model=EpisodeDetailRead)

--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -40,7 +40,7 @@ from app.schemas import (
     SubscriptionCreate,
     SubscriptionRead,
 )
-from app.services import actor, links, local_state, memory_sync, search_index
+from app.services import actor, links, local_state, memory_sync, pagination, search_index
 from app.services.embedding import embed_text
 from app.services.filesystem import (
     delete_memory_file,
@@ -349,6 +349,17 @@ async def upsert_memories(room_name: str, payload: MemoryBatchCreate) -> list[Me
     return results
 
 
+def _memory_sort_key(entry: tuple[str, dict[str, Any], str]) -> tuple[str, str]:
+    """A memory's keyset sort key: when it was last written, then its key.
+
+    The memory key breaks ties — memories written in the same second are common
+    (a batch write), and without a total order a cursor sitting inside that run
+    would skip or repeat rows.
+    """
+    key, meta, _content = entry
+    return (str(meta.get("updated_at", "")), key)
+
+
 @router.get("")
 async def list_memories(
     room_name: str,
@@ -356,32 +367,49 @@ async def list_memories(
     prefix: str | None = Query(None, description="Key prefix filter"),
     limit: int = Query(100, ge=1, le=1000),
     offset: int = Query(0, ge=0),
+    cursor: str | None = Query(
+        None, description="Opaque cursor from a previous page's X-Next-Cursor header"
+    ),
 ):
-    """List memories in a room (from the filesystem).
+    """List memories in a room (from the filesystem), newest-written first.
 
     Supports ETag / If-None-Match for efficient sync — returns 304 if nothing
-    changed.
+    changed. The body stays a bare list, so this list carries its pagination in
+    the ``X-Next-Cursor`` / ``X-Has-More`` headers rather than in an envelope
+    (see ``app/services/pagination.py``).
     """
     _require_room(room_name)
     room_dir = get_room_dir(room_name)
-    file_entries = list_memory_files(room_dir, prefix=prefix, limit=limit + offset)
+    file_entries = list_memory_files(room_dir, prefix=prefix, limit=None)
 
     latest_ts = max((meta.get("updated_at", "") for _, meta, _ in file_entries), default="")
     etag = '"' + hashlib.md5(str(latest_ts).encode()).hexdigest() + '"' if latest_ts else '"empty"'
     if request.headers.get("if-none-match") == etag:
         return Response(status_code=304, headers={"ETag": etag})
 
-    page = file_entries[offset : offset + limit]
+    try:
+        page = pagination.paginate(
+            file_entries, key=_memory_sort_key, limit=limit, cursor=cursor, offset=offset
+        )
+    except pagination.InvalidCursor as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     memories = [
-        _memory_read_from_file(room_name, key, meta, content) for key, meta, content in page
+        _memory_read_from_file(room_name, key, meta, content) for key, meta, content in page.items
     ]
 
     from fastapi.encoders import jsonable_encoder
 
+    headers = {
+        "ETag": etag,
+        "X-Has-More": "true" if page.has_more else "false",
+        "X-Total-Count": str(page.total),
+    }
+    if page.next_cursor:
+        headers["X-Next-Cursor"] = page.next_cursor
     return Response(
         content=json.dumps(jsonable_encoder(memories)),
         media_type="application/json",
-        headers={"ETag": etag},
+        headers=headers,
     )
 
 

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -25,7 +25,7 @@ from app.schemas import (
     MessageRead,
     MessageType,
 )
-from app.services import actor, local_state, persister, principals, room_channels
+from app.services import actor, local_state, pagination, persister, principals, room_channels
 from app.services.filesystem import room_exists
 
 logger = logging.getLogger(__name__)
@@ -144,11 +144,28 @@ def _read_messages(
     return persister.room_conversation(channel)
 
 
+def _message_sort_key(msg: local_state.StoredMessage) -> tuple[str, str]:
+    """A message's keyset sort key: when it was created, then its id.
+
+    The id breaks ties so the order is total — without it two messages sharing a
+    timestamp could swap between reads and a cursor sitting on them would skip
+    or repeat a row.
+    """
+    return (pagination.timestamp_key(msg.created_at), str(msg.id))
+
+
 @router.get("", response_model=MessageListResponse)
 async def list_messages(
     room_name: str,
     limit: int = Query(50, le=500),
     offset: int = 0,
+    cursor: str | None = Query(
+        None,
+        description=(
+            "Opaque cursor from a previous page's next_cursor; returns the messages "
+            "immediately older than it. Stable while the room keeps growing (unlike offset)."
+        ),
+    ),
     sender: str | None = None,
     message_type: str | None = None,
     kind: str | None = Query(None, description="Filter events by metadata.kind"),
@@ -158,7 +175,11 @@ async def list_messages(
         None, description="Only messages belonging to this L9 episode URN (one negotiation/session)"
     ),
 ):
-    """List messages in a room (or coordination session), newest first."""
+    """List messages in a room (or coordination session), newest first.
+
+    Walk backward through history by following ``next_cursor``; ``offset`` stays
+    for callers that haven't migrated but shifts under a live room.
+    """
     channel, coord = _resolve_channel(room_name)
     now = datetime.now(UTC)
 
@@ -181,13 +202,18 @@ async def list_messages(
             continue
         filtered.append(m)
 
-    filtered.sort(key=lambda m: m.created_at, reverse=True)
-    total = len(filtered)
-    page = filtered[offset : offset + limit]
+    try:
+        page = pagination.paginate(
+            filtered, key=_message_sort_key, limit=limit, cursor=cursor, offset=offset
+        )
+    except pagination.InvalidCursor as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return MessageListResponse(
-        messages=[MessageRead.model_validate(m) for m in page],
-        total=total,
+        messages=[MessageRead.model_validate(m) for m in page.items],
+        total=page.total,
+        next_cursor=page.next_cursor,
+        has_more=page.has_more,
     )
 
 

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -177,7 +177,22 @@ class MessageRead(BaseModel):
     model_config = {"from_attributes": True, "populate_by_name": True}
 
 
-class MessageListResponse(BaseModel):
+class CursorPage(BaseModel):
+    """The keyset-pagination fields every list response carries.
+
+    ``next_cursor`` continues in the list's own traversal direction (older, for
+    a newest-first list) and is null on the last page. Tokens are opaque: they
+    encode the sort key of the row the page ended on, so they stay valid while
+    the list grows. See ``app/services/pagination.py``.
+    """
+
+    next_cursor: str | None = Field(
+        None, description="Opaque cursor for the next page; null when this is the last page"
+    )
+    has_more: bool = Field(False, description="Whether more rows follow this page")
+
+
+class MessageListResponse(CursorPage):
     messages: list[MessageRead]
     total: int
 
@@ -581,8 +596,9 @@ class EpisodeSummaryRead(BaseModel):
     updated_by: str = ""
 
 
-class EpisodeListResponse(BaseModel):
+class EpisodeListResponse(CursorPage):
     episodes: list[EpisodeSummaryRead]
+    total: int = 0
 
 
 class EpisodeDetailRead(EpisodeSummaryRead):

--- a/fastapi-backend/app/services/episode_records.py
+++ b/fastapi-backend/app/services/episode_records.py
@@ -148,8 +148,12 @@ def live_episode_summary(room_name: str) -> dict[str, Any] | None:
     }
 
 
-def room_episodes(room_name: str, *, limit: int = 50) -> list[dict[str, Any]]:
-    """Episode summaries for a room, newest first, with an in-progress one first."""
+def room_episodes(room_name: str, *, limit: int | None = 50) -> list[dict[str, Any]]:
+    """Episode summaries for a room, newest first, with an in-progress one first.
+
+    ``limit=None`` returns every episode — what a paginated caller wants, since
+    truncating here would hide the pages past the cut.
+    """
     records = list_memory_files(get_room_dir(room_name), prefix=EPISODES_PREFIX, limit=limit)
     episodes = [episode_summary(key, meta, content) for key, meta, content in records]
     live = live_episode_summary(room_name)

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -199,11 +199,13 @@ def delete_memory_file(base_dir: Path, key: str) -> bool:
 def list_memory_files(
     base_dir: Path,
     prefix: str | None = None,
-    limit: int = 1000,
+    limit: int | None = 1000,
 ) -> list[tuple[str, dict[str, Any], str]]:
     """List memory files, optionally filtered by key prefix.
 
     Returns list of (key, metadata, content) tuples, sorted by updated_at desc.
+    ``limit=None`` returns every match, which is what a paginating caller needs
+    (a truncation here would hide the pages past the cut).
     """
     if not base_dir.exists():
         return []
@@ -236,7 +238,7 @@ def list_memory_files(
         return item[1].get("updated_at", "")
 
     results.sort(key=sort_key, reverse=True)
-    return results[:limit]
+    return results if limit is None else results[:limit]
 
 
 def _cleanup_empty_dirs(directory: Path, stop_at: Path) -> None:

--- a/fastapi-backend/app/services/pagination.py
+++ b/fastapi-backend/app/services/pagination.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Keyset (cursor) pagination, shared by every list route.
+
+A cursor is an **opaque token carrying the sort key of the row a page ended
+on** — not a position. The next page is "every row that sorts strictly past
+this key", so pages stay stable while the list grows at the head: new rows
+arriving while a client walks backward through history shift no offset, and a
+row deleted mid-walk doesn't skip its neighbour (the comparison still
+resolves, the row is simply gone).
+
+That property is why this exists. Offset paging is fine for a frozen list and
+wrong for a live one — reverse-scrolling a busy room duplicates and skips rows
+between pages.
+
+Using it takes two things: a **key function** returning a tuple of strings that
+totally orders the rows (end it with an id so ties can't collapse), and a
+direction. :func:`timestamp_key` renders a datetime as a fixed-width UTC string
+so lexicographic comparison matches chronological order.
+
+    page = paginate(rows, key=lambda m: (timestamp_key(m.created_at), str(m.id)),
+                    limit=50, cursor=cursor)
+    return {"messages": page.items, "total": page.total,
+            "next_cursor": page.next_cursor, "has_more": page.has_more}
+
+Routes expose the same three names everywhere — ``cursor`` in, ``next_cursor``
+and ``has_more`` out — so one client-side walker drives any list. ``next_cursor``
+continues in the list's own traversal direction: for a newest-first list that is
+older rows, which is what a reverse scroll wants.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+CursorKey = tuple[str, ...]
+
+# Bumped only if the token payload shape changes; an older token then decodes to
+# None and the route serves page one rather than 400-ing a client mid-scroll.
+_CURSOR_VERSION = 1
+
+
+class InvalidCursor(ValueError):
+    """A cursor token that isn't one we minted (routes map this to 400)."""
+
+
+def encode_cursor(key: Sequence[str]) -> str:
+    """Render a sort key as the opaque token clients echo back."""
+    raw = json.dumps([_CURSOR_VERSION, list(key)], separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decode_cursor(token: str) -> CursorKey:
+    """Recover the sort key a token carries.
+
+    Raises :class:`InvalidCursor` for anything malformed. A token from a
+    superseded version decodes to ``()`` — the caller reads that as "no cursor"
+    and serves the first page.
+    """
+    padded = token + "=" * (-len(token) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(padded.encode("ascii"))
+        version, key = json.loads(raw)
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise InvalidCursor(f"malformed cursor: {token!r}") from exc
+    if version != _CURSOR_VERSION:
+        return ()
+    if not isinstance(key, list) or not all(isinstance(part, str) for part in key):
+        raise InvalidCursor(f"malformed cursor: {token!r}")
+    return tuple(key)
+
+
+def timestamp_key(value: datetime | str | None) -> str:
+    """A datetime as a fixed-width UTC string that sorts lexicographically.
+
+    ``isoformat`` is not safe to compare as text — the offset suffix and
+    optional microseconds make two equal instants order arbitrarily — so
+    normalize to UTC and one fixed shape. A string comes back unchanged (a
+    stored ISO stamp, already the room's own ordering) and None sorts first.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    moment = value.astimezone(UTC) if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    return moment.strftime("%Y%m%dT%H%M%S.%f")
+
+
+@dataclass(frozen=True)
+class Page(Generic[T]):
+    """One page of a list, plus what a client needs to ask for the next."""
+
+    items: list[T]
+    next_cursor: str | None
+    has_more: bool
+    total: int
+
+
+def paginate(
+    rows: Sequence[T],
+    *,
+    key: Callable[[T], Sequence[str]],
+    limit: int,
+    cursor: str | None = None,
+    offset: int = 0,
+    descending: bool = True,
+) -> Page[T]:
+    """Sort ``rows`` by ``key`` and return the page that follows ``cursor``.
+
+    ``descending`` is the list's natural traversal direction (newest first for
+    a transcript); ``next_cursor`` always continues that way. ``offset`` is the
+    legacy positional path, honored only when no cursor is given, so callers
+    that haven't migrated keep working.
+    """
+    ordered = sorted(rows, key=lambda row: tuple(key(row)), reverse=descending)
+    total = len(ordered)
+
+    start = 0
+    if cursor:
+        anchor = decode_cursor(cursor)
+        if anchor:
+            # Comparison, not position: the page starts at the first row sorting
+            # strictly past the anchor, whether or not the anchor's row survives.
+            start = next(
+                (
+                    i
+                    for i, row in enumerate(ordered)
+                    if (tuple(key(row)) < anchor if descending else tuple(key(row)) > anchor)
+                ),
+                total,
+            )
+    elif offset:
+        start = min(offset, total)
+
+    items = list(ordered[start : start + limit])
+    has_more = start + len(items) < total
+    next_cursor = encode_cursor(key(items[-1])) if items and has_more else None
+    return Page(items=items, next_cursor=next_cursor, has_more=has_more, total=total)

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -432,10 +432,21 @@ def stored_message_from_record(room: str, record: TranscriptRecord) -> StoredMes
     return msg
 
 
-# Per-room cache of the mapped conversational view, invalidated when the
-# transcript file changes, so a hot UI poll re-stats (cheap) rather than
-# re-parsing the whole file every read.
-_conversational_cache: dict[str, tuple[tuple[int, int], list[StoredMessage]]] = {}
+@dataclass
+class _ConversationCache:
+    """A room's projected transcript, and how much of the file produced it."""
+
+    stamp: tuple[int, int]
+    consumed: int
+    seal: bytes
+    messages: list[StoredMessage]
+
+
+# Per-room cache of the mapped conversational view. The transcript is append-only,
+# so a grown file is re-read *from where the last read stopped* rather than from
+# the top: a hot UI poll, or a walk back through a long room's history one page at
+# a time, costs the bytes that arrived since — not the whole file, every time.
+_conversational_cache: dict[str, _ConversationCache] = {}
 
 
 def _stat_stamp(path: Path) -> tuple[int, int] | None:
@@ -445,6 +456,56 @@ def _stat_stamp(path: Path) -> tuple[int, int] | None:
     except OSError:
         return None
     return (st.st_mtime_ns, st.st_size)
+
+
+def _whole_lines(text: str) -> tuple[str, int, bytes]:
+    """Split ``text`` at its last newline into (parsable, bytes, seal).
+
+    A transcript read can catch a record mid-append. Only whole lines count as
+    history — the rest waits for the write to finish rather than being parsed as
+    a truncated row — so what was consumed ends on a line boundary. The seal is
+    the final consumed line, which the next read re-checks against the file to be
+    sure it is still continuing the same history.
+    """
+    end = text.rfind("\n")
+    if end < 0:
+        return ("", 0, b"")
+    whole = text[: end + 1]
+    seal = whole[:-1].rsplit("\n", 1)[-1] + "\n"
+    return (whole, len(whole.encode("utf-8")), seal.encode("utf-8"))
+
+
+def _appended_since(path: Path, cached: _ConversationCache) -> str | None:
+    """The text appended since ``cached``, or None if that isn't safe to assume.
+
+    None means "re-read from the top": the file shrank, or its last consumed line
+    is no longer where we left it — the file was rewritten, not appended to.
+    """
+    try:
+        with path.open("rb") as fh:
+            fh.seek(cached.consumed - len(cached.seal))
+            if fh.read(len(cached.seal)) != cached.seal:
+                return None
+            return fh.read().decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _extended(
+    room: str, path: Path, cached: _ConversationCache | None, stamp: tuple[int, int]
+) -> _ConversationCache | None:
+    """The cache entry a plain append yields, or None if the file must be re-read."""
+    if cached is None or not cached.seal or stamp[1] < cached.consumed:
+        return None
+    appended = _appended_since(path, cached)
+    if appended is None:
+        return None
+    text, grew, seal = _whole_lines(appended)
+    if not grew:  # nothing but a half-written line: keep what we have
+        return _ConversationCache(stamp, cached.consumed, cached.seal, cached.messages)
+    return _ConversationCache(
+        stamp, cached.consumed + grew, seal, cached.messages + _project(room, text)
+    )
 
 
 def conversational_messages(room: str) -> list[StoredMessage]:
@@ -463,13 +524,25 @@ def conversational_messages(room: str) -> list[StoredMessage]:
         _conversational_cache.pop(room, None)
         return []
     cached = _conversational_cache.get(room)
-    if cached is not None and cached[0] == stamp:
-        return list(cached[1])
-    messages = [
-        m for r in load_transcript(room) if (m := stored_message_from_record(room, r)) is not None
-    ]
-    _conversational_cache[room] = (stamp, messages)
-    return list(messages)
+    if cached is not None and cached.stamp == stamp:
+        return list(cached.messages)
+
+    entry = _extended(room, path, cached, stamp)
+    if entry is None:
+        try:
+            body = path.read_text(encoding="utf-8")
+        except OSError:
+            return []
+        text, consumed, seal = _whole_lines(body)
+        entry = _ConversationCache(stamp, consumed, seal, _project(room, text))
+
+    _conversational_cache[room] = entry
+    return list(entry.messages)
+
+
+def _project(room: str, text: str) -> list[StoredMessage]:
+    """Parse a slice of transcript JSONL into the chat rows the read path serves."""
+    return [m for r in _parse_jsonl(text) if (m := stored_message_from_record(room, r)) is not None]
 
 
 def room_conversation(room: str) -> list[StoredMessage]:

--- a/fastapi-backend/tests/test_list_pagination.py
+++ b/fastapi-backend/tests/test_list_pagination.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The other paginated lists (issue #654).
+
+Pagination is one primitive with one vocabulary — ``cursor`` in, ``next_cursor``
+and ``has_more`` out — so a client that can walk one list can walk any of them.
+Memory keeps a bare-list body, so it carries the same two values as headers;
+these assert both spellings of the same contract.
+"""
+
+import pytest
+
+from app.services import l9_episode
+
+
+async def _seed_memories(client, room: str, count: int) -> None:
+    await client.post("/api/rooms", json={"name": room})
+    for i in range(count):
+        await client.post(
+            f"/api/rooms/{room}/memory",
+            json={
+                "items": [
+                    {
+                        "key": f"notes/n{i:02d}",
+                        "value": f"note {i}",
+                        "created_by": "avery",
+                        "embed": False,
+                    }
+                ]
+            },
+        )
+
+
+async def _seed_episodes(client, room: str, count: int) -> None:
+    await client.post("/api/rooms", json={"name": room})
+    for i in range(count):
+        ep = l9_episode.open_episode(
+            parent_room=room,
+            short_id=f"ep{i:04d}",
+            workspace_id="ws-1",
+            mas_id="mas-1",
+            agents=["alice"],
+            joined_intents="- alice: ship it",
+        )
+        l9_episode.write_episode_record(ep, outcome="converged", metrics=None, plan_file=None)
+
+
+@pytest.mark.asyncio
+async def test_a_memory_walk_reaches_every_memory_exactly_once(client):
+    await _seed_memories(client, "mem-room", 12)
+
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(20):
+        url = "/api/rooms/mem-room/memory?limit=5"
+        if cursor:
+            url += f"&cursor={cursor}"
+        resp = await client.get(url)
+        seen.extend(m["key"] for m in resp.json())
+        if resp.headers["x-has-more"] == "false":
+            break
+        cursor = resp.headers["x-next-cursor"]
+    else:
+        pytest.fail("cursor walk did not terminate")
+
+    assert sorted(seen) == [f"notes/n{i:02d}" for i in range(12)]
+    assert len(seen) == len(set(seen))
+
+
+@pytest.mark.asyncio
+async def test_the_memory_list_reports_the_full_count_not_the_page(client):
+    await _seed_memories(client, "mem-count-room", 7)
+
+    resp = await client.get("/api/rooms/mem-count-room/memory?limit=3")
+
+    assert len(resp.json()) == 3
+    assert resp.headers["x-total-count"] == "7"
+    assert resp.headers["x-has-more"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_a_memory_page_past_the_end_reports_no_more(client):
+    await _seed_memories(client, "mem-short-room", 2)
+
+    resp = await client.get("/api/rooms/mem-short-room/memory?limit=50")
+
+    assert resp.headers["x-has-more"] == "false"
+    assert "x-next-cursor" not in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_an_episode_walk_reaches_every_episode_exactly_once(client):
+    await _seed_episodes(client, "ep-room", 9)
+
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(20):
+        url = "/api/rooms/ep-room/episodes?limit=4"
+        if cursor:
+            url += f"&cursor={cursor}"
+        body = (await client.get(url)).json()
+        seen.extend(e["short_id"] for e in body["episodes"])
+        if not body["has_more"]:
+            break
+        cursor = body["next_cursor"]
+    else:
+        pytest.fail("cursor walk did not terminate")
+
+    assert sorted(seen) == [f"ep{i:04d}" for i in range(9)]
+    assert len(seen) == len(set(seen))
+
+
+def test_an_in_progress_episode_sorts_ahead_of_every_closed_one():
+    """The episode list's one ordering quirk has to be part of the sort, not an
+    insert after it — otherwise a live episode drifts onto a later page mid-walk."""
+    from app.routes.episodes import _episode_sort_key
+
+    live = {"short_id": "livexx", "outcome": "open", "updated_at": ""}
+    newest_closed = {"short_id": "ep0009", "outcome": "converged", "updated_at": "2099-01-01"}
+
+    assert sorted([newest_closed, live], key=_episode_sort_key, reverse=True)[0] is live
+
+
+@pytest.mark.asyncio
+async def test_a_bad_cursor_is_rejected_by_every_list(client):
+    await _seed_memories(client, "bad-room", 2)
+    await _seed_episodes(client, "bad-ep-room", 2)
+
+    assert (await client.get("/api/rooms/bad-room/memory?cursor=%%%")).status_code == 400
+    assert (await client.get("/api/rooms/bad-ep-room/episodes?cursor=%%%")).status_code == 400

--- a/fastapi-backend/tests/test_message_pagination.py
+++ b/fastapi-backend/tests/test_message_pagination.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Walking back through a room's history over HTTP (issue #654).
+
+The list route's end of the contract: ``cursor`` in, ``next_cursor``/``has_more``
+out, pages that stay coherent while the room keeps talking. The primitive's own
+properties are covered in ``test_pagination``; these assert the route wires it up
+and that the transcript-backed read path pages the same as the in-memory one.
+"""
+
+import pytest
+
+from app.services import l9, persister
+from app.services.filesystem import get_room_dir
+from app.services.l9_models import Kind
+from app.services.l9_slim import serialize_content
+
+
+def _record(seq: int, *, sender: str = "alice", text: str | None = None):
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode="urn:ioc:mycelium:episode:r:s",
+        sender=sender,
+        recipients=[l9.SYSTEM_ACTOR_ID],
+        topic="urn:concept:mycelium:r",
+        message_id=f"m-{seq:04d}",
+        payload_type="reply",
+    )
+    record = persister.record_from(
+        env, serialize_content(env, extra={"content": text or f"line {seq}"})
+    )
+    # One second apart so the walk has an unambiguous chronological order.
+    record.recorded_at = f"2026-08-20T10:{seq // 60:02d}:{seq % 60:02d}+00:00"
+    return record
+
+
+async def _seed(client, room: str, count: int) -> None:
+    await client.post("/api/rooms", json={"name": room})
+    get_room_dir(room)
+    for i in range(count):
+        persister.append_transcript(room, _record(i))
+
+
+async def _walk_all(client, room: str, *, limit: int, on_page=None) -> list[str]:
+    """Follow ``next_cursor`` to the end, collecting message content."""
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(50):  # guard: a broken cursor must fail the test, not hang it
+        url = f"/api/rooms/{room}/messages?limit={limit}"
+        if cursor:
+            url += f"&cursor={cursor}"
+        body = (await client.get(url)).json()
+        seen.extend(m["content"] for m in body["messages"])
+        if not body["has_more"]:
+            return seen
+        cursor = body["next_cursor"]
+        assert cursor, "has_more with no cursor leaves the client stranded"
+        if on_page is not None:
+            await on_page()
+    pytest.fail("cursor walk did not terminate")
+
+
+@pytest.mark.asyncio
+async def test_a_walk_back_reaches_history_past_the_first_page(client):
+    """The bug: a room deeper than one window had its older messages unreachable."""
+    await _seed(client, "deep-room", 25)
+
+    walked = await _walk_all(client, "deep-room", limit=10)
+
+    assert walked == [f"line {i}" for i in reversed(range(25))]
+
+
+@pytest.mark.asyncio
+async def test_pages_stay_coherent_while_the_room_keeps_talking(client):
+    """New messages land at the head mid-walk; the walk back is unaffected."""
+    room = "live-room"
+    await _seed(client, room, 20)
+    extra = iter(range(100, 110))
+
+    async def post_one():
+        persister.append_transcript(room, _record(next(extra), text="live"))
+
+    walked = await _walk_all(client, room, limit=6, on_page=post_one)
+
+    # Every history row, in order, exactly once — and the rows that arrived at
+    # the head after the walk began stay out of it (they reach a live client over
+    # SSE, not by being shuffled into a page of the past).
+    assert walked == [f"line {i}" for i in reversed(range(20))]
+
+
+@pytest.mark.asyncio
+async def test_the_first_page_is_the_newest_messages(client):
+    await _seed(client, "newest-room", 12)
+
+    body = (await client.get("/api/rooms/newest-room/messages?limit=4")).json()
+
+    assert [m["content"] for m in body["messages"]] == ["line 11", "line 10", "line 9", "line 8"]
+    assert body["total"] == 12
+    assert body["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_short_room_reports_the_end_of_history(client):
+    await _seed(client, "short-room", 3)
+
+    body = (await client.get("/api/rooms/short-room/messages?limit=50")).json()
+
+    assert body["has_more"] is False
+    assert body["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_filtered_walk_pages_only_the_matching_rows(client):
+    """Filters compose with the cursor — a page is a page of the filtered list."""
+    room = "filtered-room"
+    await client.post("/api/rooms", json={"name": room})
+    get_room_dir(room)
+    for i in range(12):
+        persister.append_transcript(room, _record(i, sender="alice" if i % 2 else "bob"))
+
+    first = (await client.get(f"/api/rooms/{room}/messages?limit=3&sender=alice")).json()
+    second = (
+        await client.get(
+            f"/api/rooms/{room}/messages?limit=3&sender=alice&cursor={first['next_cursor']}"
+        )
+    ).json()
+
+    assert first["total"] == 6
+    assert [m["content"] for m in first["messages"]] == ["line 11", "line 9", "line 7"]
+    assert [m["content"] for m in second["messages"]] == ["line 5", "line 3", "line 1"]
+
+
+@pytest.mark.asyncio
+async def test_offset_paging_still_works_for_callers_that_have_not_migrated(client):
+    await _seed(client, "offset-room", 10)
+
+    body = (await client.get("/api/rooms/offset-room/messages?limit=3&offset=3")).json()
+
+    assert [m["content"] for m in body["messages"]] == ["line 6", "line 5", "line 4"]
+
+
+@pytest.mark.asyncio
+async def test_a_bad_cursor_is_a_400_not_a_silent_first_page(client):
+    await _seed(client, "bad-cursor-room", 5)
+
+    resp = await client.get("/api/rooms/bad-cursor-room/messages?cursor=not-a-cursor")
+
+    assert resp.status_code == 400

--- a/fastapi-backend/tests/test_pagination.py
+++ b/fastapi-backend/tests/test_pagination.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The shared keyset-pagination primitive (issue #654).
+
+The properties every list route inherits from it: a cursor names a *key*, not a
+position, so a page boundary survives rows arriving at the head and rows
+vanishing underneath it — the two ways offset paging goes wrong on a live list.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.pagination import (
+    InvalidCursor,
+    decode_cursor,
+    encode_cursor,
+    paginate,
+    timestamp_key,
+)
+
+
+def _rows(n: int) -> list[tuple[str, str]]:
+    """``n`` rows keyed (stamp, id), oldest first."""
+    return [(f"2026-08-20T10:00:{i:02d}", f"id-{i:02d}") for i in range(n)]
+
+
+def _key(row: tuple[str, str]) -> tuple[str, str]:
+    return row
+
+
+def _walk(rows, *, limit: int, mutate=None) -> list[tuple[str, str]]:
+    """Page all the way through ``rows``, applying ``mutate`` between pages."""
+    seen: list[tuple[str, str]] = []
+    cursor: str | None = None
+    while True:
+        page = paginate(rows, key=_key, limit=limit, cursor=cursor)
+        seen.extend(page.items)
+        if not page.has_more:
+            return seen
+        cursor = page.next_cursor
+        assert cursor is not None
+        if mutate is not None:
+            rows = mutate(rows)
+
+
+def test_a_cursor_walk_covers_every_row_exactly_once():
+    rows = _rows(10)
+    walked = _walk(rows, limit=3)
+    assert walked == sorted(rows, reverse=True)
+
+
+def test_rows_arriving_at_the_head_neither_duplicate_nor_skip():
+    """The reverse-scroll case: a busy room grows while the reader walks back.
+
+    Under offset paging each new row shifts every later page by one; keyed on the
+    boundary row instead, the walk is untouched by what lands at the head.
+    """
+    rows = _rows(10)
+    fresh = iter([("2026-08-20T11:00:00", f"id-new-{i}") for i in range(5)])
+    walked = _walk(rows, limit=3, mutate=lambda current: [*current, next(fresh)])
+    assert walked == sorted(rows, reverse=True)
+
+
+def test_deleting_the_boundary_row_still_resolves_the_next_page():
+    """A cursor is a comparison, not a lookup — the row it names may be gone."""
+    rows = _rows(6)
+    first = paginate(rows, key=_key, limit=2)
+    remaining = [r for r in rows if r != first.items[-1]]
+
+    second = paginate(remaining, key=_key, limit=2, cursor=first.next_cursor)
+    assert second.items == sorted(rows, reverse=True)[2:4]
+
+
+def test_the_last_page_reports_no_more_and_no_cursor():
+    page = paginate(_rows(4), key=_key, limit=10)
+    assert len(page.items) == 4
+    assert page.has_more is False
+    assert page.next_cursor is None
+
+
+def test_total_counts_the_whole_list_not_the_page():
+    page = paginate(_rows(30), key=_key, limit=5)
+    assert page.total == 30
+    assert len(page.items) == 5
+
+
+def test_offset_still_pages_when_no_cursor_is_given():
+    """Back-compat: callers that haven't migrated keep their positional paging."""
+    ordered = sorted(_rows(10), reverse=True)
+    page = paginate(_rows(10), key=_key, limit=3, offset=6)
+    assert page.items == ordered[6:9]
+
+
+def test_a_cursor_wins_over_an_offset():
+    ordered = sorted(_rows(10), reverse=True)
+    first = paginate(_rows(10), key=_key, limit=4)
+    page = paginate(_rows(10), key=_key, limit=4, cursor=first.next_cursor, offset=9)
+    assert page.items == ordered[4:8]
+
+
+def test_ascending_lists_walk_forward():
+    ordered = sorted(_rows(7))
+    first = paginate(_rows(7), key=_key, limit=3, descending=False)
+    second = paginate(_rows(7), key=_key, limit=3, cursor=first.next_cursor, descending=False)
+    assert first.items == ordered[:3]
+    assert second.items == ordered[3:6]
+
+
+def test_a_cursor_round_trips_its_key():
+    assert decode_cursor(encode_cursor(("2026-08-20", "id-7"))) == ("2026-08-20", "id-7")
+
+
+def test_a_cursor_token_is_opaque_and_url_safe():
+    token = encode_cursor(("2026-08-20T10:00:00+00:00", "id/with?punctuation"))
+    assert token == token.strip()
+    assert not set(token) & set("+/= ")
+
+
+@pytest.mark.parametrize("token", ["not base64!!", "eyJub3QiOiAibGlzdCJ9", "%%%"])
+def test_a_malformed_cursor_is_rejected_rather_than_guessed(token):
+    with pytest.raises(InvalidCursor):
+        paginate(_rows(3), key=_key, limit=2, cursor=token)
+
+
+def test_an_empty_cursor_reads_as_no_cursor():
+    assert (
+        paginate(_rows(3), key=_key, limit=2, cursor="").items == sorted(_rows(3), reverse=True)[:2]
+    )
+
+
+def test_timestamp_keys_sort_chronologically_across_offsets():
+    """Two spellings of the same instant must compare equal, and an earlier
+    instant must sort earlier — which raw ``isoformat`` text does not guarantee."""
+    from datetime import timedelta, timezone
+
+    utc = datetime(2026, 8, 20, 10, 0, 0, tzinfo=UTC)
+    elsewhere = utc.astimezone(timezone(timedelta(hours=-7)))
+    assert timestamp_key(utc) == timestamp_key(elsewhere)
+    assert timestamp_key(utc - timedelta(seconds=1)) < timestamp_key(utc)
+    assert timestamp_key(datetime(2026, 8, 20, 10, 0, 0)) == timestamp_key(utc)
+
+
+def test_a_naive_and_aware_stamp_do_not_crash_the_sort():
+    """Message rows come from two stores; a mixed batch must still order."""
+    rows = [
+        ("naive", datetime(2026, 8, 20, 10, 0, 1)),
+        ("aware", datetime(2026, 8, 20, 10, 0, 2, tzinfo=UTC)),
+    ]
+    page = paginate(rows, key=lambda r: (timestamp_key(r[1]), r[0]), limit=10)
+    assert [r[0] for r in page.items] == ["aware", "naive"]

--- a/fastapi-backend/tests/test_persister.py
+++ b/fastapi-backend/tests/test_persister.py
@@ -828,3 +828,100 @@ async def test_ingest_knowledge_stale_base_is_a_conflict_not_a_merge():
     assert got[1] == "v2 content"  # the newer local content was not overwritten
     assert p.knowledge_applied == 1  # the stale write did not count as applied
     assert p.knowledge_conflicts == 1
+
+
+def _chat_record(message_id: str, *, text: str, sender: str = "growth"):
+    """A transcript record the read path projects as chat (a human-facing reply)."""
+    env, content = _msg_content(message_id, sender=sender, text=text, payload_type="reply")
+    return persister.record_from(env, content)
+
+
+def test_a_grown_transcript_is_read_from_where_the_last_read_stopped(tmp_path, monkeypatch):
+    """Paging a long room must not re-parse the whole file per page (issue #654).
+
+    The transcript is append-only, so each read parses only the lines that arrived
+    since the last one — measured directly, by counting the lines handed to the
+    parser.
+    """
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    room = "incremental-room"
+    get_room_dir(room)
+
+    parsed: list[int] = []
+    real_parse = persister._parse_jsonl
+    monkeypatch.setattr(
+        persister,
+        "_parse_jsonl",
+        lambda text: (parsed.append(len(text.splitlines())), real_parse(text))[1],
+    )
+
+    for i in range(20):
+        persister.append_transcript(room, _chat_record(f"a-{i}", text=f"line {i}"))
+    assert len(persister.conversational_messages(room)) == 20
+    assert parsed == [20]  # cold read: the whole file, once
+
+    persister.append_transcript(room, _chat_record("a-20", text="line 20"))
+    served = persister.conversational_messages(room)
+
+    assert [m.content for m in served] == [f"line {i}" for i in range(21)]
+    assert parsed == [20, 1]  # and then only what was appended
+
+
+def test_a_cached_transcript_is_not_re_read_at_all_when_nothing_changed(tmp_path, monkeypatch):
+    """Repeated pages over a quiet room touch the parser zero further times."""
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    room = "quiet-room"
+    get_room_dir(room)
+    persister.append_transcript(room, _chat_record("a-1", text="only"))
+    persister.conversational_messages(room)
+
+    calls: list[str] = []
+    monkeypatch.setattr(persister, "_parse_jsonl", lambda text: calls.append(text) or [])
+
+    assert [m.content for m in persister.conversational_messages(room)] == ["only"]
+    assert calls == []
+
+
+def test_a_transcript_rewritten_under_the_cache_is_re_read(tmp_path, monkeypatch):
+    """The other side of that bargain: when the prefix we parsed is no longer
+    there, the cache must not stitch a tail onto history that never happened."""
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    room = "rewritten-room"
+    get_room_dir(room)
+
+    persister.append_transcript(room, _chat_record("a-1", text="original"))
+    assert [m.content for m in persister.conversational_messages(room)] == ["original"]
+
+    persister.write_transcript(
+        room,
+        [
+            _chat_record("b-1", text="replaced"),
+            _chat_record("b-2", text="and appended"),
+        ],
+    )
+
+    assert [m.content for m in persister.conversational_messages(room)] == [
+        "replaced",
+        "and appended",
+    ]
+
+
+def test_a_half_written_final_line_waits_for_the_rest(tmp_path, monkeypatch):
+    """A record caught mid-append is not history yet — it is served once the
+    writer finishes the line, never as a truncated row."""
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    room = "partial-room"
+    path = get_room_dir(room) / persister.TRANSCRIPT_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    persister.append_transcript(room, _chat_record("a-1", text="complete"))
+    persister.conversational_messages(room)
+
+    whole = persister._transcript_line(_chat_record("a-2", text="torn")) + "\n"
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(whole[: len(whole) // 2])
+    assert [m.content for m in persister.conversational_messages(room)] == ["complete"]
+
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(whole[len(whole) // 2 :])
+    assert [m.content for m in persister.conversational_messages(room)] == ["complete", "torn"]

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
+from mycelium import pagination
 from mycelium.client import hub_client, typed_client
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
@@ -347,36 +348,55 @@ def memory_get(
     console.print(content)
 
 
-def _fetch_memories(room_name: str, prefix: str | None, limit: int) -> list[dict[str, Any]]:
+def _fetch_memories(
+    room_name: str, prefix: str | None, limit: int, *, walk_all: bool = False
+) -> list[dict[str, Any]]:
     """Fetch a room's memories from the hub, newest-first as the hub orders them.
 
-    Returns the raw JSON records (the list endpoint is untyped in the generated
-    client), or exits with a clear message when the room is unknown.
+    One page, or every page when ``walk_all``. Returns the raw JSON records (the
+    list endpoint is untyped in the generated client), or exits with a clear
+    message when the room is unknown.
     """
     from mycelium_backend_client.api.memory import (
         list_memories_api_rooms_room_name_memory_get as list_api,
     )
+    from mycelium_backend_client.types import UNSET
 
     with _hub_session() as client:
-        try:
-            entries = list_api.sync(room_name=room_name, client=client, prefix=prefix, limit=limit)
-        except UnexpectedStatus as exc:
-            if exc.status_code == 404:
-                console.print(
-                    f"[red]Not found:[/red] room '{room_name}' does not exist on the hub "
-                    f"at {_hub_url()}"
-                )
-                raise typer.Exit(1) from exc
-            raise
 
-    if not isinstance(entries, list):
-        return []
-    return cast("list[dict[str, Any]]", [r for r in entries if isinstance(r, dict)])
+        def fetch(cursor: str | None) -> tuple[list[dict[str, Any]], str | None]:
+            try:
+                resp = list_api.sync_detailed(
+                    room_name=room_name,
+                    client=client,
+                    prefix=prefix,
+                    limit=limit,
+                    cursor=cursor or UNSET,
+                )
+            except UnexpectedStatus as exc:
+                if exc.status_code == 404:
+                    console.print(
+                        f"[red]Not found:[/red] room '{room_name}' does not exist on the hub "
+                        f"at {_hub_url()}"
+                    )
+                    raise typer.Exit(1) from exc
+                raise
+            entries = resp.parsed if isinstance(resp.parsed, list) else []
+            rows = cast("list[dict[str, Any]]", [r for r in entries if isinstance(r, dict)])
+            # This list keeps a bare-list body, so its cursor rides in the headers.
+            return rows, pagination.cursor_from_headers(resp.headers)
+
+        if walk_all:
+            return pagination.walk_pages(fetch)
+        return fetch(None)[0]
 
 
 @doc_ref(
-    usage="mycelium memory ls [prefix/]",
-    desc="List memories from the hub. Optional prefix filters by namespace.",
+    usage="mycelium memory ls [prefix/] [--all]",
+    desc=(
+        "List memories from the hub. Optional prefix filters by namespace; "
+        "<code>--all</code> walks past the first page."
+    ),
     group="memory",
 )
 @app.command(name="ls")
@@ -388,13 +408,14 @@ def memory_ls(
     prefix: str | None = typer.Option(
         None, "--prefix", "-p", help="Key prefix filter (same as positional arg)"
     ),
-    limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Results per page"),
+    walk_all: bool = pagination.AllOption,
 ) -> None:
     """List memories in a room (from the hub)."""
     prefix = namespace or prefix
     room_name = _get_active_room(room)
 
-    entries = _fetch_memories(room_name, prefix, limit)
+    entries = _fetch_memories(room_name, prefix, limit, walk_all=walk_all)
     if not entries:
         console.print("[dim]No memories found[/dim]")
         return

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -20,9 +20,11 @@ Commands:
 
 import json as json_module
 import os
+from typing import Any
 
 import typer
 
+from mycelium import pagination
 from mycelium.client import hub_client
 from mycelium.client import typed_client as _typed_client
 from mycelium.config import MyceliumConfig
@@ -847,32 +849,47 @@ def send(
 
 
 @doc_ref(
-    usage="mycelium room messages [<room>] [--limit N] [--sender <handle>] [--type <type>]",
-    desc="Read recent messages in a room (point-in-time, newest first). Filter with <code>--sender</code> / <code>--type</code>.",
+    usage=(
+        "mycelium room messages [<room>] [--limit N] [--all] [--cursor <cursor>] "
+        "[--sender <handle>] [--type <type>]"
+    ),
+    desc=(
+        "Read messages in a room, newest first. <code>--all</code> walks the full history; "
+        "<code>--cursor</code> resumes from a previous page. Filter with "
+        "<code>--sender</code> / <code>--type</code>."
+    ),
     group="room",
 )
 @app.command("messages")
 def messages(
     ctx: typer.Context,
     room: str | None = typer.Argument(None, help="Room to read (defaults to active room)"),
-    limit: int = typer.Option(20, "--limit", "-l", help="Max messages to show (newest first)"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Messages per page (newest first)"),
     sender: str | None = typer.Option(
         None, "--sender", "-s", help="Only messages from this handle"
     ),
     message_type: str | None = typer.Option(
         None, "--type", "-t", help="Only this message type (e.g. direct, broadcast, announce)"
     ),
+    cursor: str | None = pagination.CursorOption,
+    walk_all: bool = pagination.AllOption,
 ) -> None:
     """
-    Read recent messages in a room: a point-in-time snapshot, newest first.
+    Read messages in a room, newest first.
 
     Unlike `mycelium room watch` (which streams live), this returns immediately
-    with the most recent messages and exits. Handy for scripts and for checking
-    whether an agent's reply has landed.
+    and exits. Handy for scripts and for checking whether an agent's reply landed.
+
+    One page by default. To go further back, either follow the cursor a page
+    hands you (`--json` prints it as `next_cursor`) or let `--all` walk to the
+    beginning for you. Cursors name a message rather than a position, so a walk
+    holds its place even while the room keeps talking.
 
     Examples:
         mycelium room messages
         mycelium room messages design-review --limit 5
+        mycelium room messages my-room --all
+        mycelium room messages my-room --cursor eyJ2IjoxfQ
         mycelium room messages cc-e2e --sender cc-x
         mycelium room messages my-room --type broadcast
     """
@@ -889,26 +906,34 @@ def messages(
         from mycelium_backend_client.models import HTTPValidationError
         from mycelium_backend_client.types import UNSET
 
-        with _typed_client(config) as client:
-            result = list_api.sync(
-                room_name=room_name,
-                client=client,
-                limit=limit,
-                sender=sender or UNSET,
-                message_type=message_type or UNSET,
-            )
+        last_page: dict[str, Any] = {"messages": [], "total": 0, "next_cursor": None}
 
-        if not result or isinstance(result, HTTPValidationError):
-            msgs = []
-        else:
-            msgs = result.messages
+        with _typed_client(config) as client:
+
+            def fetch(page_cursor: str | None):
+                result = list_api.sync(
+                    room_name=room_name,
+                    client=client,
+                    limit=limit,
+                    cursor=page_cursor or UNSET,
+                    sender=sender or UNSET,
+                    message_type=message_type or UNSET,
+                )
+                if not result or isinstance(result, HTTPValidationError):
+                    return [], None
+                last_page.update(result.to_dict())
+                return list(result.messages), result.next_cursor
+
+            if walk_all:
+                msgs = pagination.walk_pages(fetch, start=cursor)
+            else:
+                msgs, _ = fetch(cursor)
 
         if json_output:
-            payload = (
-                result.to_dict()
-                if result and not isinstance(result, HTTPValidationError)
-                else {"messages": [], "total": 0}
-            )
+            # The rows the walk actually produced, but the paging fields of the
+            # page it stopped on — so a script can resume exactly where this left
+            # off (null after --all: there is nothing further back).
+            payload = {**last_page, "messages": [m.to_dict() for m in msgs], "count": len(msgs)}
             typer.echo(json_module.dumps(payload, indent=2, default=str))
             return
 
@@ -931,6 +956,14 @@ def messages(
             typer.echo(f"  {stamp}  {m.sender_handle}{own} [{m.message_type}]: {first}")
             for line in rest:
                 typer.echo(f"              {line}")
+        # Tell the reader there is more history and exactly how to reach it,
+        # rather than leaving the window looking like the whole room.
+        if last_page.get("next_cursor"):
+            typer.secho(
+                f"\n  … more history — mycelium room messages {room_name} "
+                f"--cursor {last_page['next_cursor']}  (or --all)",
+                fg=typer.colors.BRIGHT_BLACK,
+            )
         typer.echo()
 
     except (typer.Exit, typer.Abort):

--- a/mycelium-cli/src/mycelium/pagination.py
+++ b/mycelium-cli/src/mycelium/pagination.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Walking a paginated list from the client side.
+
+The hub pages every list the same way (``app/services/pagination.py``): you ask
+with a ``cursor``, you get back a page plus the ``next_cursor`` that continues
+it, and a null cursor means you reached the end. Because the cursor names a row
+rather than a position, a walk stays coherent while the room keeps talking —
+which is the whole reason a script can page backward through live history at all.
+
+That sameness is what this module trades on: give :func:`walk_pages` a function
+that fetches one page, and it walks any list on the hub.
+
+    rows = walk_pages(lambda cursor: fetch_one_page(cursor), limit=200)
+
+Two response shapes carry the same two values: an envelope (``next_cursor`` /
+``has_more`` in the body) or a bare list (the ``X-Next-Cursor`` / ``X-Has-More``
+headers). :func:`cursor_from_headers` reads the second one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, MutableMapping
+
+import typer
+
+# One page of a list: the rows, and the cursor that continues past them.
+type PageFetcher[T] = Callable[[str | None], tuple[list[T], str | None]]
+
+# Shared flags, so walking back reads the same on every command that lists.
+CursorOption = typer.Option(
+    None, "--cursor", help="Continue from a previous page's next_cursor (walk further back)"
+)
+AllOption = typer.Option(
+    False, "--all", help="Walk every page to the end of history, not just the first"
+)
+
+# A walk stops here rather than spinning forever if a server ever hands back a
+# cursor that doesn't advance. Generous: at the CLI's page sizes this is far more
+# history than any room holds.
+MAX_PAGES = 1000
+
+
+def walk_pages[T](
+    fetch: PageFetcher[T], *, start: str | None = None, max_pages: int = MAX_PAGES
+) -> list[T]:
+    """Follow ``next_cursor`` from ``start`` to the end of the list, in page order.
+
+    ``fetch`` takes a cursor (None for the first page) and returns that page's
+    rows plus the cursor after them. ``start`` resumes a walk someone else began.
+    A repeated or empty cursor ends it, so a server that stops advancing costs
+    one wasted page, not an infinite loop.
+    """
+    rows: list[T] = []
+    cursor: str | None = start
+    seen: set[str] = set()
+    for _ in range(max_pages):
+        page, cursor = fetch(cursor)
+        rows.extend(page)
+        if not cursor or cursor in seen:
+            break
+        seen.add(cursor)
+    return rows
+
+
+def cursor_from_headers(headers: MutableMapping[str, str]) -> str | None:
+    """The next-page cursor of a bare-list response, or None at the end of it."""
+    if headers.get("x-has-more", "false").lower() != "true":
+        return None
+    return headers.get("x-next-cursor") or None

--- a/mycelium-cli/tests/test_memory_commands.py
+++ b/mycelium-cli/tests/test_memory_commands.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
+from http import HTTPStatus
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,7 @@ from typer.testing import CliRunner
 
 from mycelium.commands import memory as memory_cmd
 from mycelium_backend_client.errors import UnexpectedStatus
+from mycelium_backend_client.types import Response
 
 runner = CliRunner()
 
@@ -97,21 +99,40 @@ def _stub_get(monkeypatch: pytest.MonkeyPatch, result: Any) -> None:
     )
 
 
-def _stub_list(monkeypatch: pytest.MonkeyPatch, result: Any) -> list[dict[str, Any]]:
-    """Stub the list-memories API; returns the kwargs it was called with."""
-    calls: list[dict[str, Any]] = []
+def _stub_list(
+    monkeypatch: pytest.MonkeyPatch, result: Any, pages: list[Any] | None = None
+) -> list[dict[str, Any]]:
+    """Stub the list-memories API; returns the kwargs it was called with.
 
-    def _sync(**kwargs: Any):
+    ``pages`` serves a paginated hub: each entry is one page, and every page but
+    the last advertises a next cursor in its headers (where this list carries its
+    pagination, its body being a bare list).
+    """
+    calls: list[dict[str, Any]] = []
+    queued = list(pages) if pages is not None else None
+
+    def _sync_detailed(**kwargs: Any):
         calls.append(kwargs)
         if isinstance(result, Exception):
             raise result
-        return result
+        if queued is None:
+            return _response(result, more=False)
+        page = queued.pop(0) if queued else []
+        return _response(page, more=bool(queued), cursor=f"cursor-{len(calls)}")
 
     monkeypatch.setattr(
-        "mycelium_backend_client.api.memory.list_memories_api_rooms_room_name_memory_get.sync",
-        _sync,
+        "mycelium_backend_client.api.memory.list_memories_api_rooms_room_name_memory_get"
+        ".sync_detailed",
+        _sync_detailed,
     )
     return calls
+
+
+def _response(parsed: Any, *, more: bool, cursor: str = "") -> Response:
+    headers = {"x-has-more": "true" if more else "false"}
+    if more:
+        headers["x-next-cursor"] = cursor
+    return Response(status_code=HTTPStatus.OK, content=b"", headers=headers, parsed=parsed)
 
 
 def _stub_create(monkeypatch: pytest.MonkeyPatch) -> list:
@@ -358,3 +379,38 @@ def test_memory_search_no_results(monkeypatch: pytest.MonkeyPatch) -> None:
     result = runner.invoke(memory_cmd.app, ["search", "nothing", "--room", "demo"])
     assert result.exit_code == 0, result.output
     assert "No matching memories found" in result.output
+
+
+def test_memory_ls_walks_every_page_with_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Past the first page a room's memories used to be unreachable (issue #654)."""
+    calls = _stub_list(
+        monkeypatch,
+        None,
+        pages=[
+            [_record("decisions/db", "postgres")],
+            [_record("decisions/lang", "python")],
+            [_record("decisions/ui", "next")],
+        ],
+    )
+
+    result = runner.invoke(memory_cmd.app, ["ls", "--room", "demo", "-n", "1", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert "decisions/db" in result.output
+    assert "decisions/lang" in result.output
+    assert "decisions/ui" in result.output
+    assert [c["cursor"] for c in calls][1:] == ["cursor-1", "cursor-2"]
+
+
+def test_memory_ls_reads_one_page_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_list(
+        monkeypatch,
+        None,
+        pages=[[_record("decisions/db", "postgres")], [_record("decisions/lang", "python")]],
+    )
+
+    result = runner.invoke(memory_cmd.app, ["ls", "--room", "demo", "-n", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert "decisions/lang" not in result.output
+    assert len(calls) == 1

--- a/mycelium-cli/tests/test_pagination.py
+++ b/mycelium-cli/tests/test_pagination.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The client-side page walker (issue #654).
+
+Every list on the hub pages the same way, so one walker drives all of them. What
+it owes its callers: every row, in page order, and a guaranteed stop — a walk
+that spins forever on a server quirk is worse than a short read.
+"""
+
+from mycelium.pagination import cursor_from_headers, walk_pages
+
+
+def _pages(*pages: list[str]):
+    """A fetcher serving ``pages`` in order, each cursor naming the next."""
+    served: list[str | None] = []
+
+    def fetch(cursor: str | None):
+        served.append(cursor)
+        index = 0 if cursor is None else int(cursor)
+        rows = pages[index] if index < len(pages) else []
+        return rows, str(index + 1) if index + 1 < len(pages) else None
+
+    return fetch, served
+
+
+def test_a_walk_returns_every_row_in_page_order():
+    fetch, served = _pages(["a", "b"], ["c", "d"], ["e"])
+
+    assert walk_pages(fetch) == ["a", "b", "c", "d", "e"]
+    assert served == [None, "1", "2"]
+
+
+def test_a_single_page_costs_a_single_request():
+    fetch, served = _pages(["only"])
+
+    assert walk_pages(fetch) == ["only"]
+    assert served == [None]
+
+
+def test_an_empty_list_walks_to_nothing():
+    fetch, _served = _pages([])
+
+    assert walk_pages(fetch) == []
+
+
+def test_a_cursor_that_never_advances_ends_the_walk():
+    """A server that keeps handing back the same cursor costs one wasted page,
+    not an unbounded loop."""
+    calls: list[str | None] = []
+
+    def fetch(cursor: str | None):
+        calls.append(cursor)
+        return ["row"], "stuck"
+
+    assert walk_pages(fetch) == ["row", "row"]
+    assert calls == [None, "stuck"]
+
+
+def test_a_walk_is_bounded_even_if_every_cursor_is_new():
+    calls: list[str | None] = []
+
+    def fetch(cursor: str | None):
+        calls.append(cursor)
+        return ["row"], f"c{len(calls)}"
+
+    assert len(walk_pages(fetch, max_pages=5)) == 5
+
+
+def test_headers_carry_the_cursor_of_a_bare_list_response():
+    assert cursor_from_headers({"x-has-more": "true", "x-next-cursor": "c1"}) == "c1"
+
+
+def test_the_last_page_of_a_bare_list_reports_no_cursor():
+    assert cursor_from_headers({"x-has-more": "false", "x-next-cursor": "c1"}) is None
+    assert cursor_from_headers({}) is None
+
+
+def test_a_walk_can_resume_from_someone_else_s_cursor():
+    """A script that stopped mid-history picks up exactly where it left off."""
+    fetch, served = _pages(["a"], ["b"], ["c"])
+
+    assert walk_pages(fetch, start="1") == ["b", "c"]
+    assert served == ["1", "2"]

--- a/mycelium-cli/tests/test_room_messages.py
+++ b/mycelium-cli/tests/test_room_messages.py
@@ -17,6 +17,9 @@ from typer.testing import CliRunner
 
 from mycelium.commands import room as room_cmd
 
+# What the generated client sends when a query parameter is simply not set.
+UNSET_SENTINEL = __import__("mycelium_backend_client.types", fromlist=["UNSET"]).UNSET
+
 
 def _make_messages() -> list:
     from mycelium_backend_client.models import MessageRead
@@ -152,3 +155,122 @@ def test_room_messages_indents_multiline_content(monkeypatch: pytest.MonkeyPatch
     assert result.exit_code == 0, result.output
     assert "first line" in result.output
     assert "second line" in result.output
+
+
+def _page(contents: list[str], *, cursor: str | None):
+    """One page of the room's history, with the cursor that continues past it."""
+    from mycelium_backend_client.models import MessageListResponse, MessageRead
+
+    return MessageListResponse(
+        messages=[
+            MessageRead(
+                id=uuid4(),
+                sender_handle="operator",
+                message_type="broadcast",
+                content=text,
+                created_at=datetime.datetime(2026, 6, 11, 21, 22, 56),  # noqa: DTZ001
+            )
+            for text in contents
+        ],
+        total=6,
+        next_cursor=cursor,
+        has_more=cursor is not None,
+    )
+
+
+def _paged(monkeypatch: pytest.MonkeyPatch, pages: list) -> list[dict]:
+    """Serve ``pages`` in order; returns the kwargs each call was made with."""
+    calls: list[dict] = []
+    queued = list(pages)
+
+    def fake_sync(**kwargs):
+        calls.append(kwargs)
+        return queued.pop(0) if queued else _page([], cursor=None)
+
+    _patch_common(monkeypatch, fake_sync)
+    return calls
+
+
+def test_room_messages_walks_the_whole_history_with_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gap this closes: a room deeper than one page was unreadable past it."""
+    calls = _paged(
+        monkeypatch,
+        [
+            _page(["newest", "second"], cursor="c1"),
+            _page(["third", "fourth"], cursor="c2"),
+            _page(["fifth", "oldest"], cursor=None),
+        ],
+    )
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest", "--limit", "2", "--all"])
+
+    assert result.exit_code == 0, result.output
+    for text in ("newest", "second", "third", "fourth", "fifth", "oldest"):
+        assert text in result.output
+    assert [c["cursor"] for c in calls] == [UNSET_SENTINEL, "c1", "c2"]
+    assert "6 messages" in result.output
+
+
+def test_room_messages_points_at_the_history_it_did_not_show(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A page that isn't the end says so, and hands over the cursor to continue."""
+    _paged(monkeypatch, [_page(["newest", "second"], cursor="c1")])
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest", "--limit", "2"])
+
+    assert result.exit_code == 0, result.output
+    assert "more history" in result.output
+    assert "--cursor c1" in result.output
+
+
+def test_room_messages_stops_at_the_end_of_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    _paged(monkeypatch, [_page(["only"], cursor=None)])
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest"])
+
+    assert result.exit_code == 0, result.output
+    assert "more history" not in result.output
+
+
+def test_room_messages_resumes_from_a_given_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _paged(monkeypatch, [_page(["older"], cursor=None)])
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest", "--cursor", "c9"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0]["cursor"] == "c9"
+
+
+def test_room_messages_json_carries_the_cursor_for_a_script(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A script drives the walk itself, so the cursor has to survive --json."""
+    import json
+
+    from mycelium.cli import app as root_app
+
+    _paged(monkeypatch, [_page(["newest"], cursor="c1")])
+
+    result = CliRunner().invoke(root_app, ["--json", "room", "messages", "msgtest"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["next_cursor"] == "c1"
+    assert payload["has_more"] is True
+    assert [m["content"] for m in payload["messages"]] == ["newest"]
+
+
+def test_room_messages_all_resumes_from_a_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--all and --cursor compose: walk the rest of history from where I stopped."""
+    calls = _paged(
+        monkeypatch,
+        [_page(["third"], cursor="c2"), _page(["fourth"], cursor=None)],
+    )
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest", "--cursor", "c1", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert [c["cursor"] for c in calls] == ["c1", "c2"]
+    assert "third" in result.output
+    assert "fourth" in result.output

--- a/mycelium-frontend/src/components/event-stream.history.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.history.test.tsx
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Reverse-scrolling a room's history (issue #654).
+ *
+ * The feed used to show one fixed window of the newest messages and stop there,
+ * leaving everything older unreachable in the browser. It now walks back a page
+ * at a time as the reader nears the top — without yanking them to the bottom or
+ * showing a message twice.
+ */
+
+import { act } from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeEventSource } from "@/test/fake-event-source";
+import { FakeIntersectionObserver } from "@/test/fake-intersection-observer";
+
+const fetchMessages = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  getSSEUrl: (room: string) => `/api/rooms/${room}/messages/stream`,
+  fetchMessages: (...args: unknown[]) => fetchMessages(...args),
+  fetchRoomAgents: vi.fn().mockResolvedValue([]),
+  fetchPendingInvites: vi.fn().mockResolvedValue([]),
+  respondToInvite: vi.fn(),
+  logFetchError: () => () => undefined,
+}));
+
+import { EventStream } from "@/components/event-stream";
+
+const CREATED = "2026-08-04T10:00:00.000000+00:00";
+
+/** A page of chat, newest first — the order the hub serves. */
+function page(ids: string[], nextCursor: string | null) {
+  return {
+    messages: ids.map((id) => ({
+      id,
+      message_type: "broadcast",
+      sender_handle: "operator",
+      content: `message ${id}`,
+      created_at: CREATED,
+    })),
+    total: 6,
+    next_cursor: nextCursor,
+    has_more: nextCursor !== null,
+  };
+}
+
+/** Render the feed with its first page loaded and the SSE stream open. */
+async function openRoom() {
+  render(<EventStream roomName="sprint" />);
+  await act(async () => {});
+  await act(async () => {
+    FakeEventSource.latest().open();
+  });
+}
+
+/** Scroll to the top and let the page that lands settle. */
+async function scrollToTop() {
+  await act(async () => {
+    FakeIntersectionObserver.latest().trigger();
+  });
+  await act(async () => {});
+}
+
+describe("<EventStream /> history pagination", () => {
+  beforeEach(() => {
+    FakeEventSource.reset();
+    FakeIntersectionObserver.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+    fetchMessages.mockReset();
+  });
+
+  it("opens on the newest page and asks for it by page, not for everything", async () => {
+    fetchMessages.mockResolvedValue(page(["m6", "m5"], "cursor-1"));
+
+    await openRoom();
+
+    expect(await screen.findByText("message m5")).toBeInTheDocument();
+    expect(fetchMessages).toHaveBeenCalledWith("sprint", 50, null);
+  });
+
+  it("loads the page before it when the reader reaches the top", async () => {
+    fetchMessages
+      .mockResolvedValueOnce(page(["m6", "m5"], "cursor-1"))
+      .mockResolvedValueOnce(page(["m4", "m3"], null));
+
+    await openRoom();
+    await screen.findByText("message m5");
+    await scrollToTop();
+
+    // The older page arrived, and it arrived *above* what was already there.
+    expect(await screen.findByText("message m3")).toBeInTheDocument();
+    expect(fetchMessages).toHaveBeenLastCalledWith("sprint", 50, "cursor-1");
+    const rendered = screen.getAllByText(/^message m\d$/).map((el) => el.textContent);
+    expect(rendered).toEqual(["message m3", "message m4", "message m5", "message m6"]);
+  });
+
+  it("stops asking once history runs out", async () => {
+    fetchMessages.mockResolvedValue(page(["m2", "m1"], null));
+
+    await openRoom();
+    await screen.findByText("message m1");
+
+    // A first page that ends history leaves nothing to observe for.
+    expect(FakeIntersectionObserver.instances).toHaveLength(0);
+    expect(fetchMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a message once when the live stream already delivered it", async () => {
+    fetchMessages
+      .mockResolvedValueOnce(page(["m6"], "cursor-1"))
+      .mockResolvedValueOnce(page(["m6", "m5"], null));
+
+    await openRoom();
+    await screen.findByText("message m6");
+    await scrollToTop();
+
+    await screen.findByText("message m5");
+    expect(screen.getAllByText("message m6")).toHaveLength(1);
+  });
+
+  it("does not yank a reader who has scrolled up down to the newest message", async () => {
+    fetchMessages
+      .mockResolvedValueOnce(page(["m6", "m5"], "cursor-1"))
+      .mockResolvedValueOnce(page(["m4", "m3"], null));
+
+    await openRoom();
+    await screen.findByText("message m5");
+
+    const viewport = document.querySelector("[data-slot=scroll-area-viewport]");
+    if (!viewport) throw new Error("no scroll viewport rendered");
+    Object.defineProperty(viewport, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(viewport, "clientHeight", { value: 200, configurable: true });
+    Object.defineProperty(viewport, "scrollTop", { value: 0, writable: true, configurable: true });
+    await act(async () => {
+      viewport.dispatchEvent(new Event("scroll"));
+    });
+
+    const scrollTo = vi.spyOn(Element.prototype, "scrollTo");
+    await scrollToTop();
+    await screen.findByText("message m3");
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});
+
+describe("<EventStream /> history pagination across rooms", () => {
+  beforeEach(() => {
+    FakeEventSource.reset();
+    FakeIntersectionObserver.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+    fetchMessages.mockReset();
+  });
+
+  it("does not spill a page in flight into the room the reader switched to", async () => {
+    // A page requested for one room lands after the reader has moved to another.
+    // It belongs to a history nobody is looking at any more.
+    let releaseSprint: (value: unknown) => void = () => {};
+    fetchMessages
+      .mockImplementationOnce(
+        () => new Promise((resolve) => { releaseSprint = resolve; }),
+      )
+      .mockResolvedValueOnce(page(["m1"], null));
+
+    const view = render(<EventStream roomName="sprint" />);
+    await act(async () => {});
+    view.rerender(<EventStream roomName="retro" />);
+    await act(async () => {});
+    await screen.findByText("message m1");
+
+    await act(async () => {
+      releaseSprint(page(["stale"], "cursor-1"));
+    });
+
+    expect(screen.queryByText("message stale")).not.toBeInTheDocument();
+    expect(screen.getByText("message m1")).toBeInTheDocument();
+  });
+});
+
+describe("<EventStream /> history pagination, when a page holds no chat", () => {
+  beforeEach(() => {
+    FakeEventSource.reset();
+    FakeIntersectionObserver.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+    fetchMessages.mockReset();
+  });
+
+  it("keeps walking rather than declaring the room empty", async () => {
+    // The newest page is all non-chat rows the channel view filters out. That is
+    // a window with nothing to show, not a room with nothing in it.
+    fetchMessages
+      .mockResolvedValueOnce({
+        messages: [
+          { id: "t1", message_type: "coordination_tick", sender_handle: "aligner", content: "{}" },
+        ],
+        total: 2,
+        next_cursor: "cursor-1",
+        has_more: true,
+      })
+      .mockResolvedValueOnce(page(["m1"], null));
+
+    await openRoom();
+    expect(screen.queryByText("No messages yet")).not.toBeInTheDocument();
+
+    await scrollToTop();
+
+    expect(await screen.findByText("message m1")).toBeInTheDocument();
+  });
+});

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   getSSEUrl,
   fetchMessages,
@@ -13,6 +13,9 @@ import {
   logFetchError,
   type PendingInvite,
 } from "@/lib/api";
+import { mergeOlder } from "@/lib/cursor-pagination";
+import { useCursorPagination } from "@/lib/use-cursor-pagination";
+import { useReverseScroll, useStickToBottom } from "@/lib/use-reverse-scroll";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomPlanHeader } from "@/components/room-plan-header";
 import { ConsentDialog } from "@/components/consent-dialog";
@@ -47,6 +50,10 @@ interface Event {
 }
 
 const CHAT_TYPES = new Set(["broadcast", "direct", "announce", "delegate"]);
+
+// Messages fetched per page of history. Big enough that a reader scrolling up
+// rarely waits, small enough that opening a long-lived room stays instant.
+const HISTORY_PAGE_SIZE = 50;
 
 // The L9 "raise-up" whitelist: message types promoted from the L9 inspector
 // into the primary channel/chat surface. This must mirror
@@ -379,17 +386,42 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
     };
   }, [roomName]);
 
-  // Load initial messages
-  useEffect(() => {
-    fetchMessages(roomName).then(data => {
-      const msgs = (data.messages || []).reverse();
-      setEvents(msgs.map(parseEvent));
-      setHistoryLoaded(true);
-    }).catch((err) => {
-      logFetchError("fetchMessages")(err);
-      setHistoryLoaded(true);
+  // History, a page at a time. The feed holds the newest page on mount and walks
+  // back from there as the reader scrolls up, so a room with thousands of
+  // messages opens as fast as an empty one and still gives up all of its past.
+  const { loadMore, exhausted } = useCursorPagination<Event>(
+    (cursor) =>
+      fetchMessages(roomName, HISTORY_PAGE_SIZE, cursor).then((data) => ({
+        ...data,
+        items: (data.messages || []).reverse().map(parseEvent),
+      })),
+    roomName,
+  );
+
+  // A page of history goes in front of what is already on screen, minus anything
+  // the live stream has shown already — the two overlap by design (SSE keeps
+  // running while a page is in flight), and a message must appear once.
+  const loadOlder = useCallback(async () => {
+    const older = await loadMore();
+    if (!older.length) return 0;
+    let added = 0;
+    setEvents((prev) => {
+      const merged = mergeOlder(prev, older, (e) => e.messageId);
+      added = merged.length - prev.length;
+      return merged;
     });
-  }, [roomName]);
+    return added;
+  }, [loadMore]);
+
+  useEffect(() => {
+    setEvents([]);
+    setHistoryLoaded(false);
+    loadOlder()
+      .catch(logFetchError("fetchMessages"))
+      .finally(() => setHistoryLoaded(true));
+    // Re-runs when the room changes — a different room is a different history.
+    // loadOlder is stable within one, so it never re-fires the load by itself.
+  }, [roomName, loadOlder]);
 
   // Load any consent prompts already open (an @-invite raised before this
   // client connected). Live ones arrive over SSE below.
@@ -467,12 +499,22 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
     onFocusConsumed?.();
   }, [focusMessageId, onFocusConsumed]);
 
+  // Load older history when the reader reaches the top, holding their place.
+  const topSentinelRef = useReverseScroll({
+    viewportRef: scrollRef,
+    itemCount: visible.length,
+    enabled: historyLoaded && !exhausted && view === "channel",
+    onLoadOlder: loadOlder,
+  });
+
   // Auto-scroll when new events arrive — but not over a message the user was
-  // just sent to, which is the one place in the feed they're looking.
+  // just sent to, which is the one place in the feed they're looking, and not
+  // when they have scrolled up (reading history, or a page of it just landed).
+  const following = useStickToBottom(scrollRef);
   useEffect(() => {
-    if (highlight) return;
+    if (highlight || !following()) return;
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
-  }, [visible, highlight]);
+  }, [visible, highlight, following]);
 
   useEffect(() => {
     if (!highlight) return;
@@ -570,7 +612,9 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
           <RoomPlanHeader roomName={roomName} refreshTrigger={planRefreshTrigger} />
         ) : !historyLoaded ? (
           <ChannelSkeleton />
-        ) : visible.length === 0 ? (
+        ) : visible.length === 0 && exhausted ? (
+          // Only once the walk has reached the beginning is an empty feed
+          // really empty — until then it is a window that hasn't found chat yet.
           <EmptyState
             className="h-full"
             icon={MessagesSquare}
@@ -579,6 +623,13 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
           />
         ) : (
         <div className="py-3">
+        {/* Crossing this marks the top of what's loaded and pulls in the page
+            before it, carrying the notice so the reader sees history arriving
+            rather than a stall. */}
+        <div ref={topSentinelRef} aria-hidden className="h-px" />
+        {!exhausted && (
+          <div className="px-5 py-2 text-micro text-muted-foreground">loading earlier messages…</div>
+        )}
         {visible.map((ev, idx) => {
               // Coordination + plan lifecycle events render as slim, centered
               // system notices — quiet dividers woven into the conversation,

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -387,6 +387,15 @@ export async function addPlanTask(roomName: string, text: string, slug = "tasks"
 }
 
 // ── Messages ─────────────────────────────────────────────────────────────────
+/** The keyset-pagination fields every paginated list on the hub returns.
+ *  `next_cursor` continues in the list's own direction — older, for a
+ *  newest-first list — and is null once there is nothing further. */
+export interface CursorPage {
+  next_cursor?: string | null;
+  has_more?: boolean;
+}
+
+
 
 export interface RoomMessage {
   id?: string;
@@ -403,7 +412,7 @@ export interface RoomMessage {
   [key: string]: unknown;
 }
 
-export interface MessagesResponse {
+export interface MessagesResponse extends CursorPage {
   messages: RoomMessage[];
   total?: number;
 }
@@ -411,11 +420,21 @@ export interface MessagesResponse {
 const isMessagesResponse = (d: unknown): d is MessagesResponse =>
   !!d && typeof d === "object" && Array.isArray((d as { messages?: unknown }).messages);
 
-export async function fetchMessages(roomName: string, limit?: number): Promise<MessagesResponse> {
-  const url = limit
-    ? `/api/rooms/${roomName}/messages?limit=${limit}`
-    : `/api/rooms/${roomName}/messages`;
-  return apiFetch<MessagesResponse>(url, {
+/** One page of a room's messages, newest first.
+ *
+ *  Pass the previous page's `next_cursor` to read the page *before* it — that
+ *  cursor names a message rather than a position, so a reader walking back
+ *  through history keeps its place while the room keeps talking. */
+export async function fetchMessages(
+  roomName: string,
+  limit?: number,
+  cursor?: string | null,
+): Promise<MessagesResponse> {
+  const query = new URLSearchParams();
+  if (limit) query.set("limit", String(limit));
+  if (cursor) query.set("cursor", cursor);
+  const suffix = query.toString() ? `?${query}` : "";
+  return apiFetch<MessagesResponse>(`/api/rooms/${roomName}/messages${suffix}`, {
     cache: "no-store",
     fallback: { messages: [] },
     guard: isMessagesResponse,

--- a/mycelium-frontend/src/lib/cursor-pagination.test.ts
+++ b/mycelium-frontend/src/lib/cursor-pagination.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import { mergeOlder } from "@/lib/cursor-pagination";
+
+interface Row {
+  id: string | null;
+  text: string;
+}
+
+const key = (row: Row) => row.id;
+
+describe("mergeOlder", () => {
+  it("puts a page of history in front of what is already on screen", () => {
+    const onScreen = [{ id: "c", text: "third" }];
+    const older = [
+      { id: "a", text: "first" },
+      { id: "b", text: "second" },
+    ];
+
+    expect(mergeOlder(onScreen, older, key).map((r) => r.text)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("shows a message once when a page and the live stream both carry it", () => {
+    // The overlap is by design: SSE keeps delivering while a page is in flight.
+    const onScreen = [{ id: "b", text: "second" }];
+    const older = [
+      { id: "a", text: "first" },
+      { id: "b", text: "second" },
+    ];
+
+    expect(mergeOlder(onScreen, older, key).map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  it("drops repeats inside a single page too", () => {
+    const older = [
+      { id: "a", text: "first" },
+      { id: "a", text: "first again" },
+    ];
+
+    expect(mergeOlder([], older, key)).toHaveLength(1);
+  });
+
+  it("keeps a row with no id rather than losing that piece of history", () => {
+    const older = [
+      { id: null, text: "unidentified" },
+      { id: null, text: "also unidentified" },
+    ];
+
+    expect(mergeOlder([], older, key)).toHaveLength(2);
+  });
+
+  it("returns the same list when a page adds nothing, so React can skip the render", () => {
+    const onScreen = [{ id: "a", text: "first" }];
+
+    expect(mergeOlder(onScreen, [{ id: "a", text: "first" }], key)).toBe(onScreen);
+  });
+
+  it("leaves the list alone when there is no older page", () => {
+    const onScreen = [{ id: "a", text: "first" }];
+
+    expect(mergeOlder(onScreen, [], key)).toBe(onScreen);
+  });
+});

--- a/mycelium-frontend/src/lib/cursor-pagination.ts
+++ b/mycelium-frontend/src/lib/cursor-pagination.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Reading a paginated list from the hub.
+ *
+ * Every list the backend serves pages the same way (`app/services/pagination.py`):
+ * ask with a `cursor`, get back a page plus the `next_cursor` that continues it,
+ * and a null cursor means the end. The cursor names a row rather than a position,
+ * so a reader walking back through history keeps its place while the list grows
+ * at the head — which is what makes reverse scroll in a live room possible at all.
+ *
+ * This module is the merge half of that: pure functions a component can test
+ * without a DOM. The fetching half is `use-cursor-pagination`.
+ */
+
+import type { CursorPage } from "@/lib/api";
+
+/** One page as the hub returns it: the rows, plus where to continue. */
+export interface CursorPageOf<T> extends CursorPage {
+  items: T[];
+}
+
+/**
+ * Fold an older page into a list that already holds newer rows.
+ *
+ * Older rows go in front, and any row already present is dropped rather than
+ * repeated: a page of history and the live stream can name the same message, and
+ * the reader must see it once. Identity comes from `keyOf`; a row with no key
+ * (nothing to compare) is kept, since dropping it would lose history.
+ */
+export function mergeOlder<T>(
+  existing: T[],
+  older: T[],
+  keyOf: (row: T) => string | null | undefined,
+): T[] {
+  const known = new Set(existing.map(keyOf).filter(Boolean) as string[]);
+  const fresh = older.filter((row) => {
+    const key = keyOf(row);
+    if (!key) return true;
+    if (known.has(key)) return false;
+    known.add(key);
+    return true;
+  });
+  return fresh.length ? [...fresh, ...existing] : existing;
+}

--- a/mycelium-frontend/src/lib/use-cursor-pagination.ts
+++ b/mycelium-frontend/src/lib/use-cursor-pagination.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { CursorPageOf } from "@/lib/cursor-pagination";
+
+/**
+ * Walk a cursor-paginated list one page at a time.
+ *
+ * Holds the cursor, the in-flight guard, and whether the list is exhausted —
+ * the state every paged reader needs and none of them should re-invent. It
+ * deliberately does *not* own the rows: a chat feed merges pages into a list the
+ * live stream is also writing to, so merging belongs to the caller (`mergeOlder`).
+ *
+ *     const { loadMore, loading, exhausted } = useCursorPagination(
+ *       (cursor) => fetchMessages(room, 50, cursor).then((r) => ({ ...r, items: r.messages })),
+ *       room,
+ *     );
+ *
+ * `resetKey` re-arms the walk from the top when it changes (a different room is
+ * a different list). `loadMore` resolves with the page's rows, or an empty array
+ * when there is nothing left, a request is already in flight, or the fetch fails
+ * — a page that can't load is a page not shown, never a broken feed.
+ */
+export function useCursorPagination<T>(
+  fetchPage: (cursor: string | null) => Promise<CursorPageOf<T>>,
+  resetKey?: unknown,
+) {
+  const [loading, setLoading] = useState(false);
+  const [exhausted, setExhausted] = useState(false);
+  const cursor = useRef<string | null>(null);
+  const inFlight = useRef(false);
+  // Which list the walk is on. A request outlives a reset — switch rooms with a
+  // page in flight and it lands after — so a page from a superseded walk is
+  // dropped rather than merged into whatever the reader is now looking at.
+  const walk = useRef(0);
+  // Held in a ref so a caller passing an inline closure (the usual case) doesn't
+  // re-create loadMore on every render and re-fire the effects watching it.
+  const fetcher = useRef(fetchPage);
+  fetcher.current = fetchPage;
+
+  useEffect(() => {
+    walk.current += 1;
+    cursor.current = null;
+    inFlight.current = false;
+    setExhausted(false);
+    setLoading(false);
+  }, [resetKey]);
+
+  const loadMore = useCallback(async (): Promise<T[]> => {
+    if (inFlight.current) return [];
+    const mine = walk.current;
+    inFlight.current = true;
+    setLoading(true);
+    try {
+      const page = await fetcher.current(cursor.current);
+      if (mine !== walk.current) return [];
+      cursor.current = page.next_cursor ?? null;
+      if (!page.next_cursor || page.has_more === false) setExhausted(true);
+      return page.items;
+    } catch {
+      if (mine === walk.current) setExhausted(true); // stop asking a list that can't answer
+      return [];
+    } finally {
+      if (mine === walk.current) {
+        inFlight.current = false;
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  return { loadMore, loading, exhausted };
+}

--- a/mycelium-frontend/src/lib/use-reverse-scroll.ts
+++ b/mycelium-frontend/src/lib/use-reverse-scroll.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useCallback, useEffect, useLayoutEffect, useRef, type RefObject } from "react";
+
+/** How close to the top older rows start loading, and how close to the bottom
+ *  still counts as "following the conversation". */
+const LOAD_MARGIN_PX = 300;
+const BOTTOM_SLACK_PX = 80;
+
+interface ReverseScrollOptions {
+  /** The scrolling element the sentinel lives inside. */
+  viewportRef: RefObject<HTMLElement | null>;
+  /** How many rows are rendered — the signal that a prepend has landed. */
+  itemCount: number;
+  /** Off once history is exhausted, or before the first page has arrived. */
+  enabled: boolean;
+  /** Load the next page of older rows; resolves with how many were added. */
+  onLoadOlder: () => Promise<number>;
+}
+
+/**
+ * Load older rows when the reader scrolls to the top, without moving the page
+ * under them.
+ *
+ * Prepending rows grows the document upward, so a viewport that holds its
+ * `scrollTop` appears to leap backward through the conversation. This measures
+ * the reader's distance from the *bottom* before the load and restores that
+ * distance after the rows land, which leaves the row they were reading exactly
+ * where it was.
+ *
+ * Attach the returned ref to an element at the very top of the list.
+ */
+export function useReverseScroll({
+  viewportRef,
+  itemCount,
+  enabled,
+  onLoadOlder,
+}: ReverseScrollOptions): RefObject<HTMLDivElement | null> {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  // Distance from the bottom, held between asking for a page and its rows
+  // arriving. Null when no load is outstanding.
+  const anchor = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || anchor.current === null) return;
+    viewport.scrollTop = viewport.scrollHeight - anchor.current;
+    anchor.current = null;
+  }, [itemCount, viewportRef]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const viewport = viewportRef.current;
+    if (!enabled || !sentinel || !viewport || typeof IntersectionObserver === "undefined") return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        // The observer keeps firing while the sentinel stays in view; only the
+        // call that takes the anchor may release it, so a repeat can't drop the
+        // measurement the outstanding load is going to restore.
+        const claimed = anchor.current === null;
+        if (claimed) anchor.current = viewport.scrollHeight - viewport.scrollTop;
+        void onLoadOlder().then((added) => {
+          if (!added && claimed) anchor.current = null;
+        });
+      },
+      { root: viewport, rootMargin: `${LOAD_MARGIN_PX}px 0px 0px 0px` },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [enabled, onLoadOlder, viewportRef]);
+
+  return sentinelRef;
+}
+
+/**
+ * Whether the feed should still follow new rows to the bottom.
+ *
+ * A reader parked at the bottom wants each new message brought into view; a
+ * reader who has scrolled up — to read history, or because a page of it just
+ * loaded — does not, and yanking them down loses their place. Call the returned
+ * function before auto-scrolling.
+ */
+export function useStickToBottom(viewportRef: RefObject<HTMLElement | null>): () => boolean {
+  const following = useRef(true);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const onScroll = () => {
+      const distance = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+      following.current = distance <= BOTTOM_SLACK_PX;
+    };
+    onScroll();
+    viewport.addEventListener("scroll", onScroll, { passive: true });
+    return () => viewport.removeEventListener("scroll", onScroll);
+  }, [viewportRef]);
+
+  return useCallback(() => following.current, []);
+}

--- a/mycelium-frontend/src/test/fake-intersection-observer.ts
+++ b/mycelium-frontend/src/test/fake-intersection-observer.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// An IntersectionObserver stand-in for component tests. jsdom has none, and it
+// is what tells the feed the reader has scrolled to the top; tests grab the
+// latest instance and `trigger()` it to play that moment.
+export class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+
+  private targets: Element[] = [];
+
+  constructor(
+    private callback: (entries: { isIntersecting: boolean; target: Element }[]) => void,
+    readonly options?: { root?: Element | Document | null; rootMargin?: string },
+  ) {
+    FakeIntersectionObserver.instances.push(this);
+  }
+
+  static reset(): void {
+    FakeIntersectionObserver.instances = [];
+  }
+
+  static latest(): FakeIntersectionObserver {
+    const observer = FakeIntersectionObserver.instances.at(-1);
+    if (!observer) throw new Error("no IntersectionObserver was constructed");
+    return observer;
+  }
+
+  observe(target: Element): void {
+    this.targets.push(target);
+  }
+
+  unobserve(target: Element): void {
+    this.targets = this.targets.filter((t) => t !== target);
+  }
+
+  disconnect(): void {
+    this.targets = [];
+  }
+
+  /** Play "the observed element scrolled into view". */
+  trigger(): void {
+    this.callback(this.targets.map((target) => ({ isIntersecting: true, target })));
+  }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -420,6 +420,29 @@
             },
             "title": "Episodes",
             "type": "array"
+          },
+          "has_more": {
+            "default": false,
+            "description": "Whether more rows follow this page",
+            "title": "Has More",
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for the next page; null when this is the last page",
+            "title": "Next Cursor"
+          },
+          "total": {
+            "default": 0,
+            "title": "Total",
+            "type": "integer"
           }
         },
         "required": [
@@ -1285,12 +1308,30 @@
       },
       "MessageListResponse": {
         "properties": {
+          "has_more": {
+            "default": false,
+            "description": "Whether more rows follow this page",
+            "title": "Has More",
+            "type": "boolean"
+          },
           "messages": {
             "items": {
               "$ref": "#/components/schemas/MessageRead"
             },
             "title": "Messages",
             "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for the next page; null when this is the last page",
+            "title": "Next Cursor"
           },
           "total": {
             "title": "Total",
@@ -3145,8 +3186,28 @@
             "required": false,
             "schema": {
               "default": 50,
+              "maximum": 500,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque cursor from a previous page's next_cursor",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from a previous page's next_cursor",
+              "title": "Cursor"
             }
           }
         ],
@@ -3559,7 +3620,7 @@
     },
     "/api/rooms/{room_name}/memory": {
       "get": {
-        "description": "List memories in a room (from the filesystem).\n\nSupports ETag / If-None-Match for efficient sync \u2014 returns 304 if nothing\nchanged.",
+        "description": "List memories in a room (from the filesystem), newest-written first.\n\nSupports ETag / If-None-Match for efficient sync \u2014 returns 304 if nothing\nchanged. The body stays a bare list, so this list carries its pagination in\nthe ``X-Next-Cursor`` / ``X-Has-More`` headers rather than in an envelope\n(see ``app/services/pagination.py``).",
         "operationId": "list_memories_api_rooms__room_name__memory_get",
         "parameters": [
           {
@@ -3610,6 +3671,24 @@
               "minimum": 0,
               "title": "Offset",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque cursor from a previous page's X-Next-Cursor header",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from a previous page's X-Next-Cursor header",
+              "title": "Cursor"
             }
           }
         ],
@@ -3990,7 +4069,7 @@
     },
     "/api/rooms/{room_name}/messages": {
       "get": {
-        "description": "List messages in a room (or coordination session), newest first.",
+        "description": "List messages in a room (or coordination session), newest first.\n\nWalk backward through history by following ``next_cursor``; ``offset`` stays\nfor callers that haven't migrated but shifts under a live room.",
         "operationId": "list_messages_api_rooms__room_name__messages_get",
         "parameters": [
           {
@@ -4021,6 +4100,24 @@
               "default": 0,
               "title": "Offset",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque cursor from a previous page's next_cursor; returns the messages immediately older than it. Stable while the room keeps growing (unlike offset).",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from a previous page's next_cursor; returns the messages immediately older than it. Stable while the room keeps growing (unlike offset).",
+              "title": "Cursor"
             }
           },
           {


### PR DESCRIPTION
## Summary

Neither the UI feed nor `mycelium room messages` could walk backward through a room's history. Both showed a fixed newest-N window and stopped there, so once a room grew past it the older messages were unreachable in the browser and in the CLI — even though the durable transcript on disk held them all.

Offset paging doesn't fix that on a live list. New messages arriving at the head shift every offset, so reverse-scrolling a busy room duplicates and skips rows between pages. So this pages by **keyset cursor**: a token carries the sort key of the row a page ended on, not a position, and the next page is "everything sorting strictly past this key". That boundary survives both rows arriving at the head and the anchor row being deleted mid-walk.

Per the follow-up ask, that's built as **one primitive every list shares** rather than a messages-only cursor — the same three names (`cursor` in, `next_cursor` / `has_more` out) on every list, so one client-side walker drives all of them. The issue proposed `before=`; a single direction-neutral `cursor` reads the same for a newest-first list and generalizes to the others, and `next_cursor` continues in each list's own traversal direction.

## Changes

**Backend**
- `app/services/pagination.py` — the shared primitive: opaque URL-safe cursor tokens, `paginate()` over any ordered list given a key function, and `timestamp_key()` (raw `isoformat` is not safe to compare as text — an offset suffix and optional microseconds order two equal instants arbitrarily).
- Applied to `GET /rooms/{room}/messages`, `GET /rooms/{room}/memory`, and `GET /rooms/{room}/episodes`. Existing `offset` keeps working where it already did; a malformed cursor is a 400, not a silent first page.
- Memory keeps its bare-list body (ETag sync unchanged), so it carries the same two values as `X-Next-Cursor` / `X-Has-More` headers.
- Episodes' "an in-progress one first" rule moved into the sort key, so a live episode can't drift onto page two mid-walk.
- **Paging no longer re-reads the whole conversation per page.** The transcript is append-only, so `conversational_messages` now resumes from where the last read stopped, sealed against the last consumed line so an in-place rewrite is re-read rather than stitched onto. A record caught mid-append waits for its line to finish instead of being parsed as a truncated row (that last one was a latent bug on the cold-read path).

**CLI** — one walker (`mycelium/pagination.py`), not per-command paging code
- `mycelium room messages`: `--all` walks history to the beginning, `--cursor` resumes a walk, and the two compose. `--json` carries `next_cursor` so a script can drive the walk itself; a partial page prints the command that continues it.
- `mycelium memory ls --all` walks past the first page (reading the cursor from the headers).
- The walk is bounded: a cursor that stops advancing costs one wasted page, never a hang.

**Frontend** — generic hooks, then wiring
- `use-cursor-pagination.ts` (cursor/loading/exhausted state for any paged list, with a guard so a page in flight when the reader switches rooms can't land in the new room), `use-reverse-scroll.ts` (top-sentinel loading + scroll anchoring + stick-to-bottom), `cursor-pagination.ts` (`mergeOlder`, pure).
- `event-stream.tsx`: an `IntersectionObserver` sentinel loads the page before the top and prepends it, anchored on distance from the bottom so the viewport doesn't jump; prepended history is deduped against live SSE inserts by message id; and the feed no longer yanks a reader who has scrolled up down to the newest message. A page whose rows are all filtered out of the channel view keeps walking instead of showing "No messages yet".

`openapi.json` refreshed; `docs/reference.html` updated for the two changed commands only (a full regen also pulls in ~400 lines of unrelated pre-existing drift, which didn't belong in this diff).

## Testing

All three gates run clean locally.

- Backend: 697 passed, 9 skipped. New: `test_pagination.py` (the primitive's properties — a walk covers every row once; rows arriving at the head neither duplicate nor skip; a deleted boundary row still resolves), `test_message_pagination.py` (the walk over HTTP, including under concurrent appends), `test_list_pagination.py` (memory + episodes speak the same contract), plus transcript-cache tests that **measure** incrementality by counting the lines handed to the parser.
- CLI: 500 passed. New `test_pagination.py` for the walker; `room messages` / `memory ls` walk, resume, and cursor-in-`--json` coverage.
- Frontend: 196 passed. New `event-stream.history.test.tsx` (loads the page before the top, prepends above, dedups against the live stream, doesn't yank a scrolled-up reader, keeps walking past a chat-less page, and doesn't spill a cross-room page) — the cross-room test was verified to fail with the guard removed.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `uv run ty check .`, `tsc --noEmit`, `pnpm test`

Not run here: the live-node SLIM slices and live-LLM tests (no node/keys in this environment); they skip by design.

## Related Issues

Closes #654


---
_Generated by [Claude Code](https://claude.ai/code/session_012xHEPCVM5CAAUgP6CjbvR5)_