### PR TITLE
docs: regenerate the docs site from current markdown sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,22 @@ jobs:
         working-directory: mycelium-cli
         run: uv run pytest tests/ -q
 
+      # docs/*.html and docs/llms-full.txt are generated from the markdown under
+      # mycelium-cli/src/mycelium/docs/, the @doc_ref decorators, and the pydantic
+      # config schema. Same contract as the openapi.json check above: regenerate,
+      # fail if the tree moves. Without it the committed output drifts silently and
+      # the backlog lands as unrelated diff in whichever PR next runs the generator.
+      - name: Docs site is current
+        run: |
+          (cd mycelium-cli && uv run python ../docs/generate_docs.py)
+          if [ -n "$(git status --porcelain -- docs/)" ]; then
+            echo "::error file=docs/llms-full.txt::Generated docs are stale — run 'cd mycelium-cli && uv run python ../docs/generate_docs.py' and commit docs/."
+            git status --porcelain -- docs/
+            git diff --stat -- docs/
+            exit 1
+          fi
+          echo "Generated docs match their markdown + CLI sources."
+
   build-collector:
     # Smoke-build the OTLP collector image so PRs that touch the collector
     # source / Dockerfile fail fast in CI rather than at the next release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ MYCELIUM_SLIM_ENDPOINT=http://127.0.0.1:46357 uv run pytest tests/test_slim_roun
 # the spec). CI + the wheel/binary builds run this themselves.
 SPEC_FILE=openapi.json ./scripts/gen-mycelium-client.sh
 
+# Regenerate the docs site (docs/*.html + docs/llms-full.txt) from the markdown
+# under mycelium-cli/src/mycelium/docs/, the @doc_ref decorators, and the config
+# schema. Needs the OpenAPI client above. Run it in any PR that touches those
+# sources — CI fails on drift.
+cd mycelium-cli && uv run python ../docs/generate_docs.py
+
 # CLI (install globally)
 cd mycelium-cli && uv tool install -e . --with mycelium-backend-client@../mycelium-client --force
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1038,25 +1038,28 @@ machine) owns the whole agent workflow.
 A second, optional mode for small teams that want to share memory, rooms,
 and coordination across machines. One machine runs the SLIM node and
 backend (the **hub**); other machines run only the CLI + agents (**spokes**)
-and connect to the hub's channel.
+as **thin HTTP clients** to the hub API.
 
 | Role  | What runs locally | When to use |
 |-------|-------------------|-------------|
 | **Hub**   | The SLIM node + the thin FastAPI backend (room moderator). | The team's shared coordination server. One per team. |
-| **Spoke** | CLI + agents only. Points at the hub's SLIM address. | Each teammate's laptop. Agents on the spoke participate in shared rooms hosted by the hub. |
+| **Spoke** | CLI + agents only. Points `server.api_url` at the hub backend. | Each teammate's laptop. Memory and participation go over HTTP `:8000`. |
 
-Stand a hub up and point spokes at it:
+Stand a hub up and point spokes at the **backend** (required):
 
 ```bash
-# On the hub: starts the SLIM node + backend, prints the connect address
+# On the hub: starts the SLIM node + backend
 mycelium hub host
+mycelium up
 
-# On each spoke: point this machine at the hub's channel
-mycelium hub connect http://<hub-ip>:46357
+# On each spoke: point at the hub's HTTP API
+mycelium config set server.api_url http://<hub-ip>:8000
 ```
 
-See the [Hub & Spoke Setup guide](#hub-and-spoke) for step-by-step
-instructions.
+Spokes do not need `MYCELIUM_SLIM_MASTER_SECRET` for the default path. The
+SLIM/MLS fabric is hub-side; spokes use `await`/`respond` over HTTP. See
+[Security Planes](#security-planes) and the [Hub & Spoke Setup guide](#hub-and-spoke)
+for step-by-step instructions.
 
 `mycelium doctor` auto-detects which mode you're in by looking at
 `server.api_url` in `~/.mycelium/config.toml`: if it points to
@@ -1090,13 +1093,13 @@ mycelium room clone my-project --from http://ec2-host:8000
 Mycelium runs on **one SLIM node** and a thin backend: no database, no
 message broker, no vector store.
 
-Agents coordinate over an [AGNTCY SLIM](https://github.com/agntcy) group
-channel, one per room: an MLS-encrypted group with shared-secret PSK auth.
-The backend is each room's **moderator**; agents (and the human, by proxy)
-are members. Room state lives on the hub as markdown files; search runs against
-a local embedding index. Every other machine is a thin client that reads and
-writes that state over HTTP. Coordination messages ride SLIM as additive
-[L9 envelopes](#l9-protocol).
+The hub backend moderates an [AGNTCY SLIM](https://github.com/agntcy) group
+channel per room (MLS-encrypted; PSK or SignerJwt/SPIRE on the **SLIM plane**).
+Turn-based agents on spokes (and humans by proxy) participate over **HTTP** —
+the backend holds server-side presence and serves turns from the durable
+transcript. Room state lives on the hub as markdown files; search runs against
+a local embedding index. Every spoke reads and writes that state over HTTP.
+Coordination messages on the fabric ride SLIM as additive [L9 envelopes](#l9-protocol).
 
 | Layer | Technology | Used for |
 |-------|-----------|----------|
@@ -1305,138 +1308,115 @@ Keys without a known category prefix skip validation entirely:
 # Hub & Spoke Setup
 
 Run Mycelium across two or more machines so a small team shares rooms,
-memory, and coordination over one SLIM node.
+memory, and coordination from one hub.
 
-Coordination rides an AGNTCY SLIM group channel, an MLS-encrypted messaging
-fabric. One machine is the **hub**: it runs the SLIM node plus the always-on
-backend that moderates each room. Every other machine is a **spoke** that
-points at the hub's node. There is no database and no separate channel server;
-the node is a blind ciphertext forwarder, so the hub never sees room contents
-in the clear.
+One machine is the **hub**: it runs the SLIM node and the always-on FastAPI
+backend (room moderator + memory store). Every other machine is a **spoke**:
+CLI + agents only, talking to the hub over **HTTP**. There is no database and
+no separate channel server.
+
+> **Two planes.** Spokes use the **HTTP API** (`:8000`) for memory and
+> participation. The **SLIM/MLS fabric** (`:46357`) is used by the hub backend
+> as moderator; spokes do not join it in the default path and do **not** need
+> `MYCELIUM_SLIM_MASTER_SECRET`. See [Security Planes](#security-planes).
 
 ## When to use this
 
 Use hub-and-spoke when people on different machines need to join the same
 rooms, see the same memories, and run negotiations together. If everything
-runs on one machine, the default single-device install already does this.
+runs on one machine, the default single-device install already does this;
+see the [Quick Start](#quickstart).
 
 ## Topology
 
 ```
-┌──────────────────────────────────┐
-│  Hub  (one machine)              │
-│                                  │
-│  mycelium install                │
-│  mycelium hub host  → SLIM :46357│
-│  mycelium up        → backend    │
-│  mycelium up --ui   → frontend   │
-└────────────┬─────────────────────┘
-             │  SLIM (MLS-encrypted)
-     ┌───────┴───────┐
-     │               │
-┌────┴─────┐   ┌─────┴────┐
-│ Spoke A  │   │ Spoke B  │
-│          │   │          │
-│ mycelium │   │ mycelium │
-│ connect  │   │ connect  │
-│ + agents │   │ + agents │
-└──────────┘   └──────────┘
+┌─────────────────────────────────────────────┐
+│  Hub  (one machine)                         │
+│                                             │
+│  mycelium install                           │
+│  mycelium hub host                          │
+│  ├─ SLIM node        :46357  (MLS fabric)   │
+│  └─ FastAPI backend  :8000  (HTTP API)     │
+│       moderator + memory store              │
+└──────────────────┬──────────────────────────┘
+                   │
+         HTTP :8000  (memory, await, respond)
+                   │
+     ┌─────────────┴─────────────┐
+     │                           │
+┌────┴──────┐              ┌─────┴─────┐
+│ Spoke A   │              │ Spoke B   │
+│ CLI       │              │ CLI       │
+│ + agents  │              │ + agents  │
+└───────────┘              └───────────┘
 ```
 
-Spokes run only the CLI and their agents. They connect to the hub's node
-address and coordinate over the shared channel.
+Spokes are **thin HTTP clients**. They keep no copy of room memory locally;
+every `memory`, `await`, and `respond` call goes to the hub API.
+
+The SLIM node on the hub forwards MLS **ciphertext** between native SLIM
+members. The backend moderator decrypts for the transcript, aligner, and
+memory — it is not a blind observer of room content.
 
 ## Step 1: Stand up the hub
 
-On the hub machine, install the stack:
+On the hub machine, install the stack and start the SLIM node:
 
 ```bash
 mycelium install
-```
-
-Start the SLIM node — this prints the address spokes connect to:
-
-```bash
 mycelium hub host
 ```
+
+`mycelium hub host` starts the `slim` node container and prints addresses:
 
 ```
 SLIM node running.
   local     → http://127.0.0.1:46357  (this machine, saved to config)
   for peers → http://192.168.1.20:46357
-
-  Peers connect with:  mycelium connect http://192.168.1.20:46357
 ```
 
-Note the `for peers` LAN address. Then bring up the backend (and optionally
-the frontend UI):
+Ensure the backend is up as well (`mycelium up` or the full install stack).
+
+Verify with:
 
 ```bash
-mycelium up          # backend only
-mycelium up --ui     # backend + frontend at http://hub-ip:3000
-```
-
-Verify everything is running:
-
-```bash
-mycelium status
 mycelium doctor
 ```
 
 `doctor` auto-detects hub vs spoke mode from `server.api_url` (a local
-backend means hub) and runs the checks that apply.
+backend means hub) and runs the checks that apply. Override with
+`--mode hub|spoke` if needed.
+
+### Hub-only: SLIM master secret
+
+The hub SLIM PSK lives in **`config.toml`**, not as a hand-edited `.env` entry.
+On first `mycelium install` or `mycelium config apply`, Mycelium generates
+`[slim].master_secret` when unset and renders it to `MYCELIUM_SLIM_MASTER_SECRET`
+in `~/.mycelium/.env` for the backend container.
+
+```bash
+mycelium config apply    # generates [slim].master_secret if missing
+mycelium config show     # SLIM PSK shown masked
+```
+
+To rotate:
+
+```bash
+mycelium config set slim.master_secret "$(openssl rand -hex 32)"
+mycelium config apply --restart
+```
+
+Spokes never need this value. Re-running `config apply` preserves the secret.
 
 ### Open ports
 
-Spokes need to reach the hub on:
+| Port  | Service        | Spokes need it? | Purpose |
+|-------|----------------|-----------------|---------|
+| **8000** | FastAPI backend | **Yes** | Memory, `await`/`respond`, room ops |
+| 46357 | SLIM node      | No (default)    | Native SLIM on hub; optional for `slim send` |
 
-| Port  | Service          | Required |
-|-------|------------------|----------|
-| 46357 | SLIM node        | Yes      |
-| 8000  | Backend HTTP API | Yes      |
-| 3000  | Frontend UI      | Optional |
-
-The SLIM node forwards only MLS ciphertext. Restrict access with a VPN,
-Tailscale, or firewall rules regardless — access to a channel is gated by
-its shared-secret PSK, but defence in depth applies.
-
-### Shared secret
-
-The per-channel MLS key is derived offline from
-`MYCELIUM_SLIM_MASTER_SECRET`. Every host that shares rooms must set the
-**same** value:
-
-```bash
-# On every host (hub and all spokes)
-export MYCELIUM_SLIM_MASTER_SECRET="your-private-secret-here"
-```
-
-Add it to `~/.mycelium/.env` or your system environment. The built-in dev
-default is public — anyone with the repo can derive it. Set your own value
-before any shared or internet-facing use.
-
-### Accessing the UI from a public IP or NAT
-
-If you run `mycelium up --ui` and access the frontend from a browser
-whose origin differs from `localhost` (common on cloud VMs accessed over
-a public IP), Next.js dev mode returns 403 on internal endpoints. Fix it
-by allowlisting the browser's origin:
-
-```bash
-mycelium config set runtime.allowed_dev_origins "203.0.113.42"
-mycelium config apply
-```
-
-`mycelium config apply` writes `MYCELIUM_ALLOWED_DEV_ORIGINS` to
-`~/.mycelium/.env`, which the frontend container reads. Comma-separate
-multiple origins:
-
-```bash
-mycelium config set runtime.allowed_dev_origins "203.0.113.42,10.0.0.5"
-```
-
-This is a dev-mode concern only. Production builds serve the browser from
-the same origin, so no allowlist is needed.
+Restrict `:8000` on the hub when the team shares a network. Enable the
+[HTTP JWT gate](#auth) — that is what protects spokes, not the SLIM PSK.
 
 ## Step 2: Connect each spoke
 
@@ -1446,29 +1426,44 @@ On each spoke, install the CLI:
 curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash
 ```
 
-Point it at the hub's SLIM node (the `for peers` line from Step 1) and at
-the hub's backend:
+Point the spoke at the **hub backend** (required):
+
+```bash
+mycelium config set server.api_url http://192.168.1.20:8000
+```
+
+Or during init:
+
+```bash
+mycelium init --api-url http://192.168.1.20:8000
+```
+
+**Optional:** store the hub's SLIM node address (only needed for native SLIM
+tooling such as `mycelium slim send`, not for normal participation):
 
 ```bash
 mycelium connect http://192.168.1.20:46357
-mycelium config set server.api_url http://192.168.1.20:8000
 ```
 
 Verify:
 
 ```bash
-mycelium status
 mycelium doctor
 ```
 
-The spoke reports backend connectivity and skips checks that only apply to
-a local backend.
+The spoke reports **spoke mode**, checks backend reachability and HTTP auth
+status, and skips hub-only checks (Docker, SLIM PSK).
+
+### Secure a shared hub
+
+When spokes reach the hub over a LAN or VPN, turn on HTTP authentication on
+the hub. See [Authentication](#auth). Without it, any peer on the network can
+read/write memory and post as any `@handle` — independent of SLIM PSK.
 
 ## Step 3: Use a room from a spoke
 
-There is one store: the hub's. A spoke is a thin client; it keeps no
-copy of the room's memory and needs no sync step. Create the room on the
-hub, then use it from anywhere.
+There is one store: the hub's. Create the room on the hub, then use it from
+anywhere.
 
 ```bash
 # On the hub
@@ -1482,158 +1477,189 @@ On a spoke, just make it the active room:
 mycelium room use portfolio
 ```
 
-Every memory command now resolves against the hub over HTTP:
+Every memory command resolves against the hub over HTTP:
 
 ```bash
-mycelium memory ls                       # the hub's memories
+mycelium memory ls
 mycelium memory get decisions/allocation
 mycelium memory set decisions/allocation "60/40 equities to bonds"
 mycelium memory search "what did we decide about risk"
 ```
 
-Because reads go to the hub, a spoke sees a write the moment it lands;
-there is no local copy to drift. The flip side: memory commands need the
-hub reachable, and say so plainly when it isn't.
+Because reads go to the hub, a spoke sees a write the moment it lands.
+Memory commands need the hub reachable and report plainly when it is not.
 
-> `mycelium room clone` pulls a point-in-time HTTP snapshot of a room's
-> memories to local files, useful for backups or offline reads. It is not
-> how agents join or stay in sync — that is the live SLIM channel.
+> `mycelium room clone` pulls a point-in-time snapshot to local files (backup
+> or offline read). It is not part of joining a room from a spoke.
 
 ## Step 4: Run a negotiation across machines
 
-Register the aligner once in the room:
+Register the [aligner](#aligner) once in the room, post opening positions,
+and loop on participation. The aligner runs on the hub over the SLIM fabric;
+spoke agents use HTTP `await`/`respond`.
 
 ```bash
 mycelium engine create aligner --kind aligner --room portfolio
 ```
 
-Each machine registers its agent:
+Each participant posts an opening position:
 
 ```bash
-# On hub
-mycelium agent create hub-agent --room portfolio
-
-# On spoke A
-mycelium agent create spoke-a --room portfolio
-
-# On spoke B
-mycelium agent create spoke-b --room portfolio
-```
-
-### Resident agent loops
-
-The recommended way to keep an agent awake across the whole negotiation is
-`await --loop --exec`. The command receives each turn's JSON on stdin and
-is expected to call `mycelium respond`:
-
-```bash
-# On each machine — using Pi as the agent brain
-mycelium await --loop --room portfolio --handle hub-agent \
-  --exec "env MYCELIUM_ROOM=portfolio MYCELIUM_HANDLE=hub-agent ./pi-driver.sh"
-```
-
-A minimal Pi driver (`pi-driver.sh`):
-
-```bash
-#!/usr/bin/env bash
-TURN=$(cat)
-PROMPT=$(echo "$TURN" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('content',''))")
-REPLY=$(pi --print --mode json --no-tools --no-session \
-    --model "your-provider/your-model" \
-    --api-key "$YOUR_API_KEY" \
-    "$PROMPT" 2>/dev/null | python3 -c "
-import sys, json
-for line in sys.stdin:
-    try:
-        d = json.loads(line)
-        if d.get('type') == 'message_update':
-            ev = d.get('assistantMessageEvent', {})
-            if ev.get('type') == 'text_end':
-                print(ev.get('content', ''))
-                exit(0)
-    except: pass
-")
-mycelium respond --room "\$MYCELIUM_ROOM" --handle "\$MYCELIUM_HANDLE" "\$REPLY"
-```
-
-### Manual participation
-
-For manual or scripted participation without a resident loop:
-
-```bash
-# Each participant posts an opening position
+# Spoke A's agent
 mycelium respond --room portfolio --handle alice "I want 60% equities."
+
+# Spoke B's agent
 mycelium respond --room portfolio --handle bob "No more than 40% equities."
 ```
 
-A human summons the aligner:
+Summon the aligner:
 
 ```bash
 mycelium engine invoke aligner "converge on the equities allocation"
 ```
 
-Each participant reads the aligner's prompt and replies:
+Each participant loops over HTTP (no SLIM socket on the spoke):
 
 ```bash
 mycelium await --room portfolio --handle alice --json
 mycelium respond --room portfolio --handle alice "accept 50%, meets my floor"
 ```
 
-### Outcome
-
-On agreement the aligner emits `commit:converged`, records the episode, and
-compiles the room's shared `plan/tasks.md`. Read it on any machine:
+On agreement the aligner compiles `plan/tasks.md`. Read it on any machine:
 
 ```bash
 mycelium plan tasks
 ```
 
-Agents work the `@handle` tasks assigned to them. The compiled plan syncs as
-a `knowledge` memory to every machine on the channel.
-
 ## Agent identity
 
-Each agent needs a unique handle across the whole deployment. The handle is
+Each agent needs a unique handle across the deployment. The handle is
 resolved from, in order:
 
 1. `identity.name` in `~/.mycelium/config.toml`
 2. The `MYCELIUM_AGENT_HANDLE` environment variable
 3. The `--handle` flag on `await` / `respond`
 
+On a shared hub with [auth enabled](#auth), the token — not the body alone —
+is the actor of record. Configure agent credentials for unattended spokes.
+
 ## Troubleshooting
 
-### Spoke can't reach the hub's SLIM node
+### Spoke can't reach the hub
 
-```bash
-curl http://192.168.1.20:46357
-```
-
-If this fails, check firewall rules, VPN connectivity, or security groups.
-The SLIM node binds inside Docker; the host firewall may block external
-access.
-
-### Spoke can't reach the backend
+Check the **backend** first (the path spokes actually use):
 
 ```bash
 curl http://192.168.1.20:8000/health
 ```
 
-Ensure port 8000 is open on the hub and `mycelium up` is running. Check
-`mycelium status` on the hub.
+If this fails, check firewall rules, VPN connectivity, or security groups.
+The backend must be reachable on port **8000**.
 
-### Invites silently fail / agents can't join channels
-
-The most common cause is a `MYCELIUM_SLIM_MASTER_SECRET` mismatch. Every
-host must use the **same** secret; a mismatch means channel keys don't
-agree and invites are silently dropped. Verify the value is identical on
-hub and all spokes, then restart the backend on the hub.
+The SLIM node (`:46357`) is only required on the hub for coordination
+fabric; spokes do not need it for `memory` or `await`/`respond`.
 
 ### `doctor` reports "spoke mode" unexpectedly
 
 `mycelium doctor` infers mode from `server.api_url`. If it points at a
 non-local address, doctor assumes spoke mode. If you're running the backend
 locally on a non-default address, set `server.api_url` to
-`http://localhost:8000`, or force the mode with `mycelium doctor --mode hub`.
+`http://localhost:8000` in `~/.mycelium/config.toml`, or force hub mode:
+
+```bash
+mycelium doctor --mode hub
+```
+
+See [Troubleshooting](#troubleshooting) for the full runbook and
+[Security Planes](#security-planes) for HTTP vs SLIM protection.
+
+
+---
+
+# Security Planes
+
+Mycelium has **two enforcement planes**. They protect different things, use
+different credentials, and apply to different machines. Conflating them is the
+most common hub-and-spoke misconfiguration.
+
+## The two planes
+
+| Plane | Port (default) | Who uses it | What it protects | Default | Upgrade |
+|-------|----------------|-------------|------------------|---------|---------|
+| **HTTP API** | 8000 | Spokes, humans, agents (`memory`, `await`, `respond`) | Memory, participation, handle attribution | Open (no token) | [Authentication](#auth) (`auth.enabled`) |
+| **SLIM / MLS** | 46357 | Hub backend (moderator); dev `slim send`; future native connectors | Native SLIM group membership on the coordination fabric | Shared-secret **PSK** (hub only) | [SignerJwt](#spire-identity) / [SPIRE](#spire-identity) |
+
+**Spokes do not use the SLIM plane for normal work.** A spoke is a thin HTTP
+client: it points `server.api_url` at the hub backend and never needs
+`MYCELIUM_SLIM_MASTER_SECRET`.
+
+The hub backend holds the room's SLIM/MLS session as **moderator**. Spoke agents
+participate over HTTP; the backend keeps them present via a **server-held lease**
+and delivers turns from the **durable transcript**. That path bypasses PSK
+entirely.
+
+## What PSK actually protects
+
+PSK (`MYCELIUM_SLIM_MASTER_SECRET` → HMAC per `workspace/room` →
+`create_app_with_secret`) is the **SLIM-plane room gate**:
+
+- It decides who may **authenticate as a SLIM app and join a room's MLS group**.
+- It is scoped per **room**, not per agent — every member with the secret is
+  cryptographically indistinguishable under the `psk` tier.
+- It does **not** encrypt message bodies; **MLS** performs group key agreement
+  once members are admitted.
+- It does **not** protect spokes, memory, or `@handle` impersonation over HTTP.
+
+With the public dev literal shipped in the repo, PSK protects nothing by itself.
+A fresh hub install generates a private `[slim].master_secret` in
+`config.toml` on first `mycelium config apply` (rendered to `.env` for Docker).
+Override with `mycelium config set slim.master_secret …` to rotate.
+
+## What protects spokes
+
+For hub-and-spoke, the urgent control is the **HTTP API gate**, not PSK:
+
+```bash
+mycelium config set auth.enabled true
+mycelium config set auth.audience mycelium
+# … configure [[auth.issuers]] …
+mycelium config apply
+```
+
+See [Authentication](#auth) for humans and agent service accounts.
+
+Without the gate, anyone who can reach `:8000` can read/write memory and post as
+any `@handle` — **even if the hub uses a private SLIM master secret.**
+
+## Deployment profiles
+
+| Profile | HTTP API | SLIM (hub) | Spoke config |
+|---------|----------|------------|--------------|
+| **Solo dev** | Open | Dev PSK literal (fallback if no config secret) | N/A (all-in-one) |
+| **LAN team** | JWT on | Auto-generated `[slim].master_secret` on hub | `server.api_url` → hub:8000 only |
+| **Hosted** | JWT required | Private hub secret + SignerJwt or SPIRE | Same; no master secret on spokes |
+
+`mycelium doctor` reports HTTP auth status from the hub's `/health` endpoint.
+In **hub** mode it also warns when `[slim].master_secret` is missing or still
+the public dev literal.
+
+## SLIM identity ladder (hub native clients)
+
+| Tier | Plane | Spoke needs it? |
+|------|-------|-----------------|
+| `psk` | SLIM | No (hub backend only today) |
+| `signerjwt` | SLIM | Only if the spoke runs a native SLIM connector |
+| `spire` | SLIM | Same |
+
+`mycelium config set slim.identity signerjwt` changes **SLIM channel identity** on
+machines that open native SLIM connections. It does **not** turn on HTTP API auth.
+Configure `[auth]` separately.
+
+## Related guides
+
+- [Hub & Spoke Setup](#hub-and-spoke) — topology and spoke checklist
+- [Authentication](#auth) — HTTP JWT gate (spokes and hub API)
+- [Attested Identity (SPIRE)](#spire-identity) — hardened SLIM plane
 
 
 ---
@@ -1643,6 +1669,10 @@ locally on a non-default address, set `server.api_url` to
 Mycelium's backend can require a signed **bearer token** on every HTTP API call,
 validated against an OIDC issuer you configure. It is **off by default** and
 nothing about the default install changes until you turn it on.
+
+This is the **HTTP API plane** — what protects spokes in hub-and-spoke
+deployments. It is separate from SLIM/MLS PSK or SignerJwt on the coordination
+fabric; see [Security Planes](#security-planes).
 
 ## Off by default, on purpose
 
@@ -2398,30 +2428,35 @@ mycelium init --api-url http://your-hub:8000
 
 ---
 
-### 4. SLIM Node Unreachable
+### 4. Spoke Can't Reach the Hub (or Backend Down)
 
-**Symptom**: agents join a room but never exchange anything; `mycelium await`
-hangs; `mycelium doctor` flags the backend or a spoke can't reach the hub.
+**Symptom**: `Cannot connect to Mycelium API`; memory/`await`/`respond` fail;
+`mycelium doctor` reports backend unreachable.
 
-Agents coordinate over a **SLIM group channel** served by the hub's SLIM node
-(default port **46357**). If that node is down or unreachable, no messages flow.
-
-```bash
-mycelium doctor                     # detects hub vs spoke, checks reachability
-docker ps | grep slim               # is the SLIM node up on the hub?
-mycelium hub host                   # (re)start the SLIM node and print its address
-```
-
-On a spoke, confirm it points at the right node and the port is open:
+Spokes talk to the hub over **HTTP** (`server.api_url`, default port **8000**).
+They do not need the SLIM node for normal participation.
 
 ```bash
-grep node_endpoint ~/.mycelium/config.toml
-curl http://<hub-ip>:46357            # raw reachability from the spoke
-mycelium connect http://<hub-ip>:46357  # re-point at the hub node
+mycelium doctor                     # detects hub vs spoke; checks /health
+curl http://<hub-ip>:8000/health    # from the spoke
+mycelium config get server.api_url    # should point at the hub backend
 ```
 
-Common causes: firewall/security group blocks 46357, VPN/Tailscale not
-connected, or a stale endpoint in `config.toml`.
+On the **hub**, ensure the backend and SLIM node are running:
+
+```bash
+mycelium up
+docker ps | grep mycelium
+mycelium hub host                   # (re)start the SLIM node if needed
+```
+
+If coordination still fails on the hub itself, check the SLIM node (port
+**46357**) — the backend moderator needs it. Spokes rarely need `:46357`
+unless you use native SLIM tooling (`mycelium slim send`).
+
+Common causes: firewall blocks **8000**, wrong `server.api_url`, VPN not
+connected, or auth enabled on the hub without `mycelium login` on the spoke.
+See [Security Planes](#security-planes) and [Authentication](#auth).
 
 ---
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -114,6 +114,7 @@
       <div class="nav-section-label">Guides</div>
       <a href="#structured-memory" class="nav-link sub">Structured Memory</a>
       <a href="#hub-and-spoke" class="nav-link sub">Hub &amp; Spoke</a>
+      <a href="#security-planes" class="nav-link sub">Security Planes</a>
       <a href="#auth" class="nav-link sub">Authentication</a>
       <a href="#keycloak-oidc" class="nav-link sub">Keycloak / OIDC Setup</a>
       <a href="#spire-identity" class="nav-link sub">Attested Identity (SPIRE)</a>
@@ -136,7 +137,7 @@
       <p>Everything (the backend, the SLIM node, agents, and CLI) runs on one machine, typically a developer&#x27;s laptop. This is what <code>mycelium install</code> sets up out of the box. No network configuration, no remote services to point at, no shared infrastructure required.</p>
       <p>This is the primary deployment target. Use it when one person (or one machine) owns the whole agent workflow.</p>
       <h3 id="architecture-2-hub-and-spoke-small-teams">2. Hub-and-spoke (small teams)</h3>
-      <p>A second, optional mode for small teams that want to share memory, rooms, and coordination across machines. One machine runs the SLIM node and backend (the <strong>hub</strong>); other machines run only the CLI + agents (<strong>spokes</strong>) and connect to the hub&#x27;s channel.</p>
+      <p>A second, optional mode for small teams that want to share memory, rooms, and coordination across machines. One machine runs the SLIM node and backend (the <strong>hub</strong>); other machines run only the CLI + agents (<strong>spokes</strong>) as <strong>thin HTTP clients</strong> to the hub API.</p>
       <div class="table-wrap">
         <table>
           <thead>
@@ -154,19 +155,20 @@
             </tr>
             <tr>
               <td><strong>Spoke</strong></td>
-              <td>CLI + agents only. Points at the hub&#x27;s SLIM address.</td>
-              <td>Each teammate&#x27;s laptop. Agents on the spoke participate in shared rooms hosted by the hub.</td>
+              <td>CLI + agents only. Points <code>server.api_url</code> at the hub backend.</td>
+              <td>Each teammate&#x27;s laptop. Memory and participation go over HTTP <code>:8000</code>.</td>
             </tr>
           </tbody>
         </table>
       </div>
-      <p>Stand a hub up and point spokes at it:</p>
-      <pre><code><span class="comment"># On the hub: starts the SLIM node + backend, prints the connect address</span>
+      <p>Stand a hub up and point spokes at the <strong>backend</strong> (required):</p>
+      <pre><code><span class="comment"># On the hub: starts the SLIM node + backend</span>
 <span class="bin">mycelium</span> <span class="cmd">hub</span> <span class="cmd">host</span>
+<span class="bin">mycelium</span> <span class="cmd">up</span>
 
-<span class="comment"># On each spoke: point this machine at the hub&#x27;s channel</span>
-<span class="bin">mycelium</span> <span class="cmd">hub</span> <span class="cmd">connect</span> http://&lt;hub-ip&gt;:46357</code></pre>
-      <p>See the <a href="#hub-and-spoke">Hub &amp; Spoke Setup guide</a> for step-by-step instructions.</p>
+<span class="comment"># On each spoke: point at the hub&#x27;s HTTP API</span>
+<span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> server.api_url http://&lt;hub-ip&gt;:8000</code></pre>
+      <p>Spokes do not need <code>MYCELIUM_SLIM_MASTER_SECRET</code> for the default path. The SLIM/MLS fabric is hub-side; spokes use <code>await</code>/<code>respond</code> over HTTP. See <a href="#security-planes">Security Planes</a> and the <a href="#hub-and-spoke">Hub &amp; Spoke Setup guide</a> for step-by-step instructions.</p>
       <p><code>mycelium doctor</code> auto-detects which mode you&#x27;re in by looking at <code>server.api_url</code> in <code>~/.mycelium/config.toml</code>: if it points to <code>localhost</code>/<code>127.0.0.1</code>, you&#x27;re a hub; otherwise a spoke. Override the auto-detection with:</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">doctor</span> <span class="flag">--mode</span> hub     # force hub checks
 <span class="bin">mycelium</span> <span class="cmd">doctor</span> <span class="flag">--mode</span> spoke   # force spoke checks (skip local-only)
@@ -178,7 +180,7 @@
 <span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">clone</span> my-project <span class="flag">--from</span> <span class="url">http://ec2-host:8000</span></code></pre>
       <h2 id="architecture-stack">Stack</h2>
       <p>Mycelium runs on <strong>one SLIM node</strong> and a thin backend: no database, no message broker, no vector store.</p>
-      <p>Agents coordinate over an <a href="https://github.com/agntcy">AGNTCY SLIM</a> group channel, one per room: an MLS-encrypted group with shared-secret PSK auth. The backend is each room&#x27;s <strong>moderator</strong>; agents (and the human, by proxy) are members. Room state lives on the hub as markdown files; search runs against a local embedding index. Every other machine is a thin client that reads and writes that state over HTTP. Coordination messages ride SLIM as additive <a href="#l9-protocol">L9 envelopes</a>.</p>
+      <p>The hub backend moderates an <a href="https://github.com/agntcy">AGNTCY SLIM</a> group channel per room (MLS-encrypted; PSK or SignerJwt/SPIRE on the <strong>SLIM plane</strong>). Turn-based agents on spokes (and humans by proxy) participate over <strong>HTTP</strong> — the backend holds server-side presence and serves turns from the durable transcript. Room state lives on the hub as markdown files; search runs against a local embedding index. Every spoke reads and writes that state over HTTP. Coordination messages on the fabric ride SLIM as additive <a href="#l9-protocol">L9 envelopes</a>.</p>
       <div class="table-wrap">
         <table>
           <thead>
@@ -893,6 +895,9 @@
 <span class="comment"># SLIM channel identity tier: &#x27;psk&#x27; (default, off-by-default #567) is the shared-secret credential every room member derives (zero infra, no per-agent identity). &#x27;signerjwt&#x27; opts into the SignerJwt floor (#476): each member presents a per-agent self-signed ES256 identity so members are cryptographically distinct, individually revocable MLS participants. &#x27;spire&#x27; opts into SPIRE/SPIFFE (#579): each member presents a SPIRE-attested JWT-SVID from the Workload API (tightest attestation, heaviest deploy: a co-located SPIRE server + node daemon, brought up automatically by &#x27;mycelium up&#x27; via the shipped &#x27;spire&#x27; compose profile; #588. Selecting &#x27;signerjwt&#x27;/&#x27;spire&#x27; with no resolvable material degrades to &#x27;psk&#x27; unless MYCELIUM_SLIM_IDENTITY_REQUIRE=1 fails closed.</span>
 <span class="arg">identity</span> = <span class="str">&quot;psk&quot;</span>
 
+<span class="comment"># Hub-only SLIM PSK master secret. Auto-generated on first ``mycelium config apply`` / install when unset; rendered to ``MYCELIUM_SLIM_MASTER_SECRET`` in ~/.mycelium/.env for the backend container. Spokes do not need this. Override with ``mycelium config set slim.master_secret …`` to rotate.</span>
+<span class="arg">master_secret</span> = <span class="str">&quot;&quot;</span>
+
 <span class="comment"># First-party Cognition Engine runtime configuration.</span>
 <span class="cmd" id="config-engine">[engine]</span>
 
@@ -1168,186 +1173,278 @@ procedures/  Reusable how-to steps (do this again later)</code></pre>
 
     <section class="doc-section" id="hub-and-spoke">
       <h1>Hub &amp; Spoke Setup</h1>
-      <p>Run Mycelium across two or more machines so a small team shares rooms, memory, and coordination over one SLIM node.</p>
-      <p>Coordination rides an AGNTCY SLIM group channel, an MLS-encrypted messaging fabric. One machine is the <strong>hub</strong>: it runs the SLIM node plus the always-on backend that moderates each room. Every other machine is a <strong>spoke</strong> that points at the hub&#x27;s node. There is no database and no separate channel server; the node is a blind ciphertext forwarder, so the hub never sees room contents in the clear.</p>
+      <p>Run Mycelium across two or more machines so a small team shares rooms, memory, and coordination from one hub.</p>
+      <p>One machine is the <strong>hub</strong>: it runs the SLIM node and the always-on FastAPI backend (room moderator + memory store). Every other machine is a <strong>spoke</strong>: CLI + agents only, talking to the hub over <strong>HTTP</strong>. There is no database and no separate channel server.</p>
+      <div class="callout callout-note">
+        <div class="callout-bar"></div>
+        <div class="callout-body"><strong>Two planes.</strong> Spokes use the <strong>HTTP API</strong> (<code>:8000</code>) for memory and participation. The <strong>SLIM/MLS fabric</strong> (<code>:46357</code>) is used by the hub backend as moderator; spokes do not join it in the default path and do <strong>not</strong> need <code>MYCELIUM_SLIM_MASTER_SECRET</code>. See <a href="#security-planes">Security Planes</a>.</div>
+      </div>
       <h2 id="hub-and-spoke-when-to-use-this">When to use this</h2>
-      <p>Use hub-and-spoke when people on different machines need to join the same rooms, see the same memories, and run negotiations together. If everything runs on one machine, the default single-device install already does this.</p>
+      <p>Use hub-and-spoke when people on different machines need to join the same rooms, see the same memories, and run negotiations together. If everything runs on one machine, the default single-device install already does this; see the <a href="#quickstart">Quick Start</a>.</p>
       <h2 id="hub-and-spoke-topology">Topology</h2>
-      <pre><code>┌──────────────────────────────────┐
-│  Hub  (one machine)              │
-│                                  │
-│  <span class="bin">mycelium</span> <span class="cmd">install</span>                │
-│  <span class="bin">mycelium</span> <span class="cmd">hub</span> <span class="cmd">host</span>  → SLIM :46357│
-│  <span class="bin">mycelium</span> <span class="cmd">up</span>        → backend    │
-│  <span class="bin">mycelium</span> <span class="cmd">up</span> <span class="flag">--ui</span>   → frontend   │
-└────────────┬─────────────────────┘
-             │  SLIM (MLS-encrypted)
-     ┌───────┴───────┐
-     │               │
-┌────┴─────┐   ┌─────┴────┐
-│ Spoke A  │   │ Spoke B  │
-│          │   │          │
-│ <span class="bin">mycelium</span> │   │ <span class="bin">mycelium</span> │
-│ connect  │   │ connect  │
-│ + agents │   │ + agents │
-└──────────┘   └──────────┘</code></pre>
-      <p>Spokes run only the CLI and their agents. They connect to the hub&#x27;s node address and coordinate over the shared channel.</p>
+      <pre><code>┌─────────────────────────────────────────────┐
+│  Hub  (one machine)                         │
+│                                             │
+│  <span class="bin">mycelium</span> <span class="cmd">install</span>                           │
+│  <span class="bin">mycelium</span> <span class="cmd">hub</span> <span class="cmd">host</span>                          │
+│  ├─ SLIM node        :46357  (MLS fabric)   │
+│  └─ FastAPI backend  :8000  (HTTP API)     │
+│       moderator + memory store              │
+└──────────────────┬──────────────────────────┘
+                   │
+         HTTP :8000  (memory, await, respond)
+                   │
+     ┌─────────────┴─────────────┐
+     │                           │
+┌────┴──────┐              ┌─────┴─────┐
+│ Spoke A   │              │ Spoke B   │
+│ CLI       │              │ CLI       │
+│ + agents  │              │ + agents  │
+└───────────┘              └───────────┘</code></pre>
+      <p>Spokes are <strong>thin HTTP clients</strong>. They keep no copy of room memory locally; every <code>memory</code>, <code>await</code>, and <code>respond</code> call goes to the hub API.</p>
+      <p>The SLIM node on the hub forwards MLS <strong>ciphertext</strong> between native SLIM members. The backend moderator decrypts for the transcript, aligner, and memory — it is not a blind observer of room content.</p>
       <h2 id="hub-and-spoke-step-1-stand-up-the-hub">Step 1: Stand up the hub</h2>
-      <p>On the hub machine, install the stack:</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">install</span></code></pre>
-      <p>Start the SLIM node — this prints the address spokes connect to:</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">hub</span> <span class="cmd">host</span></code></pre>
+      <p>On the hub machine, install the stack and start the SLIM node:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">install</span>
+<span class="bin">mycelium</span> <span class="cmd">hub</span> <span class="cmd">host</span></code></pre>
+      <p><code>mycelium hub host</code> starts the <code>slim</code> node container and prints addresses:</p>
       <pre><code>SLIM node running.
   local     → <span class="url">http://127.0.0.1:46357</span>  (this machine, saved to config)
-  for peers → <span class="url">http://192.168.1.20:46357</span>
-
-  Peers connect with:  <span class="bin">mycelium</span> <span class="cmd">connect</span> <span class="url">http://192.168.1.20:46357</span></code></pre>
-      <p>Note the <code>for peers</code> LAN address. Then bring up the backend (and optionally the frontend UI):</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">up</span>          # backend only
-<span class="bin">mycelium</span> <span class="cmd">up</span> <span class="flag">--ui</span>     # backend + frontend at <span class="url">http://hub-ip:3000</span></code></pre>
-      <p>Verify everything is running:</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">status</span>
-<span class="bin">mycelium</span> <span class="cmd">doctor</span></code></pre>
-      <p><code>doctor</code> auto-detects hub vs spoke mode from <code>server.api_url</code> (a local backend means hub) and runs the checks that apply.</p>
+  for peers → <span class="url">http://192.168.1.20:46357</span></code></pre>
+      <p>Ensure the backend is up as well (<code>mycelium up</code> or the full install stack).</p>
+      <p>Verify with:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">doctor</span></code></pre>
+      <p><code>doctor</code> auto-detects hub vs spoke mode from <code>server.api_url</code> (a local backend means hub) and runs the checks that apply. Override with <code>--mode hub|spoke</code> if needed.</p>
+      <h3 id="hub-and-spoke-hub-only-slim-master-secret">Hub-only: SLIM master secret</h3>
+      <p>The hub SLIM PSK lives in <strong><code>config.toml</code></strong>, not as a hand-edited <code>.env</code> entry. On first <code>mycelium install</code> or <code>mycelium config apply</code>, Mycelium generates <code>[slim].master_secret</code> when unset and renders it to <code>MYCELIUM_SLIM_MASTER_SECRET</code> in <code>~/.mycelium/.env</code> for the backend container.</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">apply</span>    # generates [slim].master_secret if missing
+<span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">show</span>     # SLIM PSK shown masked</code></pre>
+      <p>To rotate:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> slim.master_secret <span class="str">&quot;$(openssl rand <span class="flag">-hex</span> 32)&quot;</span>
+<span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">apply</span> <span class="flag">--restart</span></code></pre>
+      <p>Spokes never need this value. Re-running <code>config apply</code> preserves the secret.</p>
       <h3 id="hub-and-spoke-open-ports">Open ports</h3>
-      <p>Spokes need to reach the hub on:</p>
       <div class="table-wrap">
         <table>
           <thead>
             <tr>
               <th>Port</th>
               <th>Service</th>
-              <th>Required</th>
+              <th>Spokes need it?</th>
+              <th>Purpose</th>
             </tr>
           </thead>
           <tbody>
             <tr>
+              <td><strong>8000</strong></td>
+              <td>FastAPI backend</td>
+              <td><strong>Yes</strong></td>
+              <td>Memory, <code>await</code>/<code>respond</code>, room ops</td>
+            </tr>
+            <tr>
               <td>46357</td>
               <td>SLIM node</td>
-              <td>Yes</td>
-            </tr>
-            <tr>
-              <td>8000</td>
-              <td>Backend HTTP API</td>
-              <td>Yes</td>
-            </tr>
-            <tr>
-              <td>3000</td>
-              <td>Frontend UI</td>
-              <td>Optional</td>
+              <td>No (default)</td>
+              <td>Native SLIM on hub; optional for <code>slim send</code></td>
             </tr>
           </tbody>
         </table>
       </div>
-      <p>The SLIM node forwards only MLS ciphertext. Restrict access with a VPN, Tailscale, or firewall rules regardless — access to a channel is gated by its shared-secret PSK, but defence in depth applies.</p>
-      <h3 id="hub-and-spoke-shared-secret">Shared secret</h3>
-      <p>The per-channel MLS key is derived offline from <code>MYCELIUM_SLIM_MASTER_SECRET</code>. Every host that shares rooms must set the <strong>same</strong> value:</p>
-      <pre><code><span class="comment"># On every host (hub and all spokes)</span>
-export MYCELIUM_SLIM_MASTER_SECRET=<span class="str">&quot;your-private-secret-here&quot;</span></code></pre>
-      <p>Add it to <code>~/.mycelium/.env</code> or your system environment. The built-in dev default is public — anyone with the repo can derive it. Set your own value before any shared or internet-facing use.</p>
-      <h3 id="hub-and-spoke-accessing-the-ui-from-a-public-ip-or-nat">Accessing the UI from a public IP or NAT</h3>
-      <p>If you run <code>mycelium up --ui</code> and access the frontend from a browser whose origin differs from <code>localhost</code> (common on cloud VMs accessed over a public IP), Next.js dev mode returns 403 on internal endpoints. Fix it by allowlisting the browser&#x27;s origin:</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> runtime.allowed_dev_origins <span class="str">&quot;203.0.113.42&quot;</span>
-<span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">apply</span></code></pre>
-      <p><code>mycelium config apply</code> writes <code>MYCELIUM_ALLOWED_DEV_ORIGINS</code> to <code>~/.mycelium/.env</code>, which the frontend container reads. Comma-separate multiple origins:</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> runtime.allowed_dev_origins <span class="str">&quot;203.0.113.42,10.0.0.5&quot;</span></code></pre>
-      <p>This is a dev-mode concern only. Production builds serve the browser from the same origin, so no allowlist is needed.</p>
+      <p>Restrict <code>:8000</code> on the hub when the team shares a network. Enable the <a href="#auth">HTTP JWT gate</a> — that is what protects spokes, not the SLIM PSK.</p>
       <h2 id="hub-and-spoke-step-2-connect-each-spoke">Step 2: Connect each spoke</h2>
       <p>On each spoke, install the CLI:</p>
       <pre><code><span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="url">https://mycelium-io.github.io/mycelium/install.sh</span> | bash</code></pre>
-      <p>Point it at the hub&#x27;s SLIM node (the <code>for peers</code> line from Step 1) and at the hub&#x27;s backend:</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">connect</span> <span class="url">http://192.168.1.20:46357</span>
-<span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> server.api_url <span class="url">http://192.168.1.20:8000</span></code></pre>
+      <p>Point the spoke at the <strong>hub backend</strong> (required):</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> server.api_url <span class="url">http://192.168.1.20:8000</span></code></pre>
+      <p>Or during init:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">init</span> <span class="flag">--api-url</span> <span class="url">http://192.168.1.20:8000</span></code></pre>
+      <p><strong>Optional:</strong> store the hub&#x27;s SLIM node address (only needed for native SLIM tooling such as <code>mycelium slim send</code>, not for normal participation):</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">connect</span> <span class="url">http://192.168.1.20:46357</span></code></pre>
       <p>Verify:</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">status</span>
-<span class="bin">mycelium</span> <span class="cmd">doctor</span></code></pre>
-      <p>The spoke reports backend connectivity and skips checks that only apply to a local backend.</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">doctor</span></code></pre>
+      <p>The spoke reports <strong>spoke mode</strong>, checks backend reachability and HTTP auth status, and skips hub-only checks (Docker, SLIM PSK).</p>
+      <h3 id="hub-and-spoke-secure-a-shared-hub">Secure a shared hub</h3>
+      <p>When spokes reach the hub over a LAN or VPN, turn on HTTP authentication on the hub. See <a href="#auth">Authentication</a>. Without it, any peer on the network can read/write memory and post as any <code>@handle</code> — independent of SLIM PSK.</p>
       <h2 id="hub-and-spoke-step-3-use-a-room-from-a-spoke">Step 3: Use a room from a spoke</h2>
-      <p>There is one store: the hub&#x27;s. A spoke is a thin client; it keeps no copy of the room&#x27;s memory and needs no sync step. Create the room on the hub, then use it from anywhere.</p>
+      <p>There is one store: the hub&#x27;s. Create the room on the hub, then use it from anywhere.</p>
       <pre><code><span class="comment"># On the hub</span>
 <span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">create</span> portfolio
 <span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">use</span> portfolio</code></pre>
       <p>On a spoke, just make it the active room:</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">use</span> portfolio</code></pre>
-      <p>Every memory command now resolves against the hub over HTTP:</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">ls</span>                       # the hub&#x27;s memories
+      <p>Every memory command resolves against the hub over HTTP:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">ls</span>
 <span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">get</span> decisions/allocation
 <span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">set</span> decisions/allocation <span class="str">&quot;60/40 equities to bonds&quot;</span>
 <span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">search</span> <span class="str">&quot;what did we decide about risk&quot;</span></code></pre>
-      <p>Because reads go to the hub, a spoke sees a write the moment it lands; there is no local copy to drift. The flip side: memory commands need the hub reachable, and say so plainly when it isn&#x27;t.</p>
+      <p>Because reads go to the hub, a spoke sees a write the moment it lands. Memory commands need the hub reachable and report plainly when it is not.</p>
       <div class="callout callout-note">
         <div class="callout-bar"></div>
-        <div class="callout-body"><code>mycelium room clone</code> pulls a point-in-time HTTP snapshot of a room&#x27;s memories to local files, useful for backups or offline reads. It is not how agents join or stay in sync — that is the live SLIM channel.</div>
+        <div class="callout-body"><code>mycelium room clone</code> pulls a point-in-time snapshot to local files (backup or offline read). It is not part of joining a room from a spoke.</div>
       </div>
       <h2 id="hub-and-spoke-step-4-run-a-negotiation-across-machines">Step 4: Run a negotiation across machines</h2>
-      <p>Register the aligner once in the room:</p>
+      <p>Register the <a href="#aligner">aligner</a> once in the room, post opening positions, and loop on participation. The aligner runs on the hub over the SLIM fabric; spoke agents use HTTP <code>await</code>/<code>respond</code>.</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">engine</span> <span class="cmd">create</span> aligner <span class="flag">--kind</span> aligner <span class="flag">--room</span> portfolio</code></pre>
-      <p>Each machine registers its agent:</p>
-      <pre><code><span class="comment"># On hub</span>
-<span class="bin">mycelium</span> <span class="cmd">agent</span> <span class="cmd">create</span> hub-agent <span class="flag">--room</span> portfolio
-
-<span class="comment"># On spoke A</span>
-<span class="bin">mycelium</span> <span class="cmd">agent</span> <span class="cmd">create</span> spoke-a <span class="flag">--room</span> portfolio
-
-<span class="comment"># On spoke B</span>
-<span class="bin">mycelium</span> <span class="cmd">agent</span> <span class="cmd">create</span> spoke-b <span class="flag">--room</span> portfolio</code></pre>
-      <h3 id="hub-and-spoke-resident-agent-loops">Resident agent loops</h3>
-      <p>The recommended way to keep an agent awake across the whole negotiation is <code>await --loop --exec</code>. The command receives each turn&#x27;s JSON on stdin and is expected to call <code>mycelium respond</code>:</p>
-      <pre><code><span class="comment"># On each machine — using Pi as the agent brain</span>
-<span class="bin">mycelium</span> <span class="cmd">await</span> <span class="flag">--loop</span> <span class="flag">--room</span> portfolio <span class="flag">--handle</span> hub-agent \
-  <span class="flag">--exec</span> <span class="str">&quot;env MYCELIUM_ROOM=portfolio MYCELIUM_HANDLE=hub-agent ./pi-driver.sh&quot;</span></code></pre>
-      <p>A minimal Pi driver (<code>pi-driver.sh</code>):</p>
-      <pre><code><span class="comment">#!/usr/bin/env bash</span>
-TURN=$(cat)
-PROMPT=$(echo <span class="str">&quot;$TURN&quot;</span> | python3 <span class="flag">-c</span> &quot;import sys,json; d=json.load(sys.stdin); print(d.get(&#x27;content&#x27;,&#x27;&#x27;))&quot;)
-REPLY=$(pi <span class="flag">--print</span> <span class="flag">--mode</span> json <span class="flag">--no-tools</span> <span class="flag">--no-session</span> \
-    <span class="flag">--model</span> <span class="str">&quot;your-provider/your-model&quot;</span> \
-    <span class="flag">--api-key</span> <span class="str">&quot;$YOUR_API_KEY&quot;</span> \
-    <span class="str">&quot;$PROMPT&quot;</span> 2&gt;/dev/null | python3 <span class="flag">-c</span> &quot;
-import sys, json
-for line in sys.stdin:
-    try:
-        d = json.loads(line)
-        if d.get(&#x27;type&#x27;) == &#x27;message_update&#x27;:
-            ev = d.get(&#x27;assistantMessageEvent&#x27;, {})
-            if ev.get(&#x27;type&#x27;) == &#x27;text_end&#x27;:
-                print(ev.get(&#x27;content&#x27;, &#x27;&#x27;))
-                exit(0)
-    except: pass
-&quot;)
-<span class="bin">mycelium</span> <span class="cmd">respond</span> <span class="flag">--room</span> <span class="str">&quot;\$MYCELIUM_ROOM&quot;</span> <span class="flag">--handle</span> <span class="str">&quot;\$MYCELIUM_HANDLE&quot;</span> <span class="str">&quot;\$REPLY&quot;</span></code></pre>
-      <h3 id="hub-and-spoke-manual-participation">Manual participation</h3>
-      <p>For manual or scripted participation without a resident loop:</p>
-      <pre><code><span class="comment"># Each participant posts an opening position</span>
+      <p>Each participant posts an opening position:</p>
+      <pre><code><span class="comment"># Spoke A&#x27;s agent</span>
 <span class="bin">mycelium</span> <span class="cmd">respond</span> <span class="flag">--room</span> portfolio <span class="flag">--handle</span> alice <span class="str">&quot;I want 60% equities.&quot;</span>
+
+<span class="comment"># Spoke B&#x27;s agent</span>
 <span class="bin">mycelium</span> <span class="cmd">respond</span> <span class="flag">--room</span> portfolio <span class="flag">--handle</span> bob <span class="str">&quot;No more than 40% equities.&quot;</span></code></pre>
-      <p>A human summons the aligner:</p>
+      <p>Summon the aligner:</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">engine</span> <span class="cmd">invoke</span> aligner <span class="str">&quot;converge on the equities allocation&quot;</span></code></pre>
-      <p>Each participant reads the aligner&#x27;s prompt and replies:</p>
+      <p>Each participant loops over HTTP (no SLIM socket on the spoke):</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">await</span> <span class="flag">--room</span> portfolio <span class="flag">--handle</span> alice <span class="flag">--json</span>
 <span class="bin">mycelium</span> <span class="cmd">respond</span> <span class="flag">--room</span> portfolio <span class="flag">--handle</span> alice <span class="str">&quot;accept 50%, meets my floor&quot;</span></code></pre>
-      <h3 id="hub-and-spoke-outcome">Outcome</h3>
-      <p>On agreement the aligner emits <code>commit:converged</code>, records the episode, and compiles the room&#x27;s shared <code>plan/tasks.md</code>. Read it on any machine:</p>
+      <p>On agreement the aligner compiles <code>plan/tasks.md</code>. Read it on any machine:</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">plan</span> <span class="cmd">tasks</span></code></pre>
-      <p>Agents work the <code>@handle</code> tasks assigned to them. The compiled plan syncs as a <code>knowledge</code> memory to every machine on the channel.</p>
       <h2 id="hub-and-spoke-agent-identity">Agent identity</h2>
-      <p>Each agent needs a unique handle across the whole deployment. The handle is resolved from, in order:</p>
+      <p>Each agent needs a unique handle across the deployment. The handle is resolved from, in order:</p>
       <ol class="steps">
         <li><code>identity.name</code> in <code>~/.mycelium/config.toml</code></li>
         <li>The <code>MYCELIUM_AGENT_HANDLE</code> environment variable</li>
         <li>The <code>--handle</code> flag on <code>await</code> / <code>respond</code></li>
       </ol>
+      <p>On a shared hub with <a href="#auth">auth enabled</a>, the token — not the body alone — is the actor of record. Configure agent credentials for unattended spokes.</p>
       <h2 id="hub-and-spoke-troubleshooting">Troubleshooting</h2>
-      <h3 id="hub-and-spoke-spoke-cant-reach-the-hubs-slim-node">Spoke can&#x27;t reach the hub&#x27;s SLIM node</h3>
-      <pre><code><span class="cmd">curl</span> <span class="url">http://192.168.1.20:46357</span></code></pre>
-      <p>If this fails, check firewall rules, VPN connectivity, or security groups. The SLIM node binds inside Docker; the host firewall may block external access.</p>
-      <h3 id="hub-and-spoke-spoke-cant-reach-the-backend">Spoke can&#x27;t reach the backend</h3>
+      <h3 id="hub-and-spoke-spoke-cant-reach-the-hub">Spoke can&#x27;t reach the hub</h3>
+      <p>Check the <strong>backend</strong> first (the path spokes actually use):</p>
       <pre><code><span class="cmd">curl</span> <span class="url">http://192.168.1.20:8000/health</span></code></pre>
-      <p>Ensure port 8000 is open on the hub and <code>mycelium up</code> is running. Check <code>mycelium status</code> on the hub.</p>
-      <h3 id="hub-and-spoke-invites-silently-fail-agents-cant-join-channels">Invites silently fail / agents can&#x27;t join channels</h3>
-      <p>The most common cause is a <code>MYCELIUM_SLIM_MASTER_SECRET</code> mismatch. Every host must use the <strong>same</strong> secret; a mismatch means channel keys don&#x27;t agree and invites are silently dropped. Verify the value is identical on hub and all spokes, then restart the backend on the hub.</p>
+      <p>If this fails, check firewall rules, VPN connectivity, or security groups. The backend must be reachable on port <strong>8000</strong>.</p>
+      <p>The SLIM node (<code>:46357</code>) is only required on the hub for coordination fabric; spokes do not need it for <code>memory</code> or <code>await</code>/<code>respond</code>.</p>
       <h3 id="hub-and-spoke-doctor-reports-spoke-mode-unexpectedly"><code>doctor</code> reports &quot;spoke mode&quot; unexpectedly</h3>
-      <p><code>mycelium doctor</code> infers mode from <code>server.api_url</code>. If it points at a non-local address, doctor assumes spoke mode. If you&#x27;re running the backend locally on a non-default address, set <code>server.api_url</code> to <code>http://localhost:8000</code>, or force the mode with <code>mycelium doctor --mode hub</code>.</p>
+      <p><code>mycelium doctor</code> infers mode from <code>server.api_url</code>. If it points at a non-local address, doctor assumes spoke mode. If you&#x27;re running the backend locally on a non-default address, set <code>server.api_url</code> to <code>http://localhost:8000</code> in <code>~/.mycelium/config.toml</code>, or force hub mode:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">doctor</span> <span class="flag">--mode</span> hub</code></pre>
+      <p>See <a href="#troubleshooting">Troubleshooting</a> for the full runbook and <a href="#security-planes">Security Planes</a> for HTTP vs SLIM protection.</p>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="security-planes">
+      <h1>Security Planes</h1>
+      <p>Mycelium has <strong>two enforcement planes</strong>. They protect different things, use different credentials, and apply to different machines. Conflating them is the most common hub-and-spoke misconfiguration.</p>
+      <h2 id="security-planes-the-two-planes">The two planes</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Plane</th>
+              <th>Port (default)</th>
+              <th>Who uses it</th>
+              <th>What it protects</th>
+              <th>Default</th>
+              <th>Upgrade</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>HTTP API</strong></td>
+              <td>8000</td>
+              <td>Spokes, humans, agents (<code>memory</code>, <code>await</code>, <code>respond</code>)</td>
+              <td>Memory, participation, handle attribution</td>
+              <td>Open (no token)</td>
+              <td><a href="#auth">Authentication</a> (<code>auth.enabled</code>)</td>
+            </tr>
+            <tr>
+              <td><strong>SLIM / MLS</strong></td>
+              <td>46357</td>
+              <td>Hub backend (moderator); dev <code>slim send</code>; future native connectors</td>
+              <td>Native SLIM group membership on the coordination fabric</td>
+              <td>Shared-secret <strong>PSK</strong> (hub only)</td>
+              <td><a href="#spire-identity">SignerJwt</a> / <a href="#spire-identity">SPIRE</a></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p><strong>Spokes do not use the SLIM plane for normal work.</strong> A spoke is a thin HTTP client: it points <code>server.api_url</code> at the hub backend and never needs <code>MYCELIUM_SLIM_MASTER_SECRET</code>.</p>
+      <p>The hub backend holds the room&#x27;s SLIM/MLS session as <strong>moderator</strong>. Spoke agents participate over HTTP; the backend keeps them present via a <strong>server-held lease</strong> and delivers turns from the <strong>durable transcript</strong>. That path bypasses PSK entirely.</p>
+      <h2 id="security-planes-what-psk-actually-protects">What PSK actually protects</h2>
+      <p>PSK (<code>MYCELIUM_SLIM_MASTER_SECRET</code> → HMAC per <code>workspace/room</code> → <code>create_app_with_secret</code>) is the <strong>SLIM-plane room gate</strong>:</p>
+      <ul>
+        <li>It decides who may <strong>authenticate as a SLIM app and join a room&#x27;s MLS group</strong>.</li>
+        <li>It is scoped per <strong>room</strong>, not per agent — every member with the secret is cryptographically indistinguishable under the <code>psk</code> tier.</li>
+        <li>It does <strong>not</strong> encrypt message bodies; <strong>MLS</strong> performs group key agreement once members are admitted.</li>
+        <li>It does <strong>not</strong> protect spokes, memory, or <code>@handle</code> impersonation over HTTP.</li>
+      </ul>
+      <p>With the public dev literal shipped in the repo, PSK protects nothing by itself. A fresh hub install generates a private <code>[slim].master_secret</code> in <code>config.toml</code> on first <code>mycelium config apply</code> (rendered to <code>.env</code> for Docker). Override with <code>mycelium config set slim.master_secret …</code> to rotate.</p>
+      <h2 id="security-planes-what-protects-spokes">What protects spokes</h2>
+      <p>For hub-and-spoke, the urgent control is the <strong>HTTP API gate</strong>, not PSK:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> auth.enabled true
+<span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> auth.audience mycelium
+<span class="comment"># … configure [[auth.issuers]] …</span>
+<span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">apply</span></code></pre>
+      <p>See <a href="#auth">Authentication</a> for humans and agent service accounts.</p>
+      <p>Without the gate, anyone who can reach <code>:8000</code> can read/write memory and post as any <code>@handle</code> — <strong>even if the hub uses a private SLIM master secret.</strong></p>
+      <h2 id="security-planes-deployment-profiles">Deployment profiles</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Profile</th>
+              <th>HTTP API</th>
+              <th>SLIM (hub)</th>
+              <th>Spoke config</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Solo dev</strong></td>
+              <td>Open</td>
+              <td>Dev PSK literal (fallback if no config secret)</td>
+              <td>N/A (all-in-one)</td>
+            </tr>
+            <tr>
+              <td><strong>LAN team</strong></td>
+              <td>JWT on</td>
+              <td>Auto-generated <code>[slim].master_secret</code> on hub</td>
+              <td><code>server.api_url</code> → hub:8000 only</td>
+            </tr>
+            <tr>
+              <td><strong>Hosted</strong></td>
+              <td>JWT required</td>
+              <td>Private hub secret + SignerJwt or SPIRE</td>
+              <td>Same; no master secret on spokes</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p><code>mycelium doctor</code> reports HTTP auth status from the hub&#x27;s <code>/health</code> endpoint. In <strong>hub</strong> mode it also warns when <code>[slim].master_secret</code> is missing or still the public dev literal.</p>
+      <h2 id="security-planes-slim-identity-ladder-hub-native-clients">SLIM identity ladder (hub native clients)</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Tier</th>
+              <th>Plane</th>
+              <th>Spoke needs it?</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>psk</code></td>
+              <td>SLIM</td>
+              <td>No (hub backend only today)</td>
+            </tr>
+            <tr>
+              <td><code>signerjwt</code></td>
+              <td>SLIM</td>
+              <td>Only if the spoke runs a native SLIM connector</td>
+            </tr>
+            <tr>
+              <td><code>spire</code></td>
+              <td>SLIM</td>
+              <td>Same</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p><code>mycelium config set slim.identity signerjwt</code> changes <strong>SLIM channel identity</strong> on machines that open native SLIM connections. It does <strong>not</strong> turn on HTTP API auth. Configure <code>[auth]</code> separately.</p>
+      <h2 id="security-planes-related-guides">Related guides</h2>
+      <ul>
+        <li><a href="#hub-and-spoke">Hub &amp; Spoke Setup</a> — topology and spoke checklist</li>
+        <li><a href="#auth">Authentication</a> — HTTP JWT gate (spokes and hub API)</li>
+        <li><a href="#spire-identity">Attested Identity (SPIRE)</a> — hardened SLIM plane</li>
+      </ul>
     </section>
 
     <hr class="divider">
@@ -1355,6 +1452,7 @@ for line in sys.stdin:
     <section class="doc-section" id="auth">
       <h1>Authentication</h1>
       <p>Mycelium&#x27;s backend can require a signed <strong>bearer token</strong> on every HTTP API call, validated against an OIDC issuer you configure. It is <strong>off by default</strong> and nothing about the default install changes until you turn it on.</p>
+      <p>This is the <strong>HTTP API plane</strong> — what protects spokes in hub-and-spoke deployments. It is separate from SLIM/MLS PSK or SignerJwt on the coordination fabric; see <a href="#security-planes">Security Planes</a>.</p>
       <h2 id="auth-off-by-default-on-purpose">Off by default, on purpose</h2>
       <p>Auth must never be a wall between someone and trying Mycelium. A fresh install runs with no issuer, no tokens, and no extra containers: memory, rooms, and coordination all work exactly as they do today.</p>
       <p>Turn it on when a <strong>team shares a hub over a network</strong>. Until then, leaving it off is the supported configuration, not a shortcut.</p>
@@ -1808,17 +1906,18 @@ export AUTH_SESSION_SECRET=$(openssl rand <span class="flag">-hex</span> 32)
 <span class="comment"># or point at a remote hub:</span>
 <span class="bin">mycelium</span> <span class="cmd">init</span> <span class="flag">--api-url</span> <span class="url">http://your-hub:8000</span></code></pre>
       <hr class="divider">
-      <h3 id="troubleshooting-4-slim-node-unreachable">4. SLIM Node Unreachable</h3>
-      <p><strong>Symptom</strong>: agents join a room but never exchange anything; <code>mycelium await</code> hangs; <code>mycelium doctor</code> flags the backend or a spoke can&#x27;t reach the hub.</p>
-      <p>Agents coordinate over a <strong>SLIM group channel</strong> served by the hub&#x27;s SLIM node (default port <strong>46357</strong>). If that node is down or unreachable, no messages flow.</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">doctor</span>                     # detects hub vs spoke, checks reachability
-<span class="cmd">docker</span> ps | grep slim               # is the SLIM node up on the hub?
-<span class="bin">mycelium</span> <span class="cmd">hub</span> <span class="cmd">host</span>                   # (re)start the SLIM node and print its address</code></pre>
-      <p>On a spoke, confirm it points at the right node and the port is open:</p>
-      <pre><code>grep node_endpoint ~/.mycelium/config.toml
-<span class="cmd">curl</span> http://&lt;hub-ip&gt;:46357            # raw reachability from the spoke
-<span class="bin">mycelium</span> <span class="cmd">connect</span> <span class="cmd">http</span>://&lt;hub-ip&gt;:46357  # re-point at the hub node</code></pre>
-      <p>Common causes: firewall/security group blocks 46357, VPN/Tailscale not connected, or a stale endpoint in <code>config.toml</code>.</p>
+      <h3 id="troubleshooting-4-spoke-cant-reach-the-hub-or-backend-down">4. Spoke Can&#x27;t Reach the Hub (or Backend Down)</h3>
+      <p><strong>Symptom</strong>: <code>Cannot connect to Mycelium API</code>; memory/<code>await</code>/<code>respond</code> fail; <code>mycelium doctor</code> reports backend unreachable.</p>
+      <p>Spokes talk to the hub over <strong>HTTP</strong> (<code>server.api_url</code>, default port <strong>8000</strong>). They do not need the SLIM node for normal participation.</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">doctor</span>                     # detects hub vs spoke; checks /health
+<span class="cmd">curl</span> http://&lt;hub-ip&gt;:8000/health    # from the spoke
+<span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">get</span> server.api_url    # should point at the hub backend</code></pre>
+      <p>On the <strong>hub</strong>, ensure the backend and SLIM node are running:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">up</span>
+<span class="cmd">docker</span> ps | grep mycelium
+<span class="bin">mycelium</span> <span class="cmd">hub</span> <span class="cmd">host</span>                   # (re)start the SLIM node if needed</code></pre>
+      <p>If coordination still fails on the hub itself, check the SLIM node (port <strong>46357</strong>) — the backend moderator needs it. Spokes rarely need <code>:46357</code> unless you use native SLIM tooling (<code>mycelium slim send</code>).</p>
+      <p>Common causes: firewall blocks <strong>8000</strong>, wrong <code>server.api_url</code>, VPN not connected, or auth enabled on the hub without <code>mycelium login</code> on the spoke. See <a href="#security-planes">Security Planes</a> and <a href="#auth">Authentication</a>.</p>
       <hr class="divider">
       <h3 id="troubleshooting-5-port-already-in-use">5. Port Already in Use</h3>
       <p><strong>Symptom</strong>: <code>bind: address already in use</code></p>


### PR DESCRIPTION
The generated HTML + llms-full.txt on main lagged the markdown under
mycelium-cli/src/mycelium/docs/ by several commits — most visibly the
two-plane security / hub-and-spoke-over-HTTP rewrite (#671), which
changed the sources but never regenerated the output. Every unrelated PR
that happened to run the generator picked up ~850 lines of drift.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AfWF4WFXeX6Cwy6RSQfmZg