### PR TITLE
feat(aligner): track the least-satisfied agent on a converged episode (#682)

### DIFF
--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -371,6 +371,7 @@ class AlignerEngine:
                     text="✗ not converged — could not structure the discussion into issues.",
                 )
 
+            ep.issue_options = {i["name"]: [str(o) for o in i["options"]] for i in issues}
             loop = asyncio.get_running_loop()
             negotiation = mediator.MediatedNegotiation(
                 issues=issues,
@@ -391,6 +392,18 @@ class AlignerEngine:
             assignments = mediator.agreement_assignments(mech, negotiation.names)
             converged = assignments is not None
             _, metrics = self._verdict(ep)
+            # Post-hoc satisfaction (#682): how close the agreed outcome sits to
+            # each agent's opening ask, and the room minimum — the least-happy
+            # agent. Independent of MPC/GAR/SCR (which need stated confidence the
+            # mediated path rarely has), so it rides alongside in ``metrics``.
+            if converged and assignments:
+                satisfaction = l9_episode.estimate_satisfaction(
+                    ep.opening_offers, assignments, ep.issue_options
+                )
+                if satisfaction:
+                    metrics = dict(metrics or {})
+                    metrics["satisfaction"] = satisfaction
+                    metrics["min_satisfaction"] = round(min(satisfaction.values()), 4)
             logger.info(
                 "aligner (mediator) room %s → %s in %d steps (%s)",
                 room,
@@ -662,6 +675,9 @@ class AlignerEngine:
         if isinstance(offer, dict):
             reply["offer"] = offer
             reply.setdefault("action", "accept" if proposing else "reject")
+            # The agent's first concrete offer is its opening ask — the baseline
+            # #682 scores the agreed outcome's satisfaction against.
+            ep.opening_offers.setdefault(handle, {k: str(v) for k, v in offer.items()})
         # The wire move type, kept distinct from the collapsed metric ``action``
         # above: the mediator's raw verb when it's one of the closed vocabulary,
         # else a bare offer is a ``counter`` (the opening position included).

--- a/fastapi-backend/app/services/l9_episode.py
+++ b/fastapi-backend/app/services/l9_episode.py
@@ -95,6 +95,13 @@ class EpisodeState:
     # on the common path (no mismatch, no clarifying round).
     term_mismatches: list[dict[str, Any]] = field(default_factory=list)
     clarifications: dict[str, str] = field(default_factory=dict)
+    # Each agent's first concrete SAO offer (issue -> value), captured as the
+    # mediator reads it — the "opening ask" a converged outcome's satisfaction is
+    # scored against (#682). Distinct from opening_positions (prose): parsed offers.
+    opening_offers: dict[str, dict[str, str]] = field(default_factory=dict)
+    # The negotiable issues' ordered option grids (issue -> options), so
+    # satisfaction can be scored as ordinal distance on the grid actually negotiated.
+    issue_options: dict[str, list[str]] = field(default_factory=dict)
     # Ordered record of every envelope in the episode (dicts, wire shape).
     messages: list[dict[str, Any]] = field(default_factory=list)
     # handle -> l9 message id of the last tick sent to that agent.
@@ -361,6 +368,40 @@ def compute_metrics(ep: EpisodeState) -> dict[str, Any] | None:
     }
 
 
+def estimate_satisfaction(
+    opening_offers: dict[str, dict[str, str]],
+    assignments: dict[str, Any],
+    issue_options: dict[str, list[str]],
+) -> dict[str, float]:
+    """Estimate each agent's satisfaction with the agreed outcome, relative to its
+    own opening offer, as mean closeness across the issues it stated.
+
+    Closeness on an issue is ``1 - grid_distance / grid_span``, treating each
+    issue's option list as ordinal — the order ``discover_issues`` emits (ascending
+    numbers, low->high scope). An agent that got exactly its opening ask scores
+    ``1.0``; the further the agreed value sits from it on the grid, the lower. It's
+    a post-hoc estimate, not a utility the agent stated: agents with no recorded
+    offer, and issues absent from an offer or the agreement, are skipped rather
+    than guessed. The room's minimum flags a consensus that one participant barely
+    tolerated.
+    """
+    out: dict[str, float] = {}
+    for handle, offer in opening_offers.items():
+        scores: list[float] = []
+        for issue, options in issue_options.items():
+            want, got = offer.get(issue), assignments.get(issue)
+            if want is None or got is None:
+                continue
+            try:
+                distance = abs(options.index(str(want)) - options.index(str(got)))
+            except ValueError:
+                continue
+            scores.append(1.0 - distance / max(1, len(options) - 1))
+        if scores:
+            out[handle] = round(sum(scores) / len(scores), 4)
+    return out
+
+
 def build_consensus_envelope(
     ep: EpisodeState,
     *,
@@ -410,11 +451,17 @@ def write_episode_record(
             f"- outcome: **{outcome}**",
             f"- participants: {', '.join(ep.agents)}",
         ]
-        if metrics:
+        if metrics and "mpc" in metrics:
             lines.append(
                 f"- quality: MPC {metrics['mpc']:.2f} · GAR {metrics['gar']:.2f} · "
                 f"SCR {metrics['scr']:.2f} · provenance weight "
                 f"{metrics['provenance_weight']:.2f}"
+            )
+        if metrics and metrics.get("min_satisfaction") is not None:
+            per_agent = metrics.get("satisfaction", {})
+            lines.append(
+                f"- satisfaction: min {metrics['min_satisfaction']:.2f} "
+                f"(least-happy of {len(per_agent)} agents, relative to opening asks)"
             )
         if plan_file:
             lines.append(f"- plan: `{plan_file}`")

--- a/fastapi-backend/app/services/mediator.py
+++ b/fastapi-backend/app/services/mediator.py
@@ -256,6 +256,20 @@ class MediatedNegotiation:
         # Last outcome we actually *read* from each proposer, so an unreadable
         # later turn holds that agent's own line instead of fabricating one.
         self._last_offer: dict[str, tuple[str, ...]] = {}
+        # Each agent's first concrete offer (issue -> value) — its opening ask.
+        # The turn-order policy (#683) scores satisfaction with the standing offer
+        # against this; captured once per agent, on its first readable proposal.
+        self.opening_offers: dict[str, dict[str, str]] = {}
+
+    @property
+    def issue_options(self) -> dict[str, list[str]]:
+        """Each issue's ordered options as strings (the grid satisfaction scores on)."""
+        return {n: [str(o) for o in self._options[n]] for n in self._names}
+
+    def note_opening_offer(self, handle: str, offer: dict[str, Any]) -> None:
+        """Record ``handle``'s opening ask the first time it makes a readable offer."""
+        if offer:
+            self.opening_offers.setdefault(handle, {k: str(v) for k, v in offer.items()})
 
     # -- mediator LLM stages (run in the negotiator thread) --
 
@@ -415,10 +429,12 @@ class LiveNegotiator(SAONegotiator):
             self.handle, state.current_offer, proposing=True, round_n=state.step
         )
         reading = self._neg.interpret(self.handle, prose, proposing=True)
-        read = self._neg.to_outcome(reading.get("offer", {}) if isinstance(reading, dict) else {})
+        offer = reading.get("offer", {}) if isinstance(reading, dict) else {}
+        read = self._neg.to_outcome(offer)
         if read is not None:
             # Faithful read of this agent's move — record and remember it.
             self._neg.set_last_offer(self.handle, read)
+            self._neg.note_opening_offer(self.handle, offer)
             outcome = read
         else:
             # Unreadable move (silence, off-grid, garbage). Hold THIS agent's own
@@ -454,15 +470,76 @@ class LiveNegotiator(SAONegotiator):
         return resp
 
 
+def least_satisfied_order(
+    order: list[str],
+    id_to_handle: dict[str, str | None],
+    opening_offers: dict[str, dict[str, str]],
+    standing: dict[str, str] | None,
+    issue_options: dict[str, list[str]],
+) -> list[str]:
+    """Reorder a step's negotiator ids so the least-satisfied agent acts first (#683).
+
+    Satisfaction is each agent's opening ask scored against the ``standing`` offer
+    (the same ordinal-grid estimate the episode uses post-hoc). Pure and total: with
+    no standing offer yet (round 0) or no captured opening offers it returns ``order``
+    unchanged — the default round-robin. The sort is stable, so agents whose
+    satisfaction can't be scored keep their round-robin position (treated as
+    already-satisfied, i.e. not pulled forward).
+    """
+    if not standing or not opening_offers:
+        return list(order)
+    from app.services.l9_episode import estimate_satisfaction
+
+    satisfaction = estimate_satisfaction(opening_offers, standing, issue_options)
+    if not satisfaction:
+        return list(order)
+    return sorted(order, key=lambda nid: satisfaction.get(id_to_handle.get(nid) or "", 1.0))
+
+
+class SatisfactionOrderedSAO(SAOMechanism):
+    """SAO mechanism that addresses the least-satisfied agent next, not round-robin.
+
+    NEGMAS decides each step's turn order in ``next_negotitor_ids`` (its spelling);
+    we override it to sort by satisfaction with the current standing offer, so the
+    aligner spends turns on the agent who actually needs to move rather than on one
+    already content with the offer. Termination is untouched — NEGMAS still stops at
+    unanimity regardless of who is asked in what order (the anti-theatre property).
+    """
+
+    def __init__(self, *args: Any, negotiation: MediatedNegotiation, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._neg = negotiation
+
+    def _standing_offer(self) -> dict[str, str] | None:
+        offer = self.state.current_offer
+        if not offer:
+            return None
+        names = self._neg.names
+        return {names[i]: str(offer[i]) for i in range(min(len(names), len(offer)))}
+
+    def next_negotitor_ids(self) -> list[str]:
+        return least_satisfied_order(
+            super().next_negotitor_ids(),
+            {n.id: getattr(n, "handle", None) for n in self.negotiators},
+            self._neg.opening_offers,
+            self._standing_offer(),
+            self._neg.issue_options,
+        )
+
+
 def build_mechanism(
     issues: list[dict[str, Any]], handles: list[str], negotiation: MediatedNegotiation, *, cap: int
 ) -> SAOMechanism:
-    """Assemble the SAO mechanism with one live negotiator per participant."""
+    """Assemble the SAO mechanism with one live negotiator per participant.
+
+    The mechanism addresses the least-satisfied agent first each step (#683); until
+    a standing offer exists it is exactly NEGMAS's round-robin.
+    """
     negmas_issues = [
         make_issue(values=[str(v) for v in issue["options"]], name=issue["name"])
         for issue in issues
     ]
-    mech = SAOMechanism(issues=negmas_issues, n_steps=cap)
+    mech = SatisfactionOrderedSAO(issues=negmas_issues, n_steps=cap, negotiation=negotiation)
     for handle in handles:
         mech.add(LiveNegotiator(handle, negotiation))
     return mech

--- a/fastapi-backend/tests/test_l9_episode.py
+++ b/fastapi-backend/tests/test_l9_episode.py
@@ -543,3 +543,56 @@ def test_episode_record_omits_term_clarifications_when_absent(tmp_path, monkeypa
     l9_episode.write_episode_record(_open(), outcome="converged", metrics=None, plan_file=None)
     body = (tmp_path / "rooms" / "sprint" / "log" / "episodes" / "abc123.md").read_text()
     assert "## Term Clarifications" not in body
+
+
+# ── minimum satisfaction (#682) ───────────────────────────────────────────────
+
+
+def test_estimate_satisfaction_ordinal_distance():
+    """Each agent's satisfaction is 1 - grid distance from its opening ask; the
+    room minimum is the least-happy agent."""
+    opening = {"growth": {"cap": "60"}, "risk": {"cap": "30"}}
+    options = {"cap": ["30", "40", "50", "60"]}
+    sat = l9_episode.estimate_satisfaction(opening, {"cap": "50"}, options)
+    assert sat["growth"] == round(1 - 1 / 3, 4)  # wanted 60, got 50 → one step
+    assert sat["risk"] == round(1 - 2 / 3, 4)  # wanted 30, got 50 → two steps
+    assert min(sat.values()) == sat["risk"]
+
+
+def test_estimate_satisfaction_exact_ask_scores_one():
+    opening = {"a": {"cap": "50", "scope": "Full"}}
+    options = {"cap": ["30", "40", "50"], "scope": ["Thin", "Mid", "Full"]}
+    sat = l9_episode.estimate_satisfaction(opening, {"cap": "50", "scope": "Full"}, options)
+    assert sat["a"] == 1.0
+
+
+def test_estimate_satisfaction_skips_agents_and_values_it_cannot_score():
+    opening = {"stated": {"cap": "40"}, "silent": {}, "offgrid": {"cap": "999"}}
+    options = {"cap": ["30", "40", "50"]}
+    sat = l9_episode.estimate_satisfaction(opening, {"cap": "50"}, options)
+    assert sat == {"stated": round(1 - 1 / 2, 4)}  # silent has no offer; 999 not on grid
+
+
+def test_episode_record_renders_satisfaction(tmp_path, monkeypatch):
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "MYCELIUM_DATA_DIR", str(tmp_path))
+    metrics = {"min_satisfaction": 0.33, "satisfaction": {"a1": 0.33, "a2": 0.8}}
+    l9_episode.write_episode_record(_open(), outcome="converged", metrics=metrics, plan_file=None)
+    body = (tmp_path / "rooms" / "sprint" / "log" / "episodes" / "abc123.md").read_text()
+    assert "- satisfaction: min 0.33 (least-happy of 2 agents" in body
+
+
+def test_record_satisfaction_renders_without_siep_metrics(tmp_path, monkeypatch):
+    """Satisfaction rides even when MPC/GAR/SCR are absent (the mediated path
+    rarely has stated confidence) — and the missing SIEP line never KeyErrors."""
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "MYCELIUM_DATA_DIR", str(tmp_path))
+    metrics = {"min_satisfaction": 0.5, "satisfaction": {"a1": 0.5, "a2": 0.5}}
+    l9_episode.write_episode_record(_open(), outcome="converged", metrics=metrics, plan_file=None)
+    body = (tmp_path / "rooms" / "sprint" / "log" / "episodes" / "abc123.md").read_text()
+    assert "MPC" not in body
+    assert "- satisfaction: min 0.50" in body

--- a/fastapi-backend/tests/test_mediator.py
+++ b/fastapi-backend/tests/test_mediator.py
@@ -15,6 +15,7 @@ step cap.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -473,6 +474,114 @@ async def test_mediate_survives_a_failing_term_check(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(mediator, "detect_term_mismatch", boom)
 
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "aligner"])
+
+    verdict = await _engine(manager).mediate(_ROOM)
+
+    assert verdict is not None
+    assert verdict["header"]["subkind"] == "converged"
+
+
+# ── #683: address the least-satisfied agent next (turn order) ─────────────────
+
+_ISSUES_683 = [{"name": "cap", "options": ["30", "40", "50", "60"]}]
+_OPTIONS_683 = {"cap": ["30", "40", "50", "60"]}
+
+
+def _negotiation() -> mediator.MediatedNegotiation:
+    """A MediatedNegotiation for turn-order tests; the seams it doesn't use here
+    (fetch_prose/llm) are inert stubs since these tests never run the mechanism."""
+    return mediator.MediatedNegotiation(
+        issues=_ISSUES_683,
+        cap=10,
+        loop=asyncio.new_event_loop(),
+        fetch_prose=lambda *a: None,  # type: ignore[arg-type,return-value]
+        turn_timeout_s=1.0,
+        llm=lambda *a, **k: "",
+    )
+
+
+def test_negmas_turn_order_seam_present() -> None:
+    """Explainer guard: if NEGMAS renames ``next_negotitor_ids`` or drops
+    ``state.current_offer``, this fails with a clear message instead of the
+    least-satisfied ordering silently reverting to round-robin."""
+    from negmas import SAOMechanism
+    from negmas.outcomes import make_issue
+
+    m = SAOMechanism(issues=[make_issue(values=["a", "b"], name="x")], n_steps=5)
+    neg = _negotiation()
+    m.add(mediator.LiveNegotiator("growth", neg))
+    m.add(mediator.LiveNegotiator("risk", neg))
+    assert callable(getattr(m, "next_negotitor_ids", None)), "NEGMAS turn-order seam moved"
+    # Default (no standing offer): every negotiator, NEGMAS's round-robin.
+    assert set(m.next_negotitor_ids()) == set(m.negotiator_ids)
+    assert hasattr(m.state, "current_offer"), "NEGMAS state.current_offer seam moved"
+
+
+def test_least_satisfied_order_puts_worst_first() -> None:
+    order = ["g", "r"]
+    id_to_handle = {"g": "growth", "r": "risk"}
+    opening = {"growth": {"cap": "60"}, "risk": {"cap": "30"}}
+    # Standing 40 sits next to risk's 30, far from growth's 60 → growth least happy.
+    assert mediator.least_satisfied_order(
+        order, id_to_handle, opening, {"cap": "40"}, _OPTIONS_683
+    ) == [
+        "g",
+        "r",
+    ]
+    # Standing 50 flips it — now risk is furthest from satisfied.
+    assert mediator.least_satisfied_order(
+        order, id_to_handle, opening, {"cap": "50"}, _OPTIONS_683
+    ) == [
+        "r",
+        "g",
+    ]
+
+
+def test_least_satisfied_order_falls_back_to_round_robin() -> None:
+    order = ["g", "r"]
+    id_to_handle = {"g": "growth", "r": "risk"}
+    opening = {"growth": {"cap": "60"}, "risk": {"cap": "30"}}
+    # No standing offer yet (round 0) → unchanged.
+    assert mediator.least_satisfied_order(order, id_to_handle, opening, None, _OPTIONS_683) == order
+    # No opening offers captured → unchanged.
+    assert (
+        mediator.least_satisfied_order(order, id_to_handle, {}, {"cap": "40"}, _OPTIONS_683)
+        == order
+    )
+    # Unscoreable handles keep round-robin (stable, treated as satisfied).
+    assert (
+        mediator.least_satisfied_order(
+            order, {"g": None, "r": None}, opening, {"cap": "40"}, _OPTIONS_683
+        )
+        == order
+    )
+
+
+def test_mechanism_addresses_least_satisfied_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The override composes NEGMAS order + negotiator→handle map + satisfaction."""
+    neg = _negotiation()
+    neg.opening_offers = {"growth": {"cap": "60"}, "risk": {"cap": "30"}}
+    mech = mediator.build_mechanism(_ISSUES_683, ["growth", "risk"], neg, cap=10)
+    monkeypatch.setattr(mech, "_standing_offer", lambda: {"cap": "40"})  # near risk's floor
+    id_to_handle = {n.id: n.handle for n in mech.negotiators}
+    ordered = [id_to_handle[i] for i in mech.next_negotitor_ids()]
+    assert ordered[0] == "growth"
+
+
+def test_mechanism_defaults_to_round_robin_before_first_offer() -> None:
+    neg = _negotiation()  # no opening offers, no standing offer
+    mech = mediator.build_mechanism(_ISSUES_683, ["growth", "risk"], neg, cap=10)
+    assert set(mech.next_negotitor_ids()) == set(mech.negotiator_ids)
+
+
+@pytest.mark.asyncio
+async def test_least_satisfied_order_preserves_termination() -> None:
+    """Reordering who is asked must not break termination: a converging run still
+    stops at agreement, not the step cap (the anti-theatre invariant)."""
     persister = FakePersister()
     channel = FakeChannel(persister, reply_conf=0.9)
     managed = FakeManaged(_ROOM, "mycelium", channel, persister)


### PR DESCRIPTION
Closes #682. Part of #684 (sharpen aligner negotiation quality). Sets up #683.

## What

"Converged" alone doesn't tell you whether the agreement was comfortable for everyone or barely tolerable for one participant. This adds a **post-hoc satisfaction estimate**: for each converged negotiation, score how close the agreed outcome sits to each agent's opening ask, and log the room **minimum** — the least-happy agent — alongside the existing quality metrics. Useful for judging how fragile a consensus is, and for catching a negotiation that's technically successful but bad for one side.

## How

- **`estimate_satisfaction(opening_offers, assignments, issue_options)`** — pure and testable. Per issue, `1 - grid_distance / grid_span`, treating each issue's option list as ordinal (the order `discover_issues` emits: ascending numbers, low→high scope); mean across the issues an agent stated; min across the room. It's an **estimate, not a stated utility** — agents with no recorded offer and issues that can't be scored are skipped rather than guessed.
- `EpisodeState` carries `opening_offers` (each agent's first concrete SAO offer, captured in `_fold_reading`) and `issue_options` (the discovered grids).
- Computed at verdict for **converged episodes only**, merged into `metrics` so it rides the `commit:converged` envelope and renders as a `satisfaction: min X` line in the episode record. It's **independent of MPC/GAR/SCR** (which need stated confidence the mediated path rarely has), so the SIEP line is now guarded and satisfaction renders on its own.
- **No change to termination behavior** (the acceptance criterion).

## Validated live

Ran through the real `mediate()` on the harness with a deliberately lopsided negotiation — growth opens 60%/Q3, risk opens 30%/Q4, growth caves and they agree **35%/Q4**:

```
assignments: {tech_budget_percent: 35, release_timeline: Q4}
per-agent  : {growth: 0.08, risk: 0.92}
min        : 0.08
episode record: "- satisfaction: min 0.08 (least-happy of 2 agents, relative to opening asks)"
```

Correctly flags a consensus growth barely tolerated.

## Tests

5 new: ordinal-distance scoring, exact-ask → 1.0, skipping unscoreable agents/values, record rendering, and rendering with satisfaction but no SIEP metrics (the mediated-path case — no KeyError). Full episode/aligner/mediator suites green; `ruff` + `ty` clean.