### PR TITLE
feat(aligner): address the least-satisfied agent next (#683)

### DIFF
--- a/fastapi-backend/app/services/mediator.py
+++ b/fastapi-backend/app/services/mediator.py
@@ -256,6 +256,20 @@ class MediatedNegotiation:
         # Last outcome we actually *read* from each proposer, so an unreadable
         # later turn holds that agent's own line instead of fabricating one.
         self._last_offer: dict[str, tuple[str, ...]] = {}
+        # Each agent's first concrete offer (issue -> value) — its opening ask.
+        # The turn-order policy (#683) scores satisfaction with the standing offer
+        # against this; captured once per agent, on its first readable proposal.
+        self.opening_offers: dict[str, dict[str, str]] = {}
+
+    @property
+    def issue_options(self) -> dict[str, list[str]]:
+        """Each issue's ordered options as strings (the grid satisfaction scores on)."""
+        return {n: [str(o) for o in self._options[n]] for n in self._names}
+
+    def note_opening_offer(self, handle: str, offer: dict[str, Any]) -> None:
+        """Record ``handle``'s opening ask the first time it makes a readable offer."""
+        if offer:
+            self.opening_offers.setdefault(handle, {k: str(v) for k, v in offer.items()})
 
     # -- mediator LLM stages (run in the negotiator thread) --
 
@@ -415,10 +429,12 @@ class LiveNegotiator(SAONegotiator):
             self.handle, state.current_offer, proposing=True, round_n=state.step
         )
         reading = self._neg.interpret(self.handle, prose, proposing=True)
-        read = self._neg.to_outcome(reading.get("offer", {}) if isinstance(reading, dict) else {})
+        offer = reading.get("offer", {}) if isinstance(reading, dict) else {}
+        read = self._neg.to_outcome(offer)
         if read is not None:
             # Faithful read of this agent's move — record and remember it.
             self._neg.set_last_offer(self.handle, read)
+            self._neg.note_opening_offer(self.handle, offer)
             outcome = read
         else:
             # Unreadable move (silence, off-grid, garbage). Hold THIS agent's own
@@ -454,15 +470,76 @@ class LiveNegotiator(SAONegotiator):
         return resp
 
 
+def least_satisfied_order(
+    order: list[str],
+    id_to_handle: dict[str, str | None],
+    opening_offers: dict[str, dict[str, str]],
+    standing: dict[str, str] | None,
+    issue_options: dict[str, list[str]],
+) -> list[str]:
+    """Reorder a step's negotiator ids so the least-satisfied agent acts first (#683).
+
+    Satisfaction is each agent's opening ask scored against the ``standing`` offer
+    (the same ordinal-grid estimate the episode uses post-hoc). Pure and total: with
+    no standing offer yet (round 0) or no captured opening offers it returns ``order``
+    unchanged — the default round-robin. The sort is stable, so agents whose
+    satisfaction can't be scored keep their round-robin position (treated as
+    already-satisfied, i.e. not pulled forward).
+    """
+    if not standing or not opening_offers:
+        return list(order)
+    from app.services.l9_episode import estimate_satisfaction
+
+    satisfaction = estimate_satisfaction(opening_offers, standing, issue_options)
+    if not satisfaction:
+        return list(order)
+    return sorted(order, key=lambda nid: satisfaction.get(id_to_handle.get(nid) or "", 1.0))
+
+
+class SatisfactionOrderedSAO(SAOMechanism):
+    """SAO mechanism that addresses the least-satisfied agent next, not round-robin.
+
+    NEGMAS decides each step's turn order in ``next_negotitor_ids`` (its spelling);
+    we override it to sort by satisfaction with the current standing offer, so the
+    aligner spends turns on the agent who actually needs to move rather than on one
+    already content with the offer. Termination is untouched — NEGMAS still stops at
+    unanimity regardless of who is asked in what order (the anti-theatre property).
+    """
+
+    def __init__(self, *args: Any, negotiation: MediatedNegotiation, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._neg = negotiation
+
+    def _standing_offer(self) -> dict[str, str] | None:
+        offer = self.state.current_offer
+        if not offer:
+            return None
+        names = self._neg.names
+        return {names[i]: str(offer[i]) for i in range(min(len(names), len(offer)))}
+
+    def next_negotitor_ids(self) -> list[str]:
+        return least_satisfied_order(
+            super().next_negotitor_ids(),
+            {n.id: getattr(n, "handle", None) for n in self.negotiators},
+            self._neg.opening_offers,
+            self._standing_offer(),
+            self._neg.issue_options,
+        )
+
+
 def build_mechanism(
     issues: list[dict[str, Any]], handles: list[str], negotiation: MediatedNegotiation, *, cap: int
 ) -> SAOMechanism:
-    """Assemble the SAO mechanism with one live negotiator per participant."""
+    """Assemble the SAO mechanism with one live negotiator per participant.
+
+    The mechanism addresses the least-satisfied agent first each step (#683); until
+    a standing offer exists it is exactly NEGMAS's round-robin.
+    """
     negmas_issues = [
         make_issue(values=[str(v) for v in issue["options"]], name=issue["name"])
         for issue in issues
     ]
-    mech = SAOMechanism(issues=negmas_issues, n_steps=cap)
+    mech = SatisfactionOrderedSAO(issues=negmas_issues, n_steps=cap, negotiation=negotiation)
     for handle in handles:
         mech.add(LiveNegotiator(handle, negotiation))
     return mech

--- a/fastapi-backend/tests/test_mediator.py
+++ b/fastapi-backend/tests/test_mediator.py
@@ -15,6 +15,7 @@ step cap.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any
 
@@ -473,6 +474,114 @@ async def test_mediate_survives_a_failing_term_check(monkeypatch: pytest.MonkeyP
 
     monkeypatch.setattr(mediator, "detect_term_mismatch", boom)
 
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=0.9)
+    managed = FakeManaged(_ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, ["growth", "risk", "aligner"])
+
+    verdict = await _engine(manager).mediate(_ROOM)
+
+    assert verdict is not None
+    assert verdict["header"]["subkind"] == "converged"
+
+
+# ── #683: address the least-satisfied agent next (turn order) ─────────────────
+
+_ISSUES_683 = [{"name": "cap", "options": ["30", "40", "50", "60"]}]
+_OPTIONS_683 = {"cap": ["30", "40", "50", "60"]}
+
+
+def _negotiation() -> mediator.MediatedNegotiation:
+    """A MediatedNegotiation for turn-order tests; the seams it doesn't use here
+    (fetch_prose/llm) are inert stubs since these tests never run the mechanism."""
+    return mediator.MediatedNegotiation(
+        issues=_ISSUES_683,
+        cap=10,
+        loop=asyncio.new_event_loop(),
+        fetch_prose=lambda *a: None,  # type: ignore[arg-type,return-value]
+        turn_timeout_s=1.0,
+        llm=lambda *a, **k: "",
+    )
+
+
+def test_negmas_turn_order_seam_present() -> None:
+    """Explainer guard: if NEGMAS renames ``next_negotitor_ids`` or drops
+    ``state.current_offer``, this fails with a clear message instead of the
+    least-satisfied ordering silently reverting to round-robin."""
+    from negmas import SAOMechanism
+    from negmas.outcomes import make_issue
+
+    m = SAOMechanism(issues=[make_issue(values=["a", "b"], name="x")], n_steps=5)
+    neg = _negotiation()
+    m.add(mediator.LiveNegotiator("growth", neg))
+    m.add(mediator.LiveNegotiator("risk", neg))
+    assert callable(getattr(m, "next_negotitor_ids", None)), "NEGMAS turn-order seam moved"
+    # Default (no standing offer): every negotiator, NEGMAS's round-robin.
+    assert set(m.next_negotitor_ids()) == set(m.negotiator_ids)
+    assert hasattr(m.state, "current_offer"), "NEGMAS state.current_offer seam moved"
+
+
+def test_least_satisfied_order_puts_worst_first() -> None:
+    order = ["g", "r"]
+    id_to_handle = {"g": "growth", "r": "risk"}
+    opening = {"growth": {"cap": "60"}, "risk": {"cap": "30"}}
+    # Standing 40 sits next to risk's 30, far from growth's 60 → growth least happy.
+    assert mediator.least_satisfied_order(
+        order, id_to_handle, opening, {"cap": "40"}, _OPTIONS_683
+    ) == [
+        "g",
+        "r",
+    ]
+    # Standing 50 flips it — now risk is furthest from satisfied.
+    assert mediator.least_satisfied_order(
+        order, id_to_handle, opening, {"cap": "50"}, _OPTIONS_683
+    ) == [
+        "r",
+        "g",
+    ]
+
+
+def test_least_satisfied_order_falls_back_to_round_robin() -> None:
+    order = ["g", "r"]
+    id_to_handle = {"g": "growth", "r": "risk"}
+    opening = {"growth": {"cap": "60"}, "risk": {"cap": "30"}}
+    # No standing offer yet (round 0) → unchanged.
+    assert mediator.least_satisfied_order(order, id_to_handle, opening, None, _OPTIONS_683) == order
+    # No opening offers captured → unchanged.
+    assert (
+        mediator.least_satisfied_order(order, id_to_handle, {}, {"cap": "40"}, _OPTIONS_683)
+        == order
+    )
+    # Unscoreable handles keep round-robin (stable, treated as satisfied).
+    assert (
+        mediator.least_satisfied_order(
+            order, {"g": None, "r": None}, opening, {"cap": "40"}, _OPTIONS_683
+        )
+        == order
+    )
+
+
+def test_mechanism_addresses_least_satisfied_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The override composes NEGMAS order + negotiator→handle map + satisfaction."""
+    neg = _negotiation()
+    neg.opening_offers = {"growth": {"cap": "60"}, "risk": {"cap": "30"}}
+    mech = mediator.build_mechanism(_ISSUES_683, ["growth", "risk"], neg, cap=10)
+    monkeypatch.setattr(mech, "_standing_offer", lambda: {"cap": "40"})  # near risk's floor
+    id_to_handle = {n.id: n.handle for n in mech.negotiators}
+    ordered = [id_to_handle[i] for i in mech.next_negotitor_ids()]
+    assert ordered[0] == "growth"
+
+
+def test_mechanism_defaults_to_round_robin_before_first_offer() -> None:
+    neg = _negotiation()  # no opening offers, no standing offer
+    mech = mediator.build_mechanism(_ISSUES_683, ["growth", "risk"], neg, cap=10)
+    assert set(mech.next_negotitor_ids()) == set(mech.negotiator_ids)
+
+
+@pytest.mark.asyncio
+async def test_least_satisfied_order_preserves_termination() -> None:
+    """Reordering who is asked must not break termination: a converging run still
+    stops at agreement, not the step cap (the anti-theatre invariant)."""
     persister = FakePersister()
     channel = FakeChannel(persister, reply_conf=0.9)
     managed = FakeManaged(_ROOM, "mycelium", channel, persister)


### PR DESCRIPTION
Closes #683. Part of #684. **Stacked on #695 (#682)** — base is `feat/682-min-satisfaction`, so this diff is just the #683 change; it retargets to `main` once #695 merges.

## What

When a round doesn't converge, the aligner addressed agents in NEGMAS's fixed round-robin order — wasting turns on agents already content with the standing offer instead of the one who needs to move. Now each step it addresses the agent **furthest from satisfied**.

## How

- **`SatisfactionOrderedSAO`** subclasses `SAOMechanism` and overrides NEGMAS's `next_negotitor_ids` (their spelling) to sort the step's negotiators by satisfaction with the current standing offer — reusing **#682's `estimate_satisfaction`** against each agent's opening ask. **Termination is untouched**: NEGMAS still stops at unanimity regardless of order (the anti-theatre property).
- **`least_satisfied_order`** is a pure, total helper: with no standing offer yet (round 0) or no captured opening offers it returns NEGMAS's round-robin unchanged; the sort is stable, so agents whose satisfaction can't be scored keep their round-robin position.
- `MediatedNegotiation` captures each agent's opening offer (first readable proposal) and exposes `issue_options`; the override reads `current_offer` off the SAO state.

## Guarding the NEGMAS seam (per the discussion)

`next_negotitor_ids` is an internal NEGMAS method, so the guard is **behavioural, not `hasattr`** — a behavioural test fails if the seam is *renamed* or its *semantics* shift, strictly stronger than a canary. A small seam test exists purely to give a clear error message when NEGMAS moves. The five:
1. `test_negmas_turn_order_seam_present` — the explainer: seam callable + default round-robin + `state.current_offer` present.
2. `test_least_satisfied_order_puts_worst_first` — worst-first, and it flips when the standing offer flips.
3. `test_least_satisfied_order_falls_back_to_round_robin` — no standing / no openings / unscoreable → unchanged.
4. `test_mechanism_addresses_least_satisfied_first` — the override composes NEGMAS order + negotiator→handle map + satisfaction.
5. `test_least_satisfied_order_preserves_termination` — a converging run still stops at agreement with the override on (the invariant).

NEGMAS is version-pinned (0.15.7), so these don't flap.

## Validated live

Ran through the real `mediate()` on the harness — converged `40%/Q4`, and once the standing offer favoured risk, growth (the least-satisfied) was the one addressed. Deterministic proof is test #4; the live run confirms the integrated path (real brain + override) runs and still terminates.

## Note on the acceptance criterion

"Converges in fewer rounds" is inherently comparative and non-deterministic with real LLM agents; and with two agents round-robin and least-satisfied-first often coincide (the win compounds with 3+ agents, where a satisfied agent would otherwise waste a turn). The deterministic ordering guarantee is covered by the unit tests. `ruff` + `ty` clean; full mediator/aligner/episode suites green.