### PR TITLE
fix(cli): mycelium up --build builds from local source

### DIFF
--- a/mycelium-cli/src/mycelium/commands/install.py
+++ b/mycelium-cli/src/mycelium/commands/install.py
@@ -307,6 +307,18 @@ def _refresh_compose_templates(*, backup: bool = True) -> list[Path]:
     compose_dest.write_bytes(compose_ref.read_bytes())
     refreshed.append(compose_dest)
 
+    # Copy companion override files. These are always bundled (docker/* in
+    # package-data) and are not user-edited, so no backup is needed for them.
+    for companion in ("compose-dev.yml", "compose-keycloak.yml", "compose-auth-dev.yml"):
+        try:
+            ref = importlib.resources.files("mycelium.docker") / companion
+            data = ref.read_bytes()
+            dest = dest_dir / companion
+            dest.write_bytes(data)
+            refreshed.append(dest)
+        except Exception:
+            pass  # file absent in this wheel version — skip silently
+
     return refreshed
 
 

--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -579,7 +579,38 @@ def start(
 
             _ensure_shared_dir(Path.home() / ".mycelium" / "metrics")
         up_args = ["up", "-d", "--remove-orphans"]
+        build_env: dict[str, str] | None = None
         if build:
+            # Include compose-dev.yml so `--build` builds from the local source
+            # tree instead of downloading pre-built GHCR images. compose-dev.yml
+            # adds build: stanzas and sets pull_policy: never for all first-party
+            # services.
+            #
+            # Build contexts in compose-dev.yml use ${MYCELIUM_REPO_ROOT} (an
+            # absolute path) so that Docker BuildKit resolves them correctly when
+            # the bake definition is piped via stdin — relative paths break in
+            # that transport because buildkit uses CWD, not the compose file
+            # location.
+            dev_compose: Path | None = None
+            try:
+                # instance.py → commands/ → mycelium/ → docker/compose-dev.yml
+                here = Path(__file__).parent.parent / "docker" / "compose-dev.yml"
+                if here.exists():
+                    dev_compose = here
+            except Exception:
+                pass
+            if dev_compose is not None:
+                base = base + ["-f", str(dev_compose)]
+                # Compute repo root: mycelium-cli/src/mycelium/docker/ → up 4 → repo root
+                repo_root = dev_compose.parent.parent.parent.parent.parent
+                build_env = {**__import__("os").environ, "MYCELIUM_REPO_ROOT": str(repo_root)}
+            else:
+                typer.secho(
+                    "  ⚠  --build requires an editable (development) install; "
+                    "compose-dev.yml not found in the package source tree. "
+                    "Falling back to pulling released images.",
+                    fg=typer.colors.YELLOW,
+                )
             up_args.append("--build")
 
         # SPIRE two-phase (#588): the node daemon needs a join token minted against
@@ -597,7 +628,7 @@ def start(
         typer.echo("Starting Mycelium...")
 
         quiet_cmd = base[:2] + ["--progress=plain"] + base[2:] + up_args
-        result = subprocess.run(quiet_cmd, capture_output=True, text=True)
+        result = subprocess.run(quiet_cmd, capture_output=True, text=True, env=build_env)
 
         if result.returncode != 0:
             output = (result.stdout or "") + (result.stderr or "")
@@ -609,7 +640,7 @@ def start(
                     fg=typer.colors.YELLOW,
                 )
                 _remove_managed_containers()
-                result = subprocess.run(base + up_args, check=False)
+                result = subprocess.run(base + up_args, check=False, env=build_env)
                 if result.returncode != 0:
                     raise typer.Exit(result.returncode)
             else:

--- a/mycelium-cli/src/mycelium/docker/compose-dev.yml
+++ b/mycelium-cli/src/mycelium/docker/compose-dev.yml
@@ -1,12 +1,15 @@
-# Dev override: build mycelium-backend from local source instead of pulling.
+# Dev override: build first-party services from local source instead of pulling.
 #
-# Run from the repo root:
+# `mycelium up --build` sets MYCELIUM_REPO_ROOT and injects this file automatically.
+#
+# For manual use, export the variable first:
+#   export MYCELIUM_REPO_ROOT=/path/to/mycelium
 #   docker compose -f mycelium-cli/src/mycelium/docker/compose.yml \
 #                  -f mycelium-cli/src/mycelium/docker/compose-dev.yml \
 #                  up -d --build
 #
-# Build context paths are relative to this file's location (docker/).
-# env_file paths are also relative to this file's location.
+# Build contexts use MYCELIUM_REPO_ROOT (absolute) so that Docker BuildKit
+# resolves them correctly regardless of CWD or the bake-stdin transport.
 services:
   # The `slim` node service is defined in compose.yml with a pulled upstream
   # image (ghcr.io/agntcy/slim) and inline node config. compose-dev.yml is an
@@ -14,12 +17,9 @@ services:
   # dev stack automatically — there is nothing dev-specific to build or override
   # for it, so no `slim:` block is needed here.
 
-  # Override env_file for all services to point at ~/.mycelium/.env so that
-  # LLM_MODEL etc. are available when running compose manually from the repo
-  # root (compose.yml's ../.env path resolves incorrectly then).
   mycelium-backend:
     build:
-      context: ../../../../fastapi-backend
+      context: ${MYCELIUM_REPO_ROOT}/fastapi-backend
       dockerfile: Dockerfile
     pull_policy: never
     image: mycelium-backend:dev
@@ -35,14 +35,14 @@ services:
   # `--build` on the next `up` — so pin it to the dev tag and never pull here.
   mycelium-frontend:
     build:
-      context: ../../../../mycelium-frontend
+      context: ${MYCELIUM_REPO_ROOT}/mycelium-frontend
       dockerfile: Dockerfile
     pull_policy: never
     image: mycelium-frontend:dev
 
   mycelium-collector:
     build:
-      context: ../../../
+      context: ${MYCELIUM_REPO_ROOT}/mycelium-cli
       dockerfile: Dockerfile.collector
     pull_policy: never
     image: mycelium-collector:dev


### PR DESCRIPTION
## Summary

- **`compose-dev.yml`**: Replace `../../../../fastapi-backend` relative paths with `${MYCELIUM_REPO_ROOT}` (absolute). Docker BuildKit's bake-stdin transport resolves relative context paths from CWD rather than the compose file's own directory, so the relative paths were resolving to `/fastapi-backend` (filesystem root).
- **`instance.py`**: When `--build` is passed, derive the repo root from `__file__` and inject `MYCELIUM_REPO_ROOT` into the subprocess environment — so paths are always absolute regardless of which directory `mycelium up` is run from.
- **`install.py`**: Refresh `compose-dev.yml` (and other companion override files) to `~/.mycelium/docker/` during `install`/`upgrade`, keeping them current after updates.

## Test plan

- [ ] `cd mycelium-cli && uv tool install -e . --with mycelium-backend-client@../mycelium-client --force`
- [ ] Run `mycelium up --build` from any directory (not the repo root) — confirm it builds `mycelium-backend:dev` from `fastapi-backend/` rather than pulling the GHCR image
- [ ] Confirm `unable to prepare context: path "/fastapi-backend" not found` no longer appears
- [ ] Run `mycelium up` without `--build` — confirm normal pull behaviour is unchanged


Made with [Cursor](https://cursor.com)