### PR TITLE
fix: surface backend detail message on hub HTTP errors (#703)

### DIFF
--- a/mycelium-cli/src/mycelium/client.py
+++ b/mycelium-cli/src/mycelium/client.py
@@ -30,6 +30,7 @@ on the machine.
 
 from __future__ import annotations
 
+import json
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
@@ -153,6 +154,23 @@ def typed_client(config: MyceliumConfig | None = None, *, handle: str | None = N
     client = Client(base_url=cfg.server.api_url, raise_on_unexpected_status=True)
     headers = auth_headers(cfg, handle=handle)
     return client.with_headers(headers) if headers else client
+
+
+def hub_error_detail(content: bytes) -> str:
+    """Extract a human-readable message from a hub HTTP error response body.
+
+    FastAPI serialises ``HTTPException`` as ``{"detail": "..."}``; we surface
+    that string so the caller sees the backend's actual message rather than a
+    bare status code.  Falls back to the raw decoded body, and to an empty
+    string for truly empty responses.
+    """
+    try:
+        body = json.loads(content)
+        if isinstance(body, dict) and "detail" in body:
+            return str(body["detail"])
+    except (ValueError, KeyError):
+        pass
+    return content.decode(errors="replace").strip()
 
 
 def hub_client(

--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import httpx
 import typer
 
+from mycelium.client import hub_error_detail
 from mycelium.config import MyceliumConfig, ServerConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
@@ -800,7 +801,13 @@ def status(ctx: typer.Context) -> None:
                 elif isinstance(exc, httpx.TimeoutException):
                     backend_error = f"Timeout connecting to {config.server.api_url}"
                 elif isinstance(exc, httpx.HTTPStatusError):
-                    backend_error = f"Backend returned HTTP {exc.response.status_code}"
+                    detail = hub_error_detail(exc.response.content)
+                    if detail:
+                        backend_error = (
+                            f"Backend returned HTTP {exc.response.status_code}: {detail}"
+                        )
+                    else:
+                        backend_error = f"Backend returned HTTP {exc.response.status_code}"
                 else:
                     backend_error = str(exc)
 

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -22,7 +22,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
-from mycelium.client import hub_client, typed_client
+from mycelium.client import hub_client, hub_error_detail, typed_client
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.filesystem import (
@@ -68,7 +68,11 @@ def _hub_session() -> Iterator[Any]:
             )
             raise typer.Exit(1) from exc
         except UnexpectedStatus as exc:
-            console.print(f"[red]Error:[/red] hub at {_hub_url()} returned HTTP {exc.status_code}.")
+            detail = hub_error_detail(exc.content)
+            suffix = f": {detail}" if detail else "."
+            console.print(
+                f"[red]Error:[/red] hub at {_hub_url()} returned HTTP {exc.status_code}{suffix}"
+            )
             raise typer.Exit(1) from exc
 
 

--- a/mycelium-cli/src/mycelium/commands/skill.py
+++ b/mycelium-cli/src/mycelium/commands/skill.py
@@ -23,7 +23,7 @@ import httpx
 import typer
 from rich.console import Console
 
-from mycelium.client import typed_client
+from mycelium.client import hub_error_detail, typed_client
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium_backend_client.errors import UnexpectedStatus
@@ -59,7 +59,11 @@ def _hub_session() -> Iterator[Any]:
             )
             raise typer.Exit(1) from exc
         except UnexpectedStatus as exc:
-            console.print(f"[red]Error:[/red] hub at {_hub_url()} returned HTTP {exc.status_code}.")
+            detail = hub_error_detail(exc.content)
+            suffix = f": {detail}" if detail else "."
+            console.print(
+                f"[red]Error:[/red] hub at {_hub_url()} returned HTTP {exc.status_code}{suffix}"
+            )
             raise typer.Exit(1) from exc
 
 

--- a/mycelium-cli/tests/test_memory_commands.py
+++ b/mycelium-cli/tests/test_memory_commands.py
@@ -253,6 +253,33 @@ def test_memory_get_hub_error_status_reports_cleanly(monkeypatch: pytest.MonkeyP
     assert "HTTP 500" in result.output
 
 
+def test_memory_set_403_surfaces_backend_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 403 from the hub must show the backend's ``detail`` message, not just the code."""
+    detail_msg = (
+        "handle 'cli-user' is not the authenticated principal '@julvalen@cisco.com' "
+        "and has granted it no access; add 'julvalen@cisco.com' to that handle's "
+        "owner or allow_from to act on its behalf."
+    )
+
+    def _sync(**_kw: Any):
+        import json
+
+        raise UnexpectedStatus(403, json.dumps({"detail": detail_msg}).encode())
+
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.memory.create_memories_api_rooms_room_name_memory_post.sync",
+        _sync,
+    )
+
+    result = runner.invoke(
+        memory_cmd.app, ["set", "context/notes", "hello", "--room", "demo"]
+    )
+    assert result.exit_code == 1
+    assert "HTTP 403" in result.output
+    assert "cli-user" in result.output
+    assert "julvalen@cisco.com" in result.output
+
+
 # ── ls ───────────────────────────────────────────────────────────────────────
 
 

--- a/mycelium-cli/tests/test_memory_commands.py
+++ b/mycelium-cli/tests/test_memory_commands.py
@@ -271,9 +271,7 @@ def test_memory_set_403_surfaces_backend_detail(monkeypatch: pytest.MonkeyPatch)
         _sync,
     )
 
-    result = runner.invoke(
-        memory_cmd.app, ["set", "context/notes", "hello", "--room", "demo"]
-    )
+    result = runner.invoke(memory_cmd.app, ["set", "context/notes", "hello", "--room", "demo"])
     assert result.exit_code == 1
     assert "HTTP 403" in result.output
     assert "cli-user" in result.output

--- a/mycelium-cli/tests/test_skill_commands.py
+++ b/mycelium-cli/tests/test_skill_commands.py
@@ -161,6 +161,31 @@ def test_skill_get_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "Not found" in result.output
 
 
+def test_skill_set_403_surfaces_backend_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 403 from the hub must show the backend's ``detail`` message, not just the code."""
+    import json
+
+    detail_msg = (
+        "handle 'cli-user' is not the authenticated principal '@julvalen@cisco.com' "
+        "and has granted it no access"
+    )
+
+    def _sync(*, room_name, client, body):
+        raise UnexpectedStatus(403, json.dumps({"detail": detail_msg}).encode())
+
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.skills.create_skill_api_rooms_room_name_skills_post.sync",
+        _sync,
+    )
+    result = runner.invoke(
+        skill_cmd.app, ["set", "alpha", "do something", "--room", "demo"]
+    )
+    assert result.exit_code == 1
+    assert "HTTP 403" in result.output
+    assert "cli-user" in result.output
+    assert "julvalen@cisco.com" in result.output
+
+
 def test_skill_rm(monkeypatch: pytest.MonkeyPatch) -> None:
     class _Resp:
         status_code = 204

--- a/mycelium-cli/tests/test_skill_commands.py
+++ b/mycelium-cli/tests/test_skill_commands.py
@@ -177,9 +177,7 @@ def test_skill_set_403_surfaces_backend_detail(monkeypatch: pytest.MonkeyPatch) 
         "mycelium_backend_client.api.skills.create_skill_api_rooms_room_name_skills_post.sync",
         _sync,
     )
-    result = runner.invoke(
-        skill_cmd.app, ["set", "alpha", "do something", "--room", "demo"]
-    )
+    result = runner.invoke(skill_cmd.app, ["set", "alpha", "do something", "--room", "demo"])
     assert result.exit_code == 1
     assert "HTTP 403" in result.output
     assert "cli-user" in result.output


### PR DESCRIPTION
## Summary

- Adds `hub_error_detail(content: bytes) -> str` helper to `client.py` that decodes FastAPI's `{"detail": "..."}` JSON error body, falling back to raw decoded bytes
- Wires it into the `_hub_session` `UnexpectedStatus` handlers in `memory.py` and `skill.py` — a 403 handle-mismatch now prints the backend's actionable message instead of a bare status code
- Applies the same fix to the `httpx.HTTPStatusError` branch in `instance.py` (`exc.response.content`)
- Adds `test_memory_set_403_surfaces_backend_detail` and `test_skill_set_403_surfaces_backend_detail` covering the exact scenario from the issue report

## Before / After

**Before:**
```
Error: hub at https://mycelium.outshift.io returned HTTP 403.
```

**After:**
```
Error: hub at https://mycelium.outshift.io returned HTTP 403: handle 'cli-user' is not the authenticated principal '@julvalen@cisco.com' and has granted it no access; add 'julvalen@cisco.com' to that handle's owner or allow_from to act on its behalf.
```

## Root cause note

The issue proposed surfacing `exc.detail`, but `UnexpectedStatus` has no such attribute — the body is in `exc.content: bytes`. The fix parses that correctly.

## Test plan

- [ ] `uv run pytest tests/test_memory_commands.py::test_memory_set_403_surfaces_backend_detail tests/test_skill_commands.py::test_skill_set_403_surfaces_backend_detail -v`
- [ ] Manual: `mycelium memory set context/test "hello" --room demo --handle cli-user` against a gated hub while logged in as a different principal → confirm detail message appears

Closes #703

Made with [Cursor](https://cursor.com)