### PR TITLE
feat(frontend): show memory count on home dashboard room cards

### DIFF
--- a/mycelium-frontend/src/components/home-dashboard.tsx
+++ b/mycelium-frontend/src/components/home-dashboard.tsx
@@ -11,8 +11,8 @@ import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CreateRoomDialog } from "@/components/create-room-dialog";
 import { useOpenInstallModal } from "@/components/install-modal";
-import { type EpisodeSummary, type Room } from "@/lib/api";
-import { useRoomAgents, useRoomEpisodes, useRooms, type RoomQueryOptions } from "@/lib/room-data";
+import { MEMORIES_PAGE_LIMIT, type EpisodeSummary, type Room } from "@/lib/api";
+import { useRoomAgents, useRoomEpisodes, useRoomMemories, useRooms, type RoomQueryOptions } from "@/lib/room-data";
 import { useBackendHealth } from "@/lib/use-status";
 
 /** The cards read the shared caches but don't drive them: a grid of rooms is a
@@ -183,8 +183,17 @@ function RoomCard({ room }: { room: Room }) {
   // and opening a room is what starts watching it.
   const { agents, loading: agentsLoading } = useRoomAgents(room.name, NO_POLL);
   const { episodes } = useRoomEpisodes(room.name, NO_POLL);
+  const { memories, loading: memoriesLoading } = useRoomMemories(room.name, NO_POLL);
 
   const agentCount = agentsLoading ? null : agents.length;
+  // A room card is a glance, not a paginated view: a count that hit the fetch's
+  // own page cap is "at least this many," not "exactly this many," so it reads
+  // as a floor rather than a false total.
+  const memoryCount = memoriesLoading
+    ? null
+    : memories.length >= MEMORIES_PAGE_LIMIT
+      ? `${memories.length}+`
+      : String(memories.length);
   const live = episodes.map(episodeState).filter(s => s.live).length;
   const latest = episodes[0];
   const latestState = latest ? episodeState(latest) : null;
@@ -219,6 +228,9 @@ function RoomCard({ room }: { room: Room }) {
         </span>
         <span className="tabular">
           <span className="text-text">{episodes?.length ?? "-"}</span> episode{episodes?.length === 1 ? "" : "s"}
+        </span>
+        <span className="tabular">
+          <span className="text-text">{memoryCount ?? "-"}</span> memor{memories.length === 1 ? "y" : "ies"}
         </span>
         {latestState && !latestState.live && (
           <span className="ml-auto flex items-center gap-1.5 capitalize" style={{ color: latestState.color }}>

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -193,8 +193,13 @@ export async function createMemories(
   });
 }
 
+/** `fetchMemories`'s page size — exported so a caller showing a raw count
+ *  (the dashboard's room cards) can tell "exactly this many" apart from
+ *  "at least this many" instead of reporting the cap as a true total. */
+export const MEMORIES_PAGE_LIMIT = 50;
+
 export async function fetchMemories(roomName: string, prefix?: string): Promise<Memory[]> {
-  const params = new URLSearchParams({ limit: "50" });
+  const params = new URLSearchParams({ limit: String(MEMORIES_PAGE_LIMIT) });
   if (prefix) params.set("prefix", prefix);
   return apiFetch<Memory[]>(`/api/rooms/${roomName}/memory?${params}`, {
     cache: "no-store",


### PR DESCRIPTION
## Summary

- Adds a fourth stat to each room card on the home dashboard: memory count, alongside the existing agents/episodes stats. Same `NO_POLL` glance pattern — reads once, doesn't poll.
- `fetchMemories`'s page cap (50) is now an exported `MEMORIES_PAGE_LIMIT` constant, so the card can tell "exactly this many" apart from "at least this many": a room at or past the cap shows `50+` rather than reporting the cap as a false total.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Verified locally against the local Docker backend: `demo` room (12 memories, under the cap) shows the exact count