### PR TITLE
fix(tests): skip engine tests when negmas optional extra is absent

### DIFF
--- a/mycelium-cli/tests/test_engine_mediator.py
+++ b/mycelium-cli/tests/test_engine_mediator.py
@@ -16,6 +16,8 @@ import json
 
 import pytest
 
+pytest.importorskip("negmas", reason="negmas not installed; install mycelium[engine]")
+
 from mycelium.engine import mediator
 
 

--- a/mycelium-cli/tests/test_engine_runtime.py
+++ b/mycelium-cli/tests/test_engine_runtime.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import pytest
 
+pytest.importorskip("negmas", reason="negmas not installed; install mycelium[engine]")
+
 from mycelium.engine.runtime import EngineDrive
 from mycelium.slim import l9
 


### PR DESCRIPTION
## Problem

`test_engine_mediator.py` and `test_engine_runtime.py` both import from
`mycelium.engine`, which in turn imports `negmas` at module level.
`negmas` lives in the optional `[engine]` extra — not the base `dev`
venv — so `pytest` crashed during **collection** (not test execution)
on a standard `uv sync --group dev` install, masking the 2 engine test
files entirely with an `ImportError`.

`ty` already had an `[[overrides]]` rule suppressing the unresolved-import
for `mediator.py`; this fix mirrors that intent in the test layer.

## Fix

Add `pytest.importorskip("negmas", reason="…")` at the top of each
affected test file. pytest will **skip** the module cleanly instead of
erroring, and contributors who have installed `mycelium[engine]` will
run the tests normally.

## Test plan

- [x] `uv run pytest tests/ -q` with the base dev venv → `452 passed, 2 skipped`
- [x] No collection errors

Made with [Cursor](https://cursor.com)