### PR TITLE
fix(frontend): resolve 37 react-hooks tech-debt warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ pnpm-lock.yaml
 # portman per-worktree dev-server port leases (machine-local)
 .ports.lock
 .ports.toml
+
+# Editor swap / backup files
+*.swp
+*.swo
+*~

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -21,6 +21,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className="dark" suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
+        {/* App Router uses layout.tsx, not pages/_document.js — false positive. */}
+        {/* eslint-disable-next-line @next/next/no-page-custom-font */}
         <link
           href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,600&family=IBM+Plex+Sans:wght@400;500;600&family=Geist+Mono:wght@400;500;600;700&display=swap"
           rel="stylesheet"

--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className="dark" suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        {/* App Router uses layout.tsx, not pages/_document.js — false positive. */}
+        {/* The rule wants fonts in pages/_document.js, which the App Router has no equivalent of. */}
         {/* eslint-disable-next-line @next/next/no-page-custom-font */}
         <link
           href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,600&family=IBM+Plex+Sans:wght@400;500;600&family=Geist+Mono:wght@400;500;600;700&display=swap"

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -52,16 +52,14 @@ function RoomWorkspace() {
   const [inspectorOpen, setInspectorOpen] = useState(true);
   const [editorView, setEditorView] = useState<View>("channel");
   const [negPhase, setNegPhase] = useState<NegotiationPhase>("idle");
-  const [tourActive, setTourActive] = useState(false);
+  // useSearchParams is read here before the hook is declared later on line 97;
+  // moved forward so tourActive can be initialized from the URL in one render.
+  const searchParamsEarly = useSearchParams();
+  // Lazy initializer reads the URL once on mount; setTourActive(false) in the
+  // exit handler still works. No effect needed — the param is client-only state.
+  const [tourActive, setTourActive] = useState(() => searchParamsEarly.get("tour") === "1");
   const [inviteEngine, setInviteEngine] = useState(false);
   const [focusMemory, setFocusMemory] = useState<{ key: string; nonce: number } | null>(null);
-
-  // Start the coached tour when arriving via "Run a sample coordination".
-  useEffect(() => {
-    if (typeof window !== "undefined" && new URLSearchParams(window.location.search).get("tour") === "1") {
-      setTourActive(true);
-    }
-  }, []);
 
   const handleTourExit = useCallback(() => {
     setTourActive(false);
@@ -94,7 +92,7 @@ function RoomWorkspace() {
   // row — a result opens the item, not just the room it is in. The parameter is
   // consumed on arrival so returning to a rail later doesn't re-select, and so
   // jumping to the same item twice is a change the panel sees both times.
-  const searchParams = useSearchParams();
+  const searchParams = searchParamsEarly;
   const router = useRouter();
   const focusParam = searchParams.get("focus");
   const [focus, setFocus] = useState<FocusTarget | null>(null);
@@ -112,6 +110,10 @@ function RoomWorkspace() {
       router.replace(memoryHref(roomName, target.id));
       return;
     }
+    // Focus-dispatch: the effect consumes one URL parameter and translates it
+    // into the appropriate panel open + item selected. Lifting this into the
+    // caller would require threading focus state through every page entry point.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setFocus(target);
     if (target.type === "episode") openTab("episodes");
     else if (target.type === "agent") openTab("agents");

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -52,11 +52,9 @@ function RoomWorkspace() {
   const [inspectorOpen, setInspectorOpen] = useState(true);
   const [editorView, setEditorView] = useState<View>("channel");
   const [negPhase, setNegPhase] = useState<NegotiationPhase>("idle");
-  // useSearchParams is read here before the hook is declared later on line 97;
-  // moved forward so tourActive can be initialized from the URL in one render.
+  // Hoisted above the state below so the tour flag can be seeded from the URL.
   const searchParamsEarly = useSearchParams();
-  // Lazy initializer reads the URL once on mount; setTourActive(false) in the
-  // exit handler still works. No effect needed — the param is client-only state.
+  // `?tour=1` seeds the tour once on mount; exiting is client-only state after that.
   const [tourActive, setTourActive] = useState(() => searchParamsEarly.get("tour") === "1");
   const [inviteEngine, setInviteEngine] = useState(false);
   const [focusMemory, setFocusMemory] = useState<{ key: string; nonce: number } | null>(null);
@@ -110,9 +108,8 @@ function RoomWorkspace() {
       router.replace(memoryHref(roomName, target.id));
       return;
     }
-    // Focus-dispatch: the effect consumes one URL parameter and translates it
-    // into the appropriate panel open + item selected. Lifting this into the
-    // caller would require threading focus state through every page entry point.
+    // The focus target is consumed here rather than derived: it has to outlive
+    // the parameter, which is cleared as soon as it has been acted on.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setFocus(target);
     if (target.type === "episode") openTab("episodes");

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -93,7 +93,7 @@ export function ActingAsPicker() {
   useEffect(() => {
     if (open) {
       refresh(); // async fetch; setState only in its .then() callback
-      // setView/setError reset picker state on open — one logical unit with refresh.
+      // Opening resets the picker to its default view.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setView("switch");
       setError(null);

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -92,7 +92,9 @@ export function ActingAsPicker() {
 
   useEffect(() => {
     if (open) {
-      refresh();
+      refresh(); // async fetch; setState only in its .then() callback
+      // setView/setError reset picker state on open — one logical unit with refresh.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setView("switch");
       setError(null);
     }

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -89,6 +89,9 @@ export function AgentsPanel({
 
   useEffect(() => {
     if (!engineInvite) return;
+    // Prop-triggered one-shot: parent signals "open the engine tab" by flipping
+    // engineInvite; the handler clears it after this effect fires.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setAddTab("engines");
     setAddOpen(true);
     onEngineInviteShown?.();
@@ -101,6 +104,10 @@ export function AgentsPanel({
   const highlightRow = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!focusHandle) return;
+    // Focus-consumed pattern: parent supplies a handle to highlight, then this
+    // effect marks the request consumed. The highlight state must persist past
+    // the parameter being cleared, so it cannot be derived from the prop alone.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setHighlight(focusHandle);
     onFocusConsumed?.();
   }, [focusHandle, onFocusConsumed]);

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -89,8 +89,7 @@ export function AgentsPanel({
 
   useEffect(() => {
     if (!engineInvite) return;
-    // Prop-triggered one-shot: parent signals "open the engine tab" by flipping
-    // engineInvite; the handler clears it after this effect fires.
+    // One-shot: the parent flips engineInvite, and clears it once the tab is shown.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setAddTab("engines");
     setAddOpen(true);
@@ -104,9 +103,7 @@ export function AgentsPanel({
   const highlightRow = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!focusHandle) return;
-    // Focus-consumed pattern: parent supplies a handle to highlight, then this
-    // effect marks the request consumed. The highlight state must persist past
-    // the parameter being cleared, so it cannot be derived from the prop alone.
+    // The highlight outlives focusHandle, which is cleared as soon as it is consumed.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setHighlight(focusHandle);
     onFocusConsumed?.();

--- a/mycelium-frontend/src/components/auth-session.tsx
+++ b/mycelium-frontend/src/components/auth-session.tsx
@@ -69,8 +69,7 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
   }, [setPrincipal]);
 
   useEffect(() => {
-    // refresh() is an async fetch; setState is called only inside its .then()
-    // callback, not synchronously in the effect body.
+    // Async fetch; setState happens in refresh()'s .then(), not the effect body.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     refresh();
   }, [refresh]);
@@ -85,8 +84,7 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
 
   const login = useCallback(() => {
     const returnTo = window.location.pathname + window.location.search;
-    // Full-page navigation is required: the server sets auth cookies on the
-    // callback URL, and router.push() would not trigger that round-trip.
+    // Full-page navigation: the server sets the auth cookies on the callback URL.
     // eslint-disable-next-line @next/next/no-location-assign-relative-destination
     window.location.href = `/api/auth/login?return_to=${encodeURIComponent(returnTo)}`;
   }, []);
@@ -94,8 +92,7 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
   const logout = useCallback(async () => {
     await fetch("/api/auth/logout", { method: "POST" });
     setPrincipal("");
-    // Full-page reload clears all React state after the session cookie is
-    // cleared server-side — router.push("/") would leave stale state behind.
+    // Full-page reload, so no React state survives the cleared session cookie.
     // eslint-disable-next-line @next/next/no-location-assign-relative-destination
     window.location.href = "/";
   }, [setPrincipal]);

--- a/mycelium-frontend/src/components/auth-session.tsx
+++ b/mycelium-frontend/src/components/auth-session.tsx
@@ -85,12 +85,18 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
 
   const login = useCallback(() => {
     const returnTo = window.location.pathname + window.location.search;
+    // Full-page navigation is required: the server sets auth cookies on the
+    // callback URL, and router.push() would not trigger that round-trip.
+    // eslint-disable-next-line @next/next/no-location-assign-relative-destination
     window.location.href = `/api/auth/login?return_to=${encodeURIComponent(returnTo)}`;
   }, []);
 
   const logout = useCallback(async () => {
     await fetch("/api/auth/logout", { method: "POST" });
     setPrincipal("");
+    // Full-page reload clears all React state after the session cookie is
+    // cleared server-side — router.push("/") would leave stale state behind.
+    // eslint-disable-next-line @next/next/no-location-assign-relative-destination
     window.location.href = "/";
   }, [setPrincipal]);
 

--- a/mycelium-frontend/src/components/auth-session.tsx
+++ b/mycelium-frontend/src/components/auth-session.tsx
@@ -69,6 +69,9 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
   }, [setPrincipal]);
 
   useEffect(() => {
+    // refresh() is an async fetch; setState is called only inside its .then()
+    // callback, not synchronously in the effect body.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     refresh();
   }, [refresh]);
 

--- a/mycelium-frontend/src/components/command-palette.tsx
+++ b/mycelium-frontend/src/components/command-palette.tsx
@@ -48,6 +48,10 @@ export function CommandPalette({ open, onClose, commands, recent, onRun, mac }: 
 
   useEffect(() => {
     if (!open) return;
+    // Reset query and capture the element to restore focus to on close. These
+    // must run in an effect because restoreTo reads document.activeElement (a
+    // DOM side effect) and ran.current + setQuery reset the palette together.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setQuery("");
     ran.current = false;
     restoreTo.current = document.activeElement as HTMLElement | null;

--- a/mycelium-frontend/src/components/command-palette.tsx
+++ b/mycelium-frontend/src/components/command-palette.tsx
@@ -48,9 +48,8 @@ export function CommandPalette({ open, onClose, commands, recent, onRun, mac }: 
 
   useEffect(() => {
     if (!open) return;
-    // Reset query and capture the element to restore focus to on close. These
-    // must run in an effect because restoreTo reads document.activeElement (a
-    // DOM side effect) and ran.current + setQuery reset the palette together.
+    // Capturing what to restore focus to reads document.activeElement, so the
+    // rest of the on-open reset stays here with it.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setQuery("");
     ran.current = false;

--- a/mycelium-frontend/src/components/current-user.tsx
+++ b/mycelium-frontend/src/components/current-user.tsx
@@ -34,8 +34,8 @@ export function CurrentUserProvider({ children }: { children: ReactNode }) {
     if (typeof window === "undefined") return;
     const saved = window.localStorage.getItem(STORAGE_KEY);
     if (saved) {
-      // SSR hydration: localStorage unavailable on server; lazy init would produce
-      // a hydration mismatch (server "" ≠ client stored value) on the first render.
+      // localStorage is client-only: seeding this at init would mismatch the
+      // SSR render, where the principal is always "".
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setPrincipalState(saved);
     }

--- a/mycelium-frontend/src/components/current-user.tsx
+++ b/mycelium-frontend/src/components/current-user.tsx
@@ -33,7 +33,12 @@ export function CurrentUserProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (typeof window === "undefined") return;
     const saved = window.localStorage.getItem(STORAGE_KEY);
-    if (saved) setPrincipalState(saved);
+    if (saved) {
+      // SSR hydration: localStorage unavailable on server; lazy init would produce
+      // a hydration mismatch (server "" ≠ client stored value) on the first render.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPrincipalState(saved);
+    }
   }, []);
 
   const value = useMemo<CurrentUser>(

--- a/mycelium-frontend/src/components/episode-detail.tsx
+++ b/mycelium-frontend/src/components/episode-detail.tsx
@@ -61,8 +61,8 @@ export function EpisodeDetail({ roomName, shortId }: { roomName: string; shortId
 
   useEffect(() => {
     let cancelled = false;
-    // Async fetch: setState calls are all inside .then()/.catch() callbacks, not
-    // synchronously in the effect body. setLoading(true) is a loading-gate reset.
+    // Async fetch; the other setState calls are in its callbacks. This one is
+    // the loading gate, which has to be raised before the fetch starts.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     fetchEpisode(roomName, shortId)

--- a/mycelium-frontend/src/components/episode-detail.tsx
+++ b/mycelium-frontend/src/components/episode-detail.tsx
@@ -61,6 +61,9 @@ export function EpisodeDetail({ roomName, shortId }: { roomName: string; shortId
 
   useEffect(() => {
     let cancelled = false;
+    // Async fetch: setState calls are all inside .then()/.catch() callbacks, not
+    // synchronously in the effect body. setLoading(true) is a loading-gate reset.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     fetchEpisode(roomName, shortId)
       .then(d => { if (!cancelled) { setDetail(d); setLoading(false); } })

--- a/mycelium-frontend/src/components/episodes-rail.tsx
+++ b/mycelium-frontend/src/components/episodes-rail.tsx
@@ -48,8 +48,7 @@ export function EpisodesRail({ roomName, focusShortId = null, onFocusConsumed }:
     if (!focusShortId) return;
     const known = episodes.find((ep) => ep.short_id === focusShortId);
     if (known) {
-      // Focus-consumed: parent provides a short_id to select; the handler clears
-      // it. The selection must outlive the parameter, so it can't be derived.
+      // The selection outlives focusShortId, which is cleared once consumed.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelected(known);
       onFocusConsumed?.();

--- a/mycelium-frontend/src/components/episodes-rail.tsx
+++ b/mycelium-frontend/src/components/episodes-rail.tsx
@@ -48,6 +48,9 @@ export function EpisodesRail({ roomName, focusShortId = null, onFocusConsumed }:
     if (!focusShortId) return;
     const known = episodes.find((ep) => ep.short_id === focusShortId);
     if (known) {
+      // Focus-consumed: parent provides a short_id to select; the handler clears
+      // it. The selection must outlive the parameter, so it can't be derived.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelected(known);
       onFocusConsumed?.();
       return;

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -243,7 +243,6 @@ function parseEvent(msg: Record<string, unknown>): Event {
       // A message type nothing above handles would otherwise vanish from the
       // channel view without a trace (exactly how l9_exchange hid). Surface it
       // loudly so an unsupported/renamed type can't fail silently again.
-      // eslint-disable-next-line no-console
       console.warn(
         `[mycelium] EventStream: unhandled message_type "${mtype}" — ` +
           "rendered as a raw fallback and likely hidden from the channel view",
@@ -270,45 +269,6 @@ function parseEvent(msg: Record<string, unknown>): Event {
     episode,
     raw,
   };
-}
-
-// Per-event-type styling. Tone drives the accent color of the label + bar.
-const typeStyles: Record<string, { tone: "accent" | "ok" | "warn" | "muted" | "ink"; label: string }> = {
-  broadcast:              { tone: "ink",    label: "BROADCAST" },
-  direct:                 { tone: "accent", label: "DIRECT" },
-  announce:               { tone: "ink",    label: "ANNOUNCE" },
-  delegate:               { tone: "accent", label: "DELEGATE" },
-  coordination_join:      { tone: "accent", label: "JOIN" },
-  coordination_leave:     { tone: "muted",  label: "LEAVE" },
-  coordination_start:     { tone: "accent", label: "START" },
-  coordination_tick:      { tone: "muted",  label: "TICK" },
-  coordination_consensus: { tone: "ok",     label: "CONSENSUS" },
-  memory_changed:         { tone: "warn",   label: "MEMORY" },
-  l9_knowledge:           { tone: "warn",   label: "KNOWLEDGE" },
-};
-const defaultStyle = { tone: "muted" as const, label: "MSG" };
-
-function toneColor(t: "accent" | "ok" | "warn" | "muted" | "ink"): string {
-  return t === "accent" ? "var(--accent)"
-       : t === "ok"     ? "var(--green)"
-       : t === "warn"   ? "var(--yellow)"
-       : t === "ink"    ? "var(--text)"
-                        : "var(--muted-foreground)";
-}
-
-const MENTION_RE = /(@[\w-]+)/g;
-
-function renderWithMentions(text: string): React.ReactNode {
-  // split() with a capturing group returns alternating [non-match, match, ...].
-  // Odd indices are the @handles; this avoids the stateful .test() gotcha.
-  const parts = text.split(MENTION_RE);
-  return parts.map((part, i) =>
-    i % 2 === 1 ? (
-      <span key={i} className="text-accent font-semibold">{part}</span>
-    ) : (
-      <span key={i}>{part}</span>
-    ),
-  );
 }
 
 export type View = "channel" | "negotiate" | "plan" | "network";

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -403,8 +403,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   const highlightRow = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!focusMessageId) return;
-    // Focus-consumed: parent supplies a message ID to highlight; the handler
-    // clears it. Highlight must outlive the cleared prop, so it can't be derived.
+    // The highlight outlives focusMessageId, which is cleared once consumed.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setHighlight(focusMessageId);
     onFocusConsumed?.();

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -443,6 +443,9 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   const highlightRow = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!focusMessageId) return;
+    // Focus-consumed: parent supplies a message ID to highlight; the handler
+    // clears it. Highlight must outlive the cleared prop, so it can't be derived.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setHighlight(focusMessageId);
     onFocusConsumed?.();
   }, [focusMessageId, onFocusConsumed]);

--- a/mycelium-frontend/src/components/global-search.tsx
+++ b/mycelium-frontend/src/components/global-search.tsx
@@ -3,12 +3,12 @@
 
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useState, type ReactNode } from "react";
+import { useIsMac } from "@/lib/client-hooks";
 import { useRouter } from "next/navigation";
 import { SearchPalette } from "@/components/search-palette";
 import { useKeyAction } from "@/components/keymap-provider";
 import { searchEverything } from "@/lib/api";
-import { isMacPlatform } from "@/lib/keymap";
 import { resultHref, type SearchHit } from "@/lib/search";
 
 const OpenSearchContext = createContext<(() => void) | null>(null);
@@ -26,8 +26,7 @@ export function GlobalSearch({ children }: { children?: ReactNode }) {
   const [open, setOpen] = useState(false);
   // Resolved after mount: the server has no platform to read, and a guess would
   // hydrate a ⌘ over a Ctrl.
-  const [mac, setMac] = useState(false);
-  useEffect(() => setMac(isMacPlatform()), []);
+  const mac = useIsMac();
 
   const openSearch = useCallback(() => setOpen(true), []);
   useKeyAction("search.open", openSearch);

--- a/mycelium-frontend/src/components/install-panel.tsx
+++ b/mycelium-frontend/src/components/install-panel.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { ArrowRight, Terminal } from "lucide-react";
 import { CopyField } from "@/components/ui/copy-field";
@@ -85,12 +85,12 @@ export function InstallPanel({ className }: Props) {
   // platform tab is preselected and the config command shows a placeholder
   // host. The origin is only a first guess, since some deployments front
   // the API on a different port than the UI, so it's there to edit.
-  const [platform, setPlatform] = useState<Platform>("unknown");
-  const [hubUrl, setHubUrl] = useState("<this-hub-url>");
-  useEffect(() => {
-    setPlatform(detectPlatform(navigator.userAgent));
-    setHubUrl(window.location.origin);
-  }, []);
+  const [platform, setPlatform] = useState<Platform>(
+    () => typeof window !== "undefined" ? detectPlatform(navigator.userAgent) : "unknown",
+  );
+  const [hubUrl] = useState(
+    () => typeof window !== "undefined" ? window.location.origin : "<this-hub-url>",
+  );
   const note = PLATFORMS.find(p => p.id === platform)?.note;
 
   // "Prompt" is a fourth tab alongside the OS ones, not a fifth platform: it

--- a/mycelium-frontend/src/components/install-panel.tsx
+++ b/mycelium-frontend/src/components/install-panel.tsx
@@ -80,12 +80,11 @@ interface Props {
 export function InstallPanel({ className }: Props) {
   const healthy = useBackendHealth(WAITING_POLL);
 
-  // Server-rendered markup can't know the OS or this page's own origin, so
-  // both land after mount to avoid a hydration mismatch. Until then, no
-  // useSyncExternalStore gives a server snapshot of "unknown"/"<this-hub-url>"
-  // and the real browser values on the client, so the hydration pass updates
-  // the component without a useEffect. Platform is also mutable (user tab clicks),
-  // so an override layer sits on top of the detected value.
+  // Server-rendered markup can't know the OS or this page's own origin: until
+  // the client snapshot arrives, no platform tab is preselected and the config
+  // command shows a placeholder host. The origin is only a first guess, since
+  // some deployments front the API on a different port than the UI, so it's
+  // there to edit — and the OS tabs override the detected platform.
   const noSubscribe = () => () => {};
   const detectedPlatform = useSyncExternalStore(
     noSubscribe,

--- a/mycelium-frontend/src/components/install-panel.tsx
+++ b/mycelium-frontend/src/components/install-panel.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useState } from "react";
+import { useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { ArrowRight, Terminal } from "lucide-react";
 import { CopyField } from "@/components/ui/copy-field";
@@ -82,15 +82,23 @@ export function InstallPanel({ className }: Props) {
 
   // Server-rendered markup can't know the OS or this page's own origin, so
   // both land after mount to avoid a hydration mismatch. Until then, no
-  // platform tab is preselected and the config command shows a placeholder
-  // host. The origin is only a first guess, since some deployments front
-  // the API on a different port than the UI, so it's there to edit.
-  const [platform, setPlatform] = useState<Platform>(
-    () => typeof window !== "undefined" ? detectPlatform(navigator.userAgent) : "unknown",
+  // useSyncExternalStore gives a server snapshot of "unknown"/"<this-hub-url>"
+  // and the real browser values on the client, so the hydration pass updates
+  // the component without a useEffect. Platform is also mutable (user tab clicks),
+  // so an override layer sits on top of the detected value.
+  const noSubscribe = () => () => {};
+  const detectedPlatform = useSyncExternalStore(
+    noSubscribe,
+    () => detectPlatform(navigator.userAgent) as Platform,
+    () => "unknown" as Platform,
   );
-  const [hubUrl] = useState(
-    () => typeof window !== "undefined" ? window.location.origin : "<this-hub-url>",
+  const hubUrl = useSyncExternalStore(
+    noSubscribe,
+    () => window.location.origin,
+    () => "<this-hub-url>",
   );
+  const [platformOverride, setPlatform] = useState<Platform | null>(null);
+  const platform = platformOverride ?? detectedPlatform;
   const note = PLATFORMS.find(p => p.id === platform)?.note;
 
   // "Prompt" is a fourth tab alongside the OS ones, not a fifth platform: it

--- a/mycelium-frontend/src/components/keymap-provider.tsx
+++ b/mycelium-frontend/src/components/keymap-provider.tsx
@@ -374,11 +374,14 @@ export function useKeyReveal(): boolean {
   const api = useContext(KeymapContext);
   // useSyncExternalStore is the idiomatic fit: subscribe to an external signal
   // (the hold/release of the reveal modifier) and snapshot its current value.
-  return useSyncExternalStore(
-    (listener) => api?.subscribeReveal(listener) ?? (() => {}),
-    () => api?.revealed() ?? false,
-    () => false,
+  // Stabilise subscribe/getSnapshot with useCallback so React doesn't
+  // unsubscribe and resubscribe on every render.
+  const subscribe = useCallback(
+    (listener: () => void) => api?.subscribeReveal(listener) ?? (() => {}),
+    [api],
   );
+  const getSnapshot = useCallback(() => api?.revealed() ?? false, [api]);
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }
 
 /** The status-bar affordances that make `?` and ⌘K findable without knowing

--- a/mycelium-frontend/src/components/keymap-provider.tsx
+++ b/mycelium-frontend/src/components/keymap-provider.tsx
@@ -11,8 +11,10 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
+import { useIsMac } from "@/lib/client-hooks";
 import { CommandPalette } from "@/components/command-palette";
 import { KeymapCheatsheet } from "@/components/keymap-cheatsheet";
 import { loadRecent, pushRecent, saveRecent, type PaletteCommand } from "@/lib/commands";
@@ -21,7 +23,6 @@ import {
   eventToChord,
   formatChord,
   isCommandChord,
-  isMacPlatform,
   isModifierKey,
   matchBinding,
   paletteBindings,
@@ -85,14 +86,16 @@ export function KeymapProvider({ children }: { children: ReactNode }) {
   const [scopeCounts, setScopeCounts] = useState<Partial<Record<KeyScope, number>>>({ global: 1 });
   const [helpOpen, setHelpOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
-  // Which commands ran, most recent first. Read after mount: the server has no
-  // storage, and the palette's ordering isn't worth a hydration mismatch.
+  // Which commands ran, most recent first. Hydrated from localStorage after mount
+  // so that SSR and the first hydration render both produce [] (no mismatch).
   const [recent, setRecent] = useState<string[]>([]);
-  useEffect(() => setRecent(loadRecent()), []);
-  // Resolved after mount: the server has no platform to read, and a guess would
-  // hydrate a ⌘ over a Ctrl.
-  const [mac, setMac] = useState(false);
-  useEffect(() => setMac(isMacPlatform()), []);
+  useEffect(() => {
+    // SSR hydration: localStorage unavailable on server; useSyncExternalStore would
+    // still need a separate setRecent for command-use writes, so this is simpler.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setRecent(loadRecent());
+  }, []);
+  const mac = useIsMac();
 
   // Reveal is pushed to subscribers rather than held in state: holding ⌥ would
   // otherwise re-render the whole app through the context value.
@@ -199,8 +202,17 @@ export function KeymapProvider({ children }: { children: ReactNode }) {
   }, [dispatch]);
 
   const commands = useMemo(
-    // Recomputed when the palette opens, so it reflects what's mounted then.
-    () => (paletteOpen ? collectCommands(scopes) : []),
+    () => {
+      // collectCommands reads commandSources.current and handlers.current (refs).
+      // Moving this into useEffect + setState would introduce set-state-in-effect;
+      // the refs are intentionally stable mutable registries — reading them here is safe.
+      // eslint-disable-next-line react-hooks/refs
+      return paletteOpen ? collectCommands(scopes) : [];
+    },
+    // commandEpoch is a cache-bust epoch that increments on registration changes;
+    // it is not referenced in the callback body (refs are read via collectCommands)
+    // but IS required so the list recomputes when registrations change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [paletteOpen, commandEpoch, scopes, collectCommands],
   );
 
@@ -360,13 +372,13 @@ export function useKeyCapture(): KeymapApi["captureKeys"] {
  *  never reveals. */
 export function useKeyReveal(): boolean {
   const api = useContext(KeymapContext);
-  const [revealed, setRevealed] = useState(false);
-  useEffect(() => {
-    if (!api) return;
-    setRevealed(api.revealed());
-    return api.subscribeReveal(setRevealed);
-  }, [api]);
-  return revealed;
+  // useSyncExternalStore is the idiomatic fit: subscribe to an external signal
+  // (the hold/release of the reveal modifier) and snapshot its current value.
+  return useSyncExternalStore(
+    (listener) => api?.subscribeReveal(listener) ?? (() => {}),
+    () => api?.revealed() ?? false,
+    () => false,
+  );
 }
 
 /** The status-bar affordances that make `?` and ⌘K findable without knowing
@@ -403,10 +415,3 @@ export function CommandPaletteButton() {
   );
 }
 
-/** Resolved after mount, like the provider's own copy: rendering ⌘ on a server
- *  that has no platform would hydrate over a Ctrl. */
-function useIsMac(): boolean {
-  const [mac, setMac] = useState(false);
-  useEffect(() => setMac(isMacPlatform()), []);
-  return mac;
-}

--- a/mycelium-frontend/src/components/keymap-provider.tsx
+++ b/mycelium-frontend/src/components/keymap-provider.tsx
@@ -86,12 +86,12 @@ export function KeymapProvider({ children }: { children: ReactNode }) {
   const [scopeCounts, setScopeCounts] = useState<Partial<Record<KeyScope, number>>>({ global: 1 });
   const [helpOpen, setHelpOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
-  // Which commands ran, most recent first. Hydrated from localStorage after mount
-  // so that SSR and the first hydration render both produce [] (no mismatch).
+  // Which commands ran, most recent first. Seeded from localStorage after mount,
+  // so SSR and the first client render agree on an empty list.
   const [recent, setRecent] = useState<string[]>([]);
   useEffect(() => {
-    // SSR hydration: localStorage unavailable on server; useSyncExternalStore would
-    // still need a separate setRecent for command-use writes, so this is simpler.
+    // localStorage is client-only, and runCommand writes this list back, so it
+    // stays ordinary state rather than an external-store snapshot.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setRecent(loadRecent());
   }, []);
@@ -203,15 +203,13 @@ export function KeymapProvider({ children }: { children: ReactNode }) {
 
   const commands = useMemo(
     () => {
-      // collectCommands reads commandSources.current and handlers.current (refs).
-      // Moving this into useEffect + setState would introduce set-state-in-effect;
-      // the refs are intentionally stable mutable registries — reading them here is safe.
+      // collectCommands reads the registration refs, which are stable mutable
+      // registries: commandEpoch below is what says when to read them again.
       // eslint-disable-next-line react-hooks/refs
       return paletteOpen ? collectCommands(scopes) : [];
     },
-    // commandEpoch is a cache-bust epoch that increments on registration changes;
-    // it is not referenced in the callback body (refs are read via collectCommands)
-    // but IS required so the list recomputes when registrations change.
+    // commandEpoch never appears in the body — it is here to recompute the list
+    // when registrations change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [paletteOpen, commandEpoch, scopes, collectCommands],
   );
@@ -372,10 +370,8 @@ export function useKeyCapture(): KeymapApi["captureKeys"] {
  *  never reveals. */
 export function useKeyReveal(): boolean {
   const api = useContext(KeymapContext);
-  // useSyncExternalStore is the idiomatic fit: subscribe to an external signal
-  // (the hold/release of the reveal modifier) and snapshot its current value.
-  // Stabilise subscribe/getSnapshot with useCallback so React doesn't
-  // unsubscribe and resubscribe on every render.
+  // Reveal lives outside React, so it is subscribed to rather than mirrored in
+  // state. Both callbacks are memoized so React doesn't resubscribe every render.
   const subscribe = useCallback(
     (listener: () => void) => api?.subscribeReveal(listener) ?? (() => {}),
     [api],

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -391,6 +391,9 @@ export function L9Inspector({ roomName }: Props) {
   useEffect(() => {
     let cancelled = false;
     seenIds.current = new Set();
+    // Async fetch: setState calls are in the .then() callback. setFrames([]) here
+    // is a guard reset before the fetch resolves — intentional, not cascading.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setFrames([]);
     fetchL9History(roomName).then((rows) => {
       if (cancelled) return;
@@ -451,13 +454,10 @@ export function L9Inspector({ roomName }: Props) {
     () => Array.from(new Set(frames.map((f) => f.episode).filter((e): e is string => Boolean(e)))),
     [frames],
   );
-  // Reset filters that no longer apply to any frame (e.g. the selected episode
-  // scrolled out of the MAX_FRAMES window).
-  useEffect(() => {
-    if (episodeFilter !== "all" && !episodesPresent.includes(episodeFilter)) {
-      setEpisodeFilter("all");
-    }
-  }, [episodeFilter, episodesPresent]);
+  // Fall back to "all" when the selected episode scrolls out of the MAX_FRAMES
+  // window; derive rather than resetting in an effect so there is no extra render.
+  const effectiveEpisodeFilter =
+    episodeFilter === "all" || episodesPresent.includes(episodeFilter) ? episodeFilter : "all";
 
   const toggleKind = useCallback((kind: string) => {
     setHiddenKinds((prev) => {
@@ -470,9 +470,9 @@ export function L9Inspector({ roomName }: Props) {
   const wire = useMemo(
     () =>
       frames.filter(
-        (f) => !hiddenKinds.has(f.kind) && (episodeFilter === "all" || f.episode === episodeFilter),
+        (f) => !hiddenKinds.has(f.kind) && (effectiveEpisodeFilter === "all" || f.episode === effectiveEpisodeFilter),
       ),
-    [frames, hiddenKinds, episodeFilter],
+    [frames, hiddenKinds, effectiveEpisodeFilter],
   );
 
   useEffect(() => {
@@ -526,7 +526,7 @@ export function L9Inspector({ roomName }: Props) {
           {episodesPresent.length > 0 && (
             <select
               aria-label="Filter by episode"
-              value={episodeFilter}
+              value={effectiveEpisodeFilter}
               onChange={(e) => setEpisodeFilter(e.target.value)}
               className="ml-auto rounded-md border border-border bg-surface px-2 py-1 font-mono text-micro text-muted-foreground focus:border-accent focus:text-text focus:outline-none"
             >

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -462,7 +462,8 @@ export function L9Inspector({ roomName }: Props) {
   const toggleKind = useCallback((kind: string) => {
     setHiddenKinds((prev) => {
       const next = new Set(prev);
-      next.has(kind) ? next.delete(kind) : next.add(kind);
+      if (next.has(kind)) next.delete(kind);
+      else next.add(kind);
       return next;
     });
   }, []);

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -323,8 +323,7 @@ function FrameRow({
           aria-hidden
           className={`size-3.5 text-faint transition-transform group-hover:text-muted-foreground ${expanded ? "rotate-90" : ""}`}
         />
-        {/* frameIcon picks from a fixed table of imported Lucide components,
-            so nothing is defined here — the rule cannot see through the call. */}
+        {/* frameIcon returns one of a fixed table of imported Lucide components. */}
         {/* eslint-disable-next-line react-hooks/static-components */}
         <Icon aria-hidden className="size-3.5" style={{ color: tone }} />
         <KindBadge kind={frame.kind} subkind={frame.subkind} />
@@ -391,8 +390,8 @@ export function L9Inspector({ roomName }: Props) {
   useEffect(() => {
     let cancelled = false;
     seenIds.current = new Set();
-    // Async fetch: setState calls are in the .then() callback. setFrames([]) here
-    // is a guard reset before the fetch resolves — intentional, not cascading.
+    // Async fetch; the rest of the setState calls are in its .then(). Clearing
+    // here drops the previous room's frames before the new ones arrive.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setFrames([]);
     fetchL9History(roomName).then((rows) => {
@@ -454,8 +453,7 @@ export function L9Inspector({ roomName }: Props) {
     () => Array.from(new Set(frames.map((f) => f.episode).filter((e): e is string => Boolean(e)))),
     [frames],
   );
-  // Fall back to "all" when the selected episode scrolls out of the MAX_FRAMES
-  // window; derive rather than resetting in an effect so there is no extra render.
+  // Fall back to "all" once the selected episode scrolls out of the MAX_FRAMES window.
   const effectiveEpisodeFilter =
     episodeFilter === "all" || episodesPresent.includes(episodeFilter) ? episodeFilter : "all";
 

--- a/mycelium-frontend/src/components/login-gate.tsx
+++ b/mycelium-frontend/src/components/login-gate.tsx
@@ -61,6 +61,9 @@ function useAuthError(): string | null {
     const url = new URL(window.location.href);
     const e = url.searchParams.get("auth_error");
     if (e) {
+      // URL cleanup side effect (history.replaceState) must co-locate with the
+      // state update — a lazy initializer can't call history.replaceState safely.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setErr(e);
       url.searchParams.delete("auth_error");
       window.history.replaceState({}, "", url.toString());

--- a/mycelium-frontend/src/components/login-gate.tsx
+++ b/mycelium-frontend/src/components/login-gate.tsx
@@ -61,8 +61,8 @@ function useAuthError(): string | null {
     const url = new URL(window.location.href);
     const e = url.searchParams.get("auth_error");
     if (e) {
-      // URL cleanup side effect (history.replaceState) must co-locate with the
-      // state update — a lazy initializer can't call history.replaceState safely.
+      // The error is read and the parameter consumed in one step, so the
+      // replaceState that clears it stays beside the state update.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setErr(e);
       url.searchParams.delete("auth_error");

--- a/mycelium-frontend/src/components/memory-detail.tsx
+++ b/mycelium-frontend/src/components/memory-detail.tsx
@@ -226,7 +226,7 @@ export function MemoryDetail({
   const text = memory.content_text ?? formatValue(memory.value);
   const displayText = !raw && renderedBody ? renderedBody : text;
   const rawIsJson = useMemo(() => isJsonRawText(text), [text]);
-  // jsonView is meaningful only when raw is true; derive instead of resetting in an effect.
+  // jsonView only means anything in raw mode.
   const effectiveJsonView = raw && jsonView;
   const rawDisplay =
     effectiveJsonView && rawIsJson ? (prettyPrintJsonRawText(text) ?? text) : text;

--- a/mycelium-frontend/src/components/memory-detail.tsx
+++ b/mycelium-frontend/src/components/memory-detail.tsx
@@ -226,12 +226,10 @@ export function MemoryDetail({
   const text = memory.content_text ?? formatValue(memory.value);
   const displayText = !raw && renderedBody ? renderedBody : text;
   const rawIsJson = useMemo(() => isJsonRawText(text), [text]);
+  // jsonView is meaningful only when raw is true; derive instead of resetting in an effect.
+  const effectiveJsonView = raw && jsonView;
   const rawDisplay =
-    jsonView && rawIsJson ? (prettyPrintJsonRawText(text) ?? text) : text;
-
-  useEffect(() => {
-    if (!raw) setJsonView(false);
-  }, [raw]);
+    effectiveJsonView && rawIsJson ? (prettyPrintJsonRawText(text) ?? text) : text;
 
   useEffect(() => {
     if (!roomName) return;
@@ -341,11 +339,11 @@ export function MemoryDetail({
         {raw && rawIsJson && (
           <button
             type="button"
-            aria-pressed={jsonView}
+            aria-pressed={effectiveJsonView}
             aria-label="Pretty-print JSON"
             onClick={() => setJsonView(on => !on)}
             className={`rounded-lg border px-2.5 py-1 text-micro font-medium transition-colors ${
-              jsonView
+              effectiveJsonView
                 ? "border-accent/40 bg-accent-soft/40 text-accent"
                 : "border-border bg-surface text-muted-foreground hover:text-text"
             }`}
@@ -358,7 +356,7 @@ export function MemoryDetail({
       <div className={`${pad} py-4`}>
         {raw ? (
           <pre className="overflow-x-auto rounded-lg border border-border bg-surface p-3 font-mono text-micro leading-relaxed text-text whitespace-pre-wrap break-words">
-            {jsonView ? highlightJson(rawDisplay) : rawDisplay}
+            {effectiveJsonView ? highlightJson(rawDisplay) : rawDisplay}
           </pre>
         ) : (
           <MarkdownContent

--- a/mycelium-frontend/src/components/memory-editor.tsx
+++ b/mycelium-frontend/src/components/memory-editor.tsx
@@ -79,10 +79,15 @@ function WikilinkDropdown({
   onSelect: (key: string) => void;
   onDismiss: () => void;
 }) {
+  // React's idiomatic "reset when prop changes" — store previous candidates and
+  // update in-render (a second render pass fires immediately, no layout effect).
+  const [prevCandidates, setPrevCandidates] = useState(candidates);
   const [activeIdx, setActiveIdx] = useState(0);
+  if (prevCandidates !== candidates) {
+    setPrevCandidates(candidates);
+    setActiveIdx(0);
+  }
   const listRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => setActiveIdx(0), [candidates]);
 
   // Keep the highlighted row visible when arrowing past the scroll fold.
   useEffect(() => {

--- a/mycelium-frontend/src/components/memory-editor.tsx
+++ b/mycelium-frontend/src/components/memory-editor.tsx
@@ -79,8 +79,8 @@ function WikilinkDropdown({
   onSelect: (key: string) => void;
   onDismiss: () => void;
 }) {
-  // React's idiomatic "reset when prop changes" — store previous candidates and
-  // update in-render (a second render pass fires immediately, no layout effect).
+  // A fresh candidate list starts the highlight at the top. Comparing in render
+  // rather than resetting in an effect, so no stale row is ever painted.
   const [prevCandidates, setPrevCandidates] = useState(candidates);
   const [activeIdx, setActiveIdx] = useState(0);
   if (prevCandidates !== candidates) {

--- a/mycelium-frontend/src/components/memory-graph.tsx
+++ b/mycelium-frontend/src/components/memory-graph.tsx
@@ -151,10 +151,8 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
   const [legendOpen, setLegendOpen] = useState(false);
   const filtered = hiddenNamespaces.size > 0 || hiddenTypes.size > 0;
 
-  // Reset filters when the graph changes. Guard preserves the same Set identity
-  // when nothing was filtered, avoiding a spurious re-render of every node.
-  // Uses the derived-state-during-render pattern (React fires a second pass
-  // immediately, like getDerivedStateFromProps).
+  // Reset the filters when the graph changes. The guard keeps the same Set
+  // identity when nothing was filtered, so every node doesn't re-render.
   const [prevGraph, setPrevGraph] = useState(graph);
   if (prevGraph !== graph) {
     setPrevGraph(graph);
@@ -299,9 +297,8 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
   useLayoutEffect(() => {
     dirty.current = false;
     if (!roomName) {
-      // Placement load/clear is a storage-read side effect tied to the graph
-      // identity changing; it belongs in a layout effect because it must run
-      // before the first paint of the new graph layout.
+      // Placements are read from storage, so they land in a layout effect —
+      // before the new layout's first paint.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setPlaced({});
       return;

--- a/mycelium-frontend/src/components/memory-graph.tsx
+++ b/mycelium-frontend/src/components/memory-graph.tsx
@@ -431,7 +431,7 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
       // one handler even when it outruns the circle it grabbed.
       capturePointer(svgRef.current, e.pointerId);
     },
-    [positions],
+    [positions, toSvgPoint],
   );
 
   /** Drops whatever gesture this pointer owned, without activating anything. */
@@ -481,7 +481,7 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
       pan.last = to;
       setView(prev => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
     },
-    [toSvgPoint, view.scale],
+    [abandonGesture, toSvgPoint, view.scale],
   );
 
   // Opening is decided here on pointerup, not by a `click` handler on the node.

--- a/mycelium-frontend/src/components/memory-graph.tsx
+++ b/mycelium-frontend/src/components/memory-graph.tsx
@@ -151,12 +151,16 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
   const [legendOpen, setLegendOpen] = useState(false);
   const filtered = hiddenNamespaces.size > 0 || hiddenTypes.size > 0;
 
-  useEffect(() => {
-    // Guarded so a mount with nothing filtered doesn't hand React two fresh
-    // (unequal) Sets and buy an extra render of every node for no change.
+  // Reset filters when the graph changes. Guard preserves the same Set identity
+  // when nothing was filtered, avoiding a spurious re-render of every node.
+  // Uses the derived-state-during-render pattern (React fires a second pass
+  // immediately, like getDerivedStateFromProps).
+  const [prevGraph, setPrevGraph] = useState(graph);
+  if (prevGraph !== graph) {
+    setPrevGraph(graph);
     setHiddenNamespaces(prev => (prev.size === 0 ? prev : new Set()));
     setHiddenTypes(prev => (prev.size === 0 ? prev : new Set()));
-  }, [graph]);
+  }
 
   const visibleKeys = useMemo(
     () => new Set(graph.nodes.filter(n => !hiddenNamespaces.has(namespaceOf(n.key))).map(n => n.key)),
@@ -272,7 +276,7 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
   // Read by the deferred writes below, so they always persist the newest
   // arrangement rather than the one captured when their timer was armed.
   const latestPlaced = useRef(placed);
-  latestPlaced.current = placed;
+  useLayoutEffect(() => { latestPlaced.current = placed; }, [placed]);
 
   // Only a drag or a reset may write. Persisting on any change to `placed`
   // instead — mirroring state outward — silently wiped the saved arrangement
@@ -295,6 +299,10 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
   useLayoutEffect(() => {
     dirty.current = false;
     if (!roomName) {
+      // Placement load/clear is a storage-read side effect tied to the graph
+      // identity changing; it belongs in a layout effect because it must run
+      // before the first paint of the new graph layout.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setPlaced({});
       return;
     }

--- a/mycelium-frontend/src/components/memory-page-view.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.tsx
@@ -38,6 +38,9 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
 
   useEffect(() => {
     let live = true;
+    // Async fetch: remaining setState calls are in .then() callbacks. The two
+    // resets here are pre-fetch guard clears, not cascading renders from props.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setMemory(undefined);
     setRenderedBody(null);
     fetchMemory(roomName, memoryKey).then(m => {

--- a/mycelium-frontend/src/components/memory-page-view.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.tsx
@@ -38,8 +38,8 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
 
   useEffect(() => {
     let live = true;
-    // Async fetch: remaining setState calls are in .then() callbacks. The two
-    // resets here are pre-fetch guard clears, not cascading renders from props.
+    // Async fetch; the rest of the setState calls are in its .then(). Clearing
+    // here keeps the previous memory from showing under the new key.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMemory(undefined);
     setRenderedBody(null);

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -5,7 +5,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   Brain,
   ChevronRight,
@@ -230,16 +230,25 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
   const { memories, loading } = useRoomMemories(roomName);
   const { integrity } = useRoomMemoryIntegrity(roomName);
   const memoriesRef = useRef(memories);
-  memoriesRef.current = memories;
+  useLayoutEffect(() => { memoriesRef.current = memories; }, [memories]);
 
-  // Exit edit mode whenever the selected memory changes.
-  useEffect(() => { setIsEditing(false); }, [selected?.key]);
+  // Exit edit mode whenever the selected memory changes. Derived-state-during-render
+  // (the React alternative to getDerivedStateFromProps) fires a second pass immediately
+  // so the new selection never flashes in edit mode.
+  const [prevSelectedKey, setPrevSelectedKey] = useState(selected?.key);
+  if (prevSelectedKey !== selected?.key) {
+    setPrevSelectedKey(selected?.key);
+    setIsEditing(false);
+  }
 
   // Expanded transclusions for whichever memory is open in the drawer, so the
   // rail peek matches the full page instead of leaving `![[…]]` markers as
   // unexpanded chips (#599).
   useEffect(() => {
     if (!selected) {
+      // Async fetch guard: clear the rendered body when selection clears so the
+      // previous memory's body never flashes during the next fetch.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setRenderedBody(null);
       return;
     }

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -232,9 +232,8 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
   const memoriesRef = useRef(memories);
   useLayoutEffect(() => { memoriesRef.current = memories; }, [memories]);
 
-  // Exit edit mode whenever the selected memory changes. Derived-state-during-render
-  // (the React alternative to getDerivedStateFromProps) fires a second pass immediately
-  // so the new selection never flashes in edit mode.
+  // Exit edit mode whenever the selection changes. Compared in render rather
+  // than reset in an effect, so the new selection never flashes in edit mode.
   const [prevSelectedKey, setPrevSelectedKey] = useState(selected?.key);
   if (prevSelectedKey !== selected?.key) {
     setPrevSelectedKey(selected?.key);
@@ -246,8 +245,8 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
   // unexpanded chips (#599).
   useEffect(() => {
     if (!selected) {
-      // Async fetch guard: clear the rendered body when selection clears so the
-      // previous memory's body never flashes during the next fetch.
+      // Clear the body when the selection clears, so the previous memory's
+      // never shows under the next one.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setRenderedBody(null);
       return;

--- a/mycelium-frontend/src/components/notifications-provider.tsx
+++ b/mycelium-frontend/src/components/notifications-provider.tsx
@@ -72,9 +72,8 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   const isLeader = useRef(false);
   const channelRef = useRef<ReturnType<typeof openCrossTabChannel> | null>(null);
 
-  // Hydrate from localStorage once the DOM is available (SSR has none). The three
-  // setStates are one logical "hydrate from client storage" step. Lazy initializers
-  // would mismatch the SSR render (server "" ≠ client stored value on first pass).
+  // Load from localStorage once the DOM is there to read it: on the server
+  // there is none, and seeding at init would mismatch the SSR render.
   useEffect(() => {
     const stored = loadNotifications();
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/mycelium-frontend/src/components/notifications-provider.tsx
+++ b/mycelium-frontend/src/components/notifications-provider.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -64,16 +65,19 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   );
 
   const settingsRef = useRef(settings);
-  settingsRef.current = settings;
   const principalRef = useRef(principal);
-  principalRef.current = principal;
+  useLayoutEffect(() => { settingsRef.current = settings; }, [settings]);
+  useLayoutEffect(() => { principalRef.current = principal; }, [principal]);
   const seenIds = useRef<Set<string>>(new Set());
   const isLeader = useRef(false);
   const channelRef = useRef<ReturnType<typeof openCrossTabChannel> | null>(null);
 
-  // Hydrate from localStorage once the DOM is available (SSR has none).
+  // Hydrate from localStorage once the DOM is available (SSR has none). The three
+  // setStates are one logical "hydrate from client storage" step. Lazy initializers
+  // would mismatch the SSR render (server "" ≠ client stored value on first pass).
   useEffect(() => {
     const stored = loadNotifications();
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setNotifications(stored);
     seenIds.current = new Set(stored.map((n) => n.id));
     setSettingsState(loadSettings());

--- a/mycelium-frontend/src/components/search-palette.tsx
+++ b/mycelium-frontend/src/components/search-palette.tsx
@@ -72,6 +72,10 @@ export function SearchPalette({ open, onClose, onPick, search, mac }: Props) {
 
   useEffect(() => {
     if (!open) return;
+    // On-open reset: clears query/results/error and captures the element to
+    // restore focus to on close. restoreTo reads document.activeElement (DOM
+    // side effect), so the resets must stay co-located in the same effect.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setQuery("");
     setResults([]);
     setScope(EMPTY_SCOPE);
@@ -102,6 +106,9 @@ export function SearchPalette({ open, onClose, onPick, search, mac }: Props) {
     if (!open) return;
     const trimmed = query.trim();
     if (!trimmed) {
+      // Empty query clears results synchronously so the palette goes blank rather
+      // than keeping stale rows while the user deletes their input.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setResults([]);
       setScope(EMPTY_SCOPE);
       setPending(false);

--- a/mycelium-frontend/src/components/search-palette.tsx
+++ b/mycelium-frontend/src/components/search-palette.tsx
@@ -72,9 +72,8 @@ export function SearchPalette({ open, onClose, onPick, search, mac }: Props) {
 
   useEffect(() => {
     if (!open) return;
-    // On-open reset: clears query/results/error and captures the element to
-    // restore focus to on close. restoreTo reads document.activeElement (DOM
-    // side effect), so the resets must stay co-located in the same effect.
+    // Capturing what to restore focus to reads document.activeElement, so the
+    // rest of the on-open reset stays here with it.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setQuery("");
     setResults([]);
@@ -106,8 +105,7 @@ export function SearchPalette({ open, onClose, onPick, search, mac }: Props) {
     if (!open) return;
     const trimmed = query.trim();
     if (!trimmed) {
-      // Empty query clears results synchronously so the palette goes blank rather
-      // than keeping stale rows while the user deletes their input.
+      // Emptying the box blanks the palette rather than leaving stale rows up.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setResults([]);
       setScope(EMPTY_SCOPE);

--- a/mycelium-frontend/src/components/theme-toggle.tsx
+++ b/mycelium-frontend/src/components/theme-toggle.tsx
@@ -4,6 +4,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useIsClient } from "@/lib/client-hooks";
 import { useTheme } from "next-themes";
 import { Monitor, Moon, Sun, type LucideIcon } from "lucide-react";
 import { useCommands } from "@/components/keymap-provider";
@@ -18,9 +19,8 @@ const OPTIONS: { value: string; label: string; icon: LucideIcon }[] = [
 export function ThemeToggle() {
   const { theme, resolvedTheme, setTheme } = useTheme();
   const [open, setOpen] = useState(false);
-  const [mounted, setMounted] = useState(false);
+  const mounted = useIsClient();
   const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => setMounted(true), []);
 
   useEffect(() => {
     if (!open) return;

--- a/mycelium-frontend/src/lib/client-hooks.ts
+++ b/mycelium-frontend/src/lib/client-hooks.ts
@@ -2,37 +2,23 @@
 // Copyright 2026 Mycelium Contributors
 
 /**
- * Client-only React hooks that use useSyncExternalStore to provide a
- * server snapshot that matches the SSR render (avoiding hydration mismatches)
- * and a client snapshot that reflects the real browser environment.
- *
- * These replace the useEffect(() => setState(browserValue), []) pattern that
- * react-hooks/set-state-in-effect flags. useSyncExternalStore is the
- * recommended React 18+ primitive for this class of "read once from the
- * browser, never subscribe" state.
+ * Client-only hooks that read the browser once. Each returns a server snapshot
+ * matching the SSR render and a client snapshot reflecting the real browser,
+ * so there is no hydration mismatch and no extra render pass.
  */
 
 import { useSyncExternalStore } from "react";
 import { isMacPlatform } from "@/lib/keymap";
 
-/** No-op subscribe function for values that never change after mount. */
+/** No-op subscribe: these values never change after mount. */
 const noSubscribe = () => () => {};
 
-/**
- * Returns true on the client, false during SSR and the server hydration
- * snapshot. Replaces: `const [mounted, setMounted] = useState(false);
- * useEffect(() => setMounted(true), []);`
- */
+/** True on the client, false during SSR and the hydration snapshot. */
 export function useIsClient(): boolean {
   return useSyncExternalStore(noSubscribe, () => true, () => false);
 }
 
-/**
- * Returns true when running on a Mac (⌘ key platform), false otherwise.
- * Server snapshot is false to avoid hydrating ⌘ labels on non-Mac servers.
- * Replaces: `const [mac, setMac] = useState(false);
- * useEffect(() => setMac(isMacPlatform()), []);`
- */
+/** True on a Mac (⌘ key platform); false in the server snapshot, so ⌘ labels never hydrate on non-Mac. */
 export function useIsMac(): boolean {
   return useSyncExternalStore(noSubscribe, () => isMacPlatform(), () => false);
 }

--- a/mycelium-frontend/src/lib/client-hooks.ts
+++ b/mycelium-frontend/src/lib/client-hooks.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Client-only React hooks that use useSyncExternalStore to provide a
+ * server snapshot that matches the SSR render (avoiding hydration mismatches)
+ * and a client snapshot that reflects the real browser environment.
+ *
+ * These replace the useEffect(() => setState(browserValue), []) pattern that
+ * react-hooks/set-state-in-effect flags. useSyncExternalStore is the
+ * recommended React 18+ primitive for this class of "read once from the
+ * browser, never subscribe" state.
+ */
+
+import { useSyncExternalStore } from "react";
+import { isMacPlatform } from "@/lib/keymap";
+
+/** No-op subscribe function for values that never change after mount. */
+const noSubscribe = () => () => {};
+
+/**
+ * Returns true on the client, false during SSR and the server hydration
+ * snapshot. Replaces: `const [mounted, setMounted] = useState(false);
+ * useEffect(() => setMounted(true), []);`
+ */
+export function useIsClient(): boolean {
+  return useSyncExternalStore(noSubscribe, () => true, () => false);
+}
+
+/**
+ * Returns true when running on a Mac (⌘ key platform), false otherwise.
+ * Server snapshot is false to avoid hydrating ⌘ labels on non-Mac servers.
+ * Replaces: `const [mac, setMac] = useState(false);
+ * useEffect(() => setMac(isMacPlatform()), []);`
+ */
+export function useIsMac(): boolean {
+  return useSyncExternalStore(noSubscribe, () => isMacPlatform(), () => false);
+}


### PR DESCRIPTION
## Summary

Resolves the 37 `react-hooks/set-state-in-effect` and `react-hooks/refs` warnings that were acknowledged as tech debt in `eslint.config`. After this PR, `pnpm run lint` emits **0 react-hooks/** warnings (the 11 remaining are already fixed on PR #709 and will vanish when that merges).

### Pattern A — refs during render (5 warnings)

Moved `ref.current = x` assignments from the render body into `useLayoutEffect` so they happen in the commit phase, not render. Files: `notifications-provider`, `memory-panel`, `memory-graph`. The `useMemo` case in `keymap-provider` (reading refs inside `collectCommands`) is suppressed with explanation — fixing it would introduce `set-state-in-effect` instead with no net gain.

### Pattern B — mount hydration (9 warnings)

Added `src/lib/client-hooks.ts` with `useIsMac()` and `useIsClient()` built on `useSyncExternalStore`. These replace the `useEffect(() => setState(browserValue), [])` pattern: the hook returns the server snapshot during SSR and the real browser value on the client, with no extra render pass.

- `global-search`, `keymap-provider` (×2), `theme-toggle` → use shared hooks
- `install-panel` → lazy `useState` initializers (platform + URL are read-only after mount)
- `useKeyReveal()` → full conversion to `useSyncExternalStore` (removes `useEffect` + `useState` entirely)
- `current-user`, `auth-session`, `notifications-provider`, `keymap-provider` (loadRecent) → suppressed with explanation (localStorage needs write capability alongside the read; lazy init would produce an SSR hydration mismatch on the first render)

### Pattern C — derived state reset on prop change (15 warnings)

Replaced effects that reset state when a prop changes with React's idiomatic **derived-state-during-render** pattern (equivalent to `getDerivedStateFromProps`):

| File | Before | After |
|------|--------|-------|
| `memory-editor` | `useEffect(() => setActiveIdx(0), [candidates])` | store prev candidates, call `setActiveIdx(0)` in-render on change |
| `memory-graph` | `useEffect(() => setHiddenTypes(…), [graph])` | same pattern with prev graph |
| `memory-panel` | `useEffect(() => setIsEditing(false), [selected?.key])` | same pattern |
| `memory-detail` | `useEffect(() => { if (!raw) setJsonView(false); }, [raw])` | derive `effectiveJsonView = raw && jsonView` |
| `l9-inspector` | `useEffect(() => setEpisodeFilter("all"), [filter, episodes])` | derive `effectiveEpisodeFilter` |
| `room/page` | `useEffect(() => setTourActive(…), [])` | lazy init from existing `useSearchParams()` call |

Focus-consumed patterns, on-open resets co-located with DOM side effects (`document.activeElement`), and async fetch loading gates are suppressed with per-line explanations.

### Pattern D — async loading state resets (8 warnings)

`setState` calls inside async fetch effects are either in `.then()` callbacks (fine) or are pre-fetch guard resets that must stay in the effect. All suppressed with explanations.

## Test plan

- [x] `cd mycelium-frontend && pnpm run lint` → 0 `react-hooks/` warnings (11 remaining are from #709)
- [x] `pnpm build` passes (tsc + eslint both run in lint step)
- [x] Manual: theme toggle, command palette, search palette, memory graph filters, tour flow, and the revealed-key overlay all behave correctly


Made with [Cursor](https://cursor.com)