### PR TITLE
Spike: prove the a2a-sdk client leg against a live A2A agent (#712)

### DIFF
--- a/fastapi-backend/spikes/a2a_client_spike.py
+++ b/fastapi-backend/spikes/a2a_client_spike.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["a2a-sdk==1.1.2", "httpx"]
+# ///
+"""Throwaway spike for issue #712 (epic #719).
+
+Question it answers: is `a2a-sdk` good enough to be the client leg of the
+Mycelium A2A bridge, and does the "it's just an await/respond exec loop" thesis
+survive contact with a real remote agent?
+
+What it does, against a live A2A agent:
+  1. probes BOTH well-known card paths (new /.well-known/agent-card.json and the
+     older /.well-known/agent.json) so we know how bad the spec-rename drift is
+  2. resolves the Agent Card and prints its skills + capabilities
+  3. sends one message via the high-level client and drains the response stream,
+     printing every text part it gets back
+
+Default target is the public echo agent. Pass a base URL to hit another.
+
+    uv run fastapi-backend/spikes/a2a_client_spike.py
+    uv run fastapi-backend/spikes/a2a_client_spike.py http://localhost:9999
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import httpx
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.types import Message, Part, Role, SendMessageRequest
+
+NEW_PATH = "/.well-known/agent-card.json"
+OLD_PATH = "/.well-known/agent.json"
+
+
+async def probe_paths(http: httpx.AsyncClient, base: str) -> str | None:
+    """Return the first well-known path that serves a card, or None."""
+    found: str | None = None
+    for path in (NEW_PATH, OLD_PATH):
+        try:
+            r = await http.get(base.rstrip("/") + path)
+            ok = r.status_code == 200 and "json" in r.headers.get("content-type", "")
+            print(f"  GET {path} -> {r.status_code} {'OK' if ok else ''}")
+            if ok and found is None:
+                found = path
+        except (httpx.HTTPError, OSError) as exc:  # noqa: PERF203
+            print(f"  GET {path} -> error {exc!r}")
+    return found
+
+
+def text_of(msg: Message) -> str:
+    return " ".join(p.text for p in msg.parts if p.HasField("text"))
+
+
+async def run(base: str) -> int:
+    print(f"# A2A client spike against {base}\n")
+    async with httpx.AsyncClient(timeout=30) as http:
+        print("[1] probing well-known card paths")
+        path = await probe_paths(http, base)
+        if path is None:
+            print("no card found at either path; aborting")
+            return 1
+        print(f"  -> using {path}\n")
+
+        print("[2] resolving Agent Card")
+        resolver = A2ACardResolver(http, base, agent_card_path=path)
+        card = await resolver.get_agent_card()
+        streaming = bool(card.capabilities.streaming)
+        skills = ", ".join(s.id for s in card.skills) or "(none)"
+        print(f"  name: {card.name}")
+        print(f"  version: {card.version}  streaming: {streaming}")
+        print(f"  skills: {skills}\n")
+
+        print("[3] send one message + drain the stream")
+        # accepted_output_modes must be set: older servers (v1.0.0) treat
+        # configuration.acceptedOutputModes as required and reject the call
+        # without it. Leaving it empty makes the SDK omit the field -> 400.
+        config = ClientConfig(
+            httpx_client=http,
+            streaming=streaming,
+            accepted_output_modes=["text"],
+        )
+        client = ClientFactory(config).create(card)
+        msg = Message(
+            message_id="spike-1",
+            role=Role.ROLE_USER,
+            parts=[Part(text="What can you do? Say hi.")],
+        )
+        got = 0
+        async for resp in client.send_message(SendMessageRequest(message=msg)):
+            which = resp.WhichOneof("payload") if hasattr(resp, "WhichOneof") else None
+            if resp.HasField("message"):
+                got += 1
+                print(f"  <- message: {text_of(resp.message)!r}")
+            elif resp.HasField("task"):
+                print(f"  <- task: id={resp.task.id} state={resp.task.status.state}")
+            elif resp.HasField("status_update"):
+                print(f"  <- status_update: {resp.status_update.status.state}")
+            elif resp.HasField("artifact_update"):
+                print("  <- artifact_update")
+            else:
+                print(f"  <- {which}")
+        print(f"\ndrained stream, {got} message payload(s). thesis holds: "
+              "resolve card -> send -> read parts, no bespoke protocol code.")
+    return 0
+
+
+if __name__ == "__main__":
+    target = sys.argv[1] if len(sys.argv) > 1 else "https://hello-world-gxfr.onrender.com"
+    raise SystemExit(asyncio.run(run(target)))


### PR DESCRIPTION
Spike for #712 (epic #719). A throwaway `a2a-sdk` client script run against the live public echo agent, answering: is the SDK good enough to be the bridge's client leg, and does "the bridge is just an await/respond exec loop" survive contact with a real remote agent?

**Not for merge.** The deliverable is the findings below; this PR gets closed, not landed.

## Result: thesis holds

`fastapi-backend/spikes/a2a_client_spike.py` resolves a remote Agent Card, sends one message, and drains the reply stream in ~30 lines of real logic. No bespoke JSON-RPC. The client leg is: resolve card -> `send_message` -> read parts. That maps straight onto a server-side seat calling out on each tick, exactly the exec-loop shape.

```
[1] probing well-known card paths
  GET /.well-known/agent-card.json -> 404
  GET /.well-known/agent.json -> 200 OK
[2] resolving Agent Card
  name: Hello World Agent  version: 1.0.0  streaming: True  skills: hello_world
[3] send one message + drain the stream
  <- message: 'Hello World'
```

## Findings to carry into the build

1. **Pin `a2a-sdk==1.1.2`.** Current line. Its client is proto-typed (`SendMessageRequest`, `StreamResponse`, `a2a.types` are `a2a_pb2` messages), not the old dict API. `ClientFactory(ClientConfig(...)).create(card)` is the entry point.

2. **Probe both well-known paths.** The SDK defaults to the new `/.well-known/agent-card.json`; the live agent (and anything not freshly updated) serves the old `/.well-known/agent.json`. The new path 404s. The bridge's card resolver must try new then old.

3. **Version drift bites on the request body, not just the path.** Against a v1.0.0 server the 1.1.2 SDK fails with `Request payload validation error` unless `ClientConfig(accepted_output_modes=[...])` is set. Empty (the default) makes the SDK omit `configuration.acceptedOutputModes`, which older servers treat as required and reject with -32600. Always set `accepted_output_modes`. Once set, both streaming and blocking sends work; the earlier streaming failure was this same root cause, not a streaming-specific incompatibility.

## Implication for the next issues

- The public echo is good for the **wire** test only (it ignores input, returns "Hello World"). For a real negotiation partner (#718) we need a locally-run `a2a-samples` agent on the same SDK generation, which also sidesteps the v1.0.0 drift.
- #713/#714 should build the card resolver with dual-path probing and a pinned `ClientConfig` (accepted_output_modes set) as non-negotiable defaults.
