### PR TITLE
feat(a2a): answer @-mentions of an a2a agent, normal chat flow (#714)

### DIFF
--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -105,20 +105,27 @@ async def lifespan(app: FastAPI):
     # Wire the SIEP aligner into every room's summon seam before any
     # channel is provisioned, so all persisters pick it up. Dormant until an
     # @-summon of its reserved handle arrives — zero idle cost.
+    # Several handlers share the one summon seam: two engine kinds (aligner,
+    # synthesizer) plus the A2A responder. Each self-selects by the summoned
+    # handle's manifest (kind for engines, adapter=a2a for the responder), so a
+    # fan-out dispatcher is enough — no central table. Only one ever acts per
+    # summon since a handle maps to a single runtime.
+    from app.services.a2a_bridge import A2aResponder
     from app.services.aligner import AlignerEngine
     from app.services.plan_sync import PlanSyncEngine
     from app.services.room_channels import manager as room_channel_manager
     from app.services.synthesizer import SynthesizerEngine
 
-    # Two engine kinds share the one summon seam. Each engine self-selects by the
-    # summoned handle's manifest kind (and the aligner's reserved-handle
-    # fallback), so a fan-out dispatcher is enough — no central kind table. Only
-    # one engine ever acts per summon since a handle maps to a single kind.
     app.state.aligner = AlignerEngine(room_channel_manager)
     app.state.synthesizer = SynthesizerEngine(room_channel_manager)
+    # The A2A responder shares the seam too: it answers @-mentions of a
+    # registered a2a agent by calling the remote endpoint, gating on the manifest
+    # like the engines gate on their kind, so only one handler ever acts.
+    app.state.a2a_responder = A2aResponder(room_channel_manager)
     _engine_handlers = (
         app.state.aligner.handle_summon,
         app.state.synthesizer.handle_summon,
+        app.state.a2a_responder.handle_summon,
     )
 
     def _dispatch_summon(

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Drive a registered A2A agent as a backend-held room seat (epic #719, #714).
+
+The bridge's client leg. :func:`send_to_a2a` is the one primitive that matters:
+given a remote agent's card URL and a prompt, call it over A2A and return its
+reply text. Everything the seat loop does around it (hold membership, watch for
+ticks addressed to the handle, post the reply as that handle) is the same
+``await``/``respond`` turn a resident agent runs, so the aligner addresses the
+seat exactly like any other member.
+
+The send path carries the #712 spike findings: resolve the card (dual well-known
+path), then build a client with ``accepted_output_modes`` set — without it,
+older servers reject the send with a pydantic ``-32600``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from a2a.client import ClientConfig, ClientFactory
+from a2a.client.errors import A2AClientError
+from a2a.types import Message, Part, Role, SendMessageRequest
+
+from app.services.a2a_card import A2aCardError, resolve_raw_card
+
+logger = logging.getLogger(__name__)
+
+_SEND_TIMEOUT_S = 120.0
+
+
+class A2aSendError(Exception):
+    """A round-trip to the remote A2A agent failed."""
+
+
+def _reply_text(response: object) -> str:
+    """Pull the text parts out of one A2A stream response, if any."""
+    message = getattr(response, "message", None)
+    if message is None or not getattr(response, "HasField", lambda _f: False)("message"):
+        return ""
+    parts = getattr(message, "parts", []) or []
+    return "".join(p.text for p in parts if p.HasField("text"))
+
+
+async def send_to_a2a(
+    card_url: str,
+    text: str,
+    *,
+    http: httpx.AsyncClient | None = None,
+    timeout_s: float = _SEND_TIMEOUT_S,
+) -> str:
+    """Send ``text`` to the A2A agent at ``card_url`` and return its reply prose.
+
+    Raises :class:`A2aSendError` on an unresolvable card or a failed exchange, so
+    the seat can fall back faithfully (silence, never a fabricated reply).
+    """
+    owns_client = http is None
+    client_http = http or httpx.AsyncClient(timeout=timeout_s)
+    try:
+        try:
+            card, _path = await resolve_raw_card(card_url, http=client_http)
+        except A2aCardError as exc:
+            raise A2aSendError(f"card unresolvable: {exc}") from exc
+
+        streaming = bool(getattr(getattr(card, "capabilities", None), "streaming", False))
+        config = ClientConfig(
+            httpx_client=client_http,
+            streaming=streaming,
+            accepted_output_modes=["text"],
+        )
+        client = ClientFactory(config).create(card)
+        message = Message(
+            message_id="mycelium-seat",
+            role=Role.ROLE_USER,
+            parts=[Part(text=text)],
+        )
+
+        chunks: list[str] = []
+        try:
+            async for response in client.send_message(SendMessageRequest(message=message)):
+                chunk = _reply_text(response)
+                if chunk:
+                    chunks.append(chunk)
+        except (A2AClientError, httpx.HTTPError) as exc:
+            raise A2aSendError(f"send failed: {exc}") from exc
+
+        reply = "".join(chunks).strip()
+        if not reply:
+            raise A2aSendError("remote agent returned no text")
+        return reply
+    finally:
+        if owns_client:
+            await client_http.aclose()

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Drive a registered A2A agent as a backend-held room seat (epic #719, #714).
+"""Drive a registered A2A agent as a backend-held room member (epic #719, #714).
 
-The bridge's client leg. :func:`send_to_a2a` is the one primitive that matters:
-given a remote agent's card URL and a prompt, call it over A2A and return its
-reply text. Everything the seat loop does around it (hold membership, watch for
-ticks addressed to the handle, post the reply as that handle) is the same
-``await``/``respond`` turn a resident agent runs, so the aligner addresses the
-seat exactly like any other member.
+Two pieces:
+
+- :func:`send_to_a2a` — the client leg: given a remote agent's card URL and a
+  prompt, call it over A2A and return its reply text.
+- :class:`A2aResponder` — the seat: an event-driven ``@``-mention responder
+  wired to the persister's ``on_summon`` seam (the same one the engines use). It
+  does *not* poll and is not coupled to negotiation. When someone ``@``-mentions
+  a registered ``a2a`` agent in normal chat, it calls the remote and posts the
+  reply back as that handle. The aligner addressing the agent mid-negotiation is
+  just one caller that happens to ``@``-mention it.
 
 The send path carries the #712 spike findings: resolve the card (dual well-known
 path), then build a client with ``accepted_output_modes`` set — without it,
@@ -17,18 +21,55 @@ older servers reject the send with a pydantic ``-32600``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import TYPE_CHECKING, Any
 
 import httpx
+import yaml
 from a2a.client import ClientConfig, ClientFactory
 from a2a.client.errors import A2AClientError
 from a2a.types import Message, Part, Role, SendMessageRequest
 
+from app.services import l9
 from app.services.a2a_card import A2aCardError, resolve_raw_card
+from app.services.l9_slim import serialize_content
+from app.services.persister import envelope_message_id, envelope_sender
+
+if TYPE_CHECKING:
+    from app.services.l9_models import L9
+    from app.services.room_channels import RoomChannelManager
 
 logger = logging.getLogger(__name__)
 
 _SEND_TIMEOUT_S = 120.0
+
+
+def _norm(handle: str | None) -> str:
+    return (handle or "").strip().lstrip("@").lower()
+
+
+def registered_a2a_card(room: str, handle: str) -> str | None:
+    """The card URL if ``handle`` is a registered ``a2a`` agent in ``room``.
+
+    Mirrors the aligner's engine gate: reads the ``agents/<handle>`` manifest and
+    returns its ``a2a_card`` only for an ``adapter: a2a`` manifest, else ``None``
+    — so summoning a teammate, engine, or unknown handle never fires the bridge.
+    """
+    from app.services.filesystem import get_room_dir, read_memory_file
+
+    result = read_memory_file(get_room_dir(room), f"agents/{handle}")
+    if result is None:
+        return None
+    _meta, body = result
+    try:
+        data = yaml.safe_load(body) or {}
+    except yaml.YAMLError:
+        return None
+    if isinstance(data, dict) and data.get("adapter") == "a2a":
+        card = data.get("a2a_card")
+        return card if isinstance(card, str) and card else None
+    return None
 
 
 class A2aSendError(Exception):
@@ -93,3 +134,101 @@ async def send_to_a2a(
     finally:
         if owns_client:
             await client_http.aclose()
+
+
+class A2aResponder:
+    """Answer ``@``-mentions of a registered A2A agent by calling the remote.
+
+    Wired onto the same summon seam as the engines: the persister fires
+    ``on_summon`` for every ``@``-mention, and this responder acts only when the
+    mentioned handle is a registered ``a2a`` agent. It calls the remote agent
+    with the message text and posts the reply back as that handle — normal chat
+    flow, no polling and no negotiation coupling. The aligner addressing the
+    agent mid-negotiation is just one caller that happens to ``@``-mention it.
+    """
+
+    def __init__(self, manager: RoomChannelManager, *, timeout_s: float = _SEND_TIMEOUT_S) -> None:
+        self._manager = manager
+        self._timeout_s = timeout_s
+        # (room, handle, message_id) currently in flight — a re-fire is ignored.
+        self._active: set[tuple[str, str, str]] = set()
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    # -- the summon seam (sync; called from the persister's on_summon) --
+
+    def handle_summon(
+        self,
+        room: str,
+        handle: str,
+        envelope: L9,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
+    ) -> None:
+        card = registered_a2a_card(room, handle)
+        if card is None:
+            return  # not an a2a agent — let the engines / a teammate handle it
+        sender = envelope_sender(envelope)
+        if _norm(sender) == _norm(handle):
+            return  # never answer our own message (loop guard)
+        prompt = (message_text or "").strip()
+        if not prompt:
+            return
+        mid = envelope_message_id(envelope) or ""
+        key = (room, _norm(handle), mid)
+        if key in self._active:
+            return
+        self._active.add(key)
+        task = asyncio.create_task(self._run_and_release(room, handle, card, prompt, envelope, key))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _run_and_release(
+        self,
+        room: str,
+        handle: str,
+        card: str,
+        prompt: str,
+        envelope: L9,
+        key: tuple[str, str, str],
+    ) -> None:
+        try:
+            reply = await send_to_a2a(card, prompt, timeout_s=self._timeout_s)
+            await self._respond(room, handle, reply, envelope)
+        except A2aSendError:
+            # Fail-faithful: a dead/unreadable remote posts nothing rather than a
+            # fabricated reply. The caller (human or aligner) sees silence.
+            logger.warning("a2a responder: @%s in %s did not answer", handle, room)
+        except Exception:
+            logger.exception("a2a responder run failed for @%s in %s", handle, room)
+        finally:
+            self._active.discard(key)
+
+    async def _respond(self, room: str, handle: str, text: str, in_reply_to: L9) -> None:
+        """Post ``text`` into the room as ``handle``, addressed to the summoner."""
+        managed = self._manager.get(room)
+        if managed is None:
+            return
+        summoner = envelope_sender(in_reply_to)
+        parent = envelope_message_id(in_reply_to)
+        env = l9.build_envelope(
+            kind=l9.Kind.exchange,
+            episode=l9.episode_urn(room, "live"),
+            parents=[parent] if parent else None,
+            sender=handle,
+            sender_role="agent",
+            recipients=[summoner] if summoner else None,
+            topic=l9.topic_urn(room),
+            payload_type="reply",
+        )
+        content = serialize_content(env, extra={"content": text})
+        try:
+            await managed.channel.send(env, extra={"content": text})
+        except Exception:
+            logger.warning("a2a responder failed to broadcast @%s reply on %s", handle, room)
+        if managed.persister is not None:
+            managed.persister.ingest_local(env, content, list_write=True)
+        # Best-effort presence: a handle that just answered is live in the room.
+        try:
+            self._manager.refresh_lease(room, handle)
+        except Exception:
+            logger.debug("a2a responder: lease refresh skipped for @%s in %s", handle, room)

--- a/fastapi-backend/app/services/a2a_card.py
+++ b/fastapi-backend/app/services/a2a_card.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 import httpx
 from a2a.client import A2ACardResolver
 from a2a.client.errors import A2AClientError
+from a2a.types import AgentCard
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,21 @@ async def resolve_card(
     Tries the new well-known path then the old one. Raises
     :class:`A2aCardError` with a human-readable reason if neither resolves.
     """
+    raw, path = await resolve_raw_card(base_url, http=http)
+    return _project(raw, base=base_url.strip().rstrip("/"), card_path=path)
+
+
+async def resolve_raw_card(
+    base_url: str,
+    *,
+    http: httpx.AsyncClient | None = None,
+) -> tuple[AgentCard, str]:
+    """Resolve the raw proto ``AgentCard`` + the well-known path that served it.
+
+    The dual-path probe shared by registration (which projects the card) and the
+    seat driver (which needs the raw card to build a send client). Raises
+    :class:`A2aCardError` if neither path resolves.
+    """
     base = base_url.strip().rstrip("/")
     if not base.startswith(("http://", "https://")):
         raise A2aCardError(f"card URL must be http(s): {base_url!r}")
@@ -89,7 +105,7 @@ async def resolve_card(
                 last_error = exc
                 logger.debug("a2a card probe %s%s failed: %r", base, path, exc)
                 continue
-            return _project(card, base=base, card_path=path)
+            return card, path
         raise A2aCardError(
             f"no Agent Card at {base}{NEW_CARD_PATH} or {OLD_CARD_PATH}: {last_error}"
         )

--- a/fastapi-backend/tests/fakes.py
+++ b/fastapi-backend/tests/fakes.py
@@ -123,7 +123,9 @@ class FakePersister:
         self.log = DeliveryLog(records or [])
         self.ingested: list[tuple[Any, dict[str, Any]]] = []
 
-    def ingest_local(self, envelope: Any, content: dict[str, Any]) -> None:
+    def ingest_local(
+        self, envelope: Any, content: dict[str, Any], *, list_write: bool = False
+    ) -> None:
         self.ingested.append((envelope, content))
 
 

--- a/fastapi-backend/tests/test_a2a_bridge.py
+++ b/fastapi-backend/tests/test_a2a_bridge.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The A2A bridge send primitive (#714).
+
+``send_to_a2a`` is the client leg: card URL + prompt -> reply prose. The live
+wire is exercised by the env-gated test; the hermetic test pins the fail-faithful
+contract (a bad endpoint raises rather than fabricating a reply).
+"""
+
+import os
+
+import pytest
+
+from app.services.a2a_bridge import A2aSendError, send_to_a2a
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_bad_scheme():
+    """A non-http card can't be reached, and that surfaces as A2aSendError."""
+    with pytest.raises(A2aSendError):
+        await send_to_a2a("ftp://nope", "hi")
+
+
+@pytest.mark.asyncio
+async def test_send_raises_on_unresolvable_card():
+    with pytest.raises(A2aSendError, match="unresolvable"):
+        await send_to_a2a("https://example.com", "hi")
+
+
+@pytest.mark.skipif(
+    os.getenv("MYCELIUM_A2A_LIVE") != "1",
+    reason="live A2A wire test; set MYCELIUM_A2A_LIVE=1 to run",
+)
+@pytest.mark.asyncio
+async def test_send_to_live_public_agent():
+    reply = await send_to_a2a("https://hello-world-gxfr.onrender.com", "hello from the seat")
+    assert reply == "Hello World"

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The A2A responder (#714) — answer @-mentions by calling the remote agent.
+
+Node-free: the remote call (`send_to_a2a`) is patched, so these exercise the
+summon gate, the loop guards, and that the reply is posted back as the handle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import yaml
+
+from app.services import a2a_bridge, l9
+from app.services.filesystem import get_room_dir, write_memory_file
+from app.services.l9_models import Kind
+from tests.fakes import FakeChannel, FakeManaged, FakeManager, FakePersister
+
+_ROOM = "portfolio"
+
+
+def _register_a2a(handle: str = "researcher", card: str = "https://remote.example") -> None:
+    body = yaml.safe_dump({"adapter": "a2a", "a2a_card": card, "description": "does research"})
+    write_memory_file(get_room_dir(_ROOM), f"agents/{handle}", body, created_by="web-ui")
+
+
+def _register_engine(handle: str = "aligner") -> None:
+    body = yaml.safe_dump({"adapter": "engine", "kind": "aligner"})
+    write_memory_file(get_room_dir(_ROOM), f"agents/{handle}", body, created_by="web-ui")
+
+
+def _summon_envelope(sender: str, *, message_id: str = "m1"):
+    return l9.build_envelope(
+        kind=Kind.exchange,
+        episode=l9.episode_urn(_ROOM, "live"),
+        sender=sender,
+        sender_role="human",
+        recipients=["researcher"],
+        topic=l9.topic_urn(_ROOM),
+        payload_type="message",
+        message_id=message_id,
+    )
+
+
+def _responder(monkeypatch, *, reply: str = "the remote reply"):
+    persister = FakePersister()
+    channel = FakeChannel(persister)
+    managed = FakeManaged(room=_ROOM, channel=channel, persister=persister)
+    manager = FakeManager(managed, ["avery", "researcher"])
+    responder = a2a_bridge.A2aResponder(manager)  # type: ignore[arg-type]
+
+    calls: list[tuple[str, str]] = []
+
+    async def _fake_send(card_url, text, **_kwargs):
+        calls.append((card_url, text))
+        if reply is None:
+            raise a2a_bridge.A2aSendError("dead remote")
+        return reply
+
+    monkeypatch.setattr(a2a_bridge, "send_to_a2a", _fake_send)
+    return responder, channel, persister, calls
+
+
+async def _drain(responder):
+    if responder._tasks:
+        await asyncio.gather(*list(responder._tasks))
+
+
+@pytest.mark.asyncio
+async def test_mention_calls_remote_and_posts_reply(monkeypatch):
+    _register_a2a()
+    responder, channel, persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(
+        _ROOM, "researcher", _summon_envelope("avery"), [], "what do you think?"
+    )
+    await _drain(responder)
+
+    # It called the remote with the message text…
+    assert calls == [("https://remote.example", "what do you think?")]
+    # …and posted the reply back into the room as the handle.
+    assert len(channel.sent) == 1
+    env, extra = channel.sent[0]
+    assert extra["content"] == "the remote reply"
+    assert env.header.participants.actors[0].id == "researcher"
+    assert persister.ingested
+
+
+@pytest.mark.asyncio
+async def test_non_a2a_handle_is_ignored(monkeypatch):
+    _register_engine("aligner")  # an engine, not a2a
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "aligner", _summon_envelope("avery"), [], "mediate us")
+    await _drain(responder)
+
+    assert calls == []
+    assert channel.sent == []
+
+
+@pytest.mark.asyncio
+async def test_self_message_does_not_loop(monkeypatch):
+    _register_a2a()
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    # The summoner IS the a2a agent — its own post must not trigger a reply.
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("researcher"), [], "hi all")
+    await _drain(responder)
+
+    assert calls == []
+    assert channel.sent == []
+
+
+@pytest.mark.asyncio
+async def test_empty_prompt_is_ignored(monkeypatch):
+    _register_a2a()
+    responder, _channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "   ")
+    await _drain(responder)
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_same_mention_runs_once(monkeypatch):
+    _register_a2a()
+    responder, _channel, _persister, calls = _responder(monkeypatch)
+
+    env = _summon_envelope("avery", message_id="dup")
+    responder.handle_summon(_ROOM, "researcher", env, [], "hello")
+    responder.handle_summon(_ROOM, "researcher", env, [], "hello")
+    await _drain(responder)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_dead_remote_posts_nothing(monkeypatch):
+    _register_a2a()
+    responder, channel, _persister, calls = _responder(monkeypatch, reply=None)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "you there?")
+    await _drain(responder)
+
+    assert calls  # it tried
+    assert channel.sent == []  # fail-faithful: no fabricated reply


### PR DESCRIPTION
Closes #714. Part of epic #719. **Targets `feat/a2a-bridge`.**

Makes a registered A2A agent actually respond. Following your steer, this is **not** a negotiation seat — it's normal chat flow: `@`-mention the agent, it answers.

## Design (reframed after discussion)

The seat is an **event-driven `@`-mention responder**, not a polling loop and not coupled to the aligner:

- The persister already fires `on_summon` for every `@`-mention (`persister.py`). `A2aResponder` hooks that seam alongside the aligner/synthesizer engines, and gates on the manifest (`adapter: a2a`) exactly like the engines gate on their `kind`.
- On a mention it calls the remote agent via `send_to_a2a(card, text)` and posts the reply back as that handle. No polling, zero idle cost.
- The aligner addressing the agent mid-negotiation is just *one caller* that happens to `@`-mention it — negotiation is not the backbone.

## What's here

- `send_to_a2a(card_url, text)` — the client leg. Resolves the card (dual-path) and sends with `accepted_output_modes` set (the #712 findings). **Proven live** against the public echo agent. Fail-faithful: an unresolvable card / empty reply raises rather than fabricating.
- `A2aResponder` — the event-driven responder. Guards: acts only for `adapter: a2a`; ignores its own messages (loop guard), empty prompts, and re-fires of the same message id. A dead remote posts nothing (silence, never a fabricated reply). Best-effort presence lease so a handle that just answered shows live.
- Wired into the summon fan-out in `main.py`.
- Refactored `a2a_card` to share `resolve_raw_card` between registration (projection) and the send path (raw card for the client).

## Tests / gate

- `test_a2a_responder.py` (6, node-free via the shared fakes): mention → remote call → reply posted as the handle; the non-a2a, self-message, empty-prompt, dedupe, and dead-remote guards.
- `test_a2a_bridge.py`: send fail-faithful contract + env-gated (`MYCELIUM_A2A_LIVE=1`) live send.
- Backend 708 passed, ruff/ty clean. `FakePersister.ingest_local` grew the `list_write` kwarg to match the real signature.

## Deferred (by design)
- Richer part/L9 translation (data parts, structured payloads) → #715
- Auth on the remote call + the not-an-MLS-member docs → #717
- Live end-to-end with a real reasoning partner → #718
