### PR TITLE
feat(a2a): expose a room as an A2A agent, inbound mirror (#716)

### DIFF
--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -30,6 +30,7 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routes.a2a_agents import router as a2a_agents_router
+from app.routes.a2a_server import router as a2a_server_router
 from app.routes.agents import router as agents_router
 from app.routes.engines import router as engines_router
 from app.routes.episodes import router as episodes_router
@@ -234,6 +235,7 @@ app.add_middleware(
 # Core routes. Health endpoints stay top-level for orchestrator probes.
 app.include_router(agents_router, prefix="/api")
 app.include_router(a2a_agents_router, prefix="/api")
+app.include_router(a2a_server_router, prefix="/api")
 app.include_router(engines_router, prefix="/api")
 app.include_router(rooms_router, prefix="/api")
 app.include_router(messages_router, prefix="/api")

--- a/fastapi-backend/app/routes/a2a_server.py
+++ b/fastapi-backend/app/routes/a2a_server.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Expose a room *as* an A2A agent (epic #719, #716) — the inbound mirror.
+
+Where ``a2a_bridge`` lets a room call *out* to a remote A2A agent, this lets an
+external A2A client call *in*: it discovers a room's Agent Card and sends it a
+message, which lands in the room like any other post. Card serialization and the
+JSON-RPC wire are the SDK's (``agent_card_to_dict`` + ``JsonRpcDispatcher``), so
+the bytes are correct by construction; we only supply the room-specific card and
+an :class:`AgentExecutor` that injects the message into the room.
+
+Per-room: each room is its own A2A agent at ``/rooms/{room}/…``. The card + a
+throwaway request handler are built per request, so a new room needs no route
+wiring.
+
+Scope (v1): ``message/send`` delivers the message into the room and returns an
+ack. If the message ``@``-mentions a room agent, normal room dynamics take over
+(including the outbound a2a responder) — this endpoint just doesn't block on that
+async reply. Returning the room's reply synchronously is a follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.request_handlers.response_helpers import agent_card_to_dict
+from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+    Message,
+    Part,
+    Role,
+)
+from fastapi import APIRouter, HTTPException, Request
+from starlette.responses import JSONResponse, Response
+
+from app.services import l9
+from app.services.filesystem import room_exists
+from app.services.l9_slim import serialize_content
+from app.services.skills import list_room_skills
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/rooms/{room_name}", tags=["a2a"])
+
+_GUEST_HANDLE = "a2a-guest"
+
+
+def _build_room_card(room: str, request: Request) -> AgentCard:
+    """The A2A Agent Card for a room, skills drawn from its ``skills/`` namespace."""
+    base = str(request.base_url).rstrip("/")
+    rpc_url = f"{base}/api/rooms/{room}/a2a"
+    skills = [
+        AgentSkill(
+            id=name,
+            name=str(meta.get("title") or name),
+            description=str(meta.get("description") or ""),
+        )
+        for name, meta, _body in list_room_skills(room)
+    ]
+    return AgentCard(
+        name=room,
+        description=f"Mycelium coordination room '{room}'. Post a message to reach its members.",
+        version="1.0.0",
+        capabilities=AgentCapabilities(streaming=False),
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+        skills=skills,
+        supported_interfaces=[AgentInterface(url=rpc_url, protocol_binding="JSONRPC")],
+    )
+
+
+async def _inject_into_room(room: str, text: str) -> str:
+    """Post ``text`` into the room as the a2a guest; return an ack line."""
+    from app.services.room_channels import manager
+
+    managed = manager.get(room)
+    if managed is None:
+        return f"Room '{room}' is not active."
+    env = l9.build_envelope(
+        kind=l9.Kind.exchange,
+        episode=l9.episode_urn(room, "live"),
+        sender=_GUEST_HANDLE,
+        sender_role="agent",
+        topic=l9.topic_urn(room),
+        payload_type="message",
+    )
+    content = serialize_content(env, extra={"content": text})
+    try:
+        await managed.channel.send(env, extra={"content": text})
+    except Exception:
+        logger.warning("a2a-server: failed to broadcast inbound message to room %s", room)
+    if managed.persister is not None:
+        managed.persister.ingest_local(env, content, list_write=True)
+    return f"Delivered to room '{room}'."
+
+
+class _RoomAgentExecutor(AgentExecutor):
+    """Deliver an inbound A2A message into a room and ack it."""
+
+    def __init__(self, room: str) -> None:
+        self._room = room
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        text = (context.get_user_input() or "").strip()
+        ack = (
+            await _inject_into_room(self._room, text)
+            if text
+            else "Empty message; nothing delivered."
+        )
+        await event_queue.enqueue_event(
+            Message(
+                message_id=uuid.uuid4().hex,
+                role=Role.ROLE_AGENT,
+                parts=[Part(text=ack)],
+                context_id=context.context_id or "",
+            )
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        # message/send is fire-and-ack; there's no long-running task to cancel.
+        return
+
+
+@router.get("/.well-known/agent-card.json")
+async def a2a_agent_card(room_name: str, request: Request) -> Response:
+    """Serve the room's A2A Agent Card (the discovery half)."""
+    if not room_exists(room_name):
+        raise HTTPException(status_code=404, detail="Room not found")
+    card = _build_room_card(room_name, request)
+    return JSONResponse(agent_card_to_dict(card))
+
+
+@router.post("/a2a")
+async def a2a_rpc(room_name: str, request: Request) -> Response:
+    """Handle A2A JSON-RPC (``message/send``) for the room."""
+    if not room_exists(room_name):
+        raise HTTPException(status_code=404, detail="Room not found")
+    card = _build_room_card(room_name, request)
+    handler = DefaultRequestHandler(_RoomAgentExecutor(room_name), InMemoryTaskStore(), card)
+    dispatcher = JsonRpcDispatcher(handler, enable_v0_3_compat=True)
+    return await dispatcher.handle_requests(request)

--- a/fastapi-backend/pyproject.toml
+++ b/fastapi-backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "negmas>=0.15.7",
     "pyjwt[crypto]>=2.10,<3",
     "a2a-sdk==1.1.2",
+    "sse-starlette>=3.4.8",
 ]
 
 [dependency-groups]

--- a/fastapi-backend/tests/test_a2a_server_route.py
+++ b/fastapi-backend/tests/test_a2a_server_route.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Expose a room as an A2A agent (#716) — the inbound mirror.
+
+The card is resolved by the *real* a2a-sdk client over the app's ASGI transport
+(proving wire compatibility). The message/send path is driven with a raw
+JSON-RPC POST — the server's dispatcher parses it and runs our executor — so the
+test exercises our server without depending on the SDK client's streaming
+iterator semantics over ASGITransport.
+"""
+
+import pytest
+from a2a.client import A2ACardResolver
+
+from app.services import room_channels
+from app.services.filesystem import get_room_dir, write_memory_file
+from tests.fakes import FakeChannel, FakeManaged, FakePersister
+
+_CARD_PATH = "/api/rooms/portfolio/.well-known/agent-card.json"
+
+
+async def _make_room(client, name: str = "portfolio") -> None:
+    resp = await client.post("/api/rooms", json={"name": name})
+    assert resp.status_code in (200, 201)
+
+
+async def _resolve(client):
+    return await A2ACardResolver(client, "http://test", agent_card_path=_CARD_PATH).get_agent_card()
+
+
+@pytest.mark.asyncio
+async def test_room_card_is_resolvable_by_the_sdk(client):
+    await _make_room(client)
+    # Seed a skill directly (no embedding) so the card projects it.
+    write_memory_file(
+        get_room_dir("portfolio"),
+        "skills/summarize",
+        "Distill the room.",
+        created_by="web-ui",
+        extra_meta={"description": "distills the room"},
+    )
+
+    card = await _resolve(client)
+    assert card.name == "portfolio"
+    skill = next((s for s in card.skills if s.id == "summarize"), None)
+    assert skill is not None
+    assert skill.description == "distills the room"
+    # the SDK derived a JSON-RPC endpoint from the card
+    assert any(i.url.endswith("/api/rooms/portfolio/a2a") for i in card.supported_interfaces)
+
+
+@pytest.mark.asyncio
+async def test_missing_room_card_is_404(client):
+    resolver = A2ACardResolver(
+        client, "http://test", agent_card_path="/api/rooms/ghost/.well-known/agent-card.json"
+    )
+    with pytest.raises(Exception):  # noqa: B017 - resolver raises on non-200
+        await resolver.get_agent_card()
+
+
+@pytest.mark.asyncio
+async def test_message_send_delivers_into_the_room(client, monkeypatch):
+    await _make_room(client)
+
+    # Route the room injection at a fake channel so we can assert delivery.
+    persister = FakePersister()
+    channel = FakeChannel(persister)
+    managed = FakeManaged(room="portfolio", channel=channel, persister=persister)
+    monkeypatch.setattr(room_channels.manager, "get", lambda _r: managed)
+
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "message/send",
+        "params": {
+            "configuration": {"acceptedOutputModes": ["text"]},
+            "message": {
+                "kind": "message",
+                "messageId": "in1",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "hello room"}],
+            },
+        },
+    }
+    resp = await client.post("/api/rooms/portfolio/a2a", json=rpc)
+    assert resp.status_code == 200, resp.text
+    result = resp.json()["result"]
+    ack = "".join(p.get("text", "") for p in result["parts"])
+    assert "Delivered to room" in ack
+    # the message actually reached the room channel
+    assert any(extra and extra.get("content") == "hello room" for _env, extra in channel.sent)
+
+
+@pytest.mark.asyncio
+async def test_message_send_missing_room_404(client):
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "message/send",
+        "params": {"message": {"kind": "message", "messageId": "x", "role": "user", "parts": []}},
+    }
+    resp = await client.post("/api/rooms/ghost/a2a", json=rpc)
+    assert resp.status_code == 404

--- a/fastapi-backend/uv.lock
+++ b/fastapi-backend/uv.lock
@@ -945,6 +945,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "rapidfuzz" },
     { name = "slim-bindings" },
+    { name = "sse-starlette" },
     { name = "tiktoken" },
     { name = "watchdog" },
 ]
@@ -975,6 +976,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rapidfuzz", specifier = ">=3.14.5" },
     { name = "slim-bindings", specifier = ">=2.1,<2.2" },
+    { name = "sse-starlette", specifier = ">=3.4.8" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
@@ -1812,6 +1814,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #716. Part of epic #719. **Targets `feat/a2a-bridge`.**

The inbound mirror: an external A2A client can now **discover a room and message it**. You were right that this had a clear solution — the a2a-sdk ships the server side, so the wire is correct by construction (no hand-rolled JSON).

- **`GET /rooms/{room}/.well-known/agent-card.json`** serves the room's Agent Card via the SDK's `agent_card_to_dict`, with skills drawn from the room's `skills/` namespace and a JSON-RPC interface URL built from the request host.
- **`POST /rooms/{room}/a2a`** delegates to the SDK's `JsonRpcDispatcher` + a per-request `DefaultRequestHandler`. A `RoomAgentExecutor` injects the inbound `message/send` into the room as an `a2a-guest` post and acks. If the message `@`-mentions a room agent, normal room dynamics take over — including the outbound responder from #714, so an inbound A2A message can drive an outbound A2A agent. Nice symmetry.

Per-room with zero route wiring: the card + handler are built per request, so a new room just works.

**Tested end to end:** the *real* a2a-sdk `A2ACardResolver` resolves the card over the app's ASGI transport (proving wire compatibility), and a raw JSON-RPC `message/send` delivers into a fake room channel. (Debugging note: the handler's `enqueue_event` is async — the first cut hung until I awaited it.) Backend **713 green**, ruff/ty clean. Adds `sse-starlette` (the SDK's http-server routes need it).

**Scope:** v1 acks delivery; returning the room's *async* reply synchronously (bounded wait) is a clean follow-up.
