### PR TITLE
Spike: can A2A ride SLIM natively in our stack? (epic #719)

### DIFF
--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -29,6 +29,7 @@ os.environ.setdefault("HF_HUB_OFFLINE", "1")
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.routes.a2a_agents import router as a2a_agents_router
 from app.routes.agents import router as agents_router
 from app.routes.engines import router as engines_router
 from app.routes.episodes import router as episodes_router
@@ -225,6 +226,7 @@ app.add_middleware(
 
 # Core routes. Health endpoints stay top-level for orchestrator probes.
 app.include_router(agents_router, prefix="/api")
+app.include_router(a2a_agents_router, prefix="/api")
 app.include_router(engines_router, prefix="/api")
 app.include_router(rooms_router, prefix="/api")
 app.include_router(messages_router, prefix="/api")

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -105,20 +105,27 @@ async def lifespan(app: FastAPI):
     # Wire the SIEP aligner into every room's summon seam before any
     # channel is provisioned, so all persisters pick it up. Dormant until an
     # @-summon of its reserved handle arrives — zero idle cost.
+    # Several handlers share the one summon seam: two engine kinds (aligner,
+    # synthesizer) plus the A2A responder. Each self-selects by the summoned
+    # handle's manifest (kind for engines, adapter=a2a for the responder), so a
+    # fan-out dispatcher is enough — no central table. Only one ever acts per
+    # summon since a handle maps to a single runtime.
+    from app.services.a2a_bridge import A2aResponder
     from app.services.aligner import AlignerEngine
     from app.services.plan_sync import PlanSyncEngine
     from app.services.room_channels import manager as room_channel_manager
     from app.services.synthesizer import SynthesizerEngine
 
-    # Two engine kinds share the one summon seam. Each engine self-selects by the
-    # summoned handle's manifest kind (and the aligner's reserved-handle
-    # fallback), so a fan-out dispatcher is enough — no central kind table. Only
-    # one engine ever acts per summon since a handle maps to a single kind.
     app.state.aligner = AlignerEngine(room_channel_manager)
     app.state.synthesizer = SynthesizerEngine(room_channel_manager)
+    # The A2A responder shares the seam too: it answers @-mentions of a
+    # registered a2a agent by calling the remote endpoint, gating on the manifest
+    # like the engines gate on their kind, so only one handler ever acts.
+    app.state.a2a_responder = A2aResponder(room_channel_manager)
     _engine_handlers = (
         app.state.aligner.handle_summon,
         app.state.synthesizer.handle_summon,
+        app.state.a2a_responder.handle_summon,
     )
 
     def _dispatch_summon(

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -30,6 +30,7 @@ from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routes.a2a_agents import router as a2a_agents_router
+from app.routes.a2a_server import router as a2a_server_router
 from app.routes.agents import router as agents_router
 from app.routes.engines import router as engines_router
 from app.routes.episodes import router as episodes_router
@@ -234,6 +235,7 @@ app.add_middleware(
 # Core routes. Health endpoints stay top-level for orchestrator probes.
 app.include_router(agents_router, prefix="/api")
 app.include_router(a2a_agents_router, prefix="/api")
+app.include_router(a2a_server_router, prefix="/api")
 app.include_router(engines_router, prefix="/api")
 app.include_router(rooms_router, prefix="/api")
 app.include_router(messages_router, prefix="/api")

--- a/fastapi-backend/app/routes/a2a_agents.py
+++ b/fastapi-backend/app/routes/a2a_agents.py
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""POST /rooms/{room_name}/a2a-agents — register an external A2A agent.
+
+An A2A agent is a remote Agent2Agent endpoint fielded as a room member. Like an
+engine, registration is a backend-owned manifest write with no machine-local
+side effects, so the web UI can invite one natively. Unlike an engine it has one
+extra step: we resolve the remote Agent Card first, so a bad URL fails at
+registration rather than at the first summon. The manifest lands at
+``agents/<handle>`` with ``adapter: a2a`` plus the resolved card fields the seat
+driver (#714) needs to call the remote agent.
+"""
+
+import logging
+import re
+
+import yaml
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app.routes.memory import upsert_memories
+from app.schemas import HANDLE_PATTERN, AgentRead, MemoryBatchCreate, MemoryCreate
+from app.services import actor
+from app.services.a2a_card import A2aCardError, resolve_card
+from app.services.filesystem import get_room_dir, read_memory_file, room_exists
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/rooms/{room_name}/a2a-agents", tags=["a2a"])
+
+_HANDLE_RE = re.compile(HANDLE_PATTERN)
+
+
+class A2aAgentCreate(BaseModel):
+    """Request body to invite an external A2A agent into a room."""
+
+    handle: str = Field(..., min_length=1, max_length=64)
+    card: str = Field(..., description="Base URL serving the remote agent's Agent Card.")
+    description: str = Field("", description="Overrides the card's description when set.")
+    allow_from: list[str] = Field(
+        default_factory=list, description="Sender handles allowed to summon (empty = anyone)."
+    )
+    owner: str | None = None
+    team: str | None = None
+    created_by: str | None = Field(
+        None, description="Who registered the agent; defaults to the web UI."
+    )
+
+
+def _norm(handle: str | None) -> str | None:
+    if not handle:
+        return None
+    cleaned = handle.strip().lstrip("@").lower()
+    return cleaned or None
+
+
+@router.post("", response_model=AgentRead, status_code=201)
+async def create_a2a_agent(room_name: str, payload: A2aAgentCreate, request: Request) -> AgentRead:
+    """Resolve the remote card, register the manifest, return the room view."""
+    if not room_exists(room_name):
+        raise HTTPException(status_code=404, detail="Room not found")
+
+    registrar = actor.bind_optional_actor(request, payload.created_by, field="created_by")
+
+    handle = _norm(payload.handle)
+    if not handle or not _HANDLE_RE.match(handle):
+        raise HTTPException(
+            status_code=422,
+            detail="Handle must be a lowercase slug (a-z, 0-9, '-', '_') starting alphanumeric.",
+        )
+
+    key = f"agents/{handle}"
+    room_dir = get_room_dir(room_name)
+    if read_memory_file(room_dir, key) is not None:
+        raise HTTPException(status_code=409, detail=f"@{handle} already exists in {room_name}")
+
+    # Resolve the card now so an unreachable or malformed endpoint is a clean 502
+    # at registration, not a surprise when the aligner first addresses the seat.
+    try:
+        card = await resolve_card(payload.card)
+    except A2aCardError as exc:
+        raise HTTPException(status_code=502, detail=f"Could not resolve A2A card: {exc}") from exc
+
+    description = payload.description.strip() or card.description
+
+    body = {
+        "adapter": "a2a",
+        "description": description,
+        "a2a_card": payload.card.strip().rstrip("/"),
+        "a2a_endpoint": card.endpoint,
+        "a2a_binding": card.protocol_binding,
+        "a2a_card_path": card.card_path,
+        "a2a_streaming": card.streaming,
+        "a2a_skills": card.skill_ids,
+        "allow_from": [h for h in (_norm(a) for a in payload.allow_from) if h],
+        "owner": _norm(payload.owner),
+        "team": _norm(payload.team),
+    }
+    yaml_body = yaml.safe_dump(body, sort_keys=False, default_flow_style=False).strip()
+
+    batch = MemoryBatchCreate(
+        items=[
+            MemoryCreate(
+                key=key,
+                value=yaml_body,
+                created_by=registrar or "web-ui",
+                embed=False,
+                tags=["agent-manifest"],
+            )
+        ]
+    )
+    await upsert_memories(room_name, batch)
+    logger.info(
+        "room %s: registered a2a agent @%s (%s, %d skills)",
+        room_name,
+        handle,
+        card.endpoint,
+        len(card.skills),
+    )
+
+    return AgentRead(
+        handle=handle,
+        adapter="a2a",
+        description=description,
+        owner=body["owner"],
+        team=body["team"],
+        allow_from=body["allow_from"],
+        a2a_card=body["a2a_card"],
+        a2a_endpoint=card.endpoint,
+        a2a_skills=card.skill_ids,
+    )

--- a/fastapi-backend/app/routes/a2a_server.py
+++ b/fastapi-backend/app/routes/a2a_server.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Expose a room *as* an A2A agent (epic #719, #716) — the inbound mirror.
+
+Where ``a2a_bridge`` lets a room call *out* to a remote A2A agent, this lets an
+external A2A client call *in*: it discovers a room's Agent Card and sends it a
+message, which lands in the room like any other post. Card serialization and the
+JSON-RPC wire are the SDK's (``agent_card_to_dict`` + ``JsonRpcDispatcher``), so
+the bytes are correct by construction; we only supply the room-specific card and
+an :class:`AgentExecutor` that injects the message into the room.
+
+Per-room: each room is its own A2A agent at ``/rooms/{room}/…``. The card + a
+throwaway request handler are built per request, so a new room needs no route
+wiring.
+
+Scope (v1): ``message/send`` delivers the message into the room and returns an
+ack. If the message ``@``-mentions a room agent, normal room dynamics take over
+(including the outbound a2a responder) — this endpoint just doesn't block on that
+async reply. Returning the room's reply synchronously is a follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.request_handlers.response_helpers import agent_card_to_dict
+from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+    Message,
+    Part,
+    Role,
+)
+from fastapi import APIRouter, HTTPException, Request
+from starlette.responses import JSONResponse, Response
+
+from app.services import l9
+from app.services.filesystem import room_exists
+from app.services.l9_slim import serialize_content
+from app.services.skills import list_room_skills
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/rooms/{room_name}", tags=["a2a"])
+
+_GUEST_HANDLE = "a2a-guest"
+
+
+def _build_room_card(room: str, request: Request) -> AgentCard:
+    """The A2A Agent Card for a room, skills drawn from its ``skills/`` namespace."""
+    base = str(request.base_url).rstrip("/")
+    rpc_url = f"{base}/api/rooms/{room}/a2a"
+    skills = [
+        AgentSkill(
+            id=name,
+            name=str(meta.get("title") or name),
+            description=str(meta.get("description") or ""),
+        )
+        for name, meta, _body in list_room_skills(room)
+    ]
+    return AgentCard(
+        name=room,
+        description=f"Mycelium coordination room '{room}'. Post a message to reach its members.",
+        version="1.0.0",
+        capabilities=AgentCapabilities(streaming=False),
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+        skills=skills,
+        supported_interfaces=[AgentInterface(url=rpc_url, protocol_binding="JSONRPC")],
+    )
+
+
+async def _inject_into_room(room: str, text: str) -> str:
+    """Post ``text`` into the room as the a2a guest; return an ack line."""
+    from app.services.room_channels import manager
+
+    managed = manager.get(room)
+    if managed is None:
+        return f"Room '{room}' is not active."
+    env = l9.build_envelope(
+        kind=l9.Kind.exchange,
+        episode=l9.episode_urn(room, "live"),
+        sender=_GUEST_HANDLE,
+        sender_role="agent",
+        topic=l9.topic_urn(room),
+        payload_type="message",
+    )
+    content = serialize_content(env, extra={"content": text})
+    try:
+        await managed.channel.send(env, extra={"content": text})
+    except Exception:
+        logger.warning("a2a-server: failed to broadcast inbound message to room %s", room)
+    if managed.persister is not None:
+        managed.persister.ingest_local(env, content, list_write=True)
+    return f"Delivered to room '{room}'."
+
+
+class _RoomAgentExecutor(AgentExecutor):
+    """Deliver an inbound A2A message into a room and ack it."""
+
+    def __init__(self, room: str) -> None:
+        self._room = room
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        text = (context.get_user_input() or "").strip()
+        ack = (
+            await _inject_into_room(self._room, text)
+            if text
+            else "Empty message; nothing delivered."
+        )
+        await event_queue.enqueue_event(
+            Message(
+                message_id=uuid.uuid4().hex,
+                role=Role.ROLE_AGENT,
+                parts=[Part(text=ack)],
+                context_id=context.context_id or "",
+            )
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        # message/send is fire-and-ack; there's no long-running task to cancel.
+        return
+
+
+@router.get("/.well-known/agent-card.json")
+async def a2a_agent_card(room_name: str, request: Request) -> Response:
+    """Serve the room's A2A Agent Card (the discovery half)."""
+    if not room_exists(room_name):
+        raise HTTPException(status_code=404, detail="Room not found")
+    card = _build_room_card(room_name, request)
+    return JSONResponse(agent_card_to_dict(card))
+
+
+@router.post("/a2a")
+async def a2a_rpc(room_name: str, request: Request) -> Response:
+    """Handle A2A JSON-RPC (``message/send``) for the room."""
+    if not room_exists(room_name):
+        raise HTTPException(status_code=404, detail="Room not found")
+    card = _build_room_card(room_name, request)
+    handler = DefaultRequestHandler(_RoomAgentExecutor(room_name), InMemoryTaskStore(), card)
+    dispatcher = JsonRpcDispatcher(handler, enable_v0_3_compat=True)
+    return await dispatcher.handle_requests(request)

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -480,6 +480,11 @@ class AgentRead(BaseModel):
     owner: str | None = None
     team: str | None = None
     allow_from: list[str] = Field(default_factory=list)
+    # a2a adapter: the remote Agent Card locator, resolved endpoint, and the
+    # skills it advertises. None/empty for every other adapter.
+    a2a_card: str | None = None
+    a2a_endpoint: str | None = None
+    a2a_skills: list[str] = Field(default_factory=list)
 
 
 class SubscriptionCreate(BaseModel):

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Drive a registered A2A agent as a backend-held room seat (epic #719, #714).
+
+The bridge's client leg. :func:`send_to_a2a` is the one primitive that matters:
+given a remote agent's card URL and a prompt, call it over A2A and return its
+reply text. Everything the seat loop does around it (hold membership, watch for
+ticks addressed to the handle, post the reply as that handle) is the same
+``await``/``respond`` turn a resident agent runs, so the aligner addresses the
+seat exactly like any other member.
+
+The send path carries the #712 spike findings: resolve the card (dual well-known
+path), then build a client with ``accepted_output_modes`` set — without it,
+older servers reject the send with a pydantic ``-32600``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from a2a.client import ClientConfig, ClientFactory
+from a2a.client.errors import A2AClientError
+from a2a.types import Message, Part, Role, SendMessageRequest
+
+from app.services.a2a_card import A2aCardError, resolve_raw_card
+
+logger = logging.getLogger(__name__)
+
+_SEND_TIMEOUT_S = 120.0
+
+
+class A2aSendError(Exception):
+    """A round-trip to the remote A2A agent failed."""
+
+
+def _reply_text(response: object) -> str:
+    """Pull the text parts out of one A2A stream response, if any."""
+    message = getattr(response, "message", None)
+    if message is None or not getattr(response, "HasField", lambda _f: False)("message"):
+        return ""
+    parts = getattr(message, "parts", []) or []
+    return "".join(p.text for p in parts if p.HasField("text"))
+
+
+async def send_to_a2a(
+    card_url: str,
+    text: str,
+    *,
+    http: httpx.AsyncClient | None = None,
+    timeout_s: float = _SEND_TIMEOUT_S,
+) -> str:
+    """Send ``text`` to the A2A agent at ``card_url`` and return its reply prose.
+
+    Raises :class:`A2aSendError` on an unresolvable card or a failed exchange, so
+    the seat can fall back faithfully (silence, never a fabricated reply).
+    """
+    owns_client = http is None
+    client_http = http or httpx.AsyncClient(timeout=timeout_s)
+    try:
+        try:
+            card, _path = await resolve_raw_card(card_url, http=client_http)
+        except A2aCardError as exc:
+            raise A2aSendError(f"card unresolvable: {exc}") from exc
+
+        streaming = bool(getattr(getattr(card, "capabilities", None), "streaming", False))
+        config = ClientConfig(
+            httpx_client=client_http,
+            streaming=streaming,
+            accepted_output_modes=["text"],
+        )
+        client = ClientFactory(config).create(card)
+        message = Message(
+            message_id="mycelium-seat",
+            role=Role.ROLE_USER,
+            parts=[Part(text=text)],
+        )
+
+        chunks: list[str] = []
+        try:
+            async for response in client.send_message(SendMessageRequest(message=message)):
+                chunk = _reply_text(response)
+                if chunk:
+                    chunks.append(chunk)
+        except (A2AClientError, httpx.HTTPError) as exc:
+            raise A2aSendError(f"send failed: {exc}") from exc
+
+        reply = "".join(chunks).strip()
+        if not reply:
+            raise A2aSendError("remote agent returned no text")
+        return reply
+    finally:
+        if owns_client:
+            await client_http.aclose()

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Drive a registered A2A agent as a backend-held room seat (epic #719, #714).
+"""Drive a registered A2A agent as a backend-held room member (epic #719, #714).
 
-The bridge's client leg. :func:`send_to_a2a` is the one primitive that matters:
-given a remote agent's card URL and a prompt, call it over A2A and return its
-reply text. Everything the seat loop does around it (hold membership, watch for
-ticks addressed to the handle, post the reply as that handle) is the same
-``await``/``respond`` turn a resident agent runs, so the aligner addresses the
-seat exactly like any other member.
+Two pieces:
+
+- :func:`send_to_a2a` — the client leg: given a remote agent's card URL and a
+  prompt, call it over A2A and return its reply text.
+- :class:`A2aResponder` — the seat: an event-driven ``@``-mention responder
+  wired to the persister's ``on_summon`` seam (the same one the engines use). It
+  does *not* poll and is not coupled to negotiation. When someone ``@``-mentions
+  a registered ``a2a`` agent in normal chat, it calls the remote and posts the
+  reply back as that handle. The aligner addressing the agent mid-negotiation is
+  just one caller that happens to ``@``-mention it.
 
 The send path carries the #712 spike findings: resolve the card (dual well-known
 path), then build a client with ``accepted_output_modes`` set — without it,
@@ -17,18 +21,55 @@ older servers reject the send with a pydantic ``-32600``.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from typing import TYPE_CHECKING, Any
 
 import httpx
+import yaml
 from a2a.client import ClientConfig, ClientFactory
 from a2a.client.errors import A2AClientError
 from a2a.types import Message, Part, Role, SendMessageRequest
 
+from app.services import l9
 from app.services.a2a_card import A2aCardError, resolve_raw_card
+from app.services.l9_slim import serialize_content
+from app.services.persister import envelope_message_id, envelope_sender
+
+if TYPE_CHECKING:
+    from app.services.l9_models import L9
+    from app.services.room_channels import RoomChannelManager
 
 logger = logging.getLogger(__name__)
 
 _SEND_TIMEOUT_S = 120.0
+
+
+def _norm(handle: str | None) -> str:
+    return (handle or "").strip().lstrip("@").lower()
+
+
+def registered_a2a_card(room: str, handle: str) -> str | None:
+    """The card URL if ``handle`` is a registered ``a2a`` agent in ``room``.
+
+    Mirrors the aligner's engine gate: reads the ``agents/<handle>`` manifest and
+    returns its ``a2a_card`` only for an ``adapter: a2a`` manifest, else ``None``
+    — so summoning a teammate, engine, or unknown handle never fires the bridge.
+    """
+    from app.services.filesystem import get_room_dir, read_memory_file
+
+    result = read_memory_file(get_room_dir(room), f"agents/{handle}")
+    if result is None:
+        return None
+    _meta, body = result
+    try:
+        data = yaml.safe_load(body) or {}
+    except yaml.YAMLError:
+        return None
+    if isinstance(data, dict) and data.get("adapter") == "a2a":
+        card = data.get("a2a_card")
+        return card if isinstance(card, str) and card else None
+    return None
 
 
 class A2aSendError(Exception):
@@ -93,3 +134,101 @@ async def send_to_a2a(
     finally:
         if owns_client:
             await client_http.aclose()
+
+
+class A2aResponder:
+    """Answer ``@``-mentions of a registered A2A agent by calling the remote.
+
+    Wired onto the same summon seam as the engines: the persister fires
+    ``on_summon`` for every ``@``-mention, and this responder acts only when the
+    mentioned handle is a registered ``a2a`` agent. It calls the remote agent
+    with the message text and posts the reply back as that handle — normal chat
+    flow, no polling and no negotiation coupling. The aligner addressing the
+    agent mid-negotiation is just one caller that happens to ``@``-mention it.
+    """
+
+    def __init__(self, manager: RoomChannelManager, *, timeout_s: float = _SEND_TIMEOUT_S) -> None:
+        self._manager = manager
+        self._timeout_s = timeout_s
+        # (room, handle, message_id) currently in flight — a re-fire is ignored.
+        self._active: set[tuple[str, str, str]] = set()
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    # -- the summon seam (sync; called from the persister's on_summon) --
+
+    def handle_summon(
+        self,
+        room: str,
+        handle: str,
+        envelope: L9,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
+    ) -> None:
+        card = registered_a2a_card(room, handle)
+        if card is None:
+            return  # not an a2a agent — let the engines / a teammate handle it
+        sender = envelope_sender(envelope)
+        if _norm(sender) == _norm(handle):
+            return  # never answer our own message (loop guard)
+        prompt = (message_text or "").strip()
+        if not prompt:
+            return
+        mid = envelope_message_id(envelope) or ""
+        key = (room, _norm(handle), mid)
+        if key in self._active:
+            return
+        self._active.add(key)
+        task = asyncio.create_task(self._run_and_release(room, handle, card, prompt, envelope, key))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _run_and_release(
+        self,
+        room: str,
+        handle: str,
+        card: str,
+        prompt: str,
+        envelope: L9,
+        key: tuple[str, str, str],
+    ) -> None:
+        try:
+            reply = await send_to_a2a(card, prompt, timeout_s=self._timeout_s)
+            await self._respond(room, handle, reply, envelope)
+        except A2aSendError:
+            # Fail-faithful: a dead/unreadable remote posts nothing rather than a
+            # fabricated reply. The caller (human or aligner) sees silence.
+            logger.warning("a2a responder: @%s in %s did not answer", handle, room)
+        except Exception:
+            logger.exception("a2a responder run failed for @%s in %s", handle, room)
+        finally:
+            self._active.discard(key)
+
+    async def _respond(self, room: str, handle: str, text: str, in_reply_to: L9) -> None:
+        """Post ``text`` into the room as ``handle``, addressed to the summoner."""
+        managed = self._manager.get(room)
+        if managed is None:
+            return
+        summoner = envelope_sender(in_reply_to)
+        parent = envelope_message_id(in_reply_to)
+        env = l9.build_envelope(
+            kind=l9.Kind.exchange,
+            episode=l9.episode_urn(room, "live"),
+            parents=[parent] if parent else None,
+            sender=handle,
+            sender_role="agent",
+            recipients=[summoner] if summoner else None,
+            topic=l9.topic_urn(room),
+            payload_type="reply",
+        )
+        content = serialize_content(env, extra={"content": text})
+        try:
+            await managed.channel.send(env, extra={"content": text})
+        except Exception:
+            logger.warning("a2a responder failed to broadcast @%s reply on %s", handle, room)
+        if managed.persister is not None:
+            managed.persister.ingest_local(env, content, list_write=True)
+        # Best-effort presence: a handle that just answered is live in the room.
+        try:
+            self._manager.refresh_lease(room, handle)
+        except Exception:
+            logger.debug("a2a responder: lease refresh skipped for @%s in %s", handle, room)

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -23,13 +23,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import httpx
 import yaml
 from a2a.client import ClientConfig, ClientFactory
 from a2a.client.errors import A2AClientError
-from a2a.types import Message, Part, Role, SendMessageRequest
+from a2a.types import Message, Part, Role, SendMessageRequest, StreamResponse
 
 from app.services import l9
 from app.services.a2a_card import A2aCardError, resolve_raw_card
@@ -76,26 +77,60 @@ class A2aSendError(Exception):
     """A round-trip to the remote A2A agent failed."""
 
 
-def _reply_text(response: object) -> str:
-    """Pull the text parts out of one A2A stream response, if any."""
-    message = getattr(response, "message", None)
-    if message is None or not getattr(response, "HasField", lambda _f: False)("message"):
-        return ""
-    parts = getattr(message, "parts", []) or []
-    return "".join(p.text for p in parts if p.HasField("text"))
+@dataclass(frozen=True)
+class A2aReply:
+    """A remote agent's answer plus the conversation id to thread the next turn."""
+
+    text: str
+    context_id: str | None = None
+
+
+def _parts_text(parts: Any) -> str:
+    return "".join(p.text for p in (parts or []) if p.HasField("text"))
+
+
+def _collect(response: StreamResponse) -> tuple[str, str | None]:
+    """Text + context id from one A2A stream response, across all payload shapes.
+
+    A remote agent may answer as a bare ``message``, or as a ``task`` (text in
+    its artifacts / status message), or stream ``status_update`` /
+    ``artifact_update`` events. We read text from whichever arrived and pick up
+    the ``context_id`` so the next turn threads the same conversation.
+    """
+    has = getattr(response, "HasField", lambda _f: False)
+    if has("message"):
+        m = response.message
+        return _parts_text(m.parts), (m.context_id or None)
+    if has("task"):
+        tk = response.task
+        chunks = [_parts_text(a.parts) for a in (tk.artifacts or [])]
+        if tk.status.HasField("message"):
+            chunks.append(_parts_text(tk.status.message.parts))
+        return " ".join(c for c in chunks if c), (tk.context_id or None)
+    if has("status_update"):
+        su = response.status_update
+        text = _parts_text(su.status.message.parts) if su.status.HasField("message") else ""
+        return text, (su.context_id or None)
+    if has("artifact_update"):
+        au = response.artifact_update
+        return _parts_text(au.artifact.parts), (au.context_id or None)
+    return "", None
 
 
 async def send_to_a2a(
     card_url: str,
     text: str,
     *,
+    context_id: str | None = None,
     http: httpx.AsyncClient | None = None,
     timeout_s: float = _SEND_TIMEOUT_S,
-) -> str:
-    """Send ``text`` to the A2A agent at ``card_url`` and return its reply prose.
+) -> A2aReply:
+    """Send ``text`` to the A2A agent at ``card_url`` and return its reply.
 
-    Raises :class:`A2aSendError` on an unresolvable card or a failed exchange, so
-    the seat can fall back faithfully (silence, never a fabricated reply).
+    Pass ``context_id`` (from a prior :class:`A2aReply`) to continue the same
+    conversation, so the remote agent keeps its own memory of the thread. Raises
+    :class:`A2aSendError` on an unresolvable card or a failed exchange, so the
+    caller can fall back faithfully (silence, never a fabricated reply).
     """
     owns_client = http is None
     client_http = http or httpx.AsyncClient(timeout=timeout_s)
@@ -117,20 +152,25 @@ async def send_to_a2a(
             role=Role.ROLE_USER,
             parts=[Part(text=text)],
         )
+        if context_id:
+            message.context_id = context_id
 
         chunks: list[str] = []
+        thread: str | None = context_id
         try:
             async for response in client.send_message(SendMessageRequest(message=message)):
-                chunk = _reply_text(response)
+                chunk, ctx = _collect(response)
                 if chunk:
                     chunks.append(chunk)
+                if ctx:
+                    thread = ctx
         except (A2AClientError, httpx.HTTPError) as exc:
             raise A2aSendError(f"send failed: {exc}") from exc
 
-        reply = "".join(chunks).strip()
+        reply = " ".join(c for c in chunks if c).strip()
         if not reply:
             raise A2aSendError("remote agent returned no text")
-        return reply
+        return A2aReply(text=reply, context_id=thread)
     finally:
         if owns_client:
             await client_http.aclose()
@@ -153,6 +193,10 @@ class A2aResponder:
         # (room, handle, message_id) currently in flight — a re-fire is ignored.
         self._active: set[tuple[str, str, str]] = set()
         self._tasks: set[asyncio.Task[Any]] = set()
+        # (room, handle) -> A2A context id, so each mention continues the same
+        # remote conversation instead of starting cold. In-memory: a restart
+        # resets threads (the room transcript is still the durable record).
+        self._threads: dict[tuple[str, str], str] = {}
 
     # -- the summon seam (sync; called from the persister's on_summon) --
 
@@ -191,9 +235,21 @@ class A2aResponder:
         envelope: L9,
         key: tuple[str, str, str],
     ) -> None:
+        thread_key = (room, _norm(handle))
+        summoner = envelope_sender(envelope)
+        # Name the speaker so the remote agent can follow a multi-party room; the
+        # threaded context id carries the rest of the history on the remote side.
+        addressed = f"@{_norm(summoner)}: {prompt}" if summoner else prompt
         try:
-            reply = await send_to_a2a(card, prompt, timeout_s=self._timeout_s)
-            await self._respond(room, handle, reply, envelope)
+            reply = await send_to_a2a(
+                card,
+                addressed,
+                context_id=self._threads.get(thread_key),
+                timeout_s=self._timeout_s,
+            )
+            if reply.context_id:
+                self._threads[thread_key] = reply.context_id
+            await self._respond(room, handle, reply.text, envelope)
         except A2aSendError:
             # Fail-faithful: a dead/unreadable remote posts nothing rather than a
             # fabricated reply. The caller (human or aligner) sees silence.

--- a/fastapi-backend/app/services/a2a_card.py
+++ b/fastapi-backend/app/services/a2a_card.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Resolve and validate an external agent's A2A Agent Card.
+
+The client leg of the A2A bridge (epic #719). Given a base URL, fetch the
+remote agent's Agent Card and project the handful of fields the room needs to
+register it as a member: display name, advertised skills, and the endpoint the
+seat driver (#714) will call.
+
+Two drift facts, proven by the #712 spike against a live agent, are baked in:
+
+- **Dual-path probe.** The current spec serves the card at
+  ``/.well-known/agent-card.json``; deployed agents still serve the older
+  ``/.well-known/agent.json``. We try the new path first, then the old.
+- The send-time quirk (older servers require ``configuration.acceptedOutputModes``)
+  lives with the seat driver, not here — resolution is a plain card GET.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import httpx
+from a2a.client import A2ACardResolver
+from a2a.client.errors import A2AClientError
+
+logger = logging.getLogger(__name__)
+
+NEW_CARD_PATH = "/.well-known/agent-card.json"
+OLD_CARD_PATH = "/.well-known/agent.json"
+CARD_PATHS = (NEW_CARD_PATH, OLD_CARD_PATH)
+
+_RESOLVE_TIMEOUT_S = 20.0
+
+
+class A2aCardError(Exception):
+    """The remote agent's card could not be resolved or is unusable."""
+
+
+@dataclass(frozen=True)
+class ResolvedSkill:
+    id: str
+    name: str
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class ResolvedCard:
+    """The bridge-relevant projection of a remote Agent Card."""
+
+    name: str
+    version: str
+    endpoint: str
+    protocol_binding: str
+    card_path: str
+    streaming: bool
+    description: str = ""
+    skills: list[ResolvedSkill] = field(default_factory=list)
+
+    @property
+    def skill_ids(self) -> list[str]:
+        return [s.id for s in self.skills]
+
+
+async def resolve_card(
+    base_url: str,
+    *,
+    http: httpx.AsyncClient | None = None,
+) -> ResolvedCard:
+    """Fetch and project the Agent Card served under ``base_url``.
+
+    Tries the new well-known path then the old one. Raises
+    :class:`A2aCardError` with a human-readable reason if neither resolves.
+    """
+    base = base_url.strip().rstrip("/")
+    if not base.startswith(("http://", "https://")):
+        raise A2aCardError(f"card URL must be http(s): {base_url!r}")
+
+    owns_client = http is None
+    client = http or httpx.AsyncClient(timeout=_RESOLVE_TIMEOUT_S)
+    try:
+        last_error: Exception | None = None
+        for path in CARD_PATHS:
+            try:
+                card = await A2ACardResolver(client, base, agent_card_path=path).get_agent_card()
+            except (A2AClientError, httpx.HTTPError, ValueError) as exc:
+                last_error = exc
+                logger.debug("a2a card probe %s%s failed: %r", base, path, exc)
+                continue
+            return _project(card, base=base, card_path=path)
+        raise A2aCardError(
+            f"no Agent Card at {base}{NEW_CARD_PATH} or {OLD_CARD_PATH}: {last_error}"
+        )
+    finally:
+        if owns_client:
+            await client.aclose()
+
+
+def _pick_interface(card: object, base: str) -> tuple[str, str]:
+    """Endpoint URL + protocol binding, preferring a JSON-RPC interface.
+
+    The proto card carries the endpoint in ``supported_interfaces`` (each an
+    url + ``protocol_binding``), not a top-level ``url``. JSON-RPC is the
+    transport the seat driver speaks, so prefer it; fall back to the first
+    interface, then to the card's base URL.
+    """
+    interfaces = list(getattr(card, "supported_interfaces", []) or [])
+    for iface in interfaces:
+        if (getattr(iface, "protocol_binding", "") or "").upper() == "JSONRPC" and iface.url:
+            return iface.url, "JSONRPC"
+    if interfaces and interfaces[0].url:
+        return interfaces[0].url, getattr(interfaces[0], "protocol_binding", "") or ""
+    return base, ""
+
+
+def _project(card: object, *, base: str, card_path: str) -> ResolvedCard:
+    name = getattr(card, "name", "") or ""
+    if not name:
+        raise A2aCardError("Agent Card has no name")
+    endpoint, binding = _pick_interface(card, base)
+    skills = [
+        ResolvedSkill(
+            id=s.id,
+            name=getattr(s, "name", "") or s.id,
+            description=getattr(s, "description", "") or "",
+        )
+        for s in getattr(card, "skills", []) or []
+        if getattr(s, "id", "")
+    ]
+    caps = getattr(card, "capabilities", None)
+    return ResolvedCard(
+        name=name,
+        version=getattr(card, "version", "") or "",
+        endpoint=endpoint,
+        protocol_binding=binding,
+        card_path=card_path,
+        streaming=bool(getattr(caps, "streaming", False)),
+        description=getattr(card, "description", "") or "",
+        skills=skills,
+    )

--- a/fastapi-backend/app/services/a2a_card.py
+++ b/fastapi-backend/app/services/a2a_card.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 import httpx
 from a2a.client import A2ACardResolver
 from a2a.client.errors import A2AClientError
+from a2a.types import AgentCard
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,21 @@ async def resolve_card(
     Tries the new well-known path then the old one. Raises
     :class:`A2aCardError` with a human-readable reason if neither resolves.
     """
+    raw, path = await resolve_raw_card(base_url, http=http)
+    return _project(raw, base=base_url.strip().rstrip("/"), card_path=path)
+
+
+async def resolve_raw_card(
+    base_url: str,
+    *,
+    http: httpx.AsyncClient | None = None,
+) -> tuple[AgentCard, str]:
+    """Resolve the raw proto ``AgentCard`` + the well-known path that served it.
+
+    The dual-path probe shared by registration (which projects the card) and the
+    seat driver (which needs the raw card to build a send client). Raises
+    :class:`A2aCardError` if neither path resolves.
+    """
     base = base_url.strip().rstrip("/")
     if not base.startswith(("http://", "https://")):
         raise A2aCardError(f"card URL must be http(s): {base_url!r}")
@@ -89,7 +105,7 @@ async def resolve_card(
                 last_error = exc
                 logger.debug("a2a card probe %s%s failed: %r", base, path, exc)
                 continue
-            return _project(card, base=base, card_path=path)
+            return card, path
         raise A2aCardError(
             f"no Agent Card at {base}{NEW_CARD_PATH} or {OLD_CARD_PATH}: {last_error}"
         )

--- a/fastapi-backend/app/services/agent_registry.py
+++ b/fastapi-backend/app/services/agent_registry.py
@@ -56,6 +56,10 @@ def room_agents(room_name: str) -> list[AgentRead]:
         if not isinstance(allow_from, list):
             allow_from = []
 
+        skills = data.get("a2a_skills") or []
+        if not isinstance(skills, list):
+            skills = []
+
         agents.append(
             AgentRead(
                 handle=handle,
@@ -66,6 +70,9 @@ def room_agents(room_name: str) -> list[AgentRead]:
                 owner=_norm(data.get("owner")),
                 team=_norm(data.get("team")),
                 allow_from=[str(h) for h in allow_from if h],
+                a2a_card=str(data["a2a_card"]) if data.get("a2a_card") else None,
+                a2a_endpoint=str(data["a2a_endpoint"]) if data.get("a2a_endpoint") else None,
+                a2a_skills=[str(s) for s in skills if s],
             )
         )
 

--- a/fastapi-backend/pyproject.toml
+++ b/fastapi-backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "negmas>=0.15.7",
     "pyjwt[crypto]>=2.10,<3",
     "a2a-sdk==1.1.2",
+    "sse-starlette>=3.4.8",
 ]
 
 [dependency-groups]

--- a/fastapi-backend/pyproject.toml
+++ b/fastapi-backend/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "slim-bindings>=2.1,<2.2",
     "negmas>=0.15.7",
     "pyjwt[crypto]>=2.10,<3",
+    "a2a-sdk==1.1.2",
 ]
 
 [dependency-groups]

--- a/fastapi-backend/spikes/a2a_over_slim_spike.py
+++ b/fastapi-backend/spikes/a2a_over_slim_spike.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env -S uv run --quiet --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "slima2a @ git+https://github.com/agntcy/slim-a2a-python",
+#   "slim-bindings==2.1.0",
+# ]
+# ///
+"""Throwaway spike (epic #719): can A2A ride SLIM natively in *our* stack?
+
+Question: AGNTCY ships `slima2a` (agntcy/slim-a2a-python), a SLIMRPC transport
+for the a2a-python SDK, so an A2A hop can travel over SLIM instead of plain
+HTTPS. Before we decide HTTP-vs-SLIM for the bridge's outbound send, does that
+package even coexist with Mycelium's pinned `slim-bindings 2.1.x`, and does it
+leave our a2a-sdk usage intact?
+
+This does NOT do a live SLIMRPC round-trip (that needs a running SLIM node +
+two endpoints). It answers the dependency + API-surface question, which is the
+risk worth retiring first.
+
+Run:  uv run fastapi-backend/spikes/a2a_over_slim_spike.py
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as md
+
+
+def _ver(pkg: str) -> str:
+    try:
+        return md.version(pkg)
+    except md.PackageNotFoundError:
+        return "MISSING"
+
+
+def main() -> int:
+    print("# A2A-over-SLIM dependency spike\n")
+    print("[versions resolved together]")
+    for pkg in ("slima2a", "slim-bindings", "a2a-sdk"):
+        print(f"  {pkg}: {_ver(pkg)}")
+
+    print("\n[slima2a transport API]")
+    import slima2a
+
+    print("  exports:", [n for n in dir(slima2a) if not n.startswith("_")])
+
+    print("\n[our bridge's a2a-sdk symbols on this a2a-sdk]")
+    from a2a.client import A2ACardResolver, ClientConfig, ClientFactory  # noqa: F401
+    from a2a.server.request_handlers import DefaultRequestHandler  # noqa: F401
+    from a2a.server.request_handlers.response_helpers import agent_card_to_dict  # noqa: F401
+    from a2a.types import Message, SendMessageRequest, StreamResponse  # noqa: F401
+
+    print("  client + server-core + types: all import OK")
+
+    print(
+        "\nFindings:\n"
+        "  - slima2a coexists with slim-bindings 2.1.0 (its `slim-bindings ~=2.0`).\n"
+        "  - BUT slima2a pins `a2a-sdk==1.1.0` exactly; our backend is on 1.1.2.\n"
+        "    Adopting the SLIM transport means pinning the whole bridge to\n"
+        "    a2a-sdk==1.1.0 (all our symbols exist there — verified above).\n"
+        "  - SLIMRPC is point-to-point RPC to a SLIM identity, NOT room-group MLS\n"
+        "    membership: it hardens the hop (SLIM identity + encryption vs plain\n"
+        "    HTTPS), it does not make the A2A agent a member of the room channel.\n"
+        "  - Not proven here: a live SLIMRPC round-trip over a SLIM node."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fastapi-backend/tests/fakes.py
+++ b/fastapi-backend/tests/fakes.py
@@ -123,7 +123,9 @@ class FakePersister:
         self.log = DeliveryLog(records or [])
         self.ingested: list[tuple[Any, dict[str, Any]]] = []
 
-    def ingest_local(self, envelope: Any, content: dict[str, Any]) -> None:
+    def ingest_local(
+        self, envelope: Any, content: dict[str, Any], *, list_write: bool = False
+    ) -> None:
         self.ingested.append((envelope, content))
 
 

--- a/fastapi-backend/tests/test_a2a_agents_route.py
+++ b/fastapi-backend/tests/test_a2a_agents_route.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""POST /rooms/{room}/a2a-agents — register an external A2A agent.
+
+Like the engine route, an A2A agent is backend-owned, so the web UI registers
+one directly. The extra step is card resolution: a bad endpoint must fail at
+registration. Card resolution itself is mocked here so the tests stay hermetic;
+the live wire is exercised by the env-gated test at the bottom.
+"""
+
+import os
+
+import pytest
+
+from app.services import a2a_card
+from app.services.a2a_card import A2aCardError, ResolvedCard, ResolvedSkill
+
+_FAKE_CARD = ResolvedCard(
+    name="Research Agent",
+    version="1.2.0",
+    endpoint="https://remote.example/rpc",
+    protocol_binding="JSONRPC",
+    card_path="/.well-known/agent-card.json",
+    streaming=True,
+    description="Does research.",
+    skills=[ResolvedSkill(id="deep_search", name="Deep Search", description="finds things")],
+)
+
+
+async def _make_room(client, name: str = "portfolio") -> None:
+    resp = await client.post("/api/rooms", json={"name": name})
+    assert resp.status_code in (200, 201)
+
+
+@pytest.fixture
+def stub_card(monkeypatch):
+    async def _fake_resolve(url, **_kwargs):
+        return _FAKE_CARD
+
+    monkeypatch.setattr("app.routes.a2a_agents.resolve_card", _fake_resolve)
+
+
+@pytest.mark.asyncio
+async def test_register_a2a_agent_resolves_and_lists(client, stub_card):
+    await _make_room(client)
+
+    resp = await client.post(
+        "/api/rooms/portfolio/a2a-agents",
+        json={"handle": "researcher", "card": "https://remote.example"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["handle"] == "researcher"
+    assert body["adapter"] == "a2a"
+    assert body["a2a_endpoint"] == "https://remote.example/rpc"
+    assert body["a2a_skills"] == ["deep_search"]
+    # description falls back to the card's when not overridden
+    assert body["description"] == "Does research."
+
+    # It surfaces in the structured agents listing with its a2a fields.
+    agents = (await client.get("/api/rooms/portfolio/agents")).json()
+    row = next(a for a in agents if a["handle"] == "researcher")
+    assert row["adapter"] == "a2a"
+    assert row["a2a_card"] == "https://remote.example"
+    assert row["a2a_skills"] == ["deep_search"]
+
+
+@pytest.mark.asyncio
+async def test_description_override_wins(client, stub_card):
+    await _make_room(client)
+    resp = await client.post(
+        "/api/rooms/portfolio/a2a-agents",
+        json={"handle": "researcher", "card": "https://remote.example", "description": "mine"},
+    )
+    assert resp.json()["description"] == "mine"
+
+
+@pytest.mark.asyncio
+async def test_unreachable_card_is_502(client, monkeypatch):
+    await _make_room(client)
+
+    async def _boom(url, **_kwargs):
+        raise A2aCardError("no Agent Card at https://nope")
+
+    monkeypatch.setattr("app.routes.a2a_agents.resolve_card", _boom)
+    resp = await client.post(
+        "/api/rooms/portfolio/a2a-agents",
+        json={"handle": "researcher", "card": "https://nope"},
+    )
+    assert resp.status_code == 502
+    assert "resolve" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_handle_conflicts(client, stub_card):
+    await _make_room(client)
+    body = {"handle": "researcher", "card": "https://remote.example"}
+    assert (await client.post("/api/rooms/portfolio/a2a-agents", json=body)).status_code == 201
+    assert (await client.post("/api/rooms/portfolio/a2a-agents", json=body)).status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_invalid_handle_rejected(client, stub_card):
+    await _make_room(client)
+    resp = await client.post(
+        "/api/rooms/portfolio/a2a-agents",
+        json={"handle": "Bad Handle!", "card": "https://remote.example"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_missing_room_404(client, stub_card):
+    resp = await client.post(
+        "/api/rooms/nope/a2a-agents",
+        json={"handle": "researcher", "card": "https://remote.example"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_non_http_card_scheme_rejected():
+    """Hermetic: the scheme guard trips before any network I/O."""
+    with pytest.raises(A2aCardError):
+        await a2a_card.resolve_card("ftp://nope")
+
+
+@pytest.mark.skipif(
+    os.getenv("MYCELIUM_A2A_LIVE") != "1",
+    reason="live A2A wire test; set MYCELIUM_A2A_LIVE=1 to run",
+)
+@pytest.mark.asyncio
+async def test_resolve_live_public_agent():
+    card = await a2a_card.resolve_card("https://hello-world-gxfr.onrender.com")
+    assert card.name == "Hello World Agent"
+    assert "hello_world" in card.skill_ids
+    # confirms the old-path fallback is still exercised end to end
+    assert card.card_path == a2a_card.OLD_CARD_PATH

--- a/fastapi-backend/tests/test_a2a_bridge.py
+++ b/fastapi-backend/tests/test_a2a_bridge.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The A2A bridge send primitive (#714).
+
+``send_to_a2a`` is the client leg: card URL + prompt -> reply prose. The live
+wire is exercised by the env-gated test; the hermetic test pins the fail-faithful
+contract (a bad endpoint raises rather than fabricating a reply).
+"""
+
+import os
+
+import pytest
+
+from app.services.a2a_bridge import A2aSendError, send_to_a2a
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_bad_scheme():
+    """A non-http card can't be reached, and that surfaces as A2aSendError."""
+    with pytest.raises(A2aSendError):
+        await send_to_a2a("ftp://nope", "hi")
+
+
+@pytest.mark.asyncio
+async def test_send_raises_on_unresolvable_card():
+    with pytest.raises(A2aSendError, match="unresolvable"):
+        await send_to_a2a("https://example.com", "hi")
+
+
+@pytest.mark.skipif(
+    os.getenv("MYCELIUM_A2A_LIVE") != "1",
+    reason="live A2A wire test; set MYCELIUM_A2A_LIVE=1 to run",
+)
+@pytest.mark.asyncio
+async def test_send_to_live_public_agent():
+    reply = await send_to_a2a("https://hello-world-gxfr.onrender.com", "hello from the seat")
+    assert reply == "Hello World"

--- a/fastapi-backend/tests/test_a2a_bridge.py
+++ b/fastapi-backend/tests/test_a2a_bridge.py
@@ -35,4 +35,4 @@ async def test_send_raises_on_unresolvable_card():
 @pytest.mark.asyncio
 async def test_send_to_live_public_agent():
     reply = await send_to_a2a("https://hello-world-gxfr.onrender.com", "hello from the seat")
-    assert reply == "Hello World"
+    assert reply.text == "Hello World"

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -15,6 +15,7 @@ import pytest
 import yaml
 
 from app.services import a2a_bridge, l9
+from app.services.a2a_bridge import A2aReply
 from app.services.filesystem import get_room_dir, write_memory_file
 from app.services.l9_models import Kind
 from tests.fakes import FakeChannel, FakeManaged, FakeManager, FakePersister
@@ -52,13 +53,13 @@ def _responder(monkeypatch, *, reply: str = "the remote reply"):
     manager = FakeManager(managed, ["avery", "researcher"])
     responder = a2a_bridge.A2aResponder(manager)  # type: ignore[arg-type]
 
-    calls: list[tuple[str, str]] = []
+    calls: list[dict] = []
 
-    async def _fake_send(card_url, text, **_kwargs):
-        calls.append((card_url, text))
+    async def _fake_send(card_url, text, *, context_id=None, **_kwargs):
+        calls.append({"card": card_url, "text": text, "context_id": context_id})
         if reply is None:
             raise a2a_bridge.A2aSendError("dead remote")
-        return reply
+        return A2aReply(text=reply, context_id="ctx-1")
 
     monkeypatch.setattr(a2a_bridge, "send_to_a2a", _fake_send)
     return responder, channel, persister, calls
@@ -79,14 +80,35 @@ async def test_mention_calls_remote_and_posts_reply(monkeypatch):
     )
     await _drain(responder)
 
-    # It called the remote with the message text…
-    assert calls == [("https://remote.example", "what do you think?")]
+    # It called the remote with the attributed message text…
+    assert len(calls) == 1
+    assert calls[0]["card"] == "https://remote.example"
+    assert calls[0]["text"] == "@avery: what do you think?"
     # …and posted the reply back into the room as the handle.
     assert len(channel.sent) == 1
     env, extra = channel.sent[0]
     assert extra["content"] == "the remote reply"
     assert env.header.participants.actors[0].id == "researcher"
     assert persister.ingested
+
+
+@pytest.mark.asyncio
+async def test_thread_continues_across_mentions(monkeypatch):
+    _register_a2a()
+    responder, _channel, _persister, calls = _responder(monkeypatch)
+
+    # First mention starts a thread; the second continues the same context id.
+    responder.handle_summon(
+        _ROOM, "researcher", _summon_envelope("avery", message_id="m1"), [], "one"
+    )
+    await _drain(responder)
+    responder.handle_summon(
+        _ROOM, "researcher", _summon_envelope("avery", message_id="m2"), [], "two"
+    )
+    await _drain(responder)
+
+    assert calls[0]["context_id"] is None  # cold start
+    assert calls[1]["context_id"] == "ctx-1"  # threaded from the first reply
 
 
 @pytest.mark.asyncio

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The A2A responder (#714) — answer @-mentions by calling the remote agent.
+
+Node-free: the remote call (`send_to_a2a`) is patched, so these exercise the
+summon gate, the loop guards, and that the reply is posted back as the handle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import yaml
+
+from app.services import a2a_bridge, l9
+from app.services.filesystem import get_room_dir, write_memory_file
+from app.services.l9_models import Kind
+from tests.fakes import FakeChannel, FakeManaged, FakeManager, FakePersister
+
+_ROOM = "portfolio"
+
+
+def _register_a2a(handle: str = "researcher", card: str = "https://remote.example") -> None:
+    body = yaml.safe_dump({"adapter": "a2a", "a2a_card": card, "description": "does research"})
+    write_memory_file(get_room_dir(_ROOM), f"agents/{handle}", body, created_by="web-ui")
+
+
+def _register_engine(handle: str = "aligner") -> None:
+    body = yaml.safe_dump({"adapter": "engine", "kind": "aligner"})
+    write_memory_file(get_room_dir(_ROOM), f"agents/{handle}", body, created_by="web-ui")
+
+
+def _summon_envelope(sender: str, *, message_id: str = "m1"):
+    return l9.build_envelope(
+        kind=Kind.exchange,
+        episode=l9.episode_urn(_ROOM, "live"),
+        sender=sender,
+        sender_role="human",
+        recipients=["researcher"],
+        topic=l9.topic_urn(_ROOM),
+        payload_type="message",
+        message_id=message_id,
+    )
+
+
+def _responder(monkeypatch, *, reply: str = "the remote reply"):
+    persister = FakePersister()
+    channel = FakeChannel(persister)
+    managed = FakeManaged(room=_ROOM, channel=channel, persister=persister)
+    manager = FakeManager(managed, ["avery", "researcher"])
+    responder = a2a_bridge.A2aResponder(manager)  # type: ignore[arg-type]
+
+    calls: list[tuple[str, str]] = []
+
+    async def _fake_send(card_url, text, **_kwargs):
+        calls.append((card_url, text))
+        if reply is None:
+            raise a2a_bridge.A2aSendError("dead remote")
+        return reply
+
+    monkeypatch.setattr(a2a_bridge, "send_to_a2a", _fake_send)
+    return responder, channel, persister, calls
+
+
+async def _drain(responder):
+    if responder._tasks:
+        await asyncio.gather(*list(responder._tasks))
+
+
+@pytest.mark.asyncio
+async def test_mention_calls_remote_and_posts_reply(monkeypatch):
+    _register_a2a()
+    responder, channel, persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(
+        _ROOM, "researcher", _summon_envelope("avery"), [], "what do you think?"
+    )
+    await _drain(responder)
+
+    # It called the remote with the message text…
+    assert calls == [("https://remote.example", "what do you think?")]
+    # …and posted the reply back into the room as the handle.
+    assert len(channel.sent) == 1
+    env, extra = channel.sent[0]
+    assert extra["content"] == "the remote reply"
+    assert env.header.participants.actors[0].id == "researcher"
+    assert persister.ingested
+
+
+@pytest.mark.asyncio
+async def test_non_a2a_handle_is_ignored(monkeypatch):
+    _register_engine("aligner")  # an engine, not a2a
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "aligner", _summon_envelope("avery"), [], "mediate us")
+    await _drain(responder)
+
+    assert calls == []
+    assert channel.sent == []
+
+
+@pytest.mark.asyncio
+async def test_self_message_does_not_loop(monkeypatch):
+    _register_a2a()
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    # The summoner IS the a2a agent — its own post must not trigger a reply.
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("researcher"), [], "hi all")
+    await _drain(responder)
+
+    assert calls == []
+    assert channel.sent == []
+
+
+@pytest.mark.asyncio
+async def test_empty_prompt_is_ignored(monkeypatch):
+    _register_a2a()
+    responder, _channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "   ")
+    await _drain(responder)
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_same_mention_runs_once(monkeypatch):
+    _register_a2a()
+    responder, _channel, _persister, calls = _responder(monkeypatch)
+
+    env = _summon_envelope("avery", message_id="dup")
+    responder.handle_summon(_ROOM, "researcher", env, [], "hello")
+    responder.handle_summon(_ROOM, "researcher", env, [], "hello")
+    await _drain(responder)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_dead_remote_posts_nothing(monkeypatch):
+    _register_a2a()
+    responder, channel, _persister, calls = _responder(monkeypatch, reply=None)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "you there?")
+    await _drain(responder)
+
+    assert calls  # it tried
+    assert channel.sent == []  # fail-faithful: no fabricated reply

--- a/fastapi-backend/tests/test_a2a_server_route.py
+++ b/fastapi-backend/tests/test_a2a_server_route.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Expose a room as an A2A agent (#716) — the inbound mirror.
+
+The card is resolved by the *real* a2a-sdk client over the app's ASGI transport
+(proving wire compatibility). The message/send path is driven with a raw
+JSON-RPC POST — the server's dispatcher parses it and runs our executor — so the
+test exercises our server without depending on the SDK client's streaming
+iterator semantics over ASGITransport.
+"""
+
+import pytest
+from a2a.client import A2ACardResolver
+
+from app.services import room_channels
+from app.services.filesystem import get_room_dir, write_memory_file
+from tests.fakes import FakeChannel, FakeManaged, FakePersister
+
+_CARD_PATH = "/api/rooms/portfolio/.well-known/agent-card.json"
+
+
+async def _make_room(client, name: str = "portfolio") -> None:
+    resp = await client.post("/api/rooms", json={"name": name})
+    assert resp.status_code in (200, 201)
+
+
+async def _resolve(client):
+    return await A2ACardResolver(client, "http://test", agent_card_path=_CARD_PATH).get_agent_card()
+
+
+@pytest.mark.asyncio
+async def test_room_card_is_resolvable_by_the_sdk(client):
+    await _make_room(client)
+    # Seed a skill directly (no embedding) so the card projects it.
+    write_memory_file(
+        get_room_dir("portfolio"),
+        "skills/summarize",
+        "Distill the room.",
+        created_by="web-ui",
+        extra_meta={"description": "distills the room"},
+    )
+
+    card = await _resolve(client)
+    assert card.name == "portfolio"
+    skill = next((s for s in card.skills if s.id == "summarize"), None)
+    assert skill is not None
+    assert skill.description == "distills the room"
+    # the SDK derived a JSON-RPC endpoint from the card
+    assert any(i.url.endswith("/api/rooms/portfolio/a2a") for i in card.supported_interfaces)
+
+
+@pytest.mark.asyncio
+async def test_missing_room_card_is_404(client):
+    resolver = A2ACardResolver(
+        client, "http://test", agent_card_path="/api/rooms/ghost/.well-known/agent-card.json"
+    )
+    with pytest.raises(Exception):  # noqa: B017 - resolver raises on non-200
+        await resolver.get_agent_card()
+
+
+@pytest.mark.asyncio
+async def test_message_send_delivers_into_the_room(client, monkeypatch):
+    await _make_room(client)
+
+    # Route the room injection at a fake channel so we can assert delivery.
+    persister = FakePersister()
+    channel = FakeChannel(persister)
+    managed = FakeManaged(room="portfolio", channel=channel, persister=persister)
+    monkeypatch.setattr(room_channels.manager, "get", lambda _r: managed)
+
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "message/send",
+        "params": {
+            "configuration": {"acceptedOutputModes": ["text"]},
+            "message": {
+                "kind": "message",
+                "messageId": "in1",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "hello room"}],
+            },
+        },
+    }
+    resp = await client.post("/api/rooms/portfolio/a2a", json=rpc)
+    assert resp.status_code == 200, resp.text
+    result = resp.json()["result"]
+    ack = "".join(p.get("text", "") for p in result["parts"])
+    assert "Delivered to room" in ack
+    # the message actually reached the room channel
+    assert any(extra and extra.get("content") == "hello room" for _env, extra in channel.sent)
+
+
+@pytest.mark.asyncio
+async def test_message_send_missing_room_404(client):
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "message/send",
+        "params": {"message": {"kind": "message", "messageId": "x", "role": "user", "parts": []}},
+    }
+    resp = await client.post("/api/rooms/ghost/a2a", json=rpc)
+    assert resp.status_code == 404

--- a/fastapi-backend/uv.lock
+++ b/fastapi-backend/uv.lock
@@ -945,6 +945,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "rapidfuzz" },
     { name = "slim-bindings" },
+    { name = "sse-starlette" },
     { name = "tiktoken" },
     { name = "watchdog" },
 ]
@@ -975,6 +976,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rapidfuzz", specifier = ">=3.14.5" },
     { name = "slim-bindings", specifier = ">=2.1,<2.2" },
+    { name = "sse-starlette", specifier = ">=3.4.8" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
@@ -1812,6 +1814,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
 ]
 
 [[package]]

--- a/fastapi-backend/uv.lock
+++ b/fastapi-backend/uv.lock
@@ -1,10 +1,43 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 resolution-markers = [
     "sys_platform == 'win32'",
     "sys_platform == 'emscripten'",
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "a2a-sdk"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "culsans" },
+    { name = "google-api-core" },
+    { name = "googleapis-common-protos" },
+    { name = "httpx" },
+    { name = "json-rpc" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/cc/59b35c518d8289bd59d20d9d216ca29ccb41c4697eb85971efe41d1adaf3/a2a_sdk-1.1.2.tar.gz", hash = "sha256:f928d8bf9a0dc0a473ee8258bd5226c1b8520a85c70e7f233c3b9b0e30a1bd10", size = 379627, upload-time = "2026-07-22T13:40:51.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/33/d414a03d5ef5a7d6d09a20dc9f8094e7fb9edb488662ff99c535a2a62cf1/a2a_sdk-1.1.2-py3-none-any.whl", hash = "sha256:eb9a698f526dc45a9ea967d7804e7aa363ff273d2c44fbed699bc68c9399f9c9", size = 245981, upload-time = "2026-07-22T13:40:49.484Z" },
+]
+
+[[package]]
+name = "aiologic"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/d3/2d310b1b839014034dba0cba685e492df8a5c7ad32c19cab7e979eed6554/aiologic-0.17.1-py3-none-any.whl", hash = "sha256:c66b319830fedb7ca3d2b2125fa6f5b653f89418c2a27ea76f259ec5f00943c0", size = 161331, upload-time = "2026-06-27T20:41:31.877Z" },
 ]
 
 [[package]]
@@ -270,6 +303,19 @@ wheels = [
 ]
 
 [[package]]
+name = "culsans"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiologic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5d/9fb19fb38f6d6120422064279ea5532e22b84aa2be8831d49607194feda3/culsans-0.11.0-py3-none-any.whl", hash = "sha256:278d118f63fc75b9db11b664b436a1b83cc30d9577127848ba41420e66eb5a47", size = 21811, upload-time = "2025-12-31T23:15:37.189Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -501,6 +547,47 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.34.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7c/9be3903e3d45415e8ca493c75f8990a0f6f579d168015d44c379350d0ab0/google_api_core-2.34.0.tar.gz", hash = "sha256:98a779fe72de956eb1c9c2f47ff4c4432a668ece1a002ec38bed07ec2698ae59", size = 187953, upload-time = "2026-08-06T06:23:58.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/c1/a8a92ae1bc4b1a8f804c776d7d3f0c771b78a62c3ad4df1be41b3fd8c767/google_api_core-2.34.0-py3-none-any.whl", hash = "sha256:cdf9c67e7ca2402d86ccbfde5f2503fc83e3cc3f58cc78456ae96cad24a6d2de", size = 180545, upload-time = "2026-08-06T06:22:47.502Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/4c/fa42116a48bab3f7a143cf5042ecff7df9c8b73f8a376203cd534d1dc966/google_auth-2.56.3.tar.gz", hash = "sha256:40e229fc901f0a305b553050e5fce562d509bee0435be053abfa91582b51b90c", size = 367110, upload-time = "2026-08-06T06:24:01.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl", hash = "sha256:8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53", size = 259116, upload-time = "2026-08-06T06:22:51.788Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/74bcab964c9a7a61f2bb71e8179b0f13e6fa98f7ce00fd168aab291e4a2e/googleapis_common_protos-1.75.1.tar.gz", hash = "sha256:d3042c6c5a2d4e67113104d6b6818b59b6bd92a197f2a91508e801fe815cf071", size = 150967, upload-time = "2026-08-06T06:24:51.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/51/186c02b8549b69ccda44429cf6ff5081e4b61a602ddfe6a8020d1be31d1b/googleapis_common_protos-1.75.1-py3-none-any.whl", hash = "sha256:28a1934bcd33b9c9da66ac301a0a4227e3367f095a17d0375cb98f0a09d93b79", size = 300626, upload-time = "2026-08-06T06:23:46.696Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -667,6 +754,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "json-rpc"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9e/59f4a5b7855ced7346ebf40a2e9a8942863f644378d956f68bcef2c88b90/json-rpc-1.15.0.tar.gz", hash = "sha256:e6441d56c1dcd54241c937d0a2dcd193bdf0bdc539b5316524713f554b7f85b9", size = 28854, upload-time = "2023-06-11T09:45:49.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/9e/820c4b086ad01ba7d77369fb8b11470a01fac9b4977f02e18659cf378b6b/json_rpc-1.15.0-py2.py3-none-any.whl", hash = "sha256:4a4668bbbe7116feb4abbd0f54e64a4adcf4b8f648f19ffa0848ad0f6606a9bf", size = 39450, upload-time = "2023-06-11T09:45:47.136Z" },
 ]
 
 [[package]]
@@ -837,6 +933,7 @@ name = "mycelium-backend"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "a2a-sdk" },
     { name = "anthropic" },
     { name = "fastapi", extra = ["standard"] },
     { name = "fastembed" },
@@ -866,6 +963,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2a-sdk", specifier = "==1.1.2" },
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0,<0.142" },
     { name = "fastembed", specifier = ">=0.8.0" },
@@ -1146,18 +1244,30 @@ wheels = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "7.34.1"
+name = "proto-plus"
+version = "1.28.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/6a/056256feb4bd000869aba5c16cf2aa911572ca2a2feb185f86e457b5171e/proto_plus-1.28.3.tar.gz", hash = "sha256:5f91b30dafa6bb38d432c5557a6ee1d35ffd40b4b1e0e3ca27260448560b91d9", size = 58051, upload-time = "2026-08-06T06:24:55.581Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
-    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
-    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
-    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
-    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+    { url = "https://files.pythonhosted.org/packages/61/3a/cfee3c50294f55a2f0f9575052dec2c2a48891ad4b1c2a133b05a87026cd/proto_plus-1.28.3-py3-none-any.whl", hash = "sha256:dc76880b8ee951cca002098574376cf71e055f9f16d9ba6570fb8a06f726d281", size = 50795, upload-time = "2026-08-06T06:23:50.653Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -1216,6 +1326,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/ee/d822e1ee31fe31ec5d057210e0605c950b975dcd8d9a332976cc859a9df8/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:20887a762dd61dcc530f93a140840ab1f6aa7836b33270e42d627ab3cf11e537", size = 49941005, upload-time = "2026-07-10T08:27:21.274Z" },
     { url = "https://files.pythonhosted.org/packages/33/1b/207a90cc64619a095eb75a263ae069735f2810056d43c667befd573ec083/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58d1ab556b0cea1c93fdb799b24ad58adb2f2a2788dbce782a94f64ae1a5cc9b", size = 53112355, upload-time = "2026-07-10T08:27:27.911Z" },
     { url = "https://files.pythonhosted.org/packages/7e/fe/81d1e5f8beed15c01e98649d5c6e2167b67fd395884a2488f18bf1cf0dba/pyarrow-25.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f356afe61186395c861d5cd63dc21ff7d5fa335012a4668d979257df7fea0f5", size = 27945954, upload-time = "2026-07-10T08:27:32.903Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1457,7 +1588,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1465,9 +1596,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1992,4 +2123,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b0/c1f5a970721f06b85c0cd5142e0ff8fe067708abd779b0c4f4be7d61d09f/wrapt-2.3.0.tar.gz", hash = "sha256:681a2d0eefd721998f90642762b8e75c2159ec531b20ad5e437245ea7b06a107", size = 131509, upload-time = "2026-07-28T06:06:14.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/4a/d17a0fad1bf1c5f2c887ff71fef75654141b0880bff71d157d955b5bec3a/wrapt-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0a45ffae742ce91a16e11cb6c7cd71e7f9994f3cbd283b962ab093f5c6dcf525", size = 82139, upload-time = "2026-07-28T06:04:35.082Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/55/51b92daaf6defb57f4dc56bdcce985400f75c6984a03ca5e78ccac717028/wrapt-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69e477046f2237ef0bc6547544ee73008dc764ca26eff44f09e976d221b34d5d", size = 82723, upload-time = "2026-07-28T06:04:36.502Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7f/cfd9bc4b1f5e424eeea83d0493e43f3b1b02707ce8e50c47945873982bd5/wrapt-2.3.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d221a6e6ddd302b8397433184e96b59f259f50024b854db1c411a881586b6b8", size = 172381, upload-time = "2026-07-28T06:04:37.674Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/89/ff7814f6eb6856b479946117d1138a2fbb46cdb6b1f379db359056c69743/wrapt-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:392158c9a7f2ab1b8699418bfc0fe6f83548788c418b27d7bf2019ad3405cebb", size = 174120, upload-time = "2026-07-28T06:04:38.987Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1e/8eded8615d39e3ce81f626937a3a87b280a2a86239a2bf14a4b4bb345034/wrapt-2.3.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e5301c35cf75655eb33498f2bd6ae8703ca19940e3167dc9cdf740c712a39c60", size = 163035, upload-time = "2026-07-28T06:04:40.361Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ea/a0af2d9da62897af2a055484920de05dade30d2ba2c0d65cbdea875d3d8b/wrapt-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:418f54bb09d1762db02c7009b4051149893af3153a87f92d70356703c11eea02", size = 171887, upload-time = "2026-07-28T06:04:41.614Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/dd/63cd4c864c65ef4906df64bd2d378f4a62b54f28063f282dfb3bf93caead/wrapt-2.3.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1598becd30f8f2777d18564064eb4f4dbe1ab0e05a8f09786d0ef505ac782bf3", size = 161113, upload-time = "2026-07-28T06:04:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ee/82f1fc9e431b5c2c5a6d201aa865dbeae3984c311c6d11a185f0c8367cf6/wrapt-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3da470536bf9645143323dd41b32db55c6f4304ad382094c1a1da8a92061e10d", size = 170530, upload-time = "2026-07-28T06:04:44.212Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a5/5dc590e863a419930d988f8b7ca3e75a6befcfb10b6003b3a152f3d5f732/wrapt-2.3.0-cp312-cp312-win32.whl", hash = "sha256:fb8e2e6704a1e0b1b989546c69e2688371ef4a07fa5f61bde3eb6211186f5ac1", size = 78323, upload-time = "2026-07-28T06:04:45.484Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f9/4a6925a07951df56394f7e6ebe14f69f1c5ef9d87aa63e0839acf15aa63a/wrapt-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:cdc021cb0b62471d6aac7f2bd92f3b4658073775f9ee7fcd325c511129e7bcc8", size = 81180, upload-time = "2026-07-28T06:04:47.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/4f/8b5de0395b2a72216751d41c9861df6facaeb611b619d8810ed2b3b23eb2/wrapt-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:67bfe2485f50368c3fcd2275fc1fd100e350d601e0058921a7c82678a465aeab", size = 80155, upload-time = "2026-07-28T06:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/00/39/3daf9f47be208606586de4568ba6713db53ebc8fd7a575aea1fe57983b69/wrapt-2.3.0-py3-none-any.whl", hash = "sha256:d8c7ed08477429752b8c44991f40ad7838b18332a160698740a6bfbc10d998a2", size = 61866, upload-time = "2026-07-28T06:06:12.9Z" },
 ]

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -667,6 +667,64 @@ def _create_wizard(
     )
 
 
+def _create_a2a_agent(
+    *,
+    config: MyceliumConfig,
+    room: str | None,
+    handle: str,
+    card: str | None,
+    description: str,
+    allow_from: str | None,
+    owner: str | None,
+    team: str | None,
+    handle_flag: str,
+) -> None:
+    """Register an external A2A agent by resolving its card on the hub.
+
+    Unlike claude_code/cursor, there's no local manifest to build: the backend
+    resolves the remote Agent Card (failing fast on a bad URL) and holds the
+    seat, so this is one authenticated hub call.
+    """
+    if not (card and card.strip()):
+        typer.secho(
+            "--adapter a2a needs --card <url> (the host serving the agent's Agent Card).",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
+
+    room_name = _resolve_room(config, room)
+    allow_list = [a.strip() for a in (allow_from or "").split(",") if a.strip()]
+    body = {
+        "handle": handle,
+        "card": card.strip(),
+        "description": description,
+        "allow_from": allow_list,
+        "owner": _default_owner(owner, handle_flag),
+        "team": team,
+        "created_by": handle_flag,
+    }
+
+    with hub_client(config, timeout=30) as client:
+        resp = client.post(f"/api/rooms/{room_name}/a2a-agents", json=body)
+
+    if resp.status_code != 201:
+        detail = ""
+        try:
+            detail = resp.json().get("detail", "")
+        except ValueError:
+            detail = resp.text
+        typer.secho(
+            f"Could not register @{handle}: {detail or resp.status_code}", fg=typer.colors.RED
+        )
+        raise typer.Exit(1)
+
+    read = resp.json()
+    skills = ", ".join(read.get("a2a_skills") or []) or "(none advertised)"
+    console.print(f"[green]Created a2a agent[/green] @{read['handle']} in {room_name}")
+    console.print(f"  endpoint: {read.get('a2a_endpoint') or read.get('a2a_card')}")
+    console.print(f"  skills:   {skills}")
+
+
 @app.command("create")
 def agent_create(
     ctx: typer.Context,
@@ -689,6 +747,14 @@ def agent_create(
             "claude_code / cursor: optional working dir for the agent's session. "
             "For cursor it's also where .cursor/rules/mycelium.mdc + AGENTS.md "
             "(mycelium section) are dropped."
+        ),
+    ),
+    card: str | None = typer.Option(
+        None,
+        "--card",
+        help=(
+            "a2a: base URL serving the external agent's Agent Card "
+            "(the host of its /.well-known/agent-card.json). Required for --adapter a2a."
         ),
     ),
     room: str | None = typer.Option(
@@ -764,6 +830,23 @@ def agent_create(
             known = ", ".join(sorted(AGENT_ADAPTERS))
             typer.secho(f"Unknown adapter '{adapter}'. Known: {known}.", fg=typer.colors.RED)
             raise typer.Exit(1)
+
+        # An a2a agent is a remote endpoint with no local runtime: the backend
+        # resolves its card and holds the seat, so registration is a single hub
+        # call rather than a locally-built manifest.
+        if adapter == "a2a":
+            _create_a2a_agent(
+                config=config,
+                room=room,
+                handle=handle,
+                card=card,
+                description=description,
+                allow_from=allow_from,
+                owner=owner,
+                team=team,
+                handle_flag=handle_flag,
+            )
+            return
 
         allow_list: list[str] = []
         if allow_from:

--- a/mycelium-cli/src/mycelium/integrations/__init__.py
+++ b/mycelium-cli/src/mycelium/integrations/__init__.py
@@ -20,12 +20,14 @@ boundary.
 
 from __future__ import annotations
 
+from mycelium.integrations.a2a import A2aIntegration
 from mycelium.integrations.base import AddOptions, AgentAdapter, Integration
 from mycelium.integrations.claude_code import ClaudeCodeIntegration
 from mycelium.integrations.cursor import CursorIntegration
 from mycelium.integrations.engine import EngineIntegration
 
 __all__ = [
+    "A2aIntegration",
     "AddOptions",
     "AgentAdapter",
     "Integration",
@@ -58,6 +60,7 @@ def get_integration(
     *,
     cwd: str | None = None,
     engine_kind: str | None = None,
+    card: str | None = None,
 ) -> Integration:
     """Return an integration instance for *name* (any accepted spelling).
 
@@ -76,6 +79,10 @@ def get_integration(
         # First-party cognition-engine family; ``engine_kind`` selects the CE
         # (aligner today). The other kwargs are irrelevant here.
         return EngineIntegration(kind=engine_kind)
+    if canonical == "a2a":
+        # External Agent2Agent endpoint; ``card`` locates its Agent Card. The
+        # backend resolves it and holds the seat.
+        return A2aIntegration(card=card)
     raise ValueError(f"unknown integration: {name!r}")
 
 

--- a/mycelium-cli/src/mycelium/integrations/a2a/__init__.py
+++ b/mycelium-cli/src/mycelium/integrations/a2a/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""External Agent2Agent (A2A) runtime family."""
+
+from __future__ import annotations
+
+from mycelium.integrations.a2a.dispatch import A2aIntegration
+
+__all__ = ["A2aIntegration"]

--- a/mycelium-cli/src/mycelium/integrations/a2a/dispatch.py
+++ b/mycelium-cli/src/mycelium/integrations/a2a/dispatch.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The ``a2a`` integration: an *external* Agent2Agent endpoint as a room member.
+
+Unlike ``engine`` (our own cognition) or ``claude_code``/``cursor`` (a resident
+third-party session on the user's box), an ``a2a`` agent is a remote endpoint
+that speaks the Agent2Agent protocol. The backend resolves its Agent Card and
+holds the seat that calls it, so — like an engine — ``lifecycle="backend_engine"``
+and there are no host-side assets (no-op install/register facets).
+
+Registration differs from the other families in one way: the card must be
+resolved on the hub (the thin CLI has no A2A client), so ``agent create
+--adapter a2a --card <url>`` posts to the backend's ``a2a-agents`` route rather
+than building the manifest locally. This class exists so ``a2a`` is a first-class
+family everywhere the registry is the source of truth (``agent ls``, manifest
+parsing, the integration contract).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typer
+
+from mycelium.integrations.base import AddOptions, Integration
+from mycelium.protocol import AgentManifest
+
+if TYPE_CHECKING:
+    from mycelium.config import MyceliumConfig
+
+
+class A2aIntegration(Integration):
+    name = "a2a"
+    lifecycle = "backend_engine"
+
+    def __init__(self, *, card: str | None = None) -> None:
+        # ``card`` is the one a2a-specific flag, threaded in at construction so
+        # ``build_manifest`` keeps a uniform signature (like ``kind`` for engine).
+        self._card = card
+
+    # ── dispatch facet ──────────────────────────────────────────────────────
+
+    def build_manifest(
+        self,
+        *,
+        handle: str,
+        opts: AddOptions,
+        description: str,
+        allow_from: list[str],
+        owner: str | None = None,
+        team: str | None = None,
+    ) -> AgentManifest:
+        return AgentManifest(
+            handle=handle,
+            adapter="a2a",
+            a2a_card=self._card,
+            description=description,
+            allow_from=allow_from,
+            owner=owner,
+            team=team,
+        )
+
+    def register(
+        self, *, manifest: AgentManifest, config: MyceliumConfig, opts: AddOptions
+    ) -> None:
+        # No host side effects; the backend resolves the card and holds the seat.
+        return
+
+    def destroy(
+        self, *, manifest: AgentManifest, config: MyceliumConfig, room: str, full: bool
+    ) -> None:
+        # No host assets and no local runtime; nothing to tear down.
+        return
+
+    def describe(self, manifest: AgentManifest, *, room: str) -> list[str]:
+        lines = [
+            f"  adapter:  {manifest.adapter}",
+            f"  card:     {manifest.a2a_card}",
+        ]
+        if manifest.a2a_skills:
+            lines.append(f"  skills:   {', '.join(manifest.a2a_skills)}")
+        if manifest.allow_from:
+            lines.append(f"  allow:    {', '.join(manifest.allow_from)}")
+        return lines
+
+    # ── install facet (no host assets; the backend drives the seat) ─────────
+
+    def install(
+        self,
+        *,
+        config: MyceliumConfig,
+        verbose: bool,
+        profile: str | None,
+        container: str | None,
+        reinstall: bool,
+    ) -> None:
+        return
+
+    def uninstall(self, *, record: dict, profile: str | None, container: str | None) -> None:
+        return
+
+    def reinstall_targets(self, *, profile: str | None, container: str | None) -> list[str]:
+        return []
+
+    def dry_run_lines(
+        self, *, config: MyceliumConfig, profile: str | None, container: str | None
+    ) -> list[str]:
+        return ["  (no host-level install for a2a agents; the backend drives them)"]
+
+    def post_install_banner(
+        self,
+        *,
+        config: MyceliumConfig,
+        reinstall: bool,
+        profile: str | None,
+        container: str | None,
+    ) -> None:
+        typer.secho("A2A family ready.", fg=typer.colors.GREEN)
+        typer.echo("  Register an external A2A agent in a room:")
+        typer.secho(
+            "    $ mycelium agent create <handle> --adapter a2a --card <url> --room <room>",
+            fg=typer.colors.CYAN,
+        )
+
+    def run_step(
+        self,
+        step: str,
+        *,
+        config: MyceliumConfig,
+        verbose: bool,
+        profile: str | None,
+        container: str | None,
+        remove: bool,
+    ) -> None:
+        return
+
+    def status_check(self, *, name: str, info: dict) -> dict:
+        # No host binary/asset to probe; the backend owns the seat.
+        return {"ok": True, "details": [f"api_url: {info.get('api_url', '')}"]}

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -297,7 +297,8 @@ class MemoryLogEntry(BaseModel):
 #   claude_code → a resident Claude Code session (kept woken with `await --loop`)
 #   cursor      → a resident Cursor session (same resident lifecycle)
 #   engine      → a first-party cognition engine the backend runs
-AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "engine"})
+#   a2a         → an external Agent2Agent endpoint, driven by a backend-held seat
+AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "engine", "a2a"})
 
 #: Cognition-engine kinds hosted by the first-party ``engine`` runtime family.
 #: The extensibility axis: ``aligner`` (SIEP converge) and ``synthesizer`` (room
@@ -329,7 +330,7 @@ class AgentManifest(BaseModel):
     """
 
     handle: str = Field(..., min_length=1, pattern=HANDLE_PATTERN)
-    adapter: Literal["claude_code", "cursor", "engine"] = "claude_code"
+    adapter: Literal["claude_code", "cursor", "engine", "a2a"] = "claude_code"
     kind: str | None = Field(
         default=None,
         description=(
@@ -369,6 +370,18 @@ class AgentManifest(BaseModel):
             "grants no one."
         ),
     )
+    a2a_card: str | None = Field(
+        default=None,
+        description="a2a: base URL of the remote Agent Card. Required for the a2a adapter.",
+    )
+    a2a_endpoint: str | None = Field(
+        default=None,
+        description="a2a: resolved RPC endpoint the backend-held seat calls.",
+    )
+    a2a_skills: list[str] = Field(
+        default_factory=list,
+        description="a2a: skill ids advertised by the remote card (for the roster).",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -403,6 +416,10 @@ class AgentManifest(BaseModel):
                 raise ValueError(
                     f"unknown engine kind {self.kind!r}; known: {sorted(ENGINE_KINDS)}"
                 )
+        # An a2a agent is a remote endpoint: its manifest must name the card so
+        # the backend-held seat knows who to call.
+        if self.adapter == "a2a" and not (self.a2a_card and self.a2a_card.strip()):
+            raise ValueError("a2a agents require an 'a2a_card' (the remote Agent Card URL)")
         return self
 
     @property

--- a/mycelium-cli/tests/test_agent_a2a.py
+++ b/mycelium-cli/tests/test_agent_a2a.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""`mycelium agent create --adapter a2a` — register an external A2A endpoint.
+
+The a2a family has no local runtime: the CLI posts to the backend's a2a-agents
+route (which resolves the card), rather than building a manifest locally. These
+tests mock the hub so they stay offline, and pin the integration-registry
+invariants for the new family.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from mycelium.commands import agent as agent_cmd
+from mycelium.integrations import get_adapter
+from mycelium.protocol import AGENT_ADAPTERS, AgentManifest
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def fake_hub(monkeypatch):
+    """Route the create command's config + hub call through fakes."""
+    monkeypatch.setattr(agent_cmd.MyceliumConfig, "load", staticmethod(lambda: MagicMock()))
+    monkeypatch.setattr(agent_cmd, "_resolve_room", lambda _c, _r: "portfolio")
+    monkeypatch.setattr(agent_cmd, "_default_owner", lambda owner, handle: owner or handle)
+
+    posts: list[dict] = []
+
+    def _install(response):
+        @contextmanager
+        def _client(_config, **_kwargs):
+            fake = MagicMock()
+
+            def _post(url, json):
+                posts.append({"url": url, "json": json})
+                return response
+
+            fake.post = _post
+            yield fake
+
+        monkeypatch.setattr(agent_cmd, "hub_client", _client)
+
+    return _install, posts
+
+
+def test_create_a2a_posts_to_backend(fake_hub):
+    install, posts = fake_hub
+    resp = MagicMock(status_code=201)
+    resp.json.return_value = {
+        "handle": "researcher",
+        "adapter": "a2a",
+        "a2a_endpoint": "https://remote.example/rpc",
+        "a2a_skills": ["deep_search"],
+    }
+    install(resp)
+
+    result = runner.invoke(
+        agent_cmd.app,
+        ["create", "researcher", "--adapter", "a2a", "--card", "https://remote.example"],
+    )
+    assert result.exit_code == 0, result.output
+    assert posts and posts[0]["url"] == "/api/rooms/portfolio/a2a-agents"
+    assert posts[0]["json"]["card"] == "https://remote.example"
+    assert "deep_search" in result.output
+
+
+def test_create_a2a_requires_card(fake_hub):
+    install, _posts = fake_hub
+    install(MagicMock(status_code=201))
+    result = runner.invoke(agent_cmd.app, ["create", "researcher", "--adapter", "a2a"])
+    assert result.exit_code == 1
+    assert "--card" in result.output
+
+
+def test_create_a2a_surfaces_bad_card_detail(fake_hub):
+    install, _posts = fake_hub
+    resp = MagicMock(status_code=502)
+    resp.json.return_value = {"detail": "Could not resolve A2A card: no card found"}
+    install(resp)
+
+    result = runner.invoke(
+        agent_cmd.app,
+        ["create", "researcher", "--adapter", "a2a", "--card", "https://nope"],
+    )
+    assert result.exit_code == 1
+    assert "Could not resolve A2A card" in result.output
+
+
+def test_a2a_is_a_registered_family():
+    assert "a2a" in AGENT_ADAPTERS
+    impl = get_adapter("a2a", card="https://remote.example")
+    assert impl.name == "a2a"
+    assert impl.lifecycle == "backend_engine"
+
+
+def test_a2a_manifest_round_trips():
+    manifest = get_adapter("a2a", card="https://remote.example").build_manifest(
+        handle="researcher",
+        opts=agent_cmd.AddOptions(room="portfolio"),
+        description="does research",
+        allow_from=[],
+    )
+    assert manifest.adapter == "a2a"
+    assert manifest.a2a_card == "https://remote.example"
+    # a manifest without a card is rejected — an a2a agent must name its endpoint
+    with pytest.raises(ValueError, match="a2a_card"):
+        AgentManifest(handle="x", adapter="a2a")

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -5,7 +5,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Users } from "lucide-react";
-import { createEngine, type EngineKind, type PresenceMember } from "@/lib/api";
+import { createEngine, registerA2aAgent, type EngineKind, type PresenceMember } from "@/lib/api";
 import { useRoomRoster } from "@/lib/room-data";
 import { Button } from "@/components/ui/button";
 import { Chip } from "@/components/ui/chip";
@@ -78,7 +78,7 @@ export function AgentsPanel({
   onFocusConsumed,
 }: Props) {
   const [mineOnly, setMineOnly] = useState(false);
-  const [addTab, setAddTab] = useState<"agents" | "engines">("agents");
+  const [addTab, setAddTab] = useState<"agents" | "engines" | "a2a">("agents");
   const [addOpen, setAddOpen] = useState(false);
   const { principal } = useCurrentUser();
 
@@ -163,11 +163,12 @@ export function AgentsPanel({
                 Add an agent or engine
               </DialogTitle>
               <DialogDescription className="text-label text-muted-foreground leading-relaxed">
-                <span className="text-text">Engines</span> are backend-owned, so
-                you can invite one right here. <span className="text-text">Agents</span>{" "}
-                are registered from the CLI, because they have machine-local side
-                effects (resident session, workspace assets) the web UI can&apos;t
-                perform.
+                <span className="text-text">Engines</span> are backend-owned and{" "}
+                <span className="text-text">A2A agents</span> are external services,
+                so you can register either right here.{" "}
+                <span className="text-text">Agents</span> are registered from the
+                CLI, because they have machine-local side effects (resident session,
+                workspace assets) the web UI can&apos;t perform.
               </DialogDescription>
             </DialogHeader>
             <div className="flex items-center gap-1.5 mt-2">
@@ -187,8 +188,16 @@ export function AgentsPanel({
               >
                 Engines
               </Chip>
+              <Chip
+                variant="accent"
+                active={addTab === "a2a"}
+                onClick={() => setAddTab("a2a")}
+                className="px-2.5 py-0.5 text-micro"
+              >
+                A2A agent
+              </Chip>
             </div>
-            {addTab === "agents" ? (
+            {addTab === "agents" && (
               <div className="space-y-6 mt-2">
                 <section>
                   <div className="text-label font-semibold text-text mb-1.5">
@@ -222,10 +231,20 @@ export function AgentsPanel({
                   </p>
                 </section>
               </div>
-            ) : (
+            )}
+            {addTab === "engines" && (
               <EngineInviteForm
                 roomName={roomName}
                 createdBy={principal}
+                onCreated={() => {
+                  refresh();
+                  setAddOpen(false);
+                }}
+              />
+            )}
+            {addTab === "a2a" && (
+              <A2aAgentForm
+                roomName={roomName}
                 onCreated={() => {
                   refresh();
                   setAddOpen(false);
@@ -330,12 +349,22 @@ export function AgentsPanel({
                       · {a.team}
                     </span>
                   )}
+                  {a.adapter === "a2a" && (
+                    <span
+                      className="inline-flex items-center rounded-md border border-accent/30 bg-accent-soft/40 px-1.5 py-0 text-micro font-medium text-accent"
+                      title={a.a2a_endpoint ?? a.a2a_card ?? "external A2A agent"}
+                    >
+                      a2a
+                    </span>
+                  )}
                 </div>
                 <div className="mt-0.5 truncate text-micro text-muted-foreground">
                   {subtext(
                     a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter,
                     presenceNote(memberPresence),
-                    a.description,
+                    a.adapter === "a2a" && a.a2a_skills && a.a2a_skills.length > 0
+                      ? a.a2a_skills.join(", ")
+                      : a.description,
                   )}
                 </div>
               </div>
@@ -469,6 +498,107 @@ function EngineInviteForm({
         <span className="text-micro text-muted-foreground">
           or <code className="font-mono">mycelium engine create</code> from the CLI
         </span>
+      </div>
+    </div>
+  );
+}
+
+/** Register an external A2A agent by its agent-card base URL — the backend
+ *  resolves the card to discover the endpoint + skills, so a bad/unreachable
+ *  card comes back as a 502 whose detail we surface verbatim. */
+function A2aAgentForm({
+  roomName,
+  onCreated,
+}: {
+  roomName: string;
+  onCreated: () => void;
+}) {
+  const [handle, setHandle] = useState("");
+  const [card, setCard] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmedHandle = handle.trim().replace(/^@/, "");
+  const trimmedCard = card.trim();
+  const canSubmit = trimmedHandle.length > 0 && trimmedCard.length > 0 && !submitting;
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await registerA2aAgent(roomName, {
+        handle: trimmedHandle,
+        card: trimmedCard,
+        description: description.trim(),
+      });
+      onCreated();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to register A2A agent");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4 mt-2">
+      <div className="space-y-1.5">
+        <label className="text-label font-medium text-text">Handle</label>
+        <Input
+          value={handle}
+          onChange={(e) => setHandle(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+          }}
+          placeholder="researcher"
+          autoCapitalize="none"
+          spellCheck={false}
+          aria-invalid={!!error}
+        />
+        <p className="text-micro text-muted-foreground leading-snug">
+          Address it in the channel with{" "}
+          <code className="font-mono text-accent">@{trimmedHandle || "handle"}</code>.
+          Lowercase slug.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-label font-medium text-text">Agent card URL</label>
+        <Input
+          value={card}
+          onChange={(e) => setCard(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") submit();
+          }}
+          placeholder="https://agent.example.com"
+          autoCapitalize="none"
+          spellCheck={false}
+          aria-invalid={!!error}
+        />
+        <p className="text-micro text-muted-foreground leading-snug">
+          The base URL of the agent&apos;s A2A agent card. The hub resolves it to
+          discover the endpoint and advertised skills.
+        </p>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-label font-medium text-text">
+          Description <span className="text-faint">(optional)</span>
+        </label>
+        <Input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="What this agent does in the room"
+        />
+      </div>
+
+      {error && <p className="text-micro text-[#f87171] leading-snug">{error}</p>}
+
+      <div className="flex items-center gap-2">
+        <Button variant="default" size="sm" onClick={submit} disabled={!canSubmit}>
+          {submitting ? "Registering…" : "Register A2A agent"}
+        </Button>
       </div>
     </div>
   );

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -557,6 +557,11 @@ export interface AgentSummary {
   owner: string | null;
   team: string | null;
   allow_from: string[];
+  /** For `adapter === "a2a"` agents: the agent card base URL, resolved endpoint,
+   *  and advertised skills. Null/empty for every other adapter. */
+  a2a_card?: string | null;
+  a2a_endpoint?: string | null;
+  a2a_skills?: string[];
 }
 
 /** List addressable agents in a room. Used to drive `@`-mention autocomplete. */
@@ -578,6 +583,20 @@ export async function createEngine(
   data: { handle: string; kind: EngineKind; description?: string; created_by?: string },
 ): Promise<AgentSummary> {
   return apiFetch<AgentSummary>(`/api/rooms/${roomName}/engines`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+/** Register an external A2A agent as a room member. The backend resolves the
+ *  agent card at `card` (a base URL) to discover its endpoint + skills; a
+ *  bad/unreachable card surfaces as a 502 whose detail we let propagate. */
+export async function registerA2aAgent(
+  roomName: string,
+  data: { handle: string; card: string; description?: string },
+): Promise<AgentSummary> {
+  return apiFetch<AgentSummary>(`/api/rooms/${roomName}/a2a-agents`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),


### PR DESCRIPTION
Throwaway spike for the #717 discussion / new issue #726. **Not for merge** — the deliverable is the findings, mirrored to #726.

Question: AGNTCY's `slima2a` (agntcy/slim-a2a-python) is a SLIMRPC transport for the a2a-python SDK, so an A2A hop can ride SLIM instead of plain HTTPS. Does it coexist with our pinned `slim-bindings 2.1.x`?

**Findings:**
- `slima2a 0.7.0` installs alongside `slim-bindings 2.1.0` (constraint `~=2.0`).
- It pins `a2a-sdk==1.1.0` **exactly** (we're on 1.1.2). All our bridge symbols exist on 1.1.0, so it's viable but couples us to that exact pin.
- SLIMRPC is point-to-point RPC to a SLIM identity, **not** room-group MLS membership — hardens the hop, doesn't make the agent a room member. The #717 boundary holds.
- Not proven: a live SLIMRPC round-trip over a SLIM node.

Decision tracked in #726. Reproduce: `uv run fastapi-backend/spikes/a2a_over_slim_spike.py`.