### PR TITLE
feat(a2a): authorize bridged agents + document the honest boundary (#717)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,20 @@ is no litellm dependency.
   `openclaw` and `hermes` are **gone**, not deprecated — they rode the removed
   SSE/coordination-tick model and their packages were deleted (#503). Don't
   reintroduce them as adapter options.
+- **A2A bridge is proxied, not an MLS member (be honest).** The A2A bridge (epic
+  #719) makes a room speak Agent2Agent both ways: `adapter: a2a` registers a
+  remote endpoint as a room member (`a2a_bridge.py` answers its `@`-mentions by
+  calling it — event-driven off the summon seam, chat-first, not negotiation-
+  scoped), and `a2a_server.py` exposes a room *as* an A2A agent via the a2a-sdk
+  server (card + JSON-RPC). **Honest boundary:** a bridged A2A agent is **not** a
+  member of the room's MLS group — it's proxied by a backend seat that reads
+  plaintext and calls the remote out-of-band. The hop is plain HTTPS today; it
+  can ride SLIM (SLIMRPC) via `agntcy/slim-a2a-python`, but that's point-to-point
+  RPC to a SLIM identity, still not room-group membership, and slima2a pins
+  `a2a-sdk==1.1.0` (HTTP-vs-SLIM decision: #726). Either way the hub sees
+  plaintext, so it is **NOT** E2E-from-the-hub. Remote auth is a bearer token
+  named by `a2a_auth_env` and resolved from the backend env — the secret never
+  lands in room memory.
 
 ## Local development
 

--- a/fastapi-backend/app/routes/a2a_agents.py
+++ b/fastapi-backend/app/routes/a2a_agents.py
@@ -38,6 +38,13 @@ class A2aAgentCreate(BaseModel):
     handle: str = Field(..., min_length=1, max_length=64)
     card: str = Field(..., description="Base URL serving the remote agent's Agent Card.")
     description: str = Field("", description="Overrides the card's description when set.")
+    auth_env: str | None = Field(
+        None,
+        description=(
+            "Name of a backend env var holding the bearer token for the remote agent. "
+            "Only the var name is stored (in room memory); the secret stays in the env."
+        ),
+    )
     allow_from: list[str] = Field(
         default_factory=list, description="Sender handles allowed to summon (empty = anyone)."
     )
@@ -93,6 +100,8 @@ async def create_a2a_agent(room_name: str, payload: A2aAgentCreate, request: Req
         "a2a_card_path": card.card_path,
         "a2a_streaming": card.streaming,
         "a2a_skills": card.skill_ids,
+        # Only the env var NAME lands in room memory; the token stays in the env.
+        "a2a_auth_env": payload.auth_env.strip() if payload.auth_env else None,
         "allow_from": [h for h in (_norm(a) for a in payload.allow_from) if h],
         "owner": _norm(payload.owner),
         "team": _norm(payload.team),

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -17,12 +17,25 @@ Two pieces:
 The send path carries the #712 spike findings: resolve the card (dual well-known
 path), then build a client with ``accepted_output_modes`` set — without it,
 older servers reject the send with a pydantic ``-32600``.
+
+**Honest scope boundary (keep it honest here + in the user-facing docs).** A
+bridged A2A agent is **not** a member of the room's MLS group channel — it never
+holds a group key. It is proxied by this backend seat, which reads the room's
+plaintext (as moderator/custodian) and calls the remote agent out-of-band. Today
+that hop is plain HTTPS; it *can* be moved onto SLIM (SLIMRPC, SLIM-identity
+authenticated + encrypted) via ``agntcy/slim-a2a-python`` — but even then it is
+point-to-point RPC to a distinct SLIM identity, **not** room-group membership
+(see #726). Either way the hub is the translation boundary and sees plaintext,
+so this is **NOT** E2E-from-the-hub. Auth to the remote is a bearer token whose
+value lives in the backend env (``a2a_auth_env`` names the var); the room
+manifest never stores the secret.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -50,12 +63,23 @@ def _norm(handle: str | None) -> str:
     return (handle or "").strip().lstrip("@").lower()
 
 
-def registered_a2a_card(room: str, handle: str) -> str | None:
-    """The card URL if ``handle`` is a registered ``a2a`` agent in ``room``.
+@dataclass(frozen=True)
+class A2aAgentRef:
+    """A registered a2a agent's call config: where to reach it and how to auth."""
+
+    card: str
+    #: Name of the backend env var holding the bearer token, if the remote needs
+    #: auth. The secret itself is NEVER stored in the room manifest (it's readable
+    #: room memory) — only the env var name is, and it's resolved at send time.
+    auth_env: str | None = None
+
+
+def resolve_a2a_agent(room: str, handle: str) -> A2aAgentRef | None:
+    """Call config if ``handle`` is a registered ``a2a`` agent in ``room``, else None.
 
     Mirrors the aligner's engine gate: reads the ``agents/<handle>`` manifest and
-    returns its ``a2a_card`` only for an ``adapter: a2a`` manifest, else ``None``
-    — so summoning a teammate, engine, or unknown handle never fires the bridge.
+    acts only for an ``adapter: a2a`` manifest, so summoning a teammate, engine,
+    or unknown handle never fires the bridge.
     """
     from app.services.filesystem import get_room_dir, read_memory_file
 
@@ -67,10 +91,19 @@ def registered_a2a_card(room: str, handle: str) -> str | None:
         data = yaml.safe_load(body) or {}
     except yaml.YAMLError:
         return None
-    if isinstance(data, dict) and data.get("adapter") == "a2a":
-        card = data.get("a2a_card")
-        return card if isinstance(card, str) and card else None
-    return None
+    if not (isinstance(data, dict) and data.get("adapter") == "a2a"):
+        return None
+    card = data.get("a2a_card")
+    if not (isinstance(card, str) and card):
+        return None
+    env = data.get("a2a_auth_env")
+    return A2aAgentRef(card=card, auth_env=env if isinstance(env, str) and env else None)
+
+
+def registered_a2a_card(room: str, handle: str) -> str | None:
+    """The card URL if ``handle`` is a registered ``a2a`` agent, else None."""
+    ref = resolve_a2a_agent(room, handle)
+    return ref.card if ref else None
 
 
 class A2aSendError(Exception):
@@ -122,18 +155,22 @@ async def send_to_a2a(
     text: str,
     *,
     context_id: str | None = None,
+    auth_token: str | None = None,
     http: httpx.AsyncClient | None = None,
     timeout_s: float = _SEND_TIMEOUT_S,
 ) -> A2aReply:
     """Send ``text`` to the A2A agent at ``card_url`` and return its reply.
 
     Pass ``context_id`` (from a prior :class:`A2aReply`) to continue the same
-    conversation, so the remote agent keeps its own memory of the thread. Raises
-    :class:`A2aSendError` on an unresolvable card or a failed exchange, so the
-    caller can fall back faithfully (silence, never a fabricated reply).
+    conversation, so the remote agent keeps its own memory of the thread. Pass
+    ``auth_token`` to send it as a bearer credential (for agents whose card
+    declares a security scheme). Raises :class:`A2aSendError` on an unresolvable
+    card or a failed exchange, so the caller can fall back faithfully (silence,
+    never a fabricated reply).
     """
     owns_client = http is None
-    client_http = http or httpx.AsyncClient(timeout=timeout_s)
+    headers = {"Authorization": f"Bearer {auth_token}"} if auth_token else None
+    client_http = http or httpx.AsyncClient(timeout=timeout_s, headers=headers)
     try:
         try:
             card, _path = await resolve_raw_card(card_url, http=client_http)
@@ -208,8 +245,8 @@ class A2aResponder:
         co_summons: list[str] | None = None,
         message_text: str = "",
     ) -> None:
-        card = registered_a2a_card(room, handle)
-        if card is None:
+        ref = resolve_a2a_agent(room, handle)
+        if ref is None:
             return  # not an a2a agent — let the engines / a teammate handle it
         sender = envelope_sender(envelope)
         if _norm(sender) == _norm(handle):
@@ -222,7 +259,12 @@ class A2aResponder:
         if key in self._active:
             return
         self._active.add(key)
-        task = asyncio.create_task(self._run_and_release(room, handle, card, prompt, envelope, key))
+        # Resolve the bearer credential from the backend env (the manifest holds
+        # only the var name), so the secret never lives in room memory.
+        token = os.environ.get(ref.auth_env) if ref.auth_env else None
+        task = asyncio.create_task(
+            self._run_and_release(room, handle, ref.card, prompt, envelope, key, token)
+        )
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
 
@@ -234,6 +276,7 @@ class A2aResponder:
         prompt: str,
         envelope: L9,
         key: tuple[str, str, str],
+        auth_token: str | None = None,
     ) -> None:
         thread_key = (room, _norm(handle))
         summoner = envelope_sender(envelope)
@@ -245,6 +288,7 @@ class A2aResponder:
                 card,
                 addressed,
                 context_id=self._threads.get(thread_key),
+                auth_token=auth_token,
                 timeout_s=self._timeout_s,
             )
             if reply.context_id:

--- a/fastapi-backend/app/services/auth.py
+++ b/fastapi-backend/app/services/auth.py
@@ -51,6 +51,12 @@ ALLOWED_ALGORITHMS = frozenset(
 #: describe the API rather than exposing any of it.
 PUBLIC_PATHS = frozenset({"/", "/health", "/healthz", "/docs", "/redoc", "/openapi.json"})
 
+#: The A2A Agent Card is per-room, so it can't be a fixed PUBLIC_PATHS entry; it's
+#: matched by suffix. The A2A spec serves the card to unauthenticated GET (like
+#: /.well-known/openid-configuration) — it's discovery metadata (room name +
+#: advertised skills), not room content. The room's RPC endpoint stays gated.
+A2A_CARD_SUFFIX = "/.well-known/agent-card.json"
+
 #: Shortest gap between forced JWKS re-fetches triggered by an unknown ``kid``.
 #: Rotation is picked up within this bound; without it, a flood of junk ``kid``s
 #: would be an amplified request generator pointed at the issuer.
@@ -368,6 +374,8 @@ async def auth_gate(request: Request) -> Principal | None:
         return None
     path = request.url.path
     if path in PUBLIC_PATHS or path.rstrip("/") in PUBLIC_PATHS:
+        return None
+    if path.endswith(A2A_CARD_SUFFIX):
         return None
     if settings.AUTH_LOCALHOST_BYPASS and is_loopback_client(request):
         return None

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -23,9 +23,17 @@ from tests.fakes import FakeChannel, FakeManaged, FakeManager, FakePersister
 _ROOM = "portfolio"
 
 
-def _register_a2a(handle: str = "researcher", card: str = "https://remote.example") -> None:
-    body = yaml.safe_dump({"adapter": "a2a", "a2a_card": card, "description": "does research"})
-    write_memory_file(get_room_dir(_ROOM), f"agents/{handle}", body, created_by="web-ui")
+def _register_a2a(
+    handle: str = "researcher",
+    card: str = "https://remote.example",
+    auth_env: str | None = None,
+) -> None:
+    manifest = {"adapter": "a2a", "a2a_card": card, "description": "does research"}
+    if auth_env:
+        manifest["a2a_auth_env"] = auth_env
+    write_memory_file(
+        get_room_dir(_ROOM), f"agents/{handle}", yaml.safe_dump(manifest), created_by="web-ui"
+    )
 
 
 def _register_engine(handle: str = "aligner") -> None:
@@ -55,8 +63,10 @@ def _responder(monkeypatch, *, reply: str = "the remote reply"):
 
     calls: list[dict] = []
 
-    async def _fake_send(card_url, text, *, context_id=None, **_kwargs):
-        calls.append({"card": card_url, "text": text, "context_id": context_id})
+    async def _fake_send(card_url, text, *, context_id=None, auth_token=None, **_kwargs):
+        calls.append(
+            {"card": card_url, "text": text, "context_id": context_id, "auth_token": auth_token}
+        )
         if reply is None:
             raise a2a_bridge.A2aSendError("dead remote")
         return A2aReply(text=reply, context_id="ctx-1")
@@ -109,6 +119,29 @@ async def test_thread_continues_across_mentions(monkeypatch):
 
     assert calls[0]["context_id"] is None  # cold start
     assert calls[1]["context_id"] == "ctx-1"  # threaded from the first reply
+
+
+@pytest.mark.asyncio
+async def test_auth_token_resolved_from_env_not_manifest(monkeypatch):
+    monkeypatch.setenv("RESEARCHER_TOKEN", "s3cret")
+    _register_a2a(auth_env="RESEARCHER_TOKEN")
+    responder, _channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "hi")
+    await _drain(responder)
+
+    assert calls[0]["auth_token"] == "s3cret"
+
+
+@pytest.mark.asyncio
+async def test_no_auth_env_means_no_token(monkeypatch):
+    _register_a2a()  # no a2a_auth_env
+    responder, _channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "hi")
+    await _drain(responder)
+
+    assert calls[0]["auth_token"] is None
 
 
 @pytest.mark.asyncio

--- a/fastapi-backend/tests/test_auth_gate.py
+++ b/fastapi-backend/tests/test_auth_gate.py
@@ -539,3 +539,30 @@ async def test_a_real_token_becomes_the_author_of_a_write(
     )
     assert resp.status_code == 201
     assert resp.json()[0]["created_by"] == "poc-agent"
+
+
+# ── A2A inbound: card is public discovery, RPC is gated (#717) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_card_is_public_when_gate_on(client: AsyncClient, auth_on):
+    """The Agent Card is discovery metadata — served unauthenticated by A2A spec.
+
+    A missing room returns 404 (the route ran), not 401 (the gate blocked it),
+    which is what proves the exemption fired.
+    """
+    resp = await client.get("/api/rooms/ghost/.well-known/agent-card.json")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a2a_rpc_endpoint_is_gated_when_gate_on(client: AsyncClient, auth_on):
+    """The room's JSON-RPC endpoint is not exempt — no token means 401."""
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "method": "message/send",
+        "params": {"message": {"kind": "message", "messageId": "x", "role": "user", "parts": []}},
+    }
+    resp = await client.post("/api/rooms/ghost/a2a", json=rpc)
+    assert resp.status_code == 401

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -673,6 +673,7 @@ def _create_a2a_agent(
     room: str | None,
     handle: str,
     card: str | None,
+    card_auth_env: str | None,
     description: str,
     allow_from: str | None,
     owner: str | None,
@@ -698,6 +699,7 @@ def _create_a2a_agent(
         "handle": handle,
         "card": card.strip(),
         "description": description,
+        "auth_env": card_auth_env.strip() if card_auth_env else None,
         "allow_from": allow_list,
         "owner": _default_owner(owner, handle_flag),
         "team": team,
@@ -755,6 +757,14 @@ def agent_create(
         help=(
             "a2a: base URL serving the external agent's Agent Card "
             "(the host of its /.well-known/agent-card.json). Required for --adapter a2a."
+        ),
+    ),
+    card_auth_env: str | None = typer.Option(
+        None,
+        "--card-auth-env",
+        help=(
+            "a2a: name of a backend env var holding the remote agent's bearer token. "
+            "Only the var name is stored; the secret stays in the hub's environment."
         ),
     ),
     room: str | None = typer.Option(
@@ -840,6 +850,7 @@ def agent_create(
                 room=room,
                 handle=handle,
                 card=card,
+                card_auth_env=card_auth_env,
                 description=description,
                 allow_from=allow_from,
                 owner=owner,


### PR DESCRIPTION
Closes #717. Part of epic #719. **Targets `feat/a2a-bridge`.** Informed by the SLIM spike (#726).

Authorizes bridged agents on both legs and writes down the honest boundary.

- **Inbound gate.** The per-room Agent Card (`/.well-known/agent-card.json`) is exempted from the HTTP auth gate — it's discovery metadata, served unauthenticated by the A2A spec (like `/.well-known/openid-configuration`). The room's JSON-RPC endpoint stays gated.
- **Outbound auth, secret kept out of room memory.** `send_to_a2a` honors a bearer credential. The manifest stores only the env var **name** (`a2a_auth_env`); the responder resolves the actual token from the backend env at send time. New CLI flag `--card-auth-env`, backend `A2aAgentCreate.auth_env`.
- **The honest boundary, corrected by the spike.** A bridged A2A agent is **not** a member of the room's MLS group — it's proxied by a backend seat that reads plaintext and calls the remote out-of-band. The hop is plain HTTPS today; it *can* ride SLIM (SLIMRPC via `slima2a`), but that's point-to-point RPC to a SLIM identity, **still not** room-group membership (#726). Either way the hub sees plaintext, so it is **NOT** E2E-from-the-hub. Documented in `a2a_bridge.py` and `CLAUDE.md`.

**Tests:** auth-gate exemption (card public / RPC 401 when gate on), env-resolved token flow (secret from env, not manifest). Backend **717 green**, CLI **492 green**, ruff/ty clean.

Note: "every agent emits an Agent Card, not just a2a" (raised in review) is filed as a follow-up, it doesn't block this.
