### PR TITLE
feat(a2a): live e2e chat round-trip + bridge docs (#718)

### DIFF
--- a/docs/a2a-bridge.md
+++ b/docs/a2a-bridge.md
@@ -1,0 +1,77 @@
+# The A2A bridge
+
+Mycelium speaks [Agent2Agent (A2A)](https://github.com/a2aproject/A2A), the open
+agent-interop protocol, in both directions. You can pull any A2A agent into a
+room and talk to it like a teammate, and you can hand any room to an outside A2A
+client as if the room itself were an agent.
+
+## Bring an A2A agent into a room
+
+Register a remote A2A endpoint as a room member. Mycelium resolves its Agent
+Card at registration, so a bad URL fails right away instead of at first use.
+
+```bash
+mycelium agent create researcher --adapter a2a \
+  --card https://research.example.com \
+  --room my-room
+```
+
+Now `@researcher` is a member. Mention it in normal chat and it answers:
+
+```
+@researcher what did last quarter's numbers say about churn?
+```
+
+Under the hood the backend calls the remote agent over A2A with your message and
+posts its reply back into the room as `@researcher`. Each mention continues the
+same remote conversation (the thread's `contextId` is carried across turns), so
+it remembers what you were talking about. This is plain chat, not a special
+negotiation mode. When the aligner runs a negotiation and addresses `@researcher`,
+that is just one more caller mentioning it.
+
+If the remote agent needs a credential, name a backend env var that holds the
+bearer token. The secret stays in the hub's environment; only the var name is
+stored in the room.
+
+```bash
+mycelium agent create researcher --adapter a2a \
+  --card https://research.example.com \
+  --card-auth-env RESEARCHER_TOKEN
+```
+
+## Expose a room as an A2A agent
+
+Every room is discoverable and callable as an A2A agent. Its Agent Card is served
+at:
+
+```
+GET /api/rooms/{room}/.well-known/agent-card.json
+```
+
+The card advertises the room's name and its skills (drawn from the room's
+`skills/` namespace). An external A2A client sends the room a message at
+`POST /api/rooms/{room}/a2a`; the message lands in the room like any other post.
+If it mentions a room agent, normal room dynamics take over, including the
+inbound-to-outbound path where an incoming A2A message drives an A2A agent that
+lives in the room.
+
+The card endpoint is public (discovery is unauthenticated by the A2A spec, like
+`/.well-known/openid-configuration`). The room's message endpoint is gated by the
+hub's auth when auth is enabled.
+
+## What the bridge is, and what it is not
+
+A bridged A2A agent is a member of the room in the coordination sense: it is on
+the roster, it answers when mentioned, its replies are attributed to its handle.
+
+It is **not** a member of the room's end-to-end-encrypted MLS group. It never
+holds a group key. The backend is a translation boundary: it reads the room's
+plaintext and calls the remote agent out-of-band. Today that call is plain
+HTTPS. It can be moved onto SLIM (SLIM identity, encrypted transport) via
+`agntcy/slim-a2a-python`, but even then it is point-to-point RPC to a separate
+SLIM identity, not membership in the room's group channel.
+
+Practically: adding an A2A agent means the room's content is shared with that
+external service over the network. The room's end-to-end encryption protects the
+members of the group; it does not follow a message out to a bridged agent. Add
+one the way you would grant any third party access to a conversation.

--- a/fastapi-backend/tests/test_a2a_e2e.py
+++ b/fastapi-backend/tests/test_a2a_e2e.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""End-to-end A2A bridge smoke test (#718) against a LIVE public agent.
+
+Env-gated (``MYCELIUM_A2A_LIVE=1``) so CI stays hermetic. Unlike the unit tests,
+nothing here is mocked on the A2A side: it registers a real remote agent through
+the real backend route (which resolves its live Agent Card), then drives a real
+``@``-mention through the responder so the live remote is actually called and its
+reply is posted back. The room channel is faked (no SLIM node needed); the A2A
+hop is real.
+
+The public echo agent returns "Hello World" for any input — enough to prove the
+whole outbound chat path end to end. Point it at a model-backed a2a-samples agent
+for a behavioural run.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+from app.services import a2a_bridge, l9, room_channels
+from app.services.l9_models import Kind
+from tests.fakes import FakeChannel, FakeManaged, FakePersister
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("MYCELIUM_A2A_LIVE") != "1",
+    reason="live A2A e2e; set MYCELIUM_A2A_LIVE=1 to run",
+)
+
+_ECHO = "https://hello-world-gxfr.onrender.com"
+_ROOM = "portfolio"
+
+
+@pytest.mark.asyncio
+async def test_register_then_chat_with_a_live_a2a_agent(client, monkeypatch):
+    # 1. Register the live agent through the real route — resolves its live card.
+    assert (await client.post("/api/rooms", json={"name": _ROOM})).status_code in (200, 201)
+    resp = await client.post(
+        f"/api/rooms/{_ROOM}/a2a-agents", json={"handle": "echo", "card": _ECHO}
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["adapter"] == "a2a"
+    assert body["a2a_endpoint"]  # a real endpoint came back from the live card
+
+    # 2. @-mention it. The responder calls the LIVE agent and posts its reply.
+    persister = FakePersister()
+    channel = FakeChannel(persister)
+    managed = FakeManaged(room=_ROOM, channel=channel, persister=persister)
+    monkeypatch.setattr(room_channels.manager, "get", lambda _r: managed)
+
+    responder = a2a_bridge.A2aResponder(room_channels.manager)
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=l9.episode_urn(_ROOM, "live"),
+        sender="avery",
+        sender_role="human",
+        recipients=["echo"],
+        topic=l9.topic_urn(_ROOM),
+        payload_type="message",
+        message_id="m1",
+    )
+    responder.handle_summon(_ROOM, "echo", env, [], "hello there")
+    await asyncio.gather(*list(responder._tasks))
+
+    posted = [extra.get("content") for _env, extra in channel.sent if extra]
+    assert any("Hello World" in (p or "") for p in posted), posted


### PR DESCRIPTION
Closes #718. Part of epic #719. **Targets `feat/a2a-bridge`.** The last issue.

Proves the bridge end to end against a live external A2A agent, and documents it.

- **`docs/a2a-bridge.md`** — consumer-first guide: register an A2A agent and chat with it (with continuity + env-ref auth), expose a room as an A2A agent, and the honest not-an-MLS-member / not-E2E boundary.
- **`tests/test_a2a_e2e.py`** — env-gated (`MYCELIUM_A2A_LIVE=1`) end-to-end. Nothing mocked on the A2A side: it registers the remote through the *real* backend route (which resolves its live Agent Card), then drives a real `@`-mention so the live remote is actually called and its reply is posted back as the handle. The room channel is faked (no SLIM node needed); the A2A hop is real. Point `_ECHO` at a model-backed `a2a-samples` agent for a behavioural (reasoning) run.

Proven green against the public echo agent; **skips by default** so CI stays hermetic. Backend **717 passed**.

Note: a Claude-Code-style e2e *skill* wrapper could be added later; the gated pytest is the substantive, runnable e2e.
