### PR TITLE
PoC(a2a): carry the outbound hop over SLIM (SLIMRPC) — #726

### DIFF
--- a/fastapi-backend/app/services/a2a_slim_transport.py
+++ b/fastapi-backend/app/services/a2a_slim_transport.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""PoC (#726): carry the A2A bridge's outbound hop over SLIM instead of HTTPS.
+
+The outbound send today (:func:`app.services.a2a_bridge.send_to_a2a`) talks A2A
+over plain HTTPS. AGNTCY's ``slima2a`` (agntcy/slim-a2a-python) is a SLIMRPC
+transport for the a2a-python SDK, so the same A2A ``send_message`` can ride SLIM
+with SLIM-identity auth and SLIM's encryption. :func:`send_over_slim` is that
+path, structurally identical to the HTTP send (build client -> send -> collect
+parts) but over a SLIM channel.
+
+**PoC scope / honesty.** This is a proof of concept for the HTTP-vs-SLIM decision,
+NOT merged behavior. Two facts to weigh (see #726):
+
+- ``slima2a`` pins ``a2a-sdk==1.1.0`` exactly; adopting it pins the whole bridge
+  to 1.1.0 (the full backend suite passes there — that's the main cost).
+- SLIMRPC is point-to-point RPC to a distinct SLIM identity, so this hardens the
+  hop; it does **not** make the remote a member of the room's MLS group.
+
+Reaching a remote over SLIM needs the remote to run a ``slima2a`` server
+(``SRPCHandler``) with a SLIM name, and a reachable SLIM node — so the live
+round-trip is env-gated, not a unit test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import cast
+
+from a2a.types import AgentCard, Message, Part, Role, SendMessageRequest, StreamResponse
+from slima2a import setup_slim_client
+from slima2a.client_transport import (
+    ClientConfig,
+    MultiAgentClientFactory,
+    slimrpc_channel_factory,
+)
+
+from app.config import settings
+from app.services.a2a_bridge import A2aReply, A2aSendError, _collect
+from app.services.slim_client import resolve_master_secret
+
+logger = logging.getLogger(__name__)
+
+# Our SLIM client identity when calling out as the bridge. A namespace/group/name
+# triple, the SLIM addressing unit. The PoC uses one fixed caller identity.
+_CALLER_NS = "mycelium"
+_CALLER_GROUP = "a2a-bridge"
+_CALLER_NAME = "outbound-seat"
+
+# slima2a's setup_slim_client retries a connection rather than failing fast, so
+# an unreachable node would hang. Bound it (a real operational consideration for
+# the HTTP-vs-SLIM decision — HTTP surfaces a connect error immediately).
+_CONNECT_TIMEOUT_S = 10.0
+
+
+async def send_over_slim(
+    card: AgentCard,
+    text: str,
+    *,
+    context_id: str | None = None,
+    slim_url: str | None = None,
+    secret: str | None = None,
+) -> A2aReply:
+    """Send ``text`` to a SLIM-reachable A2A agent (described by ``card``).
+
+    ``card`` is the remote's Agent Card carrying a SLIM interface (its SLIM
+    name). Mirrors :func:`send_to_a2a` but over SLIMRPC. Raises
+    :class:`A2aSendError` on failure so the caller falls back faithfully.
+    """
+    url = slim_url or settings.SLIM_NODE_ENDPOINT
+    key = secret or resolve_master_secret()
+    try:
+        _service, app_handle, _local_name, conn_id = await asyncio.wait_for(
+            setup_slim_client(_CALLER_NS, _CALLER_GROUP, _CALLER_NAME, slim_url=url, secret=key),
+            timeout=_CONNECT_TIMEOUT_S,
+        )
+    except Exception as exc:  # timeout or any SLIM setup failure -> send failure
+        raise A2aSendError(f"SLIM connect failed ({url}): {exc}") from exc
+
+    channel_factory = slimrpc_channel_factory(app_handle, conn_id)
+    streaming = bool(getattr(getattr(card, "capabilities", None), "streaming", False))
+    config = ClientConfig(
+        streaming=streaming,
+        accepted_output_modes=["text"],
+        grpc_channel_factory=channel_factory,
+    )
+    client = MultiAgentClientFactory(config).create(card=card)
+
+    message = Message(message_id="mycelium-seat", role=Role.ROLE_USER, parts=[Part(text=text)])
+    if context_id:
+        message.context_id = context_id
+
+    chunks: list[str] = []
+    thread: str | None = context_id
+    try:
+        async for response in client.send_message(SendMessageRequest(message=message)):
+            chunk, ctx = _collect(cast(StreamResponse, response))
+            if chunk:
+                chunks.append(chunk)
+            if ctx:
+                thread = ctx
+    except Exception as exc:  # SLIMRPC surfaces various transport errors
+        raise A2aSendError(f"SLIM send failed: {exc}") from exc
+
+    reply = " ".join(c for c in chunks if c).strip()
+    if not reply:
+        raise A2aSendError("remote agent returned no text over SLIM")
+    return A2aReply(text=reply, context_id=thread)

--- a/fastapi-backend/pyproject.toml
+++ b/fastapi-backend/pyproject.toml
@@ -17,8 +17,9 @@ dependencies = [
     "slim-bindings>=2.1,<2.2",
     "negmas>=0.15.7",
     "pyjwt[crypto]>=2.10,<3",
-    "a2a-sdk==1.1.2",
+    "a2a-sdk==1.1.0",
     "sse-starlette>=3.4.8",
+    "slima2a",
 ]
 
 [dependency-groups]
@@ -35,6 +36,9 @@ dev = [
 
 [tool.uv]
 package = false
+
+[tool.uv.sources]
+slima2a = { git = "https://github.com/agntcy/slim-a2a-python" }
 
 [build-system]
 requires = ["uv_build"]

--- a/fastapi-backend/tests/test_a2a_slim_transport.py
+++ b/fastapi-backend/tests/test_a2a_slim_transport.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""PoC (#726): the A2A-over-SLIM outbound transport.
+
+A live SLIMRPC round-trip needs a reachable SLIM node AND the remote running a
+``slima2a`` server, so it can't be a unit test. What's hermetic is the
+error-wrapping contract: any SLIM setup/transport failure surfaces as
+``A2aSendError`` so the responder falls back faithfully, same as the HTTP path.
+"""
+
+import os
+
+import pytest
+from a2a.types import AgentCapabilities, AgentCard
+
+from app.services import a2a_slim_transport
+from app.services.a2a_bridge import A2aSendError
+from app.services.a2a_slim_transport import send_over_slim
+
+_CARD = AgentCard(name="remote", version="1.0.0", capabilities=AgentCapabilities(streaming=False))
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_surfaces_as_a2a_send_error(monkeypatch):
+    async def _boom(*_a, **_k):
+        raise RuntimeError("no node here")
+
+    monkeypatch.setattr(a2a_slim_transport, "setup_slim_client", _boom)
+    with pytest.raises(A2aSendError, match="SLIM connect failed"):
+        await send_over_slim(_CARD, "hi")
+
+
+@pytest.mark.skipif(
+    not os.getenv("MYCELIUM_SLIM_ENDPOINT"),
+    reason="needs a reachable SLIM node (MYCELIUM_SLIM_ENDPOINT) + a slima2a server",
+)
+@pytest.mark.asyncio
+async def test_live_slim_hop():
+    # With a node but no remote server, the send fails after connect — which still
+    # proves the SLIM client connects to the node and the transport is wired.
+    with pytest.raises(A2aSendError):
+        await send_over_slim(_CARD, "hi", slim_url=os.environ["MYCELIUM_SLIM_ENDPOINT"])

--- a/fastapi-backend/uv.lock
+++ b/fastapi-backend/uv.lock
@@ -9,21 +9,31 @@ resolution-markers = [
 
 [[package]]
 name = "a2a-sdk"
-version = "1.1.2"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "culsans" },
     { name = "google-api-core" },
     { name = "googleapis-common-protos" },
     { name = "httpx" },
+    { name = "httpx-sse" },
     { name = "json-rpc" },
     { name = "packaging" },
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/cc/59b35c518d8289bd59d20d9d216ca29ccb41c4697eb85971efe41d1adaf3/a2a_sdk-1.1.2.tar.gz", hash = "sha256:f928d8bf9a0dc0a473ee8258bd5226c1b8520a85c70e7f233c3b9b0e30a1bd10", size = 379627, upload-time = "2026-07-22T13:40:51.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/7e/8ac10bbf8b15b16574355f39b17dbdf617a282c27b41c7ff2116e30336df/a2a_sdk-1.1.0.tar.gz", hash = "sha256:e8102dad1b36709dbdc3d19319e38e6dfa3b3a79c30416030eb2d482576be204", size = 375726, upload-time = "2026-05-29T09:34:43.015Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/33/d414a03d5ef5a7d6d09a20dc9f8094e7fb9edb488662ff99c535a2a62cf1/a2a_sdk-1.1.2-py3-none-any.whl", hash = "sha256:eb9a698f526dc45a9ea967d7804e7aa363ff273d2c44fbed699bc68c9399f9c9", size = 245981, upload-time = "2026-07-22T13:40:49.484Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ea/3a5b160cfd51c67759b08748051094d9365ceff18127633d0021950c9860/a2a_sdk-1.1.0-py3-none-any.whl", hash = "sha256:d7f5846caf18033d8bf3108b11ec827dd8dd32f867c98848ede0e39474be93be", size = 241886, upload-time = "2026-05-29T09:34:41.484Z" },
+]
+
+[package.optional-dependencies]
+sqlite = [
+    { name = "sqlalchemy", extra = ["aiosqlite", "asyncio"] },
+]
+telemetry = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
 ]
 
 [[package]]
@@ -38,6 +48,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/d3/2d310b1b839014034dba0cba685e492df8a5c7ad32c19cab7e979eed6554/aiologic-0.17.1-py3-none-any.whl", hash = "sha256:c66b319830fedb7ca3d2b2125fa6f5b653f89418c2a27ea76f259ec5f00943c0", size = 161331, upload-time = "2026-06-27T20:41:31.877Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
 ]
 
 [[package]]
@@ -588,6 +607,24 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/7e/9ecd0285e3153532ae07aeb88063c43c72b4221cf0d4d123b02f3682e3ff/greenlet-3.5.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:49520f0c95a48b42cf55414b8e8479beb274ea70431afc33e3f79903c71f4380", size = 295809, upload-time = "2026-08-10T13:25:34.023Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/60e4bbcc89252037b18087f2ec16405d5b2d5be42dde191bbf3667e96102/greenlet-3.5.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55272212cbc5f43d1d723725ab931f1939969b7e9523882ca58b55061769d053", size = 611910, upload-time = "2026-08-10T14:14:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/cd5134be659cd4a443e7a61ae670dabec165a814c51162916d637b6dd38e/greenlet-3.5.5-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655bca754a2ef4efcb0eb48a94d3f4593536d0f3d48f8ed44343c01d16a92f95", size = 624198, upload-time = "2026-08-10T14:27:25.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/30/87c212b5c684d0e72974f1063b7a9687631e8985902c06e1016542c874e7/greenlet-3.5.5-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ca5d6ae0739e5764f2cfcfaa562ac5a990cbdaedca93251c5e3cf07c362371f", size = 629504, upload-time = "2026-08-10T14:30:07.967Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ac/5c5b959999b6f09c3026b5dfe171575bc3121c5236ce74f495096f25b203/greenlet-3.5.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:147b25a42e5ca5be3d42356e8f608b37af715a1c196e9bf9d1627f3341adfe1d", size = 621439, upload-time = "2026-08-10T13:40:49.391Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2c/eb487fafc9f50ffff2b1e0b697f70fb34bf150821c08ab225aacf5583a7e/greenlet-3.5.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:1b5ed9162c0c098e0bbc2cf88a94f433c1b8926f831745252e099e5d83e17759", size = 432462, upload-time = "2026-08-10T14:30:02.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8b/6acf112ed8aee499f25b4d6949820fb02ac950ff9c1f3d793bd5be0599f2/greenlet-3.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:27493374cff1d1b7919dc8126547f2aea582737e3046147b434b1e12de56389b", size = 1581342, upload-time = "2026-08-10T14:15:05.653Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d7/734e5f198888876b42d7616ff6644c075baf6b8a2412deadd6b0e1b8b20c/greenlet-3.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12e2ee66c2aba86133f10fd99d6a8856c6d351ffb7be0e4d52ef2cc5fbb705b2", size = 1645744, upload-time = "2026-08-10T13:40:30.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/30/1f42b88dc587b5899ee50616ad56ee40cafaf225df4fb829f10183c62a5c/greenlet-3.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:49ddacd36af37735fab103846f4ee4d18a492dde72730d1699c0c8ebe30d9f18", size = 324171, upload-time = "2026-08-10T13:28:44.472Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e5/4dee4d8d2e603fe5fdd7b444e63219f7b9bd852c60c6214511c7157cbe88/greenlet-3.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:5f1b1ff4828cdc1aba4266aff814085d04a1d07959287219af021b838b265d52", size = 308362, upload-time = "2026-08-10T13:26:46.839Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -653,6 +690,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -945,6 +991,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "rapidfuzz" },
     { name = "slim-bindings" },
+    { name = "slima2a" },
     { name = "sse-starlette" },
     { name = "tiktoken" },
     { name = "watchdog" },
@@ -964,7 +1011,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = "==1.1.2" },
+    { name = "a2a-sdk", specifier = "==1.1.0" },
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0,<0.142" },
     { name = "fastembed", specifier = ">=0.8.0" },
@@ -976,6 +1023,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rapidfuzz", specifier = ">=3.14.5" },
     { name = "slim-bindings", specifier = ">=2.1,<2.2" },
+    { name = "slima2a", git = "https://github.com/agntcy/slim-a2a-python" },
     { name = "sse-starlette", specifier = ">=3.4.8" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "watchdog", specifier = ">=6.0.0" },
@@ -1095,6 +1143,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d640eb9f3782689b55cfa715094474cd5662f2f137be6a6f847a594b6e9705c", size = 17244912, upload-time = "2026-03-17T22:04:37.251Z" },
     { url = "https://files.pythonhosted.org/packages/8b/f4/6b89e297b93704345f0f3f8c62229bee323ef25682a3f9b4f89a39324950/onnxruntime-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:535b29475ca42b593c45fbb2152fbf1cdf3f287315bf650e6a724a0a1d065cdb", size = 12596856, upload-time = "2026-03-17T22:05:41.224Z" },
     { url = "https://files.pythonhosted.org/packages/43/06/8b8ec6e9e6a474fcd5d772453f627ad4549dfe3ab8c0bf70af5afcde551b/onnxruntime-1.24.4-cp312-cp312-win_arm64.whl", hash = "sha256:e6214096e14b7b52e3bee1903dc12dc7ca09cb65e26664668a4620cc5e6f9a90", size = 12270275, upload-time = "2026-03-17T22:05:31.132Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
@@ -1808,12 +1895,51 @@ wheels = [
 ]
 
 [[package]]
+name = "slima2a"
+version = "0.7.0"
+source = { git = "https://github.com/agntcy/slim-a2a-python#a7a3cd251d67f0b32467ac3a135b4834cb43e281" }
+dependencies = [
+    { name = "a2a-sdk", extra = ["sqlite", "telemetry"] },
+    { name = "slim-bindings" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/d5/1b77a026d161f98a08f11af1a5f6c47b98ee7c7e2648af525a1004826c78/sqlalchemy-2.0.52-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:be8c49131665dfe2cc74c498aa1240ffb548d0fd901325dd11c2c7a18956f727", size = 2170940, upload-time = "2026-08-11T20:58:11.25Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bd/f444444adb37b5d53753fb1730ee7a421628e2e3b756c4da461af7e6394a/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b2d9e507a458832adcfbd8af6e2036ddf069b7710b799448542ebccae2dceee", size = 3383415, upload-time = "2026-08-11T21:02:38.534Z" },
+    { url = "https://files.pythonhosted.org/packages/be/57/2eadf93a552568c57e8680b7e58bb5e9770d80942a1bdbaf4f2f63f0d7c8/sqlalchemy-2.0.52-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8738008376d22f30f411ea3efecf39b51110b6996d80bb73786f30bcfdd5fd3b", size = 3398577, upload-time = "2026-08-11T21:16:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c3/2887cf9dd111d1fbf05d22165b404c221ef43e029f7a2695e7302f27a7cc/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37a4d548327b6cab9c7d8cdb4e0e82feabee0110c4d150059068e2d1cfbd99ee", size = 3328225, upload-time = "2026-08-11T21:02:40.183Z" },
+    { url = "https://files.pythonhosted.org/packages/02/0f/466bdf9e1feeeef5587f868c187d8687e21ff8c85b1775e9041130181132/sqlalchemy-2.0.52-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e49f51a5d59857a7a0dcaf9469febf7197d9394bd88f00d69c2c4e848112cdbf", size = 3357374, upload-time = "2026-08-11T21:17:01.076Z" },
+    { url = "https://files.pythonhosted.org/packages/22/20/5c2b4583904af4173076dda1c9e53c9e2ffc7a702d2efde0216bbacbf7cb/sqlalchemy-2.0.52-cp312-cp312-win32.whl", hash = "sha256:afda3ec521d0517d0de783fc70030775841900896d832de5bbd066549290470e", size = 2129366, upload-time = "2026-08-11T21:14:50.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/06/543dab8ef62d4e9fb96fb31a30c2b8b14a8763bccf48d428294d6b3041c0/sqlalchemy-2.0.52-cp312-cp312-win_amd64.whl", hash = "sha256:2d5e53e36e37129fe0be8b9d08b6e4052c10a963ee6cda56c8c10dcc194b99ca", size = 2157344, upload-time = "2026-08-11T21:14:52.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
+]
+
+[package.optional-dependencies]
+aiosqlite = [
+    { name = "aiosqlite" },
+    { name = "greenlet" },
+    { name = "typing-extensions" },
+]
+asyncio = [
+    { name = "greenlet" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Draft PoC for #726 — do not merge as-is.** Targets `feat/a2a-bridge`. This exists so we can weigh HTTP-vs-SLIM for the bridge's outbound hop concretely.

## What it does
Carries the A2A bridge's outbound send over **SLIM (SLIMRPC)** instead of plain HTTPS, using AGNTCY's `slima2a`. `send_over_slim()` mirrors `send_to_a2a()` exactly (build client → send → collect parts), just over a SLIM channel.

## Pros
- **SLIM-native hop.** SLIM identity auth + SLIM's encryption instead of plain TLS to a third party. No plain-HTTPS egress. Aligns with the SLIM-native architecture and the identity tiers (signerjwt/spire).
- **Tiny code delta.** The send path is structurally identical to HTTP; it reuses `A2aReply` / `_collect`. One new module.
- **The forced downgrade is benign.** slima2a pins `a2a-sdk==1.1.0`; on 1.1.0 the **full backend suite passes (718)**, ruff + ty clean.

## Cons
- **Exact-pin coupling.** slima2a pins `a2a-sdk==1.1.0` *exactly*, so adopting it pins the **whole backend** to 1.1.0 — blocks any future a2a-sdk bump (security/features) until slima2a moves. Coupling to a young package.
- **Git-only dependency.** slima2a isn't confirmed on PyPI; a git dep is a supply-chain + reproducibility concern for a backend runtime dep.
- **Heavier install.** Pulls `opentelemetry-*`, `sqlalchemy`, `aiosqlite`, `greenlet`, `httpx-sse` (the `a2a-sdk[telemetry,sqlite]` extras slima2a requires).
- **Different addressing model, not a drop-in.** SLIM agents are addressed by SLIM identity (namespace/group/name), not an HTTPS card URL. A SLIM agent needs a SLIM-interface card and the remote must run a `slima2a` SRPCHandler. Registration/resolution would need a parallel flow.
- **Connect retries, not fail-fast.** `setup_slim_client` retries on an unreachable node (I had to bound it with a timeout); HTTP surfaces a connect error immediately.
- **Does NOT change the security boundary.** SLIMRPC is point-to-point RPC to a *distinct* SLIM identity — it hardens the hop but the remote is **still not** a member of the room's MLS group, and the hub still sees plaintext. Not E2E either way (#717).
- **Not proven live here.** A round-trip needs a SLIM node + a slima2a server; only the fail-faithful error path is unit-tested.

## My recommendation
**Don't merge yet.** The `a2a-sdk==1.1.0` exact-pin coupling to a young, git-only package is a real maintenance tax, and what it buys (a hardened hop) does not change the honest boundary — the agent still isn't a room MLS member and the hub still sees plaintext. Keep **HTTP as default**; revisit when slima2a is on PyPI with a looser a2a-sdk range, or when a specific identity-tier deployment requires no plain-HTTPS egress. This PoC + the analysis is the deliverable for #726.
