### PR TITLE
fix(a2a): SSRF guard + a2a->a2a runaway guard (review blockers)

### DIFF
--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -144,6 +144,12 @@ class Settings(BaseSettings):
     ALIGNER_PI_OPENSHELL: bool = False
     # Per-turn wall-clock bound (seconds) on one pi brain call before it is killed.
     ALIGNER_PI_TIMEOUT_S: float = 120.0
+    # A2A bridge SSRF guard: registering/summoning an a2a agent makes the backend
+    # dial the card's host, so by default a host that resolves to a private,
+    # loopback, or link-local address (e.g. the cloud metadata endpoint) is
+    # refused. Flip to True only for a trusted deployment whose a2a agents live on
+    # the internal network.
+    A2A_ALLOW_PRIVATE_HOSTS: bool = False
     # Synthesizer engine (kind ``synthesizer``) — reads a room's memory and
     # compiles a structured summary as a ``knowledge`` memory. Dormant by
     # default like the aligner: nothing runs until a registered synthesizer

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -251,6 +251,13 @@ class A2aResponder:
         sender = envelope_sender(envelope)
         if _norm(sender) == _norm(handle):
             return  # never answer our own message (loop guard)
+        # Runaway guard: an a2a agent's auto-reply must not summon another a2a
+        # agent. Two agents that mention each other would otherwise ping-pong
+        # forever, each hop a real remote call. Humans, the aligner, and resident
+        # agents still trigger a reply; only registered-a2a -> registered-a2a is cut.
+        if sender and resolve_a2a_agent(room, sender) is not None:
+            logger.debug("a2a responder: skip @%s summoned by a2a agent @%s", handle, sender)
+            return
         prompt = (message_text or "").strip()
         if not prompt:
             return

--- a/fastapi-backend/app/services/a2a_card.py
+++ b/fastapi-backend/app/services/a2a_card.py
@@ -19,13 +19,19 @@ Two drift facts, proven by the #712 spike against a live agent, are baked in:
 
 from __future__ import annotations
 
+import asyncio
+import ipaddress
 import logging
+import socket
 from dataclasses import dataclass, field
+from urllib.parse import urlparse
 
 import httpx
 from a2a.client import A2ACardResolver
 from a2a.client.errors import A2AClientError
 from a2a.types import AgentCard
+
+from app.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +44,34 @@ _RESOLVE_TIMEOUT_S = 20.0
 
 class A2aCardError(Exception):
     """The remote agent's card could not be resolved or is unusable."""
+
+
+async def _guard_public_host(base: str) -> None:
+    """Refuse a card host that resolves to a non-public address (SSRF guard).
+
+    Registering or summoning an a2a agent makes the backend dial the card's
+    host, so a caller-supplied ``http://169.254.169.254/...`` or an internal
+    address would otherwise let an (unauthenticated, under the default gate-off)
+    user reach the backend's own network. We resolve the host and reject any
+    non-global IP. Best-effort against DNS rebinding: httpx re-resolves at
+    connect time, so this narrows the window rather than closing it fully.
+    """
+    if settings.A2A_ALLOW_PRIVATE_HOSTS:
+        return
+    host = urlparse(base).hostname
+    if not host:
+        raise A2aCardError(f"card URL has no host: {base!r}")
+    try:
+        infos = await asyncio.get_running_loop().getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise A2aCardError(f"card host {host!r} did not resolve: {exc}") from exc
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global:
+            raise A2aCardError(
+                f"card host {host!r} resolves to a non-public address {ip} (SSRF guard); "
+                "set A2A_ALLOW_PRIVATE_HOSTS=1 only for a trusted internal deployment"
+            )
 
 
 @dataclass(frozen=True)
@@ -93,6 +127,7 @@ async def resolve_raw_card(
     base = base_url.strip().rstrip("/")
     if not base.startswith(("http://", "https://")):
         raise A2aCardError(f"card URL must be http(s): {base_url!r}")
+    await _guard_public_host(base)
 
     owns_client = http is None
     client = http or httpx.AsyncClient(timeout=_RESOLVE_TIMEOUT_S)

--- a/fastapi-backend/tests/test_a2a_agents_route.py
+++ b/fastapi-backend/tests/test_a2a_agents_route.py
@@ -126,6 +126,31 @@ async def test_non_http_card_scheme_rejected():
         await a2a_card.resolve_card("ftp://nope")
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8080",
+        "http://169.254.169.254/latest/meta-data",  # cloud metadata endpoint
+        "http://localhost:9000",
+        "http://[::1]:8080",
+    ],
+)
+@pytest.mark.asyncio
+async def test_private_host_card_rejected_ssrf(url):
+    """SSRF guard: a card host resolving to a non-public address is refused."""
+    with pytest.raises(A2aCardError, match="SSRF|non-public|did not resolve"):
+        await a2a_card.resolve_card(url)
+
+
+@pytest.mark.asyncio
+async def test_ssrf_guard_can_be_opted_out(monkeypatch):
+    """A trusted internal deployment can allow private hosts; then the guard is a no-op
+    and resolution proceeds (and fails later on the unreachable host, not the guard)."""
+    monkeypatch.setattr("app.config.settings.A2A_ALLOW_PRIVATE_HOSTS", True)
+    with pytest.raises(A2aCardError, match="no Agent Card|did not resolve"):
+        await a2a_card.resolve_card("http://127.0.0.1:9")
+
+
 @pytest.mark.skipif(
     os.getenv("MYCELIUM_A2A_LIVE") != "1",
     reason="live A2A wire test; set MYCELIUM_A2A_LIVE=1 to run",

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -157,6 +157,22 @@ async def test_non_a2a_handle_is_ignored(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_a2a_agent_does_not_summon_another_a2a(monkeypatch):
+    # Runaway guard: @alpha (a registered a2a agent) posting a message that
+    # mentions @beta must NOT trigger beta's remote call — else two agents that
+    # mention each other ping-pong forever.
+    _register_a2a("beta", card="https://beta.example")
+    _register_a2a("alpha", card="https://alpha.example")
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "beta", _summon_envelope("alpha"), [], "hey @beta")
+    await _drain(responder)
+
+    assert calls == []
+    assert channel.sent == []
+
+
+@pytest.mark.asyncio
 async def test_self_message_does_not_loop(monkeypatch):
     _register_a2a()
     responder, channel, _persister, calls = _responder(monkeypatch)


### PR DESCRIPTION
Targets `feat/a2a-bridge`. Fixes the two review findings I'd block on before the epic reaches `main` (#719 review).

**#2 SSRF (the serious one).** Registering or summoning an a2a agent makes the backend dial the card's host, and `resolve_card` only checked the URL scheme. With the auth gate off (default) + web UI reachable, anyone could register `http://169.254.169.254/...` or an internal host and have the backend dial it. `_guard_public_host` now resolves the host and refuses any non-global IP (loopback, link-local incl. the metadata endpoint, private, IPv6 ::1). Opt out with `A2A_ALLOW_PRIVATE_HOSTS=1` for a trusted internal deployment. Runs on both registration and every send. (Best-effort vs DNS rebinding — httpx re-resolves at connect; noted in the code.)

**#3 a2a→a2a runaway.** The only loop guard was self-mention. If `@alpha`'s reply mentioned `@beta` and vice-versa they'd summon each other forever, each hop a real 120s call. Now a registered a2a agent's reply does not summon another a2a agent. Humans / aligner / resident agents still trigger replies; the inbound `a2a-guest` (unregistered) still composes with the outbound path. Only registered-a2a → registered-a2a is cut.

**Tests:** SSRF rejection across loopback/link-local/private/IPv6 + the opt-out; the a2a→a2a guard. Backend 723 passed, ruff/ty clean, openapi.json unchanged (config-only).

The other four findings (#1 allow_from, #4 message_id, #5 shared threads, #6 auth_env fail-closed) + the dedup cleanup are filed as separate follow-ups.
