### PR TITLE
docs: paint the status bar through the iOS home-indicator strip

### DIFF
--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Adapters · mycelium</title>
 <meta name="description" content="Connect Claude Code, Cursor, or any HTTP client to the Mycelium coordination layer.">
 <meta property="og:title" content="Adapters · mycelium">

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -999,7 +999,7 @@ def _head(title: str, description: str, file_name: str) -> str:
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>{html.escape(title)}</title>
 <meta name="description" content="{html.escape(description)}">
 <meta property="og:title" content="{html.escape(title)}">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>mycelium Docs</title>
 <meta name="description" content="A shared space for humans and agents. Install Mycelium and learn the core concepts: rooms, memory, plan, engines (the aligner and synthesizer), and the L9 protocol.">
 <meta property="og:title" content="mycelium Docs">

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -144,6 +144,16 @@
   --sidebar-width: 260px;
   --topbar-height: 60px;
   --statusbar-height: 26px;
+
+  /* Device safe areas. iOS reports these only when the viewport meta opts into
+   * viewport-fit=cover; everywhere else the fallback keeps them at zero, so the
+   * same expressions hold on every platform. --statusbar-total is what the rest
+   * of the layout offsets against: the bar plus whatever it has to reach down
+   * through to sit flush with the physical bottom of the screen. */
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --statusbar-total: calc(var(--statusbar-height) + var(--safe-bottom));
   /* The row the search field drops to on small screens. */
   --searchbar-height: 46px;
 
@@ -200,6 +210,7 @@ body {
   font-size: var(--text-prose);
   line-height: 1.65;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 ::selection { background: var(--accent-soft); color: var(--text); }
@@ -245,6 +256,8 @@ html { scrollbar-color: var(--border2) transparent; scrollbar-width: thin; }
   position: fixed;
   top: 0; left: 0; right: 0;
   height: var(--topbar-height);
+  padding-left: var(--safe-left);
+  padding-right: var(--safe-right);
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
@@ -387,11 +400,11 @@ a.topnav-page:hover { color: var(--text); text-decoration: none; }
 .docs-footer {
   position: fixed;
   left: 0; right: 0; bottom: 0;
-  height: var(--statusbar-height);
+  height: var(--statusbar-total);
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 0 12px;
+  padding: 0 calc(12px + var(--safe-right)) var(--safe-bottom) calc(12px + var(--safe-left));
   border-top: 1px solid var(--border);
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   backdrop-filter: blur(14px);
@@ -417,15 +430,17 @@ a.topnav-page:hover { color: var(--text); text-decoration: none; }
   display: flex;
   padding-top: var(--topbar-height);
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 /* ── SIDEBAR (the app's Explorer rail) ── */
 .sidebar {
-  width: var(--sidebar-width);
+  width: calc(var(--sidebar-width) + var(--safe-left));
+  padding-left: var(--safe-left);
   flex-shrink: 0;
   position: fixed;
   top: var(--topbar-height);
-  bottom: var(--statusbar-height);
+  bottom: var(--statusbar-total);
   overflow-y: auto;
   padding: 18px 0 28px;
   border-right: 1px solid var(--border);
@@ -548,7 +563,7 @@ a.topnav-page:hover { color: var(--text); text-decoration: none; }
 .main {
   margin-left: var(--sidebar-width);
   flex: 1;
-  padding: 28px 32px calc(var(--statusbar-height) + 40px);
+  padding: 28px 32px calc(var(--statusbar-total) + 40px);
   min-width: 0;
 }
 /* The reading pane. Near-solid so prose stays crisp; the mycelial network
@@ -1314,7 +1329,7 @@ h3:hover .header-anchor,
 /* ── RESPONSIVE ── */
 @media (max-width: 1080px) {
   .docsearch-field input { width: 130px; }
-  .main { padding: 24px 20px calc(var(--statusbar-height) + 32px); }
+  .main { padding: 24px 20px calc(var(--statusbar-total) + 32px); }
 }
 @media (max-width: 860px) {
   .main { margin-left: 0; }
@@ -1374,7 +1389,7 @@ h3:hover .header-anchor,
     right: 12px;
     width: auto;
   }
-  .main { padding: 20px 14px calc(var(--statusbar-height) + 28px); }
+  .main { padding: 20px 14px calc(var(--statusbar-total) + 28px); }
   .main-inner { padding: 24px 18px 32px; border-radius: var(--radius-lg); }
   h1 { font-size: 1.6rem; }
   h2 { font-size: 1.2rem; }

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Reference · mycelium</title>
 <meta name="description" content="Architecture, CLI reference, configuration, dependencies and compatibility, guides, and troubleshooting for Mycelium.">
 <meta property="og:title" content="Reference · mycelium">


### PR DESCRIPTION
## Summary

Fixes the gap between the bottom rail and Safari's collapsed URL pill on iOS.

**Needs a check on a real device before merging** — see Testing.

## The cause

The rail is `position: fixed; bottom: 0`, but the page never opted into `viewport-fit=cover`. Without it iOS keeps the layout viewport *above* the home-indicator safe area, so `bottom: 0` resolves to the top of that strip rather than the physical bottom of the screen. The strip below is painted with the page background — not the rail's surface — so what you see is: rail, then a band of page background, then Safari's pill. That band is the gap.

## Changes

- **`viewport-fit=cover`** in the viewport meta, so the page can paint edge to edge.
- **The rail reaches through the inset.** Its height and bottom padding now include `env(safe-area-inset-bottom)`, so its surface fills the strip while the text stays above the indicator.
- **Everything that clears the rail follows it.** A new `--statusbar-total` (bar height + bottom inset) replaces the bare height at all four offset sites — the left rail's `bottom`, and the reading pane's bottom padding at each of its three widths — so nothing ends up overlapped instead.
- **Landscape insets.** `viewport-fit=cover` also puts the notch over the top bar and the left rail in landscape, so both now inset horizontally. This is a consequence of the opt-in, not a separate change.
- **`100dvh`.** `100vh` on iOS is the *large* viewport, as though the toolbars were hidden, which makes the page taller than what the reader can see. `body` and `.layout` now prefer `100dvh` with `100vh` left in place as the fallback.

The insets resolve to `0px` off iOS, so this is inert on desktop and Android.

## Testing

Chromium always reports zero safe-area insets and does not emulate Safari's toolbar, so **I could not verify the actual iOS behaviour here.** What I did verify:

- **Nothing regresses at zero inset.** Rail is 26px and flush to the viewport bottom, rail/pane offsets unchanged, at both 390px and 1440px.
- **The plumbing responds correctly to real insets**, by overriding the inset variables at runtime and re-measuring:

  | insets | rail height | flush to bottom | text clears inset | pane bottom padding |
  | --- | --- | --- | --- | --- |
  | none | 26px | yes | 2px | 54px |
  | 34px bottom (iPhone portrait) | 60px | yes | 36px | 88px |
  | 21px bottom, 47px sides (landscape notch) | 47px | yes | 23px | 75px |

  So the surface fills the strip, the text stays above the indicator, and the content offsets track — which is the mechanism the fix depends on.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 479 passed, 2 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)
- [x] Docs-drift check clean: regeneration is idempotent

## If a gap remains

There is a second, separate iOS behaviour this does not address: Safari does not repaint fixed elements in step with the toolbar collapse/expand animation, which can show a transient gap during the transition regardless of safe-area handling. If that is what is left after this, the fix is a `visualViewport` listener driving the rail's transform, or dropping `position: fixed` on the rail below the mobile breakpoint so it simply ends the document. Worth confirming on a device first rather than adding either pre-emptively.

---
_Generated by [Claude Code](https://claude.ai/code/session_014B5igvWYYx4MCaG1PsDc63)_