### PR TITLE
Show a bell, not an at-sign, on the room row's notification control

### DIFF
--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { AtSign, BarChart3, Bell, BellOff, Boxes, Check, Plus, Search, SearchX, type LucideIcon } from "lucide-react";
+import { BarChart3, Bell, BellOff, BellRing, Boxes, Check, Plus, Search, SearchX, type LucideIcon } from "lucide-react";
 import { getAppEventsSSEUrl, type Room } from "@/lib/api";
 import { useRooms } from "@/lib/room-data";
 import { roomLevel, type RoomLevel } from "@/lib/notifications";
@@ -291,9 +291,11 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   );
 }
 
+// Every level wears a bell: the glyph is a notification control, not a mention
+// marker, so the row reads as "notifications for this room" at a glance.
 const LEVEL_OPTIONS: { level: RoomLevel; label: string; hint: string; Icon: LucideIcon }[] = [
-  { level: "all", label: "All messages", hint: "badge + bell + sound", Icon: Bell },
-  { level: "mentions", label: "Only mentions", hint: "badge; bell on @you", Icon: AtSign },
+  { level: "all", label: "All messages", hint: "badge + bell + sound", Icon: BellRing },
+  { level: "mentions", label: "Only mentions", hint: "badge; bell on @you", Icon: Bell },
   { level: "muted", label: "Muted", hint: "nothing", Icon: BellOff },
 ];
 

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -291,16 +291,15 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   );
 }
 
-// Every level wears a bell: the glyph is a notification control, not a mention
-// marker, so the row reads as "notifications for this room" at a glance.
 const LEVEL_OPTIONS: { level: RoomLevel; label: string; hint: string; Icon: LucideIcon }[] = [
   { level: "all", label: "All messages", hint: "badge + bell + sound", Icon: BellRing },
   { level: "mentions", label: "Only mentions", hint: "badge; bell on @you", Icon: Bell },
   { level: "muted", label: "Muted", hint: "nothing", Icon: BellOff },
 ];
 
-/** Discord-style notification level picker for one room. The trigger wears the
- *  current level's glyph; the menu sets it. */
+/** Discord-style notification level picker for one room. The trigger is always a
+ *  bell — it's the notification control, not a readout of the level; the level
+ *  lives in the menu it opens (and the row's own BellOff marks a muted room). */
 function RoomLevelMenu({
   room,
   level,
@@ -311,7 +310,6 @@ function RoomLevelMenu({
   onSet: (room: string, level: RoomLevel) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const Current = LEVEL_OPTIONS.find((o) => o.level === level)?.Icon ?? Bell;
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger
@@ -319,7 +317,7 @@ function RoomLevelMenu({
         onClick={(e) => e.preventDefault()}
         className="flex size-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-surface hover:text-text"
       >
-        <Current className="size-3.5" />
+        <Bell className="size-3.5" />
       </PopoverTrigger>
       <PopoverContent className="w-48 p-1">
         {LEVEL_OPTIONS.map(({ level: l, label, hint, Icon }) => (


### PR DESCRIPTION
## Summary

Each room row in the sidebar reveals a per-room notification control on hover. It was rendering the current level's glyph, and the default level is `mentions` (scope `needs-me` → `mentions`), whose glyph was `AtSign` — so in practice every room in the list showed an `@` where a notification affordance belongs.

The trigger is a control, not a readout: it now always shows a bell. The level it opens to is already shown in the menu with a checkmark, and a muted room already carries its own persistent `BellOff` on the row.

## Changes

`mycelium-frontend/src/components/rooms-sidebar.tsx`:

- `RoomLevelMenu`'s trigger renders `Bell` unconditionally instead of looking the glyph up from the current level.
- `LEVEL_OPTIONS` (the menu rows) moved into the bell family too — `BellRing` / `Bell` / `BellOff` for all / mentions / muted — so the picker reads as one notification ladder. `AtSign` is no longer imported anywhere in the app.

The menu rows keep their labels, hints, and checkmark, so choosing a level stays unambiguous.

## Testing

Frontend gate (this PR touches no Python):

- `pnpm lint` (`tsc --noEmit && eslint .`) — 0 errors, 48 pre-existing warnings, none in the touched file
- `pnpm test` — 35 files, 327 tests, all passing

- [x] Unit tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Format check passes (covered by `pnpm lint`)

## Related Issues

None.