### PR TITLE
docs: drop the status rail on mobile

### DIFF
--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -429,6 +429,8 @@ a.topnav-page:hover { color: var(--text); text-decoration: none; }
 .layout {
   display: flex;
   padding-top: var(--topbar-height);
+  padding-left: var(--safe-left);
+  padding-right: var(--safe-right);
   min-height: 100vh;
   min-height: 100dvh;
 }
@@ -1332,6 +1334,14 @@ h3:hover .header-anchor,
   .main { padding: 24px 20px calc(var(--statusbar-total) + 32px); }
 }
 @media (max-width: 860px) {
+  /* iOS does not repaint fixed elements in step with Safari's toolbar
+     collapsing, so the rail detaches and floats mid-page with content showing
+     beneath it. It carries decoration — repo link, licence, tagline — and the
+     repo link is already in the top bar, so the mobile layout drops it rather
+     than fighting the browser chrome. Zeroing the total is what reclaims the
+     space every offset was reserving for it. */
+  .docs-footer { display: none; }
+  :root { --statusbar-total: 0px; }
   .main { margin-left: 0; }
   .topnav-brand { width: auto; }
   .copy-page-btn, .copy-docs-btn { display: none; }


### PR DESCRIPTION
## Summary

Follow-up to #740. The safe-area fix there closed a real gap, but not the reported one — the rail still detaches and floats mid-page on iOS. Below 860px the rail is now dropped entirely.

## Why the previous fix wasn't enough

#740 addressed the home-indicator strip: without `viewport-fit=cover` the rail stopped short of the physical bottom and the strip below showed page background. That was real and is fixed.

The remaining problem is different. iOS doesn't repaint `position: fixed` elements in step with Safari's toolbar collapsing, so the rail ends up somewhere the browser no longer agrees is the bottom of the viewport — visibly mid-page, with content showing beneath it. No amount of bottom-inset arithmetic fixes that, because the bar isn't where the browser thinks it is. The options were to drive it from `visualViewport` in JS, or to stop pinning it on mobile.

## Changes

- **`.docs-footer` is hidden below 860px** — the stylesheet's existing mobile breakpoint, where the layout already switches to the drawer nav. The rail carries decoration (repo link, licence, tagline) and the repo link is already in the top bar, so nothing becomes unreachable.
- **`--statusbar-total` is zeroed in the same block**, which reclaims the space every offset was reserving for the rail. One redefinition rather than four edited call sites, and the page now ends on the reading pane's own padding instead of a dead band.
- **The reading pane insets horizontally.** `viewport-fit=cover` — which #740 needed — lets content reach the notch in landscape. The two rails already inset themselves; the pane is in the normal flow, so `.layout` insets it. This closes a gap #740 opened.

## Testing

Measured in Chromium at 390 / 640 / 860 / 861 / 1080 / 1440px:

| width | rail | pane bottom padding | space below content |
| --- | --- | --- | --- |
| 390 | hidden | 28px | 28px |
| 640 | hidden | 28px | 28px |
| 860 | hidden | 32px | 32px |
| 861 | shown | 58px | 58px |
| 1080 | shown | 58px | 58px |
| 1440 | shown | 66px | 66px |

Space below content matches the padding exactly at every width, so nothing is reserved for a rail that isn't there, and the rail still has its clearance where it is.

With 47px side insets simulated (landscape notch), the reading pane clears both edges — 67px at 812px wide, 61px at 390px — with no horizontal overflow at any width.

Chromium can't reproduce Safari's toolbar behaviour, so the fix for the reported symptom is by construction: there is no fixed element left at the bottom on mobile to detach.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 479 passed, 2 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)
- [x] Docs-drift check clean: regeneration is idempotent

## Related Issues

Follow-up to #728 / #732 / #734 / #740.

---
_Generated by [Claude Code](https://claude.ai/code/session_014B5igvWYYx4MCaG1PsDc63)_