### PR TITLE
fix(memory): recover timestamps instead of stamping them with read time

### DIFF
--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -48,6 +48,7 @@ from app.services.filesystem import (
     list_memory_files,
     parse_timestamp,
     read_memory_file,
+    recover_timestamps,
     room_exists,
     value_to_content,
     write_memory_file,
@@ -90,8 +91,14 @@ def _reconstruct_value(meta: dict, content: str) -> dict | str:
 
 
 def _memory_read_from_file(room_name: str, key: str, meta: dict, content: str) -> MemoryRead:
-    """Build a MemoryRead from a memory file's frontmatter + body."""
-    now = datetime.now(UTC)
+    """Build a MemoryRead from a memory file's frontmatter + body.
+
+    Stamps come from :func:`recover_timestamps`, which falls back to the file's
+    mtime rather than to read time — a memory whose frontmatter lost its
+    ``updated_at`` would otherwise report a different, always-newest timestamp on
+    every read and drift to the end of any time-ordered view.
+    """
+    created_at, updated_at = recover_timestamps(meta, get_room_dir(room_name) / f"{key}.md")
     return MemoryRead(
         id=stable_memory_id(room_name, key),
         room_name=room_name,
@@ -103,8 +110,8 @@ def _memory_read_from_file(room_name: str, key: str, meta: dict, content: str) -
         version=meta.get("version", 1),
         tags=meta.get("tags"),
         expandable=links.is_expandable(meta),
-        created_at=meta.get("created_at", now),
-        updated_at=meta.get("updated_at", now),
+        created_at=created_at,
+        updated_at=updated_at,
         file_path=f"rooms/{room_name}/{key}.md",
     )
 
@@ -364,7 +371,7 @@ async def list_memories(
     room_dir = get_room_dir(room_name)
     file_entries = list_memory_files(room_dir, prefix=prefix, limit=limit + offset)
 
-    latest_ts = max((meta.get("updated_at", "") for _, meta, _ in file_entries), default="")
+    latest_ts = max((str(meta.get("updated_at", "")) for _, meta, _ in file_entries), default="")
     etag = '"' + hashlib.md5(str(latest_ts).encode()).hexdigest() + '"' if latest_ts else '"empty"'
     if request.headers.get("if-none-match") == etag:
         return Response(status_code=304, headers={"ETag": etag})
@@ -405,12 +412,15 @@ async def search_memories(room_name: str, payload: MemorySearchRequest):
         min_similarity=payload.min_similarity,
     )
 
-    now = datetime.now(UTC)
+    room_dir = get_room_dir(room_name)
     results = []
     for rec, similarity in hits:
         value = rec.get("value")
         if value is None:
             value = {"text": rec.get("content_text")} if rec.get("content_text") else {}
+        # An index record predating a stamp resolves against the file it points
+        # at, never against read time (see _memory_read_from_file).
+        created_at, updated_at = recover_timestamps(rec, room_dir / f"{rec['key']}.md")
         memory_read = MemoryRead(
             id=stable_memory_id(room_name, rec["key"]),
             room_name=room_name,
@@ -422,8 +432,8 @@ async def search_memories(room_name: str, payload: MemorySearchRequest):
             version=rec.get("version", 1),
             tags=rec.get("tags"),
             expandable=bool(rec.get("expandable")),
-            created_at=rec.get("created_at", now),
-            updated_at=rec.get("updated_at", now),
+            created_at=created_at,
+            updated_at=updated_at,
             file_path=rec.get("file_path"),
         )
         results.append(MemorySearchResult(memory=memory_read, similarity=similarity))

--- a/fastapi-backend/app/routes/skills.py
+++ b/fastapi-backend/app/routes/skills.py
@@ -16,7 +16,6 @@ DELETE /rooms/{room}/skills/{name}   — delete a skill
 """
 
 import logging
-from datetime import UTC, datetime
 
 from fastapi import APIRouter, HTTPException, Request
 
@@ -28,7 +27,12 @@ from app.schemas import (
     SkillRead,
 )
 from app.services import actor, links, search_index, skills
-from app.services.filesystem import delete_memory_file, get_room_dir, room_exists
+from app.services.filesystem import (
+    delete_memory_file,
+    get_room_dir,
+    recover_timestamps,
+    room_exists,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -40,8 +44,18 @@ def _require_room(room_name: str) -> None:
         raise HTTPException(status_code=404, detail="Room not found")
 
 
-def _skill_read(name: str, meta: dict, body: str) -> SkillRead:
-    now = datetime.now(UTC)
+def _skill_read(room_name: str, name: str, meta: dict, body: str) -> SkillRead:
+    """Build a SkillRead from a skill memory's frontmatter + body.
+
+    A skill is a memory under ``skills/``, so its stamps are recovered the same
+    way a memory's are — off the frontmatter, else the file — never off read
+    time. ``get_skill`` reads the file directly, so without this it would report
+    a different time on each request while ``list_skills`` (which goes through
+    ``list_memory_files``) reported the recovered one.
+    """
+    created_at, updated_at = recover_timestamps(
+        meta, get_room_dir(room_name) / f"{skills.skill_key(name)}.md"
+    )
     return SkillRead(
         name=name,
         description=meta.get("description", ""),
@@ -50,8 +64,8 @@ def _skill_read(name: str, meta: dict, body: str) -> SkillRead:
         created_by=meta.get("created_by", "unknown"),
         updated_by=meta.get("updated_by"),
         version=meta.get("version", 1),
-        created_at=meta.get("created_at", now),
-        updated_at=meta.get("updated_at", now),
+        created_at=created_at,
+        updated_at=updated_at,
     )
 
 
@@ -93,7 +107,8 @@ async def list_skills(room_name: str) -> SkillListResponse:
     """List a room's skills, newest-updated first."""
     _require_room(room_name)
     items = [
-        _skill_read(name, meta, body) for name, meta, body in skills.list_room_skills(room_name)
+        _skill_read(room_name, name, meta, body)
+        for name, meta, body in skills.list_room_skills(room_name)
     ]
     return SkillListResponse(skills=items, total=len(items))
 
@@ -106,7 +121,7 @@ async def get_skill(room_name: str, name: str) -> SkillRead:
     if found is None:
         raise HTTPException(status_code=404, detail="Skill not found")
     meta, body = found
-    return _skill_read(name, meta, body)
+    return _skill_read(room_name, name, meta, body)
 
 
 @router.delete("/{name}", status_code=204)

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -37,6 +37,9 @@ ROOM_META_FILENAME = ".room.json"
 # Sentinel for "no default" so we can distinguish None from missing
 _MISSING = object()
 
+# Last-resort stamp for a memory with no recoverable time (see recover_timestamps).
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
 
 def get_data_dir() -> Path:
     """Get the .mycelium data directory, creating it if needed."""
@@ -95,15 +98,46 @@ def parse_timestamp(value: object) -> datetime | None:
     ``serialize_memory`` writes timestamps with ``.isoformat()``, so YAML quotes
     them and returns a string on the next read. Hand-written or older files may
     carry a bare timestamp that YAML parses as a datetime, hence both branches.
+    A naive value is read as UTC, so every stamp this returns is comparable with
+    every other one — a mixed list of aware and naive stamps raises on sort.
     """
     if isinstance(value, datetime):
-        return value
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
     if value is None:
         return None
     try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
     except (ValueError, TypeError):
         return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _file_mtime(path: Path | None) -> datetime | None:
+    """``path``'s modification time as an aware UTC datetime, or ``None``."""
+    if path is None:
+        return None
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+    except OSError:
+        return None
+
+
+def recover_timestamps(meta: dict[str, Any], path: Path | None = None) -> tuple[datetime, datetime]:
+    """A memory's ``(created_at, updated_at)``, recovered — never invented.
+
+    Frontmatter first; then the other stamp; then the file's mtime; only an
+    unreadable file with no stamps at all falls back to the epoch. Read time is
+    not a candidate: "now" is always the newest value there is, so substituting
+    it re-dates the memory on every read and pins it to whichever end of a
+    time-sorted list "newest" lands on.
+    """
+    created = parse_timestamp(meta.get("created_at"))
+    updated = parse_timestamp(meta.get("updated_at"))
+    if created is None or updated is None:
+        mtime = _file_mtime(path)
+        created = created or updated or mtime or _EPOCH
+        updated = updated or mtime or created
+    return created, updated
 
 
 def serialize_memory(
@@ -237,21 +271,26 @@ def list_memory_files(
     else:
         files = list(base_dir.rglob("*.md"))
 
-    results = []
+    dated: list[tuple[datetime, tuple[str, dict[str, Any], str]]] = []
     for f in files:
         try:
             text = f.read_text(encoding="utf-8")
             meta, content = parse_memory(text)
             key = _key_from_path(f, base_dir)
-            results.append((key, meta, content))
         except Exception:
             logger.warning("Failed to read memory file: %s", f)
+            continue
+        # Normalize the stamps into the meta every caller reads, so a file
+        # missing one (or carrying a bare timestamp YAML hands back as a
+        # datetime rather than a string) can neither sort to an end it doesn't
+        # belong at nor raise comparing a str against a datetime.
+        created, updated = recover_timestamps(meta, f)
+        meta["created_at"] = created.isoformat()
+        meta["updated_at"] = updated.isoformat()
+        dated.append((updated, (key, meta, content)))
 
-    def sort_key(item: tuple[str, dict[str, Any], str]) -> str:
-        return item[1].get("updated_at", "")
-
-    results.sort(key=sort_key, reverse=True)
-    return results[:limit]
+    dated.sort(key=lambda item: item[0], reverse=True)
+    return [entry for _, entry in dated[:limit]]
 
 
 def _cleanup_empty_dirs(directory: Path, stop_at: Path) -> None:

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -136,7 +136,10 @@ def recover_timestamps(meta: dict[str, Any], path: Path | None = None) -> tuple[
     if created is None or updated is None:
         mtime = _file_mtime(path)
         created = created or updated or mtime or _EPOCH
-        updated = updated or mtime or created
+        if updated is None:
+            # A restore or `cp -p` can leave an mtime behind the created stamp;
+            # never report a memory as last updated before it existed.
+            updated = max(mtime, created) if mtime else created
     return created, updated
 
 

--- a/fastapi-backend/app/services/indexer.py
+++ b/fastapi-backend/app/services/indexer.py
@@ -63,6 +63,11 @@ def _build_record(room_name: str, key: str, content: str, meta: dict) -> dict:
         "expandable": links.is_expandable(meta),
         "created_at": _iso(meta.get("created_at"), now),
         "updated_at": _iso(meta.get("updated_at"), now),
+        # When this record was built, which is what the unchanged-file check
+        # compares against the file's mtime. ``updated_at`` can't stand in for
+        # it: a memory synced from another store carries *that* store's write
+        # time, which is older than the mtime of the file it just landed in.
+        "indexed_at": now.isoformat(),
         "file_path": f"rooms/{room_name}/{key}.md",
     }
 
@@ -91,7 +96,7 @@ async def index_room(room_name: str, *, force: bool = False) -> dict:
             prior = existing.get(key)
             if not force and prior is not None:
                 mtime = _file_mtime(room_dir, key)
-                indexed_at = parse_timestamp(prior.get("updated_at"))
+                indexed_at = parse_timestamp(prior.get("indexed_at") or prior.get("updated_at"))
                 if indexed_at and indexed_at >= mtime:
                     records.append(prior)
                     stats["skipped"] += 1

--- a/fastapi-backend/app/services/memory_sync.py
+++ b/fastapi-backend/app/services/memory_sync.py
@@ -183,7 +183,7 @@ def apply_knowledge_to_dir(base_dir: Any, write: KnowledgeWrite) -> ApplyResult:
     the (heavier) index. Returns an :class:`ApplyResult`; never raises on a
     conflict — a stale-base write is a *result*, not an error.
     """
-    from app.services.filesystem import read_memory_file, write_memory_file
+    from app.services.filesystem import parse_timestamp, read_memory_file, write_memory_file
 
     existing = read_memory_file(base_dir, write.key)
     if existing is not None:
@@ -218,6 +218,13 @@ def apply_knowledge_to_dir(base_dir: Any, write: KnowledgeWrite) -> ApplyResult:
                 },
             )
 
+    # Replicate the write's own timestamps rather than the applier's clock: a
+    # knowledge message carries when the write happened, so stamping it "now"
+    # re-dates every synced memory to whenever this store caught up — a restart
+    # re-serving a backlog would land the lot at one instant. ``created_at``
+    # stays whatever the local file already had; this is an update.
+    written_at = parse_timestamp(write.updated_at)
+    created_at = parse_timestamp(existing[0].get("created_at")) if existing else None
     write_memory_file(
         base_dir,
         write.key,
@@ -225,6 +232,8 @@ def apply_knowledge_to_dir(base_dir: Any, write: KnowledgeWrite) -> ApplyResult:
         created_by=write.created_by,
         updated_by=write.updated_by,
         version=write.version,
+        created_at=created_at or written_at,
+        updated_at=written_at,
     )
     return ApplyResult(
         key=write.key,

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -394,11 +394,14 @@ def _conversational_text(content: dict[str, Any]) -> str | None:
 
 
 def parse_recorded_at(recorded_at: str) -> datetime | None:
-    """Read a record's ``recorded_at`` back as a datetime, or ``None`` if unusable."""
-    try:
-        return datetime.fromisoformat(recorded_at)
-    except (ValueError, TypeError):
-        return None
+    """Read a record's ``recorded_at`` back as an aware datetime, or ``None``.
+
+    Naive input is read as UTC. Every other timestamp the message list sorts
+    against is aware, and mixing the two raises rather than misordering.
+    """
+    from app.services.filesystem import parse_timestamp
+
+    return parse_timestamp(recorded_at)
 
 
 def stored_message_from_record(

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -393,13 +393,29 @@ def _conversational_text(content: dict[str, Any]) -> str | None:
     return text
 
 
-def stored_message_from_record(room: str, record: TranscriptRecord) -> StoredMessage | None:
+def parse_recorded_at(recorded_at: str) -> datetime | None:
+    """Read a record's ``recorded_at`` back as a datetime, or ``None`` if unusable."""
+    try:
+        return datetime.fromisoformat(recorded_at)
+    except (ValueError, TypeError):
+        return None
+
+
+def stored_message_from_record(
+    room: str, record: TranscriptRecord, *, fallback: datetime | None = None
+) -> StoredMessage | None:
     """Project a transcript record into the ``StoredMessage`` the list/UI reads.
 
     Returns None for a non-conversational, non-raise-up record. The synthetic id is
     derived from the envelope id so it's stable across reads, and ``message_id``
     carries that envelope id as the cross-store correlation key (dedup against
     ``local_state``).
+
+    ``fallback`` stands in when a record carries no readable ``recorded_at`` —
+    :func:`conversational_messages` passes the neighbouring record's stamp, the
+    tightest true bound the append-ordered transcript offers. Without one the row
+    keeps ``StoredMessage``'s read-time default, which sorts it to the newest end
+    of the feed no matter when it was actually recorded.
     """
     from app.services.local_state import StoredMessage
 
@@ -427,8 +443,9 @@ def stored_message_from_record(room: str, record: TranscriptRecord) -> StoredMes
         message_id=record.message_id or None,
         id=uuid.uuid5(_MESSAGE_ID_NS, seed),
     )
-    with contextlib.suppress(ValueError, TypeError):
-        msg.created_at = datetime.fromisoformat(record.recorded_at)
+    recorded = parse_recorded_at(record.recorded_at) or fallback
+    if recorded is not None:
+        msg.created_at = recorded
     return msg
 
 
@@ -445,6 +462,34 @@ def _stat_stamp(path: Path) -> tuple[int, int] | None:
     except OSError:
         return None
     return (st.st_mtime_ns, st.st_size)
+
+
+def _project_transcript(room: str, records: list[TranscriptRecord]) -> list[StoredMessage]:
+    """Project a whole transcript, healing records whose ``recorded_at`` is unusable.
+
+    An unstamped record inherits the nearest stamp around it in append order —
+    the record before it, or, for a leading run, the first stamped record after.
+    That keeps it where it was written instead of letting a read-time default
+    date it to now and float it to the end of the feed.
+    """
+    stamps = [parse_recorded_at(r.recorded_at) for r in records]
+    earlier: datetime | None = None
+    for i, stamp in enumerate(stamps):
+        if stamp is None:
+            stamps[i] = earlier
+        else:
+            earlier = stamp
+    later: datetime | None = None
+    for i in reversed(range(len(stamps))):
+        if stamps[i] is None:
+            stamps[i] = later
+        else:
+            later = stamps[i]
+    projected = [
+        stored_message_from_record(room, record, fallback=stamp)
+        for record, stamp in zip(records, stamps, strict=True)
+    ]
+    return [m for m in projected if m is not None]
 
 
 def conversational_messages(room: str) -> list[StoredMessage]:
@@ -465,9 +510,7 @@ def conversational_messages(room: str) -> list[StoredMessage]:
     cached = _conversational_cache.get(room)
     if cached is not None and cached[0] == stamp:
         return list(cached[1])
-    messages = [
-        m for r in load_transcript(room) if (m := stored_message_from_record(room, r)) is not None
-    ]
+    messages = _project_transcript(room, load_transcript(room))
     _conversational_cache[room] = (stamp, messages)
     return list(messages)
 

--- a/fastapi-backend/tests/test_memory_sync.py
+++ b/fastapi-backend/tests/test_memory_sync.py
@@ -8,10 +8,12 @@ apply-to-local-store write + reindex, and the last-write-wins conflict policy
 (idempotent same-version loopback; stale-base rejection with details, no merge).
 """
 
+from datetime import UTC, datetime
+
 import pytest
 
 from app.services import memory_sync, search_index
-from app.services.filesystem import get_room_dir, read_memory_file
+from app.services.filesystem import get_room_dir, parse_timestamp, read_memory_file
 from app.services.l9_models import Kind
 
 
@@ -112,6 +114,43 @@ class TestApplyKnowledge:
         assert res.applied
         got = read_memory_file(get_room_dir("r"), "plan/tasks")
         assert got is not None and "v2 wins" in got[1] and got[0]["version"] == 2
+
+
+class TestAppliedTimestamps:
+    """A knowledge message carries when the write happened; the applier replicates
+    that stamp rather than dating the memory to whenever this store caught up.
+    A restart re-serving a backlog would otherwise land the whole backlog at one
+    instant and re-sort every synced memory to the same end of the list."""
+
+    async def test_apply_keeps_the_write_s_own_updated_at(self):
+        await memory_sync.apply_knowledge("r", _write(version=1))
+
+        got = read_memory_file(get_room_dir("r"), "plan/tasks")
+
+        assert got is not None
+        assert got[0]["updated_at"] == "2026-08-04T00:00:00+00:00"
+
+    async def test_apply_does_not_stamp_the_memory_with_the_applier_s_clock(self):
+        before = datetime.now(UTC)
+
+        await memory_sync.apply_knowledge("r", _write(version=1))
+
+        got = read_memory_file(get_room_dir("r"), "plan/tasks")
+        assert got is not None
+        applied_at = parse_timestamp(got[0]["updated_at"])
+        assert applied_at is not None and applied_at < before
+
+    async def test_an_update_keeps_the_created_at_already_on_disk(self):
+        await memory_sync.apply_knowledge("r", _write(version=1))
+        first = read_memory_file(get_room_dir("r"), "plan/tasks")
+        assert first is not None
+        created = first[0]["created_at"]
+
+        await memory_sync.apply_knowledge("r", _write(version=2, base=1, content="# v2"))
+
+        got = read_memory_file(get_room_dir("r"), "plan/tasks")
+        assert got is not None
+        assert got[0]["created_at"] == created
 
 
 class TestConflictPolicy:

--- a/fastapi-backend/tests/test_memory_timestamps.py
+++ b/fastapi-backend/tests/test_memory_timestamps.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""A memory's timestamps are recovered from what's stored, never from read time.
+
+Substituting ``now`` for a stamp the store can't find is the worst available
+guess: "now" is by definition the newest value there is, so the memory reports a
+different time on every read and pins itself to whichever end of a time-ordered
+view "newest" lands on — the whole set drifts to one end of the room's memory
+list and of the chat feed's knowledge notices.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.routes.memory import _memory_read_from_file
+from app.services.filesystem import (
+    get_room_dir,
+    list_memory_files,
+    parse_memory,
+    read_memory_file,
+    recover_timestamps,
+    write_memory_file,
+)
+
+ROOM = "stamps"
+
+
+@pytest.fixture(autouse=True)
+def _stub_embeddings(monkeypatch):
+    """Keep the index test off the fastembed ONNX model (see test_memory_sync.py)."""
+    monkeypatch.setattr("app.services.embedding._STUB", True)
+
+
+def _unstamped(room_dir, key: str, *, body: str = "note") -> None:
+    """Write a memory whose frontmatter carries no timestamps at all."""
+    path = room_dir / f"{key}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\nkey: {key}\ncreated_by: julia\nversion: 1\n---\n{body}\n")
+
+
+def _bare_stamps(room_dir, key: str, when: str) -> None:
+    """Write a memory with *unquoted* stamps — YAML hands these back as datetimes,
+    where the store's own writes come back as strings."""
+    path = room_dir / f"{key}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"---\nkey: {key}\ncreated_by: julia\nversion: 1\n"
+        f"created_at: {when}\nupdated_at: {when}\n---\nnote\n"
+    )
+
+
+class TestRecoverTimestamps:
+    def test_frontmatter_stamps_are_used_as_written(self, tmp_path):
+        meta = {
+            "created_at": "2026-08-19T09:48:00+00:00",
+            "updated_at": "2026-08-20T10:12:00+00:00",
+        }
+        created, updated = recover_timestamps(meta, tmp_path / "missing.md")
+        assert created == datetime(2026, 8, 19, 9, 48, tzinfo=UTC)
+        assert updated == datetime(2026, 8, 20, 10, 12, tzinfo=UTC)
+
+    def test_a_missing_stamp_falls_back_to_the_file_not_to_now(self, tmp_path):
+        path = tmp_path / "note.md"
+        path.write_text("---\nkey: note\n---\nbody\n")
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+
+        created, updated = recover_timestamps({}, path)
+
+        assert created == mtime
+        assert updated == mtime
+
+    def test_a_naive_stamp_is_read_as_utc_so_it_stays_comparable(self, tmp_path):
+        created, updated = recover_timestamps({"updated_at": datetime(2026, 8, 19, 9, 48)}, None)
+        assert updated.tzinfo is not None
+        assert created == updated
+
+    def test_the_recovered_stamp_does_not_move_between_reads(self, tmp_path):
+        path = tmp_path / "note.md"
+        path.write_text("---\nkey: note\n---\nbody\n")
+        assert recover_timestamps({}, path) == recover_timestamps({}, path)
+
+
+class TestMemoryListOrdering:
+    def test_a_memory_with_no_stamp_sorts_by_its_file_not_to_the_bottom(self):
+        room_dir = get_room_dir(ROOM)
+        old = datetime.now(UTC) - timedelta(days=3)
+        write_memory_file(
+            room_dir, "decisions/old", "b", created_by="julia", created_at=old, updated_at=old
+        )
+        _unstamped(room_dir, "agents/590")
+
+        keys = [key for key, _, _ in list_memory_files(room_dir)]
+
+        # The unstamped memory was written just now, so it belongs first — the
+        # empty-string sort key used to drop it below everything with a stamp.
+        assert keys == ["agents/590", "decisions/old"]
+
+    def test_a_bare_yaml_timestamp_does_not_break_the_listing(self):
+        room_dir = get_room_dir(ROOM)
+        write_memory_file(room_dir, "decisions/quoted", "b", created_by="julia")
+        _bare_stamps(room_dir, "agents/hand", "2026-08-19T09:48:00+00:00")
+
+        # Sorting a str against a datetime raised TypeError and took out the
+        # whole list, not just the one odd file.
+        keys = [key for key, _, _ in list_memory_files(room_dir)]
+
+        assert keys == ["decisions/quoted", "agents/hand"]
+
+    def test_listing_reports_the_recovered_stamp_to_its_callers(self):
+        room_dir = get_room_dir(ROOM)
+        _unstamped(room_dir, "agents/590")
+
+        (_key, meta, _content) = list_memory_files(room_dir)[0]
+
+        assert meta["updated_at"]
+        assert meta["updated_at"] == meta["created_at"]
+
+
+class TestMemoryReadStability:
+    def test_reading_the_same_file_twice_reports_the_same_updated_at(self):
+        room_dir = get_room_dir(ROOM)
+        _unstamped(room_dir, "agents/590")
+        stored = read_memory_file(room_dir, "agents/590")
+        assert stored is not None
+        meta, body = stored
+
+        first = _memory_read_from_file(ROOM, "agents/590", meta, body)
+        second = _memory_read_from_file(ROOM, "agents/590", meta, body)
+
+        assert first.updated_at == second.updated_at
+        assert first.created_at == second.created_at
+
+    def test_an_unstamped_memory_does_not_report_the_time_it_was_read(self):
+        room_dir = get_room_dir(ROOM)
+        _unstamped(room_dir, "agents/590")
+        stored = read_memory_file(room_dir, "agents/590")
+        assert stored is not None
+        meta, body = stored
+
+        read = _memory_read_from_file(ROOM, "agents/590", meta, body)
+
+        assert read.updated_at < datetime.now(UTC)
+
+
+@pytest.mark.asyncio
+async def test_list_endpoint_orders_an_unstamped_memory_by_its_file(client):
+    room_dir = get_room_dir(ROOM)
+    old = datetime.now(UTC) - timedelta(days=3)
+    write_memory_file(
+        room_dir, "decisions/old", "b", created_by="julia", created_at=old, updated_at=old
+    )
+    _unstamped(room_dir, "agents/590")
+
+    resp = await client.get(f"/api/rooms/{ROOM}/memory")
+
+    assert resp.status_code == 200
+    assert [m["key"] for m in resp.json()] == ["agents/590", "decisions/old"]
+
+
+def test_parse_memory_still_returns_frontmatter_untouched():
+    meta, body = parse_memory("---\nkey: k\nversion: 2\n---\nbody\n")
+    assert meta == {"key": "k", "version": 2}
+    assert body == "body"
+
+
+class TestIndexSkipCheck:
+    """The unchanged-file check compares when the record was *indexed* against the
+    file's mtime. A memory synced from another store carries that store's write
+    time, which is older than the mtime of the file it just landed in — reading
+    it as an index time would re-embed the memory on every scan."""
+
+    async def test_a_synced_memory_is_not_reindexed_on_every_scan(self):
+        from app.services import memory_sync
+        from app.services.indexer import index_room
+
+        await memory_sync.apply_knowledge(
+            ROOM,
+            memory_sync.KnowledgeWrite(
+                key="plan/tasks",
+                content="# Plan",
+                version=1,
+                created_by="julia",
+                updated_by="julia",
+                updated_at="2026-08-04T00:00:00+00:00",
+            ),
+        )
+        await index_room(ROOM)
+
+        stats = await index_room(ROOM)
+
+        assert stats["indexed"] == 0
+        assert stats["skipped"] == 1

--- a/fastapi-backend/tests/test_memory_timestamps.py
+++ b/fastapi-backend/tests/test_memory_timestamps.py
@@ -71,6 +71,17 @@ class TestRecoverTimestamps:
         assert created == mtime
         assert updated == mtime
 
+    def test_updated_never_predates_created(self, tmp_path):
+        path = tmp_path / "note.md"
+        path.write_text("---\nkey: note\n---\nbody\n")
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+        # A restore or `cp -p` can leave the file older than its created stamp.
+        created_stamp = (mtime + timedelta(days=1)).isoformat()
+
+        created, updated = recover_timestamps({"created_at": created_stamp}, path)
+
+        assert updated >= created
+
     def test_a_naive_stamp_is_read_as_utc_so_it_stays_comparable(self, tmp_path):
         created, updated = recover_timestamps({"updated_at": datetime(2026, 8, 19, 9, 48)}, None)
         assert updated.tzinfo is not None
@@ -192,3 +203,47 @@ class TestIndexSkipCheck:
 
         assert stats["indexed"] == 0
         assert stats["skipped"] == 1
+
+
+class TestSkillTimestamps:
+    """A skill is a memory under ``skills/``, read through the same frontmatter —
+    so ``GET /skills/{name}`` (a direct file read) must recover its stamps the way
+    the list endpoint does, not report the time it was called."""
+
+    async def test_get_skill_does_not_report_the_time_it_was_read(self, client):
+        room_dir = get_room_dir(ROOM)
+        _unstamped(room_dir, "skills/deploy")
+
+        first = await client.get(f"/api/rooms/{ROOM}/skills/deploy")
+        second = await client.get(f"/api/rooms/{ROOM}/skills/deploy")
+
+        assert first.status_code == 200
+        assert first.json()["updated_at"] == second.json()["updated_at"]
+
+    async def test_get_and_list_agree_on_a_skill_s_stamps(self, client):
+        room_dir = get_room_dir(ROOM)
+        _unstamped(room_dir, "skills/deploy")
+
+        listed = (await client.get(f"/api/rooms/{ROOM}/skills")).json()["skills"][0]
+        fetched = (await client.get(f"/api/rooms/{ROOM}/skills/deploy")).json()
+
+        assert listed["updated_at"] == fetched["updated_at"]
+        assert listed["created_at"] == fetched["created_at"]
+
+
+class TestTranscriptStampParsing:
+    def test_a_naive_recorded_at_comes_back_aware(self):
+        """Every other stamp the message list sorts against is aware; mixing the
+        two raises rather than misordering."""
+        from app.services.persister import parse_recorded_at
+
+        parsed = parse_recorded_at("2026-08-19T09:48:00")
+
+        assert parsed is not None
+        assert parsed.tzinfo is not None
+
+    def test_an_unusable_recorded_at_is_none(self):
+        from app.services.persister import parse_recorded_at
+
+        assert parse_recorded_at("") is None
+        assert parse_recorded_at("not a time") is None

--- a/fastapi-backend/tests/test_messages_read_path.py
+++ b/fastapi-backend/tests/test_messages_read_path.py
@@ -9,6 +9,8 @@ merge/dedup directly, node-free: they seed the transcript + list store and asser
 what ``_read_messages`` returns.
 """
 
+from datetime import UTC, datetime
+
 from app.routes.messages import _read_messages
 from app.services import l9, local_state, persister
 from app.services.filesystem import get_room_dir
@@ -83,3 +85,89 @@ def test_read_merges_event_ledger_rows_that_only_live_in_memory(tmp_path, monkey
 
     served = _read_messages(room, None)
     assert {m.content for m in served} == {"chat", "a PR opened"}
+
+
+def _knowledge_record(message_id: str, *, key: str, recorded_at: str | None):
+    """A raise-up ``knowledge`` record, optionally with its ``recorded_at`` stripped."""
+    from app.services import memory_sync
+
+    write = memory_sync.KnowledgeWrite(
+        key=key,
+        content="note",
+        version=1,
+        created_by="julia",
+        updated_by="julia",
+        updated_at="2026-08-19T09:48:00+00:00",
+    )
+    env = memory_sync.build_knowledge_envelope(
+        room="r",
+        write=write,
+        recipients=[l9.SYSTEM_ACTOR_ID],
+        subkind=memory_sync.MEMORY_WRITE_SUBKIND,
+    )
+    record = persister.record_from(
+        env, serialize_content(env, extra={"content": f"memory updated → {key}"})
+    )
+    record.message_id = message_id
+    record.recorded_at = recorded_at or ""
+    return record
+
+
+def _stamped(message_id: str, *, text: str, recorded_at: str):
+    record = _record(message_id, sender="julia", text=text)
+    record.recorded_at = recorded_at
+    return record
+
+
+def test_a_record_with_no_stamp_holds_its_place_instead_of_dating_to_now(tmp_path, monkeypatch):
+    """A transcript line the read path can't get a time out of used to fall back to
+    read time — always the newest value there is, so the row jumped to the end of
+    the feed and reported a different time on every read."""
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    local_state.clear_all()
+    room = "unstamped-room"
+    get_room_dir(room)
+    for record in (
+        _stamped("c-1", text="morning", recorded_at="2026-08-19T09:00:00+00:00"),
+        _knowledge_record("k-1", key="agents/590", recorded_at=None),
+        _stamped("c-2", text="evening", recorded_at="2026-08-20T22:17:00+00:00"),
+    ):
+        persister.append_transcript(room, record)
+
+    served = sorted(_read_messages(room, None), key=lambda m: m.created_at)
+
+    # Beside the record it was appended after, not below the newest message.
+    assert [m.message_type for m in served] == ["broadcast", "l9_knowledge", "broadcast"]
+    assert served[1].created_at == served[0].created_at
+
+
+def test_an_unstamped_record_reports_the_same_time_on_every_read(tmp_path, monkeypatch):
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    local_state.clear_all()
+    room = "unstamped-stable-room"
+    get_room_dir(room)
+    persister.append_transcript(
+        room, _stamped("c-1", text="morning", recorded_at="2026-08-19T09:00:00+00:00")
+    )
+    persister.append_transcript(room, _knowledge_record("k-1", key="agents/590", recorded_at=None))
+
+    first = _read_messages(room, None)
+    persister._conversational_cache.clear()
+    second = _read_messages(room, None)
+
+    assert [m.created_at for m in first] == [m.created_at for m in second]
+
+
+def test_a_leading_unstamped_record_inherits_the_first_stamp_that_follows(tmp_path, monkeypatch):
+    monkeypatch.setattr("app.config.settings.MYCELIUM_DATA_DIR", str(tmp_path / ".mycelium"))
+    local_state.clear_all()
+    room = "leading-unstamped-room"
+    get_room_dir(room)
+    persister.append_transcript(room, _knowledge_record("k-1", key="agents/590", recorded_at=None))
+    persister.append_transcript(
+        room, _stamped("c-1", text="morning", recorded_at="2026-08-19T09:00:00+00:00")
+    )
+
+    served = _read_messages(room, None)
+
+    assert {m.created_at for m in served} == {datetime(2026, 8, 19, 9, 0, tzinfo=UTC)}

--- a/mycelium-cli/src/mycelium/filesystem.py
+++ b/mycelium-cli/src/mycelium/filesystem.py
@@ -116,7 +116,12 @@ def recover_updated_at(meta: dict[str, Any], path: Path) -> datetime:
     Read time is deliberately not a candidate, and neither is an empty sort key:
     the first re-dates the memory every time it is looked at, the second parks
     every unstamped memory at the bottom of the list regardless of its age.
-    Mirrors the backend's ``recover_timestamps``.
+
+    The CLI's counterpart to the backend's ``recover_timestamps``, holding the
+    same never-read-time rule over a narrower surface: this store only orders
+    memories, so it resolves one stamp where the backend resolves the
+    ``(created_at, updated_at)`` pair a read model needs. Keep the rule in step
+    across the two; the shapes differ on purpose.
     """
     stamp = parse_timestamp(meta.get("updated_at")) or parse_timestamp(meta.get("created_at"))
     if stamp is not None:

--- a/mycelium-cli/src/mycelium/filesystem.py
+++ b/mycelium-cli/src/mycelium/filesystem.py
@@ -91,6 +91,42 @@ def serialize_memory(
     return f"---\n{frontmatter}\n---\n{content}\n"
 
 
+def parse_timestamp(value: object) -> datetime | None:
+    """Read a frontmatter timestamp back as a datetime, or ``None``.
+
+    ``serialize_memory`` writes ``.isoformat()``, so YAML quotes the value and
+    hands back a string; a hand-written or older file may carry a bare timestamp
+    YAML parses as a datetime. A naive value is read as UTC so every stamp
+    returned here is comparable with every other one.
+    """
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if value is None:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def recover_updated_at(meta: dict[str, Any], path: Path) -> datetime:
+    """When a memory was last written — from frontmatter, else the file's mtime.
+
+    Read time is deliberately not a candidate, and neither is an empty sort key:
+    the first re-dates the memory every time it is looked at, the second parks
+    every unstamped memory at the bottom of the list regardless of its age.
+    Mirrors the backend's ``recover_timestamps``.
+    """
+    stamp = parse_timestamp(meta.get("updated_at")) or parse_timestamp(meta.get("created_at"))
+    if stamp is not None:
+        return stamp
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+    except OSError:
+        return datetime(1970, 1, 1, tzinfo=UTC)
+
+
 def parse_memory(text: str) -> tuple[dict[str, Any], str]:
     """Parse a markdown file into (frontmatter_dict, content_body)."""
     match = re.match(r"^---\n(.*?)\n---\n(.*)", text, re.DOTALL)
@@ -176,6 +212,7 @@ def apply_knowledge(
     version: int,
     created_by: str = "system",
     updated_by: str = "system",
+    updated_at: str | None = None,
 ) -> KnowledgeApplyResult:
     """Write a carried ``knowledge`` memory locally (last-write-wins).
 
@@ -213,6 +250,10 @@ def apply_knowledge(
                     "updated_at": meta.get("updated_at"),
                 },
             )
+    # Replicate the write's own ``updated_at`` where the message carries one,
+    # rather than dating the memory to whenever this store caught up.
+    written_at = parse_timestamp(updated_at)
+    created_at = parse_timestamp(existing[0].get("created_at")) if existing else None
     write_memory(
         base_dir,
         key,
@@ -220,6 +261,8 @@ def apply_knowledge(
         created_by=created_by,
         updated_by=updated_by,
         version=version,
+        created_at=created_at or written_at,
+        updated_at=written_at,
     )
     return KnowledgeApplyResult(
         key=key, applied=True, conflict=False, reason="applied", version=version
@@ -244,7 +287,7 @@ def list_memories(
     else:
         files = list(base_dir.rglob("*.md"))
 
-    results = []
+    dated: list[tuple[datetime, tuple[str, dict[str, Any], str]]] = []
     for f in files:
         try:
             text = f.read_text(encoding="utf-8")
@@ -252,10 +295,9 @@ def list_memories(
             key = str(f.relative_to(base_dir))
             if key.endswith(".md"):
                 key = key[:-3]
-            results.append((key, meta, content))
         except Exception:
-            pass
+            continue
+        dated.append((recover_updated_at(meta, f), (key, meta, content)))
 
-    # Sort by updated_at descending (normalize to str to handle datetime objects from YAML)
-    results.sort(key=lambda x: str(x[1].get("updated_at", "")), reverse=True)
-    return results[:limit]
+    dated.sort(key=lambda item: item[0], reverse=True)
+    return [entry for _, entry in dated[:limit]]

--- a/mycelium-cli/tests/test_memory_timestamps.py
+++ b/mycelium-cli/tests/test_memory_timestamps.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The CLI store's timestamps are recovered, never invented at read time.
+
+Mirrors the backend's ``tests/test_memory_timestamps.py``. Falling back to
+``now`` (or to an empty sort key) re-dates a memory on every read and parks it at
+one end of the list regardless of its age.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from mycelium.filesystem import (
+    apply_knowledge,
+    list_memories,
+    parse_memory,
+    parse_timestamp,
+    read_memory,
+    recover_updated_at,
+    write_memory,
+)
+
+
+def _unstamped(base_dir, key: str) -> None:
+    path = base_dir / f"{key}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"---\nkey: {key}\ncreated_by: julia\nversion: 1\n---\nnote\n")
+
+
+class TestRecoverUpdatedAt:
+    def test_uses_the_frontmatter_stamp(self, tmp_path):
+        meta = {"updated_at": "2026-08-19T09:48:00+00:00"}
+        assert recover_updated_at(meta, tmp_path / "x.md") == datetime(
+            2026, 8, 19, 9, 48, tzinfo=UTC
+        )
+
+    def test_falls_back_to_the_file_not_to_now(self, tmp_path):
+        path = tmp_path / "x.md"
+        path.write_text("---\nkey: x\n---\nbody\n")
+        assert recover_updated_at({}, path) == datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+
+    def test_a_bare_yaml_datetime_is_read_as_utc(self, tmp_path):
+        stamp = recover_updated_at({"updated_at": datetime(2026, 8, 19, 9, 48)}, tmp_path / "x.md")
+        assert stamp == datetime(2026, 8, 19, 9, 48, tzinfo=UTC)
+
+
+class TestListMemories:
+    def test_an_unstamped_memory_sorts_by_its_file_not_to_the_bottom(self, tmp_path):
+        old = datetime.now(UTC) - timedelta(days=3)
+        write_memory(tmp_path, "decisions/old", "b", created_by="julia", updated_at=old)
+        _unstamped(tmp_path, "agents/590")
+
+        assert [key for key, _, _ in list_memories(tmp_path)] == ["agents/590", "decisions/old"]
+
+    def test_a_bare_yaml_timestamp_sorts_against_a_quoted_one(self, tmp_path):
+        write_memory(tmp_path, "decisions/new", "b", created_by="julia")
+        path = tmp_path / "agents/hand.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            "---\nkey: agents/hand\ncreated_by: julia\nversion: 1\n"
+            "updated_at: 2026-08-19T09:48:00+00:00\n---\nnote\n"
+        )
+
+        assert [key for key, _, _ in list_memories(tmp_path)] == ["decisions/new", "agents/hand"]
+
+
+class TestApplyKnowledge:
+    def test_a_carried_updated_at_is_replicated_not_restamped(self, tmp_path):
+        apply_knowledge(
+            tmp_path,
+            key="plan/tasks",
+            content="# Plan",
+            version=1,
+            updated_at="2026-08-04T00:00:00+00:00",
+        )
+
+        stored = read_memory(tmp_path, "plan/tasks")
+        assert stored is not None
+        assert parse_timestamp(stored[0]["updated_at"]) == datetime(2026, 8, 4, tzinfo=UTC)
+
+    def test_an_update_keeps_the_created_at_already_on_disk(self, tmp_path):
+        apply_knowledge(
+            tmp_path, key="k", content="v1", version=1, updated_at="2026-08-04T00:00:00+00:00"
+        )
+        first = read_memory(tmp_path, "k")
+        assert first is not None
+        created = first[0]["created_at"]
+
+        apply_knowledge(
+            tmp_path, key="k", content="v2", version=2, updated_at="2026-08-05T00:00:00+00:00"
+        )
+
+        second = read_memory(tmp_path, "k")
+        assert second is not None
+        assert second[0]["created_at"] == created
+
+    def test_without_a_carried_stamp_the_write_still_lands(self, tmp_path):
+        result = apply_knowledge(tmp_path, key="k", content="v1", version=1)
+
+        assert result.applied
+        meta, _body = parse_memory((tmp_path / "k.md").read_text())
+        assert parse_timestamp(meta["updated_at"]) is not None


### PR DESCRIPTION
## Summary

Knowledge notices in the room feed were showing a timestamp that had nothing to do with when the memory was written, and they piled up at the bottom of the feed — worse the longer a room had been in use, and reliably so after the containers were brought down and back up. The same defect re-sorted memories in the memory list.

Root cause: when a stored timestamp is missing or unreadable, several read paths silently substituted `datetime.now()`. "Now" is always the newest value there is, so the row reports a different time on every read *and* pins itself to whichever end of a time-ordered view "newest" lands on. It only bites on rows the store can't get a stamp for, which is why it looks like corruption that appears out of nowhere rather than a consistent offset.

Reproduced both surfaces before fixing:

```
--- room feed, oldest-first (before) ---
  08-19 09:00  broadcast     morning
  08-19 12:00  broadcast     midday
  08-20 22:17  broadcast     evening
  08-21 23:44  l9_knowledge  memory updated → agents/590   <- read time, not write time
  08-21 23:44  l9_knowledge  memory updated → agents/565

--- memory list, newest-first (before) ---
  decisions/b    updated_at='2026-08-21T23:47:49...'
  decisions/a    updated_at='2026-08-21T23:47:49...'
  agents/590     updated_at=None                            <- sorts last whatever its age
```

A memory with no `updated_at` also reported a *different* `updated_at` on each read of the same untouched file.

## Changes

- **`filesystem.recover_timestamps`** — one answer for "when was this memory written": frontmatter, then the other stamp, then the file's mtime. Read time is never a candidate. Wired into `_memory_read_from_file`, memory search, and `list_memory_files`, which also normalizes the recovered stamps into the meta it hands back so no caller has to guess again.
- **`list_memory_files` ordering** — sorted on `meta.get("updated_at", "")`, so an empty key parked every unstamped memory at the bottom. A bare (unquoted) YAML timestamp also comes back as a `datetime`, and comparing it against a quoted one raised `TypeError` and took out the whole listing, not just the odd file. Now sorts on recovered stamps, all timezone-aware.
- **`stored_message_from_record`** — left `StoredMessage`'s read-time default when a transcript record's `recorded_at` was unusable. It now inherits the neighbouring record's stamp (the record before it, or for a leading run the first stamped record after) — the tightest true bound the append-ordered transcript offers, so the row stays where it was written.
- **`apply_knowledge_to_dir`** — the emit side puts the write's `updated_at` on the wire and the apply side threw it away, re-stamping with the applier's clock. A restart re-serving a backlog therefore re-dated every synced memory to a single instant. It now replicates the carried stamp and keeps whatever `created_at` the local file already had.
- **`indexer`** — records `indexed_at`, so the unchanged-file check still compares an *index* time against the file's mtime. Without it a synced memory (whose `updated_at` is now legitimately older than the file it landed in) would re-embed on every scan.
- **CLI store** — `mycelium/filesystem.py` mirrors these backend primitives, so it gets the same sort fix and the same `updated_at` passthrough on apply.

## Testing

- `fastapi-backend/tests/test_memory_timestamps.py` (new) — recovery never returns read time, an unstamped memory sorts by its file rather than to the bottom, a bare YAML timestamp no longer breaks the listing, repeated reads of one file report one timestamp, and a synced memory is not re-indexed on every scan.
- `fastapi-backend/tests/test_messages_read_path.py` — an unstamped transcript record holds its place in the feed, reports the same time across reads, and a leading unstamped run inherits the first stamp that follows.
- `fastapi-backend/tests/test_memory_sync.py` — apply keeps the write's own `updated_at`, never the applier's clock, and keeps the `created_at` already on disk.
- `mycelium-cli/tests/test_memory_timestamps.py` (new) — the mirrored fixes in the CLI store.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — backend 697 passed, 9 skipped; CLI 487 passed, 2 skipped
- [x] Linting passes (`uv run ruff check .`) — backend + CLI
- [x] Format check passes (`uv run ruff format --check .`) — backend + CLI
- [x] `uv run ty check .` — backend + CLI

## Related Issues

<!-- none filed -->

---
_Generated by [Claude Code](https://claude.ai/code/session_016o27pxA8uu6KkgsqM7nbir)_