### PR TITLE
Preview a memory on hover in the Memory rail

### DIFF
--- a/mycelium-frontend/src/components/memory-panel.test.tsx
+++ b/mycelium-frontend/src/components/memory-panel.test.tsx
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Mycelium Contributors
 
-import { act, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { renderWithSWR } from "@/test/swr";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryPanel } from "@/components/memory-panel";
 
 const push = vi.fn();
@@ -170,5 +170,82 @@ describe("<MemoryPanel /> peek navigation", () => {
     await waitFor(() => expect(fetchMemoryExpanded).toHaveBeenCalledWith("demo", offTree.key));
     await waitFor(() => expect(detail).toHaveAttribute("data-has-integrity", "yes"));
     expect(detail).toHaveAttribute("data-rendered-body", "expanded transclusion body");
+  });
+});
+
+const treeMemory = {
+  key: "decisions/ship-it",
+  value: { text: "## Ship it\n\nWe agreed to **ship** on Friday." },
+  content_text: "Ship it",
+  version: 3,
+  created_by: "alice",
+  updated_by: "bob",
+  updated_at: "2026-01-01T00:00:00Z",
+  tags: ["consensus"],
+};
+
+describe("<MemoryPanel /> preview hovercard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.mocked(fetchMemories).mockResolvedValue([treeMemory]);
+    vi.mocked(fetchMemory).mockReset();
+    vi.mocked(fetchMemoryIntegrity).mockResolvedValue(EMPTY_INTEGRITY);
+    vi.mocked(fetchMemoryExpanded).mockResolvedValue(EMPTY_EXPAND);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const hoverRow = async () => {
+    const row = (await screen.findByText("ship-it.md")).closest("div")!;
+    fireEvent.mouseEnter(row);
+    return row;
+  };
+
+  it("opens a preview of the memory body after the hover delay", async () => {
+    renderWithSWR(<MemoryPanel roomName="demo" />);
+    const row = await hoverRow();
+
+    expect(screen.queryByTestId("memory-preview-card")).toBeNull();
+    await act(async () => { vi.advanceTimersByTime(400); });
+
+    const card = screen.getByTestId("memory-preview-card");
+    expect(card).toHaveTextContent("Ship it");
+    expect(card).toHaveTextContent("We agreed to ship on Friday.");
+    expect(card).toHaveTextContent("v3");
+    expect(card).toHaveTextContent("bob");
+    expect(row).toBeInTheDocument();
+  });
+
+  it("does not open when the pointer leaves before the delay elapses", async () => {
+    renderWithSWR(<MemoryPanel roomName="demo" />);
+    const row = await hoverRow();
+
+    await act(async () => { vi.advanceTimersByTime(200); });
+    fireEvent.mouseLeave(row);
+    await act(async () => { vi.advanceTimersByTime(400); });
+
+    expect(screen.queryByTestId("memory-preview-card")).toBeNull();
+  });
+
+  it("closes the preview once the pointer leaves the row", async () => {
+    renderWithSWR(<MemoryPanel roomName="demo" />);
+    const row = await hoverRow();
+    await act(async () => { vi.advanceTimersByTime(400); });
+    expect(screen.getByTestId("memory-preview-card")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(row);
+    expect(screen.queryByTestId("memory-preview-card")).toBeNull();
+  });
+
+  it("closes the preview when the row is clicked open", async () => {
+    renderWithSWR(<MemoryPanel roomName="demo" />);
+    await hoverRow();
+    await act(async () => { vi.advanceTimersByTime(400); });
+
+    fireEvent.click(screen.getByText("ship-it.md"));
+    await waitFor(() => expect(screen.getByTestId("memory-drawer")).toBeInTheDocument());
+    expect(screen.queryByTestId("memory-preview-card")).toBeNull();
   });
 });

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -28,6 +28,8 @@ import {
 import { useRoomMemories, useRoomMemoryIntegrity, useRoomRevalidate } from "@/lib/room-data";
 import { memoryGraphHref, memoryHref } from "@/lib/memory-routes";
 import { expandedPathsForKey, resolveMemoryPeekNavigation } from "@/lib/memory-panel-nav";
+import { MemoryPreviewCard, type PreviewAnchor } from "@/components/memory-preview-card";
+import { memoryValueText } from "@/lib/memory-preview";
 import { DetailDrawer } from "@/components/detail-drawer";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -87,16 +89,6 @@ function buildTree(memories: Memory[]): TreeNode[] {
   return root.children;
 }
 
-function formatValue(v: unknown): string {
-  if (typeof v === "string") return v;
-  if (typeof v === "object" && v !== null) {
-    const obj = v as Record<string, unknown>;
-    if ("text" in obj) return obj.text as string;
-    return JSON.stringify(v, null, 0);
-  }
-  return String(v);
-}
-
 // Filename for a memory leaf, with its extension. Keys usually omit it (they're
 // stored as markdown); a structured value with no `text` field is really JSON.
 // A key that already carries an extension is shown as-is.
@@ -109,6 +101,7 @@ function fileName(node: TreeNode): string {
 
 const ROW_H = 22; // px, matches vscode compact density
 const INDENT = 12; // px per depth level
+const PEEK_DELAY = 350; // ms of hover intent before the preview card opens
 
 interface TreeRowsProps {
   nodes: TreeNode[];
@@ -117,9 +110,20 @@ interface TreeRowsProps {
   onToggle: (path: string) => void;
   onSelect: (mem: Memory) => void;
   selected: Memory | null;
+  onPeek: (mem: Memory, row: HTMLElement) => void;
+  onPeekEnd: () => void;
 }
 
-function TreeRows({ nodes, depth, collapsed, onToggle, onSelect, selected }: TreeRowsProps) {
+function TreeRows({
+  nodes,
+  depth,
+  collapsed,
+  onToggle,
+  onSelect,
+  selected,
+  onPeek,
+  onPeekEnd,
+}: TreeRowsProps) {
   return (
     <>
       {nodes.map(node => {
@@ -132,6 +136,10 @@ function TreeRows({ nodes, depth, collapsed, onToggle, onSelect, selected }: Tre
           <div key={node.path}>
             <div
               style={{ paddingLeft, height: ROW_H }}
+              onMouseEnter={e => node.memory && onPeek(node.memory, e.currentTarget)}
+              onMouseLeave={onPeekEnd}
+              onFocus={e => node.memory && onPeek(node.memory, e.currentTarget)}
+              onBlur={onPeekEnd}
               className={`flex w-full items-center gap-1.5 pr-3 transition-colors
                 ${isSelected ? "bg-accent/15 text-text" : "hover:bg-muted text-muted-foreground hover:text-text"}`}
             >
@@ -194,6 +202,8 @@ function TreeRows({ nodes, depth, collapsed, onToggle, onSelect, selected }: Tre
                 onToggle={onToggle}
                 onSelect={onSelect}
                 selected={selected}
+                onPeek={onPeek}
+                onPeekEnd={onPeekEnd}
               />
             )}
           </div>
@@ -213,15 +223,50 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [renderedBody, setRenderedBody] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
+  const [peek, setPeek] = useState<{ memory: Memory; anchor: PreviewAnchor } | null>(null);
+  const paneRef = useRef<HTMLDivElement>(null);
+  const peekTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { principal } = useCurrentUser();
   const revalidate = useRoomRevalidate(roomName);
+
+  // Hovering a row opens a preview card after a beat of hover intent. It is
+  // anchored to the pane's left edge rather than the row, so it never covers
+  // the list the reader is scanning.
+  const endPeek = useCallback(() => {
+    if (peekTimer.current) {
+      clearTimeout(peekTimer.current);
+      peekTimer.current = null;
+    }
+    setPeek(null);
+  }, []);
+
+  const startPeek = useCallback((memory: Memory, row: HTMLElement) => {
+    if (peekTimer.current) clearTimeout(peekTimer.current);
+    peekTimer.current = setTimeout(() => {
+      const rect = row.getBoundingClientRect();
+      const pane = paneRef.current?.getBoundingClientRect();
+      setPeek({
+        memory,
+        anchor: {
+          top: rect.top,
+          height: rect.height,
+          paneLeft: pane?.left ?? rect.left,
+        },
+      });
+    }, PEEK_DELAY);
+  }, []);
+
+  useEffect(() => endPeek, [endPeek]);
 
   // Anything that would replace or unmount the editor goes through `guard`,
   // so in-progress edits are never dropped without asking.
   const { setDirty, guard, dialog: unsavedDialog } = useUnsavedGuard();
   const selectMemory = useCallback(
-    (m: Memory | null) => guard(() => setSelected(m)),
-    [guard],
+    (m: Memory | null) => {
+      endPeek();
+      guard(() => setSelected(m));
+    },
+    [endPeek, guard],
   );
 
   // The tree, plus the room-wide integrity report the drawer reads to flag a
@@ -325,7 +370,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
     }), []);
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
+    <div ref={paneRef} className="flex flex-col h-full overflow-hidden">
       {/* Stats row */}
       <div className="px-4 py-3 border-b border-border bg-paper">
         <div className="flex items-baseline gap-1.5 text-label text-muted-foreground">
@@ -357,7 +402,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto" onScroll={endPeek}>
         {/* Search */}
         <div className="px-4 py-3 border-b border-border bg-paper">
           <div className="flex gap-2">
@@ -411,7 +456,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
                   </span>
                 </div>
                 <p className="text-label text-muted-foreground line-clamp-2 leading-snug">
-                  {formatValue(r.memory.value)}
+                  {memoryValueText(r.memory.value)}
                 </p>
               </button>
             ))}
@@ -443,6 +488,8 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
                 onToggle={toggleNs}
                 onSelect={selectMemory}
                 selected={selected}
+                onPeek={startPeek}
+                onPeekEnd={endPeek}
               />
             )}
           </div>
@@ -507,6 +554,8 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
           )
         )}
       </DetailDrawer>
+
+      {peek && !selected && <MemoryPreviewCard memory={peek.memory} anchor={peek.anchor} />}
 
       {unsavedDialog}
     </div>

--- a/mycelium-frontend/src/components/memory-preview-card.tsx
+++ b/mycelium-frontend/src/components/memory-preview-card.tsx
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { FileText } from "lucide-react";
+import type { Memory } from "@/lib/api";
+import { memoryPreview, previewCardTop } from "@/lib/memory-preview";
+
+export const PREVIEW_CARD_WIDTH = 320; // px
+const GAP = 10; // px between the card and the pane's left edge
+const MARGIN = 12; // px kept clear of the viewport edges
+
+export interface PreviewAnchor {
+  /** Viewport rect of the hovered row. */
+  top: number;
+  height: number;
+  /** Left edge of the whole memories pane — the card hangs off it, not the row,
+   *  so it never covers the list it is previewing. */
+  paneLeft: number;
+}
+
+interface Props {
+  memory: Memory;
+  anchor: PreviewAnchor;
+}
+
+function relativeTime(iso: string): string {
+  if (!iso) return "";
+  const t = new Date(iso).getTime();
+  if (Number.isNaN(t)) return "";
+  const min = Math.floor((Date.now() - t) / 60_000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const d = Math.floor(hr / 24);
+  if (d === 1) return "yesterday";
+  if (d < 7) return `${d}d ago`;
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
+/** Hovercard for a memory row in the rail: a short excerpt of the body, parked
+ *  to the left of the memories pane. */
+export function MemoryPreviewCard({ memory, anchor }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [top, setTop] = useState<number | null>(null);
+  const preview = memoryPreview(memory);
+
+  // Centre on the row once the card's real height is known — before paint, so
+  // the card never appears at the provisional position first.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    setTop(
+      previewCardTop(anchor.top, anchor.height, el.offsetHeight, window.innerHeight, MARGIN),
+    );
+  }, [anchor.top, anchor.height, memory.key]);
+
+  if (typeof document === "undefined") return null;
+
+  const left = Math.max(MARGIN, anchor.paneLeft - PREVIEW_CARD_WIDTH - GAP);
+  const author = memory.updated_by || memory.created_by;
+  const when = relativeTime(memory.updated_at);
+
+  return createPortal(
+    <div
+      ref={ref}
+      role="tooltip"
+      data-testid="memory-preview-card"
+      style={{
+        position: "fixed",
+        left,
+        top: top ?? anchor.top,
+        width: PREVIEW_CARD_WIDTH,
+        visibility: top === null ? "hidden" : "visible",
+      }}
+      className="pointer-events-none z-50 animate-in fade-in-0 zoom-in-95 rounded-xl border border-border bg-elevated shadow-lg duration-100"
+    >
+      <div className="flex items-start gap-1.5 border-b border-border px-3 py-2">
+        <FileText className="mt-px size-3.5 flex-shrink-0 text-faint" />
+        <span className="min-w-0 flex-1 break-all font-mono text-label text-text">
+          {memory.key}
+        </span>
+        {memory.key.startsWith("skills/") && (
+          <span className="flex-shrink-0 rounded-sm border border-accent/30 bg-accent/10 px-1 text-[9px] font-medium leading-tight text-accent">
+            skill
+          </span>
+        )}
+      </div>
+
+      <div className="px-3 py-2">
+        {preview.empty ? (
+          <p className="text-label italic text-faint">Empty memory</p>
+        ) : (
+          <div className="space-y-1">
+            {preview.lines.map((line, i) => (
+              <p
+                key={i}
+                className={`text-label leading-snug ${line ? "text-muted-foreground" : "h-1"}`}
+              >
+                {line}
+              </p>
+            ))}
+            {preview.truncated && (
+              <p className="pt-0.5 text-micro text-faint">Click to read the rest…</p>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1 border-t border-border px-3 py-1.5 text-micro text-faint">
+        <span className="tabular">v{memory.version}</span>
+        {author && (
+          <>
+            <span>·</span>
+            <span className="font-mono">{author}</span>
+          </>
+        )}
+        {when && (
+          <>
+            <span>·</span>
+            <span className="tabular">{when}</span>
+          </>
+        )}
+        {memory.tags && memory.tags.length > 0 && (
+          <span className="ml-auto flex flex-wrap gap-1">
+            {memory.tags.slice(0, 3).map(tag => (
+              <span
+                key={tag}
+                className="rounded-full border border-border bg-surface px-1.5 font-mono text-micro text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </span>
+        )}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/mycelium-frontend/src/lib/memory-preview.test.ts
+++ b/mycelium-frontend/src/lib/memory-preview.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import {
+  flattenMarkdown,
+  memoryPreview,
+  memoryValueText,
+  previewCardTop,
+} from "@/lib/memory-preview";
+
+describe("memoryValueText", () => {
+  it("returns prose as written", () => {
+    expect(memoryValueText("just prose")).toBe("just prose");
+  });
+
+  it("unwraps the text field of a structured value", () => {
+    expect(memoryValueText({ text: "body", category: "decisions" })).toBe("body");
+  });
+
+  it("serialises a value with no text field", () => {
+    expect(memoryValueText({ a: 1 })).toBe('{"a":1}');
+  });
+});
+
+describe("flattenMarkdown", () => {
+  it("strips heading, emphasis, and code decoration", () => {
+    expect(flattenMarkdown("## Title\n\n**bold** and `code`")).toEqual([
+      "Title",
+      "",
+      "bold and code",
+    ]);
+  });
+
+  it("keeps link and wikilink text, drops the targets", () => {
+    expect(flattenMarkdown("see [the docs](http://x) and [[context/scope]]")).toEqual([
+      "see the docs and context/scope",
+    ]);
+  });
+
+  it("uses the alias of a piped wikilink", () => {
+    expect(flattenMarkdown("[[context/scope|the scope]]")).toEqual(["the scope"]);
+  });
+
+  it("marks list items with a bullet", () => {
+    expect(flattenMarkdown("- one\n2. two")).toEqual(["• one", "• two"]);
+  });
+
+  it("drops fence markers but keeps the code lines", () => {
+    expect(flattenMarkdown("```py\nx = 1\n```")).toEqual(["x = 1"]);
+  });
+
+  it("collapses blank runs and drops horizontal rules", () => {
+    expect(flattenMarkdown("a\n\n\n---\n\nb\n\n")).toEqual(["a", "", "b"]);
+  });
+});
+
+describe("memoryPreview", () => {
+  it("reports an empty body rather than rendering a blank card", () => {
+    expect(memoryPreview({ value: "   " }).empty).toBe(true);
+  });
+
+  it("clips at the line budget and flags the excerpt as truncated", () => {
+    const body = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
+    const preview = memoryPreview({ value: body }, { maxLines: 3 });
+    expect(preview.lines).toEqual(["line 0", "line 1", "line 2"]);
+    expect(preview.truncated).toBe(true);
+  });
+
+  it("clips a long line at a word boundary", () => {
+    const preview = memoryPreview({ value: "alpha beta gamma delta" }, { maxChars: 14 });
+    expect(preview.lines).toEqual(["alpha beta…"]);
+    expect(preview.truncated).toBe(true);
+  });
+
+  it("leaves a body inside both budgets whole", () => {
+    const preview = memoryPreview({ value: "short body" });
+    expect(preview.lines).toEqual(["short body"]);
+    expect(preview.truncated).toBe(false);
+  });
+
+  it("falls back to content_text when the value carries no prose", () => {
+    expect(memoryPreview({ value: "", content_text: "indexed text" }).lines).toEqual([
+      "indexed text",
+    ]);
+  });
+});
+
+describe("previewCardTop", () => {
+  it("centres the card on its row when there is room", () => {
+    expect(previewCardTop(300, 22, 200, 900)).toBe(211);
+  });
+
+  it("keeps a card near the bottom edge inside the viewport", () => {
+    expect(previewCardTop(860, 22, 200, 900, 12)).toBe(688);
+  });
+
+  it("keeps a card near the top edge inside the viewport", () => {
+    expect(previewCardTop(0, 22, 200, 900, 12)).toBe(12);
+  });
+
+  it("pins to the top margin when the card is taller than the viewport", () => {
+    expect(previewCardTop(300, 22, 800, 400, 12)).toBe(12);
+  });
+});

--- a/mycelium-frontend/src/lib/memory-preview.ts
+++ b/mycelium-frontend/src/lib/memory-preview.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import type { Memory } from "@/lib/api";
+
+/** Plain text for a memory's value: prose as written, anything else as JSON. */
+export function memoryValueText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "object" && value !== null) {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.text === "string") return obj.text;
+    return JSON.stringify(value, null, 0);
+  }
+  return String(value);
+}
+
+// The hovercard shows an excerpt, not a rendered document: markdown syntax is
+// flattened to the text it decorates so a cut-off construct can't leave a
+// dangling marker on screen.
+function flattenLine(line: string): string {
+  return line
+    .replace(/^\s{0,3}#{1,6}\s+/, "")
+    .replace(/^\s{0,3}>\s?/, "")
+    .replace(/^\s{0,3}([-*+]|\d+\.)\s+/, "• ")
+    .replace(/!?\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g, (_m, key, alias) => alias || key)
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, (_m, text) => text)
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/(\*\*|__)(.+?)\1/g, "$2")
+    .replace(/(\*|_)(.+?)\1/g, "$2")
+    .trim();
+}
+
+/** Markdown flattened to plain lines: fences dropped, blank runs collapsed. */
+export function flattenMarkdown(body: string): string[] {
+  const lines: string[] = [];
+  let inFence = false;
+  for (const raw of body.split("\n")) {
+    if (/^\s*(```|~~~)/.test(raw)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      lines.push(raw.trim());
+      continue;
+    }
+    // A setext underline or a horizontal rule is decoration with no text.
+    if (/^\s*([-*_=])\1{2,}\s*$/.test(raw)) continue;
+    const line = flattenLine(raw);
+    if (!line && (lines.length === 0 || lines[lines.length - 1] === "")) continue;
+    lines.push(line);
+  }
+  while (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+export interface MemoryPreview {
+  /** Excerpt lines, already clipped to the line and character budgets. */
+  lines: string[];
+  /** True when the body ran past the budget, so the card can say so. */
+  truncated: boolean;
+  /** True when there is no body at all — the card shows a placeholder. */
+  empty: boolean;
+}
+
+const MAX_LINES = 12;
+const MAX_CHARS = 520;
+
+/** A short excerpt of a memory's body for the rail hovercard. */
+export function memoryPreview(
+  memory: Pick<Memory, "value" | "content_text">,
+  { maxLines = MAX_LINES, maxChars = MAX_CHARS } = {},
+): MemoryPreview {
+  const body = memoryValueText(memory.value) || memory.content_text || "";
+  const all = flattenMarkdown(body);
+  if (all.length === 0) return { lines: [], truncated: false, empty: true };
+
+  const lines: string[] = [];
+  let used = 0;
+  let truncated = false;
+  for (const line of all.slice(0, maxLines)) {
+    const room = maxChars - used;
+    if (room <= 0) {
+      truncated = true;
+      break;
+    }
+    if (line.length > room) {
+      lines.push(`${clipAtWord(line, room)}…`);
+      truncated = true;
+      break;
+    }
+    lines.push(line);
+    used += line.length + 1;
+  }
+  return { lines, truncated: truncated || lines.length < all.length, empty: false };
+}
+
+function clipAtWord(line: string, limit: number): string {
+  const head = line.slice(0, limit);
+  const space = head.lastIndexOf(" ");
+  return (space > limit * 0.6 ? head.slice(0, space) : head).trimEnd();
+}
+
+/** Vertical placement for a card anchored to a row, clamped to the viewport. */
+export function previewCardTop(
+  anchorTop: number,
+  anchorHeight: number,
+  cardHeight: number,
+  viewportHeight: number,
+  margin = 12,
+): number {
+  const centered = anchorTop + anchorHeight / 2 - cardHeight / 2;
+  const lowest = viewportHeight - cardHeight - margin;
+  if (lowest < margin) return margin;
+  return Math.min(Math.max(centered, margin), lowest);
+}


### PR DESCRIPTION
## Summary

Scanning the Memory rail meant clicking a row to find out what was in it, then
clicking back out. This adds a hovercard: hover a memory row and, after a beat
of hover intent (350ms), a card opens with a short excerpt of the body plus its
version, author, age and tags.

The card is anchored to the **left edge of the whole memories pane**, not to the
row — so it never covers the list being scanned. It is vertically centred on the
hovered row and clamped to the viewport.

## Changes

- **`lib/memory-preview.ts`** (new) — the excerpt logic, all pure and unit-tested:
  - `memoryValueText` — prose as written, a structured value unwrapped via its
    `text` field, anything else serialised. This is the old `formatValue` from
    `memory-panel.tsx`, moved out and now shared with the search-results rows.
  - `flattenMarkdown` — markdown flattened to plain lines (headings, emphasis,
    code, links and `[[wikilinks]]` reduced to the text they decorate; fences and
    rules dropped; blank runs collapsed). A hovercard shows an excerpt, not a
    rendered document, so a clipped construct can't leave a dangling marker on
    screen.
  - `memoryPreview` — clips to a line and character budget, breaking a long line
    at a word boundary, and reports whether it truncated so the card can say so.
  - `previewCardTop` — vertical placement, clamped to the viewport.
- **`components/memory-preview-card.tsx`** (new) — the card itself: portalled to
  `document.body` so the rail's `overflow-hidden` can't clip it, `pointer-events-
  none` so it can't intercept a click meant for the row, positioned pre-paint in
  a layout effect once its real height is known. Built from existing design
  tokens, so it themes with everything else.
- **`components/memory-panel.tsx`** — hover-intent plumbing on the tree rows
  (`onMouseEnter`/`onMouseLeave`, plus `onFocus`/`onBlur` so keyboard traversal
  gets the same preview). The card closes on pointer-leave, on scroll, and when a
  row is clicked open into the drawer.

The excerpt comes from the memory the tree already holds — the list endpoint
returns full bodies — so opening a preview costs no request.

Search-result rows are deliberately left alone: they already render an inline
two-line snippet, so a hovercard there would be redundant.

## Testing

Frontend-only change, so the Python gates in this template don't apply; the
frontend gate is below.

- [x] Unit tests pass — `pnpm test`: 36 files, 349 tests, all green. 18 new cases
      for the preview helpers, 4 new for the panel (opens after the delay, does
      not open if the pointer leaves first, closes on leave, closes on click).
- [x] Linting + typecheck pass — `pnpm lint` (`tsc --noEmit && eslint .`): 0
      errors, and the warning count is unchanged from `main` (48 pre-existing).
- [x] Manual — driven in `dev:mock` with Playwright at 1440x900. Verified the
      card renders left of the pane with no overlap (card `x: 771..1091`, pane
      starts at `x: 1100`), centres on the hovered row, and that a long markdown
      memory flattens and clips as intended.

## Related Issues

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9J2tFJ5VxVwpd1hwQyFbJ)_