### PR TITLE
Restyle the composer send button as a chromeless paper plane

### DIFF
--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -5,8 +5,8 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
-import { ArrowUp } from "lucide-react";
 import { sendRoomMessage, type Memory } from "@/lib/api";
+import { SendPlaneIcon } from "@/components/send-plane-icon";
 import { useRoomMemories, useRoomRoster, useRoomSkills } from "@/lib/room-data";
 import { useKeyAction } from "@/components/keymap-provider";
 import { useCurrentUser } from "@/components/current-user";
@@ -205,6 +205,11 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
     }
   }, [content, onSent, roomName, principal, sending]);
 
+  // The button carries no chrome at rest — the composer's own border is the
+  // affordance and Enter is the primary path. It only colors up, and only
+  // grows a hover surface, once there is something to send.
+  const armed = content.trim().length > 0 && !sending;
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (trigger !== null && candidates.length > 0) {
       if (e.key === "ArrowDown") {
@@ -286,11 +291,17 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
             <button
               type="button"
               onClick={submit}
-              disabled={!content.trim() || sending}
+              disabled={!armed}
               aria-label="Send message"
-              className="ml-auto flex size-8 items-center justify-center rounded-full bg-accent text-accent-fg transition-opacity hover:opacity-90 disabled:opacity-30 disabled:cursor-not-allowed"
+              className={`group ml-auto grid size-8 place-items-center rounded-xl transition-colors ${
+                armed ? "text-accent hover:bg-accent-soft" : "cursor-not-allowed text-faint"
+              }`}
             >
-              <ArrowUp className="size-4" strokeWidth={2.5} />
+              <SendPlaneIcon
+                className={`size-[17px] transition-[transform,opacity] duration-200 ease-out ${
+                  sending ? "translate-x-1.5 -translate-y-1.5 opacity-0" : ""
+                } ${armed ? "group-hover:-translate-y-px group-hover:translate-x-px group-active:scale-90" : ""}`}
+              />
             </button>
           </div>
         </div>

--- a/mycelium-frontend/src/components/send-plane-icon.tsx
+++ b/mycelium-frontend/src/components/send-plane-icon.tsx
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import type { SVGProps } from "react";
+
+/**
+ * Remix Icon `send-plane-fill`, vendored as a single path.
+ *
+ * Upstream: Remix-Design/RemixIcon (Apache-2.0), icons/Business/send-plane-fill.svg.
+ * Vendored rather than taking an icon-set dependency: one 16px glyph doesn't
+ * justify pulling in `react-icons`, and the upstream license already matches
+ * this repo's. Refresh by re-copying the path from an updated checkout.
+ *
+ * The plane flies up-and-right, which is the reason it's this glyph and not a
+ * flat-right one: the composer sits below the transcript, so a message travels
+ * *up* into the room as much as it travels *out* to its members.
+ *
+ * The viewBox is shifted off 0 0 deliberately. Upstream centers the path by its
+ * bounding box, but a solid triangle reads from its ink, and this one's area
+ * centroid sits 2.1 right and 1.8 up of the box center — enough to look visibly
+ * shoved into the corner of a round button. The offset walks 70% of the way to
+ * the centroid: full correction swings the other way and crowds the nose
+ * against the right edge. Nothing is clipped at this offset.
+ */
+export function SendPlaneIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="1.476 -1.238 24 24" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M1.94607 9.31543C1.42353 9.14125 1.4194 8.86022 1.95682 8.68108L21.043 2.31901C21.5715 2.14285 21.8746 2.43866 21.7265 2.95694L16.2733 22.0432C16.1223 22.5716 15.8177 22.59 15.5944 22.0876L11.9999 14L17.9999 6.00005L9.99992 12L1.94607 9.31543Z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

The composer's send control was a filled accent circle wrapping a stroked `ArrowUp`. It read as a stock 2010s chat button: heavy at rest, and carrying a container the composer's own border already provides.

This swaps the glyph for Remix Icon's `send-plane-fill` and makes the button earn its chrome instead of assuming it.

**On the glyph.** Vendored as a single path rather than adding an icon-set dependency for one 16px mark — upstream Remix Icon is Apache-2.0, matching this repo, and attribution lives in the component's docstring. The plane flies **up-and-right**, which is why it's this glyph and not a flat-right one: the composer sits below the transcript, so a message travels *up* into the room as much as it travels *out* to its members. A hard-right glyph is the SMS convention (dispatch to one recipient) and fights the layout.

**On the container.** No, the square isn't needed — the composer's border is the affordance and `Enter` is the primary path (already documented in the hint line below it). So the button is surfaceless and `text-faint` while the composer is empty, turns `text-accent` once there's something to send, and only grows an `accent-soft` hover surface on intent.

**On centering.** The vendored `viewBox` is offset from `0 0` deliberately. Upstream centers the path by its bounding box, but a solid triangle reads from its ink, and this one's area centroid sits 2.1 right and 1.8 up of the box center — enough to look visibly shoved into the corner of a round button at 17px. The offset walks 70% of the way to the centroid; full correction swings the other way and crowds the nose against the right edge. Nothing is clipped.

## Changes

- Add `src/components/send-plane-icon.tsx` — Remix Icon `send-plane-fill` vendored as one path, with upstream/license attribution and the rationale for the offset `viewBox`.
- `room-chat-box.tsx`: replace the `bg-accent` circle + `ArrowUp` with the chromeless plane, gated on a new `armed` derivation (`content.trim()` non-empty and not mid-send), which also now drives the `disabled` state.
- Micro-interaction: the glyph nudges along its flight vector on hover, scales down on press, and flies up-and-right as it fades on submit.
- No new dependency; `package.json` and the lockfile are untouched.

## Testing

Frontend gate only — this is a presentational change with no backend surface.

- [x] Unit tests pass — `pnpm test`, 349 passed across 36 files (incl. the 6 existing `room-chat-box.test.tsx` composer-trigger tests, which exercise the `@` / `[[` / `/` sigils around this control)
- [x] Linting passes — `pnpm lint` (tsc + eslint), 0 errors; the 48 warnings are pre-existing and none are in the two touched files
- [x] Manual: captured both themes in `pnpm dev:mock` at idle, armed, hover, and press, and measured the glyph's ink centroid against the button center to pick the offset

The backend checks in the template don't apply — no Python changed.

## Related Issues

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShnFPikGLLtHhAoKnUzAwg)_