### PR TITLE
Make the workspace rails resizable

### DIFF
--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -5,6 +5,7 @@
 
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDefaultLayout } from "react-resizable-panels";
 import { type EpisodeSummary } from "@/lib/api";
 import { useRoom, useRoomRevalidate } from "@/lib/room-data";
 import { parseFocus, type FocusTarget } from "@/lib/search";
@@ -12,12 +13,20 @@ import { memoryHref } from "@/lib/memory-routes";
 import { AppShell } from "@/components/app-shell";
 import { EventStream, type View, type NegotiationPhase } from "@/components/event-stream";
 import { RoomChatBox } from "@/components/room-chat-box";
-import { RoomInspector, type Tab } from "@/components/room-inspector";
+import { RoomInspectorPanel, type Tab } from "@/components/room-inspector";
 import { RoomTour } from "@/components/room-tour";
 import { GlobalStatusItems, StatusButton } from "@/components/status-items";
 import { useCommands, useKeyAction, useKeyScope } from "@/components/keymap-provider";
 import type { PaletteCommand } from "@/lib/commands";
 import { useRoomStatus } from "@/lib/use-status";
+import { ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
+import {
+  MAIN_PANEL,
+  PANEL_INSPECTOR,
+  PANEL_MAIN,
+  ROOM_GROUP_ID,
+  layoutStorage,
+} from "@/lib/panel-layout";
 
 function episodeSummaryLabel(episodes: EpisodeSummary[] | null): { text: string; color: string } | null {
   if (!episodes || episodes.length === 0) return null;
@@ -154,6 +163,20 @@ function RoomWorkspace() {
 
   const episodeLabel = useMemo(() => episodeSummaryLabel(episodes), [episodes]);
 
+  // Chat vs. inspector is a reading preference, so the split is remembered per
+  // browser rather than reset on every visit.
+  // Both callbacks: `onLayoutChanged` fires when a drag is committed, but these
+  // are nested groups — widening the rooms rail resizes this group's container
+  // without anyone touching its own seam, and only `onLayoutChange` sees that.
+  // Saving on the commit alone leaves the stored percentages describing a
+  // container width that no longer exists, and the rail comes back a few dozen
+  // pixels off after a reload.
+  const { defaultLayout, onLayoutChange, onLayoutChanged } = useDefaultLayout({
+    id: ROOM_GROUP_ID,
+    storage: layoutStorage,
+    panelIds: [PANEL_MAIN, PANEL_INSPECTOR],
+  });
+
   const statusLeft = (
     <>
       <span
@@ -205,26 +228,33 @@ function RoomWorkspace() {
       statusLeft={statusLeft}
       statusRight={statusRight}
     >
-      <div className="flex flex-1 overflow-hidden">
-        <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <div className="flex-1 overflow-hidden">
-            <EventStream
-              roomName={roomName}
-              onMemoryChanged={handleMemoryChanged}
-              onConnectionChange={setConnected}
-              onNegotiationPhaseChange={setNegPhase}
-              onOpenMemory={openMemory}
-              view={editorView}
-              onViewChange={setEditorView}
-              suppressInvites={tourActive}
-              focusMessageId={focus?.type === "message" ? focus.id : null}
-              onFocusConsumed={clearFocus}
-            />
-          </div>
-          <RoomChatBox roomName={roomName} className={editorView !== "channel" ? "hidden" : undefined} />
-        </main>
+      <ResizablePanelGroup
+        className="min-h-0 flex-1"
+        defaultLayout={defaultLayout}
+        onLayoutChange={onLayoutChange}
+        onLayoutChanged={onLayoutChanged}
+      >
+        <ResizablePanel id={PANEL_MAIN} minSize={MAIN_PANEL.min} className="flex min-w-0">
+          <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+            <div className="flex-1 overflow-hidden">
+              <EventStream
+                roomName={roomName}
+                onMemoryChanged={handleMemoryChanged}
+                onConnectionChange={setConnected}
+                onNegotiationPhaseChange={setNegPhase}
+                onOpenMemory={openMemory}
+                view={editorView}
+                onViewChange={setEditorView}
+                suppressInvites={tourActive}
+                focusMessageId={focus?.type === "message" ? focus.id : null}
+                onFocusConsumed={clearFocus}
+              />
+            </div>
+            <RoomChatBox roomName={roomName} className={editorView !== "channel" ? "hidden" : undefined} />
+          </main>
+        </ResizablePanel>
 
-        <RoomInspector
+        <RoomInspectorPanel
           roomName={roomName}
           masId={room?.mas_id ?? null}
           tab={inspectorTab}
@@ -237,7 +267,7 @@ function RoomWorkspace() {
           onFocusConsumed={clearFocus}
           focusMemory={focusMemory}
         />
-      </div>
+      </ResizablePanelGroup>
 
       <RoomTour
         active={tourActive}

--- a/mycelium-frontend/src/components/app-shell.tsx
+++ b/mycelium-frontend/src/components/app-shell.tsx
@@ -5,6 +5,7 @@
 
 import type { ReactNode } from "react";
 import { Terminal } from "lucide-react";
+import { useDefaultLayout } from "react-resizable-panels";
 import { RoomsSidebar } from "@/components/rooms-sidebar";
 import { GlobalSearch, GlobalSearchButton } from "@/components/global-search";
 import { CommandPaletteButton, KeymapHelpButton } from "@/components/keymap-provider";
@@ -12,6 +13,19 @@ import { InstallModalProvider, useOpenInstallModal } from "@/components/install-
 import { MetricsStatusLink } from "@/components/status-items";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import {
+  PANEL_ROOMS,
+  PANEL_WORKSPACE,
+  ROOMS_PANEL,
+  SHELL_GROUP_ID,
+  WORKSPACE_PANEL,
+  layoutStorage,
+} from "@/lib/panel-layout";
 
 interface Props {
   /** The open room (highlights its sidebar row); null on the home view. */
@@ -39,7 +53,12 @@ function InstallCliButton() {
 /** The app frame: rooms sidebar, a top header row, workspace, and status bar
  *  (editor-style). The header row is shared by every page rather than each
  *  page drawing its own, so the "Install the CLI" affordance lives in one
- *  place instead of being re-added per page. */
+ *  place instead of being re-added per page.
+ *
+ *  The rooms rail is draggable and its width is remembered per browser — long
+ *  room names and a wide window pull in opposite directions, and this is the
+ *  one rail on every page, so it's the reader's call rather than a constant.
+ *  Double-clicking the seam puts it back to the default. */
 export function AppShell({
   activeRoom = null,
   header,
@@ -48,6 +67,12 @@ export function AppShell({
   statusRight,
   children,
 }: Props) {
+  const { defaultLayout, onLayoutChange, onLayoutChanged } = useDefaultLayout({
+    id: SHELL_GROUP_ID,
+    storage: layoutStorage,
+    panelIds: [PANEL_ROOMS, PANEL_WORKSPACE],
+  });
+
   return (
     <GlobalSearch>
       <InstallModalProvider>
@@ -55,9 +80,30 @@ export function AppShell({
           className="flex h-screen flex-col overflow-hidden bg-bg text-text"
           data-app-shell="ready"
         >
-          <div className="flex min-h-0 flex-1">
-            <RoomsSidebar activeRoom={activeRoom} />
-            <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <ResizablePanelGroup
+            className="min-h-0 flex-1"
+            defaultLayout={defaultLayout}
+            onLayoutChange={onLayoutChange}
+            onLayoutChanged={onLayoutChanged}
+          >
+            <ResizablePanel
+              id={PANEL_ROOMS}
+              defaultSize={ROOMS_PANEL.default}
+              minSize={ROOMS_PANEL.min}
+              maxSize={ROOMS_PANEL.max}
+              groupResizeBehavior="preserve-pixel-size"
+              className="flex"
+            >
+              <RoomsSidebar activeRoom={activeRoom} />
+            </ResizablePanel>
+
+            <ResizableHandle withHandle />
+
+            <ResizablePanel
+              id={PANEL_WORKSPACE}
+              minSize={WORKSPACE_PANEL.min}
+              className="flex min-w-0 flex-col"
+            >
               <header className="flex h-[52px] flex-shrink-0 items-center gap-3 border-b border-border bg-surface/50 px-5">
                 {header}
                 {/* Appearance sits top-right, the corner every app puts it in,
@@ -69,8 +115,8 @@ export function AppShell({
                 </div>
               </header>
               <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
-            </div>
-          </div>
+            </ResizablePanel>
+          </ResizablePanelGroup>
           <footer className="flex h-6 flex-shrink-0 items-center gap-3 border-t border-border bg-surface px-3 text-micro text-muted-foreground">
             {statusLeft}
             <div className="ml-auto flex items-center gap-3">

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -373,7 +373,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
     <div ref={paneRef} className="flex flex-col h-full overflow-hidden">
       {/* Stats row */}
       <div className="px-4 py-3 border-b border-border bg-paper">
-        <div className="flex items-baseline gap-1.5 text-label text-muted-foreground">
+        <div className="flex flex-wrap items-baseline gap-x-1.5 gap-y-1 text-label text-muted-foreground">
           <span className="text-text font-semibold tabular">{memories.length}</span>
           <span>memories</span>
           <span className="text-faint px-1">·</span>
@@ -381,7 +381,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
           <span>contributors</span>
           <Link
             href={memoryGraphHref(roomName)}
-            className="ml-auto inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+            className="ml-auto inline-flex flex-shrink-0 items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
             title="Open the memory link graph"
           >
             <Network className="size-3.5" />
@@ -407,7 +407,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
         <div className="px-4 py-3 border-b border-border bg-paper">
           <div className="flex gap-2">
             <input
-              className="flex-1 rounded-lg bg-surface border border-border px-3 py-2 text-label text-text placeholder:text-muted-foreground focus:border-accent focus:bg-bg focus:outline-none transition-colors"
+              className="min-w-0 flex-1 rounded-lg bg-surface border border-border px-3 py-2 text-label text-text placeholder:text-muted-foreground focus:border-accent focus:bg-bg focus:outline-none transition-colors"
               placeholder="Search memory…"
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
@@ -416,7 +416,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
             <button
               onClick={handleSearch}
               disabled={searching}
-              className="rounded-lg px-3.5 py-2 text-label font-medium bg-accent text-accent-fg transition-opacity hover:opacity-90 disabled:opacity-50"
+              className="flex-shrink-0 rounded-lg px-3.5 py-2 text-label font-medium bg-accent text-accent-fg transition-opacity hover:opacity-90 disabled:opacity-50"
             >
               {searching ? "…" : "Search"}
             </button>

--- a/mycelium-frontend/src/components/room-inspector.test.tsx
+++ b/mycelium-frontend/src/components/room-inspector.test.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { act } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The three rails fetch a room's data; this file is about the chrome around
+// them, so each stands in as a marker the assertions can look for.
+vi.mock("@/components/agents-panel", () => ({
+  AgentsPanel: () => <div>members panel</div>,
+}));
+vi.mock("@/components/episodes-rail", () => ({
+  EpisodesRail: () => <div>episodes panel</div>,
+}));
+vi.mock("@/components/memory-panel", () => ({
+  MemoryPanel: () => <div>memory panel</div>,
+}));
+
+import { RoomInspector } from "@/components/room-inspector";
+import { TAB_LABELS_MIN_WIDTH } from "@/lib/panel-layout";
+
+/** A ResizeObserver the test drives, standing in for a dragged panel edge. */
+const observers: ((width: number) => void)[] = [];
+
+class TestResizeObserver {
+  constructor(private callback: ResizeObserverCallback) {
+    observers.push(width => {
+      this.callback(
+        [{ contentRect: { width } } as ResizeObserverEntry],
+        this as unknown as ResizeObserver,
+      );
+    });
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+async function railWidth(width: number): Promise<void> {
+  await act(async () => {
+    for (const resize of observers) resize(width);
+  });
+}
+
+function renderInspector() {
+  render(<RoomInspector roomName="atlas" />);
+  return userEvent.setup();
+}
+
+describe("<RoomInspector /> tab strip", () => {
+  beforeEach(() => {
+    observers.length = 0;
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+  });
+
+  it("labels the tabs while the rail is wide enough to hold the words", async () => {
+    renderInspector();
+    await railWidth(TAB_LABELS_MIN_WIDTH + 40);
+
+    for (const label of ["Members", "Episodes", "Memory"]) {
+      expect(screen.getByRole("button", { name: label })).toHaveTextContent(label);
+    }
+  });
+
+  it("drops to icons alone once the rail is too narrow for them", async () => {
+    renderInspector();
+    await railWidth(TAB_LABELS_MIN_WIDTH - 40);
+
+    for (const label of ["Members", "Episodes", "Memory"]) {
+      // Still addressable by name — the label moved to the accessible name and
+      // the tooltip rather than disappearing.
+      expect(screen.getByRole("button", { name: label })).toHaveTextContent("");
+    }
+  });
+
+  it("switches tabs the same way at either width", async () => {
+    const user = renderInspector();
+    await railWidth(TAB_LABELS_MIN_WIDTH - 40);
+
+    await user.click(screen.getByRole("button", { name: "Memory" }));
+    expect(screen.getByText("memory panel")).toBeInTheDocument();
+  });
+});
+
+describe("<RoomInspector /> collapse", () => {
+  beforeEach(() => {
+    observers.length = 0;
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+  });
+
+  it("collapses to the icon strip and reopens on the tab you clicked", async () => {
+    const user = renderInspector();
+    expect(screen.getByText("members panel")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^Collapse the rail/ }));
+    expect(screen.queryByText("members panel")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Episodes" }));
+    expect(screen.getByText("episodes panel")).toBeInTheDocument();
+  });
+
+  it("names the keybind on the toggle, since the badge can't draw it", async () => {
+    const user = renderInspector();
+
+    const collapse = screen.getByRole("button", { name: "Collapse the rail (\\)" });
+    await user.click(collapse);
+    expect(screen.getByRole("button", { name: "Expand the rail (\\)" })).toBeInTheDocument();
+  });
+});

--- a/mycelium-frontend/src/components/room-inspector.tsx
+++ b/mycelium-frontend/src/components/room-inspector.tsx
@@ -3,12 +3,28 @@
 
 "use client";
 
-import { useState } from "react";
-import { Activity, Brain, PanelRightClose, PanelRightOpen, Users, type LucideIcon } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
+import {
+  Activity,
+  Brain,
+  PanelRightClose,
+  PanelRightOpen,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+import { usePanelRef } from "react-resizable-panels";
 import { AgentsPanel } from "@/components/agents-panel";
 import { EpisodesRail } from "@/components/episodes-rail";
 import { KeyBadge } from "@/components/key-badge";
 import { MemoryPanel } from "@/components/memory-panel";
+import { ResizableHandle, ResizablePanel } from "@/components/ui/resizable";
+import { chordFor, chordKey } from "@/lib/keymap";
+import {
+  COLLAPSED_THRESHOLD_PX,
+  INSPECTOR_PANEL,
+  PANEL_INSPECTOR,
+  TAB_LABELS_MIN_WIDTH,
+} from "@/lib/panel-layout";
 import type { FocusTarget } from "@/lib/search";
 
 // Skills aren't a rail: a skill is just a `skills/…` memory, so it shows up in
@@ -20,6 +36,15 @@ const TABS: { id: Tab; label: string; icon: LucideIcon }[] = [
   { id: "episodes", label: "Episodes", icon: Activity },
   { id: "memory", label: "Memory", icon: Brain },
 ];
+
+/** "Collapse the rail (\)" — the keybind is spelled out here because `\` isn't
+ *  a reveal chord, so KeyBadge can't draw it on the button. Unmodified, so
+ *  `chordKey` reads the same on every platform and survives hydration. */
+function railToggleTitle(open: boolean): string {
+  const chord = chordFor("rail.toggle");
+  const suffix = chord ? ` (${chordKey(chord)})` : "";
+  return `${open ? "Collapse" : "Expand"} the rail${suffix}`;
+}
 
 interface Props {
   roomName: string;
@@ -38,6 +63,89 @@ interface Props {
   onFocusConsumed?: () => void;
   /** Reveal a memory by key in the Memory tab (e.g. a clicked chat wikilink). */
   focusMemory?: { key: string; nonce: number } | null;
+}
+
+/**
+ * The inspector as a resizable panel: the seam beside it, the panel that holds
+ * it, and the wiring that makes the collapse button, the drag, and the `\`
+ * keybind three ways of doing the same thing.
+ *
+ * Open/closed *is* the panel's collapsed state rather than a second flag beside
+ * it. That's what lets the button reopen the rail at the width you last dragged
+ * it to instead of a constant, and it's why dragging the seam past the minimum
+ * shuts the rail rather than jamming against a wall. Double-clicking the seam
+ * puts it back to the default width.
+ */
+export function RoomInspectorPanel({ open: openProp, onOpenChange, ...rest }: Props) {
+  const [openInternal, setOpenInternal] = useState(true);
+  const open = openProp ?? openInternal;
+  const panelRef = usePanelRef();
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (openProp === undefined) setOpenInternal(next);
+      onOpenChange?.(next);
+    },
+    [openProp, onOpenChange],
+  );
+
+  // State → panel. `collapse`/`expand` are no-ops when already in that state,
+  // so this settles rather than ping-ponging with `onResize` below.
+  useEffect(() => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    if (open && panel.isCollapsed()) panel.expand();
+    else if (!open && !panel.isCollapsed()) panel.collapse();
+  }, [open, panelRef]);
+
+  return (
+    <>
+      <ResizableHandle withHandle />
+      <ResizablePanel
+        id={PANEL_INSPECTOR}
+        panelRef={panelRef}
+        collapsible
+        collapsedSize={INSPECTOR_PANEL.collapsed}
+        defaultSize={INSPECTOR_PANEL.default}
+        minSize={INSPECTOR_PANEL.min}
+        maxSize={INSPECTOR_PANEL.max}
+        groupResizeBehavior="preserve-pixel-size"
+        className="flex"
+        // Panel → state, so a drag past the minimum reads as "closed" to the
+        // status bar and the keybind, and a restored collapsed layout doesn't
+        // come back claiming to be open.
+        onResize={size => {
+          const collapsed = size.inPixels <= COLLAPSED_THRESHOLD_PX;
+          if (collapsed === open) setOpen(!collapsed);
+        }}
+      >
+        <RoomInspector {...rest} open={open} onOpenChange={setOpen} />
+      </ResizablePanel>
+    </>
+  );
+}
+
+/**
+ * How much of the tab strip fits. The rail is draggable down to a width that
+ * can't hold three labelled tabs, so below `TAB_LABELS_MIN_WIDTH` they drop to
+ * icons alone — the labels move into tooltips and accessible names rather than
+ * clipping or wrapping the strip onto a second row.
+ *
+ * Measured off the rail itself, not the viewport: the rail is the box the tabs
+ * have to fit inside, and it changes width without the window doing anything.
+ */
+function useCompactTabs(ref: RefObject<HTMLElement | null>): boolean {
+  const [compact, setCompact] = useState(false);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(([entry]) => {
+      setCompact(entry.contentRect.width < TAB_LABELS_MIN_WIDTH);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [ref]);
+  return compact;
 }
 
 /** The room's context: agents, episodes, and memory behind one tabbed right rail. */
@@ -62,13 +170,17 @@ export function RoomInspector({
   const setTab = (t: Tab) => { if (tabProp === undefined) setTabInternal(t); onTabChange?.(t); };
   const setOpen = (o: boolean) => { if (openProp === undefined) setOpenInternal(o); onOpenChange?.(o); };
 
+  const railRef = useRef<HTMLElement>(null);
+  const compact = useCompactTabs(railRef);
+
   // Collapsed: a slim strip of the three tab icons; clicking one expands to it.
   if (!open) {
     return (
-      <aside className="flex w-12 flex-shrink-0 flex-col items-center gap-1 border-l border-border bg-surface/40 pt-3">
+      <aside className="flex w-full min-w-0 flex-col items-center gap-1 overflow-hidden bg-surface/40 pt-3">
         <button
           onClick={() => setOpen(true)}
-          aria-label="Open inspector"
+          aria-label={railToggleTitle(false)}
+          title={railToggleTitle(false)}
           className="flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface hover:text-text"
         >
           <PanelRightOpen className="size-[18px]" />
@@ -93,9 +205,9 @@ export function RoomInspector({
   }
 
   return (
-    <aside className="flex w-[340px] flex-shrink-0 flex-col border-l border-border bg-surface/30">
+    <aside ref={railRef} className="flex w-full min-w-0 flex-col overflow-hidden bg-surface/30">
       <div className="flex h-[48px] flex-shrink-0 items-center gap-1 border-b border-border bg-paper px-2">
-        <div className="flex items-center gap-0.5 rounded-lg border border-border bg-surface p-0.5">
+        <div className="flex min-w-0 items-center gap-0.5 rounded-lg border border-border bg-surface p-0.5">
           {TABS.map(({ id, label, icon: Icon }) => {
             const active = tab === id;
             return (
@@ -103,21 +215,26 @@ export function RoomInspector({
                 key={id}
                 data-tour={`inspector-${id}`}
                 onClick={() => setTab(id)}
-                className={`relative flex items-center gap-1.5 rounded-md px-2.5 py-1 text-label font-medium transition-colors ${
+                aria-label={label}
+                title={compact ? label : undefined}
+                className={`relative flex items-center gap-1.5 rounded-md py-1 text-label font-medium transition-colors ${
+                  compact ? "px-2" : "px-2.5"
+                } ${
                   active ? "bg-elevated text-text shadow-sm ring-1 ring-border" : "text-muted-foreground hover:text-text"
                 }`}
               >
-                <Icon className="size-3.5" />
-                {label}
-                <KeyBadge action={`rail.${id}`} />
+                <Icon className="size-3.5 flex-shrink-0" />
+                {!compact && label}
+                <KeyBadge action={`rail.${id}`} overlay={compact} />
               </button>
             );
           })}
         </div>
         <button
           onClick={() => setOpen(false)}
-          aria-label="Collapse inspector"
-          className="ml-auto flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+          aria-label={railToggleTitle(true)}
+          title={railToggleTitle(true)}
+          className="ml-auto flex size-7 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
         >
           <PanelRightClose className="size-4" />
         </button>

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -164,7 +164,7 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   useCommands(commands);
 
   return (
-    <aside data-tour="rooms" className="flex w-[236px] flex-shrink-0 flex-col border-r border-border bg-surface/50">
+    <aside data-tour="rooms" className="flex min-w-0 flex-1 flex-col overflow-hidden bg-surface/50">
       <Link
         href="/"
         className="relative flex h-[52px] flex-shrink-0 items-center gap-2.5 border-b border-border px-4 transition-colors hover:bg-hairline"

--- a/mycelium-frontend/src/components/ui/resizable.tsx
+++ b/mycelium-frontend/src/components/ui/resizable.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import * as ResizablePrimitive from "react-resizable-panels";
+
+import { cn } from "@/lib/utils";
+
+function ResizablePanelGroup({ className, ...props }: ResizablePrimitive.GroupProps) {
+  return (
+    <ResizablePrimitive.Group
+      data-slot="resizable-panel-group"
+      className={cn("flex h-full w-full aria-[orientation=vertical]:flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+/** A panel. The library styles the inner content div `overflow: auto` inline,
+ *  which a utility class can't beat — every panel in this app scrolls inside
+ *  its own body instead, so the default is overridden here rather than at each
+ *  call site. Pass `style` to opt back in. */
+function ResizablePanel({ style, ...props }: ResizablePrimitive.PanelProps) {
+  return (
+    <ResizablePrimitive.Panel
+      data-slot="resizable-panel"
+      style={{ overflow: "hidden", ...style }}
+      {...props}
+    />
+  );
+}
+
+/** The draggable seam. It doubles as the border between two panes, so it draws
+ *  the hairline the panels no longer draw themselves. The hit target is wider
+ *  than the line (the `after:` overlay) so a 1px rule is still grabbable, and
+ *  double-clicking it resets the neighbouring panel to its default size. */
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: ResizablePrimitive.SeparatorProps & { withHandle?: boolean }) {
+  return (
+    <ResizablePrimitive.Separator
+      data-slot="resizable-handle"
+      className={cn(
+        "group/handle relative flex w-px items-center justify-center bg-border outline-none transition-colors",
+        "after:absolute after:inset-y-0 after:left-1/2 after:w-3 after:-translate-x-1/2 after:content-['']",
+        "data-[separator=hover]:bg-accent data-[separator=active]:bg-accent data-[separator=focus]:bg-accent",
+        "aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full",
+        "aria-[orientation=horizontal]:after:inset-x-0 aria-[orientation=horizontal]:after:left-0",
+        "aria-[orientation=horizontal]:after:h-3 aria-[orientation=horizontal]:after:w-full",
+        "aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2",
+        "[&[aria-orientation=horizontal]>div]:rotate-90",
+        className,
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div
+          className={cn(
+            "z-10 h-8 w-1 shrink-0 rounded-full bg-border2 opacity-0 transition-opacity",
+            "group-data-[separator=hover]/handle:opacity-100 group-data-[separator=focus]/handle:opacity-100",
+            "group-data-[separator=active]/handle:bg-accent group-data-[separator=active]/handle:opacity-100",
+          )}
+        />
+      )}
+    </ResizablePrimitive.Separator>
+  );
+}
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup };

--- a/mycelium-frontend/src/lib/panel-layout.test.ts
+++ b/mycelium-frontend/src/lib/panel-layout.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import {
+  COLLAPSED_THRESHOLD_PX,
+  INSPECTOR_PANEL,
+  ROOMS_PANEL,
+  TAB_LABELS_MIN_WIDTH,
+} from "@/lib/panel-layout";
+
+const px = (value: string) => Number.parseInt(value, 10);
+
+describe("panel sizing", () => {
+  it.each([
+    ["rooms rail", ROOMS_PANEL],
+    ["inspector rail", INSPECTOR_PANEL],
+  ])("gives the %s a default inside its own bounds", (_name, panel) => {
+    expect(px(panel.min)).toBeLessThan(px(panel.default));
+    expect(px(panel.default)).toBeLessThan(px(panel.max));
+  });
+
+  // The whole point of the compact tab strip: it has to engage somewhere the
+  // rail can actually be dragged to. A threshold at or below the minimum would
+  // mean the labelled tabs clip at the floor and the icon strip never appears.
+  it("drops the inspector's tab labels above its minimum width", () => {
+    expect(TAB_LABELS_MIN_WIDTH).toBeGreaterThan(px(INSPECTOR_PANEL.min));
+    expect(TAB_LABELS_MIN_WIDTH).toBeLessThan(px(INSPECTOR_PANEL.default));
+  });
+
+  // "Collapsed" is read off a pixel width, so the strip must be unambiguously
+  // under the threshold and the minimum unambiguously over it.
+  it("separates the collapsed strip from the smallest open rail", () => {
+    expect(px(INSPECTOR_PANEL.collapsed)).toBeLessThan(COLLAPSED_THRESHOLD_PX);
+    expect(COLLAPSED_THRESHOLD_PX).toBeLessThan(px(INSPECTOR_PANEL.min));
+  });
+});

--- a/mycelium-frontend/src/lib/panel-layout.ts
+++ b/mycelium-frontend/src/lib/panel-layout.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The resizable shell's sizing contract, in one place.
+ *
+ * Every size is in pixels rather than a percentage of the group: these are
+ * rails holding a fixed amount of chrome (a room row, a tab strip, a memory
+ * tree), so what "too narrow" means doesn't change with the window. A panel
+ * declared in pixels also keeps the width you dragged it to when the window
+ * resizes, which is what `groupResizeBehavior: "preserve-pixel-size"` buys.
+ *
+ * Minimums are the width at which a rail is still *usable*, not the width at
+ * which it stops rendering — the inspector's tab strip drops to icons before
+ * its minimum (see `TAB_LABELS_MIN_WIDTH`), so 260px is a floor with the tabs
+ * already in their compact form and the panel bodies still legible.
+ */
+
+/** Group ids. Also the localStorage keys the saved layouts live under. */
+export const SHELL_GROUP_ID = "mycelium:shell";
+export const ROOM_GROUP_ID = "mycelium:room";
+
+/** Panel ids within those groups. Stable — a saved layout is keyed by them. */
+export const PANEL_ROOMS = "rooms";
+export const PANEL_WORKSPACE = "workspace";
+export const PANEL_MAIN = "main";
+export const PANEL_INSPECTOR = "inspector";
+
+/** The rooms rail: wide enough for a monogram plus a room name. */
+export const ROOMS_PANEL = {
+  default: "236px",
+  min: "180px",
+  max: "420px",
+} as const;
+
+/** Whatever the page puts beside the rooms rail. Its minimum is what stops the
+ *  rail's maximum from swallowing the page on a small window. */
+export const WORKSPACE_PANEL = {
+  min: "420px",
+} as const;
+
+/** The room's conversation. A hard floor so the inspector can't crush chat. */
+export const MAIN_PANEL = {
+  min: "360px",
+} as const;
+
+/** The inspector rail: members / episodes / memory. Collapses to a strip of
+ *  tab icons rather than to nothing, so the rail is always one click away. */
+export const INSPECTOR_PANEL = {
+  default: "340px",
+  min: "260px",
+  max: "620px",
+  /** The icon strip's width. Matches the collapsed `<aside>`'s `w-12`. */
+  collapsed: "48px",
+} as const;
+
+/**
+ * Below this the inspector's tab strip can't hold "Members / Episodes /
+ * Memory" as words, so the tabs drop to icons alone. Measured against the
+ * rail, not the viewport: the rail is what the tabs have to fit inside.
+ */
+export const TAB_LABELS_MIN_WIDTH = 312;
+
+/**
+ * A panel is "collapsed" once it's near its collapsed size. The library
+ * reports pixel widths mid-animation, so this is a threshold rather than an
+ * equality check on `collapsed`.
+ */
+export const COLLAPSED_THRESHOLD_PX = 72;
+
+/**
+ * `useDefaultLayout` reads its storage during render, so the library's
+ * `localStorage` default throws on the server. This shim answers "nothing
+ * saved" there and hands the real value back once hydrated (React re-renders
+ * off the server snapshot), and stays quiet when storage is unavailable —
+ * a private-mode browser loses the remembered layout, not the app.
+ */
+export const layoutStorage = {
+  getItem(key: string): string | null {
+    if (typeof window === "undefined") return null;
+    try {
+      return window.localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  setItem(key: string, value: string): void {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(key, value);
+    } catch {
+      // Storage denied (private mode, quota). The layout just isn't remembered.
+    }
+  },
+};


### PR DESCRIPTION
## Summary

The rooms rail (left) and the room inspector (right) were fixed at `w-[236px]` and `w-[340px]`. Both now sit in shadcn resizable panel groups with a default, a minimum, and a maximum, and each browser remembers where it left the seams. `react-resizable-panels` was already a dependency but unused; this adds the shadcn `ui/resizable.tsx` wrapper (base-nova style, v4 API) over it.

Sizes are declared in **pixels** rather than percentages — these rails hold a fixed amount of chrome (a room row, a tab strip, a memory tree), so what "too narrow" means doesn't change with the window, and `groupResizeBehavior: "preserve-pixel-size"` keeps a rail at the width you dragged it to when the window resizes. All of them live in one place, `src/lib/panel-layout.ts`.

| panel | min | default | max |
| --- | --- | --- | --- |
| rooms rail | 180px | **236px** | 420px |
| room inspector | 260px | **340px** | 620px |
| chat (main) | 360px | — | — |
| workspace | 420px | — | — |

Defaults are byte-identical to the old fixed widths, so nothing moves until someone drags a seam.

### The expand/contract button

Open/closed *is* the panel's collapsed state now, not a separate flag beside it. That makes the collapse button, a drag past the minimum, and the `\` keybind three ways of doing one thing:

- clicking collapse snaps the rail to the 48px icon strip, and **reopening restores the width you last chose** instead of a hardcoded 340px;
- dragging the seam past the minimum shuts the rail rather than jamming against a wall;
- double-clicking a seam resets that panel to its default width;
- the button spells its keybind out in the tooltip (`Collapse the rail (\)`), since `\` isn't a reveal chord and so `KeyBadge` can't draw it.

### Tabs in a rail too narrow to hold them

Below **312px** the inspector can't fit "Members / Episodes / Memory" as words, so the tabs drop to icons alone — labels move into `title` and the accessible name rather than clipping or wrapping onto a second row. Measured off the rail with a `ResizeObserver`, not the viewport: the rail is the box the tabs have to fit inside, and it changes width without the window doing anything.

That threshold sits **above** the rail's 260px minimum, so the icon strip is reachable by dragging and the labelled tabs never clip at the floor. A unit test pins that invariant.

## Changes

- `src/components/ui/resizable.tsx` — new. shadcn base-nova `resizable`, adapted to this repo's tokens (`bg-border` seam that turns `accent` on hover/drag/focus, a grip that fades in, a 12px hit target over a 1px line). The library styles a panel's content div `overflow: auto` inline, which a utility class can't beat, so the wrapper overrides it — every panel here scrolls inside its own body.
- `src/lib/panel-layout.ts` — new. Group/panel ids, every size, the tab-label threshold, and an SSR-safe storage shim (`useDefaultLayout`'s `localStorage` default throws during render on the server).
- `app-shell.tsx` — rooms rail becomes a panel; applies to every route that uses the shell (home, room, memory page, graph, metrics).
- `room/[name]/page.tsx` — chat + inspector become a nested group.
- `room-inspector.tsx` — new `RoomInspectorPanel` owns the seam, the panel, and the state↔panel sync; `RoomInspector` gains the compact tab strip and drops its own fixed width and borders.
- `rooms-sidebar.tsx` — drops `w-[236px]`/`border-r`; the panel and the seam own those now.
- `memory-panel.tsx` — the stats row and search field now shrink at the new 260px minimum instead of pushing the Graph link and Search button past the rail's edge. A minimum should be a width where the panel is usable.

Both layout groups save on `onLayoutChange` **and** `onLayoutChanged`. They're nested, so widening the rooms rail resizes the room group's container without anyone touching its own seam, and only the former sees that; saving on the commit alone left the stored percentages describing a container width that no longer existed and the inspector came back ~37px off after a reload. Verified exact round-trip after the fix.

## Testing

- [x] Frontend unit tests pass — `pnpm test`, 358 passing (38 files), including 9 new
  - `room-inspector.test.tsx` — labelled tabs above the threshold, icon-only below with the labels still addressable by accessible name, tab switching identical at either width, collapse → icon strip → reopen on the clicked tab, and the keybind named on the toggle
  - `panel-layout.test.ts` — each default sits inside its own min/max; the tab-label threshold engages above the inspector's minimum and below its default; the collapsed strip and the smallest open rail sit on opposite sides of the collapse threshold
- [x] Lint + typecheck pass — `pnpm lint`, 0 errors (48 pre-existing warnings, unchanged from `main`)
- [x] Manual, driven with Playwright against `pnpm dev:mock`:
  - defaults measure 236 / 340, unchanged from before
  - drag → compact tabs at 270px; drag past the minimum → collapses to 48px; expand button → back to the dragged width; double-click seam → back to 340px
  - reload restores rooms 365 / main 733 / inspector 340 exactly
  - Negotiate / Plan / Network views, and the home, memory, graph, and metrics routes all lay out correctly under the new shell
  - light and dark, at 1440x900 and 1024x760

The backend checks in the template don't apply — this PR touches only `mycelium-frontend/`.

The committed `docs/` screenshots are unchanged: the default layout is identical to the old fixed widths, so there's nothing to re-capture.

## Related Issues

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHAessxT153H24uUovUGkv)_