### PR TITLE
Survey agent harnesses and grade them against the participation contract

### DIFF
--- a/.github/workflows/harness-conformance.yml
+++ b/.github/workflows/harness-conformance.yml
@@ -1,0 +1,250 @@
+# Point real agent-harness binaries at the participation contract and report what
+# happened. Mycelium claims a harness works when a resident loop has actually
+# answered a mention through it, and this is where that claim is earned — see
+# `scripts/harness_conformance.py` for the rungs and `mycelium/integrations/
+# harness_specs.py` for the family table both this workflow and the integrations
+# read.
+#
+# Nothing here gates a PR. Harness vendors ship breaking CLI changes on their own
+# schedule (GitHub removed `copilot --headless --stdio` with no deprecation), so a
+# red run means "a harness moved", which is news, not a broken pull request. The
+# job to watch is the report in the step summary.
+name: Harness conformance
+
+on:
+  schedule:
+    # Weekly, Monday 06:00 UTC: often enough to catch a vendor's breaking release
+    # within a sprint, rare enough not to burn API credit on every push.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      families:
+        description: "Space-separated families to grade (default: all)"
+        required: false
+        default: ""
+  pull_request:
+    # Only when the harness surface itself changes: the spec table, the runner, or
+    # an integration. A frontend PR has nothing to learn from a Kiro binary.
+    paths:
+      - "mycelium-cli/src/mycelium/integrations/**"
+      - "scripts/harness_conformance.py"
+      - ".github/workflows/harness-conformance.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  # ── rungs 1–3: does the binary reason? ──────────────────────────────────────
+  #
+  # No hub, no SLIM node, no adapter needed — which is the point. A candidate
+  # family with no integration still grades to `oneshot` here, so the harness is
+  # de-risked before any adapter code is written.
+  oneshot:
+    name: "oneshot: ${{ matrix.family }}"
+    runs-on: ubuntu-latest
+    # A missing binary or credential is a SKIP, not a failure; a genuine FAIL is
+    # reported without `--strict` so one broken vendor CLI doesn't mask the rest.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - family: claude_code
+            install: npm install -g @anthropic-ai/claude-code
+          - family: cursor
+            install: curl https://cursor.com/install -fsS | bash
+          - family: codex
+            install: npm install -g @openai/codex
+          - family: copilot
+            install: npm install -g @github/copilot
+          - family: kiro
+            install: curl -fsSL https://cli.kiro.dev/install | bash
+          # antigravity has no API-key env var: headless mode reuses a cached
+          # interactive login, so a cold runner cannot authenticate it. It is
+          # installed anyway so the `binary` rung tracks the CLI's availability,
+          # and `oneshot` reports the auth wall rather than pretending.
+          - family: antigravity
+            install: 'curl -fsSL https://antigravity.google/install.sh | bash || echo "installer unavailable; binary rung will skip"'
+          # perplexity is graded from the table alone: `pplx` is a Search API
+          # client, not a harness, so there is no turn to run and nothing to install.
+          - family: perplexity
+            install: "true"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      # The OpenAPI client is a build artifact, not committed (#613); the runner
+      # imports `mycelium.integrations.harness_specs`, which pulls the package in.
+      - name: Generate OpenAPI client
+        run: SPEC_FILE=openapi.json bash scripts/gen-mycelium-client.sh
+
+      - name: Install CLI deps
+        working-directory: mycelium-cli
+        run: uv sync --group dev
+
+      - name: Install ${{ matrix.family }}
+        # Vendor installers break; a failed install must leave the binary rung to
+        # report "not on PATH" rather than killing the job before it can say so.
+        continue-on-error: true
+        run: |
+          ${{ matrix.install }}
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Grade ${{ matrix.family }}
+        env:
+          # Each is optional. An absent key SKIPs that family's turn with a
+          # reason; it never fails the run, so a fork without secrets still gets
+          # a truthful binary-rung report.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          KIRO_API_KEY: ${{ secrets.KIRO_API_KEY }}
+        run: >-
+          uv run --project mycelium-cli python scripts/harness_conformance.py
+          --family ${{ matrix.family }}
+          --max-level oneshot
+          --json-report "harness-${{ matrix.family }}.json"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: harness-conformance-${{ matrix.family }}
+          path: harness-*.json
+          if-no-files-found: ignore
+
+  # ── rung 4: does a resident loop answer a mention? ──────────────────────────
+  #
+  # The full contract, and the only rung that proves an integration. It needs a
+  # live hub, and a hub needs a SLIM node — a room *is* a SLIM group channel, so
+  # without one the backend cannot provision the channel and `await` never serves
+  # a turn. Restricted to families that have an integration: `participate` needs a
+  # registered manifest, and that is what an integration provides.
+  participate:
+    name: "participate: ${{ matrix.family }}"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        family: [claude_code, cursor]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+
+      # Same shape as ci.yml's integration-slim job: `services:` containers can't
+      # override the command or mount a config file, so run the node with
+      # `docker run` (single standalone dataplane hub on :46357, TLS off).
+      - name: Start SLIM node
+        run: |
+          cat > "$RUNNER_TEMP/slim-config.yaml" <<'EOF'
+          tracing:
+            log_level: info
+          runtime:
+            n_cores: 0
+            thread_name: "slim-data-plane"
+            drain_timeout: 10s
+          services:
+            slim/0:
+              node_id: mycelium-slim
+              dataplane:
+                servers:
+                  - endpoint: "0.0.0.0:46357"
+                    tls:
+                      insecure: true
+                clients: []
+          EOF
+          docker run -d --name mycelium-slim -p 46357:46357 \
+            -v "$RUNNER_TEMP/slim-config.yaml:/slim-config.yaml" \
+            ghcr.io/agntcy/slim:2.1.0 /slim --config /slim-config.yaml
+          for _ in $(seq 1 30); do
+            if (exec 3<>/dev/tcp/127.0.0.1/46357) 2>/dev/null; then
+              exec 3>&-
+              echo "SLIM node is up on :46357"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Generate OpenAPI client
+        run: SPEC_FILE=openapi.json bash scripts/gen-mycelium-client.sh
+
+      - name: Install backend + CLI deps
+        run: |
+          uv sync --group dev --project fastapi-backend
+          uv sync --group dev --project mycelium-cli
+
+      - name: Start hub
+        env:
+          MYCELIUM_SLIM_ENDPOINT: http://127.0.0.1:46357
+          # The embedding model is irrelevant to participation and downloading it
+          # would dominate the job; the stub keeps the memory writes indexed.
+          MYCELIUM_STUB_EMBEDDINGS: "1"
+        run: |
+          mkdir -p "$RUNNER_TEMP/mycelium-data"
+          MYCELIUM_DATA_DIR="$RUNNER_TEMP/mycelium-data" \
+            uv run --project fastapi-backend uvicorn app.main:app --port 8000 \
+            > "$RUNNER_TEMP/hub.log" 2>&1 &
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8000/health >/dev/null 2>&1; then
+              echo "hub is up on :8000"
+              break
+            fi
+            sleep 2
+          done
+
+      - name: Point the CLI at the hub
+        run: |
+          echo "$PWD/mycelium-cli/.venv/bin" >> "$GITHUB_PATH"
+          uv run --project mycelium-cli mycelium config set server.api_url "http://127.0.0.1:8000"
+          uv run --project mycelium-cli mycelium config set slim.node_endpoint "http://127.0.0.1:46357"
+
+      - name: Install ${{ matrix.family }}
+        continue-on-error: true
+        run: |
+          case "${{ matrix.family }}" in
+            claude_code) npm install -g @anthropic-ai/claude-code ;;
+            cursor)      curl https://cursor.com/install -fsS | bash ;;
+          esac
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Grade ${{ matrix.family }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          MYCELIUM_SLIM_ENDPOINT: http://127.0.0.1:46357
+        run: >-
+          uv run --project mycelium-cli python scripts/harness_conformance.py
+          --family ${{ matrix.family }}
+          --json-report "harness-participate-${{ matrix.family }}.json"
+
+      - name: Hub + node logs (on failure)
+        if: failure()
+        run: |
+          echo "── hub ──"; tail -100 "$RUNNER_TEMP/hub.log" || true
+          echo "── slim ──"; docker logs mycelium-slim || true
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: harness-participate-${{ matrix.family }}
+          path: harness-participate-*.json
+          if-no-files-found: ignore

--- a/docs/agent-harnesses.md
+++ b/docs/agent-harnesses.md
@@ -1,0 +1,191 @@
+# Agent harnesses: the candidate set, and the adapter shape they imply
+
+Mycelium's resident model asks one thing of an agent runtime: hold a reasoning
+turn. `mycelium await --loop --exec <cmd>` loops await → reason → respond, and
+`<cmd>` is the harness. Everything else an integration does — dropping
+coordination instructions, building a manifest, reporting health — is in service
+of that one call.
+
+This note surveys the harnesses that clear that bar, and argues that the six
+real candidates converge hard enough that the answer is one parameterized family,
+not six hand-written adapters.
+
+The survey is data, not prose:
+[`mycelium/integrations/harness_specs.py`](../mycelium-cli/src/mycelium/integrations/harness_specs.py)
+holds the table, and [`scripts/harness_conformance.py`](../scripts/harness_conformance.py)
+grades real binaries against it.
+
+## The candidates
+
+| Harness | Binary | Headless turn | Instruction surface | Unattended auth | Grade |
+| --- | --- | --- | --- | --- | --- |
+| Claude Code | `claude` | `claude -p "…"` | `~/.claude/skills/`, `AGENTS.md` | `ANTHROPIC_API_KEY` | **proven** |
+| Cursor CLI | `cursor-agent` | `cursor-agent -p "…"` | `.cursor/rules/*.mdc`, `AGENTS.md` | `CURSOR_API_KEY` | **untested** |
+| OpenAI Codex | `codex` | `codex exec "…"` | `AGENTS.md` | `OPENAI_API_KEY` | candidate |
+| GitHub Copilot | `copilot` | `copilot -p "…" -s --no-ask-user` | `AGENTS.md`, `.github/copilot-instructions.md` | `COPILOT_GITHUB_TOKEN` | candidate |
+| Kiro | `kiro-cli` | `kiro-cli chat --no-interactive "…"` | `.kiro/steering/*.md`, `AGENTS.md` | `KIRO_API_KEY` | candidate |
+| Antigravity | `agy` | `agy -p "…"` | `AGENTS.md` | **none** | candidate |
+| Perplexity | `pplx` | — | — | `PPLX_API_KEY` | **not a harness** |
+
+### Perplexity is not a harness
+
+`pplx` is a single-binary client for the Perplexity Search API: `pplx search web`
+and `pplx content fetch`, both returning JSON. It answers questions about the
+world. It does not hold a reasoning turn, call tools, or edit files, so there is
+nothing for the resident loop to drive and no adapter to write.
+
+It is still useful, on the other side of the boundary: a *tool a harness calls*.
+The natural home is MCP, where the aligner's Pi brain and resident agents can
+reach it for grounded search. That is a different piece of work from an adapter,
+and putting it behind one would have been a category error.
+
+The table records this as `adapter_status="unsupported"` so the finding does not
+have to be rediscovered by the next person who reads the candidate list.
+
+### Antigravity authenticates, but not in CI
+
+Google's successor to Gemini CLI has the richest headless surface of the set —
+`--output-format json|stream-json`, `--json-schema` for structured output,
+`--print-timeout`, `--effort`. On a developer machine it is an excellent fit.
+
+But headless mode reuses credentials cached by a prior interactive session, and
+there is no documented API-key environment variable. A cold CI runner cannot
+authenticate it at all. That is a property of the harness, not of our test setup,
+so the conformance runner reports it as an auth wall rather than as a failure, and
+the scheduled workflow will keep grading its `binary` rung until the story changes.
+
+### Copilot is the easiest to run unattended, and the most likely to move
+
+Token auth (`COPILOT_GITHUB_TOKEN`, or a workflow's own `GITHUB_TOKEN`) makes
+Copilot the only candidate that authenticates in CI with no extra secret. Against
+that: its CLI surface churns. `--headless --stdio` was removed with no deprecation
+period, breaking every downstream integration that depended on it
+(github/copilot-cli#1606). Pin a version, and let the conformance run be what
+tells us when the next one lands.
+
+## What the survey actually shows
+
+Five of the six real harnesses read **`AGENTS.md`**, and every one of them takes a
+prompt as `-p`-or-equivalent and prints an answer on stdout. The differences that
+remain are small and enumerable:
+
+- the argv that starts a headless turn (`-p` vs `exec` vs `chat --no-interactive`);
+- one optional harness-native rules file *in addition to* `AGENTS.md`
+  (`.cursor/rules/mycelium.mdc`, `.kiro/steering/mycelium.md`,
+  `.github/copilot-instructions.md`);
+- the auth probe;
+- whether instructions install per-workspace or per-host.
+
+That is a table, not five programs. Claude Code is the genuine outlier — its
+instructions install per-host as a skill under `~/.claude/`, not per-workspace —
+and it already has its own integration.
+
+### The proposal: one AGENTS.md family, parameterized
+
+Add a single `Integration` subclass driven by a `HarnessSpec`, rather than one
+subclass per vendor:
+
+- **`build_manifest`** — identical across families today; the only variable is the
+  `adapter` literal.
+- **`register`** — drop the harness's context files into the agent's cwd, taking
+  paths and merge modes from `spec.context_files`. Mycelium owns its own rules
+  file outright and marker-merges its `AGENTS.md` section, exactly as the cursor
+  integration already does. That merge logic is the reusable part; lifting it out
+  of `cursor/install.py` is the first refactor.
+- **`status_check`** — `spec.binary` on PATH, plus the auth probe from `spec.auth`.
+  Honest by construction, with no per-family prose to keep in sync.
+- **the exec handler** — turn in, harness argv rendered, stdout back via
+  `mycelium respond`. The conformance runner already ships this handler and is
+  deliberately harness-agnostic; an adapter would ship the same script and vary
+  only `HARNESS_ARGV`.
+
+The instruction content is one document with per-harness framing, not six. The
+cursor rule and the Claude skill are already ~90% the same text: the protocol
+(post a position → await → respond → consensus → plan → work), the memory layers,
+and the identity rules. Only the container format differs.
+
+Adding a family then means an entry in `HARNESS_SPECS`, the family id in
+`AGENT_ADAPTERS` and the `AgentManifest.adapter` literal, and a conformance run
+proving the round-trip. `test_harness_specs.py` fails if a family is graded
+`proven`/`untested` without an integration behind it, or `candidate` once one
+lands.
+
+### What to build first
+
+**Codex.** It is the closest fit after Claude Code: `AGENTS.md` is its native
+instruction surface, so it needs no harness-specific rules file at all; `codex exec
+--json` emits a JSONL event stream if the handler ever wants more than stdout; and
+`codex exec resume` maps onto a durable per-agent session, which is the shape
+`await --loop` wants and which most of the field lacks.
+
+**Then Kiro**, because `.kiro/steering/**/*.md` is a near-exact analogue of
+Cursor's project rules — the cursor integration is the template, with the caveat
+that Kiro's headless output is plain text with no JSON envelope, so the handler
+must treat stdout as the answer.
+
+**Then Copilot**, gated on pinning a version.
+
+**Antigravity** waits on an unattended-auth story.
+
+## The conformance harness
+
+Claiming a harness works is only worth doing about a binary someone has run. The
+runner grades each family on a ladder and stops at the first rung it cannot climb:
+
+| Rung | What it proves | What it needs |
+| --- | --- | --- |
+| `binary` | on PATH, version probe exits 0 | the binary |
+| `auth` | a credential is detectable (**advisory**) | — |
+| `oneshot` | one headless turn echoes a nonce back | binary + credentials |
+| `participate` | a resident loop answers an `@`-mention in a live room | hub + SLIM node + an adapter |
+
+```bash
+# Grade everything the machine happens to have:
+uv run --project mycelium-cli python scripts/harness_conformance.py
+
+# Just one family, no hub needed:
+uv run --project mycelium-cli python scripts/harness_conformance.py \
+    --family codex --max-level oneshot
+```
+
+Three properties are worth calling out, because each was a design decision:
+
+**A SKIP is never a FAIL.** A runner with no Kiro binary has learned nothing about
+Kiro. Reporting that as red would train everyone to ignore the report.
+
+**`auth` is advisory and does not gate `oneshot`.** Harnesses authenticate in ways
+no probe can enumerate — a managed host may inject a token over a file descriptor,
+which is exactly what happened on the machine this was written on: `claude` was
+fully authenticated with no `ANTHROPIC_API_KEY` and no `~/.claude/.credentials.json`.
+An undetected credential must not be reported as a broken harness, so the turn is
+attempted anyway and a failure is annotated as probably-unauthenticated.
+
+**`participate` needs an adapter, and says so.** For a family with no integration
+it reports `needs-adapter` — precisely the gap an adapter closes. `oneshot` still
+grades, so a candidate is de-risked before a line of adapter code is written. That
+is the whole point of building the runner before the adapters.
+
+### CI
+
+[`.github/workflows/harness-conformance.yml`](../.github/workflows/harness-conformance.yml)
+runs it weekly, on manual dispatch, and on PRs that touch the harness surface.
+Two jobs:
+
+- **`oneshot`** — matrix over every family, installs each vendor CLI, no hub. This
+  is where candidate families get graded.
+- **`participate`** — restricted to adapter-backed families, and stands up a SLIM
+  node and a hub first. A room *is* a SLIM group channel, so with no node the hub
+  cannot provision one and `await` never serves a turn — a silent seven-minute
+  timeout until the runner learned to check for the node up front.
+
+Nothing gates a PR. Vendors ship breaking CLI changes on their own schedule, so a
+red run means "a harness moved", which is news, not a broken pull request.
+
+## Sources
+
+- [Kiro headless mode](https://kiro.dev/docs/cli/headless/) · [Kiro steering](https://kiro.dev/docs/steering/)
+- [Codex non-interactive mode](https://developers.openai.com/codex/noninteractive) · [Codex AGENTS.md](https://developers.openai.com/codex/guides/agents-md)
+- [Copilot CLI programmatic use](https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/run-cli-programmatically) · [github/copilot-cli#1606](https://github.com/github/copilot-cli/issues/1606)
+- [Antigravity CLI headless mode](https://antigravity.google/docs/cli/headless/)
+- [Perplexity CLI](https://docs.perplexity.ai/docs/cli/overview)
+- [Cursor CLI](https://cursor.com/cli) · [Claude Code headless](https://docs.claude.com/en/docs/claude-code/sdk/sdk-headless)

--- a/mycelium-cli/src/mycelium/integrations/harness_specs.py
+++ b/mycelium-cli/src/mycelium/integrations/harness_specs.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""What every agent-harness family looks like from the outside, as data.
+
+An *agent harness* is a runtime that can hold a reasoning turn: give it a prompt
+non-interactively and it thinks, uses tools, and prints an answer. That is the only
+capability Mycelium's resident model needs — ``mycelium await --loop --exec <cmd>``
+loops await → reason → respond, and the harness is what runs in the middle.
+
+Two consumers read the same table, which is why it is data and not prose:
+
+- an **integration** (``integrations/<family>/``) needs the context-file
+  conventions to know where to drop its coordination instructions, and the auth
+  story to write an honest ``status_check``;
+- the **conformance runner** (``scripts/harness_conformance.py``) needs the binary
+  name, the headless argv, and the auth probes to point a real binary at a real
+  room and report what happened.
+
+Keeping one table means a harness cannot be "supported" by an integration that the
+runner has never exercised, and cannot be exercised by a runner reading a stale
+copy of the flags.
+
+``adapter_status`` is the honest grading, mirroring the repo's rule about claiming
+capability (``claude_code`` is proven, ``cursor`` is untested):
+
+``proven``
+    An integration exists and an end-to-end round-trip has been observed.
+``untested``
+    An integration exists; no end-to-end round-trip has been observed.
+``candidate``
+    No integration. The harness clears the bar on paper (headless prompt in,
+    answer out) and the conformance runner can grade it up to ``oneshot``; the
+    participation level needs a manifest, which is what the integration provides.
+``unsupported``
+    Not an agent harness. Recorded here so the finding does not have to be
+    rediscovered.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+#: Placeholder substituted with the turn prompt when rendering ``headless_argv``.
+PROMPT_SLOT = "{prompt}"
+
+AdapterStatus = Literal["proven", "untested", "candidate", "unsupported"]
+
+#: Where a context file lives. ``workspace`` is relative to the agent's cwd (drops
+#: at ``mycelium agent create``); ``home`` is relative to ``~`` (drops once per
+#: host at ``mycelium adapter add``).
+ContextScope = Literal["workspace", "home"]
+
+#: How Mycelium writes a context file. ``own`` means the file is wholly Mycelium's
+#: and is overwritten on refresh; ``section`` means the file belongs to the user
+#: and only a marker-delimited block inside it is ours.
+ContextMerge = Literal["own", "section"]
+
+
+@dataclass(frozen=True)
+class ContextFile:
+    """One place a harness reads standing instructions from."""
+
+    path: str
+    scope: ContextScope
+    merge: ContextMerge
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class AuthSpec:
+    """How a harness proves who it is without a human at the keyboard.
+
+    ``env_vars`` is the CI-viable path: any one of them being set means the binary
+    can run unattended. ``credential_paths`` (``~``-relative) are the cached-login
+    artifacts a developer machine has after an interactive ``login_command``. A
+    harness with no ``env_vars`` cannot be driven by a scheduled workflow at all,
+    which the conformance runner reports rather than papers over.
+    """
+
+    env_vars: tuple[str, ...] = ()
+    credential_paths: tuple[str, ...] = ()
+    login_command: str | None = None
+
+    @property
+    def unattended(self) -> bool:
+        """True if some env var alone is enough to authenticate."""
+        return bool(self.env_vars)
+
+
+@dataclass(frozen=True)
+class HarnessSpec:
+    """One agent-harness family, described the way both consumers need it."""
+
+    family: str
+    label: str
+    binary: str
+    docs_url: str
+    adapter_status: AdapterStatus
+    #: Argv (after ``binary``) that prints a version and exits 0. Empty means the
+    #: harness has no version probe and the binary's presence is all we check.
+    version_argv: tuple[str, ...] = ()
+    #: Argv (after ``binary``) for one non-interactive turn. Exactly one element
+    #: must be :data:`PROMPT_SLOT`. Empty means the harness has no headless turn
+    #: at all, i.e. it is not a harness.
+    headless_argv: tuple[str, ...] = ()
+    auth: AuthSpec = field(default_factory=AuthSpec)
+    context_files: tuple[ContextFile, ...] = ()
+    install_hint: str = ""
+    note: str = ""
+
+    @property
+    def is_harness(self) -> bool:
+        """True if this runtime can hold a reasoning turn non-interactively."""
+        return bool(self.headless_argv)
+
+    def render_argv(self, prompt: str) -> list[str]:
+        """Full argv for one headless turn carrying *prompt*.
+
+        Returns a real argv list (never a shell string), so a prompt containing
+        quotes, newlines or ``$`` is passed through as one argument.
+        """
+        if not self.headless_argv:
+            raise ValueError(f"{self.family!r} has no headless turn; it is not an agent harness")
+        return [self.binary, *(prompt if arg == PROMPT_SLOT else arg for arg in self.headless_argv)]
+
+
+#: The AGENTS.md block every AGENTS.md-reading harness shares. Mycelium owns only
+#: the marker-delimited section; the surrounding file is the user's.
+_AGENTS_MD = ContextFile(
+    path="AGENTS.md",
+    scope="workspace",
+    merge="section",
+    note="shared convention; marker-delimited section, rest of the file is the user's",
+)
+
+
+HARNESS_SPECS: tuple[HarnessSpec, ...] = (
+    HarnessSpec(
+        family="claude_code",
+        label="Claude Code",
+        binary="claude",
+        docs_url="https://docs.claude.com/en/docs/claude-code/sdk/sdk-headless",
+        adapter_status="proven",
+        version_argv=("--version",),
+        headless_argv=("-p", PROMPT_SLOT),
+        auth=AuthSpec(
+            env_vars=("ANTHROPIC_API_KEY",),
+            credential_paths=(".claude/.credentials.json",),
+            login_command="claude login",
+        ),
+        context_files=(
+            ContextFile(
+                path=".claude/skills/mycelium/SKILL.md",
+                scope="home",
+                merge="own",
+                note="host-level skill; the only family whose instructions install per-host",
+            ),
+            _AGENTS_MD,
+        ),
+        install_hint="https://docs.claude.com/en/docs/claude-code/setup",
+        note="The reference implementation: proven end-to-end through the resident loop.",
+    ),
+    HarnessSpec(
+        family="cursor",
+        label="Cursor CLI",
+        binary="cursor-agent",
+        docs_url="https://cursor.com/cli",
+        adapter_status="untested",
+        version_argv=("--version",),
+        headless_argv=("-p", PROMPT_SLOT),
+        auth=AuthSpec(
+            env_vars=("CURSOR_API_KEY",),
+            credential_paths=(".config/cursor/auth.json",),
+            login_command="cursor-agent login",
+        ),
+        context_files=(
+            ContextFile(
+                path=".cursor/rules/mycelium.mdc",
+                scope="workspace",
+                merge="own",
+                note="Cursor project rule with alwaysApply: true",
+            ),
+            _AGENTS_MD,
+        ),
+        install_hint="curl https://cursor.com/install -fsS | bash",
+        note="Integration ships; no observed round-trip. The conformance runner is how that changes.",
+    ),
+    HarnessSpec(
+        family="codex",
+        label="OpenAI Codex CLI",
+        binary="codex",
+        docs_url="https://developers.openai.com/codex/noninteractive",
+        adapter_status="candidate",
+        version_argv=("--version",),
+        # `exec` is the headless mode. `--skip-git-repo-check` because an agent cwd
+        # is a workspace, not necessarily a repo, and codex exec otherwise refuses.
+        headless_argv=("exec", "--skip-git-repo-check", PROMPT_SLOT),
+        auth=AuthSpec(
+            env_vars=("OPENAI_API_KEY",),
+            credential_paths=(".codex/auth.json",),
+            login_command="codex login",
+        ),
+        context_files=(_AGENTS_MD,),
+        install_hint="npm install -g @openai/codex",
+        note=(
+            "Closest fit after claude_code: AGENTS.md is its native instruction surface, "
+            "`--json` gives a JSONL event stream, and `exec resume` maps onto a durable session."
+        ),
+    ),
+    HarnessSpec(
+        family="copilot",
+        label="GitHub Copilot CLI",
+        binary="copilot",
+        docs_url=(
+            "https://docs.github.com/en/copilot/how-tos/copilot-cli/"
+            "automate-copilot-cli/run-cli-programmatically"
+        ),
+        adapter_status="candidate",
+        version_argv=("--version",),
+        # `-s` drops session metadata so stdout is the answer; `--no-ask-user`
+        # stops it pausing for clarification when nobody is at the keyboard.
+        headless_argv=("-p", PROMPT_SLOT, "-s", "--no-ask-user"),
+        auth=AuthSpec(
+            env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
+            credential_paths=(".config/github-copilot/",),
+            login_command="copilot  # then /login",
+        ),
+        context_files=(
+            _AGENTS_MD,
+            ContextFile(
+                path=".github/copilot-instructions.md",
+                scope="workspace",
+                merge="section",
+                note="Copilot-specific repo instructions; read alongside AGENTS.md",
+            ),
+        ),
+        install_hint="npm install -g @github/copilot",
+        note=(
+            "Token auth makes it the easiest to run unattended. Weigh its CLI surface "
+            "churn: `--headless --stdio` was removed without deprecation (github/copilot-cli#1606), "
+            "so pin a version and let the conformance runner catch the next break."
+        ),
+    ),
+    HarnessSpec(
+        family="kiro",
+        label="Kiro CLI",
+        binary="kiro-cli",
+        docs_url="https://kiro.dev/docs/cli/headless/",
+        adapter_status="candidate",
+        version_argv=("--version",),
+        headless_argv=("chat", "--no-interactive", PROMPT_SLOT),
+        auth=AuthSpec(
+            env_vars=("KIRO_API_KEY",),
+            credential_paths=(".kiro/",),
+            login_command="kiro-cli login",
+        ),
+        context_files=(
+            ContextFile(
+                path=".kiro/steering/mycelium.md",
+                scope="workspace",
+                merge="own",
+                note="steering file; auto-loaded from .kiro/steering/**/*.md",
+            ),
+            _AGENTS_MD,
+        ),
+        install_hint="curl -fsSL https://cli.kiro.dev/install | bash",
+        note=(
+            "Steering files are a near-exact analogue of Cursor's project rules, so the "
+            "cursor integration is the template. Headless output is plain text only — no "
+            "JSON envelope — so the exec handler must treat stdout as the answer. "
+            "API-key auth is a paid-tier feature."
+        ),
+    ),
+    HarnessSpec(
+        family="antigravity",
+        label="Antigravity CLI",
+        binary="agy",
+        docs_url="https://antigravity.google/docs/cli/headless/",
+        adapter_status="candidate",
+        version_argv=("--version",),
+        headless_argv=("-p", PROMPT_SLOT),
+        auth=AuthSpec(
+            # No documented API-key env var: headless mode reuses credentials cached
+            # by an interactive session, so a cold CI runner cannot authenticate.
+            credential_paths=(".antigravity/", ".config/antigravity/"),
+            login_command="agy  # interactive login, then headless reuses the cache",
+        ),
+        context_files=(_AGENTS_MD,),
+        install_hint="https://antigravity.google/docs/cli/install/",
+        note=(
+            "Google's successor to Gemini CLI. Richest headless surface of the set "
+            "(`--output-format json|stream-json`, `--json-schema`, `--print-timeout`), but "
+            "it authenticates only from a cached interactive login, so it grades on a "
+            "developer machine and skips on a cold runner until that changes."
+        ),
+    ),
+    HarnessSpec(
+        family="perplexity",
+        label="Perplexity pplx",
+        binary="pplx",
+        docs_url="https://docs.perplexity.ai/docs/cli/overview",
+        adapter_status="unsupported",
+        version_argv=("--version",),
+        # Deliberately empty: `pplx` exposes `search web` and `content fetch`. It
+        # answers queries about the world, it does not hold a reasoning turn, use
+        # tools, or edit files, so there is nothing for the resident loop to drive.
+        headless_argv=(),
+        auth=AuthSpec(env_vars=("PPLX_API_KEY", "PERPLEXITY_API_KEY")),
+        install_hint="https://docs.perplexity.ai/docs/cli/overview",
+        note=(
+            "Not an agent harness: a single-binary client for the Search API "
+            "(`pplx search web`, `pplx content fetch`) returning JSON. It is a tool a "
+            "harness calls, so it belongs behind MCP for the aligner and residents to "
+            "use — not in front of an adapter."
+        ),
+    ),
+)
+
+
+#: Family id → spec, for callers that already know the family.
+SPECS_BY_FAMILY: dict[str, HarnessSpec] = {spec.family: spec for spec in HARNESS_SPECS}
+
+
+def get_spec(family: str) -> HarnessSpec:
+    """Return the spec for *family*, or raise ``KeyError`` with the known set."""
+    try:
+        return SPECS_BY_FAMILY[family]
+    except KeyError:
+        known = ", ".join(sorted(SPECS_BY_FAMILY))
+        raise KeyError(f"unknown harness family {family!r}; known: {known}") from None

--- a/mycelium-cli/tests/test_harness_specs.py
+++ b/mycelium-cli/tests/test_harness_specs.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The harness spec table is read by two consumers; these keep it honest.
+
+``integrations/<family>/`` builds an adapter from a spec, and
+``scripts/harness_conformance.py`` points a real binary at a real room from the
+same spec. The failure mode worth guarding is drift between the table's claims and
+the code: a family graded ``proven``/``untested`` with no integration behind it, an
+argv template the runner cannot render, or a capability claim nobody can check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mycelium.integrations import get_integration, normalize_family_id
+from mycelium.integrations.harness_specs import (
+    HARNESS_SPECS,
+    PROMPT_SLOT,
+    SPECS_BY_FAMILY,
+    HarnessSpec,
+    get_spec,
+)
+from mycelium.protocol import AGENT_ADAPTERS
+
+#: Statuses that assert an integration exists for the family.
+_ADAPTER_BACKED = {"proven", "untested"}
+
+
+def test_family_ids_are_unique_and_canonical() -> None:
+    families = [spec.family for spec in HARNESS_SPECS]
+    assert len(families) == len(set(families))
+    for family in families:
+        # The underscore spelling is what a manifest persists; a hyphen here would
+        # silently miss every AGENT_ADAPTERS lookup.
+        assert normalize_family_id(family) == family, f"{family!r} is not canonical"
+
+
+@pytest.mark.parametrize("spec", HARNESS_SPECS, ids=lambda s: s.family)
+def test_adapter_backed_families_have_an_integration(spec: HarnessSpec) -> None:
+    """A ``proven``/``untested`` grade is a claim that code exists to back it."""
+    if spec.adapter_status not in _ADAPTER_BACKED:
+        return
+    assert spec.family in AGENT_ADAPTERS
+    assert get_integration(spec.family).name == spec.family
+
+
+@pytest.mark.parametrize("spec", HARNESS_SPECS, ids=lambda s: s.family)
+def test_candidates_have_no_integration_yet(spec: HarnessSpec) -> None:
+    """The inverse: ``candidate`` means the adapter is the missing piece.
+
+    If someone lands an integration without regrading the spec, the table would
+    keep telling the conformance runner to skip ``participate`` for a family that
+    can now reach it.
+    """
+    if spec.adapter_status != "candidate":
+        return
+    assert spec.family not in AGENT_ADAPTERS, (
+        f"{spec.family!r} now has an integration; regrade it to 'untested' (or "
+        "'proven' once a round-trip has been observed)"
+    )
+
+
+@pytest.mark.parametrize("spec", HARNESS_SPECS, ids=lambda s: s.family)
+def test_headless_argv_renders_one_prompt_argument(spec: HarnessSpec) -> None:
+    if not spec.is_harness:
+        pytest.skip(f"{spec.family} has no headless turn")
+    assert spec.headless_argv.count(PROMPT_SLOT) == 1, "exactly one prompt slot"
+
+    prompt = 'a "quoted" prompt\nwith $shell chars & a newline'
+    argv = spec.render_argv(prompt)
+    assert argv[0] == spec.binary
+    # The prompt must survive as exactly one argv element: rendering into a shell
+    # string is how a turn carrying quotes or `$(…)` becomes an injection.
+    assert argv.count(prompt) == 1
+    assert len(argv) == len(spec.headless_argv) + 1
+
+
+def test_non_harness_refuses_to_render() -> None:
+    """`pplx` is a Search API client. Asking it for a turn is a bug, not a fallback."""
+    spec = get_spec("perplexity")
+    assert spec.adapter_status == "unsupported"
+    assert not spec.is_harness
+    with pytest.raises(ValueError, match="not an agent harness"):
+        spec.render_argv("anything")
+
+
+@pytest.mark.parametrize("spec", HARNESS_SPECS, ids=lambda s: s.family)
+def test_every_harness_states_how_it_authenticates(spec: HarnessSpec) -> None:
+    """A harness with no auth story at all cannot be graded past ``binary``."""
+    if not spec.is_harness:
+        return
+    auth = spec.auth
+    assert auth.env_vars or auth.credential_paths, f"{spec.family} has no auth probe"
+    if not auth.unattended:
+        # No API-key env var means no scheduled run can authenticate it. That is a
+        # real constraint on the family, so it has to be written down, not implied.
+        assert auth.login_command, f"{spec.family} needs a login_command"
+        assert spec.note, f"{spec.family} must explain why it cannot run unattended"
+
+
+@pytest.mark.parametrize("spec", HARNESS_SPECS, ids=lambda s: s.family)
+def test_context_files_are_relative_and_described(spec: HarnessSpec) -> None:
+    """Context paths are joined onto a workspace or ``~``; an absolute one escapes."""
+    for context in spec.context_files:
+        assert not context.path.startswith(("/", "~")), context.path
+    if spec.is_harness:
+        assert spec.context_files, (
+            f"{spec.family} has nowhere to read coordination instructions from; "
+            "an adapter would have no surface to install into"
+        )
+
+
+def test_agents_md_is_the_shared_surface() -> None:
+    """The finding that shapes the whole adapter design, asserted rather than argued.
+
+    Every harness in the table reads ``AGENTS.md``, marker-merged. That is why the
+    right shape is one AGENTS.md-based family parameterized per harness, not N
+    hand-written integrations.
+    """
+    harnesses = [s for s in HARNESS_SPECS if s.is_harness]
+    for spec in harnesses:
+        agents_md = [c for c in spec.context_files if c.path == "AGENTS.md"]
+        assert agents_md, f"{spec.family} does not read AGENTS.md — revisit the shared design"
+        assert agents_md[0].merge == "section", "AGENTS.md belongs to the user; merge a section"
+
+
+def test_get_spec_names_the_known_families() -> None:
+    assert get_spec("codex").binary == "codex"
+    with pytest.raises(KeyError, match="unknown harness family"):
+        get_spec("not-a-harness")
+    assert set(SPECS_BY_FAMILY) == {spec.family for spec in HARNESS_SPECS}

--- a/scripts/harness_conformance.py
+++ b/scripts/harness_conformance.py
@@ -1,0 +1,602 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Point real agent-harness binaries at a real room and report what happened.
+
+Mycelium's resident model asks one thing of a harness: hold a reasoning turn
+non-interactively. ``mycelium await --loop --exec <cmd>`` loops await → reason →
+respond, and ``<cmd>`` is the harness. That claim is only worth making about a
+binary someone has actually run, so this grades each family on a ladder and stops
+at the first rung it cannot climb:
+
+===============  ==========================================================
+``binary``       on PATH, and its version probe exits 0
+``auth``         an auth env var is set, or a cached-login artifact exists
+``oneshot``      one headless turn echoes a nonce back on stdout
+``participate``  a resident loop answers an ``@``-mention in a live room
+===============  ==========================================================
+
+Every rung is PASS, FAIL, or SKIP-with-a-reason, and a SKIP is never a FAIL: a
+runner with no Kiro binary has learned nothing about Kiro. That is what makes this
+safe to run per-PR — it reports the truth about the machine it is on.
+
+``auth`` is **advisory** and never blocks the rung above it. Harnesses authenticate
+in ways no probe can enumerate (a managed host may inject a token over a file
+descriptor), so an undetected credential must not be reported as a broken harness.
+When ``auth`` came back unknown and ``oneshot`` then fails, the failure is annotated
+as probably-unauthenticated rather than guessed at up front.
+
+``participate`` needs a manifest, so it needs a registered adapter. For a family
+with no integration yet it reports ``needs-adapter``, which is exactly the gap the
+integration closes; ``oneshot`` still grades, so the harness is de-risked before a
+line of adapter code is written.
+
+Usage::
+
+    uv run --project mycelium-cli python scripts/harness_conformance.py
+    uv run --project mycelium-cli python scripts/harness_conformance.py --family codex
+    uv run --project mycelium-cli python scripts/harness_conformance.py \
+        --max-level oneshot --json-report report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+from urllib.parse import urlparse
+
+from mycelium.integrations.harness_specs import HARNESS_SPECS, PROMPT_SLOT, HarnessSpec
+from mycelium.protocol import AGENT_ADAPTERS
+
+#: The ladder, in order.
+LEVELS: tuple[str, ...] = ("binary", "auth", "oneshot", "participate")
+
+#: Rungs that must pass before the next one is attempted. ``auth`` is absent on
+#: purpose: it informs the report, it does not gate it.
+BLOCKING: frozenset[str] = frozenset({"binary", "oneshot"})
+
+Status = Literal["pass", "fail", "skip"]
+
+#: How long one headless turn may take before we call it hung. Harnesses that
+#: reason for minutes are normal; a harness that never returns is the failure.
+ONESHOT_TIMEOUT_S = 240
+#: How long to wait for a resident loop's reply to land in the transcript.
+PARTICIPATE_TIMEOUT_S = 300
+
+
+@dataclass
+class Rung:
+    level: str
+    status: Status
+    detail: str
+    seconds: float = 0.0
+
+
+@dataclass
+class Report:
+    family: str
+    label: str
+    binary: str
+    adapter_status: str
+    rungs: list[Rung]
+
+    @property
+    def highest_pass(self) -> str:
+        """The highest *blocking* rung that passed — what this harness is proven to do.
+
+        ``auth`` is excluded: it is advisory, and a harness whose credentials the
+        probe merely happened to recognise has not been shown to reason.
+        """
+        passed = [r.level for r in self.rungs if r.status == "pass" and r.level != "auth"]
+        return passed[-1] if passed else "none"
+
+    @property
+    def failed(self) -> bool:
+        return any(r.status == "fail" for r in self.rungs)
+
+
+# ── the exec handler ─────────────────────────────────────────────────────────
+#
+# This is the generic bridge between a turn and a harness, and it is deliberately
+# harness-agnostic: it reads the turn from the env vars `mycelium await --exec`
+# exports, runs the argv template it is handed, and posts stdout back with
+# `mycelium respond`. Nothing in it knows which harness it is driving, which is
+# the point — an adapter would ship exactly this and vary only HARNESS_ARGV.
+
+_HANDLER = '''#!/usr/bin/env python3
+"""Turn → harness → respond. Argv template arrives as HARNESS_ARGV (JSON)."""
+import json, os, subprocess, sys
+
+sys.stdin.read()  # drain the turn JSON; the env vars carry the same fields
+
+room = os.environ["MYCELIUM_ROOM"]
+handle = os.environ["MYCELIUM_HANDLE"]
+prompt = os.environ.get("MYCELIUM_PROMPT", "")
+argv = [prompt if a == "{slot}" else a for a in json.loads(os.environ["HARNESS_ARGV"])]
+
+try:
+    proc = subprocess.run(argv, capture_output=True, text=True, timeout={timeout})
+    answer = (proc.stdout or "").strip()
+    err = (proc.stderr or "").strip()
+except Exception as exc:  # noqa: BLE001 - the handler must always answer
+    answer, err = "", f"{{type(exc).__name__}}: {{exc}}"
+
+if not answer:
+    answer = f"harness produced no output ({{err[:400]}})"
+
+subprocess.run(
+    ["mycelium", "respond", "--room", room, "--handle", handle, answer], check=False
+)
+'''
+
+
+def _write_handler(workspace: Path) -> Path:
+    handler = workspace / "harness_turn.py"
+    handler.write_text(
+        _HANDLER.format(slot=PROMPT_SLOT, timeout=ONESHOT_TIMEOUT_S), encoding="utf-8"
+    )
+    handler.chmod(0o755)
+    return handler
+
+
+# ── rungs ────────────────────────────────────────────────────────────────────
+
+
+def _run(argv: list[str], *, timeout: int, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(  # noqa: S603 - argv list from the spec table, never a shell string
+        argv,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=cwd,
+        check=False,
+    )
+
+
+def probe_binary(spec: HarnessSpec) -> Rung:
+    if not spec.is_harness:
+        return Rung("binary", "skip", f"not an agent harness — {spec.note.split('.')[0]}")
+    path = shutil.which(spec.binary)
+    if path is None:
+        return Rung("binary", "skip", f"{spec.binary} not on PATH ({spec.install_hint})")
+    if not spec.version_argv:
+        return Rung("binary", "pass", path)
+    started = time.monotonic()
+    try:
+        proc = _run([spec.binary, *spec.version_argv], timeout=60)
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return Rung("binary", "fail", f"version probe failed: {exc}", time.monotonic() - started)
+    elapsed = time.monotonic() - started
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()[:200]
+        return Rung(
+            "binary",
+            "fail",
+            f"`{spec.binary} --version` exited {proc.returncode}: {detail}",
+            elapsed,
+        )
+    return Rung("binary", "pass", f"{path} — {(proc.stdout or '').strip()[:80]}", elapsed)
+
+
+def probe_auth(spec: HarnessSpec) -> Rung:
+    present = [name for name in spec.auth.env_vars if os.environ.get(name)]
+    if present:
+        return Rung("auth", "pass", f"env: {', '.join(present)}")
+    cached = [p for p in spec.auth.credential_paths if (Path.home() / p).exists()]
+    if cached:
+        return Rung("auth", "pass", f"cached login: ~/{cached[0]}")
+    if not spec.auth.unattended:
+        return Rung(
+            "auth",
+            "skip",
+            f"undetected — {spec.label} publishes no API-key env var, so an unattended "
+            f"runner cannot authenticate at all (run `{spec.auth.login_command}` on a "
+            "developer machine and the cached login is reused)",
+        )
+    wanted = " or ".join(spec.auth.env_vars)
+    return Rung(
+        "auth",
+        "skip",
+        f"undetected: no {wanted} and no cached login (`{spec.auth.login_command}`). "
+        "Trying the turn anyway — credentials can arrive by routes a probe cannot see.",
+    )
+
+
+def probe_oneshot(spec: HarnessSpec, workspace: Path, *, auth_detected: bool) -> Rung:
+    """One headless turn must echo a nonce back — proof it reasoned and printed."""
+    nonce = f"MYCELIUM-OK-{uuid.uuid4().hex[:8].upper()}"
+    prompt = (
+        f"Reply with exactly this token and nothing else, no punctuation, no explanation: {nonce}"
+    )
+    argv = spec.render_argv(prompt)
+    started = time.monotonic()
+    try:
+        proc = _run(argv, timeout=ONESHOT_TIMEOUT_S, cwd=workspace)
+    except subprocess.TimeoutExpired:
+        return Rung(
+            "oneshot",
+            "fail",
+            f"no answer within {ONESHOT_TIMEOUT_S}s — `{' '.join(argv[:3])} …` hung",
+            time.monotonic() - started,
+        )
+    except OSError as exc:
+        return Rung("oneshot", "fail", f"could not run {spec.binary}: {exc}")
+    elapsed = time.monotonic() - started
+    stdout = proc.stdout or ""
+    if nonce in stdout:
+        return Rung("oneshot", "pass", f"echoed the nonce in {elapsed:.1f}s", elapsed)
+    tail = (proc.stderr or stdout).strip().splitlines()
+    hint = tail[-1][:200] if tail else "(no output)"
+    suspect = "" if auth_detected else " (auth was undetected; likely unauthenticated)"
+    return Rung(
+        "oneshot",
+        "fail",
+        f"exit {proc.returncode}, nonce absent from stdout: {hint}{suspect}",
+        elapsed,
+    )
+
+
+def _hub_reachable() -> bool:
+    if shutil.which("mycelium") is None:
+        return False
+    try:
+        return _run(["mycelium", "room", "ls"], timeout=45).returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def _slim_node() -> tuple[str, bool]:
+    """Return the configured SLIM node endpoint and whether it accepts a connection.
+
+    A room is a SLIM group channel, so with no node the hub cannot provision the
+    channel and ``await`` returns an empty turn forever. Probing up front turns a
+    seven-minute silent timeout into an immediate, correct SKIP.
+    """
+    from mycelium.config import MyceliumConfig
+
+    endpoint = MyceliumConfig.load().slim.node_endpoint
+    parsed = urlparse(endpoint)
+    host, port = parsed.hostname or "127.0.0.1", parsed.port or 46357
+    try:
+        with socket.create_connection((host, port), timeout=5):
+            return endpoint, True
+    except OSError:
+        return endpoint, False
+
+
+def _await_banner(loop: subprocess.Popen, timeout: int = 60) -> bool:
+    """Block until the resident loop says it is awaiting, so the mention is not
+    posted into the gap before the handle's delivery cursor is anchored."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if loop.stdout is None or loop.poll() is not None:
+            return False
+        line = loop.stdout.readline()
+        if not line:
+            continue
+        if "awaiting" in line:
+            return True
+    return False
+
+
+def _reply_landed(room: str, handle: str, nonce: str) -> bool:
+    """True once a message from *handle* carrying *nonce* is in the transcript."""
+    try:
+        proc = _run(
+            [
+                "mycelium",
+                "--json",
+                "room",
+                "messages",
+                room,
+                "--sender",
+                handle,
+                "--limit",
+                "10",
+            ],
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    if proc.returncode != 0:
+        return False
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    return any(nonce in (m.get("content") or "") for m in payload.get("messages", []))
+
+
+def probe_participate(spec: HarnessSpec, workspace: Path) -> Rung:
+    """The real thing: a resident loop answers an ``@``-mention in a live room."""
+    if spec.family not in AGENT_ADAPTERS:
+        return Rung(
+            "participate",
+            "skip",
+            f"needs-adapter: no integration for '{spec.family}', so no manifest can be "
+            "registered and the hub refuses the handle. This is the gap an adapter closes.",
+        )
+    if not _hub_reachable():
+        return Rung("participate", "skip", "no reachable hub (`mycelium room ls` failed)")
+    endpoint, node_up = _slim_node()
+    if not node_up:
+        return Rung(
+            "participate",
+            "skip",
+            f"no SLIM node at {endpoint} — a room is a SLIM group channel, so the hub "
+            "cannot provision one and `await` never serves a turn. Start one with "
+            "`mycelium hub host` or the `slim` compose service.",
+        )
+
+    suffix = uuid.uuid4().hex[:6]
+    room = f"harness-conformance-{spec.family.replace('_', '-')}-{suffix}"
+    handle = f"conf-{spec.family.replace('_', '-')}-{suffix}"
+    nonce = f"MYCELIUM-PONG-{suffix.upper()}"
+    handler = _write_handler(workspace)
+    loop: subprocess.Popen | None = None
+    started = time.monotonic()
+
+    try:
+        created = _run(["mycelium", "room", "create", room], timeout=90)
+        if created.returncode != 0:
+            return Rung(
+                "participate",
+                "fail",
+                f"room create failed: {(created.stderr or '').strip()[:200]}",
+            )
+
+        agent = _run(
+            [
+                "mycelium",
+                "agent",
+                "create",
+                handle,
+                "--adapter",
+                spec.family,
+                "--room",
+                room,
+                "--cwd",
+                str(workspace),
+                "--description",
+                "ephemeral harness-conformance probe",
+            ],
+            timeout=120,
+        )
+        if agent.returncode != 0:
+            return Rung(
+                "participate",
+                "fail",
+                f"agent create failed: {(agent.stderr or '').strip()[:200]}",
+            )
+
+        loop = subprocess.Popen(  # noqa: S603 - fixed argv
+            [
+                "mycelium",
+                "await",
+                "--loop",
+                "--room",
+                room,
+                "--handle",
+                handle,
+                "--exec",
+                f"{sys.executable} {handler}",
+            ],
+            env={**os.environ, "HARNESS_ARGV": json.dumps(list(spec.headless_argv))},
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            cwd=workspace,
+        )
+        # Wait for the loop's own "awaiting" banner rather than guessing at a
+        # sleep: the handle's delivery cursor anchors on that first long-poll, and
+        # a mention posted before it lands behind the anchor and is never served.
+        if not _await_banner(loop):
+            out = (loop.stdout.read() if loop.stdout else "").strip()
+            return Rung(
+                "participate",
+                "fail",
+                f"await --loop never reached its first poll: {out[-300:]}",
+            )
+
+        mention = _run(
+            [
+                "mycelium",
+                "room",
+                "send",
+                f"@{handle} Reply with exactly this token and nothing else: {nonce}",
+                "--room",
+                room,
+                "--handle",
+                "conformance-driver",
+            ],
+            timeout=90,
+        )
+        if mention.returncode != 0:
+            return Rung(
+                "participate",
+                "fail",
+                f"room send failed: {(mention.stderr or '').strip()[:200]}",
+            )
+
+        deadline = time.monotonic() + PARTICIPATE_TIMEOUT_S
+        while time.monotonic() < deadline:
+            if _reply_landed(room, handle, nonce):
+                elapsed = time.monotonic() - started
+                return Rung(
+                    "participate",
+                    "pass",
+                    f"resident loop answered in {elapsed:.1f}s",
+                    elapsed,
+                )
+            if loop.poll() is not None:
+                out = (loop.stdout.read() if loop.stdout else "").strip()
+                return Rung(
+                    "participate",
+                    "fail",
+                    f"await --loop exited {loop.returncode}: {out[-300:]}",
+                )
+            time.sleep(5)
+
+        return Rung(
+            "participate",
+            "fail",
+            f"no reply carrying the nonce within {PARTICIPATE_TIMEOUT_S}s",
+            time.monotonic() - started,
+        )
+    finally:
+        if loop is not None and loop.poll() is None:
+            loop.terminate()
+            try:
+                loop.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                loop.kill()
+        # Best-effort teardown: a probe must not leave rooms behind, but a
+        # cleanup failure must not turn a real result into a crash.
+        for argv in (
+            ["mycelium", "agent", "rm", handle, "--room", room, "--force"],
+            ["mycelium", "room", "delete", room, "--force"],
+        ):
+            try:
+                _run(argv, timeout=90)
+            except (subprocess.TimeoutExpired, OSError):
+                pass
+
+
+# ── driver ───────────────────────────────────────────────────────────────────
+
+
+def grade(spec: HarnessSpec, *, max_level: str, workspace: Path) -> Report:
+    cap = LEVELS.index(max_level)
+    rungs: list[Rung] = []
+    by_level: dict[str, Rung] = {}
+
+    for index, level in enumerate(LEVELS):
+        if index > cap:
+            rungs.append(Rung(level, "skip", f"above --max-level={max_level}"))
+            continue
+        blocker = next(
+            (r for r in rungs if r.level in BLOCKING and r.status != "pass"),
+            None,
+        )
+        if blocker is not None:
+            rungs.append(Rung(level, "skip", f"'{blocker.level}' did not pass"))
+            continue
+        if level == "binary":
+            rung = probe_binary(spec)
+        elif level == "auth":
+            rung = probe_auth(spec)
+        elif level == "oneshot":
+            rung = probe_oneshot(spec, workspace, auth_detected=by_level["auth"].status == "pass")
+        else:
+            rung = probe_participate(spec, workspace)
+        by_level[level] = rung
+        rungs.append(rung)
+
+    return Report(
+        family=spec.family,
+        label=spec.label,
+        binary=spec.binary,
+        adapter_status=spec.adapter_status,
+        rungs=rungs,
+    )
+
+
+_GLYPH = {"pass": "✓", "fail": "✗", "skip": "–"}
+
+
+def render_markdown(reports: list[Report]) -> str:
+    lines = [
+        "# Agent-harness conformance",
+        "",
+        "| Harness | Adapter | binary | auth | oneshot | participate | Reached |",
+        "| --- | --- | :-: | :-: | :-: | :-: | --- |",
+    ]
+    for report in reports:
+        cells = " | ".join(_GLYPH[r.status] for r in report.rungs)
+        lines.append(
+            f"| {report.label} (`{report.binary}`) | {report.adapter_status} | "
+            f"{cells} | **{report.highest_pass}** |"
+        )
+    lines += ["", "<details><summary>Detail</summary>", ""]
+    for report in reports:
+        lines.append(f"**{report.label}**")
+        lines += [f"- `{r.level}` {_GLYPH[r.status]} {r.detail}" for r in report.rungs]
+        lines.append("")
+    lines.append("</details>")
+    return "\n".join(lines)
+
+
+def render_text(reports: list[Report]) -> str:
+    out: list[str] = []
+    for report in reports:
+        out.append(f"\n{report.label}  ({report.binary}, adapter: {report.adapter_status})")
+        for rung in report.rungs:
+            out.append(f"  {_GLYPH[rung.status]} {rung.level:<12} {rung.detail}")
+        out.append(f"  → reached: {report.highest_pass}")
+    return "\n".join(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--family",
+        action="append",
+        default=[],
+        help="Grade only this family (repeatable). Default: every family in the spec table.",
+    )
+    parser.add_argument(
+        "--max-level",
+        choices=LEVELS,
+        default="participate",
+        help="Highest rung to attempt. Use 'oneshot' where no hub is running.",
+    )
+    parser.add_argument("--json-report", type=Path, help="Write the full report as JSON here.")
+    parser.add_argument("--markdown-report", type=Path, help="Write a markdown summary here.")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero on any FAIL. Without it a FAIL is reported and the exit stays 0.",
+    )
+    args = parser.parse_args()
+
+    specs = [s for s in HARNESS_SPECS if not args.family or s.family in args.family]
+    if not specs:
+        parser.error(f"no such family; known: {', '.join(s.family for s in HARNESS_SPECS)}")
+
+    with tempfile.TemporaryDirectory(prefix="harness-conformance-") as tmp:
+        workspace = Path(tmp)
+        reports = [grade(spec, max_level=args.max_level, workspace=workspace) for spec in specs]
+
+    print(render_text(reports))
+
+    if args.json_report:
+        args.json_report.write_text(
+            json.dumps([asdict(r) | {"reached": r.highest_pass} for r in reports], indent=2),
+            encoding="utf-8",
+        )
+    markdown = render_markdown(reports)
+    if args.markdown_report:
+        args.markdown_report.write_text(markdown, encoding="utf-8")
+    if summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+        with Path(summary).open("a", encoding="utf-8") as handle:
+            handle.write(markdown + "\n")
+
+    return 1 if (args.strict and any(r.failed for r in reports)) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Mycelium's resident model asks one thing of an agent runtime: hold a reasoning turn. `mycelium await --loop --exec <cmd>` loops await → reason → respond, and `<cmd>` is the harness. Everything else an integration does — dropping coordination instructions, building a manifest, reporting health — is in service of that one call.

This surveys the runtimes that clear that bar (Kiro, Codex, Cursor, Claude, Perplexity, Copilot, Antigravity), and builds the harness that *proves* a binary clears it rather than asserting it in prose. Full writeup: [`docs/agent-harnesses.md`](https://github.com/mycelium-io/mycelium/blob/claude/agent-harnesses-mycelium-oj3xl3/docs/agent-harnesses.md).

**Two findings shape the design, and are asserted in tests rather than argued:**

1. **Every harness reads `AGENTS.md` and takes a prompt on argv.** The differences that remain are enumerable: the headless argv, one optional harness-native rules file, the auth probe, and workspace-vs-host install. That is a table, not six programs — so the right shape is **one parameterized AGENTS.md family**, not six hand-written adapters. Claude Code is the genuine outlier (per-host skill under `~/.claude/`) and already has its own integration.

2. **Perplexity is not a harness.** `pplx` is a single-binary client for the Search API (`pplx search web`, `pplx content fetch`, JSON out). It answers questions about the world; it does not hold a reasoning turn, call tools, or edit files. It's a *tool a harness calls* — it belongs behind MCP for the aligner and residents to reach, not in front of an adapter. Recorded in the table as `unsupported` so it isn't rediscovered.

**Recommended first build: Codex.** `AGENTS.md` is its native instruction surface (so it needs no harness-specific rules file at all), `codex exec --json` gives a JSONL event stream, and `codex exec resume` maps onto the durable per-agent session `await --loop` wants — which most of the field lacks. Then Kiro (`.kiro/steering/**/*.md` is a near-exact analogue of Cursor's project rules, so the cursor integration is the template), then Copilot gated on pinning a version. Antigravity waits on an unattended-auth story.

## Changes

- **`mycelium-cli/src/mycelium/integrations/harness_specs.py`** — the family table as data: binary, headless argv, auth probe, context-file conventions, and an honest capability grade (`proven` / `untested` / `candidate` / `unsupported`). Two consumers read it — an integration builds an adapter from a spec, the conformance runner points a binary at a room from the same spec — so a family can't be "supported" by code the runner has never exercised, or exercised by a runner reading stale flags.

- **`scripts/harness_conformance.py`** — grades a family on a ladder (`binary` → `auth` → `oneshot` → `participate`) and stops at the first rung it can't climb. Three deliberate properties:
  - **A SKIP is never a FAIL.** A runner with no Kiro binary has learned nothing about Kiro; reporting that red trains everyone to ignore the report.
  - **`auth` is advisory and doesn't gate the turn.** Harnesses authenticate in ways no probe can enumerate — this was found empirically: `claude` on the dev machine was fully authenticated with no `ANTHROPIC_API_KEY` and no `~/.claude/.credentials.json`. The turn is attempted anyway and a failure is annotated as probably-unauthenticated.
  - **`participate` needs a manifest, so it reports `needs-adapter`** for a family with no integration — precisely the gap an adapter closes — while `oneshot` still grades. That de-risks a candidate before a line of adapter code is written, which is the point of building the runner first.
  - It also ships the generic, harness-agnostic exec handler (turn in → argv rendered → stdout back via `mycelium respond`); an adapter would ship the same script and vary only `HARNESS_ARGV`.

- **`.github/workflows/harness-conformance.yml`** — weekly, on dispatch, and on PRs touching the harness surface. `oneshot` job: matrix over every family, installs each vendor CLI, no hub. `participate` job: adapter-backed families only, stands up a SLIM node + hub first. Nothing gates a PR — vendors ship breaking CLI changes on their own schedule (GitHub removed `copilot --headless --stdio` with no deprecation, github/copilot-cli#1606), so a red run is news, not a broken pull request.

- **`mycelium-cli/tests/test_harness_specs.py`** — guards drift between the table's claims and the code: a family graded `proven`/`untested` with no integration behind it, a `candidate` that has since gained one, an argv template that can't render, a prompt that doesn't survive as exactly one argv element, or a harness with no auth story written down.

- **`docs/agent-harnesses.md`** — the survey, the per-harness findings, the adapter proposal, and the build order.

## Testing

- [x] Unit tests pass — `525 passed, 3 skipped` (`mycelium-cli`), including 39 new
- [x] Linting passes (`uv run ruff check`)
- [x] Format check passes (`uv run ruff format --check`)
- [x] Type check passes (`uv run ty check .`)
- [x] Docs generator run — no drift
- [x] **Runner validated against a real harness binary**: graded `claude` 2.1.239 to the `oneshot` rung (binary ✓, oneshot ✓ — nonce echoed in 5.8s), and correctly reported skips-with-reasons for the six binaries not on the machine.
- [x] `participate` setup validated step-by-step against a live hub (`room create`, `agent create --adapter claude_code`, `room send`, `await --loop --exec`, `--json room messages`).

**Left as draft for one reason:** the `participate` rung has not been observed green end-to-end. The dev container had no Docker daemon, so no SLIM node could be started — and a room *is* a SLIM group channel, so with no node the hub can't provision one and `await` never serves a turn. That was found the slow way (a silent 7-minute timeout) and is now a pre-flight check that skips immediately with an actionable reason. The `participate` CI job stands up the node exactly as `ci.yml`'s `integration-slim` job does, but that job's first real run is the proof, and it needs `ANTHROPIC_API_KEY` in repo secrets to get past `oneshot`.

Secrets the workflow reads (all optional; an absent key skips that family with a reason rather than failing): `ANTHROPIC_API_KEY`, `CURSOR_API_KEY`, `OPENAI_API_KEY`, `COPILOT_GITHUB_TOKEN`, `KIRO_API_KEY`.

## Related Issues

Relates to the untested `cursor` adapter — this is the harness that would move it from `untested` to `proven`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019gUfbJ3J8AzwKnWSUgS87w)_