### PR TITLE
Fold the workspace rails away on a narrow window

### DIFF
--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -13,20 +13,24 @@ import { memoryHref } from "@/lib/memory-routes";
 import { AppShell } from "@/components/app-shell";
 import { EventStream, type View, type NegotiationPhase } from "@/components/event-stream";
 import { RoomChatBox } from "@/components/room-chat-box";
-import { RoomInspectorPanel, type Tab } from "@/components/room-inspector";
+import { RoomInspector, type Tab } from "@/components/room-inspector";
 import { RoomTour } from "@/components/room-tour";
 import { GlobalStatusItems, StatusButton } from "@/components/status-items";
 import { useCommands, useKeyAction, useKeyScope } from "@/components/keymap-provider";
 import type { PaletteCommand } from "@/lib/commands";
 import { useRoomStatus } from "@/lib/use-status";
-import { ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import {
+  INSPECTOR_FOLD_WIDTH,
+  INSPECTOR_PANEL,
   MAIN_PANEL,
   PANEL_INSPECTOR,
   PANEL_MAIN,
   ROOM_GROUP_ID,
+  ROOM_PANEL_IDS,
   layoutStorage,
 } from "@/lib/panel-layout";
+import { useCollapsibleRail } from "@/lib/use-collapsible-rail";
 
 function episodeSummaryLabel(episodes: EpisodeSummary[] | null): { text: string; color: string } | null {
   if (!episodes || episodes.length === 0) return null;
@@ -174,7 +178,21 @@ function RoomWorkspace() {
   const { defaultLayout, onLayoutChange, onLayoutChanged } = useDefaultLayout({
     id: ROOM_GROUP_ID,
     storage: layoutStorage,
-    panelIds: [PANEL_MAIN, PANEL_INSPECTOR],
+    panelIds: ROOM_PANEL_IDS,
+  });
+
+  // Folded, the inspector is a plain strip beside the group rather than a panel
+  // inside it: a panel that isn't there can't be squeezed, and it comes back at
+  // the width it left at.
+  const {
+    panelRef: inspectorPanelRef,
+    size: inspectorSize,
+    onResize: onInspectorResize,
+  } = useCollapsibleRail({
+    foldWidth: INSPECTOR_FOLD_WIDTH,
+    defaultWidth: INSPECTOR_PANEL.default,
+    open: inspectorOpen,
+    onOpenChange: setInspectorOpen,
   });
 
   const statusLeft = (
@@ -228,46 +246,85 @@ function RoomWorkspace() {
       statusLeft={statusLeft}
       statusRight={statusRight}
     >
-      <ResizablePanelGroup
-        className="min-h-0 flex-1"
-        defaultLayout={defaultLayout}
-        onLayoutChange={onLayoutChange}
-        onLayoutChanged={onLayoutChanged}
-      >
-        <ResizablePanel id={PANEL_MAIN} minSize={MAIN_PANEL.min} className="flex min-w-0">
-          <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
-            <div className="flex-1 overflow-hidden">
-              <EventStream
-                roomName={roomName}
-                onMemoryChanged={handleMemoryChanged}
-                onConnectionChange={setConnected}
-                onNegotiationPhaseChange={setNegPhase}
-                onOpenMemory={openMemory}
-                view={editorView}
-                onViewChange={setEditorView}
-                suppressInvites={tourActive}
-                focusMessageId={focus?.type === "message" ? focus.id : null}
-                onFocusConsumed={clearFocus}
-              />
-            </div>
-            <RoomChatBox roomName={roomName} className={editorView !== "channel" ? "hidden" : undefined} />
-          </main>
-        </ResizablePanel>
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <ResizablePanelGroup
+          className="min-h-0 flex-1"
+          defaultLayout={defaultLayout}
+          // Only while both panels are here: a one-panel layout saved over the
+          // split would be the rail's remembered width, gone.
+          onLayoutChange={inspectorOpen ? onLayoutChange : undefined}
+          onLayoutChanged={inspectorOpen ? onLayoutChanged : undefined}
+        >
+          <ResizablePanel id={PANEL_MAIN} minSize={MAIN_PANEL.min} className="flex min-w-0">
+            <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
+              <div className="flex-1 overflow-hidden">
+                <EventStream
+                  roomName={roomName}
+                  onMemoryChanged={handleMemoryChanged}
+                  onConnectionChange={setConnected}
+                  onNegotiationPhaseChange={setNegPhase}
+                  onOpenMemory={openMemory}
+                  view={editorView}
+                  onViewChange={setEditorView}
+                  suppressInvites={tourActive}
+                  focusMessageId={focus?.type === "message" ? focus.id : null}
+                  onFocusConsumed={clearFocus}
+                />
+              </div>
+              <RoomChatBox roomName={roomName} className={editorView !== "channel" ? "hidden" : undefined} />
+            </main>
+          </ResizablePanel>
+          {inspectorOpen && (
+            <>
+              <ResizableHandle withHandle />
+              <ResizablePanel
+                id={PANEL_INSPECTOR}
+                panelRef={inspectorPanelRef}
+                collapsible
+                collapsedSize={INSPECTOR_PANEL.collapsed}
+                defaultSize={inspectorSize}
+                minSize={INSPECTOR_PANEL.min}
+                maxSize={INSPECTOR_PANEL.max}
+                groupResizeBehavior="preserve-pixel-size"
+                className="flex"
+                onResize={onInspectorResize}
+              >
+                <RoomInspector
+                  roomName={roomName}
+                  masId={room?.mas_id ?? null}
+                  tab={inspectorTab}
+                  onTabChange={setInspectorTab}
+                  open={inspectorOpen}
+                  onOpenChange={setInspectorOpen}
+                  engineInvite={inviteEngine}
+                  onEngineInviteShown={handleEngineInviteShown}
+                  focus={focus}
+                  onFocusConsumed={clearFocus}
+                  focusMemory={focusMemory}
+                />
+              </ResizablePanel>
+            </>
+          )}
+        </ResizablePanelGroup>
 
-        <RoomInspectorPanel
-          roomName={roomName}
-          masId={room?.mas_id ?? null}
-          tab={inspectorTab}
-          onTabChange={setInspectorTab}
-          open={inspectorOpen}
-          onOpenChange={setInspectorOpen}
-          engineInvite={inviteEngine}
-          onEngineInviteShown={handleEngineInviteShown}
-          focus={focus}
-          onFocusConsumed={clearFocus}
-          focusMemory={focusMemory}
-        />
-      </ResizablePanelGroup>
+        {!inspectorOpen && (
+          <div className="flex w-12 flex-none border-l border-border">
+            <RoomInspector
+            roomName={roomName}
+            masId={room?.mas_id ?? null}
+            tab={inspectorTab}
+            onTabChange={setInspectorTab}
+            open={inspectorOpen}
+            onOpenChange={setInspectorOpen}
+            engineInvite={inviteEngine}
+            onEngineInviteShown={handleEngineInviteShown}
+            focus={focus}
+            onFocusConsumed={clearFocus}
+            focusMemory={focusMemory}
+            />
+          </div>
+        )}
+      </div>
 
       <RoomTour
         active={tourActive}

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -75,7 +75,12 @@ function iamCommand(u: BoundUser): string {
  * editor and SaaS app puts it in — so identity reads the same on every screen
  * instead of riding one page's header.
  */
-export function ActingAsPicker() {
+interface Props {
+  /** Trigger as the avatar alone, for the collapsed rooms rail. */
+  compact?: boolean;
+}
+
+export function ActingAsPicker({ compact = false }: Props) {
   const { principal, setPrincipal } = useCurrentUser();
   const { signedIn, handle: sessionHandle, logout } = useAuthSession();
   const [open, setOpen] = useState(false);
@@ -173,8 +178,12 @@ export function ActingAsPicker() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger
-        title="Choose the user you're acting as"
-        className="group flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-hairline"
+        title={principal ? `Acting as @${principal}` : "Choose the user you're acting as"}
+        className={
+          compact
+            ? "group flex size-8 items-center justify-center rounded-md transition-colors hover:bg-hairline"
+            : "group flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-hairline"
+        }
       >
         {principal ? (
           <Monogram handle={principal} color="var(--muted-foreground)" className="size-7" />
@@ -186,15 +195,21 @@ export function ActingAsPicker() {
             <UserRound className="size-3.5" />
           </span>
         )}
-        <span className="min-w-0 flex-1">
-          <span className="block truncate font-mono text-label text-text">
-            {principal ? `@${principal}` : "Anonymous"}
-          </span>
-          <span className="block truncate text-micro text-muted-foreground">
-            {principal ? (signedIn ? "signed in" : "acting as") : "pick a user"}
-          </span>
-        </span>
-        <ChevronsUpDown className="size-3.5 flex-shrink-0 text-faint transition-colors group-hover:text-muted-foreground" />
+        {/* The handle and the switcher affordance are what the 48px strip
+            can't hold; the avatar carries the identity on its own there. */}
+        {!compact && (
+          <>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate font-mono text-label text-text">
+                {principal ? `@${principal}` : "Anonymous"}
+              </span>
+              <span className="block truncate text-micro text-muted-foreground">
+                {principal ? (signedIn ? "signed in" : "acting as") : "pick a user"}
+              </span>
+            </span>
+            <ChevronsUpDown className="size-3.5 flex-shrink-0 text-faint transition-colors group-hover:text-muted-foreground" />
+          </>
+        )}
       </DialogTrigger>
 
       <DialogContent className="sm:max-w-sm">

--- a/mycelium-frontend/src/components/app-shell.tsx
+++ b/mycelium-frontend/src/components/app-shell.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { Terminal } from "lucide-react";
 import { useDefaultLayout } from "react-resizable-panels";
 import { RoomsSidebar } from "@/components/rooms-sidebar";
@@ -21,11 +21,15 @@ import {
 import {
   PANEL_ROOMS,
   PANEL_WORKSPACE,
+  ROOMS_FOLD_WIDTH,
+  SHELL_PANEL_IDS,
   ROOMS_PANEL,
   SHELL_GROUP_ID,
   WORKSPACE_PANEL,
   layoutStorage,
 } from "@/lib/panel-layout";
+import { useCollapsibleRail } from "@/lib/use-collapsible-rail";
+import { useKeyAction } from "@/components/keymap-provider";
 
 interface Props {
   /** The open room (highlights its sidebar row); null on the home view. */
@@ -58,7 +62,9 @@ function InstallCliButton() {
  *  The rooms rail is draggable and its width is remembered per browser — long
  *  room names and a wide window pull in opposite directions, and this is the
  *  one rail on every page, so it's the reader's call rather than a constant.
- *  Double-clicking the seam puts it back to the default. */
+ *  Double-clicking the seam puts it back to the default, and on a window too
+ *  narrow to hold the rail and the workspace at once it folds itself down to a
+ *  strip of room monograms until there's room for names again. */
 export function AppShell({
   activeRoom = null,
   header,
@@ -70,8 +76,17 @@ export function AppShell({
   const { defaultLayout, onLayoutChange, onLayoutChanged } = useDefaultLayout({
     id: SHELL_GROUP_ID,
     storage: layoutStorage,
-    panelIds: [PANEL_ROOMS, PANEL_WORKSPACE],
+    panelIds: SHELL_PANEL_IDS,
   });
+
+  const [roomsOpen, setRoomsOpen] = useState(true);
+  const { panelRef, size, onResize } = useCollapsibleRail({
+    foldWidth: ROOMS_FOLD_WIDTH,
+    defaultWidth: ROOMS_PANEL.default,
+    open: roomsOpen,
+    onOpenChange: setRoomsOpen,
+  });
+  useKeyAction("rooms.toggle", () => setRoomsOpen(open => !open));
 
   return (
     <GlobalSearch>
@@ -80,43 +95,72 @@ export function AppShell({
           className="flex h-screen flex-col overflow-hidden bg-bg text-text"
           data-app-shell="ready"
         >
-          <ResizablePanelGroup
-            className="min-h-0 flex-1"
-            defaultLayout={defaultLayout}
-            onLayoutChange={onLayoutChange}
-            onLayoutChanged={onLayoutChanged}
-          >
-            <ResizablePanel
-              id={PANEL_ROOMS}
-              defaultSize={ROOMS_PANEL.default}
-              minSize={ROOMS_PANEL.min}
-              maxSize={ROOMS_PANEL.max}
-              groupResizeBehavior="preserve-pixel-size"
-              className="flex"
+          <div className="flex min-h-0 flex-1 overflow-hidden">
+            {/* Folded, the rail is a plain strip beside the group rather than a
+                panel inside it. A panel that isn't there can't be squeezed, and
+                comes back at the width it left at — where a panel *told* to
+                collapse is at the mercy of a group still solving for the window
+                it had a frame ago. */}
+            {!roomsOpen && (
+              <div className="flex w-12 flex-none border-r border-border">
+                <RoomsSidebar
+                  activeRoom={activeRoom}
+                  collapsed
+                  onCollapsedChange={next => setRoomsOpen(!next)}
+                />
+              </div>
+            )}
+            <ResizablePanelGroup
+              className="min-h-0 flex-1"
+              defaultLayout={defaultLayout}
+              // Only while both panels are here: a one-panel layout saved over
+              // the split would be the rail's remembered width, gone.
+              onLayoutChange={roomsOpen ? onLayoutChange : undefined}
+              onLayoutChanged={roomsOpen ? onLayoutChanged : undefined}
             >
-              <RoomsSidebar activeRoom={activeRoom} />
-            </ResizablePanel>
+              {roomsOpen && (
+                <>
+                  <ResizablePanel
+                    id={PANEL_ROOMS}
+                    panelRef={panelRef}
+                    collapsible
+                    collapsedSize={ROOMS_PANEL.collapsed}
+                    defaultSize={size}
+                    minSize={ROOMS_PANEL.min}
+                    maxSize={ROOMS_PANEL.max}
+                    groupResizeBehavior="preserve-pixel-size"
+                    className="flex"
+                    onResize={onResize}
+                  >
+                    <RoomsSidebar
+                      activeRoom={activeRoom}
+                      onCollapsedChange={next => setRoomsOpen(!next)}
+                    />
+                  </ResizablePanel>
 
-            <ResizableHandle withHandle />
+                  <ResizableHandle withHandle />
+                </>
+              )}
 
-            <ResizablePanel
-              id={PANEL_WORKSPACE}
-              minSize={WORKSPACE_PANEL.min}
-              className="flex min-w-0 flex-col"
-            >
-              <header className="flex h-[52px] flex-shrink-0 items-center gap-3 border-b border-border bg-surface/50 px-5">
-                {header}
-                {/* Appearance sits top-right, the corner every app puts it in,
-                    rather than crowding the identity row at the other end. */}
-                <div className="ml-auto flex flex-shrink-0 items-center gap-3">
-                  {headerRight}
-                  <InstallCliButton />
-                  <ThemeToggle />
-                </div>
-              </header>
-              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
-            </ResizablePanel>
-          </ResizablePanelGroup>
+              <ResizablePanel
+                id={PANEL_WORKSPACE}
+                minSize={WORKSPACE_PANEL.min}
+                className="flex min-w-0 flex-col"
+              >
+                <header className="flex h-[52px] flex-shrink-0 items-center gap-3 border-b border-border bg-surface/50 px-5">
+                  {header}
+                  {/* Appearance sits top-right, the corner every app puts it in,
+                      rather than crowding the identity row at the other end. */}
+                  <div className="ml-auto flex flex-shrink-0 items-center gap-3">
+                    {headerRight}
+                    <InstallCliButton />
+                    <ThemeToggle />
+                  </div>
+                </header>
+                <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{children}</div>
+              </ResizablePanel>
+            </ResizablePanelGroup>
+          </div>
           <footer className="flex h-6 flex-shrink-0 items-center gap-3 border-t border-border bg-surface px-3 text-micro text-muted-foreground">
             {statusLeft}
             <div className="ml-auto flex items-center gap-3">

--- a/mycelium-frontend/src/components/room-inspector.tsx
+++ b/mycelium-frontend/src/components/room-inspector.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react";
+import { useLayoutEffect, useRef, useState, type RefObject } from "react";
 import {
   Activity,
   Brain,
@@ -12,19 +12,12 @@ import {
   Users,
   type LucideIcon,
 } from "lucide-react";
-import { usePanelRef } from "react-resizable-panels";
 import { AgentsPanel } from "@/components/agents-panel";
 import { EpisodesRail } from "@/components/episodes-rail";
 import { KeyBadge } from "@/components/key-badge";
 import { MemoryPanel } from "@/components/memory-panel";
-import { ResizableHandle, ResizablePanel } from "@/components/ui/resizable";
 import { chordFor, chordKey } from "@/lib/keymap";
-import {
-  COLLAPSED_THRESHOLD_PX,
-  INSPECTOR_PANEL,
-  PANEL_INSPECTOR,
-  TAB_LABELS_MIN_WIDTH,
-} from "@/lib/panel-layout";
+import { TAB_LABELS_MIN_WIDTH } from "@/lib/panel-layout";
 import type { FocusTarget } from "@/lib/search";
 
 // Skills aren't a rail: a skill is just a `skills/…` memory, so it shows up in
@@ -63,66 +56,6 @@ interface Props {
   onFocusConsumed?: () => void;
   /** Reveal a memory by key in the Memory tab (e.g. a clicked chat wikilink). */
   focusMemory?: { key: string; nonce: number } | null;
-}
-
-/**
- * The inspector as a resizable panel: the seam beside it, the panel that holds
- * it, and the wiring that makes the collapse button, the drag, and the `\`
- * keybind three ways of doing the same thing.
- *
- * Open/closed *is* the panel's collapsed state rather than a second flag beside
- * it. That's what lets the button reopen the rail at the width you last dragged
- * it to instead of a constant, and it's why dragging the seam past the minimum
- * shuts the rail rather than jamming against a wall. Double-clicking the seam
- * puts it back to the default width.
- */
-export function RoomInspectorPanel({ open: openProp, onOpenChange, ...rest }: Props) {
-  const [openInternal, setOpenInternal] = useState(true);
-  const open = openProp ?? openInternal;
-  const panelRef = usePanelRef();
-
-  const setOpen = useCallback(
-    (next: boolean) => {
-      if (openProp === undefined) setOpenInternal(next);
-      onOpenChange?.(next);
-    },
-    [openProp, onOpenChange],
-  );
-
-  // State → panel. `collapse`/`expand` are no-ops when already in that state,
-  // so this settles rather than ping-ponging with `onResize` below.
-  useEffect(() => {
-    const panel = panelRef.current;
-    if (!panel) return;
-    if (open && panel.isCollapsed()) panel.expand();
-    else if (!open && !panel.isCollapsed()) panel.collapse();
-  }, [open, panelRef]);
-
-  return (
-    <>
-      <ResizableHandle withHandle />
-      <ResizablePanel
-        id={PANEL_INSPECTOR}
-        panelRef={panelRef}
-        collapsible
-        collapsedSize={INSPECTOR_PANEL.collapsed}
-        defaultSize={INSPECTOR_PANEL.default}
-        minSize={INSPECTOR_PANEL.min}
-        maxSize={INSPECTOR_PANEL.max}
-        groupResizeBehavior="preserve-pixel-size"
-        className="flex"
-        // Panel → state, so a drag past the minimum reads as "closed" to the
-        // status bar and the keybind, and a restored collapsed layout doesn't
-        // come back claiming to be open.
-        onResize={size => {
-          const collapsed = size.inPixels <= COLLAPSED_THRESHOLD_PX;
-          if (collapsed === open) setOpen(!collapsed);
-        }}
-      >
-        <RoomInspector {...rest} open={open} onOpenChange={setOpen} />
-      </ResizablePanel>
-    </>
-  );
 }
 
 /**

--- a/mycelium-frontend/src/components/rooms-sidebar.test.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Mycelium Contributors
 
-import { act } from "react";
+import { act, type ComponentProps } from "react";
 import { screen, within } from "@testing-library/react";
 import { renderWithSWR } from "@/test/swr";
 import userEvent from "@testing-library/user-event";
@@ -30,7 +30,11 @@ function rooms(...names: string[]) {
   return names.map(name => ({ name }));
 }
 
-async function renderSidebar(names: string[], activeRoom: string | null = null) {
+async function renderSidebar(
+  names: string[],
+  activeRoom: string | null = null,
+  props: Partial<ComponentProps<typeof RoomsSidebar>> = {},
+) {
   vi.mocked(fetchRooms).mockResolvedValue(rooms(...names) as never);
   renderWithSWR(
     <CurrentUserProvider>
@@ -38,7 +42,7 @@ async function renderSidebar(names: string[], activeRoom: string | null = null) 
         <NotificationsProvider>
           <KeymapProvider>
             <InstallModalProvider>
-              <RoomsSidebar activeRoom={activeRoom} />
+              <RoomsSidebar activeRoom={activeRoom} {...props} />
             </InstallModalProvider>
           </KeymapProvider>
         </NotificationsProvider>
@@ -145,5 +149,41 @@ describe("<RoomsSidebar /> unread badges", () => {
     const beta = screen.getByRole("link", { name: /beta/ });
     expect(within(beta).queryByLabelText(/unread/)).toBeNull();
     expect(within(beta).getByLabelText("muted")).toBeInTheDocument();
+  });
+});
+
+describe("<RoomsSidebar /> collapsed strip", () => {
+  beforeEach(() => {
+    FakeEventSource.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    window.localStorage.clear();
+  });
+
+  it("keeps every room reachable as a monogram, without the filter", async () => {
+    await renderSidebar(["alpha", "beta"], "beta", { collapsed: true });
+
+    // Named for the screen reader, drawn as initials — still one click away.
+    expect(screen.getByRole("link", { name: "alpha" })).toHaveAttribute("href", "/room/alpha");
+    expect(screen.getByRole("link", { name: "beta" })).toHaveAttribute("href", "/room/beta");
+    expect(screen.getByText("AL")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Filter rooms…")).toBeNull();
+  });
+
+  it("still badges unread activity, and offers the way back", async () => {
+    window.localStorage.setItem(
+      "mycelium.notifications",
+      JSON.stringify([{ room: "alpha", read: false }]),
+    );
+    const onCollapsedChange = vi.fn();
+    const user = await renderSidebar(["alpha", "beta"], "beta", {
+      collapsed: true,
+      onCollapsedChange,
+    });
+
+    const alpha = screen.getByRole("link", { name: /alpha/ });
+    expect(within(alpha).getByLabelText("1 unread")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Expand the rooms rail/ }));
+    expect(onCollapsedChange).toHaveBeenCalledWith(false);
   });
 });

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -7,7 +7,19 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { Bell, BellOff, BellRing, Boxes, Check, Plus, Search, SearchX, type LucideIcon } from "lucide-react";
+import {
+  Bell,
+  BellOff,
+  BellRing,
+  Boxes,
+  Check,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Plus,
+  Search,
+  SearchX,
+  type LucideIcon,
+} from "lucide-react";
 import { getAppEventsSSEUrl, type Room } from "@/lib/api";
 import { useRooms } from "@/lib/room-data";
 import { roomLevel, type RoomLevel } from "@/lib/notifications";
@@ -21,7 +33,16 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { KeyBadge } from "@/components/key-badge";
 import { useCommands, useKeyAction } from "@/components/keymap-provider";
 import { useOpenInstallModal } from "@/components/install-modal";
+import { chordFor, chordKey } from "@/lib/keymap";
 import type { PaletteCommand } from "@/lib/commands";
+
+/** "Collapse the rooms rail (⌥B)" — spelled into the title so the strip says
+ *  how to get back without holding the reveal modifier first. */
+function railToggleTitle(expanded: boolean): string {
+  const chord = chordFor("rooms.toggle");
+  const suffix = chord ? ` (${chordKey(chord)})` : "";
+  return `${expanded ? "Collapse" : "Expand"} the rooms rail${suffix}`;
+}
 
 /** Two-letter monogram from a room name (mirrors the agent avatars). */
 function monogram(name: string): string {
@@ -33,9 +54,12 @@ function monogram(name: string): string {
 interface Props {
   /** The room currently open, so its row is highlighted. Null on the home view. */
   activeRoom?: string | null;
+  /** Draw the rail as a strip of room monograms rather than a list of names. */
+  collapsed?: boolean;
+  onCollapsedChange?: (collapsed: boolean) => void;
 }
 
-export function RoomsSidebar({ activeRoom = null }: Props) {
+export function RoomsSidebar({ activeRoom = null, collapsed = false, onCollapsedChange }: Props) {
   const [query, setQuery] = useState("");
   const [showCreate, setShowCreate] = useState(false);
 
@@ -163,6 +187,82 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
   );
   useCommands(commands);
 
+  // Collapsed: the same rail as a strip of room monograms — every room still
+  // one click away, the filter and the names traded for the 48px the window
+  // can spare. The dialogs stay mounted here so the create/notification flows
+  // work from the strip too.
+  if (collapsed) {
+    return (
+      <aside data-tour="rooms" className="flex w-full min-w-0 flex-col items-center overflow-hidden bg-surface/50">
+        <Link
+          href="/"
+          title="Command center"
+          className="relative flex h-[52px] w-full flex-shrink-0 items-center justify-center border-b border-border transition-colors hover:bg-hairline"
+        >
+          <Image src="/logo.png" alt="Mycelium" width={20} height={20} className="opacity-90" />
+          <KeyBadge action="nav.home" />
+        </Link>
+
+        <button
+          onClick={() => onCollapsedChange?.(false)}
+          aria-label={railToggleTitle(false)}
+          title={railToggleTitle(false)}
+          className="relative mt-2 flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+        >
+          <PanelLeftOpen className="size-[18px]" />
+          <KeyBadge action="rooms.toggle" overlay />
+        </button>
+        <div className="mt-1 h-px w-5 bg-border" />
+
+        <ScrollArea className="min-h-0 w-full flex-1">
+          <nav className="flex flex-col items-center gap-1 py-2">
+            {filtered.map((room, i) => {
+              const active = room.name === activeRoom;
+              const unread = active ? 0 : unreadByRoom.get(room.name) ?? 0;
+              return (
+                <Link
+                  key={room.name}
+                  href={`/room/${encodeURIComponent(room.name)}`}
+                  title={unread > 0 ? `${room.name} — ${unread} unread` : room.name}
+                  className={`relative flex size-8 flex-shrink-0 items-center justify-center rounded-md font-mono text-micro font-semibold transition-colors ${
+                    active
+                      ? "bg-accent text-accent-fg"
+                      : "bg-surface text-muted-foreground hover:text-text"
+                  }`}
+                >
+                  <span aria-hidden>{monogram(room.name)}</span>
+                  <span className="sr-only">{room.name}</span>
+                  {unread > 0 && (
+                    <span
+                      aria-label={`${unread} unread`}
+                      className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-accent ring-2 ring-surface"
+                    />
+                  )}
+                  {i < 9 && <KeyBadge chord={`alt+${i + 1}`} overlay />}
+                </Link>
+              );
+            })}
+          </nav>
+        </ScrollArea>
+
+        <button
+          onClick={() => setShowCreate(true)}
+          aria-label="New room"
+          title="New room"
+          className="mb-1 flex size-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+        >
+          <Plus className="size-4" />
+        </button>
+        <div className="flex w-full flex-col items-center gap-1 border-t border-border py-2">
+          <ActingAsPicker compact />
+          <NotificationBell />
+        </div>
+
+        <CreateRoomDialog open={showCreate} onClose={() => setShowCreate(false)} onCreated={refresh} />
+      </aside>
+    );
+  }
+
   return (
     <aside data-tour="rooms" className="flex min-w-0 flex-1 flex-col overflow-hidden bg-surface/50">
       <Link
@@ -193,6 +293,15 @@ export function RoomsSidebar({ activeRoom = null }: Props) {
           className="ml-auto flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
         >
           <Plus className="size-4" />
+        </button>
+        <button
+          onClick={() => onCollapsedChange?.(true)}
+          aria-label={railToggleTitle(true)}
+          title={railToggleTitle(true)}
+          className="relative flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+        >
+          <PanelLeftClose className="size-4" />
+          <KeyBadge action="rooms.toggle" overlay />
         </button>
       </div>
       <div className="px-3 pb-2">

--- a/mycelium-frontend/src/lib/keymap.ts
+++ b/mycelium-frontend/src/lib/keymap.ts
@@ -74,6 +74,13 @@ export const KEYMAP: Binding[] = [
   },
   { id: "rooms.next", keys: ["]", "J"], label: "Next room", group: "Rooms", scope: "global" },
   { id: "rooms.prev", keys: ["[", "K"], label: "Previous room", group: "Rooms", scope: "global" },
+  {
+    id: "rooms.toggle",
+    keys: ["alt+b"],
+    label: "Collapse / expand the rooms rail",
+    group: "Rooms",
+    scope: "global",
+  },
   { id: "nav.home", keys: ["alt+h"], label: "Command center", group: "Navigate", scope: "global" },
 
   { id: "pane.channel", keys: ["alt+c"], label: "Channel", group: "Panes", scope: "room" },

--- a/mycelium-frontend/src/lib/panel-layout.test.ts
+++ b/mycelium-frontend/src/lib/panel-layout.test.ts
@@ -4,9 +4,13 @@
 import { describe, expect, it } from "vitest";
 import {
   COLLAPSED_THRESHOLD_PX,
+  INSPECTOR_FOLD_WIDTH,
   INSPECTOR_PANEL,
+  MAIN_PANEL,
+  ROOMS_FOLD_WIDTH,
   ROOMS_PANEL,
   TAB_LABELS_MIN_WIDTH,
+  WORKSPACE_PANEL,
 } from "@/lib/panel-layout";
 
 const px = (value: string) => Number.parseInt(value, 10);
@@ -33,5 +37,49 @@ describe("panel sizing", () => {
   it("separates the collapsed strip from the smallest open rail", () => {
     expect(px(INSPECTOR_PANEL.collapsed)).toBeLessThan(COLLAPSED_THRESHOLD_PX);
     expect(COLLAPSED_THRESHOLD_PX).toBeLessThan(px(INSPECTOR_PANEL.min));
+  });
+});
+
+describe("folding a rail away", () => {
+  // The whole reason the fold widths carry a margin. A group whose minimums no
+  // longer fit refuses every resize, the collapse included — so each rail has
+  // to fold while its window can still hold everything, not once it can't.
+  it("folds the inspector while the room still fits around it", () => {
+    const needed =
+      px(ROOMS_PANEL.default) + px(MAIN_PANEL.min) + px(INSPECTOR_PANEL.min) + 2;
+    expect(INSPECTOR_FOLD_WIDTH).toBeGreaterThan(needed);
+  });
+
+  it("folds the rooms rail while the window still fits it beside a chat", () => {
+    const needed =
+      px(ROOMS_PANEL.min) + px(MAIN_PANEL.min) + px(INSPECTOR_PANEL.collapsed) + 2;
+    expect(ROOMS_FOLD_WIDTH).toBeGreaterThan(needed);
+  });
+
+  // One rail at a time, widest first: the inspector is the one a room can spare,
+  // and folding it has to be enough on its own before the rooms rail goes too.
+  it("folds the inspector before the rooms rail", () => {
+    expect(ROOMS_FOLD_WIDTH).toBeLessThan(INSPECTOR_FOLD_WIDTH);
+  });
+
+  // Below the last fold, both strips plus chat still fit — the narrowest laid
+  // out window is a readable one rather than a squeezed one.
+  it("leaves room for chat between two folded strips", () => {
+    const strips = px(ROOMS_PANEL.collapsed) + px(INSPECTOR_PANEL.collapsed) + 2;
+    expect(strips + px(MAIN_PANEL.min)).toBeLessThan(ROOMS_FOLD_WIDTH);
+  });
+
+  // Both strips are read back through the same pixel threshold.
+  it("reads both folded strips as collapsed", () => {
+    expect(px(ROOMS_PANEL.collapsed)).toBeLessThan(COLLAPSED_THRESHOLD_PX);
+    expect(px(INSPECTOR_PANEL.collapsed)).toBeLessThan(COLLAPSED_THRESHOLD_PX);
+  });
+
+  // The workspace's own minimum is part of the shell's constraint set at every
+  // width, so it has to be satisfiable once the rooms rail is a strip.
+  it("keeps the workspace's minimum satisfiable beside a folded rooms rail", () => {
+    expect(px(ROOMS_PANEL.collapsed) + px(WORKSPACE_PANEL.min) + 1).toBeLessThan(
+      ROOMS_FOLD_WIDTH,
+    );
   });
 });

--- a/mycelium-frontend/src/lib/panel-layout.ts
+++ b/mycelium-frontend/src/lib/panel-layout.ts
@@ -16,6 +16,14 @@
  * already in their compact form and the panel bodies still legible.
  */
 
+/**
+ * How much room to leave above the width where a layout stops fitting, so a
+ * rail folds a step before the squeeze rather than in the middle of it. One
+ * rail's worth of chrome — enough that a window dragged quickly still crosses
+ * the fold before it crosses the floor.
+ */
+const FOLD_MARGIN = 60;
+
 /** Group ids. Also the localStorage keys the saved layouts live under. */
 export const SHELL_GROUP_ID = "mycelium:shell";
 export const ROOM_GROUP_ID = "mycelium:room";
@@ -26,11 +34,25 @@ export const PANEL_WORKSPACE = "workspace";
 export const PANEL_MAIN = "main";
 export const PANEL_INSPECTOR = "inspector";
 
-/** The rooms rail: wide enough for a monogram plus a room name. */
+/**
+ * The id lists `useDefaultLayout` takes, as constants rather than array
+ * literals at the call site. The hook memoizes the layout it reads back out of
+ * storage on the identity of this array, and hands the group a new one whenever
+ * it changes — which a fresh literal does on every render, re-applying the
+ * stored layout over whatever the group is currently doing.
+ */
+export const SHELL_PANEL_IDS = [PANEL_ROOMS, PANEL_WORKSPACE];
+export const ROOM_PANEL_IDS = [PANEL_MAIN, PANEL_INSPECTOR];
+
+/** The rooms rail: wide enough for a monogram plus a room name. Collapses to a
+ *  strip of room monograms rather than to nothing, so every room stays one
+ *  click away on a window too narrow to hold their names. */
 export const ROOMS_PANEL = {
   default: "236px",
   min: "180px",
   max: "420px",
+  /** The monogram strip's width. Matches the inspector's collapsed strip. */
+  collapsed: "48px",
 } as const;
 
 /** Whatever the page puts beside the rooms rail. Its minimum is what stops the
@@ -53,6 +75,36 @@ export const INSPECTOR_PANEL = {
   /** The icon strip's width. Matches the collapsed `<aside>`'s `w-12`. */
   collapsed: "48px",
 } as const;
+
+/** The hairline a `ResizableHandle` draws between two panels. */
+const SEAM = 1;
+
+const px = (value: string) => Number.parseInt(value, 10);
+
+/**
+ * Viewport widths at which each rail folds itself away, and unfolds again.
+ *
+ * Derived from the panels rather than picked as round numbers, and with the
+ * margin deliberate: a rail has to fold *before* the window is too narrow to
+ * hold it, not at the moment it already is. A group whose minimums no longer
+ * fit can't satisfy them, and `react-resizable-panels` answers an unsatisfiable
+ * constraint set by refusing to move anything at all — the collapse that would
+ * have made everything fit included. Folding a step early keeps the layout
+ * solvable at every width, so the collapse is always a move the group can make.
+ * Each rail's *default* is the width in the sum, not its minimum: a rail that
+ * folds before anything squeezes it folds at the width it will unfold to.
+ *
+ * The window is the measure rather than the group beside the rail: it's what
+ * the reader is actually resizing, and it doesn't move when they drag a seam.
+ * A rail dragged wide on a small window squeezes its neighbour, as it always
+ * has — that squeeze is the reader's own doing, and their drag undoes it.
+ */
+export const INSPECTOR_FOLD_WIDTH =
+  px(ROOMS_PANEL.default) + px(MAIN_PANEL.min) + px(INSPECTOR_PANEL.default) + 2 * SEAM + FOLD_MARGIN;
+
+/** With the inspector already a strip by the time this matters. */
+export const ROOMS_FOLD_WIDTH =
+  px(ROOMS_PANEL.default) + px(MAIN_PANEL.min) + px(INSPECTOR_PANEL.collapsed) + 2 * SEAM + FOLD_MARGIN;
 
 /**
  * Below this the inspector's tab strip can't hold "Members / Episodes /

--- a/mycelium-frontend/src/lib/use-collapsible-rail.test.tsx
+++ b/mycelium-frontend/src/lib/use-collapsible-rail.test.tsx
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { act, useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SETTLE_MS, useCollapsibleRail } from "@/lib/use-collapsible-rail";
+
+const FOLD_WIDTH = 600;
+
+/** A matchMedia the test drives: jsdom has none, and the window is what this
+ *  hook reads. Every listener is told the truth about the width it asked about. */
+const listeners: (() => void)[] = [];
+let windowWidth = FOLD_WIDTH + 200;
+
+function stubMatchMedia(): void {
+  vi.stubGlobal("matchMedia", (query: string) => {
+    const max = Number(/max-width:\s*(\d+)px/.exec(query)?.[1] ?? 0);
+    return {
+      get matches() {
+        return windowWidth <= max;
+      },
+      addEventListener: (_: string, onChange: () => void) => listeners.push(onChange),
+      removeEventListener: (_: string, onChange: () => void) => {
+        const at = listeners.indexOf(onChange);
+        if (at >= 0) listeners.splice(at, 1);
+      },
+    };
+  });
+}
+
+/** Resize, then let the hook's settle delay pass — it acts on a window that
+ *  has stopped moving, not on every width a drag passes through. */
+async function windowAt(width: number): Promise<void> {
+  windowWidth = width;
+  await act(async () => {
+    for (const onChange of [...listeners]) onChange();
+    await new Promise(resolve => setTimeout(resolve, SETTLE_MS + 50));
+  });
+}
+
+/** A rail with no panel behind it: the hook's panel calls no-op on a null ref,
+ *  which leaves exactly the open/closed decision this file is about. */
+function Rail() {
+  const [open, setOpen] = useState(true);
+  useCollapsibleRail({
+    foldWidth: FOLD_WIDTH,
+    defaultWidth: "300px",
+    open,
+    onOpenChange: setOpen,
+  });
+  return (
+    <>
+      <button onClick={() => setOpen(!open)}>toggle</button>
+      <span data-testid="rail">{open ? "open" : "closed"}</span>
+    </>
+  );
+}
+
+const rail = () => screen.getByTestId("rail").textContent;
+
+describe("useCollapsibleRail", () => {
+  beforeEach(() => {
+    listeners.length = 0;
+    windowWidth = FOLD_WIDTH + 200;
+    stubMatchMedia();
+  });
+
+  it("folds the rail away once the window can't hold it", async () => {
+    render(<Rail />);
+    await windowAt(FOLD_WIDTH + 200);
+    expect(rail()).toBe("open");
+
+    await windowAt(FOLD_WIDTH - 1);
+    expect(rail()).toBe("closed");
+  });
+
+  // Deliberately one-way. Which rails are open is the reader's call, and a
+  // window that grew is not them asking for one back — the strip is one click.
+  it("leaves the rail folded when the window grows again", async () => {
+    render(<Rail />);
+    await windowAt(FOLD_WIDTH - 1);
+    expect(rail()).toBe("closed");
+
+    await windowAt(FOLD_WIDTH + 200);
+    expect(rail()).toBe("closed");
+  });
+
+  it("keeps out of the reader's way while the window stays narrow", async () => {
+    const user = userEvent.setup();
+    render(<Rail />);
+    await windowAt(FOLD_WIDTH - 1);
+    expect(rail()).toBe("closed");
+
+    // Opening it on a narrow window sticks — the fold is a nudge, not a lock.
+    await user.click(screen.getByText("toggle"));
+    expect(rail()).toBe("open");
+    await windowAt(FOLD_WIDTH - 50);
+    expect(rail()).toBe("open");
+  });
+
+  // The fold acts on the crossing, so a rail reopened inside a narrow window
+  // isn't folded again until the window has been wide enough to hold it.
+  it("folds again after the window has been wide in between", async () => {
+    const user = userEvent.setup();
+    render(<Rail />);
+    await windowAt(FOLD_WIDTH - 1);
+    await user.click(screen.getByText("toggle"));
+    expect(rail()).toBe("open");
+
+    await windowAt(FOLD_WIDTH + 200);
+    await windowAt(FOLD_WIDTH - 1);
+    expect(rail()).toBe("closed");
+  });
+});

--- a/mycelium-frontend/src/lib/use-collapsible-rail.ts
+++ b/mycelium-frontend/src/lib/use-collapsible-rail.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { usePanelRef, type PanelImperativeHandle, type PanelSize } from "react-resizable-panels";
+import { COLLAPSED_THRESHOLD_PX } from "@/lib/panel-layout";
+
+interface Options {
+  /** Viewport width below which the rail folds itself away. */
+  foldWidth: number;
+  /** The width the rail mounts at before anyone has dragged it. */
+  defaultWidth: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface Rail {
+  /** Hand to the rail's `<ResizablePanel panelRef=…>`. */
+  panelRef: RefObject<PanelImperativeHandle | null>;
+  /**
+   * Hand to the rail's `<ResizablePanel defaultSize=…>` — the width it comes
+   * back at, which is the width it left at.
+   */
+  size: string;
+  /** Hand to the same panel's `onResize`. */
+  onResize: (size: PanelSize) => void;
+}
+
+/** How long the window has to hold still before a rail acts on its width. A
+ *  drag across the fold is a stream of widths, and the panel group measures
+ *  itself against the one it has settled on, not the one mid-flight. */
+export const SETTLE_MS = 150;
+
+/** True while the settled window is narrower than `width`. Reports "wide" on
+ *  the server and through hydration, then the real answer — which is also what
+ *  makes a page loaded on a narrow window fold its rails on arrival. */
+function useNarrowerThan(width: number): boolean {
+  const query = `(max-width: ${width - 1}px)`;
+  const matches = useCallback(
+    () => typeof window !== "undefined" && !!window.matchMedia && window.matchMedia(query).matches,
+    [query],
+  );
+  const [narrow, setNarrow] = useState(matches);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const media = window.matchMedia(query);
+    let settle = 0;
+    const onChange = () => {
+      clearTimeout(settle);
+      settle = window.setTimeout(() => setNarrow(media.matches), SETTLE_MS);
+    };
+    setNarrow(media.matches);
+    media.addEventListener("change", onChange);
+    return () => {
+      clearTimeout(settle);
+      media.removeEventListener("change", onChange);
+    };
+  }, [query]);
+
+  return narrow;
+}
+
+/**
+ * A rail that folds itself away when the window gets too narrow to hold it.
+ *
+ * Folding is all it does. A window that grows again leaves the rails where they
+ * are: which rails are open is the reader's call, and a window that grew is not
+ * them asking for one back. The strip puts any of them back in a click, at the
+ * width it left at.
+ *
+ * One state, three ways in — the reader, a drag past the minimum, and the
+ * window — and each of them leaves the other two agreeing.
+ */
+export function useCollapsibleRail({
+  foldWidth,
+  defaultWidth,
+  open,
+  onOpenChange,
+}: Options): Rail {
+  const narrow = useNarrowerThan(foldWidth);
+
+  // The width the rail was last at while open. The ref follows every drag; the
+  // state is read at mount, so it only has to be current by the time the rail
+  // is on its way back.
+  const width = useRef(defaultWidth);
+  const [mountWidth, setMountWidth] = useState(defaultWidth);
+  const panelRef = usePanelRef();
+
+  // However it went away — the window, the button, the keybind, a drag past the
+  // minimum — the width it comes back at is the one it went away from.
+  useEffect(() => {
+    if (!open) setMountWidth(width.current);
+  }, [open]);
+
+  // Mounting the rail asks for that width; this is what makes the group give
+  // it. A group stops tracking its own size while it holds a single panel, so
+  // the rail it hands back is measured against however wide the window was when
+  // the rail folded away. One resize on a settled window puts it right — and is
+  // a no-op when the group got it right on its own.
+  useEffect(() => {
+    if (!open) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const wanted = Number.parseInt(mountWidth, 10);
+    // Next frame, not this one: a panel that has only just registered has no
+    // layout in the group yet, and asking it to resize before it does throws.
+    const frame = requestAnimationFrame(() => {
+      if (Math.abs(panel.getSize().inPixels - wanted) > 1) panel.resize(`${wanted}px`);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [mountWidth, open, panelRef]);
+
+  // Panel → state: a drag past the minimum is how the rail is closed by hand,
+  // and the panel reports it the same way it reports every other width.
+  const onResize = useCallback(
+    (size: PanelSize) => {
+      if (size.inPixels <= COLLAPSED_THRESHOLD_PX) {
+        if (open) onOpenChange(false);
+        return;
+      }
+      // Only while the window can still hold the rail. Between the window
+      // crossing the fold and the fold settling, the rail reports the widths a
+      // group too small for it is squeezing it into — and those are the group
+      // making do, not a width the reader chose.
+      if (window.innerWidth >= foldWidth) width.current = `${Math.round(size.inPixels)}px`;
+    },
+    [foldWidth, open, onOpenChange],
+  );
+
+  // Read when the window crosses the fold, rather than resubscribing per toggle.
+  const latest = useRef({ open, onOpenChange });
+  useEffect(() => {
+    latest.current = { open, onOpenChange };
+  });
+
+  // Only the crossing folds, and only ever in the one direction. Widening the
+  // window doesn't unfold a rail: which rails are open is the reader's, and a
+  // window that grew is not them asking for one back. It stays a click away in
+  // the strip, where they left it.
+  const folded = useRef(false);
+  useEffect(() => {
+    if (!narrow || folded.current) {
+      folded.current = narrow;
+      return;
+    }
+    folded.current = true;
+    if (latest.current.open) latest.current.onOpenChange(false);
+  }, [narrow]);
+
+  return { panelRef, size: mountWidth, onResize };
+}


### PR DESCRIPTION
The rooms rail and the inspector were resizable but not responsive: on a
window too narrow to hold them, the panel group squeezed every panel past
its minimum and chat lost half its width. Both rails now fold themselves
to a strip of icons as the window crosses a width derived from what they
need (mycelium-frontend/src/lib/panel-layout.ts), leaving chat readable
down to a phone.

Folding is one-way. A window that grows again leaves the rails where they
are — which rails are open is the reader's call, and a window that grew is
not them asking for one back. Either strip puts its rail back in a click,
at the width it left at, and the rooms rail picks up ⌥B alongside the
inspector's `\`.

The rooms rail had no folded form, so it gets one: room monograms with
their unread dots, the brand, and the account corner, mirroring the
inspector's icon strip.

Folded, a rail is not a panel. It renders beside the group rather than
inside it, because a panel that isn't there can't be squeezed, and a rail
mounting back into the group is the one path that reliably lands — a group
refuses `collapse()`, `expand()` and `resize()` on the frame after a window
resize, and `isCollapsed()` answers for the window that just went away.
The fold widths carry margin for the same reason: a group whose minimums
no longer fit refuses every resize, so each rail folds a step before its
window runs out rather than in the middle of the squeeze.

Two fixes fall out of that. A group stops tracking its own size while it
holds a single panel, so a returning rail is measured against the window
it folded away on — one resize on a settled window puts it right. And
`useDefaultLayout` memoizes the stored layout on the identity of the
panel-id array, which a fresh literal at the call site broke on every
render, re-applying the saved layout over whatever the group was doing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016hYhYtxBH4N7zGXZCL7dw8