### PR TITLE
Add a summonguard engine and the room lifecycle seam it hooks

### DIFF
--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -152,6 +152,21 @@ class Settings(BaseSettings):
     SYNTHESIZER_HANDLE: str = "synthesizer"
     # Per-turn wall-clock bound (seconds) on the synthesizer's one-shot pi call.
     SYNTHESIZER_PI_TIMEOUT_S: float = 120.0
+    # Summonguard engine (kind ``summonguard``) — classifies each ``@``-mention as
+    # a summon or provenance, so a room stops waking agents that were merely named.
+    # Dormant like the others: nothing runs until a guard is registered in a room,
+    # and every failure path wakes rather than suppresses.
+    SUMMONGUARD_HANDLE: str = "summonguard"
+    # Per-message wall-clock bound (seconds) on the guard's one-shot pi call.
+    # Short: this sits between a message and an agent's turn, so a slow
+    # classification is worse than a fail-open wake.
+    SUMMONGUARD_PI_TIMEOUT_S: float = 20.0
+    # How long an ``await`` long-poll waits for an in-flight classification before
+    # serving the turn anyway. Absorbed by the poll, invisible to the caller.
+    SUMMONGUARD_WAKE_TIMEOUT_S: float = 8.0
+    # Kill switch: registered guards stay listed but classify everything as a wake,
+    # so a misbehaving guard is disarmed without editing a room's manifests.
+    SUMMONGUARD_DISABLE: bool = False
 
     # Where a registered `engine` (kind aligner) runs its NEGMAS drive — selects
     # the engine runtime. "backend" (default):

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -161,9 +161,11 @@ class Settings(BaseSettings):
     # Short: this sits between a message and an agent's turn, so a slow
     # classification is worse than a fail-open wake.
     SUMMONGUARD_PI_TIMEOUT_S: float = 20.0
-    # How long an ``await`` long-poll waits for an in-flight classification before
-    # serving the turn anyway. Absorbed by the poll, invisible to the caller.
-    SUMMONGUARD_WAKE_TIMEOUT_S: float = 8.0
+    # How long an ``await`` long-poll waits for an in-flight summon-filter
+    # judgement before serving the turn anyway. A property of the seam rather than
+    # of any one guard, so it is named for the extension point. Absorbed by the
+    # poll, invisible to the caller.
+    SUMMON_FILTER_WAIT_S: float = 8.0
     # Kill switch: registered guards stay listed but classify everything as a wake,
     # so a misbehaving guard is disarmed without editing a room's manifests.
     SUMMONGUARD_DISABLE: bool = False

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -44,6 +44,7 @@ from app.routes.search import router as search_router
 from app.routes.sessions import router as sessions_router
 from app.routes.skills import router as skills_router
 from app.routes.stream import router as stream_router
+from app.routes.summonguard import router as summonguard_router
 from app.routes.users import router as users_router
 from app.services.auth import auth_gate
 
@@ -107,17 +108,25 @@ async def lifespan(app: FastAPI):
     from app.services.aligner import AlignerEngine
     from app.services.plan_sync import PlanSyncEngine
     from app.services.room_channels import manager as room_channel_manager
+    from app.services.summonguard import SummonGuardEngine
     from app.services.synthesizer import SynthesizerEngine
 
-    # Two engine kinds share the one summon seam. Each engine self-selects by the
+    # The engine kinds share the one summon seam. Each engine self-selects by the
     # summoned handle's manifest kind (and the aligner's reserved-handle
     # fallback), so a fan-out dispatcher is enough — no central kind table. Only
     # one engine ever acts per summon since a handle maps to a single kind.
     app.state.aligner = AlignerEngine(room_channel_manager)
     app.state.synthesizer = SynthesizerEngine(room_channel_manager)
+    app.state.summonguard = SummonGuardEngine(room_channel_manager)
+    # The summonguard is the first engine that also acts on *registration*: its
+    # lifecycle subscription installs a room's summon filter when a guard manifest
+    # lands (and takes it back out when one goes). Subscribing costs nothing until
+    # a room actually registers one.
+    app.state.summonguard.wire()
     _engine_handlers = (
         app.state.aligner.handle_summon,
         app.state.synthesizer.handle_summon,
+        app.state.summonguard.handle_summon,
     )
 
     def _dispatch_summon(
@@ -135,7 +144,7 @@ async def lifespan(app: FastAPI):
 
     room_channel_manager.on_summon = _dispatch_summon
     logger.info(
-        "engines wired (aligner @%s, synthesizer @%s; brain=pi via %s)",
+        "engines wired (aligner @%s, synthesizer @%s, summonguard; brain=pi via %s)",
         app.state.aligner.handle,
         app.state.synthesizer.handle,
         settings.ALIGNER_PI_BINARY,
@@ -240,6 +249,7 @@ app.include_router(agent_context_router, prefix="/api")
 app.include_router(users_router, prefix="/api")
 app.include_router(search_router, prefix="/api")
 app.include_router(skills_router, prefix="/api")
+app.include_router(summonguard_router, prefix="/api")
 
 
 @app.get("/", tags=["health"])

--- a/fastapi-backend/app/routes/engines.py
+++ b/fastapi-backend/app/routes/engines.py
@@ -3,7 +3,7 @@
 
 """POST /rooms/{room_name}/engines — register a first-party cognition engine.
 
-Engines (``aligner``, ``synthesizer``) are backend-owned: registration is purely
+Engines (``aligner``, ``synthesizer``, ``summonguard``) are backend-owned: registration is purely
 a manifest write with *no* machine-local side effects, so — unlike
 ``claude_code``/``cursor`` agents, which need a resident session and workspace
 assets on the user's box — the web UI can invite one natively. The manifest lands
@@ -30,7 +30,7 @@ router = APIRouter(prefix="/rooms/{room_name}/engines", tags=["engines"])
 
 # The engine kinds the backend knows how to run. Mirrors the CLI's
 # ``mycelium.protocol.ENGINE_KINDS``; the summon seam self-selects by ``kind``.
-ENGINE_KINDS = frozenset({"aligner", "synthesizer"})
+ENGINE_KINDS = frozenset({"aligner", "synthesizer", "summonguard"})
 
 _HANDLE_RE = re.compile(HANDLE_PATTERN)
 

--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -27,6 +27,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
+import yaml
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import Response
 
@@ -42,6 +43,7 @@ from app.schemas import (
 )
 from app.services import actor, links, local_state, memory_sync, search_index
 from app.services.embedding import embed_text
+from app.services.engine_events import RoomEvent, lifecycle
 from app.services.filesystem import (
     delete_memory_file,
     get_room_dir,
@@ -130,6 +132,31 @@ def _notify_change(room_name: str, key: str, updated_by: str, version: int) -> N
     for sub in local_state.list_subscriptions(room_name):
         if fnmatch.fnmatch(key, sub.key_pattern):
             bus.publish(agent_channel(sub.subscriber), payload)
+
+
+def _announce_engine_manifest(room_name: str, key: str, body: str) -> None:
+    """Fire ``engine.registered`` when the write was an engine's manifest.
+
+    The manifest write is the one path both front doors share — the engines route
+    and the CLI's ``mycelium engine create`` — so an engine that installs room
+    behaviour on registration (the summonguard's summon filter) hooks in here
+    rather than in either caller. Cheap: a prefix test on every memory write, a
+    YAML parse only on the rare ``agents/<handle>`` one.
+    """
+    if not key.startswith("agents/") or "/" in key.removeprefix("agents/"):
+        return
+    try:
+        manifest = yaml.safe_load(body) or {}
+    except yaml.YAMLError:
+        return
+    if not isinstance(manifest, dict) or manifest.get("adapter") != "engine":
+        return
+    lifecycle.emit(
+        RoomEvent.ENGINE_REGISTERED,
+        room_name,
+        handle=key.removeprefix("agents/"),
+        kind=str(manifest.get("kind") or "") or None,
+    )
 
 
 # Strong refs for the fire-and-forget broadcasts below — an unreferenced
@@ -337,6 +364,7 @@ async def upsert_memories(room_name: str, payload: MemoryBatchCreate) -> list[Me
             )
         )
         _notify_change(room_name, item.key, item.created_by, new_version)
+        _announce_engine_manifest(room_name, item.key, body)
         _broadcast_memory_write(
             room_name,
             key=item.key,

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -31,7 +31,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from app.services import actor, l9, principals, room_channels, summonguard
+from app.services import actor, l9, principals, room_channels, summon_filter
 from app.services.filesystem import room_exists
 from app.services.l9_models import Kind
 from app.services.l9_slim import serialize_content, serialize_envelope
@@ -175,7 +175,7 @@ async def await_message(room_name: str, request: Request, handle: str, timeout: 
             # A protocol-addressed tick is a turn by construction; only a bare
             # ``@handle`` in prose is the guard's to judge. In an unguarded room
             # this returns True without waiting, so the poll is unchanged.
-            if kind == "mention" and not await summonguard.wakes(
+            if kind == "mention" and not await summon_filter.wakes(
                 room_name, record.message_id, handle
             ):
                 continue

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -31,7 +31,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from app.services import actor, l9, principals, room_channels
+from app.services import actor, l9, principals, room_channels, summonguard
 from app.services.filesystem import room_exists
 from app.services.l9_models import Kind
 from app.services.l9_slim import serialize_content, serialize_envelope
@@ -89,33 +89,40 @@ def _parse_marker(text: str) -> tuple[dict[str, Any], str]:
     return payload, clean
 
 
-def _addressed_to(content: dict[str, Any], handle: str) -> bool:
-    """True when a transcript record is an exchange addressed to ``handle``.
+def _addressed_kind(content: dict[str, Any], handle: str) -> str | None:
+    """How a transcript record addresses ``handle``: ``recipient``, ``mention``, or not.
 
-    Addressed = the handle is an L9 recipient, or ``@handle`` appears in the human
-    text — and the sender is not the handle itself (loop guard). Presence/keepalive
-    are never addressed turns.
+    ``recipient`` — the handle is an L9 recipient: the protocol addressed it (a
+    mediator tick, a targeted reply), so it is a turn by construction.
+    ``mention`` — only ``@handle`` in the human text, which is the wake a summon
+    guard is allowed to second-guess. Either way the sender is never itself (loop
+    guard), and presence/keepalive are never addressed turns.
     """
     env = content.get("l9") or {}
     header = env.get("header") or {}
     if header.get("kind") != "exchange":
-        return False
+        return None
     if ((env.get("payload") or {}).get("type")) in ("presence", "keepalive"):
-        return False
+        return None
     actors = (header.get("participants") or {}).get("actors") or []
     sender = actors[0].get("id") if actors and isinstance(actors[0], dict) else None
     if sender and _norm(sender) == _norm(handle):
-        return False
+        return None
     recipients = [a.get("id") for a in actors[1:] if isinstance(a, dict)]
     if any(_norm(r) == _norm(handle) for r in recipients if r):
-        return True
+        return "recipient"
     text = (content.get("content") or "").lower()
     needle = f"@{handle.lower()}"
     idx = text.find(needle)
     if idx == -1:
-        return False
+        return None
     nxt = text[idx + len(needle)] if idx + len(needle) < len(text) else ""
-    return not (nxt.isalnum() or nxt in "_-")
+    return None if (nxt.isalnum() or nxt in "_-") else "mention"
+
+
+def _addressed_to(content: dict[str, Any], handle: str) -> bool:
+    """True when a record addresses ``handle`` at all (either way)."""
+    return _addressed_kind(content, handle) is not None
 
 
 def _describe(room: str, handle: str, record: Any) -> dict[str, Any]:
@@ -162,11 +169,20 @@ async def await_message(room_name: str, request: Request, handle: str, timeout: 
         while i < len(records):
             record = records[i]
             i += 1
-            if _addressed_to(record.content, handle):
-                persister.advance_cursor(handle, i)
-                _last_tick[key] = record.content
-                room_channels.manager.refresh_lease(room_name, handle)
-                return _describe(room_name, handle, record)
+            kind = _addressed_kind(record.content, handle)
+            if kind is None:
+                continue
+            # A protocol-addressed tick is a turn by construction; only a bare
+            # ``@handle`` in prose is the guard's to judge. In an unguarded room
+            # this returns True without waiting, so the poll is unchanged.
+            if kind == "mention" and not await summonguard.wakes(
+                room_name, record.message_id, handle
+            ):
+                continue
+            persister.advance_cursor(handle, i)
+            _last_tick[key] = record.content
+            room_channels.manager.refresh_lease(room_name, handle)
+            return _describe(room_name, handle, record)
         # Nothing addressed in the scanned range: consume it (advance past the
         # observer/broadcast turns this handle doesn't await) and keep polling.
         persister.advance_cursor(handle, len(records))

--- a/fastapi-backend/app/routes/summonguard.py
+++ b/fastapi-backend/app/routes/summonguard.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""GET /rooms/{room_name}/summonguard — what the room's summon guard decided.
+
+A suppressed wake is, by design, invisible: the agent simply never gets a turn.
+That is fine when the guard is right and baffling when it is wrong, so the
+decisions are readable — whether a guard is installed at all, which engine
+installed it, and the recent verdicts with the classifier's own one-line reason.
+
+Read-only and in-memory: the window is the last few decisions per room, not an
+audit log. The transcript remains the durable record of what was said.
+"""
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from app.services import summonguard
+from app.services.filesystem import room_exists
+
+router = APIRouter(prefix="/rooms/{room_name}/summonguard", tags=["engines"])
+
+
+class SummonVerdictRead(BaseModel):
+    """One message's summon decisions."""
+
+    message_id: str
+    sender: str
+    text: str
+    decisions: dict[str, str] = Field(..., description="handle -> 'wake' | 'mention'")
+    reasons: dict[str, str] = Field(default_factory=dict)
+    source: str = Field(..., description="How it was decided: pi | leading-mention | fail-open | …")
+    decided_at: str
+
+
+class SummonGuardStatus(BaseModel):
+    """Whether a room's summons are guarded, and what the guard has been deciding."""
+
+    room: str
+    installed: bool = Field(..., description="True when a summon filter is installed.")
+    guards: list[str] = Field(default_factory=list, description="Engines that installed it.")
+    disabled: bool = Field(..., description="Kill switch: guards classify everything as a wake.")
+    verdicts: list[SummonVerdictRead] = Field(default_factory=list)
+
+
+@router.get("", response_model=SummonGuardStatus)
+async def summonguard_status(
+    room_name: str, limit: int = Query(20, ge=1, le=100)
+) -> SummonGuardStatus:
+    """The room's guard status plus its most recent verdicts, newest first."""
+    if not room_exists(room_name):
+        raise HTTPException(status_code=404, detail="Room not found")
+    from app.config import settings
+    from app.services.engine_events import SUMMON_FILTER, lifecycle
+
+    return SummonGuardStatus(
+        room=room_name,
+        installed=summonguard.guarded(room_name),
+        guards=lifecycle.owners(room_name, SUMMON_FILTER),
+        disabled=settings.SUMMONGUARD_DISABLE,
+        verdicts=[
+            SummonVerdictRead(
+                message_id=v.message_id,
+                sender=v.sender,
+                text=v.text,
+                decisions=v.decisions,
+                reasons=v.reasons,
+                source=v.source,
+                decided_at=v.decided_at,
+            )
+            for v in summonguard.verdicts.recent(room_name, limit=limit)
+        ],
+    )

--- a/fastapi-backend/app/routes/summonguard.py
+++ b/fastapi-backend/app/routes/summonguard.py
@@ -15,7 +15,7 @@ audit log. The transcript remains the durable record of what was said.
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from app.services import summonguard
+from app.services import summon_filter
 from app.services.filesystem import room_exists
 
 router = APIRouter(prefix="/rooms/{room_name}/summonguard", tags=["engines"])
@@ -51,12 +51,11 @@ async def summonguard_status(
     if not room_exists(room_name):
         raise HTTPException(status_code=404, detail="Room not found")
     from app.config import settings
-    from app.services.engine_events import SUMMON_FILTER, lifecycle
 
     return SummonGuardStatus(
         room=room_name,
-        installed=summonguard.guarded(room_name),
-        guards=lifecycle.owners(room_name, SUMMON_FILTER),
+        installed=summon_filter.guarded(room_name),
+        guards=summon_filter.owners(room_name),
         disabled=settings.SUMMONGUARD_DISABLE,
         verdicts=[
             SummonVerdictRead(
@@ -68,6 +67,6 @@ async def summonguard_status(
                 source=v.source,
                 decided_at=v.decided_at,
             )
-            for v in summonguard.verdicts.recent(room_name, limit=limit)
+            for v in summon_filter.verdicts.recent(room_name, limit=limit)
         ],
     )

--- a/fastapi-backend/app/services/engine_events.py
+++ b/fastapi-backend/app/services/engine_events.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Room lifecycle events, and the pluggable hooks engines install off them.
+
+Engines have always been *summoned*: dormant until an ``@``-mention reaches the
+persister's summon seam. That covers an engine that acts **on** a room, but not
+one that changes how the room itself behaves. The summonguard is the second
+shape: registering it has to install a filter into the room's own summon path,
+and de-registering it has to take that filter back out.
+
+This module is the seam for that, deliberately small — two concepts, no
+scheduler, no persistence:
+
+* **Lifecycle events.** :meth:`RoomLifecycle.emit` announces something happening
+  to a room (an engine manifest written, a channel provisioned). Listeners are
+  process-wide and room-agnostic; they filter on the payload themselves. A
+  listener that raises is logged and skipped — a broken engine can never break a
+  memory write.
+
+* **Room hooks.** A listener responds by *installing* a named function into one
+  room (:meth:`install`), keyed by the installing engine's handle so the same
+  engine registering twice replaces its own hook rather than stacking. The
+  room's machinery then looks the hook up by name (:meth:`hooks`) and — this is
+  the property that keeps the feature honest — finds **nothing** when no engine
+  installed one, so the un-guarded path stays exactly what it was.
+
+Hook names are constants here rather than free strings so the extension points a
+room exposes are enumerable in one place. Today there is one, ``SUMMON_FILTER``;
+the shape generalizes (a reply filter, a memory-write filter) without changing
+this module.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class RoomEvent(StrEnum):
+    """Lifecycle moments a room announces."""
+
+    #: An ``agents/<handle>`` manifest with ``adapter: engine`` was written.
+    #: Fired on every write, not only the first — engines treat it as "re-sync
+    #: this room", which is what makes installation idempotent.
+    ENGINE_REGISTERED = "engine.registered"
+    #: An engine manifest was deleted from the room.
+    ENGINE_REMOVED = "engine.removed"
+    #: A room's SLIM channel came up (backend start, or first use). Engines use
+    #: it to re-install hooks for manifests written while the backend was down.
+    ROOM_PROVISIONED = "room.provisioned"
+
+
+@dataclass(frozen=True)
+class RoomEventContext:
+    """What a lifecycle listener is told."""
+
+    event: RoomEvent
+    room: str
+    #: The engine handle the event concerns, when it concerns one.
+    handle: str | None = None
+    #: That engine's manifest ``kind``, when known at emit time.
+    kind: str | None = None
+
+
+Listener = Callable[[RoomEventContext], None]
+
+#: Extension point: filter which ``@``-mentions in a message are genuine summons.
+#: Signature ``(SummonContext) -> Awaitable[Mapping[str, str]]``, mapping each
+#: candidate handle to ``"wake"`` or ``"mention"`` (see
+#: :mod:`app.services.summonguard`).
+SUMMON_FILTER = "summon.filter"
+
+
+class RoomLifecycle:
+    """Process-wide event bus + per-room hook registry.
+
+    In-memory and per-process by design: hooks are derived state, rebuilt from
+    the room's manifests on the next ``ROOM_PROVISIONED``, exactly like the link
+    index is rebuilt from the markdown.
+    """
+
+    def __init__(self) -> None:
+        self._listeners: dict[RoomEvent, list[Listener]] = defaultdict(list)
+        # (room, hook name) -> {owner handle: function}
+        self._hooks: dict[tuple[str, str], dict[str, Any]] = {}
+
+    # -- events --
+
+    def subscribe(self, event: RoomEvent, listener: Listener) -> None:
+        """Register ``listener`` for ``event``. Idempotent per callable."""
+        listeners = self._listeners[event]
+        if listener not in listeners:
+            listeners.append(listener)
+
+    def emit(
+        self, event: RoomEvent, room: str, *, handle: str | None = None, kind: str | None = None
+    ) -> None:
+        """Announce ``event`` on ``room``; never raises into the caller."""
+        listeners = self._listeners.get(event)
+        if not listeners:
+            return
+        ctx = RoomEventContext(event=event, room=room, handle=handle, kind=kind)
+        for listener in list(listeners):
+            try:
+                listener(ctx)
+            except Exception:
+                logger.exception("lifecycle listener failed for %s on room %s", event, room)
+
+    # -- room hooks --
+
+    def install(self, room: str, hook: str, owner: str, fn: Any) -> None:
+        """Install ``fn`` as ``room``'s ``hook``, owned by engine ``owner``."""
+        slot = self._hooks.setdefault((room, hook), {})
+        first = owner not in slot
+        slot[owner] = fn
+        if first:
+            logger.info("room %s: @%s installed the %s hook", room, owner, hook)
+
+    def uninstall(self, room: str, hook: str, owner: str) -> None:
+        """Remove ``owner``'s ``hook`` from ``room`` (no-op when absent)."""
+        slot = self._hooks.get((room, hook))
+        if not slot or slot.pop(owner, None) is None:
+            return
+        logger.info("room %s: @%s removed the %s hook", room, owner, hook)
+        if not slot:
+            self._hooks.pop((room, hook), None)
+
+    def hooks(self, room: str, hook: str) -> list[Any]:
+        """Every function installed as ``room``'s ``hook``, install order."""
+        return list(self._hooks.get((room, hook), {}).values())
+
+    def owners(self, room: str, hook: str) -> list[str]:
+        """The engine handles that installed ``room``'s ``hook``."""
+        return list(self._hooks.get((room, hook), {}))
+
+    def clear(self) -> None:
+        """Drop every listener and hook (tests)."""
+        self._listeners.clear()
+        self._hooks.clear()
+
+
+#: The process-wide lifecycle. Engines subscribe at startup (``main.py``); the
+#: memory-write path and the channel manager emit.
+lifecycle = RoomLifecycle()

--- a/fastapi-backend/app/services/engine_events.py
+++ b/fastapi-backend/app/services/engine_events.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
@@ -72,9 +73,9 @@ class RoomEventContext:
 Listener = Callable[[RoomEventContext], None]
 
 #: Extension point: filter which ``@``-mentions in a message are genuine summons.
-#: Signature ``(SummonContext) -> Awaitable[Mapping[str, str]]``, mapping each
-#: candidate handle to ``"wake"`` or ``"mention"`` (see
-#: :mod:`app.services.summonguard`).
+#: The contract — signature, verdict vocabulary, how several filters merge —
+#: lives in :mod:`app.services.summon_filter`, which is what the room's summon
+#: path calls; this module only names the slot.
 SUMMON_FILTER = "summon.filter"
 
 
@@ -93,11 +94,22 @@ class RoomLifecycle:
 
     # -- events --
 
-    def subscribe(self, event: RoomEvent, listener: Listener) -> None:
-        """Register ``listener`` for ``event``. Idempotent per callable."""
+    def subscribe(self, event: RoomEvent, listener: Listener) -> Callable[[], None]:
+        """Register ``listener`` for ``event``; return a callable that removes it.
+
+        Idempotent per callable. The disposer exists so a subscription can be
+        paired with its own teardown at the point it is made; engines built at
+        the composition root live as long as the process and drop it.
+        """
         listeners = self._listeners[event]
         if listener not in listeners:
             listeners.append(listener)
+
+        def dispose() -> None:
+            with suppress(ValueError):
+                self._listeners[event].remove(listener)
+
+        return dispose
 
     def emit(
         self, event: RoomEvent, room: str, *, handle: str | None = None, kind: str | None = None

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -64,6 +64,7 @@ _MESSAGE_ID_NS = uuid.UUID("6f1d2c3b-4a59-6e7d-8c9b-0a1b2c3d4e5f")
 if TYPE_CHECKING:
     import slim_bindings
 
+    from app.services import summonguard
     from app.services.l9_models import L9
     from app.services.l9_slim import L9SlimChannel
     from app.services.local_state import StoredMessage
@@ -723,6 +724,9 @@ class RoomPersister:
         # IO + reindexing, so it can't run inline in the sync ``_ingest`` call);
         # without this the task could be GC'd mid-flight.
         self._knowledge_tasks: set[asyncio.Task[None]] = set()
+        # Strong refs to in-flight guarded-summon dispatches (only ever populated
+        # in a room where an engine installed a summon filter).
+        self._summon_tasks: set[asyncio.Task[None]] = set()
         # Health counters surfaced via RoomChannelManager.status(). ``receive_errors``
         # is genuine (fatal) transport faults; ``transient_errors`` is recoverable
         # membership-churn receive errors (retried, not lost) — split so the health
@@ -965,11 +969,8 @@ class RoomPersister:
         # other handles (``@aligner @a @b``) can scope the run to those co-mentions.
         summons = find_summons(content)
         message_text = content.get("content", "") if isinstance(content, dict) else ""
-        for handle in summons:
-            try:
-                self.on_summon(handle, envelope, summons, message_text)
-            except Exception:
-                logger.exception("summon hook failed for @%s", handle)
+        if summons:
+            self._dispatch_summons(summons, envelope, record.sender, message_text)
         if is_converged(envelope):
             try:
                 self.on_converged(envelope)
@@ -977,6 +978,68 @@ class RoomPersister:
                 logger.exception("converged hook failed")
         if memory_sync.is_knowledge(envelope):
             self._schedule_knowledge_apply(envelope)
+
+    def _fire_summons(
+        self, handles: list[str], envelope: L9, co_summons: list[str], message_text: str
+    ) -> None:
+        for handle in handles:
+            try:
+                self.on_summon(handle, envelope, co_summons, message_text)
+            except Exception:
+                logger.exception("summon hook failed for @%s", handle)
+
+    def _dispatch_summons(
+        self, summons: list[str], envelope: L9, sender: str, message_text: str
+    ) -> None:
+        """Fire the summon hook for each ``@``-mention, past any installed guard.
+
+        A room with no summon filter installed (:mod:`app.services.summonguard`)
+        takes the direct path — every mention fires the hook inline, exactly as
+        before. A guarded room classifies first, off the ingest path since
+        cognition can't run inline in a sync ingest; the mentions judged
+        provenance never reach the hook, and the verdict the classification
+        publishes is the same one ``await`` reads to decide whether to wake a
+        resident agent.
+
+        The full mention list still rides along as ``co_summons`` regardless of
+        the verdict — a scoped ``@aligner @a @b`` negotiates @a and @b whether or
+        not they were each summoned in their own right.
+        """
+        from app.services import summonguard
+
+        if not summonguard.guarded(self.room):
+            self._fire_summons(summons, envelope, summons, message_text)
+            return
+        message_id = envelope_message_id(envelope) or ""
+        ctx = summonguard.SummonContext(
+            room=self.room,
+            message_id=message_id,
+            sender=sender,
+            text=message_text,
+            handles=tuple(summons),
+        )
+        try:
+            task = asyncio.create_task(self._guarded_summons(ctx, envelope, summons, message_text))
+        except RuntimeError:
+            # No running loop (a sync ingest in a unit test): the guard needs one,
+            # and a guard that can't run must not swallow a summon.
+            self._fire_summons(summons, envelope, summons, message_text)
+            return
+        self._summon_tasks.add(task)
+        task.add_done_callback(self._summon_tasks.discard)
+
+    async def _guarded_summons(
+        self,
+        ctx: summonguard.SummonContext,
+        envelope: L9,
+        summons: list[str],
+        message_text: str,
+    ) -> None:
+        from app.services import summonguard
+
+        decisions = await summonguard.decide(ctx)
+        woken = [h for h in summons if decisions.get(h.strip().lstrip("@").lower()) != "mention"]
+        self._fire_summons(woken, envelope, summons, message_text)
 
     def _schedule_knowledge_apply(self, envelope: L9) -> None:
         """Apply an inbound ``knowledge`` write off the ingest path.

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -64,7 +64,7 @@ _MESSAGE_ID_NS = uuid.UUID("6f1d2c3b-4a59-6e7d-8c9b-0a1b2c3d4e5f")
 if TYPE_CHECKING:
     import slim_bindings
 
-    from app.services import summonguard
+    from app.services import summon_filter
     from app.services.l9_models import L9
     from app.services.l9_slim import L9SlimChannel
     from app.services.local_state import StoredMessage
@@ -993,7 +993,7 @@ class RoomPersister:
     ) -> None:
         """Fire the summon hook for each ``@``-mention, past any installed guard.
 
-        A room with no summon filter installed (:mod:`app.services.summonguard`)
+        A room with no summon filter installed (:mod:`app.services.summon_filter`)
         takes the direct path — every mention fires the hook inline, exactly as
         before. A guarded room classifies first, off the ingest path since
         cognition can't run inline in a sync ingest; the mentions judged
@@ -1005,13 +1005,13 @@ class RoomPersister:
         the verdict — a scoped ``@aligner @a @b`` negotiates @a and @b whether or
         not they were each summoned in their own right.
         """
-        from app.services import summonguard
+        from app.services import summon_filter
 
-        if not summonguard.guarded(self.room):
+        if not summon_filter.guarded(self.room):
             self._fire_summons(summons, envelope, summons, message_text)
             return
         message_id = envelope_message_id(envelope) or ""
-        ctx = summonguard.SummonContext(
+        ctx = summon_filter.SummonContext(
             room=self.room,
             message_id=message_id,
             sender=sender,
@@ -1030,14 +1030,14 @@ class RoomPersister:
 
     async def _guarded_summons(
         self,
-        ctx: summonguard.SummonContext,
+        ctx: summon_filter.SummonContext,
         envelope: L9,
         summons: list[str],
         message_text: str,
     ) -> None:
-        from app.services import summonguard
+        from app.services import summon_filter
 
-        decisions = await summonguard.decide(ctx)
+        decisions = await summon_filter.decide(ctx)
         woken = [h for h in summons if decisions.get(h.strip().lstrip("@").lower()) != "mention"]
         self._fire_summons(woken, envelope, summons, message_text)
 

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING
 
 from app.config import settings
 from app.services import custody, l9, slim_identity
+from app.services.engine_events import RoomEvent, lifecycle
 from app.services.invites import ACCEPTED, DECLINED, QUEUED, PendingInvite, PendingInviteRegistry
 from app.services.l9_models import Kind
 from app.services.l9_slim import (
@@ -439,6 +440,9 @@ class RoomChannelManager:
             self._channels[room] = managed
             self._start_persister(managed)
             self._metrics.provisions_ok += 1
+            # Let engines that install room behaviour (a summon filter) re-attach
+            # to a room whose manifests were written while this process was down.
+            lifecycle.emit(RoomEvent.ROOM_PROVISIONED, room)
             logger.info("Provisioned SLIM channel for room %s (workspace=%s)", room, ws)
             return managed
 

--- a/fastapi-backend/app/services/summon_filter.py
+++ b/fastapi-backend/app/services/summon_filter.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The summon-filter extension point: is this ``@`` a summon, or just a mention?
+
+A room treats every ``@handle`` as a wake. This is the seam where an engine can
+say otherwise — the contract the room's summon path calls, and the one a guard
+engine implements against. It sits between the generic lifecycle bus
+(:mod:`app.services.engine_events`, which knows nothing about summons) and any
+particular guard (:mod:`app.services.summonguard`, which knows nothing about how
+the room dispatches).
+
+**The room calls this module, never an engine.** The core summon path — the
+persister's trigger-watcher and ``await``'s long-poll — imports the contract and
+nothing else, so deleting every guard from the tree leaves the room importable
+and working. With no filter installed :func:`decide` wakes everything, which is
+the pre-guard behaviour exactly.
+
+**The verdict vocabulary is open.** :data:`WAKE`, :data:`MENTION` and
+:data:`ABSTAIN` are what exists today; a later engine wanting ``defer`` or
+``escalate`` adds a value without this module changing, because the merge treats
+anything it does not recognise as *no opinion* rather than an error. A filter
+returning a verdict this version has never heard of degrades to a wake — never a
+crash, and never a silent suppression.
+
+**Merge policy is fail-open, and deliberately so.** A suppression means an agent
+silently never gets a turn: a missed summon stalls the room, a spurious wake
+costs one turn. So a handle sleeps only when some filter says ``mention`` and no
+filter says ``wake``; abstentions and unrecognised answers carry no weight, and a
+filter that raises fails the whole room open. This is one policy for every room —
+see the PR notes for why a per-room policy waits for a second guard to justify it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from app.config import settings
+from app.services.engine_events import SUMMON_FILTER, lifecycle
+
+logger = logging.getLogger(__name__)
+
+#: Serve the message as the handle's turn — the room's default for every mention.
+WAKE = "wake"
+#: Record the message and let the handle sleep: it was named, not asked.
+MENTION = "mention"
+#: This filter has no opinion; leave the decision to the others (or the default).
+ABSTAIN = "abstain"
+
+#: How many verdicts per room the introspection surface keeps. Small on purpose:
+#: this is a "why didn't @alice wake?" window, not an audit log — the transcript
+#: is the durable record.
+_VERDICT_HISTORY = 100
+
+
+def norm(handle: str) -> str:
+    """Fold a handle to its comparable form (``@Alice`` → ``alice``)."""
+    return handle.strip().lstrip("@").lower()
+
+
+def now() -> str:
+    """Timestamp for a verdict, in the store's one format."""
+    return datetime.now(UTC).isoformat()
+
+
+# ── The contract types (pure) ────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SummonContext:
+    """What a filter is asked to judge: one message, its mentioned handles."""
+
+    room: str
+    message_id: str
+    sender: str
+    text: str
+    handles: tuple[str, ...]
+
+
+@dataclass
+class SummonVerdict:
+    """One message's decisions, plus how they were reached."""
+
+    room: str
+    message_id: str
+    sender: str
+    text: str
+    #: handle -> :data:`WAKE` | :data:`MENTION`
+    decisions: dict[str, str]
+    #: handle -> one-line justification (empty for short-circuited wakes)
+    reasons: dict[str, str] = field(default_factory=dict)
+    #: How it was reached — an engine's own label (``pi``, ``fail-open``, …).
+    source: str = ""
+    decided_at: str = ""
+
+    def wakes(self, handle: str) -> bool:
+        """True unless this verdict explicitly classified ``handle`` as provenance."""
+        return self.decisions.get(norm(handle), WAKE) != MENTION
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "room": self.room,
+            "message_id": self.message_id,
+            "sender": self.sender,
+            "text": self.text,
+            "decisions": dict(self.decisions),
+            "reasons": dict(self.reasons),
+            "source": self.source,
+            "decided_at": self.decided_at,
+        }
+
+
+#: What an installed filter is: judge a message, answer per handle. Async because
+#: a real judgement is a model call, and the summon path is async either side.
+SummonFilter = Callable[[SummonContext], Awaitable[Mapping[str, str]]]
+
+
+# ── Verdict store ────────────────────────────────────────────────────────────
+
+
+class VerdictStore:
+    """Per-room verdicts by message id, with waiters for one being decided.
+
+    A filter publishes on the ingest path; ``await`` needs the same answer a
+    moment later. Rather than judge twice (and risk the two paths disagreeing),
+    the poll waits here on the event a publish sets.
+
+    The store is shared across every filter in a room, so it is invalidated
+    whenever that room's filter set changes: a verdict is only meaningful as the
+    output of the filters that produced it, and one outliving its author would
+    keep suppressing wakes on an engine's behalf after the engine was removed.
+    """
+
+    def __init__(self, history: int = _VERDICT_HISTORY) -> None:
+        self._history = history
+        self._by_room: dict[str, OrderedDict[str, SummonVerdict]] = {}
+        self._waiters: dict[tuple[str, str], asyncio.Event] = {}
+
+    def _event(self, room: str, message_id: str) -> asyncio.Event:
+        return self._waiters.setdefault((room, message_id), asyncio.Event())
+
+    def begin(self, room: str, message_id: str) -> None:
+        """Mark a judgement in flight so a waiter blocks instead of failing open."""
+        self._event(room, message_id)
+
+    def put(self, verdict: SummonVerdict) -> None:
+        room = self._by_room.setdefault(verdict.room, OrderedDict())
+        room[verdict.message_id] = verdict
+        while len(room) > self._history:
+            room.popitem(last=False)
+        self._event(verdict.room, verdict.message_id).set()
+
+    def get(self, room: str, message_id: str) -> SummonVerdict | None:
+        return self._by_room.get(room, {}).get(message_id)
+
+    def pending(self, room: str, message_id: str) -> bool:
+        """True when a judgement was started for this message and hasn't landed."""
+        event = self._waiters.get((room, message_id))
+        return event is not None and not event.is_set()
+
+    async def wait(self, room: str, message_id: str, timeout_s: float) -> SummonVerdict | None:
+        """The verdict for a message, waiting up to ``timeout_s`` for one in flight."""
+        existing = self.get(room, message_id)
+        if existing is not None:
+            return existing
+        if not self.pending(room, message_id):
+            return None
+        try:
+            await asyncio.wait_for(self._event(room, message_id).wait(), timeout=timeout_s)
+        except TimeoutError:
+            return None
+        return self.get(room, message_id)
+
+    def recent(self, room: str, limit: int = 20) -> list[SummonVerdict]:
+        """Most recent verdicts for ``room``, newest first."""
+        return list(reversed(list(self._by_room.get(room, {}).values())))[:limit]
+
+    def forget_room(self, room: str) -> None:
+        """Drop ``room``'s verdicts and release anything waiting on one.
+
+        Waiters are released rather than left to time out: with the filter set
+        changed, nothing is going to publish the answer they are waiting for, and
+        the fail-open default is the right one to reach immediately.
+        """
+        self._by_room.pop(room, None)
+        for (waiting_room, _mid), event in list(self._waiters.items()):
+            if waiting_room == room:
+                event.set()
+        self._waiters = {key: e for key, e in self._waiters.items() if key[0] != room}
+
+    def clear(self) -> None:
+        self._by_room.clear()
+        self._waiters.clear()
+
+
+#: Process-wide store — filters publish, ``await`` and the status route read.
+verdicts = VerdictStore()
+
+
+# ── Installing a filter ──────────────────────────────────────────────────────
+
+
+def install(room: str, owner: str, fn: SummonFilter) -> None:
+    """Install ``owner``'s summon filter in ``room``.
+
+    An engine installs through here rather than through the bus directly, so the
+    cache invalidation below can never be forgotten at a call site: registering a
+    filter is an effect on how the room decides, and every cached decision made
+    without it is stale the moment it lands.
+    """
+    lifecycle.install(room, SUMMON_FILTER, owner, fn)
+    verdicts.forget_room(room)
+
+
+def uninstall(room: str, owner: str) -> None:
+    """Remove ``owner``'s summon filter from ``room`` (no-op when absent)."""
+    if owner not in lifecycle.owners(room, SUMMON_FILTER):
+        return
+    lifecycle.uninstall(room, SUMMON_FILTER, owner)
+    verdicts.forget_room(room)
+
+
+def owners(room: str) -> list[str]:
+    """The engines that installed a summon filter in ``room``."""
+    return lifecycle.owners(room, SUMMON_FILTER)
+
+
+def guarded(room: str) -> bool:
+    """True when some engine installed a summon filter in ``room``."""
+    return bool(lifecycle.hooks(room, SUMMON_FILTER))
+
+
+# ── The two calls the room's summon path makes ───────────────────────────────
+
+
+def _merge(handle_verdicts: list[str]) -> str:
+    """One handle's answer across every filter that had an opinion.
+
+    ``wake`` beats ``mention``; anything else — an abstention, or a verdict this
+    version does not know — is not an opinion and carries no weight. No opinions
+    at all means the default: wake.
+    """
+    opinions = [v for v in handle_verdicts if v in (WAKE, MENTION)]
+    if not opinions:
+        return WAKE
+    return MENTION if all(v == MENTION for v in opinions) else WAKE
+
+
+async def decide(ctx: SummonContext) -> dict[str, str]:
+    """Run ``ctx`` through every summon filter installed in its room.
+
+    With none installed every handle wakes — the room's behaviour before any
+    guard existed, reached without touching an engine.
+    """
+    filters = lifecycle.hooks(ctx.room, SUMMON_FILTER)
+    if not filters:
+        return {norm(h): WAKE for h in ctx.handles}
+
+    verdicts.begin(ctx.room, ctx.message_id)
+    collected: dict[str, list[str]] = {norm(h): [] for h in ctx.handles}
+    for fn in filters:
+        try:
+            result = await fn(ctx)
+        except Exception:
+            logger.exception("summon filter failed on room %s — failing the room open", ctx.room)
+            return {norm(h): WAKE for h in ctx.handles}
+        for handle, verdict in (result or {}).items():
+            collected.setdefault(norm(handle), []).append(verdict)
+    return {handle: _merge(answers) for handle, answers in collected.items()}
+
+
+async def wakes(room: str, message_id: str, handle: str) -> bool:
+    """Whether ``handle`` should be woken by ``message_id`` (the ``await`` gate).
+
+    Waits out a judgement in flight — the long-poll has the time, and the
+    alternative is serving a turn a filter was about to suppress. An unguarded
+    room, an unjudged message, or a judgement that overruns the wait all answer
+    ``True``.
+    """
+    if not guarded(room):
+        return True
+    verdict = await verdicts.wait(room, message_id, settings.SUMMON_FILTER_WAIT_S)
+    if verdict is None:
+        return True
+    return verdict.wakes(handle)

--- a/fastapi-backend/app/services/summonguard.py
+++ b/fastapi-backend/app/services/summonguard.py
@@ -9,13 +9,13 @@ for ``@alice can you cost this out?`` and wrong for ``we shipped it, credit to
 @alice`` — the second is *provenance*, and waking a resident agent for it burns
 a turn (and, for an engine, can restart a negotiation that already converged).
 
-The summonguard is the engine kind that tells the two apart. Registering it in a
-room installs a :data:`~app.services.engine_events.SUMMON_FILTER` hook (see
-:mod:`app.services.engine_events`); the room's summon path then asks that hook
-before waking anyone. No guard registered → no hook → the room behaves exactly
-as it did.
+This is the engine that tells the two apart: the cognition, and nothing else.
+The contract it implements — the verdict vocabulary, the verdict store, how
+several filters merge — belongs to :mod:`app.services.summon_filter`, which is
+what the room's summon path actually calls. Registering a guard in a room
+installs its :func:`classify` there; the room never imports this module.
 
-Three properties hold it together:
+Three properties hold the classification together:
 
 * **Fail open, always.** Every failure mode — Pi missing, timed out, empty,
   unparseable, a handle the classifier forgot — resolves to ``wake``. A guard
@@ -26,10 +26,8 @@ Three properties hold it together:
   summon shape — the mention opening the message — so the hot path costs no
   cognition. Suppression is only ever a model's judgement, never a pattern's.
 * **One classification per message.** The persister classifies at ingest, for
-  every mentioned handle at once, and the verdict is stored by message id. The
-  ``await`` long-poll reads that verdict rather than classifying again, so the
-  two paths can never disagree, and the poll simply absorbs the latency it takes
-  to produce.
+  every mentioned handle at once, and the verdict is published to the store the
+  ``await`` long-poll reads, so the two paths can never disagree.
 
 Like the synthesizer, cognition is one throwaway ``pi`` turn off the event loop
 — no session, no memory between messages.
@@ -43,16 +41,15 @@ import logging
 import re
 import tempfile
 import uuid
-from collections import OrderedDict
-from dataclasses import dataclass, field, replace
-from datetime import UTC, datetime
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from app.config import settings
-from app.services import l9
-from app.services.engine_events import SUMMON_FILTER, RoomEvent, RoomEventContext, lifecycle
+from app.services import l9, summon_filter
+from app.services.engine_events import RoomEvent, RoomEventContext, lifecycle
 from app.services.l9_slim import serialize_content
+from app.services.summon_filter import MENTION, WAKE, SummonContext, SummonVerdict, norm
 
 if TYPE_CHECKING:
     from app.services.l9_models import L9
@@ -63,76 +60,11 @@ logger = logging.getLogger(__name__)
 #: The engine kind this module owns.
 ENGINE_KIND = "summonguard"
 
-#: The two verdicts. ``wake`` serves the message as the handle's turn (today's
-#: behaviour); ``mention`` records it and lets the handle sleep.
-WAKE = "wake"
-MENTION = "mention"
-
 #: Handles that are room infrastructure rather than wakeable participants.
 _NEVER_CLASSIFIED = frozenset({"system", "backend", "everyone", "here", "room", "all"})
 
-#: How many verdicts per room the introspection surface keeps. Small on purpose:
-#: this is a "why didn't @alice wake?" window, not an audit log — the transcript
-#: is the durable record.
-_VERDICT_HISTORY = 100
-
 _LEADING_MENTION_RE = re.compile(r"^\s*(?:@[A-Za-z0-9][\w-]*[\s,:]*)+")
 _MENTION_RE = re.compile(r"(?:^|(?<=[\s(<]))@([A-Za-z0-9][\w-]*)")
-
-
-# ── Verdict types (pure) ─────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class SummonContext:
-    """What the filter is asked to judge: one message, its mentioned handles."""
-
-    room: str
-    message_id: str
-    sender: str
-    text: str
-    handles: tuple[str, ...]
-
-
-@dataclass
-class SummonVerdict:
-    """One message's decisions, plus how they were reached."""
-
-    room: str
-    message_id: str
-    sender: str
-    text: str
-    #: handle -> ``wake`` | ``mention``
-    decisions: dict[str, str]
-    #: handle -> one-line justification (empty for short-circuited wakes)
-    reasons: dict[str, str] = field(default_factory=dict)
-    #: ``pi`` | ``leading-mention`` | ``fail-open`` | ``disabled`` | ``mixed``
-    source: str = "pi"
-    decided_at: str = ""
-
-    def wakes(self, handle: str) -> bool:
-        """True unless this verdict explicitly classified ``handle`` as provenance."""
-        return self.decisions.get(_norm(handle), WAKE) != MENTION
-
-    def as_dict(self) -> dict[str, Any]:
-        return {
-            "room": self.room,
-            "message_id": self.message_id,
-            "sender": self.sender,
-            "text": self.text,
-            "decisions": dict(self.decisions),
-            "reasons": dict(self.reasons),
-            "source": self.source,
-            "decided_at": self.decided_at,
-        }
-
-
-def _norm(handle: str) -> str:
-    return handle.strip().lstrip("@").lower()
-
-
-def _now() -> str:
-    return datetime.now(UTC).isoformat()
 
 
 def _leading_mention_is_wake(text: str, handle: str) -> bool:
@@ -146,8 +78,8 @@ def _leading_mention_is_wake(text: str, handle: str) -> bool:
     match = _LEADING_MENTION_RE.match(text or "")
     if match is None:
         return False
-    lead = {_norm(h) for h in _MENTION_RE.findall(match.group(0))}
-    return _norm(handle) in lead
+    lead = {norm(h) for h in _MENTION_RE.findall(match.group(0))}
+    return norm(handle) in lead
 
 
 def parse_decisions(raw: str, handles: tuple[str, ...]) -> tuple[dict[str, str], dict[str, str]]:
@@ -169,11 +101,11 @@ def parse_decisions(raw: str, handles: tuple[str, ...]) -> tuple[dict[str, str],
     if not isinstance(data, dict):
         return {}, {}
 
-    wanted = {_norm(h) for h in handles}
+    wanted = {norm(h) for h in handles}
     decisions: dict[str, str] = {}
     reasons: dict[str, str] = {}
     for key, value in data.items():
-        handle = _norm(str(key))
+        handle = norm(str(key))
         if handle not in wanted:
             continue
         if isinstance(value, str):
@@ -239,70 +171,6 @@ def _pi_complete(prompt: str, timeout_s: float) -> str:
     return brain(prompt)
 
 
-# ── Verdict store ────────────────────────────────────────────────────────────
-
-
-class VerdictStore:
-    """Per-room verdicts by message id, with waiters for the classification.
-
-    The persister classifies on ingest; ``await`` needs the answer for the same
-    message a moment later. Rather than have the poll classify again (and risk
-    the two paths disagreeing), it waits here on the event this store sets.
-    """
-
-    def __init__(self, history: int = _VERDICT_HISTORY) -> None:
-        self._history = history
-        self._by_room: dict[str, OrderedDict[str, SummonVerdict]] = {}
-        self._waiters: dict[tuple[str, str], asyncio.Event] = {}
-
-    def _event(self, room: str, message_id: str) -> asyncio.Event:
-        return self._waiters.setdefault((room, message_id), asyncio.Event())
-
-    def begin(self, room: str, message_id: str) -> None:
-        """Mark a classification in flight so a waiter blocks instead of failing open."""
-        self._event(room, message_id)
-
-    def put(self, verdict: SummonVerdict) -> None:
-        room = self._by_room.setdefault(verdict.room, OrderedDict())
-        room[verdict.message_id] = verdict
-        while len(room) > self._history:
-            room.popitem(last=False)
-        self._event(verdict.room, verdict.message_id).set()
-
-    def get(self, room: str, message_id: str) -> SummonVerdict | None:
-        return self._by_room.get(room, {}).get(message_id)
-
-    def pending(self, room: str, message_id: str) -> bool:
-        """True when a classification was started for this message and hasn't landed."""
-        event = self._waiters.get((room, message_id))
-        return event is not None and not event.is_set()
-
-    async def wait(self, room: str, message_id: str, timeout_s: float) -> SummonVerdict | None:
-        """The verdict for a message, waiting up to ``timeout_s`` for one in flight."""
-        existing = self.get(room, message_id)
-        if existing is not None:
-            return existing
-        if not self.pending(room, message_id):
-            return None
-        try:
-            await asyncio.wait_for(self._event(room, message_id).wait(), timeout=timeout_s)
-        except TimeoutError:
-            return None
-        return self.get(room, message_id)
-
-    def recent(self, room: str, limit: int = 20) -> list[SummonVerdict]:
-        """Most recent verdicts for ``room``, newest first."""
-        return list(reversed(list(self._by_room.get(room, {}).values())))[:limit]
-
-    def clear(self) -> None:
-        self._by_room.clear()
-        self._waiters.clear()
-
-
-#: Process-wide store — the persister writes, ``await`` and the route read.
-verdicts = VerdictStore()
-
-
 # ── The engine ───────────────────────────────────────────────────────────────
 
 
@@ -311,8 +179,8 @@ class SummonGuardEngine:
 
     Unlike the aligner and the synthesizer — engines that *act* when summoned —
     this one's work happens on registration: it subscribes to the room lifecycle
-    and keeps each room's :data:`SUMMON_FILTER` hook in sync with that room's
-    manifests. Summoning it directly just asks it what it has been deciding.
+    and keeps each room's summon filter in sync with that room's manifests.
+    Summoning it directly just asks it what it has been deciding.
     """
 
     def __init__(
@@ -328,7 +196,12 @@ class SummonGuardEngine:
     # -- lifecycle wiring --
 
     def wire(self) -> None:
-        """Subscribe to the lifecycle events that install/remove the hook."""
+        """Subscribe to the lifecycle events that install/remove the filter.
+
+        The returned disposers are dropped: this engine is built at the
+        composition root and lives as long as the process, so there is no unmount
+        to tear down. An engine that becomes dynamically loadable would hold them.
+        """
         for event in (
             RoomEvent.ENGINE_REGISTERED,
             RoomEvent.ENGINE_REMOVED,
@@ -345,14 +218,17 @@ class SummonGuardEngine:
         Reads the room's engine manifests rather than trusting the event
         payload, so it is idempotent and self-healing: a guard registered while
         the backend was down installs on the room's next provision, and one
-        deleted from the room drops out on the next lifecycle event.
+        deleted from the room drops out on the next lifecycle event. The manifest
+        set is the authority — an in-memory hook never outlives it.
         """
         guards = self._registered_guards(room)
+        installed = summon_filter.owners(room)
         for owner in guards:
-            lifecycle.install(room, SUMMON_FILTER, owner, self.classify)
-        for owner in lifecycle.owners(room, SUMMON_FILTER):
+            if owner not in installed:
+                summon_filter.install(room, owner, self.classify)
+        for owner in installed:
             if owner not in guards:
-                lifecycle.uninstall(room, SUMMON_FILTER, owner)
+                summon_filter.uninstall(room, owner)
         return guards
 
     @staticmethod
@@ -372,12 +248,12 @@ class SummonGuardEngine:
     async def classify(self, ctx: SummonContext) -> dict[str, str]:
         """Decide each mentioned handle in one message; publish the verdict.
 
-        Returns the ``{handle: wake|mention}`` map, and stores the full verdict
-        (with reasons) so ``await`` and the introspection route read the same
-        decision rather than re-deriving it.
+        Returns the ``{handle: wake|mention}`` map, and publishes the full
+        verdict (with reasons) so ``await`` and the introspection route read the
+        same decision rather than re-deriving it.
         """
         candidates = tuple(
-            h for h in dict.fromkeys(_norm(h) for h in ctx.handles) if h not in _NEVER_CLASSIFIED
+            h for h in dict.fromkeys(norm(h) for h in ctx.handles) if h not in _NEVER_CLASSIFIED
         )
         decisions: dict[str, str] = {}
         reasons: dict[str, str] = {}
@@ -414,17 +290,18 @@ class SummonGuardEngine:
         for handle in candidates:
             decisions.setdefault(handle, WAKE)
 
-        verdict = SummonVerdict(
-            room=ctx.room,
-            message_id=ctx.message_id,
-            sender=ctx.sender,
-            text=ctx.text,
-            decisions=decisions,
-            reasons=reasons,
-            source=source,
-            decided_at=_now(),
+        summon_filter.verdicts.put(
+            SummonVerdict(
+                room=ctx.room,
+                message_id=ctx.message_id,
+                sender=ctx.sender,
+                text=ctx.text,
+                decisions=decisions,
+                reasons=reasons,
+                source=source,
+                decided_at=summon_filter.now(),
+            )
         )
-        verdicts.put(verdict)
         suppressed = [h for h, d in decisions.items() if d == MENTION]
         if suppressed:
             logger.info(
@@ -482,7 +359,7 @@ class SummonGuardEngine:
         if _registered_engine_kind(room, handle) != ENGINE_KIND:
             return
         sender = envelope_sender(envelope)
-        if sender is not None and _norm(sender) == _norm(handle):
+        if sender is not None and norm(sender) == norm(handle):
             return
         task = asyncio.create_task(self._report(room, handle))
         self._tasks.add(task)
@@ -492,7 +369,7 @@ class SummonGuardEngine:
         managed = self._manager.get(room)
         if managed is None:
             return
-        recent = verdicts.recent(room, limit=5)
+        recent = summon_filter.verdicts.recent(room, limit=5)
         if not recent:
             body = "Guarding this room's summons. Nothing classified yet."
         else:
@@ -519,56 +396,3 @@ class SummonGuardEngine:
             logger.warning("summonguard failed to broadcast on room %s", room)
         if managed.persister is not None:
             managed.persister.ingest_local(env, content)
-
-
-# ── The two consumer-facing helpers ──────────────────────────────────────────
-
-
-def guarded(room: str) -> bool:
-    """True when some engine installed a summon filter in ``room``."""
-    return bool(lifecycle.hooks(room, SUMMON_FILTER))
-
-
-async def decide(ctx: SummonContext) -> dict[str, str]:
-    """Run ``ctx`` through every summon filter installed in its room.
-
-    With no filter installed every handle wakes — today's behaviour. With
-    several, a handle is suppressed only when **all** of them call it provenance:
-    the guards are advisory, and the fail-open bias holds across them too.
-    """
-    filters = lifecycle.hooks(ctx.room, SUMMON_FILTER)
-    if not filters:
-        return {_norm(h): WAKE for h in ctx.handles}
-    verdicts.begin(ctx.room, ctx.message_id)
-    merged: dict[str, str] = {}
-    for fn in filters:
-        try:
-            result = await fn(ctx)
-        except Exception:
-            logger.exception("summon filter failed on room %s — failing open", ctx.room)
-            return {_norm(h): WAKE for h in ctx.handles}
-        for handle, decision in (result or {}).items():
-            key = _norm(handle)
-            if merged.get(key, MENTION) == MENTION and decision == MENTION:
-                merged[key] = MENTION
-            else:
-                merged[key] = WAKE
-    for handle in ctx.handles:
-        merged.setdefault(_norm(handle), WAKE)
-    return merged
-
-
-async def wakes(room: str, message_id: str, handle: str) -> bool:
-    """Whether ``handle`` should be woken by ``message_id`` (the ``await`` gate).
-
-    Waits out an in-flight classification — the long-poll has the time, and the
-    alternative is delivering a turn the guard was about to suppress. An
-    unguarded room, an unclassified message, or a classification that overruns
-    the wait all answer ``True``.
-    """
-    if not guarded(room):
-        return True
-    verdict = await verdicts.wait(room, message_id, settings.SUMMONGUARD_WAKE_TIMEOUT_S)
-    if verdict is None:
-        return True
-    return verdict.wakes(handle)

--- a/fastapi-backend/app/services/summonguard.py
+++ b/fastapi-backend/app/services/summonguard.py
@@ -1,0 +1,574 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The summonguard — an engine that decides which ``@``-mentions are summons.
+
+A room treats every ``@handle`` as a wake: the persister fires the summon seam
+and the handle's next ``await`` returns that message as its turn. That is right
+for ``@alice can you cost this out?`` and wrong for ``we shipped it, credit to
+@alice`` — the second is *provenance*, and waking a resident agent for it burns
+a turn (and, for an engine, can restart a negotiation that already converged).
+
+The summonguard is the engine kind that tells the two apart. Registering it in a
+room installs a :data:`~app.services.engine_events.SUMMON_FILTER` hook (see
+:mod:`app.services.engine_events`); the room's summon path then asks that hook
+before waking anyone. No guard registered → no hook → the room behaves exactly
+as it did.
+
+Three properties hold it together:
+
+* **Fail open, always.** Every failure mode — Pi missing, timed out, empty,
+  unparseable, a handle the classifier forgot — resolves to ``wake``. A guard
+  outage costs a spurious wake, never a silenced summon. The kill switch
+  (``SUMMONGUARD_DISABLE``) resolves the same way.
+* **A regex may confirm a wake, never suppress one.** The cheap pre-pass
+  (:func:`_leading_mention_is_wake`) short-circuits the overwhelmingly common
+  summon shape — the mention opening the message — so the hot path costs no
+  cognition. Suppression is only ever a model's judgement, never a pattern's.
+* **One classification per message.** The persister classifies at ingest, for
+  every mentioned handle at once, and the verdict is stored by message id. The
+  ``await`` long-poll reads that verdict rather than classifying again, so the
+  two paths can never disagree, and the poll simply absorbs the latency it takes
+  to produce.
+
+Like the synthesizer, cognition is one throwaway ``pi`` turn off the event loop
+— no session, no memory between messages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import tempfile
+import uuid
+from collections import OrderedDict
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from app.config import settings
+from app.services import l9
+from app.services.engine_events import SUMMON_FILTER, RoomEvent, RoomEventContext, lifecycle
+from app.services.l9_slim import serialize_content
+
+if TYPE_CHECKING:
+    from app.services.l9_models import L9
+    from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
+
+logger = logging.getLogger(__name__)
+
+#: The engine kind this module owns.
+ENGINE_KIND = "summonguard"
+
+#: The two verdicts. ``wake`` serves the message as the handle's turn (today's
+#: behaviour); ``mention`` records it and lets the handle sleep.
+WAKE = "wake"
+MENTION = "mention"
+
+#: Handles that are room infrastructure rather than wakeable participants.
+_NEVER_CLASSIFIED = frozenset({"system", "backend", "everyone", "here", "room", "all"})
+
+#: How many verdicts per room the introspection surface keeps. Small on purpose:
+#: this is a "why didn't @alice wake?" window, not an audit log — the transcript
+#: is the durable record.
+_VERDICT_HISTORY = 100
+
+_LEADING_MENTION_RE = re.compile(r"^\s*(?:@[A-Za-z0-9][\w-]*[\s,:]*)+")
+_MENTION_RE = re.compile(r"(?:^|(?<=[\s(<]))@([A-Za-z0-9][\w-]*)")
+
+
+# ── Verdict types (pure) ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SummonContext:
+    """What the filter is asked to judge: one message, its mentioned handles."""
+
+    room: str
+    message_id: str
+    sender: str
+    text: str
+    handles: tuple[str, ...]
+
+
+@dataclass
+class SummonVerdict:
+    """One message's decisions, plus how they were reached."""
+
+    room: str
+    message_id: str
+    sender: str
+    text: str
+    #: handle -> ``wake`` | ``mention``
+    decisions: dict[str, str]
+    #: handle -> one-line justification (empty for short-circuited wakes)
+    reasons: dict[str, str] = field(default_factory=dict)
+    #: ``pi`` | ``leading-mention`` | ``fail-open`` | ``disabled`` | ``mixed``
+    source: str = "pi"
+    decided_at: str = ""
+
+    def wakes(self, handle: str) -> bool:
+        """True unless this verdict explicitly classified ``handle`` as provenance."""
+        return self.decisions.get(_norm(handle), WAKE) != MENTION
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "room": self.room,
+            "message_id": self.message_id,
+            "sender": self.sender,
+            "text": self.text,
+            "decisions": dict(self.decisions),
+            "reasons": dict(self.reasons),
+            "source": self.source,
+            "decided_at": self.decided_at,
+        }
+
+
+def _norm(handle: str) -> str:
+    return handle.strip().lstrip("@").lower()
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _leading_mention_is_wake(text: str, handle: str) -> bool:
+    """True when ``@handle`` opens the message — the plain summon shape.
+
+    ``@alice thoughts?`` and ``@alice @bob let's settle this`` address their
+    handles; a mention anywhere further in is where provenance lives. Confirming
+    a wake here is safe in a way suppressing one would not be, so this is the
+    only decision made without cognition.
+    """
+    match = _LEADING_MENTION_RE.match(text or "")
+    if match is None:
+        return False
+    lead = {_norm(h) for h in _MENTION_RE.findall(match.group(0))}
+    return _norm(handle) in lead
+
+
+def parse_decisions(raw: str, handles: tuple[str, ...]) -> tuple[dict[str, str], dict[str, str]]:
+    """Read the classifier's JSON into ``(decisions, reasons)``.
+
+    Tolerant of a wrapping code fence or prose either side of the object, since
+    that is what models actually emit. Anything unreadable — a missing handle, a
+    verdict that is neither value — is simply left out, and the caller fills the
+    gap with ``wake``: an unparseable classification must never suppress.
+    """
+    text = (raw or "").strip()
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end <= start:
+        return {}, {}
+    try:
+        data = json.loads(text[start : end + 1])
+    except json.JSONDecodeError:
+        return {}, {}
+    if not isinstance(data, dict):
+        return {}, {}
+
+    wanted = {_norm(h) for h in handles}
+    decisions: dict[str, str] = {}
+    reasons: dict[str, str] = {}
+    for key, value in data.items():
+        handle = _norm(str(key))
+        if handle not in wanted:
+            continue
+        if isinstance(value, str):
+            verdict, reason = value, ""
+        elif isinstance(value, dict):
+            verdict = str(value.get("decision") or value.get("verdict") or "")
+            reason = str(value.get("reason") or "")
+        else:
+            continue
+        verdict = verdict.strip().lower()
+        if verdict not in (WAKE, MENTION):
+            continue
+        decisions[handle] = verdict
+        if reason:
+            reasons[handle] = reason.strip()
+    return decisions, reasons
+
+
+def build_prompt(ctx: SummonContext) -> str:
+    """The classifier prompt. Pure — unit-testable without a Pi binary."""
+    roster = "\n".join(f"- @{h}" for h in ctx.handles)
+    return (
+        "You are the summon guard for a Mycelium coordination room. A message was "
+        "posted that mentions one or more agents. For each mentioned handle, decide "
+        "whether the mention is a SUMMON (the message asks that agent to do or say "
+        "something now — it should be woken and take a turn) or a REFERENCE (the "
+        "message merely names the agent — attribution, credit, provenance, "
+        "narration, or a note addressed to someone else — and waking it would waste "
+        "a turn).\n\n"
+        "Judge each handle separately: one message can summon one agent while only "
+        "referring to another.\n\n"
+        "When you are genuinely unsure, answer 'wake'. A missed summon stalls the "
+        "room; a spurious wake only costs a turn.\n\n"
+        f"Room: {ctx.room}\n"
+        f'Message from @{ctx.sender}:\n"""\n{ctx.text.strip()}\n"""\n\n'
+        f"Mentioned handles:\n{roster}\n\n"
+        'Reply with ONLY a JSON object mapping each handle (no "@") to '
+        '{"decision": "wake"|"mention", "reason": "<max 12 words>"}. '
+        "No prose, no code fence."
+    )
+
+
+def _pi_complete(prompt: str, timeout_s: float) -> str:
+    """One blocking Pi turn producing the raw classification JSON.
+
+    A throwaway ``--session`` file keeps it a true one-shot: the guard judges
+    each message on its own text, with no memory to drift on. Isolated so tests
+    patch it without a live Pi.
+    """
+    from app.services.pi_brain import PiBrain
+
+    session_dir = Path(tempfile.gettempdir()) / "mycelium-pi-sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    brain = PiBrain(
+        session_path=session_dir / f"summonguard-{uuid.uuid4().hex}.jsonl",
+        model=settings.LLM_MODEL,
+        api_key=settings.LLM_API_KEY,
+        base_url=settings.LLM_BASE_URL,
+        binary=settings.ALIGNER_PI_BINARY,
+        timeout_s=timeout_s,
+        openshell=settings.ALIGNER_PI_OPENSHELL,
+    )
+    return brain(prompt)
+
+
+# ── Verdict store ────────────────────────────────────────────────────────────
+
+
+class VerdictStore:
+    """Per-room verdicts by message id, with waiters for the classification.
+
+    The persister classifies on ingest; ``await`` needs the answer for the same
+    message a moment later. Rather than have the poll classify again (and risk
+    the two paths disagreeing), it waits here on the event this store sets.
+    """
+
+    def __init__(self, history: int = _VERDICT_HISTORY) -> None:
+        self._history = history
+        self._by_room: dict[str, OrderedDict[str, SummonVerdict]] = {}
+        self._waiters: dict[tuple[str, str], asyncio.Event] = {}
+
+    def _event(self, room: str, message_id: str) -> asyncio.Event:
+        return self._waiters.setdefault((room, message_id), asyncio.Event())
+
+    def begin(self, room: str, message_id: str) -> None:
+        """Mark a classification in flight so a waiter blocks instead of failing open."""
+        self._event(room, message_id)
+
+    def put(self, verdict: SummonVerdict) -> None:
+        room = self._by_room.setdefault(verdict.room, OrderedDict())
+        room[verdict.message_id] = verdict
+        while len(room) > self._history:
+            room.popitem(last=False)
+        self._event(verdict.room, verdict.message_id).set()
+
+    def get(self, room: str, message_id: str) -> SummonVerdict | None:
+        return self._by_room.get(room, {}).get(message_id)
+
+    def pending(self, room: str, message_id: str) -> bool:
+        """True when a classification was started for this message and hasn't landed."""
+        event = self._waiters.get((room, message_id))
+        return event is not None and not event.is_set()
+
+    async def wait(self, room: str, message_id: str, timeout_s: float) -> SummonVerdict | None:
+        """The verdict for a message, waiting up to ``timeout_s`` for one in flight."""
+        existing = self.get(room, message_id)
+        if existing is not None:
+            return existing
+        if not self.pending(room, message_id):
+            return None
+        try:
+            await asyncio.wait_for(self._event(room, message_id).wait(), timeout=timeout_s)
+        except TimeoutError:
+            return None
+        return self.get(room, message_id)
+
+    def recent(self, room: str, limit: int = 20) -> list[SummonVerdict]:
+        """Most recent verdicts for ``room``, newest first."""
+        return list(reversed(list(self._by_room.get(room, {}).values())))[:limit]
+
+    def clear(self) -> None:
+        self._by_room.clear()
+        self._waiters.clear()
+
+
+#: Process-wide store — the persister writes, ``await`` and the route read.
+verdicts = VerdictStore()
+
+
+# ── The engine ───────────────────────────────────────────────────────────────
+
+
+class SummonGuardEngine:
+    """Installs a summon filter into every room that registers it.
+
+    Unlike the aligner and the synthesizer — engines that *act* when summoned —
+    this one's work happens on registration: it subscribes to the room lifecycle
+    and keeps each room's :data:`SUMMON_FILTER` hook in sync with that room's
+    manifests. Summoning it directly just asks it what it has been deciding.
+    """
+
+    def __init__(
+        self,
+        manager: RoomChannelManager,
+        *,
+        timeout_s: float | None = None,
+    ) -> None:
+        self._manager = manager
+        self._timeout_s = timeout_s if timeout_s is not None else settings.SUMMONGUARD_PI_TIMEOUT_S
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    # -- lifecycle wiring --
+
+    def wire(self) -> None:
+        """Subscribe to the lifecycle events that install/remove the hook."""
+        for event in (
+            RoomEvent.ENGINE_REGISTERED,
+            RoomEvent.ENGINE_REMOVED,
+            RoomEvent.ROOM_PROVISIONED,
+        ):
+            lifecycle.subscribe(event, self._on_lifecycle)
+
+    def _on_lifecycle(self, ctx: RoomEventContext) -> None:
+        self.sync_room(ctx.room)
+
+    def sync_room(self, room: str) -> list[str]:
+        """Reconcile ``room``'s summon filter against its registered manifests.
+
+        Reads the room's engine manifests rather than trusting the event
+        payload, so it is idempotent and self-healing: a guard registered while
+        the backend was down installs on the room's next provision, and one
+        deleted from the room drops out on the next lifecycle event.
+        """
+        guards = self._registered_guards(room)
+        for owner in guards:
+            lifecycle.install(room, SUMMON_FILTER, owner, self.classify)
+        for owner in lifecycle.owners(room, SUMMON_FILTER):
+            if owner not in guards:
+                lifecycle.uninstall(room, SUMMON_FILTER, owner)
+        return guards
+
+    @staticmethod
+    def _registered_guards(room: str) -> list[str]:
+        """Handles in ``room`` whose manifest is ``adapter: engine, kind: summonguard``."""
+        from app.services.agent_registry import room_agents
+
+        try:
+            agents = room_agents(room)
+        except Exception:
+            logger.exception("summonguard: could not read manifests for room %s", room)
+            return []
+        return [a.handle for a in agents if a.adapter == "engine" and a.kind == ENGINE_KIND]
+
+    # -- the filter itself (the installed hook) --
+
+    async def classify(self, ctx: SummonContext) -> dict[str, str]:
+        """Decide each mentioned handle in one message; publish the verdict.
+
+        Returns the ``{handle: wake|mention}`` map, and stores the full verdict
+        (with reasons) so ``await`` and the introspection route read the same
+        decision rather than re-deriving it.
+        """
+        candidates = tuple(
+            h for h in dict.fromkeys(_norm(h) for h in ctx.handles) if h not in _NEVER_CLASSIFIED
+        )
+        decisions: dict[str, str] = {}
+        reasons: dict[str, str] = {}
+        source = "pi"
+
+        # The kill switch stops the classification, not the verdict: every
+        # candidate falls through to the wake default below.
+        disabled = settings.SUMMONGUARD_DISABLE
+        if disabled:
+            source = "disabled"
+
+        # Cheap pre-pass: a mention that opens the message is a summon. Only
+        # what it leaves undecided is worth a cognition turn.
+        undecided = []
+        for handle in () if disabled else candidates:
+            if _leading_mention_is_wake(ctx.text, handle):
+                decisions[handle] = WAKE
+            else:
+                undecided.append(handle)
+        if decisions and not undecided:
+            source = "leading-mention"
+
+        if undecided:
+            judged, judged_reasons, ok = await self._judge(ctx, tuple(undecided))
+            decisions.update(judged)
+            reasons.update(judged_reasons)
+            if not ok:
+                source = "fail-open"
+            elif len(decisions) > len(judged):
+                source = "mixed"
+
+        # Anything still unanswered fails open — the classifier skipping a handle
+        # must not be the reason it stays asleep.
+        for handle in candidates:
+            decisions.setdefault(handle, WAKE)
+
+        verdict = SummonVerdict(
+            room=ctx.room,
+            message_id=ctx.message_id,
+            sender=ctx.sender,
+            text=ctx.text,
+            decisions=decisions,
+            reasons=reasons,
+            source=source,
+            decided_at=_now(),
+        )
+        verdicts.put(verdict)
+        suppressed = [h for h, d in decisions.items() if d == MENTION]
+        if suppressed:
+            logger.info(
+                "summonguard: room %s message %s — %s mentioned for provenance, not woken",
+                ctx.room,
+                ctx.message_id,
+                ", ".join(f"@{h}" for h in suppressed),
+            )
+        return decisions
+
+    async def _judge(
+        self, ctx: SummonContext, handles: tuple[str, ...]
+    ) -> tuple[dict[str, str], dict[str, str], bool]:
+        """One Pi turn over ``handles``; ``(decisions, reasons, succeeded)``."""
+        prompt = build_prompt(replace(ctx, handles=handles))
+        try:
+            raw = await asyncio.wait_for(
+                asyncio.to_thread(_pi_complete, prompt, self._timeout_s),
+                timeout=self._timeout_s + 5.0,
+            )
+        except Exception as exc:
+            logger.warning(
+                "summonguard: classification failed on room %s (%s) — failing open to wake",
+                ctx.room,
+                exc,
+            )
+            return {}, {}, False
+        decisions, reasons = parse_decisions(raw or "", handles)
+        if not decisions:
+            logger.warning(
+                "summonguard: unreadable classification on room %s — failing open to wake", ctx.room
+            )
+            return {}, {}, False
+        return decisions, reasons, True
+
+    # -- the summon seam (the guard, summoned itself) --
+
+    def handle_summon(
+        self,
+        room: str,
+        handle: str,
+        envelope: L9,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
+    ) -> None:
+        """Report what the guard has been deciding when it is summoned by name.
+
+        The guard has no work to *do* on summon — its work is the filter it
+        already installed — so a summon is answered with its recent decisions,
+        which is what someone asking it is actually after.
+        """
+        from app.services.aligner import _registered_engine_kind
+        from app.services.persister import envelope_sender
+
+        if _registered_engine_kind(room, handle) != ENGINE_KIND:
+            return
+        sender = envelope_sender(envelope)
+        if sender is not None and _norm(sender) == _norm(handle):
+            return
+        task = asyncio.create_task(self._report(room, handle))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _report(self, room: str, me: str) -> None:
+        managed = self._manager.get(room)
+        if managed is None:
+            return
+        recent = verdicts.recent(room, limit=5)
+        if not recent:
+            body = "Guarding this room's summons. Nothing classified yet."
+        else:
+            lines = ["Recent summon decisions (newest first):"]
+            for verdict in recent:
+                for h, d in verdict.decisions.items():
+                    why = verdict.reasons.get(h, "")
+                    lines.append(f"- @{h}: {d}" + (f" — {why}" if why else ""))
+            body = "\n".join(lines)
+        await self._say(managed, room, me, body)
+
+    async def _say(self, managed: ManagedRoomChannel, room: str, sender: str, text: str) -> None:
+        env = l9.build_envelope(
+            kind=l9.Kind.exchange,
+            episode=l9.episode_urn(room, "live"),
+            sender=sender,
+            topic=l9.topic_urn(room),
+            payload_type="message",
+        )
+        content = serialize_content(env, extra={"content": text})
+        try:
+            await managed.channel.send(env, extra={"content": text})
+        except Exception:
+            logger.warning("summonguard failed to broadcast on room %s", room)
+        if managed.persister is not None:
+            managed.persister.ingest_local(env, content)
+
+
+# ── The two consumer-facing helpers ──────────────────────────────────────────
+
+
+def guarded(room: str) -> bool:
+    """True when some engine installed a summon filter in ``room``."""
+    return bool(lifecycle.hooks(room, SUMMON_FILTER))
+
+
+async def decide(ctx: SummonContext) -> dict[str, str]:
+    """Run ``ctx`` through every summon filter installed in its room.
+
+    With no filter installed every handle wakes — today's behaviour. With
+    several, a handle is suppressed only when **all** of them call it provenance:
+    the guards are advisory, and the fail-open bias holds across them too.
+    """
+    filters = lifecycle.hooks(ctx.room, SUMMON_FILTER)
+    if not filters:
+        return {_norm(h): WAKE for h in ctx.handles}
+    verdicts.begin(ctx.room, ctx.message_id)
+    merged: dict[str, str] = {}
+    for fn in filters:
+        try:
+            result = await fn(ctx)
+        except Exception:
+            logger.exception("summon filter failed on room %s — failing open", ctx.room)
+            return {_norm(h): WAKE for h in ctx.handles}
+        for handle, decision in (result or {}).items():
+            key = _norm(handle)
+            if merged.get(key, MENTION) == MENTION and decision == MENTION:
+                merged[key] = MENTION
+            else:
+                merged[key] = WAKE
+    for handle in ctx.handles:
+        merged.setdefault(_norm(handle), WAKE)
+    return merged
+
+
+async def wakes(room: str, message_id: str, handle: str) -> bool:
+    """Whether ``handle`` should be woken by ``message_id`` (the ``await`` gate).
+
+    Waits out an in-flight classification — the long-poll has the time, and the
+    alternative is delivering a turn the guard was about to suppress. An
+    unguarded room, an unclassified message, or a classification that overruns
+    the wait all answer ``True``.
+    """
+    if not guarded(room):
+        return True
+    verdict = await verdicts.wait(room, message_id, settings.SUMMONGUARD_WAKE_TIMEOUT_S)
+    if verdict is None:
+        return True
+    return verdict.wakes(handle)

--- a/fastapi-backend/tests/test_engine_boundaries.py
+++ b/fastapi-backend/tests/test_engine_boundaries.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The room's core must not depend on any particular engine.
+
+Engines are plugins: they install behaviour through the lifecycle bus and the
+extension-point contracts, and the room's own machinery calls those contracts.
+The direction matters — a core that imports a plugin is a plugin-shaped hard
+dependency, and deleting the plugin takes the room down with it.
+
+Two tests, because they fail differently. The static one proves nothing
+*references* an engine, and catches a function-local import that reads as
+decoupled at a glance. The runtime one proves the core doesn't *break* when an
+engine is genuinely absent — the manual "delete the module and see" check, made
+permanent.
+"""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+APP = Path(__file__).resolve().parent.parent / "app"
+
+#: The room's own machinery: the summon path, the delivery queue, the channel.
+#: These may import the lifecycle bus and the extension-point contracts, and
+#: nothing that is one engine's implementation.
+CORE_MODULES = [
+    APP / "routes" / "participate.py",
+    APP / "services" / "persister.py",
+    APP / "services" / "room_channels.py",
+]
+
+#: First-party engines. ``main.py`` is the composition root and is *expected* to
+#: import every one — that is where concrete plugins are allowed to be named.
+ENGINE_MODULES = frozenset({"aligner", "synthesizer", "summonguard", "plan_sync"})
+
+
+def _imported_names(path: Path) -> set[str]:
+    """Every module name imported anywhere in ``path``, at any nesting depth.
+
+    ``ast.walk`` rather than a scan of the module body: a function-local import
+    is exactly the pattern that looks decoupled and isn't.
+    """
+    tree = ast.parse(path.read_text())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            names.add(module)
+            names.update(f"{module}.{alias.name}" for alias in node.names)
+    return names
+
+
+@pytest.mark.parametrize("path", CORE_MODULES, ids=lambda p: p.name)
+def test_core_room_machinery_names_no_engine(path: Path):
+    offenders = {
+        name
+        for name in _imported_names(path)
+        if any(part in ENGINE_MODULES for part in name.split("."))
+    }
+    assert not offenders, (
+        f"{path.name} imports {sorted(offenders)} — the room's core must reach engines "
+        "through app.services.engine_events / the extension-point contracts, never by name."
+    )
+
+
+def test_the_room_still_boots_with_every_guard_absent():
+    """Block the guard's module outright and confirm the core is unaffected.
+
+    Run in a subprocess so the import-blocking meta-path hook cannot leak into
+    the rest of the suite.
+    """
+    program = textwrap.dedent("""
+        import asyncio, sys
+
+        class Blocker:
+            def find_module(self, name, path=None):
+                return self if name == "app.services.summonguard" else None
+            def find_spec(self, name, path=None, target=None):
+                if name == "app.services.summonguard":
+                    raise ImportError("summonguard is not installed")
+                return None
+
+        sys.meta_path.insert(0, Blocker())
+
+        # The core imports and the app builds with no guard in the tree...
+        from app.main import app
+        from app.services import summon_filter
+        from app.routes import participate  # noqa: F401
+        from app.services import persister  # noqa: F401
+
+        # ...and an unguarded room decides exactly as it did before guards existed.
+        ctx = summon_filter.SummonContext(
+            room="r", message_id="m1", sender="avery",
+            text="shipped it, credit to @alice", handles=("alice",),
+        )
+        assert asyncio.run(summon_filter.decide(ctx)) == {"alice": "wake"}
+        assert asyncio.run(summon_filter.wakes("r", "m1", "alice")) is True
+
+        try:
+            import app.services.summonguard  # noqa: F401
+        except ImportError:
+            print("OK")
+        else:
+            raise AssertionError("the blocker did not take effect; test proves nothing")
+    """)
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        cwd=APP.parent,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, f"core broke without the guard:\n{result.stderr[-3000:]}"
+    assert "OK" in result.stdout

--- a/fastapi-backend/tests/test_engine_events.py
+++ b/fastapi-backend/tests/test_engine_events.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The room lifecycle bus: events in, room hooks out.
+
+The bus is what lets an engine change a room's behaviour by being *registered*
+rather than by being summoned. These cover the two guarantees the rest of the
+feature rests on: a room with nothing installed exposes nothing (so the
+un-guarded path stays the old path), and a listener that blows up cannot take
+the emitting write down with it.
+"""
+
+import pytest
+
+from app.services.engine_events import (
+    SUMMON_FILTER,
+    RoomEvent,
+    RoomEventContext,
+    RoomLifecycle,
+)
+
+
+@pytest.fixture
+def bus() -> RoomLifecycle:
+    return RoomLifecycle()
+
+
+def test_room_with_no_install_exposes_no_hooks(bus):
+    assert bus.hooks("quiet", SUMMON_FILTER) == []
+    assert bus.owners("quiet", SUMMON_FILTER) == []
+
+
+def test_install_is_scoped_to_the_room_and_keyed_by_owner(bus):
+    def guard(_ctx):
+        return {}
+
+    bus.install("alpha", SUMMON_FILTER, "watcher", guard)
+    assert bus.hooks("alpha", SUMMON_FILTER) == [guard]
+    assert bus.owners("alpha", SUMMON_FILTER) == ["watcher"]
+    # A second room is untouched.
+    assert bus.hooks("beta", SUMMON_FILTER) == []
+
+
+def test_reinstalling_the_same_owner_replaces_rather_than_stacks(bus):
+    bus.install("alpha", SUMMON_FILTER, "watcher", lambda _c: {})
+    replacement = lambda _c: {"a": "wake"}  # noqa: E731
+    bus.install("alpha", SUMMON_FILTER, "watcher", replacement)
+    assert bus.hooks("alpha", SUMMON_FILTER) == [replacement]
+
+
+def test_uninstall_removes_only_that_owner(bus):
+    first, second = lambda _c: {}, lambda _c: {}
+    bus.install("alpha", SUMMON_FILTER, "one", first)
+    bus.install("alpha", SUMMON_FILTER, "two", second)
+    bus.uninstall("alpha", SUMMON_FILTER, "one")
+    assert bus.owners("alpha", SUMMON_FILTER) == ["two"]
+    # Removing an owner that never installed is a no-op, not an error.
+    bus.uninstall("alpha", SUMMON_FILTER, "ghost")
+    assert bus.owners("alpha", SUMMON_FILTER) == ["two"]
+
+
+def test_emit_delivers_the_room_and_manifest_payload(bus):
+    seen: list[RoomEventContext] = []
+    bus.subscribe(RoomEvent.ENGINE_REGISTERED, seen.append)
+    bus.emit(RoomEvent.ENGINE_REGISTERED, "alpha", handle="watcher", kind="summonguard")
+    assert len(seen) == 1
+    assert (seen[0].room, seen[0].handle, seen[0].kind) == ("alpha", "watcher", "summonguard")
+
+
+def test_subscribing_the_same_listener_twice_delivers_once(bus):
+    seen: list[RoomEventContext] = []
+    bus.subscribe(RoomEvent.ROOM_PROVISIONED, seen.append)
+    bus.subscribe(RoomEvent.ROOM_PROVISIONED, seen.append)
+    bus.emit(RoomEvent.ROOM_PROVISIONED, "alpha")
+    assert len(seen) == 1
+
+
+def test_a_failing_listener_is_isolated_from_the_emitter_and_its_peers(bus):
+    reached: list[str] = []
+
+    def explodes(_ctx):
+        raise RuntimeError("engine is broken")
+
+    bus.subscribe(RoomEvent.ENGINE_REGISTERED, explodes)
+    bus.subscribe(RoomEvent.ENGINE_REGISTERED, lambda ctx: reached.append(ctx.room))
+    # The memory write that emitted this must not see the exception.
+    bus.emit(RoomEvent.ENGINE_REGISTERED, "alpha")
+    assert reached == ["alpha"]
+
+
+def test_emit_with_no_subscribers_is_inert(bus):
+    bus.emit(RoomEvent.ENGINE_REMOVED, "alpha", handle="watcher")

--- a/fastapi-backend/tests/test_participate_await.py
+++ b/fastapi-backend/tests/test_participate_await.py
@@ -129,3 +129,118 @@ async def test_await_ignores_turns_addressed_to_others(wired):
     wired(log)
     result = await participate.await_message("r", _REQUEST, handle="claude-code-agent", timeout=1)
     assert result["message"] is None
+
+
+# ── the summon guard's wake gate (#summonguard) ──────────────────────────────
+
+
+def _mention_record(message_id: str, *, text: str, sender: str = "avery"):
+    """A broadcast that only *names* a handle in prose — no L9 recipient.
+
+    This is the shape a guard is allowed to judge: nothing in the protocol
+    addressed the handle, the wake comes purely from ``@handle`` in the text.
+    """
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=l9.episode_urn("r", "live"),
+        sender=sender,
+        sender_role="human",
+        topic=l9.topic_urn("r"),
+        message_id=message_id,
+        payload_type="message",
+    )
+    return persister.record_from(env, serialize_content(env, extra={"content": text}))
+
+
+@pytest.fixture
+def guarded(monkeypatch):
+    """Install a summon filter returning a fixed decision map."""
+    from app.services import summonguard
+    from app.services.engine_events import SUMMON_FILTER, lifecycle
+
+    def _install(decisions: dict[str, str]) -> None:
+        async def _filter(ctx):
+            summonguard.verdicts.put(
+                summonguard.SummonVerdict(
+                    room=ctx.room,
+                    message_id=ctx.message_id,
+                    sender=ctx.sender,
+                    text=ctx.text,
+                    decisions=decisions,
+                )
+            )
+            return decisions
+
+        lifecycle.install("r", SUMMON_FILTER, "watcher", _filter)
+
+    yield _install
+    lifecycle.clear()
+    summonguard.verdicts.clear()
+
+
+@pytest.mark.asyncio
+async def test_await_skips_a_mention_the_guard_called_provenance(wired, guarded):
+    """The guard's whole point: being named in passing is not a turn."""
+    from app.services import summonguard
+
+    log = persister.DeliveryLog()
+    log.record(
+        _mention_record("m1", text="shipped it, credit to @claude-code-agent"),
+        delivered_to=set(),
+        recipients=["claude-code-agent"],
+    )
+    wired(log)
+    guarded({"claude-code-agent": "mention"})
+    await summonguard.decide(
+        summonguard.SummonContext(
+            room="r",
+            message_id="m1",
+            sender="avery",
+            text="shipped it, credit to @claude-code-agent",
+            handles=("claude-code-agent",),
+        )
+    )
+
+    result = await participate.await_message("r", _REQUEST, handle="claude-code-agent", timeout=1)
+    assert result["message"] is None
+    # The record was scanned and consumed, not merely out of the cursor's reach —
+    # otherwise this would pass for a handle the poll never looked at.
+    assert log.position("claude-code-agent") == 1
+
+
+@pytest.mark.asyncio
+async def test_await_serves_a_mention_the_guard_called_a_summon(wired, guarded):
+    from app.services import summonguard
+
+    text = "@claude-code-agent can you cost this out?"
+    log = persister.DeliveryLog()
+    log.record(
+        _mention_record("m1", text=text), delivered_to=set(), recipients=["claude-code-agent"]
+    )
+    wired(log)
+    guarded({"claude-code-agent": "wake"})
+    await summonguard.decide(
+        summonguard.SummonContext(
+            room="r", message_id="m1", sender="avery", text=text, handles=("claude-code-agent",)
+        )
+    )
+
+    result = await participate.await_message("r", _REQUEST, handle="claude-code-agent", timeout=0)
+    assert result["message_id"] == "m1"
+
+
+@pytest.mark.asyncio
+async def test_a_protocol_addressed_tick_is_never_the_guards_to_judge(wired, guarded):
+    """A mediator tick names the handle as an L9 recipient — that is a turn by
+    construction, so a guard that would suppress it does not get asked."""
+    log = persister.DeliveryLog()
+    log.record(
+        _addressed_record("m1", to="claude-code-agent"),
+        delivered_to=set(),
+        recipients=["claude-code-agent"],
+    )
+    wired(log)
+    guarded({"claude-code-agent": "mention"})
+
+    result = await participate.await_message("r", _REQUEST, handle="claude-code-agent", timeout=0)
+    assert result["message_id"] == "m1"

--- a/fastapi-backend/tests/test_participate_await.py
+++ b/fastapi-backend/tests/test_participate_await.py
@@ -131,7 +131,7 @@ async def test_await_ignores_turns_addressed_to_others(wired):
     assert result["message"] is None
 
 
-# ── the summon guard's wake gate (#summonguard) ──────────────────────────────
+# ── the summon-filter wake gate ──────────────────────────────────────────────
 
 
 def _mention_record(message_id: str, *, text: str, sender: str = "avery"):
@@ -155,13 +155,13 @@ def _mention_record(message_id: str, *, text: str, sender: str = "avery"):
 @pytest.fixture
 def guarded(monkeypatch):
     """Install a summon filter returning a fixed decision map."""
-    from app.services import summonguard
-    from app.services.engine_events import SUMMON_FILTER, lifecycle
+    from app.services import summon_filter
+    from app.services.engine_events import lifecycle
 
     def _install(decisions: dict[str, str]) -> None:
         async def _filter(ctx):
-            summonguard.verdicts.put(
-                summonguard.SummonVerdict(
+            summon_filter.verdicts.put(
+                summon_filter.SummonVerdict(
                     room=ctx.room,
                     message_id=ctx.message_id,
                     sender=ctx.sender,
@@ -171,17 +171,17 @@ def guarded(monkeypatch):
             )
             return decisions
 
-        lifecycle.install("r", SUMMON_FILTER, "watcher", _filter)
+        summon_filter.install("r", "watcher", _filter)
 
     yield _install
     lifecycle.clear()
-    summonguard.verdicts.clear()
+    summon_filter.verdicts.clear()
 
 
 @pytest.mark.asyncio
 async def test_await_skips_a_mention_the_guard_called_provenance(wired, guarded):
     """The guard's whole point: being named in passing is not a turn."""
-    from app.services import summonguard
+    from app.services import summon_filter
 
     log = persister.DeliveryLog()
     log.record(
@@ -191,8 +191,8 @@ async def test_await_skips_a_mention_the_guard_called_provenance(wired, guarded)
     )
     wired(log)
     guarded({"claude-code-agent": "mention"})
-    await summonguard.decide(
-        summonguard.SummonContext(
+    await summon_filter.decide(
+        summon_filter.SummonContext(
             room="r",
             message_id="m1",
             sender="avery",
@@ -210,7 +210,7 @@ async def test_await_skips_a_mention_the_guard_called_provenance(wired, guarded)
 
 @pytest.mark.asyncio
 async def test_await_serves_a_mention_the_guard_called_a_summon(wired, guarded):
-    from app.services import summonguard
+    from app.services import summon_filter
 
     text = "@claude-code-agent can you cost this out?"
     log = persister.DeliveryLog()
@@ -219,8 +219,8 @@ async def test_await_serves_a_mention_the_guard_called_a_summon(wired, guarded):
     )
     wired(log)
     guarded({"claude-code-agent": "wake"})
-    await summonguard.decide(
-        summonguard.SummonContext(
+    await summon_filter.decide(
+        summon_filter.SummonContext(
             room="r", message_id="m1", sender="avery", text=text, handles=("claude-code-agent",)
         )
     )

--- a/fastapi-backend/tests/test_summon_filter.py
+++ b/fastapi-backend/tests/test_summon_filter.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The summon-filter contract: what the room calls, independent of any engine.
+
+These use plain async functions as filters rather than a real guard — the point
+is the seam's own behaviour: an unguarded room, the merge across several
+filters, an open verdict vocabulary, and what happens to cached decisions when
+the filter set changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services import summon_filter
+from app.services.engine_events import lifecycle
+from app.services.summon_filter import ABSTAIN, MENTION, WAKE, SummonContext, SummonVerdict
+
+
+@pytest.fixture(autouse=True)
+def _reset_seam_state():
+    """The bus and the verdict store are process-wide; isolate each test."""
+    lifecycle.clear()
+    summon_filter.verdicts.clear()
+    yield
+    lifecycle.clear()
+    summon_filter.verdicts.clear()
+
+
+def _ctx(text: str, *handles: str, room: str = "r", message_id: str = "m1") -> SummonContext:
+    return SummonContext(
+        room=room, message_id=message_id, sender="avery", text=text, handles=handles
+    )
+
+
+def _answering(decisions: dict[str, str]):
+    """A filter that always answers ``decisions``."""
+
+    async def _filter(_ctx):
+        return decisions
+
+    return _filter
+
+
+# ── an unguarded room is the pre-guard room ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_filter_installed_wakes_everything():
+    assert summon_filter.guarded("r") is False
+    assert await summon_filter.decide(_ctx("credit to @alice", "alice")) == {"alice": WAKE}
+
+
+@pytest.mark.asyncio
+async def test_wakes_is_true_in_an_unguarded_room_without_waiting():
+    assert await summon_filter.wakes("r", "m1", "alice") is True
+
+
+# ── the merge, including verdicts this version has never heard of ────────────
+
+
+@pytest.mark.parametrize(
+    ("answers", "expected"),
+    [
+        ([WAKE], WAKE),
+        ([MENTION], MENTION),
+        ([WAKE, MENTION], WAKE),  # any wake beats a suppression
+        ([MENTION, MENTION], MENTION),  # suppress only when every opinion agrees
+        ([], WAKE),  # nobody had an opinion
+        ([ABSTAIN], WAKE),  # an abstention is not an opinion
+        ([ABSTAIN, MENTION], MENTION),  # …so it doesn't dilute a real one
+        (["defer"], WAKE),  # a verdict from a later engine: unknown, so no weight
+        (["escalate", MENTION], MENTION),
+    ],
+)
+def test_merge_policy_is_fail_open_over_opinions_only(answers, expected):
+    assert summon_filter._merge(answers) == expected
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_verdict_does_not_crash_the_room():
+    """The contract must survive an engine answering in a vocabulary it added."""
+    summon_filter.install("r", "future-guard", _answering({"alice": "defer"}))
+    assert await summon_filter.decide(_ctx("thanks @alice", "alice")) == {"alice": WAKE}
+
+
+@pytest.mark.asyncio
+async def test_an_abstaining_filter_leaves_the_decision_to_the_others():
+    summon_filter.install("r", "shy", _answering({"alice": ABSTAIN}))
+    summon_filter.install("r", "opinionated", _answering({"alice": MENTION}))
+    assert await summon_filter.decide(_ctx("thanks @alice", "alice")) == {"alice": MENTION}
+
+
+@pytest.mark.asyncio
+async def test_two_filters_suppress_only_when_both_agree():
+    summon_filter.install("r", "one", _answering({"alice": MENTION}))
+    summon_filter.install("r", "two", _answering({"alice": MENTION}))
+    assert await summon_filter.decide(_ctx("thanks @alice", "alice")) == {"alice": MENTION}
+
+    summon_filter.install("r", "two", _answering({"alice": WAKE}))
+    assert await summon_filter.decide(_ctx("thanks @alice", "alice", message_id="m2")) == {
+        "alice": WAKE
+    }
+
+
+@pytest.mark.asyncio
+async def test_a_filter_that_raises_fails_the_whole_room_open():
+    async def _broken(_ctx):
+        raise RuntimeError("guard is broken")
+
+    summon_filter.install("r", "one", _broken)
+    summon_filter.install("r", "two", _answering({"alice": MENTION}))
+    assert await summon_filter.decide(_ctx("thanks @alice", "alice")) == {"alice": WAKE}
+
+
+@pytest.mark.asyncio
+async def test_a_handle_no_filter_answered_for_still_wakes():
+    summon_filter.install("r", "one", _answering({"alice": MENTION}))
+    decisions = await summon_filter.decide(_ctx("per @alice, ask @bob", "alice", "bob"))
+    assert decisions == {"alice": MENTION, "bob": WAKE}
+
+
+# ── the await-side gate ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wakes_reads_the_verdict_the_ingest_side_published():
+    async def _filter(ctx):
+        summon_filter.verdicts.put(
+            SummonVerdict(
+                room=ctx.room,
+                message_id=ctx.message_id,
+                sender=ctx.sender,
+                text=ctx.text,
+                decisions={"alice": MENTION},
+            )
+        )
+        return {"alice": MENTION}
+
+    summon_filter.install("r", "watcher", _filter)
+    await summon_filter.decide(_ctx("shipped, thanks @alice", "alice"))
+    assert await summon_filter.wakes("r", "m1", "alice") is False
+    # A handle that message never mentioned is unaffected.
+    assert await summon_filter.wakes("r", "m1", "bob") is True
+
+
+@pytest.mark.asyncio
+async def test_a_judgement_that_overruns_the_wait_wakes(monkeypatch):
+    monkeypatch.setattr(summon_filter.settings, "SUMMON_FILTER_WAIT_S", 0.05)
+    summon_filter.install("r", "watcher", _answering({}))
+    summon_filter.verdicts.begin("r", "m1")
+    assert await summon_filter.wakes("r", "m1", "alice") is True
+
+
+# ── a verdict never outlives the filter set that produced it ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_removing_a_filter_drops_the_verdicts_it_produced():
+    """Otherwise a dead engine keeps suppressing wakes from the cache."""
+    summon_filter.install("r", "watcher", _answering({"alice": MENTION}))
+    summon_filter.verdicts.put(
+        SummonVerdict(
+            room="r", message_id="m1", sender="avery", text="", decisions={"alice": MENTION}
+        )
+    )
+    assert summon_filter.verdicts.get("r", "m1") is not None
+
+    summon_filter.uninstall("r", "watcher")
+    assert summon_filter.verdicts.get("r", "m1") is None
+    # …and with no filter left, the room is unguarded again.
+    assert await summon_filter.wakes("r", "m1", "alice") is True
+
+
+@pytest.mark.asyncio
+async def test_adding_a_filter_drops_verdicts_decided_without_it():
+    summon_filter.verdicts.put(
+        SummonVerdict(
+            room="r", message_id="m1", sender="avery", text="", decisions={"alice": MENTION}
+        )
+    )
+    summon_filter.install("r", "watcher", _answering({}))
+    assert summon_filter.verdicts.get("r", "m1") is None
+
+
+@pytest.mark.asyncio
+async def test_a_sweep_releases_a_waiter_instead_of_stranding_it():
+    """Nothing is going to publish the answer it is waiting for, so it should
+    reach the fail-open default now rather than at the timeout."""
+    summon_filter.install("r", "watcher", _answering({}))
+    summon_filter.verdicts.begin("r", "m1")
+    waiter = asyncio.create_task(summon_filter.verdicts.wait("r", "m1", timeout_s=30.0))
+    await asyncio.sleep(0)
+
+    summon_filter.uninstall("r", "watcher")
+    assert await asyncio.wait_for(waiter, timeout=1.0) is None
+
+
+def test_uninstalling_an_owner_that_never_installed_is_a_no_op():
+    summon_filter.install("r", "watcher", _answering({}))
+    summon_filter.uninstall("r", "ghost")
+    assert summon_filter.owners("r") == ["watcher"]
+
+
+def test_a_verdict_that_never_saw_a_handle_wakes_it():
+    verdict = SummonVerdict(
+        room="r", message_id="m1", sender="avery", text="", decisions={"alice": MENTION}
+    )
+    assert verdict.wakes("alice") is False
+    assert verdict.wakes("bob") is True

--- a/fastapi-backend/tests/test_summonguard.py
+++ b/fastapi-backend/tests/test_summonguard.py
@@ -1,0 +1,460 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The summonguard: which ``@``-mentions are summons.
+
+Node-free and Pi-free — the one-shot classification is patched, so these cover
+the decision logic rather than a model's judgement:
+
+* the cheap pre-pass may confirm a wake but never suppress one,
+* every failure mode (no Pi, timeout, unreadable answer, a handle the classifier
+  skipped, the kill switch) resolves to ``wake``,
+* an unguarded room is the old behaviour, byte for byte,
+* and the persister's summon seam and ``await``'s wake read the same verdict.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services import summonguard
+from app.services.engine_events import SUMMON_FILTER, lifecycle
+from app.services.summonguard import MENTION, WAKE, SummonContext, SummonGuardEngine
+
+
+@pytest.fixture(autouse=True)
+def _reset_guard_state():
+    """The lifecycle bus and verdict store are process-wide; isolate each test."""
+    lifecycle.clear()
+    summonguard.verdicts.clear()
+    yield
+    lifecycle.clear()
+    summonguard.verdicts.clear()
+
+
+@pytest.fixture
+def engine() -> SummonGuardEngine:
+    return SummonGuardEngine(manager=None, timeout_s=1.0)  # ty: ignore[invalid-argument-type]
+
+
+def _ctx(text: str, *handles: str, room: str = "r", message_id: str = "m1") -> SummonContext:
+    return SummonContext(
+        room=room, message_id=message_id, sender="avery", text=text, handles=handles
+    )
+
+
+def _classifier(answer: str):
+    """Stand in for the one-shot Pi turn, returning a fixed raw answer."""
+
+    def _fake(_prompt: str, _timeout: float) -> str:
+        return answer
+
+    return _fake
+
+
+def _install(engine: SummonGuardEngine, room: str = "r", owner: str = "watcher") -> None:
+    lifecycle.install(room, SUMMON_FILTER, owner, engine.classify)
+
+
+def _verdict(room: str = "r", message_id: str = "m1") -> summonguard.SummonVerdict:
+    """The published verdict for a message; fails the test if none landed."""
+    verdict = summonguard.verdicts.get(room, message_id)
+    assert verdict is not None, f"no verdict published for {room}/{message_id}"
+    return verdict
+
+
+# ── the pre-pass ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("text", "handle", "expected"),
+    [
+        ("@alice can you cost this out?", "alice", True),
+        ("@alice @bob let's settle this", "bob", True),
+        ("@alice, thoughts?", "alice", True),
+        ("  @alice: ping", "alice", True),
+        ("we shipped it, credit to @alice", "alice", False),
+        ("as @alice said, the budget is fixed", "alice", False),
+        ("@bob what did @alice mean?", "alice", False),
+        ("", "alice", False),
+    ],
+)
+def test_leading_mention_confirms_only_the_plain_summon_shape(text, handle, expected):
+    assert summonguard._leading_mention_is_wake(text, handle) is expected
+
+
+@pytest.mark.asyncio
+async def test_a_leading_mention_never_reaches_the_classifier(engine, monkeypatch):
+    """The hot path — ``@alice do X`` — costs no cognition turn."""
+
+    def _explode(_prompt, _timeout):
+        raise AssertionError("the classifier was called for a leading mention")
+
+    monkeypatch.setattr(summonguard, "_pi_complete", _explode)
+    decisions = await engine.classify(_ctx("@alice ship it", "alice"))
+    assert decisions == {"alice": WAKE}
+    assert _verdict().source == "leading-mention"
+
+
+# ── the classifier's answer ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_provenance_mention_is_suppressed(engine, monkeypatch):
+    monkeypatch.setattr(
+        summonguard,
+        "_pi_complete",
+        _classifier('{"alice": {"decision": "mention", "reason": "credited, not asked"}}'),
+    )
+    decisions = await engine.classify(_ctx("we shipped it, credit to @alice", "alice"))
+    assert decisions == {"alice": MENTION}
+    verdict = _verdict()
+    assert verdict.reasons["alice"] == "credited, not asked"
+    assert verdict.wakes("alice") is False
+
+
+@pytest.mark.asyncio
+async def test_one_message_can_summon_one_handle_and_only_name_another(engine, monkeypatch):
+    monkeypatch.setattr(
+        summonguard,
+        "_pi_complete",
+        _classifier('{"bob": "wake", "alice": "mention"}'),
+    )
+    decisions = await engine.classify(
+        _ctx("hey @bob, does @alice's number still hold?", "bob", "alice")
+    )
+    assert decisions == {"bob": WAKE, "alice": MENTION}
+
+
+@pytest.mark.asyncio
+async def test_a_fenced_answer_with_prose_around_it_still_parses(engine, monkeypatch):
+    monkeypatch.setattr(
+        summonguard,
+        "_pi_complete",
+        _classifier('Sure!\n```json\n{"alice": "mention"}\n```\nHope that helps.'),
+    )
+    assert await engine.classify(_ctx("nice work @alice", "alice")) == {"alice": MENTION}
+
+
+# ── every failure resolves to a wake ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_pi_binary_fails_open_to_a_wake(engine, monkeypatch):
+    def _missing(_prompt, _timeout):
+        raise RuntimeError("`pi` not found on PATH")
+
+    monkeypatch.setattr(summonguard, "_pi_complete", _missing)
+    assert await engine.classify(_ctx("thanks @alice", "alice")) == {"alice": WAKE}
+    assert _verdict().source == "fail-open"
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_answer_fails_open_to_a_wake(engine, monkeypatch):
+    monkeypatch.setattr(summonguard, "_pi_complete", _classifier("I think alice is fine?"))
+    assert await engine.classify(_ctx("thanks @alice", "alice")) == {"alice": WAKE}
+
+
+@pytest.mark.asyncio
+async def test_a_handle_the_classifier_skipped_still_wakes(engine, monkeypatch):
+    monkeypatch.setattr(summonguard, "_pi_complete", _classifier('{"alice": "mention"}'))
+    decisions = await engine.classify(_ctx("per @alice, ask @bob", "alice", "bob"))
+    assert decisions == {"alice": MENTION, "bob": WAKE}
+
+
+@pytest.mark.asyncio
+async def test_the_kill_switch_disarms_a_registered_guard(engine, monkeypatch):
+    monkeypatch.setattr(summonguard.settings, "SUMMONGUARD_DISABLE", True)
+    monkeypatch.setattr(summonguard, "_pi_complete", _classifier('{"alice": "mention"}'))
+    ctx = _ctx("thanks @alice", "alice")
+    assert await engine.classify(ctx) == {"alice": WAKE}
+    assert _verdict().source == "disabled"
+
+
+def test_a_verdict_that_never_saw_a_handle_wakes_it():
+    verdict = summonguard.SummonVerdict(
+        room="r", message_id="m1", sender="avery", text="", decisions={"alice": MENTION}
+    )
+    assert verdict.wakes("alice") is False
+    assert verdict.wakes("bob") is True
+
+
+# ── parsing (pure) ───────────────────────────────────────────────────────────
+
+
+def test_parse_decisions_ignores_unknown_handles_and_bad_verdicts():
+    raw = '{"alice": "mention", "carol": "mention", "bob": "maybe"}'
+    decisions, _ = summonguard.parse_decisions(raw, ("alice", "bob"))
+    assert decisions == {"alice": MENTION}
+
+
+def test_parse_decisions_accepts_both_shapes_and_normalizes_the_handle():
+    raw = '{"@Alice": {"decision": "WAKE", "reason": "asked directly"}, "bob": "mention"}'
+    decisions, reasons = summonguard.parse_decisions(raw, ("alice", "bob"))
+    assert decisions == {"alice": WAKE, "bob": MENTION}
+    assert reasons == {"alice": "asked directly"}
+
+
+def test_the_prompt_carries_the_message_and_every_candidate():
+    prompt = summonguard.build_prompt(_ctx("credit to @alice and @bob", "alice", "bob"))
+    assert "credit to @alice and @bob" in prompt
+    assert "- @alice" in prompt and "- @bob" in prompt
+
+
+# ── the room-level filter ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_an_unguarded_room_wakes_everything_without_classifying(monkeypatch):
+    def _explode(_prompt, _timeout):
+        raise AssertionError("an unguarded room must not classify")
+
+    monkeypatch.setattr(summonguard, "_pi_complete", _explode)
+    assert summonguard.guarded("r") is False
+    assert await summonguard.decide(_ctx("credit to @alice", "alice")) == {"alice": WAKE}
+
+
+@pytest.mark.asyncio
+async def test_a_filter_that_raises_fails_the_room_open(engine):
+    async def _broken(_ctx):
+        raise RuntimeError("guard is broken")
+
+    lifecycle.install("r", SUMMON_FILTER, "watcher", _broken)
+    assert await summonguard.decide(_ctx("credit to @alice", "alice")) == {"alice": WAKE}
+
+
+@pytest.mark.asyncio
+async def test_two_guards_suppress_only_when_both_agree():
+    async def _suppress(_ctx):
+        return {"alice": MENTION}
+
+    async def _wake(_ctx):
+        return {"alice": WAKE}
+
+    lifecycle.install("r", SUMMON_FILTER, "one", _suppress)
+    lifecycle.install("r", SUMMON_FILTER, "two", _suppress)
+    assert await summonguard.decide(_ctx("thanks @alice", "alice")) == {"alice": MENTION}
+
+    lifecycle.install("r", SUMMON_FILTER, "two", _wake)
+    assert await summonguard.decide(_ctx("thanks @alice", "alice", message_id="m2")) == {
+        "alice": WAKE
+    }
+
+
+# ── the await-side gate ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wakes_is_true_in_an_unguarded_room_without_waiting():
+    assert await summonguard.wakes("r", "m1", "alice") is True
+
+
+@pytest.mark.asyncio
+async def test_wakes_reads_the_verdict_the_ingest_side_published(engine, monkeypatch):
+    monkeypatch.setattr(summonguard, "_pi_complete", _classifier('{"alice": "mention"}'))
+    _install(engine)
+    await summonguard.decide(_ctx("shipped, thanks @alice", "alice"))
+    assert await summonguard.wakes("r", "m1", "alice") is False
+    # A handle that message never mentioned is unaffected.
+    assert await summonguard.wakes("r", "m1", "bob") is True
+
+
+@pytest.mark.asyncio
+async def test_wakes_waits_for_an_in_flight_classification(engine, monkeypatch):
+    """The long-poll absorbs the guard's latency rather than serving a turn it
+    was about to suppress."""
+    started = asyncio.Event()
+
+    def _slow(_prompt, _timeout):
+        started.set()
+        import time
+
+        time.sleep(0.2)
+        return '{"alice": "mention"}'
+
+    monkeypatch.setattr(summonguard, "_pi_complete", _slow)
+    _install(engine)
+    task = asyncio.create_task(summonguard.decide(_ctx("shipped, thanks @alice", "alice")))
+    await started.wait()
+    assert await summonguard.wakes("r", "m1", "alice") is False
+    await task
+
+
+@pytest.mark.asyncio
+async def test_a_classification_that_overruns_the_wait_wakes(engine, monkeypatch):
+    monkeypatch.setattr(summonguard.settings, "SUMMONGUARD_WAKE_TIMEOUT_S", 0.05)
+    _install(engine)
+    summonguard.verdicts.begin("r", "m1")
+    assert await summonguard.wakes("r", "m1", "alice") is True
+
+
+# ── registration installs the filter ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_registering_a_guard_installs_the_rooms_summon_filter(client, engine):
+    engine.wire()
+    await client.post("/api/rooms", json={"name": "portfolio"})
+    assert summonguard.guarded("portfolio") is False
+
+    resp = await client.post(
+        "/api/rooms/portfolio/engines",
+        json={"handle": "watcher", "kind": "summonguard", "description": "guard our summons"},
+    )
+    assert resp.status_code == 201
+    assert summonguard.guarded("portfolio") is True
+    assert lifecycle.owners("portfolio", SUMMON_FILTER) == ["watcher"]
+    # …and only that room's.
+    assert summonguard.guarded("other") is False
+
+
+@pytest.mark.asyncio
+async def test_registering_a_different_engine_kind_installs_nothing(client, engine):
+    engine.wire()
+    await client.post("/api/rooms", json={"name": "portfolio"})
+    await client.post("/api/rooms/portfolio/engines", json={"handle": "med", "kind": "aligner"})
+    assert summonguard.guarded("portfolio") is False
+
+
+@pytest.mark.asyncio
+async def test_a_removed_guard_drops_its_filter_on_the_next_sync(client, engine):
+    engine.wire()
+    await client.post("/api/rooms", json={"name": "portfolio"})
+    await client.post(
+        "/api/rooms/portfolio/engines", json={"handle": "watcher", "kind": "summonguard"}
+    )
+    assert summonguard.guarded("portfolio") is True
+
+    await client.delete("/api/rooms/portfolio/memory/agents/watcher")
+    engine.sync_room("portfolio")
+    assert summonguard.guarded("portfolio") is False
+
+
+@pytest.mark.asyncio
+async def test_status_route_reports_the_guard_and_its_verdicts(client, engine, monkeypatch):
+    engine.wire()
+    await client.post("/api/rooms", json={"name": "portfolio"})
+    await client.post(
+        "/api/rooms/portfolio/engines", json={"handle": "watcher", "kind": "summonguard"}
+    )
+    monkeypatch.setattr(
+        summonguard,
+        "_pi_complete",
+        _classifier('{"alice": {"decision": "mention", "reason": "credited only"}}'),
+    )
+    await summonguard.decide(_ctx("shipped, credit to @alice", "alice", room="portfolio"))
+
+    body = (await client.get("/api/rooms/portfolio/summonguard")).json()
+    assert body["installed"] is True
+    assert body["guards"] == ["watcher"]
+    assert body["verdicts"][0]["decisions"] == {"alice": MENTION}
+    assert body["verdicts"][0]["reasons"]["alice"] == "credited only"
+
+
+@pytest.mark.asyncio
+async def test_status_route_on_an_unguarded_room(client):
+    await client.post("/api/rooms", json={"name": "portfolio"})
+    body = (await client.get("/api/rooms/portfolio/summonguard")).json()
+    assert body == {
+        "room": "portfolio",
+        "installed": False,
+        "guards": [],
+        "disabled": False,
+        "verdicts": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_status_route_404s_for_an_unknown_room(client):
+    assert (await client.get("/api/rooms/ghost/summonguard")).status_code == 404
+
+
+# ── the persister's summon seam ──────────────────────────────────────────────
+
+
+def _exchange(message_id: str, text: str, *, sender: str = "avery"):
+    from app.services import l9
+    from app.services.l9_models import Kind
+
+    return l9.build_envelope(
+        kind=Kind.exchange,
+        episode=l9.episode_urn("r", "live"),
+        sender=sender,
+        sender_role="human",
+        topic=l9.topic_urn("r"),
+        message_id=message_id,
+        payload_type="message",
+    )
+
+
+def _persister(room: str, summoned: list[str]):
+    from app.services import persister as persister_mod
+
+    return persister_mod.RoomPersister(
+        room,
+        channel=None,  # ty: ignore[invalid-argument-type]  # _ingest is called directly
+        members_provider=lambda: set(),
+        on_summon=lambda handle, env, co, msg="": summoned.append(handle),
+        feed_bus=False,
+    )
+
+
+async def _ingest(p, message_id: str, text: str):
+    from app.services.l9_slim import serialize_content
+
+    env = _exchange(message_id, text)
+    p._ingest(env, serialize_content(env, extra={"content": text}))
+    if p._summon_tasks:
+        await asyncio.gather(*list(p._summon_tasks))
+
+
+@pytest.mark.asyncio
+async def test_an_unguarded_room_fires_the_summon_hook_inline(monkeypatch, tmp_path):
+    """No guard registered → the seam is exactly what it was, no task, no wait."""
+    summoned: list[str] = []
+    p = _persister("r", summoned)
+    await _ingest(p, "m1", "shipped it, credit to @alice")
+    assert summoned == ["alice"]
+    assert p._summon_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_a_guarded_room_withholds_the_summon_for_a_provenance_mention(engine, monkeypatch):
+    monkeypatch.setattr(summonguard, "_pi_complete", _classifier('{"alice": "mention"}'))
+    _install(engine)
+    summoned: list[str] = []
+    await _ingest(_persister("r", summoned), "m1", "shipped it, credit to @alice")
+    assert summoned == []
+    # …and the same verdict is what await will read.
+    assert await summonguard.wakes("r", "m1", "alice") is False
+
+
+@pytest.mark.asyncio
+async def test_a_guarded_room_still_fires_a_real_summon(engine, monkeypatch):
+    monkeypatch.setattr(summonguard, "_pi_complete", _classifier('{"alice": "wake"}'))
+    _install(engine)
+    summoned: list[str] = []
+    await _ingest(_persister("r", summoned), "m1", "hey @alice can you cost this out?")
+    assert summoned == ["alice"]
+
+
+@pytest.mark.asyncio
+async def test_a_scoped_summon_keeps_the_full_mention_list(engine, monkeypatch):
+    """``@aligner @a @b`` scopes the negotiation to @a/@b — so the co-mention list
+    stays whole even when a co-mention was judged provenance."""
+    monkeypatch.setattr(summonguard, "_pi_complete", _classifier('{"bob": "mention"}'))
+    _install(engine)
+    co: list[list[str]] = []
+    from app.services import persister as persister_mod
+
+    p = persister_mod.RoomPersister(
+        "r",
+        channel=None,  # ty: ignore[invalid-argument-type]
+        members_provider=lambda: set(),
+        on_summon=lambda handle, env, seen, msg="": co.append(list(seen)),
+        feed_bus=False,
+    )
+    await _ingest(p, "m1", "@mediator settle this, @bob raised it")
+    assert co == [["mediator", "bob"]]

--- a/fastapi-backend/tests/test_summonguard.py
+++ b/fastapi-backend/tests/test_summonguard.py
@@ -19,19 +19,20 @@ import asyncio
 
 import pytest
 
-from app.services import summonguard
-from app.services.engine_events import SUMMON_FILTER, lifecycle
-from app.services.summonguard import MENTION, WAKE, SummonContext, SummonGuardEngine
+from app.services import summon_filter, summonguard
+from app.services.engine_events import lifecycle
+from app.services.summon_filter import MENTION, WAKE, SummonContext
+from app.services.summonguard import SummonGuardEngine
 
 
 @pytest.fixture(autouse=True)
 def _reset_guard_state():
     """The lifecycle bus and verdict store are process-wide; isolate each test."""
     lifecycle.clear()
-    summonguard.verdicts.clear()
+    summon_filter.verdicts.clear()
     yield
     lifecycle.clear()
-    summonguard.verdicts.clear()
+    summon_filter.verdicts.clear()
 
 
 @pytest.fixture
@@ -55,12 +56,12 @@ def _classifier(answer: str):
 
 
 def _install(engine: SummonGuardEngine, room: str = "r", owner: str = "watcher") -> None:
-    lifecycle.install(room, SUMMON_FILTER, owner, engine.classify)
+    summon_filter.install(room, owner, engine.classify)
 
 
-def _verdict(room: str = "r", message_id: str = "m1") -> summonguard.SummonVerdict:
+def _verdict(room: str = "r", message_id: str = "m1") -> summon_filter.SummonVerdict:
     """The published verdict for a message; fails the test if none landed."""
-    verdict = summonguard.verdicts.get(room, message_id)
+    verdict = summon_filter.verdicts.get(room, message_id)
     assert verdict is not None, f"no verdict published for {room}/{message_id}"
     return verdict
 
@@ -174,7 +175,7 @@ async def test_the_kill_switch_disarms_a_registered_guard(engine, monkeypatch):
 
 
 def test_a_verdict_that_never_saw_a_handle_wakes_it():
-    verdict = summonguard.SummonVerdict(
+    verdict = summon_filter.SummonVerdict(
         room="r", message_id="m1", sender="avery", text="", decisions={"alice": MENTION}
     )
     assert verdict.wakes("alice") is False
@@ -203,93 +204,6 @@ def test_the_prompt_carries_the_message_and_every_candidate():
     assert "- @alice" in prompt and "- @bob" in prompt
 
 
-# ── the room-level filter ────────────────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_an_unguarded_room_wakes_everything_without_classifying(monkeypatch):
-    def _explode(_prompt, _timeout):
-        raise AssertionError("an unguarded room must not classify")
-
-    monkeypatch.setattr(summonguard, "_pi_complete", _explode)
-    assert summonguard.guarded("r") is False
-    assert await summonguard.decide(_ctx("credit to @alice", "alice")) == {"alice": WAKE}
-
-
-@pytest.mark.asyncio
-async def test_a_filter_that_raises_fails_the_room_open(engine):
-    async def _broken(_ctx):
-        raise RuntimeError("guard is broken")
-
-    lifecycle.install("r", SUMMON_FILTER, "watcher", _broken)
-    assert await summonguard.decide(_ctx("credit to @alice", "alice")) == {"alice": WAKE}
-
-
-@pytest.mark.asyncio
-async def test_two_guards_suppress_only_when_both_agree():
-    async def _suppress(_ctx):
-        return {"alice": MENTION}
-
-    async def _wake(_ctx):
-        return {"alice": WAKE}
-
-    lifecycle.install("r", SUMMON_FILTER, "one", _suppress)
-    lifecycle.install("r", SUMMON_FILTER, "two", _suppress)
-    assert await summonguard.decide(_ctx("thanks @alice", "alice")) == {"alice": MENTION}
-
-    lifecycle.install("r", SUMMON_FILTER, "two", _wake)
-    assert await summonguard.decide(_ctx("thanks @alice", "alice", message_id="m2")) == {
-        "alice": WAKE
-    }
-
-
-# ── the await-side gate ──────────────────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_wakes_is_true_in_an_unguarded_room_without_waiting():
-    assert await summonguard.wakes("r", "m1", "alice") is True
-
-
-@pytest.mark.asyncio
-async def test_wakes_reads_the_verdict_the_ingest_side_published(engine, monkeypatch):
-    monkeypatch.setattr(summonguard, "_pi_complete", _classifier('{"alice": "mention"}'))
-    _install(engine)
-    await summonguard.decide(_ctx("shipped, thanks @alice", "alice"))
-    assert await summonguard.wakes("r", "m1", "alice") is False
-    # A handle that message never mentioned is unaffected.
-    assert await summonguard.wakes("r", "m1", "bob") is True
-
-
-@pytest.mark.asyncio
-async def test_wakes_waits_for_an_in_flight_classification(engine, monkeypatch):
-    """The long-poll absorbs the guard's latency rather than serving a turn it
-    was about to suppress."""
-    started = asyncio.Event()
-
-    def _slow(_prompt, _timeout):
-        started.set()
-        import time
-
-        time.sleep(0.2)
-        return '{"alice": "mention"}'
-
-    monkeypatch.setattr(summonguard, "_pi_complete", _slow)
-    _install(engine)
-    task = asyncio.create_task(summonguard.decide(_ctx("shipped, thanks @alice", "alice")))
-    await started.wait()
-    assert await summonguard.wakes("r", "m1", "alice") is False
-    await task
-
-
-@pytest.mark.asyncio
-async def test_a_classification_that_overruns_the_wait_wakes(engine, monkeypatch):
-    monkeypatch.setattr(summonguard.settings, "SUMMONGUARD_WAKE_TIMEOUT_S", 0.05)
-    _install(engine)
-    summonguard.verdicts.begin("r", "m1")
-    assert await summonguard.wakes("r", "m1", "alice") is True
-
-
 # ── registration installs the filter ─────────────────────────────────────────
 
 
@@ -297,17 +211,17 @@ async def test_a_classification_that_overruns_the_wait_wakes(engine, monkeypatch
 async def test_registering_a_guard_installs_the_rooms_summon_filter(client, engine):
     engine.wire()
     await client.post("/api/rooms", json={"name": "portfolio"})
-    assert summonguard.guarded("portfolio") is False
+    assert summon_filter.guarded("portfolio") is False
 
     resp = await client.post(
         "/api/rooms/portfolio/engines",
         json={"handle": "watcher", "kind": "summonguard", "description": "guard our summons"},
     )
     assert resp.status_code == 201
-    assert summonguard.guarded("portfolio") is True
-    assert lifecycle.owners("portfolio", SUMMON_FILTER) == ["watcher"]
+    assert summon_filter.guarded("portfolio") is True
+    assert summon_filter.owners("portfolio") == ["watcher"]
     # …and only that room's.
-    assert summonguard.guarded("other") is False
+    assert summon_filter.guarded("other") is False
 
 
 @pytest.mark.asyncio
@@ -315,7 +229,7 @@ async def test_registering_a_different_engine_kind_installs_nothing(client, engi
     engine.wire()
     await client.post("/api/rooms", json={"name": "portfolio"})
     await client.post("/api/rooms/portfolio/engines", json={"handle": "med", "kind": "aligner"})
-    assert summonguard.guarded("portfolio") is False
+    assert summon_filter.guarded("portfolio") is False
 
 
 @pytest.mark.asyncio
@@ -325,11 +239,11 @@ async def test_a_removed_guard_drops_its_filter_on_the_next_sync(client, engine)
     await client.post(
         "/api/rooms/portfolio/engines", json={"handle": "watcher", "kind": "summonguard"}
     )
-    assert summonguard.guarded("portfolio") is True
+    assert summon_filter.guarded("portfolio") is True
 
     await client.delete("/api/rooms/portfolio/memory/agents/watcher")
     engine.sync_room("portfolio")
-    assert summonguard.guarded("portfolio") is False
+    assert summon_filter.guarded("portfolio") is False
 
 
 @pytest.mark.asyncio
@@ -344,7 +258,7 @@ async def test_status_route_reports_the_guard_and_its_verdicts(client, engine, m
         "_pi_complete",
         _classifier('{"alice": {"decision": "mention", "reason": "credited only"}}'),
     )
-    await summonguard.decide(_ctx("shipped, credit to @alice", "alice", room="portfolio"))
+    await summon_filter.decide(_ctx("shipped, credit to @alice", "alice", room="portfolio"))
 
     body = (await client.get("/api/rooms/portfolio/summonguard")).json()
     assert body["installed"] is True
@@ -428,7 +342,7 @@ async def test_a_guarded_room_withholds_the_summon_for_a_provenance_mention(engi
     await _ingest(_persister("r", summoned), "m1", "shipped it, credit to @alice")
     assert summoned == []
     # …and the same verdict is what await will read.
-    assert await summonguard.wakes("r", "m1", "alice") is False
+    assert await summon_filter.wakes("r", "m1", "alice") is False
 
 
 @pytest.mark.asyncio

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -300,10 +300,11 @@ class MemoryLogEntry(BaseModel):
 AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "engine"})
 
 #: Cognition-engine kinds hosted by the first-party ``engine`` runtime family.
-#: The extensibility axis: ``aligner`` (SIEP converge) and ``synthesizer`` (room
-#: memory → structured summary) today; ``bargainer`` (SAB), ``team_former`` (TFP),
-#: a drift evaluator, etc. later; no new adapter per CE.
-ENGINE_KINDS: frozenset[str] = frozenset({"aligner", "synthesizer"})
+#: The extensibility axis: ``aligner`` (SIEP converge), ``synthesizer`` (room
+#: memory → structured summary) and ``summonguard`` (is this ``@`` a summon or
+#: provenance?) today; ``bargainer`` (SAB), ``team_former`` (TFP), a drift
+#: evaluator, etc. later; no new adapter per CE.
+ENGINE_KINDS: frozenset[str] = frozenset({"aligner", "synthesizer", "summonguard"})
 
 
 class AgentManifest(BaseModel):

--- a/openapi.json
+++ b/openapi.json
@@ -2708,6 +2708,61 @@
         }
       }
     },
+    "/api/rooms/{room_name}/summonguard": {
+      "get": {
+        "tags": [
+          "engines"
+        ],
+        "summary": "Summonguard Status",
+        "description": "The room's guard status plus its most recent verdicts, newest first.",
+        "operationId": "summonguard_status_api_rooms__room_name__summonguard_get",
+        "parameters": [
+          {
+            "name": "room_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Room Name"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SummonGuardStatus"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "tags": [
@@ -5112,6 +5167,98 @@
           "created_at"
         ],
         "title": "SubscriptionRead"
+      },
+      "SummonGuardStatus": {
+        "properties": {
+          "room": {
+            "type": "string",
+            "title": "Room"
+          },
+          "installed": {
+            "type": "boolean",
+            "title": "Installed",
+            "description": "True when a summon filter is installed."
+          },
+          "guards": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Guards",
+            "description": "Engines that installed it."
+          },
+          "disabled": {
+            "type": "boolean",
+            "title": "Disabled",
+            "description": "Kill switch: guards classify everything as a wake."
+          },
+          "verdicts": {
+            "items": {
+              "$ref": "#/components/schemas/SummonVerdictRead"
+            },
+            "type": "array",
+            "title": "Verdicts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "room",
+          "installed",
+          "disabled"
+        ],
+        "title": "SummonGuardStatus",
+        "description": "Whether a room's summons are guarded, and what the guard has been deciding."
+      },
+      "SummonVerdictRead": {
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "title": "Message Id"
+          },
+          "sender": {
+            "type": "string",
+            "title": "Sender"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "decisions": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Decisions",
+            "description": "handle -> 'wake' | 'mention'"
+          },
+          "reasons": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Reasons"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "description": "How it was decided: pi | leading-mention | fail-open | \u2026"
+          },
+          "decided_at": {
+            "type": "string",
+            "title": "Decided At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "message_id",
+          "sender",
+          "text",
+          "decisions",
+          "source",
+          "decided_at"
+        ],
+        "title": "SummonVerdictRead",
+        "description": "One message's summon decisions."
       },
       "TaskCreate": {
         "properties": {


### PR DESCRIPTION
A room treats every @handle as a wake: the persister fires the summon seam
and the handle's next await returns that message as its turn. That is right
for "@alice can you cost this out?" and wrong for "we shipped it, credit to
@alice" — the second is provenance, and waking a resident agent for it burns
a turn (and, for an engine, can restart a negotiation that already converged).

The summonguard is the engine kind that tells the two apart. It is also the
first engine whose work happens on *registration* rather than on summon, so it
needs a seam the summon-only model didn't have.

Room lifecycle (engine_events.py). Two concepts, no scheduler, no persistence:
lifecycle events (engine.registered, engine.removed, room.provisioned) that
listeners subscribe to process-wide, and a per-room hook registry an engine
installs a named function into, keyed by the installing engine's handle. A room
with no engine installed exposes no hooks, so the un-guarded path is unchanged.
Hooks are derived state, rebuilt from the room's manifests on the next
provision — the same contract as the link index.

The guard (summonguard.py) holds three properties:

- Fail open, always. Pi missing, timed out, empty, unparseable, a handle the
  classifier skipped, the kill switch — every path resolves to wake. A guard
  outage costs a spurious wake, never a silenced summon.
- A regex may confirm a wake, never suppress one. A mention opening the message
  short-circuits to wake, so the hot path costs no cognition; suppression is
  only ever a model's judgement.
- One classification per message. The persister classifies at ingest for every
  mentioned handle at once; await's long-poll reads that verdict rather than
  classifying again, so the two paths cannot disagree and the poll absorbs the
  latency.

A protocol-addressed tick (an L9 recipient) is never the guard's to judge —
only a bare @handle in prose is. Registration is reconciled from the room's
manifests rather than trusted from the event payload, so it is idempotent and
survives a backend restart. GET /rooms/{room}/summonguard reports whether a
room is guarded and what it decided, since a suppressed wake is otherwise
invisible.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W5XAj3diSKqLNQkRwMGuJW