### PR TITLE
Add shotkit, a fast screenshot utility for coding agents

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: screenshot
+description: Take a screenshot of the running Mycelium app, or of CLI output rendered as a terminal card. Use when you need to SEE the UI — verifying a frontend change, checking a layout at phone/tablet/desktop widths, driving a multi-step flow and looking at each step, or producing an image of a `mycelium` command's output for a doc or PR. Triggers on "screenshot", "show me the app", "what does it look like", "check the layout", "responsive", "capture the terminal".
+---
+
+# Screenshot the app or the CLI
+
+`shotkit/` is this repo's camera. It holds a browser open in a background
+daemon, so the first shot costs ~2s and every later one ~150ms.
+
+Run it from the repo root:
+
+```bash
+node shotkit/bin/shot.mjs <command> [flags]
+```
+
+The absolute PNG path is the only thing on stdout — read that file back to see
+the result. Timings and warnings go to stderr.
+
+## First run on a machine
+
+```bash
+node shotkit/bin/shot.mjs doctor
+```
+
+It reports the browser, `script(1)`, whether the frontend's deps are installed,
+and whether an app is already listening. Fix anything it marks `✗` before
+capturing. Terminal and code cards need no app at all.
+
+## Screenshot the app
+
+```bash
+# boot the mock frontend (no backend, SLIM or LLM needed) and shoot a route
+node shotkit/bin/shot.mjs app /room/atlas-migration --mock
+
+# against an app you already have running
+node shotkit/bin/shot.mjs app / --base-url http://localhost:3000
+```
+
+`--mock` boots `pnpm dev:mock` **inside the daemon**, so it stays warm across
+shots — pass it on the first capture and omit it afterwards. An already-running
+dev server is found automatically, whatever port it is on.
+
+**Add `--offline` when a capture takes more than a few seconds.** The frontend
+links Google Fonts; where those are unreachable, each navigation waits ~13s on
+them. `--offline` resolves nothing but localhost and the app renders with
+fallback fonts.
+
+## Check a layout across breakpoints
+
+```bash
+node shotkit/bin/shot.mjs app / --responsive --sheet --offline
+```
+
+Four frames — phone, tablet, laptop, wide — plus one contact sheet composing
+them at their true relative widths. Read the sheet: it answers "is this
+responsive" in a single look. `--viewports phone,wide` picks a subset;
+`--viewport 1280x800@2` takes an exact size.
+
+## Drive a flow, then look
+
+For a state behind a click, either pass ordered steps to one capture:
+
+```bash
+node shotkit/bin/shot.mjs app /room/atlas-migration --offline \
+  --do click:Negotiate --do wait:.offer-grid
+```
+
+…or hold the page open and work against it, which is what you want when you
+need to see each step before deciding the next:
+
+```bash
+node shotkit/bin/shot.mjs open /room/atlas-migration --session r --offline
+node shotkit/bin/shot.mjs do click:Negotiate --session r
+node shotkit/bin/shot.mjs shoot --session r --name negotiate   # ~250ms
+node shotkit/bin/shot.mjs close --session r
+```
+
+A bare word (`click:Negotiate`) matches an accessible name, then visible text.
+For anything else use a Playwright selector: `#id`, `.class`,
+`role=button[name="Save"]`, `text=Save`. `shot help shoot` lists every verb.
+
+## Screenshot CLI output
+
+Runs the command under a pty, so Rich keeps its colors and box drawing:
+
+```bash
+node shotkit/bin/shot.mjs term --cols 84 -- mycelium memory --help
+
+# run one command, label it as another (the CLI often needs `uv run` locally)
+node shotkit/bin/shot.mjs term --cwd mycelium-cli --command "mycelium doctor" \
+  -- uv run mycelium doctor
+```
+
+Flags must come **before** the command; everything after the first plain word
+belongs to the child. `shot text <file>` renders an ANSI log you already have,
+and `shot code <file> --range 40:80` makes a syntax-highlighted code card.
+
+## Framing for a PR or doc
+
+```bash
+node shotkit/bin/shot.mjs app /room/atlas --chrome --offline          # browser window frame
+node shotkit/bin/shot.mjs app / --chrome --theme light --backdrop dusk
+```
+
+`--theme` switches the app itself, not just the browser's media query.
+
+## Rules
+
+- **Never commit anything from `.shotkit/`.** It is gitignored scratch. The
+  committed docs screenshots have their own pipeline — `pnpm screenshots` in
+  `mycelium-frontend/`, publishing per `screenshots/targets.ts`. Run that, and
+  commit its output, only when asked to update the docs assets.
+- **Don't hand-roll Playwright for a screenshot.** If shotkit is missing a
+  capability, add it there; `capture()` in `shotkit/src/api.mjs` is importable.
+- **Leave the daemon running.** It idles out after 15 minutes. `shot stop` only
+  if you need a clean slate.

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ logs/
 /mycelium-client/mycelium_backend_client/
 fastapi-backend/mycelium-client/
 
+# shotkit captures — scratch images for agents and humans, never committed.
+# Published screenshots live in docs/ and are written by `pnpm screenshots`.
+.shotkit/
+
 # Frontend
 node_modules/
 .next/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,16 @@ mycelium-client/    Generated OpenAPI client (openapi-python-client)
 mycelium-frontend/  Next.js frontend (TypeScript, Tailwind)
 docs/               Docs site (generated from mycelium-cli/src/mycelium/docs/),
                     demo script, design notes
+shotkit/            The repo's camera: fast screenshots of the running app and of
+                    CLI output, for coding agents. A daemon holds a browser open,
+                    so a shot is ~150ms rather than ~2s. `node shotkit/bin/shot.mjs`
+                    — `app` (a route, with --mock booting dev:mock), `term` (a
+                    command under a pty, so Rich keeps its colors, rendered as a
+                    Carbon-style card), `code`, plus --responsive/--sheet for
+                    breakpoints and open/do/shoot for driving a held page. See the
+                    `screenshot` skill. Captures land in gitignored `.shotkit/`;
+                    the committed docs assets are still `pnpm screenshots`, which
+                    now runs on this engine.
 mycelium-promo/     HyperFrames promo video, a code-defined HTML→MP4 walkthrough
                     (CLI install → app install → room → adapter → post positions →
                     summon the aligner → await/respond → consensus → plan → work →
@@ -67,6 +77,10 @@ cd mycelium-cli && uv run ruff check . && uv run ruff format --check . \
 
 # Frontend
 cd mycelium-frontend && pnpm install && pnpm dev
+
+# Screenshots (see shotkit/README.md; `shot doctor` checks the machine)
+node shotkit/bin/shot.mjs app /room/atlas-migration --mock --offline
+node shotkit/bin/shot.mjs term --cols 84 -- mycelium memory --help
 ```
 
 ## Architecture

--- a/mycelium-frontend/screenshots/README.md
+++ b/mycelium-frontend/screenshots/README.md
@@ -13,6 +13,7 @@ truth is the UI itself, captured in **mock mode** (`pnpm dev:mock`,
 pnpm screenshots            # boot dev:mock, capture every shot, write PNGs
 pnpm screenshots room-plan  # a subset, by shot id
 pnpm screenshots --keep     # attach to a dev:mock already running on $PORT
+pnpm screenshots --offline  # don't wait on webfont CDNs (much faster if they're unreachable)
 ```
 
 Outputs are **committed** so normal docs/splash builds never need a browser, and
@@ -25,9 +26,14 @@ the splash repo builds standalone. Re-run and commit when the UI changes.
 - **`targets.ts`** — where each shot's PNG(s) land (docs/ and/or splash), and the
   `@2x` retina variants. The splash path defaults to a sibling checkout; override
   with `MYCELIUM_SPLASH_DIR`.
-- **`capture.ts`** — boots the mock server on a free port, drives Playwright over
-  the manifest, waits for a *populated* frame (shell mounted, skeletons cleared,
-  SSE "Live", fonts loaded), optimizes with `sharp`, and fans out to targets.
+- **`capture.ts`** — maps each manifest entry to a `shotkit` spec, then optimizes
+  with `sharp` and fans out to targets. The browser work — booting the mock
+  server, finding a usable Chromium, waiting for a *populated* frame (shell
+  mounted, skeletons cleared, SSE "Live", fonts loaded), driving the page —
+  belongs to `shotkit/`, the repo's screenshot utility, because it is the same
+  problem whether the caller is this pipeline or an agent at a terminal. What
+  stays here is publication's business: which shots exist, how they're
+  optimized, and where they land.
 
 ## Adding a shot
 
@@ -35,14 +41,14 @@ the splash repo builds standalone. Re-run and commit when the UI changes.
 2. Map it to output paths in `TARGETS` in `targets.ts`.
 3. If `pnpm dev:mock` can't render that state, add/extend a fixture in
    `src/mocks/fixtures.ts` first — the pipeline can only shoot what the mock can
-   render. Interactive states (an open `@`/`[[`/`/` composer popover) are scripted
-   with a keystroke in `capture.ts`, not a fixture.
+   render. Interactive states (an open `@`/`[[`/`/` composer popover) are reached
+   with `steps`, which become shotkit actions, not with a fixture.
 4. `pnpm screenshots <id>` and eyeball the result.
 
 ## Notes
 
-- Requires the Playwright Chromium build once: `npx playwright install chromium`.
-- The capture addresses the dev server as `localhost` (not `127.0.0.1`): Next's
-  dev-server cross-origin guard only allow-lists `localhost`, so a browser 403s on
-  every `/_next/*` chunk over the IP and the app never hydrates.
+- Needs a Chromium; `node ../shotkit/bin/shot.mjs doctor` says whether one is
+  usable and how to get one.
 - Waits gate on content, never timeouts — deterministic fixtures mean no flake.
+- To iterate on a single shot interactively, `shot app <route> --mock` is the
+  faster loop: it holds the browser and the dev server open between captures.

--- a/mycelium-frontend/screenshots/capture.ts
+++ b/mycelium-frontend/screenshots/capture.ts
@@ -26,9 +26,10 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import sharp from "sharp";
-// @ts-expect-error — shotkit is plain ESM JavaScript with JSDoc types.
+// shotkit is plain ESM JavaScript; `allowJs` means its JSDoc types are checked
+// here, so a signature change over there fails this typecheck rather than this
+// pipeline at runtime.
 import { capture, shutdown } from "../../shotkit/src/api.mjs";
-// @ts-expect-error — see above.
 import { ensureMockServer, stopMockServer } from "../../shotkit/src/app.mjs";
 import { SHOTS, VIEWPORTS, type Shot } from "./shots.ts";
 import { TARGETS } from "./targets.ts";

--- a/mycelium-frontend/screenshots/capture.ts
+++ b/mycelium-frontend/screenshots/capture.ts
@@ -2,10 +2,10 @@
 // Copyright 2026 Mycelium Contributors
 
 /**
- * The app's camera. Boots the frontend in mock mode (`pnpm dev:mock`, so every
- * state renders with no backend/SLIM/LLM), drives each entry in the shot
- * manifest with Playwright, optimizes the PNGs, and writes committed assets into
- * docs/ and the splash repo per `targets.ts`.
+ * The app's camera. Drives each entry in the shot manifest against the frontend
+ * running in mock mode (`pnpm dev:mock`, so every state renders with no
+ * backend/SLIM/LLM), optimizes the PNGs, and writes committed assets into docs/
+ * and the splash repo per `targets.ts`.
  *
  * Conceptually a sibling of docs/generate_docs.py: both regenerate published
  * artifacts from a source of truth. This one's source of truth is the real UI.
@@ -13,64 +13,28 @@
  *   pnpm screenshots            # boot mock, capture all shots, publish
  *   pnpm screenshots --keep     # attach to an already-running dev:mock on $PORT
  *   pnpm screenshots room-plan  # capture a subset by shot id
+ *   pnpm screenshots --offline  # don't wait on webfont CDNs
+ *
+ * The browser work belongs to `shotkit/`, the repo's screenshot utility: booting
+ * the mock server, finding a usable Chromium, waiting for a populated frame and
+ * driving the page are the same problems whether the caller is this pipeline or
+ * an agent at a terminal, and they were solved twice before. What stays here is
+ * what is genuinely publication's business — which shots exist, how they are
+ * optimized, and where the files land.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
-import { createServer } from "node:net";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { chromium, type Browser } from "playwright";
 import sharp from "sharp";
+// @ts-expect-error — shotkit is plain ESM JavaScript with JSDoc types.
+import { capture, shutdown } from "../../shotkit/src/api.mjs";
+// @ts-expect-error — see above.
+import { ensureMockServer, stopMockServer } from "../../shotkit/src/app.mjs";
 import { SHOTS, VIEWPORTS, type Shot } from "./shots.ts";
 import { TARGETS } from "./targets.ts";
 
-const READY_SELECTOR = '[data-app-shell="ready"]';
-
 function log(msg: string): void {
   process.stdout.write(`[screenshots] ${msg}\n`);
-}
-
-async function freePort(): Promise<number> {
-  return new Promise((resolvePort, reject) => {
-    const srv = createServer();
-    srv.on("error", reject);
-    srv.listen(0, () => {
-      const addr = srv.address();
-      const port = typeof addr === "object" && addr ? addr.port : 0;
-      srv.close(() => resolvePort(port));
-    });
-  });
-}
-
-async function waitForServer(url: string, timeoutMs = 60_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url, { redirect: "manual" });
-      if (res.status > 0) return;
-    } catch {
-      // not up yet
-    }
-    await new Promise((r) => setTimeout(r, 500));
-  }
-  throw new Error(`dev:mock did not become ready at ${url} within ${timeoutMs}ms`);
-}
-
-async function bootMockServer(port: number): Promise<ChildProcess> {
-  log(`booting dev:mock on :${port}`);
-  const child = spawn("pnpm", ["dev:mock", "--port", String(port)], {
-    env: { ...process.env, MYCELIUM_UI_MOCK: "1", PORT: String(port) },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  child.stdout?.on("data", (d) => process.env.DEBUG_SCREENSHOTS && process.stdout.write(d));
-  child.stderr?.on("data", (d) => process.env.DEBUG_SCREENSHOTS && process.stderr.write(d));
-  // Address the dev server as `localhost`, not `127.0.0.1`: Next 16's dev-server
-  // cross-origin protection on `/_next/*` only allow-lists `localhost` by
-  // default, so a browser (which sends Sec-Fetch/Origin headers) 403s on every
-  // JS chunk over 127.0.0.1 and the app never hydrates.
-  await waitForServer(`http://localhost:${port}/`);
-  log("dev:mock ready");
-  return child;
 }
 
 /** Raw PNG buffer -> optimized 1x + optional @2x, written to every target. */
@@ -100,102 +64,60 @@ async function publish(shot: Shot, raw: Buffer): Promise<string[]> {
   return written;
 }
 
-/**
- * Wait for the app to reach a stable, populated frame: the shell mounts before
- * its fetches/SSE resolve, so shooting on `ready` alone catches loading
- * skeletons and a "Reconnecting…" badge. Every loading placeholder is the one
- * `.animate-pulse` Skeleton, so their absence is a reliable "content in" signal.
- */
-async function settle(page: import("playwright").Page): Promise<void> {
-  // Rooms list resolved (sidebar populated, not the "No rooms yet" empty state).
-  await page.waitForSelector('a[href^="/room/"]', { state: "visible", timeout: 15_000 });
-  // All Skeletons detached — channel + members + rails have their data.
-  await page.waitForFunction(() => document.querySelectorAll(".animate-pulse").length === 0, null, {
-    timeout: 15_000,
-  });
-  // SSE connected ("Live", not "Reconnecting…"). Best-effort: some routes never
-  // open a stream, so don't fail the shot if it stays disconnected.
-  await page
-    .waitForFunction(() => document.body.innerText.includes("Live"), null, { timeout: 8_000 })
-    .catch(() => {});
-  // Fonts loaded (Cormorant Garamond / IBM Plex Sans) so no reflow mid-shot.
-  await page.evaluate(() => document.fonts.ready);
-}
-
-async function captureShot(browser: Browser, baseUrl: string, shot: Shot): Promise<void> {
+/** One manifest entry -> one shotkit spec. */
+function specFor(shot: Shot, baseUrl: string, offline: boolean) {
   const vp = VIEWPORTS[shot.viewport];
-  const context = await browser.newContext({
-    viewport: { width: vp.width, height: vp.height },
-    deviceScaleFactor: vp.scale,
-    colorScheme: shot.theme,
-  });
-  // next-themes reads the theme from localStorage before first paint; seed it so
-  // there's no flash of the default theme in the capture.
-  await context.addInitScript((theme) => {
-    window.localStorage.setItem("theme", theme);
-  }, shot.theme);
-
-  const page = await context.newPage();
-  try {
-    // The room opens an SSE stream, so the network never goes idle — gate on the
-    // shell hook mounting instead.
-    await page.goto(`${baseUrl}${shot.route}`, { waitUntil: "domcontentloaded" });
-    await page.waitForSelector(shot.waitFor ?? READY_SELECTOR, { state: "visible" });
-    await settle(page);
+  return {
+    op: "app",
+    baseUrl,
+    route: shot.route,
+    theme: shot.theme,
+    width: vp.width,
+    height: vp.height,
+    scale: vp.scale,
+    // Deterministic fixtures mean the wait can gate on content rather than a
+    // timeout; `full` also holds for the SSE badge to read "Live".
+    settle: "full",
+    waitFor: shot.waitFor,
+    element: shot.clip,
     // Reach a view/rail behind a tab (Negotiate, Network, Memory) before shooting.
-    for (const name of shot.steps ?? []) {
-      await page.getByRole("button", { name, exact: true }).first().click();
-      await page.waitForTimeout(600);
-    }
-    // Hide the Next.js dev-tools indicator (the "N" / "Issues" badge) — it's dev
-    // chrome, not product UI, and dev mode is the only way to run the mock.
-    await page.addStyleTag({ content: "nextjs-portal { display: none !important; }" });
-
-    const clip = shot.clip ? await page.locator(shot.clip).first() : null;
-    const raw = clip
-      ? await clip.screenshot({ type: "png" })
-      : await page.screenshot({ type: "png" });
-
-    const written = await publish(shot, raw);
-    if (written.length === 0) {
-      log(`captured ${shot.id} (no target configured — not published)`);
-    } else {
-      log(`captured ${shot.id} -> ${written.length} file(s)`);
-    }
-  } finally {
-    await context.close();
-  }
+    do: (shot.steps ?? []).flatMap((name) => [`click:${name}`, "sleep:600"]),
+    // next-themes reads the theme from localStorage before first paint; seed it
+    // so there's no flash of the default theme in the capture.
+    storage: { theme: shot.theme },
+    offline,
+    stdout: true,
+  };
 }
 
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
   const keep = argv.includes("--keep");
+  const offline = argv.includes("--offline");
   const ids = argv.filter((a) => !a.startsWith("--"));
   const shots = ids.length ? SHOTS.filter((s) => ids.includes(s.id)) : SHOTS;
   if (shots.length === 0) {
     throw new Error(`no shots matched ${JSON.stringify(ids)}`);
   }
 
-  let server: ChildProcess | null = null;
-  const port = keep ? Number(process.env.PORT ?? 3000) : await freePort();
-  if (keep) {
-    log(`attaching to existing dev:mock on :${port}`);
-    await waitForServer(`http://localhost:${port}/`);
-  } else {
-    server = await bootMockServer(port);
-  }
-  const baseUrl = `http://localhost:${port}`;
+  const baseUrl = keep
+    ? `http://localhost:${process.env.PORT ?? 3000}`
+    : await ensureMockServer({ log });
+  log(`capturing against ${baseUrl}`);
 
-  const browser = await chromium.launch();
   try {
     for (const shot of shots) {
-      await captureShot(browser, baseUrl, shot);
+      const result = await capture(specFor(shot, baseUrl, offline), { log });
+      const written = await publish(shot, Buffer.from(result.base64, "base64"));
+      if (written.length === 0) {
+        log(`captured ${shot.id} in ${result.ms.total}ms (no target configured — not published)`);
+      } else {
+        log(`captured ${shot.id} in ${result.ms.total}ms -> ${written.length} file(s)`);
+      }
     }
   } finally {
-    await browser.close();
-    if (server) {
-      server.kill("SIGTERM");
-    }
+    await shutdown();
+    if (!keep) stopMockServer();
   }
   log(`done — ${shots.length} shot(s)`);
 }

--- a/shotkit/README.md
+++ b/shotkit/README.md
@@ -1,0 +1,149 @@
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!-- Copyright 2026 Mycelium Contributors -->
+
+# shotkit — the repo's camera
+
+Screenshots of the running app, and of CLI output, fast enough to take one
+mid-thought. Built for coding agents first: one line in, an absolute PNG path
+out, ready to read back.
+
+```bash
+shot term mycelium memory ls --room atlas     # a terminal card, real ANSI colors
+shot app /room/atlas-migration --mock         # the running frontend
+shot app / --responsive --sheet               # every breakpoint in one image
+shot code src/services/aligner.py --range 40:80
+```
+
+Nothing here is on the install path or in the runtime. A user never executes it.
+
+## Why it is fast
+
+A screenshot script that launches a browser per invocation spends about two
+seconds doing the same three things every time. shotkit pays them once:
+
+| | |
+|---|---|
+| **A daemon holds the browser.** | First shot ~2s, every later shot ~150ms. It starts itself, and shuts down after 15 idle minutes. |
+| **Cards never touch the network.** | `term`, `code` and `html` render a self-contained document into a page that stays open. No navigation, no fetches. |
+| **`--mock` boots the app once.** | The Next dev server is held by the daemon, not by the request, so six shots of six routes boot it once. |
+| **`--offline` skips dead CDNs.** | The frontend links Google Fonts. Where those are unreachable, waiting on them costs ~13s *per navigation* — more than everything else combined. |
+
+```
+$ shot bench
+cold (no daemon, includes browser launch): 2142ms
+warm x6: min 134ms · median 163ms · max 486ms
+speedup: 13.1x
+```
+
+## The commands
+
+| | |
+|---|---|
+| `shot app [route]` | the running frontend; `--mock` boots `pnpm dev:mock` |
+| `shot url <url>` | any URL |
+| `shot term <command…>` | run a command, shoot its terminal output |
+| `shot text <file\|->` | render an existing ANSI capture |
+| `shot code <file>` | a syntax-highlighted code card |
+| `shot html <file\|->` | render an HTML document |
+| `shot open` / `do` / `shoot` / `close` | drive a page held open — see **Navigation** |
+| `shot warm` / `status` / `stop` / `serve` | the daemon |
+| `shot doctor` / `bench` | check and time this machine |
+
+`shot help <command>` lists every flag. stdout carries the path and nothing
+else, so it composes: `open "$(shot app / --mock)"`.
+
+## Terminal cards
+
+`shot term` runs the command under a pty, so Rich emits exactly what it emits
+for a person — color, box drawing, the lot — and the output is replayed through
+a small screen buffer before rendering. That replay matters: a spinner redraws
+with `\r` and a Live region repaints by moving the cursor up, and concatenating
+the raw stream would stack every intermediate frame into one image. What you get
+is the terminal as you would have found it.
+
+```bash
+shot term --cols 84 --title mycelium -- mycelium memory --help
+shot term --command "mycelium doctor" -- uv run mycelium doctor   # run one thing, show another
+shot text ci-failure.log --window plain                           # a capture you already have
+```
+
+Colors come from the frontend's own palette, so a terminal card and an app
+screenshot sit next to each other without clashing.
+
+## Responsive
+
+```bash
+shot app / --responsive --sheet          # phone, tablet, laptop, wide + one contact sheet
+shot app / --viewports phone,wide
+shot app / --viewport 1280x800@2
+```
+
+The contact sheet composes the frames at their true relative widths — a phone
+beside a 1920 monitor reads as a phone — so checking a layout is one image to
+look at rather than four.
+
+## Navigation
+
+A one-shot capture takes ordered steps:
+
+```bash
+shot app /room/atlas --do click:Negotiate --do wait:.offer-grid --do scroll:bottom
+```
+
+For anything longer, hold the page open. The daemon keeps it under a name, so
+you can look, decide, and act, without replaying the flow from a cold load each
+time — and each shot is ~250ms.
+
+```bash
+shot open /room/atlas --session r --viewport laptop
+shot do click:Negotiate --session r
+shot shoot --session r --name negotiate
+shot shoot click:Plan sleep:300 --session r --name plan   # act and shoot in one call
+shot sessions ; shot close --session r
+```
+
+Element arguments accept any Playwright selector engine (`text=`,
+`role=button[name="Save"]`, `#id`, `//xpath`). A bare word is matched by
+accessible name, then by visible text — `click:Save` means the button labelled
+Save, not a `<save>` element.
+
+## Browser chrome
+
+`--chrome` re-renders a page capture inside the same window frame the terminal
+cards use, with an address bar:
+
+```bash
+shot app /room/atlas --chrome --backdrop dusk
+shot app / --chrome --theme light                 # app and frame both light
+shot app / --chrome --theme dark --chrome-theme light
+```
+
+`--theme` drives the app's own theme, not just the browser's `prefers-color-scheme`:
+next-themes reads `localStorage` before first paint and would otherwise ignore it.
+
+## The library
+
+```js
+import { capture } from "../shotkit/src/api.mjs";
+
+const r = await capture({ op: "app", route: "/", responsive: true, sheet: true });
+r.path;      // absolute path of the sheet
+r.shots;     // one entry per breakpoint
+```
+
+`mycelium-frontend/screenshots/capture.ts` is the other consumer: it publishes
+the committed docs assets and uses this engine for the browser work, keeping
+only what is publication's business — the shot manifest, the `sharp` pass, and
+where files land.
+
+## Notes
+
+- **macOS and Linux.** Both need `script(1)` (present by default) for terminal
+  cards, and a Chromium. `shot doctor` says what is missing.
+- **Any Chromium will do.** Playwright pins an exact build and refuses others;
+  shotkit falls back to `executablePath` for whatever is on disk, so a version
+  skew between the driver and the host's browser is not a re-download.
+- **Editing shotkit restarts the daemon.** It stamps its own source at boot and
+  the client replaces it when that moves, so a fix never silently runs stale.
+- **Captures land in `.shotkit/`** (gitignored) and overwrite by name; `--unique`
+  timestamps instead.

--- a/shotkit/bin/shot.mjs
+++ b/shotkit/bin/shot.mjs
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * `shot` — the command line.
+ *
+ * Deliberately thin. Parsing argv into a spec and handing it to a daemon that
+ * already has a browser open is the whole of the fast path, so this file imports
+ * nothing but node builtins until it knows it has to do the work itself
+ * (`--no-daemon`, or no daemon reachable). Pulling Playwright in here would put
+ * a fixed cost on every invocation, including `shot --help`.
+ *
+ * stdout is the artifact and stderr is the commentary: a bare `shot` prints the
+ * absolute path and nothing else, so `$(shot term …)` is a usable expression,
+ * while timings and warnings go to stderr where they cannot corrupt it.
+ */
+
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+import { resolve } from "node:path";
+import { helpFor, parse } from "../src/args.mjs";
+import { ACTION_HELP } from "../src/actions.mjs";
+
+const OUTPUT = {
+  out: { type: "string", alias: "o", value: "<path>", help: "exact output file" },
+  "out-dir": { type: "string", value: "<dir>", help: "directory for generated names (default .shotkit/)" },
+  name: { type: "string", value: "<slug>", help: "basename to use instead of a derived one" },
+  unique: { type: "boolean", help: "append a timestamp instead of overwriting" },
+  stdout: { type: "boolean", help: "write image bytes to stdout instead of a file" },
+  json: { type: "boolean", help: "print the full result object as JSON" },
+  format: { type: "string", value: "png|jpeg", help: "image format (default png)" },
+  quality: { type: "number", help: "jpeg quality, 1-100" },
+  open: { type: "boolean", help: "open the file when done" },
+};
+
+const FRAME = {
+  theme: { type: "string", value: "dark|light", help: "color scheme (default dark)" },
+  scale: { type: "number", help: "device pixel ratio (default 2)" },
+  width: { type: "number", alias: "w", help: "viewport width" },
+  height: { type: "number", alias: "h", help: "viewport height" },
+  transparent: { type: "boolean", help: "omit the background (png only)" },
+};
+
+const CHROME = {
+  chrome: { type: "boolean", help: "wrap the capture in browser window chrome" },
+  address: { type: "string", help: "address-bar text (default: the route)" },
+  "chrome-theme": { type: "string", value: "dark|light", help: "frame theme, when it differs from the app's" },
+  backdrop: { type: "string", value: "<preset|css>", help: "mycelium|dusk|ink|paper|none, or any CSS" },
+  padding: { type: "number", help: "gutter around the frame (default 40)" },
+  radius: { type: "number", help: "corner radius (default 12)" },
+  shadow: { type: "boolean", help: "drop shadow (default on)" },
+};
+
+const RESPONSIVE = {
+  viewport: { type: "string", value: "<preset|WxH@S>", help: "phone|tablet|laptop|desktop|wide, or 1280x800@2" },
+  viewports: { type: "string", value: "<a,b,c>", help: "shoot several presets in one run" },
+  responsive: { type: "boolean", help: "shoot the standard ladder: phone, tablet, laptop, wide" },
+  sheet: { type: "boolean", help: "also compose the frames into one contact sheet" },
+  "sheet-only": { type: "boolean", help: "keep only the contact sheet, not the individual frames" },
+  "sheet-title": { type: "string", help: "heading on the contact sheet" },
+};
+
+const DAEMON = {
+  daemon: { type: "boolean", help: "use the warm background browser (default on)" },
+  idle: { type: "number", value: "<ms>", help: "daemon idle timeout when starting one" },
+};
+
+const CARD = {
+  title: { type: "string", help: "title bar text" },
+  backdrop: { type: "string", value: "<preset|css>", help: "mycelium|dusk|ink|paper|none, or any CSS" },
+  padding: { type: "number", help: "gutter around the card (default 40)" },
+  radius: { type: "number", help: "corner radius (default 12)" },
+  shadow: { type: "boolean", help: "drop shadow (default on)" },
+  window: { type: "string", value: "mac|plain|none", help: "title bar style (default mac)" },
+  "font-size": { type: "number", help: "px (default 13.5)" },
+  "line-height": { type: "number", help: "unitless (default 1.55)" },
+  font: { type: "string", value: "<css>", help: "font-family override" },
+  cols: { type: "number", help: "fix the body to N characters wide" },
+  "max-width": { type: "number", help: "px cap on the card" },
+};
+
+const PAGE = {
+  "full-page": { type: "boolean", help: "capture the whole scrollable page" },
+  element: { type: "string", alias: "e", value: "<sel>", help: "clip to one element" },
+  wait: { type: "string", dest: "waitFor", value: "<sel>", help: "wait for a selector to be visible" },
+  "wait-text": { type: "string", value: "<text>", help: "wait for text to appear in the body" },
+  settle: { type: "string", value: "none|fast|full", help: "how hard to wait for a populated frame" },
+  do: { type: "list", value: "<verb:arg>", help: "a navigation step; repeat for an ordered sequence" },
+  click: { type: "list", dest: "clickNames", value: "<name>", help: "shorthand for --do click:<name>" },
+  "action-timeout": { type: "number", value: "<ms>", help: "per-action timeout (default 15000)" },
+  hide: { type: "list", value: "<sel>", help: "display:none a selector (repeatable)" },
+  mask: { type: "list", value: "<sel>", help: "paint over a selector (repeatable)" },
+  css: { type: "string", help: "extra stylesheet" },
+  delay: { type: "number", value: "<ms>", help: "idle before shooting" },
+  storage: { type: "map", value: "<k>=<v>", help: "seed localStorage (repeatable)" },
+  timeout: { type: "number", value: "<ms>", help: "per-wait timeout (default 30000)" },
+  offline: { type: "boolean", help: "resolve nothing but localhost — skips slow or unreachable CDNs" },
+  block: { type: "list", value: "<host>", help: "fail this host's lookups immediately (repeatable)" },
+};
+
+const TERM = {
+  cwd: { type: "string", value: "<dir>", help: "working directory for the command" },
+  command: { type: "string", value: "<text>", help: "the command line to display, when it differs from the one run" },
+  pty: { type: "boolean", help: "run under a pty so Rich emits color (default on)" },
+  prompt: { type: "string", value: "<sigil>", help: "prompt sigil, or --no-prompt to hide the line" },
+  "show-exit": { type: "boolean", help: "show a non-zero exit code (default on)" },
+  "command-timeout": { type: "number", value: "<ms>", help: "kill the command after N ms" },
+  env: { type: "map", value: "<k>=<v>", help: "extra environment (repeatable)" },
+  echo: { type: "boolean", help: "include the plain-text output in --json" },
+};
+
+const CODE = {
+  lang: { type: "string", help: "language id (default: from the extension)" },
+  "line-numbers": { type: "boolean", help: "gutter (default on)" },
+  "start-line": { type: "number", help: "number the first row as N" },
+  range: { type: "string", value: "<a:b>", help: "only these lines" },
+  highlight: { type: "string", value: "<n,n>", help: "emphasize these line numbers" },
+};
+
+const SESSION = {
+  session: { type: "string", value: "<name>", help: "which held page to act on (default \"default\")" },
+};
+
+const APP = {
+  "base-url": { type: "string", value: "<url>", help: "app origin (default: probe :3000-:3002)" },
+  mock: { type: "boolean", help: "boot pnpm dev:mock and keep it warm in the daemon" },
+};
+
+const err = (m) => process.stderr.write(`${m}\n`);
+
+const USAGE = `shot — fast screenshots of the app and of CLI output
+
+one-shot
+  shot app [route]        the running frontend (add --mock to boot dev:mock)
+  shot url <url>          any URL
+  shot term <command…>    run a command, shoot its terminal output
+  shot text <file|->      render an existing text/ANSI capture as a terminal
+  shot code <file>        a syntax-highlighted code card
+  shot html <file|->      render an HTML document
+
+responsive
+  shot app / --responsive --sheet     every breakpoint, plus one image of all of them
+  shot app / --viewports phone,wide   just these two
+
+navigation — a page held open, driven step by step
+  shot open /room/atlas --session r   open it and keep it
+  shot do click:Negotiate --session r act on it
+  shot shoot --session r              shoot it as it stands
+  shot sessions | shot close --session r
+
+daemon
+  shot warm | status | stop | serve
+  shot doctor | bench
+
+stdout carries the path and nothing else, so it composes:
+  open "$(shot app /room/atlas-migration --mock)"
+` + `
+actions (--do, and the arguments to \`shot do\` / \`shot shoot\`)${ACTION_HELP}
+`;
+
+const COMMAND_HELP = {
+  app: ["shot app [route] [options]", { ...APP, ...PAGE, ...RESPONSIVE, ...CHROME, ...FRAME, ...OUTPUT, ...DAEMON }],
+  url: ["shot url <url> [options]", { ...PAGE, ...RESPONSIVE, ...CHROME, ...FRAME, ...OUTPUT, ...DAEMON }],
+  term: ["shot term [options] <command…>   (flags must precede the command)", { ...TERM, ...CARD, ...FRAME, ...OUTPUT, ...DAEMON }],
+  text: ["shot text <file|-> [options]", { ...TERM, ...CARD, ...FRAME, ...OUTPUT, ...DAEMON }],
+  code: ["shot code <file> [options]", { ...CODE, ...CARD, ...FRAME, ...OUTPUT, ...DAEMON }],
+  html: ["shot html <file|-> [options]", { ...CARD, ...FRAME, ...OUTPUT, ...DAEMON }],
+  open: ["shot open <route|url> [options]   — hold a page open under a name", { ...SESSION, ...APP, ...PAGE, ...RESPONSIVE, ...FRAME, ...DAEMON }],
+  do: ["shot do <verb:arg…> [options]       — drive the held page", { ...SESSION, ...PAGE, ...DAEMON }],
+  shoot: ["shot shoot [verb:arg…] [options]   — shoot the held page as it stands", { ...SESSION, ...PAGE, ...CHROME, ...FRAME, ...OUTPUT, ...DAEMON }],
+  resize: ["shot resize --viewport <v> [options] — reframe the held page in place", { ...SESSION, ...RESPONSIVE, ...DAEMON }],
+  close: ["shot close [options]", { ...SESSION, ...DAEMON }],
+};
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/** Turn parsed flags into an api.mjs spec. */
+function toSpec(op, flags) {
+  const spec = { op, ...flags };
+  for (const local of ["daemon", "idle", "json", "open", "clickNames"]) delete spec[local];
+  // `--click Foo` is sugar; the ordered `--do` list is the real interface, so
+  // the shorthand lands at the end of it rather than in a second channel.
+  if (flags.clickNames?.length) {
+    spec.do = [...(flags.do ?? []), ...flags.clickNames.map((n) => `click:${n}`)];
+  }
+  if (flags.highlight) spec.highlight = String(flags.highlight).split(",").map(Number).filter(Boolean);
+  if (flags.range) {
+    const [a, b] = String(flags.range).split(":").map(Number);
+    spec.range = [a || 1, b || Number.MAX_SAFE_INTEGER];
+  }
+  return spec;
+}
+
+async function runSpec(spec, flags) {
+  const { SESSION_OPS } = await import("../src/api.mjs");
+  const isSession = SESSION_OPS.has(spec.op);
+
+  if (flags.daemon !== false) {
+    try {
+      const { ensureDaemon, send } = await import("../src/ipc.mjs");
+      await ensureDaemon({ idleMs: flags.idle });
+      return await send(isSession ? "session" : "shot", { spec });
+    } catch (e) {
+      // A failure the daemon reported is this shot's failure — retrying it in
+      // this process would only lose the daemon's state (a booted mock server,
+      // a warm cache) and produce a second, more confusing error.
+      if (e.remote) throw e;
+      if (isSession) {
+        // A held page cannot survive the process that owns it, so there is no
+        // meaningful in-process fallback for a session.
+        throw new Error(`session commands need the daemon: ${e.message}`);
+      }
+      err(`[shot] daemon unavailable (${e.message}); running in-process`);
+    }
+  }
+  const { capture, shutdown } = await import("../src/api.mjs");
+  try {
+    return await capture(spec, { mode: "direct", log: (m) => err(`[shot] ${m}`) });
+  } finally {
+    await shutdown();
+  }
+}
+
+function report(result, flags) {
+  const t = result.ms ?? {};
+  const bits = [`${t.total}ms`];
+  if (t.command) bits.push(`cmd ${t.command}ms`);
+  if (t.capture) bits.push(`capture ${t.capture}ms`);
+  const size = result.width ? ` · ${result.width}x${result.height}` : "";
+  err(`[shot] ${result.op} · ${bits.join(" · ")} · ${result.mode ?? "daemon"}${size}`);
+  if (result.meta?.exitCode) err(`[shot] command exited ${result.meta.exitCode}`);
+  for (const step of result.trace ?? []) err(`[shot]   ${step.action} (${step.ms}ms)`);
+  for (const shot of result.shots ?? []) err(`[shot]   ${shot.viewport} · ${shot.ms}ms · ${shot.width}x${shot.height}`);
+
+  if (flags.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else if (result.base64) {
+    process.stdout.write(Buffer.from(result.base64, "base64"));
+  } else if (result.shots && !result.path) {
+    for (const shot of result.shots) if (shot.path) process.stdout.write(`${shot.path}\n`);
+  } else if (result.path) {
+    process.stdout.write(`${result.path}\n`);
+  } else {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  }
+  if (flags.open && result.path) {
+    const opener = platform() === "darwin" ? "open" : "xdg-open";
+    spawn(opener, [result.path], { detached: true, stdio: "ignore" }).unref();
+  }
+}
+
+async function main() {
+  const [command, ...argv] = process.argv.slice(2);
+
+  if (!command || command === "help" || command === "--help" || command === "-h") {
+    const topic = argv[0];
+    if (topic && COMMAND_HELP[topic]) {
+      const [usage, spec] = COMMAND_HELP[topic];
+      process.stdout.write(`${usage}\n\n${helpFor(spec)}\n`);
+    } else {
+      process.stdout.write(USAGE);
+    }
+    return;
+  }
+
+  if (command === "serve") {
+    process.env.SHOTKIT_DAEMON_VERBOSE = "1";
+    await import("../src/daemon.mjs");
+    return;
+  }
+
+  if (command === "status" || command === "stop" || command === "warm") {
+    const { ensureDaemon, ping, send } = await import("../src/ipc.mjs");
+    if (command === "stop") {
+      const alive = await ping();
+      if (!alive) {
+        err("[shot] no daemon running");
+        return;
+      }
+      const res = await send("stop");
+      err(`[shot] stopped pid ${res.pid}`);
+      return;
+    }
+    if (command === "status") {
+      const alive = await ping();
+      if (!alive) {
+        err("[shot] no daemon running");
+        process.stdout.write(`${JSON.stringify({ running: false }, null, 2)}\n`);
+        return;
+      }
+      const res = await send("status");
+      process.stdout.write(`${JSON.stringify(res, null, 2)}\n`);
+      return;
+    }
+    const { flags } = parse(argv, { ...APP, ...DAEMON });
+    const t0 = Date.now();
+    await ensureDaemon({ idleMs: flags.idle });
+    const res = await send("warm", { mock: Boolean(flags.mock) }, { timeout: 180_000 });
+    err(`[shot] warm in ${Date.now() - t0}ms`);
+    process.stdout.write(`${JSON.stringify(res, null, 2)}\n`);
+    return;
+  }
+
+  if (command === "sessions") {
+    const result = await runSpec({ op: "sessions" }, {});
+    process.stdout.write(`${JSON.stringify(result.sessions, null, 2)}\n`);
+    return;
+  }
+
+  if (command === "doctor") {
+    const { doctor } = await import("../src/doctor.mjs");
+    await doctor();
+    return;
+  }
+
+  if (command === "bench") {
+    const { bench } = await import("../src/doctor.mjs");
+    await bench(argv);
+    return;
+  }
+
+  const entry = COMMAND_HELP[command];
+  if (!entry) {
+    err(`unknown command: ${command}\n`);
+    process.stdout.write(USAGE);
+    process.exitCode = 2;
+    return;
+  }
+  const [, flagSpec] = entry;
+  const { flags, rest } = parse(argv, flagSpec, { stopAtPositional: command === "term" });
+
+  let spec;
+  if (command === "term") {
+    if (rest.length === 0) throw new Error("shot term needs a command: shot term mycelium --help");
+    spec = toSpec("term", flags);
+    spec.argv = rest;
+  } else if (command === "open") {
+    spec = toSpec("open", flags);
+    const target = rest[0] ?? "/";
+    if (target.startsWith("http")) spec.url = target;
+    else spec.route = target;
+  } else if (command === "do" || command === "shoot") {
+    spec = toSpec(command === "do" ? "act" : "shoot", flags);
+    // Bare positionals are actions, so the common case reads as a sentence:
+    //   shot do click:Negotiate wait:.offer-grid
+    spec.do = [...(spec.do ?? []), ...rest];
+    if (command === "do" && spec.do.length === 0) throw new Error(`shot do needs an action${ACTION_HELP}`);
+  } else if (command === "resize" || command === "close") {
+    spec = toSpec(command, flags);
+  } else if (command === "text") {
+    const src = rest[0];
+    if (!src) throw new Error("shot text needs a file, or - for stdin");
+    const { readFile } = await import("node:fs/promises");
+    spec = toSpec("term", flags);
+    spec.text = src === "-" ? await readStdin() : await readFile(resolve(src), "utf8");
+    spec.title ??= src === "-" ? "terminal" : src.split("/").pop();
+    spec.name ??= `text-${(src === "-" ? "stdin" : src).split("/").pop()}`;
+  } else if (command === "code") {
+    if (!rest[0]) throw new Error("shot code needs a file");
+    spec = toSpec("code", flags);
+    spec.file = resolve(rest[0]);
+  } else if (command === "html") {
+    const src = rest[0];
+    if (!src) throw new Error("shot html needs a file, or - for stdin");
+    spec = toSpec("html", flags);
+    if (src === "-") spec.html = await readStdin();
+    else spec.file = resolve(src);
+  } else if (command === "url") {
+    if (!rest[0]) throw new Error("shot url needs a URL");
+    spec = toSpec("url", flags);
+    spec.url = rest[0];
+  } else {
+    spec = toSpec("app", flags);
+    spec.route = rest[0] ?? "/";
+  }
+
+  const result = await runSpec(spec, flags);
+  report(result, flags);
+}
+
+main().catch((e) => {
+  err(`[shot] ${e?.stack ?? e}`);
+  process.exit(1);
+});

--- a/shotkit/package-lock.json
+++ b/shotkit/package-lock.json
@@ -1,0 +1,75 @@
+{
+  "name": "@mycelium/shotkit",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@mycelium/shotkit",
+      "version": "0.1.0",
+      "dependencies": {
+        "highlight.js": "^11.11.1",
+        "playwright": "^1.62.1"
+      },
+      "bin": {
+        "shot": "bin/shot.mjs"
+      },
+      "engines": {
+        "node": ">=20.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.12.0.tgz",
+      "integrity": "sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/shotkit/package.json
+++ b/shotkit/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@mycelium/shotkit",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Fast screenshots of the running app and of CLI output, for coding agents.",
+  "bin": { "shot": "./bin/shot.mjs" },
+  "exports": { ".": "./src/api.mjs" },
+  "engines": { "node": ">=20.6" },
+  "scripts": {
+    "shot": "node ./bin/shot.mjs",
+    "doctor": "node ./bin/shot.mjs doctor",
+    "selftest": "node ./test/selftest.mjs"
+  },
+  "dependencies": {
+    "highlight.js": "^11.11.1",
+    "playwright": "^1.62.1"
+  }
+}

--- a/shotkit/src/actions.mjs
+++ b/shotkit/src/actions.mjs
@@ -181,4 +181,5 @@ export const ACTION_HELP = `
   eval:<js>            run JS in the page
 
   Selectors take any Playwright engine: text=Save, role=button[name="Save"],
-  #id, .class, //xpath. A bare word is matched as visible text.`;
+  #id, .class, //xpath. A bare word is matched by accessible name, then by
+  visible text — click:Save means the button labelled Save.`;

--- a/shotkit/src/actions.mjs
+++ b/shotkit/src/actions.mjs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Driving the page: an ordered list of `verb:argument` steps.
+ *
+ * Order is the point. A screenshot of a tab three clicks deep is not describable
+ * as a set of flags — `--click` twice and `--scroll` once has no defined
+ * sequence — so navigation is expressed as a list that runs front to back:
+ *
+ *   --do click:'text=Negotiate' --do wait:.offer-grid --do scroll:bottom
+ *
+ * Element arguments are passed to `page.locator()` untouched, which means every
+ * Playwright selector engine is available (`text=`, `role=button[name="Save"]`,
+ * `#id`, `.class`, XPath) without this file knowing about any of them. A string
+ * that is not valid CSS and carries no engine prefix is treated as visible text,
+ * because that is what someone typing `--do click:Negotiate` meant.
+ */
+
+const ENGINE_PREFIX = /^(css|text|role|xpath|id|data-testid|internal:[a-z-]+)[=:]/;
+/** Punctuation that only appears in a CSS selector, never in a visible label. */
+const CSS_PUNCTUATION = /[.#\[\]>+~*]|::/;
+
+/**
+ * Resolve one element argument.
+ *
+ * Order matters, and the interesting case is the bare word. `--do click:Save`
+ * means the button labelled Save, but "Save" is also a syntactically valid CSS
+ * type selector, so handing it to `locator()` silently looks for a `<save>`
+ * element and times out. A bare word is therefore matched by what it is on
+ * screen: its accessible name first — buttons, links and tabs are what
+ * navigation actually targets — and its visible text as the fallback.
+ *
+ * @param {import("playwright").Page} page
+ */
+export function locate(page, spec) {
+  if (ENGINE_PREFIX.test(spec) || spec.startsWith("//") || spec.startsWith("(")) return page.locator(spec).first();
+  if (CSS_PUNCTUATION.test(spec) || /\s/.test(spec) === false && /^[a-z]+$/.test(spec) && HTML_TAGS.has(spec)) {
+    return page.locator(spec).first();
+  }
+  return page
+    .getByRole("button", { name: spec })
+    .or(page.getByRole("link", { name: spec }))
+    .or(page.getByRole("tab", { name: spec }))
+    .or(page.getByRole("menuitem", { name: spec }))
+    .or(page.getByText(spec, { exact: true }))
+    .first();
+}
+
+/** Lowercase bare words that really are element selectors rather than labels. */
+const HTML_TAGS = new Set([
+  "a", "article", "aside", "body", "button", "canvas", "code", "dialog", "div", "footer",
+  "form", "h1", "h2", "h3", "header", "img", "input", "li", "main", "nav", "ol", "p", "pre",
+  "section", "select", "span", "svg", "table", "tbody", "td", "textarea", "th", "tr", "ul", "video",
+]);
+
+/** Split `verb:rest` on the first colon. `back` and `reload` take no argument. */
+export function parseAction(raw) {
+  const i = raw.indexOf(":");
+  if (i === -1) return { verb: raw.trim(), arg: "" };
+  return { verb: raw.slice(0, i).trim(), arg: raw.slice(i + 1) };
+}
+
+const splitPair = (arg) => {
+  const i = arg.indexOf("=");
+  if (i === -1) throw new Error(`expected <selector>=<value>, got "${arg}"`);
+  return [arg.slice(0, i), arg.slice(i + 1)];
+};
+
+/**
+ * @param {import("playwright").Page} page
+ * @param {string[]} actions
+ * @param {{baseUrl?:string, timeout?:number, log?:(m:string)=>void}} ctx
+ * @returns {Promise<{action:string, ms:number}[]>}
+ */
+export async function runActions(page, actions, ctx = {}) {
+  const timeout = ctx.timeout ?? 15_000;
+  const trace = [];
+  for (const raw of actions ?? []) {
+    const started = Date.now();
+    const { verb, arg } = parseAction(raw);
+    switch (verb) {
+      case "click":
+        await locate(page, arg).click({ timeout });
+        break;
+      case "dblclick":
+        await locate(page, arg).dblclick({ timeout });
+        break;
+      case "hover":
+        await locate(page, arg).hover({ timeout });
+        break;
+      case "focus":
+        await locate(page, arg).focus({ timeout });
+        break;
+      case "check":
+        await locate(page, arg).check({ timeout });
+        break;
+      case "uncheck":
+        await locate(page, arg).uncheck({ timeout });
+        break;
+      case "fill": {
+        const [sel, value] = splitPair(arg);
+        await locate(page, sel).fill(value, { timeout });
+        break;
+      }
+      case "select": {
+        const [sel, value] = splitPair(arg);
+        await locate(page, sel).selectOption(value, { timeout });
+        break;
+      }
+      case "press":
+        await page.keyboard.press(arg);
+        break;
+      case "typekeys":
+        await page.keyboard.type(arg, { delay: 20 });
+        break;
+      case "goto":
+        await page.goto(arg.startsWith("http") ? arg : `${ctx.baseUrl ?? ""}${arg}`, {
+          waitUntil: "domcontentloaded",
+          timeout,
+        });
+        break;
+      case "back":
+        await page.goBack({ waitUntil: "domcontentloaded" });
+        break;
+      case "forward":
+        await page.goForward({ waitUntil: "domcontentloaded" });
+        break;
+      case "reload":
+        await page.reload({ waitUntil: "domcontentloaded" });
+        break;
+      case "scroll":
+        if (arg === "bottom") await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+        else if (arg === "top") await page.evaluate(() => window.scrollTo(0, 0));
+        else if (/^-?\d+$/.test(arg)) await page.evaluate((y) => window.scrollBy(0, y), Number(arg));
+        else await locate(page, arg).scrollIntoViewIfNeeded({ timeout });
+        break;
+      case "wait":
+        await page.locator(arg).first().waitFor({ state: "visible", timeout });
+        break;
+      case "wait-hidden":
+        await page.locator(arg).first().waitFor({ state: "hidden", timeout });
+        break;
+      case "wait-text":
+        await page.waitForFunction((t) => document.body.innerText.includes(t), arg, { timeout });
+        break;
+      case "wait-url":
+        await page.waitForURL(arg.includes("*") ? arg : `**${arg}`, { timeout });
+        break;
+      case "sleep":
+        await page.waitForTimeout(Number(arg) || 0);
+        break;
+      case "eval":
+        await page.evaluate(arg);
+        break;
+      case "emulate":
+        // `emulate:dark` / `emulate:light` — flip the media query mid-session
+        // without tearing down and rebuilding the context.
+        await page.emulateMedia({ colorScheme: arg });
+        break;
+      default:
+        throw new Error(`unknown action "${verb}" in "${raw}"`);
+    }
+    trace.push({ action: raw, ms: Date.now() - started });
+    ctx.log?.(`${raw} (${Date.now() - started}ms)`);
+  }
+  return trace;
+}
+
+export const ACTION_HELP = `
+  click:<sel>          click an element        hover:<sel>        hover it
+  dblclick:<sel>       double click            focus:<sel>        focus it
+  fill:<sel>=<text>    set an input            select:<sel>=<v>   pick an option
+  check:<sel>          tick a checkbox         uncheck:<sel>      untick it
+  press:<key>          keyboard key            typekeys:<text>    type into focus
+  goto:<url|route>     navigate                back / forward     history
+  reload               reload the page         emulate:<scheme>   dark | light
+  scroll:<px|top|bottom|sel>                    sleep:<ms>
+  wait:<sel>           until visible           wait-hidden:<sel>  until gone
+  wait-text:<text>     until text appears      wait-url:<glob>    until routed
+  eval:<js>            run JS in the page
+
+  Selectors take any Playwright engine: text=Save, role=button[name="Save"],
+  #id, .class, //xpath. A bare word is matched as visible text.`;

--- a/shotkit/src/ansi.mjs
+++ b/shotkit/src/ansi.mjs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * A small screen buffer that replays an ANSI byte stream and hands back HTML.
+ *
+ * A one-shot capture of a Rich CLI is not a flat string of styled text: Rich
+ * draws spinners with `\r`, repaints Live regions by moving the cursor up, and
+ * clears rows with `ESC[K`. Concatenating the runs would stack every
+ * intermediate frame into the image. So the stream is replayed into a cell grid
+ * and only the final state is rendered — the screenshot shows the terminal as a
+ * person would have found it, not its whole redraw history.
+ *
+ * Scope is exactly that job: SGR, the cursor moves and erases a CLI actually
+ * emits. Scrollback, alt-screen and wrapping-at-width are left to the process's
+ * own `COLUMNS`.
+ */
+
+/** @typedef {{fg:any,bg:any,bold:boolean,dim:boolean,italic:boolean,underline:boolean,strike:boolean,inverse:boolean}} Style */
+
+/** @returns {Style} */
+const blank = () => ({
+  fg: null,
+  bg: null,
+  bold: false,
+  dim: false,
+  italic: false,
+  underline: false,
+  strike: false,
+  inverse: false,
+});
+
+const sameStyle = (a, b) =>
+  a.bold === b.bold &&
+  a.dim === b.dim &&
+  a.italic === b.italic &&
+  a.underline === b.underline &&
+  a.strike === b.strike &&
+  a.inverse === b.inverse &&
+  colorKey(a.fg) === colorKey(b.fg) &&
+  colorKey(a.bg) === colorKey(b.bg);
+
+const colorKey = (c) => (c === null ? "" : typeof c === "number" ? `i${c}` : `r${c.r},${c.g},${c.b}`);
+
+/** xterm-256 index -> rgb, for everything above the 16 themeable slots. */
+function cube256(n) {
+  if (n < 16) return n;
+  if (n < 232) {
+    const i = n - 16;
+    const step = (v) => (v === 0 ? 0 : 55 + v * 40);
+    return { r: step(Math.floor(i / 36) % 6), g: step(Math.floor(i / 6) % 6), b: step(i % 6) };
+  }
+  const v = 8 + (n - 232) * 10;
+  return { r: v, g: v, b: v };
+}
+
+/**
+ * Apply one SGR parameter list to `st`, in place.
+ * @param {Style} st
+ * @param {number[]} ps
+ */
+function applySgr(st, ps) {
+  for (let i = 0; i < ps.length; i++) {
+    const p = ps[i];
+    if (p === 0) Object.assign(st, blank());
+    else if (p === 1) st.bold = true;
+    else if (p === 2) st.dim = true;
+    else if (p === 3) st.italic = true;
+    else if (p === 4) st.underline = true;
+    else if (p === 7) st.inverse = true;
+    else if (p === 9) st.strike = true;
+    else if (p === 22) (st.bold = false), (st.dim = false);
+    else if (p === 23) st.italic = false;
+    else if (p === 24) st.underline = false;
+    else if (p === 27) st.inverse = false;
+    else if (p === 29) st.strike = false;
+    else if (p >= 30 && p <= 37) st.fg = p - 30;
+    else if (p === 39) st.fg = null;
+    else if (p >= 40 && p <= 47) st.bg = p - 40;
+    else if (p === 49) st.bg = null;
+    else if (p >= 90 && p <= 97) st.fg = p - 90 + 8;
+    else if (p >= 100 && p <= 107) st.bg = p - 100 + 8;
+    else if (p === 38 || p === 48) {
+      const target = p === 38 ? "fg" : "bg";
+      if (ps[i + 1] === 5) {
+        st[target] = cube256(ps[i + 2] ?? 0);
+        i += 2;
+      } else if (ps[i + 1] === 2) {
+        st[target] = { r: ps[i + 2] ?? 0, g: ps[i + 3] ?? 0, b: ps[i + 4] ?? 0 };
+        i += 4;
+      }
+    }
+  }
+}
+
+/**
+ * Replay `input` and return the final grid as rows of styled runs.
+ * @param {string} input
+ * @returns {{runs: {text:string, style:Style}[]}[]}
+ */
+export function parseAnsi(input) {
+  /** @type {{ch:string, style:Style}[][]} */
+  const rows = [[]];
+  let row = 0;
+  let col = 0;
+  let st = blank();
+
+  const rowAt = (r) => {
+    while (rows.length <= r) rows.push([]);
+    return rows[r];
+  };
+  const put = (ch) => {
+    const line = rowAt(row);
+    while (line.length < col) line.push({ ch: " ", style: blank() });
+    line[col] = { ch, style: { ...st } };
+    col++;
+  };
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+
+    if (ch === "\x1b") {
+      const next = input[i + 1];
+      if (next === "[") {
+        // CSI: parameters, then a final byte in @-~.
+        let j = i + 2;
+        let raw = "";
+        while (j < input.length && !/[@-~]/.test(input[j])) raw += input[j++];
+        const final = input[j];
+        const ps = raw
+          .replace(/^[?<>=]/, "")
+          .split(";")
+          .map((s) => (s === "" ? 0 : Number.parseInt(s, 10)))
+          .map((n) => (Number.isNaN(n) ? 0 : n));
+        const n = ps[0] || 1;
+
+        if (final === "m" && !/^[?<>=]/.test(raw)) applySgr(st, raw === "" ? [0] : ps);
+        else if (final === "A") row = Math.max(0, row - n);
+        else if (final === "B") row += n;
+        else if (final === "C") col += n;
+        else if (final === "D") col = Math.max(0, col - n);
+        else if (final === "E") (row += n), (col = 0);
+        else if (final === "F") (row = Math.max(0, row - n)), (col = 0);
+        else if (final === "G") col = Math.max(0, n - 1);
+        else if (final === "H" || final === "f") {
+          row = Math.max(0, (ps[0] || 1) - 1);
+          col = Math.max(0, (ps[1] || 1) - 1);
+        } else if (final === "K") {
+          const line = rowAt(row);
+          if (ps[0] === 1) for (let k = 0; k <= col && k < line.length; k++) line[k] = { ch: " ", style: blank() };
+          else if (ps[0] === 2) line.length = 0;
+          else line.length = Math.min(line.length, col);
+        } else if (final === "J") {
+          if (ps[0] === 2 || ps[0] === 3) {
+            rows.length = 1;
+            rows[0] = [];
+            row = 0;
+            col = 0;
+          } else rows.length = row + 1;
+        }
+        i = j;
+        continue;
+      }
+      if (next === "]") {
+        // OSC — window titles, hyperlinks. Dropped; the link text survives
+        // because it sits between the two OSC 8 wrappers, not inside them.
+        let j = i + 2;
+        while (j < input.length && !(input[j] === "\x07" || (input[j] === "\x1b" && input[j + 1] === "\\"))) j++;
+        i = input[j] === "\x1b" ? j + 1 : j;
+        continue;
+      }
+      i++; // lone two-byte escape
+      continue;
+    }
+
+    if (ch === "\n") (row += 1), (col = 0);
+    else if (ch === "\r") col = 0;
+    else if (ch === "\b") col = Math.max(0, col - 1);
+    else if (ch === "\t") {
+      const stop = col + (8 - (col % 8));
+      while (col < stop) put(" ");
+    } else if (ch === "\x07" || ch === "\x00") continue;
+    else put(ch);
+  }
+
+  // Trailing blank rows are an artifact of the final newline, not content.
+  while (rows.length > 1 && rows[rows.length - 1].length === 0) rows.pop();
+
+  return rows.map((line) => {
+    /** @type {{text:string, style:Style}[]} */
+    const runs = [];
+    for (const cell of line) {
+      const last = runs[runs.length - 1];
+      if (last && sameStyle(last.style, cell.style)) last.text += cell.ch;
+      else runs.push({ text: cell.ch, style: cell.style });
+    }
+    return { runs };
+  });
+}
+
+const escapeHtml = (s) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+/**
+ * Render parsed rows to HTML using a theme's 16 ANSI slots.
+ * @param {string} input raw stream, escapes included
+ * @param {ReturnType<import("./theme.mjs").palette>} pal
+ * @returns {{html:string, rows:number, cols:number}}
+ */
+export function ansiToHtml(input, pal) {
+  const rows = parseAnsi(input);
+  const resolve = (c, bright) => {
+    if (c === null) return null;
+    if (typeof c === "number") return pal.ansi[bright && c < 8 ? c + 8 : c];
+    return `rgb(${c.r},${c.g},${c.b})`;
+  };
+
+  let cols = 0;
+  const lines = rows.map(({ runs }) => {
+    let width = 0;
+    const spans = runs.map(({ text, style }) => {
+      width += text.length;
+      let fg = resolve(style.fg, style.bold);
+      let bg = resolve(style.bg, false);
+      if (style.inverse) {
+        const f = fg ?? pal.text;
+        const b = bg ?? pal.paper;
+        fg = b;
+        bg = f;
+      }
+      const css = [];
+      if (fg) css.push(`color:${fg}`);
+      if (bg) css.push(`background:${bg}`);
+      if (style.bold) css.push("font-weight:600");
+      if (style.dim) css.push("opacity:.62");
+      if (style.italic) css.push("font-style:italic");
+      const deco = [style.underline && "underline", style.strike && "line-through"].filter(Boolean);
+      if (deco.length) css.push(`text-decoration:${deco.join(" ")}`);
+      const body = escapeHtml(text);
+      return css.length ? `<span style="${css.join(";")}">${body}</span>` : body;
+    });
+    cols = Math.max(cols, width);
+    // A zero-width joiner keeps an empty row at full line-height.
+    return spans.join("") || "&#8203;";
+  });
+
+  return { html: lines.join("\n"), rows: rows.length, cols };
+}
+
+/** Drop every escape sequence — used for width math and `--json` echoes. */
+export function stripAnsi(s) {
+  return s.replace(/\x1b\[[0-9;?<>=]*[@-~]/g, "").replace(/\x1b\][^\x07\x1b]*(\x07|\x1b\\)/g, "");
+}

--- a/shotkit/src/api.mjs
+++ b/shotkit/src/api.mjs
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The one API. Every entry point — the `shot` CLI, the daemon, an import from a
+ * script — comes through `capture(spec)`, so there is a single place where a
+ * shot is defined and a single result shape to consume.
+ *
+ *   import { capture } from "../shotkit/src/api.mjs";
+ *   const r = await capture({ op: "term", argv: ["mycelium", "--help"] });
+ *   const s = await capture({ op: "app", route: "/", responsive: true, sheet: true });
+ *
+ * `capture` is transport-agnostic on purpose: the daemon calls it in-process
+ * after deserializing a socket request, and `--no-daemon` calls it directly.
+ */
+
+import { readFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import { Engine, REPO_ROOT, pngSize, writeShot } from "./engine.mjs";
+import { codeDocument } from "./code.mjs";
+import { terminalDocument } from "./terminal.mjs";
+import { cardDocument, imageCardDocument } from "./card.mjs";
+import { sheetDocument } from "./sheet.mjs";
+import { resolveBaseUrl } from "./app.mjs";
+import { runCommand } from "./run.mjs";
+import { stripAnsi } from "./ansi.mjs";
+import { viewportList } from "./viewports.mjs";
+
+/**
+ * @typedef {object} PageSpec
+ * @property {string} [url] for `op: "url"`
+ * @property {string} [route] for `op: "app"`
+ * @property {string} [baseUrl] app origin; probed when absent
+ * @property {boolean} [mock] boot `pnpm dev:mock` and hold it in the daemon
+ * @property {number} [width] @property {number} [height] @property {number} [scale]
+ * @property {string} [viewport] preset name or `1280x800@2`
+ * @property {string} [viewports] comma-separated presets — one shot each
+ * @property {boolean} [responsive] shorthand for the standard breakpoint ladder
+ * @property {boolean} [sheet] compose the frames into one contact sheet
+ * @property {"dark"|"light"} [theme]
+ * @property {boolean} [fullPage] @property {string} [element] clip selector
+ * @property {string} [waitFor] @property {string} [waitForText]
+ * @property {"none"|"fast"|"full"} [settle]
+ * @property {string[]} [do] ordered navigation actions, see actions.mjs
+ * @property {string[]} [hide] @property {string[]} [mask] @property {string} [css]
+ * @property {number} [delay] @property {Record<string,string>} [storage]
+ * @property {number} [timeout] @property {"png"|"jpeg"} [format] @property {number} [quality]
+ * @property {boolean} [transparent]
+ * @property {boolean} [chrome] wrap the capture in browser window chrome
+ * @property {string} [address] address-bar text when `chrome` is set
+ * @property {"dark"|"light"} [chromeTheme] frame theme, when it should differ
+ *   from the app's — a light frame around a dark app, say
+ */
+
+export const DEFAULT_OUT_DIR = process.env.SHOTKIT_OUT ?? resolve(REPO_ROOT, ".shotkit");
+
+const slug = (s) =>
+  (s || "shot").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "shot";
+
+const stamp = () => new Date().toISOString().replace(/[-:]/g, "").replace(/\..+/, "").replace("T", "-");
+
+/** Where this shot lands, given `--out` / `--out-dir` / `--name` / `--unique`. */
+function outputPath(spec, fallbackName, suffix = "") {
+  const ext = spec.format === "jpeg" ? "jpg" : "png";
+  if (spec.out && !suffix) return resolve(spec.out);
+  if (spec.out) {
+    const base = resolve(spec.out).replace(/\.(png|jpg|jpeg)$/i, "");
+    return `${base}${suffix}.${ext}`;
+  }
+  const dir = spec.outDir ? resolve(spec.outDir) : DEFAULT_OUT_DIR;
+  const name = slug(spec.name ?? fallbackName);
+  return resolve(dir, `${name}${suffix}${spec.unique ? `-${stamp()}` : ""}.${ext}`);
+}
+
+/** A process-wide engine, so an in-process caller warms up the same way. */
+let sharedEngine = null;
+export function engine() {
+  if (!sharedEngine) sharedEngine = new Engine();
+  return sharedEngine;
+}
+export async function shutdown() {
+  if (sharedEngine) await sharedEngine.close();
+  sharedEngine = null;
+}
+
+const CARD_KEYS = ["theme", "backdrop", "padding", "radius", "shadow", "window", "title", "fontSize", "lineHeight", "font", "cols", "maxWidth"];
+const pickCard = (spec) => Object.fromEntries(CARD_KEYS.filter((k) => spec[k] !== undefined).map((k) => [k, spec[k]]));
+const pickStatic = (spec) => ({
+  theme: spec.theme,
+  scale: spec.scale,
+  format: spec.format,
+  quality: spec.quality,
+  transparent: spec.transparent ?? spec.backdrop === "none",
+});
+
+/**
+ * Run one shot (or one responsive set).
+ * @param {Record<string, any>} spec
+ * @param {{log?: (m:string)=>void, mode?: string}} [ctx]
+ */
+export async function capture(spec, ctx = {}) {
+  const log = ctx.log ?? (() => {});
+  const t0 = Date.now();
+  const eng = engine();
+  const base = { ok: true, op: spec.op, mode: ctx.mode ?? "direct", engine: eng.channel };
+
+  if (spec.op === "term" || spec.op === "code" || spec.op === "html") {
+    const { buf, meta, timings, fallbackName } = await renderCard(spec, eng);
+    return finish({ ...base, meta, ms: { total: Date.now() - t0, ...timings } }, spec, buf, fallbackName);
+  }
+
+  if (spec.op === "url" || spec.op === "app") {
+    const { url, baseUrl } = await resolvePageUrl(spec, log);
+    const fallbackName = spec.op === "app" ? `app-${slug(spec.route ?? "home")}` : `url-${slug(new URL(url).pathname)}`;
+    const pageSpec = {
+      ...spec,
+      url,
+      baseUrl,
+      settle: spec.settle ?? (spec.op === "app" ? "fast" : "none"),
+      storage: themedStorage(spec),
+    };
+    const frames = viewportList(spec);
+
+    if (frames.length <= 1) {
+      const frame = frames[0]?.viewport;
+      const tCap = Date.now();
+      const raw = await eng.capturePage({ ...pageSpec, ...(frame ?? {}) });
+      const buf = await wrapChrome(eng, raw.buf, spec, prettyAddress(spec, url));
+      const meta = { url, baseUrl, viewport: frames[0]?.name, trace: raw.trace, chrome: Boolean(spec.chrome) };
+      return finish(
+        { ...base, meta, ms: { total: Date.now() - t0, capture: Date.now() - tCap } },
+        spec,
+        buf,
+        fallbackName,
+      );
+    }
+    return captureResponsive({ base, spec, pageSpec, frames, fallbackName, eng, t0, url, baseUrl });
+  }
+
+  throw new Error(`unknown op: ${spec.op}`);
+}
+
+/**
+ * Seed the app's own theme alongside the browser's.
+ *
+ * `colorScheme` on the context only sets the `prefers-color-scheme` media query,
+ * and the frontend does not follow it: next-themes reads `localStorage.theme`
+ * before first paint and wins. So `--theme light` has to write that key too,
+ * or it produces a light frame around an unchanged dark app. An explicit
+ * `--storage theme=…` still takes precedence.
+ */
+function themedStorage(spec) {
+  if (spec.op !== "app") return spec.storage;
+  return { theme: spec.theme ?? "dark", ...(spec.storage ?? {}) };
+}
+
+/**
+ * Optionally re-shoot a page capture inside browser chrome.
+ *
+ * Runs the capture back through the card renderer, so a framed app screenshot
+ * and a framed terminal card come out of one code path and match each other.
+ * @param {any} eng @param {Buffer} buf @param {Record<string,any>} spec
+ */
+async function wrapChrome(eng, buf, spec, address) {
+  if (!spec.chrome) return buf;
+  const scale = spec.scale ?? 2;
+  const { width } = pngSize(buf);
+  const html = imageCardDocument(buf.toString("base64"), Math.round(width / scale), {
+    ...pickCard(spec),
+    theme: spec.chromeTheme ?? spec.theme ?? "dark",
+    address: spec.address ?? address,
+  });
+  // Same scale as the capture, so one image pixel lands on one device pixel.
+  return eng.captureStatic({
+    html,
+    ...pickStatic(spec),
+    theme: spec.chromeTheme ?? spec.theme ?? "dark",
+    scale,
+    width: 2600,
+    height: 2000,
+  });
+}
+
+/** app/url/session ops all need to know where the app is. */
+async function resolvePageUrl(spec, log) {
+  if (spec.op === "url" || spec.url?.startsWith("http")) return { url: spec.url, baseUrl: undefined };
+  const baseUrl = await resolveBaseUrl({ baseUrl: spec.baseUrl, mock: spec.mock, log });
+  const route = spec.route ?? "/";
+  return { url: `${baseUrl}${route.startsWith("/") ? route : `/${route}`}`, baseUrl };
+}
+
+/** One page, every requested breakpoint, optionally composed into a sheet. */
+async function captureResponsive({ base, spec, pageSpec, frames, fallbackName, eng, t0, url, baseUrl }) {
+  const shots = [];
+  const composed = [];
+  for (const { name, viewport } of frames) {
+    const tCap = Date.now();
+    const raw = await eng.capturePage({ ...pageSpec, ...viewport });
+    const buf = await wrapChrome(eng, raw.buf, { ...spec, scale: viewport.scale }, prettyAddress(spec, url));
+    const size = pngSize(buf);
+    composed.push({ label: viewport.label ?? name, base64: buf.toString("base64"), ...size, scale: viewport.scale });
+    if (!spec.sheetOnly) {
+      const written = await writeShot(outputPath(spec, fallbackName, `-${name}`), buf);
+      shots.push({ viewport: name, ...written, ms: Date.now() - tCap });
+    } else {
+      shots.push({ viewport: name, ...size, ms: Date.now() - tCap });
+    }
+  }
+
+  const result = {
+    ...base,
+    meta: { url, baseUrl, viewports: frames.map((f) => f.name) },
+    shots,
+    ms: { total: Date.now() - t0 },
+  };
+
+  if (!spec.sheet) return result;
+  const html = sheetDocument(composed, {
+    theme: spec.theme ?? "dark",
+    backdrop: spec.backdrop,
+    title: spec.sheetTitle ?? `${spec.route ?? url} — ${frames.map((f) => f.name).join(" · ")}`,
+  });
+  const buf = await eng.captureStatic({ html, ...pickStatic(spec), scale: 1, width: 2600, height: 2000 });
+  const written = await writeShot(outputPath(spec, `${fallbackName}-sheet`), buf);
+  return { ...result, ...written, sheet: written.path, ms: { total: Date.now() - t0 } };
+}
+
+/** term / code / html all end in one static render. */
+async function renderCard(spec, eng) {
+  const timings = {};
+  /** @type {Record<string, any>} */
+  const meta = {};
+  let html;
+  let selector;
+  let fallbackName;
+
+  if (spec.op === "term") {
+    let output = spec.text;
+    let command = spec.command;
+    if (output === undefined) {
+      const tRun = Date.now();
+      const run = await runCommand({
+        argv: spec.argv,
+        cwd: spec.cwd,
+        cols: spec.cols ?? 100,
+        timeout: spec.commandTimeout,
+        env: spec.env,
+        pty: spec.pty,
+      });
+      timings.command = Date.now() - tRun;
+      output = run.output;
+      command = command ?? run.command;
+      meta.exitCode = run.exitCode;
+      meta.pty = run.pty;
+      if (run.timedOut) meta.timedOut = true;
+      if (spec.echo) meta.plain = stripAnsi(output);
+    }
+    const doc = terminalDocument({
+      ...pickCard(spec),
+      output,
+      command: spec.prompt === false ? undefined : command,
+      prompt: typeof spec.prompt === "string" ? spec.prompt : undefined,
+      exitCode: meta.exitCode,
+      showExit: spec.showExit !== false,
+      title: spec.title ?? (spec.argv ? spec.argv[0] : "terminal"),
+    });
+    html = doc.html;
+    meta.rows = doc.rows;
+    meta.cols = doc.cols;
+    fallbackName = `term-${slug(command ?? "text")}`;
+  } else if (spec.op === "code") {
+    const doc = await codeDocument({ ...pickCard(spec), ...pickCode(spec) });
+    html = doc.html;
+    meta.lang = doc.lang;
+    meta.rows = doc.rows;
+    fallbackName = `code-${slug(spec.file ? basename(spec.file) : (spec.lang ?? "snippet"))}`;
+  } else {
+    const source = spec.html ?? (await readFile(resolve(spec.file), "utf8"));
+    html = spec.raw === false ? cardDocument(source, pickCard(spec)) : source;
+    selector = spec.element ?? (html.includes('id="canvas"') ? "#canvas" : "body");
+    fallbackName = spec.file ? `html-${slug(basename(spec.file))}` : "html";
+  }
+
+  const tCap = Date.now();
+  const buf = await eng.captureStatic({ html, selector, ...pickStatic(spec) });
+  timings.capture = Date.now() - tCap;
+  return { buf, meta, timings, fallbackName };
+}
+
+/**
+ * What goes in the address bar. A docs screenshot reads better showing the route
+ * than `localhost:41973`, which is an artifact of how the shot was taken.
+ */
+function prettyAddress(spec, url) {
+  if (spec.op === "app" && spec.route) return spec.route;
+  return url;
+}
+
+const pickCode = (spec) => ({
+  code: spec.code,
+  file: spec.file,
+  lang: spec.lang,
+  lineNumbers: spec.lineNumbers,
+  startLine: spec.startLine,
+  highlight: spec.highlight,
+  range: spec.range,
+});
+
+/** Either hand the bytes back, or put them on disk and hand back the path. */
+async function finish(result, spec, buf, fallbackName) {
+  if (spec.stdout) return { ...result, base64: buf.toString("base64"), bytes: buf.length, ...pngSize(buf) };
+  const written = await writeShot(outputPath(spec, fallbackName), buf);
+  return { ...result, ...written };
+}
+
+/* ── Held pages ─────────────────────────────────────────────────────────────
+ * A session is a page the daemon keeps open under a name. It exists because a
+ * screenshot three clicks into a flow is otherwise a cold load plus a replay of
+ * every click, every time — and because an agent driving a UI wants to look,
+ * decide, then act, which is a conversation with one page rather than a batch.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/** @param {Record<string, any>} spec */
+export async function session(spec, ctx = {}) {
+  const log = ctx.log ?? (() => {});
+  const eng = engine();
+  const name = spec.session ?? "default";
+  const t0 = Date.now();
+
+  if (spec.op === "open") {
+    const { url, baseUrl } = await resolvePageUrl({ ...spec, op: spec.url ? "url" : "app" }, log);
+    const frame = viewportList(spec)[0]?.viewport;
+    const meta = await eng.openSession(name, { ...spec, ...(frame ?? {}), url, baseUrl, settle: spec.settle ?? "fast" });
+    return { ok: true, op: "open", session: meta, ms: { total: Date.now() - t0 } };
+  }
+  if (spec.op === "act") {
+    const { trace, meta } = await eng.actOnSession(name, spec);
+    return { ok: true, op: "act", session: meta, trace, ms: { total: Date.now() - t0 } };
+  }
+  if (spec.op === "resize") {
+    const frame = viewportList(spec)[0]?.viewport;
+    if (!frame) throw new Error("resize needs --viewport");
+    const meta = await eng.resizeSession(name, frame);
+    return { ok: true, op: "resize", session: meta, ms: { total: Date.now() - t0 } };
+  }
+  if (spec.op === "shoot") {
+    const shot = await eng.shootSession(name, spec);
+    const { trace, meta } = shot;
+    const buf = await wrapChrome(eng, shot.buf, spec, spec.address ?? meta.url);
+    const result = { ok: true, op: "shoot", session: meta, trace, mode: ctx.mode ?? "direct", ms: { total: Date.now() - t0 } };
+    return finish(result, spec, buf, `session-${slug(name)}`);
+  }
+  if (spec.op === "close") {
+    const closed = await eng.closeSession(name);
+    return { ok: true, op: "close", closed, session: { name } };
+  }
+  if (spec.op === "sessions") {
+    return { ok: true, op: "sessions", sessions: eng.listSessions() };
+  }
+  throw new Error(`unknown session op: ${spec.op}`);
+}
+
+export const SESSION_OPS = new Set(["open", "act", "resize", "shoot", "close", "sessions"]);

--- a/shotkit/src/app.mjs
+++ b/shotkit/src/app.mjs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Finding — or starting — the app to point the camera at.
+ *
+ * `--mock` boots `pnpm dev:mock` and hands the process to the daemon rather than
+ * to the request: a Next dev server takes seconds to come up, and an agent
+ * taking six screenshots of six routes should pay that once. The server lives
+ * until `shot stop` or the daemon's idle timeout, and dies with it.
+ */
+
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:net";
+import { REPO_ROOT } from "./engine.mjs";
+
+export const FRONTEND_DIR = `${REPO_ROOT}/mycelium-frontend`;
+
+/** Ports a dev server is plausibly already sitting on. */
+const PROBE_PORTS = [3000, 3001, 3002];
+
+/**
+ * Next records its own address here, which beats probing: a dev server started
+ * with `--port 0`, or by a previous daemon, is on a port nothing would guess.
+ * The file outlives the process, so the URL is still checked before it is used.
+ */
+function lockedDevServer() {
+  try {
+    const lock = JSON.parse(readFileSync(`${FRONTEND_DIR}/.next/dev/lock`, "utf8"));
+    return lock.appUrl ?? (lock.port ? `http://localhost:${lock.port}` : null);
+  } catch {
+    return null;
+  }
+}
+
+async function alive(url, timeoutMs = 700) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { redirect: "manual", signal: ac.signal });
+    return res.status > 0;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function freePort() {
+  return new Promise((res, rej) => {
+    const srv = createServer();
+    srv.on("error", rej);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      srv.close(() => res(port));
+    });
+  });
+}
+
+async function waitForServer(url, timeoutMs, check) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    check?.();
+    if (await alive(url, 1000)) return;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`dev:mock never answered at ${url} (${timeoutMs}ms)`);
+}
+
+/** @type {{proc: import("node:child_process").ChildProcess | null, url: string, adopted: boolean} | null} */
+let mockServer = null;
+
+export function mockStatus() {
+  if (!mockServer) return { running: false };
+  return { running: true, url: mockServer.url, pid: mockServer.proc?.pid ?? null, adopted: mockServer.adopted };
+}
+
+/** Next refuses a second dev server per directory, and says where the first is. */
+const ALREADY_RUNNING = /Another next dev server is already running[\s\S]*?(http:\/\/localhost:\d+)/;
+
+/**
+ * Boot `pnpm dev:mock`, or attach to the one that is already up.
+ *
+ * Attaching matters more than it looks: a dev server that outlived a previous
+ * daemon still holds the directory, and Next will refuse to start a second one
+ * rather than pick another port. Treating that refusal as an address — it names
+ * the running server's URL — turns the one failure mode this has into the
+ * fast path.
+ */
+export async function ensureMockServer({ log = () => {} } = {}) {
+  if (mockServer && (mockServer.adopted || !mockServer.proc?.killed)) {
+    if (await alive(`${mockServer.url}/`, 1500)) return mockServer.url;
+    mockServer = null;
+  }
+
+  const locked = lockedDevServer();
+  if (locked && (await alive(`${locked}/`, 1500))) {
+    log(`attaching to the dev server already running at ${locked}`);
+    mockServer = { proc: null, url: locked, adopted: true };
+    return locked;
+  }
+
+  const port = await freePort();
+  log(`booting dev:mock on :${port}`);
+  const proc = spawn("pnpm", ["dev:mock", "--port", String(port)], {
+    cwd: FRONTEND_DIR,
+    env: { ...process.env, MYCELIUM_UI_MOCK: "1", PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe"],
+    // Its own process group: `pnpm` is a wrapper, and signalling only the
+    // wrapper orphans the next-server child, which then holds the directory
+    // against every later boot.
+    detached: true,
+  });
+
+  let transcript = "";
+  const watch = (d) => {
+    transcript += d;
+    if (process.env.SHOTKIT_DAEMON_VERBOSE) process.stderr.write(d);
+  };
+  proc.stdout?.on("data", watch);
+  proc.stderr?.on("data", watch);
+
+  // Address the dev server as `localhost`, not `127.0.0.1`: Next's dev-server
+  // cross-origin guard only allow-lists `localhost`, so a browser 403s on every
+  // /_next/* chunk over the IP and the app never hydrates.
+  const url = `http://localhost:${port}`;
+  try {
+    await waitForServer(`${url}/`, 120_000, () => {
+      const m = ALREADY_RUNNING.exec(transcript);
+      if (m) throw Object.assign(new Error("adopt"), { adoptUrl: m[1] });
+    });
+  } catch (e) {
+    killTree(proc);
+    if (e.adoptUrl && (await alive(`${e.adoptUrl}/`, 3000))) {
+      log(`attaching to the dev server already running at ${e.adoptUrl}`);
+      mockServer = { proc: null, url: e.adoptUrl, adopted: true };
+      return e.adoptUrl;
+    }
+    throw new Error(`dev:mock did not come up.\n${transcript.slice(-800)}`);
+  }
+
+  mockServer = { proc, url, adopted: false };
+  log("dev:mock ready");
+  return url;
+}
+
+function killTree(proc) {
+  if (!proc?.pid) return;
+  try {
+    // Negative pid signals the whole group, so the next-server child goes too.
+    process.kill(-proc.pid, "SIGTERM");
+  } catch {
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+export function stopMockServer() {
+  if (!mockServer) return false;
+  if (mockServer.proc) killTree(mockServer.proc);
+  mockServer = null;
+  return true;
+}
+
+/**
+ * @param {{baseUrl?:string, mock?:boolean, log?:(m:string)=>void}} opts
+ * @returns {Promise<string>}
+ */
+export async function resolveBaseUrl(opts = {}) {
+  if (opts.baseUrl) return opts.baseUrl.replace(/\/$/, "");
+  if (opts.mock) return ensureMockServer(opts);
+  const fromEnv = process.env.SHOTKIT_APP_URL ?? process.env.MYCELIUM_UI_URL;
+  if (fromEnv) return fromEnv.replace(/\/$/, "");
+  // A remembered server is still checked: a dev server can wedge or be killed
+  // between shots, and returning its URL anyway turns that into a 30s
+  // navigation timeout instead of a clear "no app found".
+  if (mockServer && (await alive(`${mockServer.url}/`, 1500))) return mockServer.url;
+  mockServer = null;
+  const locked = lockedDevServer();
+  if (locked && (await alive(`${locked}/`))) return locked;
+  for (const port of PROBE_PORTS) {
+    const url = `http://localhost:${port}`;
+    if (await alive(`${url}/`)) return url;
+  }
+  throw new Error(
+    `no app found${locked ? ` (${locked} from .next/dev/lock is not answering)` : ""} ` +
+      `on ${PROBE_PORTS.map((p) => `:${p}`).join(", ")}. ` +
+      "Start it, pass --base-url, or use --mock to have shotkit boot dev:mock.",
+  );
+}

--- a/shotkit/src/app.mjs
+++ b/shotkit/src/app.mjs
@@ -59,6 +59,7 @@ async function freePort() {
   });
 }
 
+/** @param {string} url @param {number} timeoutMs @param {() => void} [check] */
 async function waitForServer(url, timeoutMs, check) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -88,6 +89,9 @@ const ALREADY_RUNNING = /Another next dev server is already running[\s\S]*?(http
  * rather than pick another port. Treating that refusal as an address — it names
  * the running server's URL — turns the one failure mode this has into the
  * fast path.
+ *
+ * @param {{log?: (message: string) => void}} [opts]
+ * @returns {Promise<string>} the base URL of a dev server that is answering
  */
 export async function ensureMockServer({ log = () => {} } = {}) {
   if (mockServer && (mockServer.adopted || !mockServer.proc?.killed)) {

--- a/shotkit/src/args.mjs
+++ b/shotkit/src/args.mjs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * A flag parser with one unusual requirement: `shot term` has to hand the rest
+ * of the line to somebody else.
+ *
+ * `shot term mycelium memory ls --room atlas` contains two flag namespaces, and
+ * `--room` belongs to the child. So a command can declare `stopAtPositional`,
+ * after which everything is collected verbatim — the same convention `env` and
+ * `timeout` use. An explicit `--` does the same thing at any point.
+ */
+
+/**
+ * @typedef {"boolean"|"string"|"number"|"list"|"map"} FlagType
+ * @typedef {{type: FlagType, alias?: string, dest?: string, help?: string, value?: string}} FlagSpec
+ */
+
+const camel = (s) => s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+
+/**
+ * @param {string[]} argv
+ * @param {Record<string, FlagSpec>} spec
+ * @param {{stopAtPositional?: boolean}} [opts]
+ */
+export function parse(argv, spec, opts = {}) {
+  /** @type {Record<string, any>} */
+  const flags = {};
+  /** @type {string[]} */
+  const rest = [];
+  const byAlias = new Map();
+  for (const [name, s] of Object.entries(spec)) if (s.alias) byAlias.set(s.alias, name);
+
+  const set = (name, s, raw) => {
+    const dest = s.dest ?? camel(name);
+    if (s.type === "boolean") flags[dest] = raw;
+    else if (s.type === "number") flags[dest] = Number(raw);
+    else if (s.type === "list") (flags[dest] ??= []).push(raw);
+    else if (s.type === "map") {
+      const eq = String(raw).indexOf("=");
+      if (eq === -1) throw new Error(`--${name} expects key=value, got ${raw}`);
+      (flags[dest] ??= {})[String(raw).slice(0, eq)] = String(raw).slice(eq + 1);
+    } else flags[dest] = raw;
+  };
+
+  let i = 0;
+  let passthrough = false;
+  for (; i < argv.length; i++) {
+    const arg = argv[i];
+    if (passthrough) {
+      rest.push(arg);
+      continue;
+    }
+    if (arg === "--") {
+      passthrough = true;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      let [name, inline] = splitOnce(arg.slice(2), "=");
+      let negated = false;
+      if (!spec[name] && name.startsWith("no-") && spec[name.slice(3)]?.type === "boolean") {
+        name = name.slice(3);
+        negated = true;
+      }
+      const s = spec[name];
+      if (!s) throw new Error(`unknown option --${name}`);
+      if (s.type === "boolean") set(name, s, !negated);
+      else set(name, s, inline ?? argv[++i]);
+      continue;
+    }
+    if (arg.startsWith("-") && arg.length > 1 && !/^-\d/.test(arg)) {
+      const name = byAlias.get(arg.slice(1));
+      const s = name && spec[name];
+      if (!s) throw new Error(`unknown option ${arg}`);
+      if (s.type === "boolean") set(name, s, true);
+      else set(name, s, argv[++i]);
+      continue;
+    }
+    rest.push(arg);
+    if (opts.stopAtPositional) passthrough = true;
+  }
+  return { flags, rest };
+}
+
+function splitOnce(s, sep) {
+  const i = s.indexOf(sep);
+  return i === -1 ? [s, undefined] : [s.slice(0, i), s.slice(i + 1)];
+}
+
+/** Render a flag spec as aligned `--flag  help` lines. */
+export function helpFor(spec) {
+  const rows = Object.entries(spec).map(([name, s]) => {
+    const left = [s.alias ? `-${s.alias},` : "   ", `--${name}`, s.value ?? (s.type === "boolean" ? "" : `<${s.type}>`)]
+      .filter(Boolean)
+      .join(" ");
+    return [left, s.help ?? ""];
+  });
+  const width = Math.max(...rows.map(([l]) => l.length));
+  return rows.map(([l, r]) => `  ${l.padEnd(width)}  ${r}`).join("\n");
+}

--- a/shotkit/src/browser.mjs
+++ b/shotkit/src/browser.mjs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Finding a Chromium to drive.
+ *
+ * Playwright pins an exact browser build per release and refuses anything else,
+ * which is a good property for a test suite and a bad one for a utility that has
+ * to run on whatever the host already has — a CI image ships one build, a
+ * developer's laptop another, and neither is worth a re-download to take a
+ * screenshot. So a failed `launch()` falls through to whatever browser is
+ * actually on disk, driven by `executablePath`.
+ *
+ * Order of preference: `SHOTKIT_CHROMIUM`, the headless shell (smaller, faster
+ * to start), full Chromium from the Playwright cache, then a system install.
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+const BROWSERS_DIR = process.env.PLAYWRIGHT_BROWSERS_PATH ||
+  (platform() === "darwin" ? join(homedir(), "Library/Caches/ms-playwright") : join(homedir(), ".cache/ms-playwright"));
+
+/** Per-platform binary path inside one downloaded browser directory. */
+const INNER = {
+  chromium_headless_shell: {
+    linux: "chrome-linux/headless_shell",
+    darwin: "chrome-mac/headless_shell",
+  },
+  chromium: {
+    linux: "chrome-linux/chrome",
+    darwin: "chrome-mac/Chromium.app/Contents/MacOS/Chromium",
+  },
+};
+
+const SYSTEM = {
+  darwin: [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+  ],
+  linux: ["/usr/bin/chromium", "/usr/bin/chromium-browser", "/usr/bin/google-chrome", "/opt/pw-browsers/chromium"],
+};
+
+/** Newest build first, so a cache with several downloads picks the current one. */
+function cached(prefix) {
+  if (!existsSync(BROWSERS_DIR)) return [];
+  const inner = INNER[prefix]?.[platform()];
+  if (!inner) return [];
+  return readdirSync(BROWSERS_DIR)
+    .filter((d) => d.startsWith(`${prefix}-`))
+    .sort((a, b) => Number(b.split("-").pop()) - Number(a.split("-").pop()))
+    .map((d) => join(BROWSERS_DIR, d, inner))
+    .filter((p) => existsSync(p));
+}
+
+/** @returns {string[]} candidate executables, best first */
+export function candidates() {
+  const os = platform();
+  return [
+    process.env.SHOTKIT_CHROMIUM,
+    ...cached("chromium_headless_shell"),
+    ...cached("chromium"),
+    ...(SYSTEM[os] ?? []),
+  ].filter((p) => p && existsSync(p));
+}
+
+/**
+ * Launch, preferring Playwright's own resolution and falling back to a browser
+ * that is merely present.
+ * @param {any} pw the playwright module
+ * @param {{args: string[]}} opts
+ * @returns {Promise<{browser: any, channel: string}>}
+ */
+export async function launchChromium(pw, opts) {
+  const errors = [];
+  for (const channel of ["chromium-headless-shell", undefined]) {
+    try {
+      const browser = await pw.chromium.launch({ channel, ...opts });
+      return { browser, channel: channel ?? "chromium" };
+    } catch (err) {
+      errors.push(err.message.split("\n")[0]);
+    }
+  }
+  for (const executablePath of candidates()) {
+    try {
+      const browser = await pw.chromium.launch({ executablePath, ...opts });
+      return { browser, channel: executablePath };
+    } catch (err) {
+      errors.push(`${executablePath}: ${err.message.split("\n")[0]}`);
+    }
+  }
+  throw new Error(
+    `no usable Chromium.\n  tried: ${errors.join("\n  tried: ")}\n` +
+      "  fix: `npx playwright install chromium`, or point SHOTKIT_CHROMIUM at a binary.",
+  );
+}

--- a/shotkit/src/card.mjs
+++ b/shotkit/src/card.mjs
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The window chrome shared by the terminal and code cards.
+ *
+ * One self-contained HTML document: no webfonts, no scripts, no fetches, so the
+ * renderer can `setContent` and shoot in the same tick. The element actually
+ * captured is `#canvas`, not `#card` — a box-shadow paints outside its element's
+ * bounding box and an element screenshot clips to that box, so the padding
+ * around the card is what keeps the shadow in frame.
+ */
+
+import { MONO_STACK, UI_STACK, backdrop, palette } from "./theme.mjs";
+
+/** Traffic lights, in macOS order. */
+const LIGHTS = ["#ff5f57", "#febc2e", "#28c840"];
+
+const escapeHtml = (s) =>
+  String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+/**
+ * @typedef {object} CardOptions
+ * @property {"dark"|"light"} [theme]
+ * @property {string} [backdrop] preset name or literal CSS
+ * @property {number} [padding] gutter between backdrop edge and card
+ * @property {number} [radius]
+ * @property {boolean} [shadow]
+ * @property {"mac"|"plain"|"browser"|"none"} [window] title bar style
+ * @property {string} [address] address-bar text, for `window: "browser"`
+ * @property {string} [bodyPadding] CSS padding for the body (default "16px 18px")
+ * @property {string} [bodyBackground] CSS background for the body
+ * @property {string} [title]
+ * @property {number} [fontSize]
+ * @property {number} [lineHeight]
+ * @property {string} [font] CSS font-family override
+ * @property {number} [cols] fix the body width to N characters
+ * @property {number} [maxWidth] px cap on the shrink-wrapped card
+ */
+
+/**
+ * @param {string} bodyHtml inner HTML of the card body
+ * @param {CardOptions} opts
+ * @param {string} [extraCss]
+ */
+export function cardDocument(bodyHtml, opts = {}, extraCss = "") {
+  const theme = opts.theme ?? "dark";
+  const pal = palette(theme);
+  const pad = opts.padding ?? 40;
+  const radius = opts.radius ?? 12;
+  const chrome = opts.window ?? "mac";
+  const fontSize = opts.fontSize ?? 13.5;
+  const lineHeight = opts.lineHeight ?? 1.55;
+  const font = opts.font ?? MONO_STACK;
+  const shadow =
+    opts.shadow === false
+      ? "none"
+      : theme === "dark"
+        ? "0 22px 50px -12px rgba(0,0,0,.72), 0 2px 8px rgba(0,0,0,.5)"
+        : "0 22px 50px -14px rgba(17,20,24,.28), 0 2px 8px rgba(17,20,24,.10)";
+
+  const bodyWidth = opts.cols ? `width:${opts.cols}ch;` : "";
+  const maxWidth = opts.maxWidth ? `max-width:${opts.maxWidth}px;` : "";
+
+  const lights =
+    chrome === "mac" || chrome === "browser"
+      ? `<div class="lights">${LIGHTS.map((c) => `<i style="background:${c}"></i>`).join("")}</div>`
+      : "";
+  // The browser bar puts the address where a browser puts it — centered, in a
+  // pill — instead of the centered title a window bar shows.
+  const titleBar =
+    chrome === "none"
+      ? ""
+      : chrome === "browser"
+        ? `<div class="bar browser">${lights}<div class="address">${escapeHtml(opts.address ?? opts.title ?? "")}</div></div>`
+        : `<div class="bar">${lights}<div class="title">${escapeHtml(opts.title ?? "")}</div></div>`;
+
+  return `<!doctype html><html><head><meta charset="utf-8"><style>
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;background:transparent}
+body{-webkit-font-smoothing:antialiased;text-rendering:geometricPrecision}
+#canvas{
+  display:inline-block;width:max-content;padding:${pad}px;
+  background:${backdrop(opts.backdrop ?? "mycelium", theme)};
+}
+#card{
+  width:max-content;${maxWidth}
+  background:${pal.paper};
+  border:1px solid ${pal.border2};
+  border-radius:${radius}px;
+  box-shadow:${shadow};
+  overflow:hidden;
+}
+.bar{
+  display:flex;align-items:center;gap:10px;position:relative;
+  height:34px;padding:0 12px;
+  background:${pal.surface};
+  border-bottom:1px solid ${pal.border};
+}
+.lights{display:flex;gap:7px}
+.lights i{width:11px;height:11px;border-radius:50%;display:block}
+.title{
+  position:absolute;left:0;right:0;text-align:center;pointer-events:none;
+  font-family:${UI_STACK};font-size:11.5px;letter-spacing:.02em;
+  color:${pal.muted};
+}
+.bar.browser{height:44px;gap:14px}
+.address{
+  flex:1;min-width:0;height:26px;line-height:26px;padding:0 14px;
+  border-radius:13px;background:${pal.bg};border:1px solid ${pal.border};
+  font-family:${UI_STACK};font-size:11.5px;color:${pal.muted};
+  text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+/* Balances the traffic lights so the address pill sits centered. */
+.bar.browser::after{content:"";width:53px;flex:none}
+.body{
+  /* content-box so an explicit --cols width means N characters of text, not
+     N characters minus the padding. */
+  box-sizing:content-box;
+  ${bodyWidth}
+  font-family:${font};
+  font-size:${fontSize}px;line-height:${lineHeight};
+  font-variant-ligatures:none;font-feature-settings:"liga" 0,"calt" 0;
+  color:${pal.text};
+  padding:${opts.bodyPadding ?? "16px 18px"};
+  ${opts.bodyBackground ? `background:${opts.bodyBackground};` : ""}
+  white-space:pre;tab-size:8;
+}
+${extraCss}
+</style></head><body><div id="canvas"><div id="card">${titleBar}<div class="body">${bodyHtml}</div></div></div></body></html>`;
+}
+
+/**
+ * Wrap an already-captured screenshot in the same window chrome the terminal and
+ * code cards use.
+ *
+ * Deliberately the same path: a browser frame is a window frame with an address
+ * bar, and giving it its own renderer would mean a second backdrop, a second
+ * shadow and a second set of traffic lights to keep in step. The image goes in
+ * as a data URI at its own CSS size, so one image pixel lands on one device
+ * pixel and the wrap costs no sharpness.
+ *
+ * @param {string} base64 PNG bytes of the page capture
+ * @param {number} cssWidth the capture's width in CSS pixels (device px / scale)
+ * @param {CardOptions} opts
+ */
+export function imageCardDocument(base64, cssWidth, opts = {}) {
+  const body = `<img src="data:image/png;base64,${base64}" width="${cssWidth}">`;
+  return cardDocument(body, {
+    window: "browser",
+    ...opts,
+    bodyPadding: "0",
+  }, `.body img{display:block;width:${cssWidth}px;height:auto}`);
+}
+
+export { escapeHtml };

--- a/shotkit/src/card.mjs
+++ b/shotkit/src/card.mjs
@@ -34,7 +34,7 @@ const escapeHtml = (s) =>
  * @property {number} [fontSize]
  * @property {number} [lineHeight]
  * @property {string} [font] CSS font-family override
- * @property {number} [cols] fix the body width to N characters
+ * @property {number} [cols] floor the body width at N characters
  * @property {number} [maxWidth] px cap on the shrink-wrapped card
  */
 
@@ -59,7 +59,10 @@ export function cardDocument(bodyHtml, opts = {}, extraCss = "") {
         ? "0 22px 50px -12px rgba(0,0,0,.72), 0 2px 8px rgba(0,0,0,.5)"
         : "0 22px 50px -14px rgba(17,20,24,.28), 0 2px 8px rgba(17,20,24,.10)";
 
-  const bodyWidth = opts.cols ? `width:${opts.cols}ch;` : "";
+  // A floor, not a fixed width: `--cols` sets what the command was given for
+  // COLUMNS, and output can still exceed it (an unwrappable path, a table). A
+  // fixed width would clip that off the right edge silently, so the card grows.
+  const bodyWidth = opts.cols ? `min-width:${opts.cols}ch;` : "";
   const maxWidth = opts.maxWidth ? `max-width:${opts.maxWidth}px;` : "";
 
   const lights =

--- a/shotkit/src/code.mjs
+++ b/shotkit/src/code.mjs
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The code card: highlight.js tokens painted with the frontend's own palette.
+ *
+ * `lib/common` rather than the full build — it carries the ~40 languages this
+ * repo actually contains and loads in a fraction of the time, which matters
+ * because the load lands on somebody's first shot. An unknown language falls
+ * back to plain text rather than pulling the full grammar set in.
+ */
+
+import { readFile } from "node:fs/promises";
+import { basename, extname } from "node:path";
+import { cardDocument, escapeHtml } from "./card.mjs";
+import { palette } from "./theme.mjs";
+
+let hljsPromise = null;
+async function loadHljs() {
+  if (!hljsPromise) {
+    hljsPromise = import("highlight.js/lib/common")
+      .then((m) => m.default ?? m)
+      .catch(() => null);
+  }
+  return hljsPromise;
+}
+
+/** Extensions the repo uses that highlight.js does not map on its own. */
+const EXT_LANG = {
+  ".mjs": "javascript",
+  ".cjs": "javascript",
+  ".ts": "typescript",
+  ".tsx": "typescript",
+  ".jsx": "javascript",
+  ".py": "python",
+  ".toml": "ini",
+  ".yml": "yaml",
+  ".yaml": "yaml",
+  ".json": "json",
+  ".md": "markdown",
+  ".sh": "bash",
+  ".bash": "bash",
+  ".rs": "rust",
+  ".go": "go",
+  ".css": "css",
+  ".html": "xml",
+  ".sql": "sql",
+  ".dockerfile": "dockerfile",
+};
+
+/** @param {string} file */
+export function guessLanguage(file) {
+  const name = basename(file).toLowerCase();
+  if (name === "dockerfile") return "dockerfile";
+  if (name === "makefile") return "makefile";
+  return EXT_LANG[extname(name)] ?? null;
+}
+
+/**
+ * Split highlight.js output on newlines without breaking its markup: a comment
+ * or string span legitimately runs across lines, so every open tag is closed at
+ * the break and reopened on the next row.
+ * @param {string} html
+ * @returns {string[]}
+ */
+export function splitHighlightedLines(html) {
+  /** @type {string[]} */
+  const lines = [];
+  /** @type {string[]} */
+  const open = [];
+  let current = "";
+  const re = /<\/?span[^>]*>/g;
+  let last = 0;
+
+  const pushText = (text) => {
+    const chunks = text.split("\n");
+    chunks.forEach((chunk, i) => {
+      if (i > 0) {
+        current += open.map(() => "</span>").join("");
+        lines.push(current);
+        current = open.join("");
+      }
+      current += chunk;
+    });
+  };
+
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    pushText(html.slice(last, m.index));
+    if (m[0].startsWith("</")) {
+      open.pop();
+      current += m[0];
+    } else {
+      open.push(m[0]);
+      current += m[0];
+    }
+    last = m.index + m[0].length;
+  }
+  pushText(html.slice(last));
+  lines.push(current);
+  return lines;
+}
+
+/** @param {"dark"|"light"} theme */
+function syntaxCss(theme) {
+  const pal = palette(theme);
+  const type = theme === "dark" ? "#65e2d7" : "#0f8c99";
+  const keyword = theme === "dark" ? "#ea8cc2" : "#c02f86";
+  const builtin = theme === "dark" ? "#8a92ea" : "#3c48c8";
+  return `
+.hljs-comment,.hljs-quote{color:${pal.faint};font-style:italic}
+.hljs-doctag{color:${pal.faint}}
+.hljs-keyword,.hljs-selector-tag,.hljs-operator,.hljs-literal-keyword{color:${keyword}}
+.hljs-string,.hljs-char\\.escape_,.hljs-regexp,.hljs-addition{color:${pal.green}}
+.hljs-number,.hljs-literal,.hljs-symbol,.hljs-bullet{color:${pal.yellow}}
+.hljs-title,.hljs-title\\.function_,.hljs-section,.hljs-name{color:${pal.accent}}
+.hljs-title\\.class_,.hljs-type,.hljs-class .hljs-title{color:${type}}
+.hljs-built_in,.hljs-selector-id,.hljs-selector-class{color:${builtin}}
+.hljs-attr,.hljs-attribute,.hljs-property,.hljs-variable,.hljs-template-variable{color:${pal.text}}
+.hljs-params{color:${pal.muted}}
+.hljs-meta{color:${pal.muted}}
+.hljs-tag{color:${pal.muted}}
+.hljs-deletion{color:${pal.red}}
+.hljs-emphasis{font-style:italic}
+.hljs-strong{font-weight:700}
+.hljs-link{color:${pal.accent};text-decoration:underline}
+.row{display:block}
+.num{
+  display:inline-block;width:${"3ch"};margin-right:1.6ch;text-align:right;
+  color:${pal.faint};user-select:none;
+}
+.row.hl{background:${pal.accentSoft};box-shadow:inset 2px 0 0 ${pal.accent};margin:0 -18px;padding:0 18px 0 16px}
+`;
+}
+
+/**
+ * @typedef {import("./card.mjs").CardOptions & {
+ *   code?: string,
+ *   file?: string,
+ *   lang?: string,
+ *   lineNumbers?: boolean,
+ *   startLine?: number,
+ *   highlight?: number[],
+ *   range?: [number, number],
+ * }} CodeOptions
+ */
+
+/**
+ * @param {CodeOptions} opts
+ * @returns {Promise<{html:string, rows:number, cols:number, lang:string}>}
+ */
+export async function codeDocument(opts) {
+  const theme = opts.theme ?? "dark";
+  let source = opts.code;
+  if (source === undefined && opts.file) source = await readFile(opts.file, "utf8");
+  source = (source ?? "").replace(/\n+$/, "");
+
+  let startLine = opts.startLine ?? 1;
+  if (opts.range) {
+    const all = source.split("\n");
+    const [from, to] = opts.range;
+    source = all.slice(Math.max(0, from - 1), to).join("\n");
+    startLine = from;
+  }
+
+  const lang = opts.lang ?? (opts.file ? guessLanguage(opts.file) : null);
+  const hljs = await loadHljs();
+  let highlighted;
+  let usedLang = "plaintext";
+  if (hljs && lang && hljs.getLanguage(lang)) {
+    highlighted = hljs.highlight(source, { language: lang, ignoreIllegals: true }).value;
+    usedLang = lang;
+  } else if (hljs && !lang) {
+    const auto = hljs.highlightAuto(source);
+    highlighted = auto.value;
+    usedLang = auto.language ?? "plaintext";
+  } else {
+    highlighted = escapeHtml(source);
+  }
+
+  const lines = splitHighlightedLines(highlighted);
+  const marked = new Set(opts.highlight ?? []);
+  const gutter = opts.lineNumbers !== false;
+  const width = String(startLine + lines.length - 1).length;
+
+  const body = lines
+    .map((line, i) => {
+      const n = startLine + i;
+      const num = gutter
+        ? `<span class="num" style="width:${width}ch">${n}</span>`
+        : "";
+      const cls = marked.has(n) ? "row hl" : "row";
+      return `<span class="${cls}">${num}${line || "&#8203;"}</span>`;
+    })
+    // No newline between rows: `.row` is already a block, and the container is
+    // `white-space: pre`, so a separator would break the line a second time.
+    .join("");
+
+  const title = opts.title ?? (opts.file ? basename(opts.file) : usedLang);
+  const cols = Math.max(...source.split("\n").map((l) => l.length), 1) + (gutter ? width + 2 : 0);
+
+  return {
+    html: cardDocument(body, { ...opts, theme, title }, syntaxCss(theme)),
+    rows: lines.length,
+    cols,
+    lang: usedLang,
+  };
+}

--- a/shotkit/src/daemon.mjs
+++ b/shotkit/src/daemon.mjs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The warm half of shotkit: a background process holding the browser open.
+ *
+ * The point is entirely amortization. Chromium launch, context creation and
+ * font loading cost roughly a second combined and are identical for every shot,
+ * so they are paid once here and every later capture is a layout and a
+ * rasterize. `--mock`'s Next dev server is held the same way and for the same
+ * reason.
+ *
+ * It shuts itself down after an idle window (`SHOTKIT_IDLE_MS`, default 15
+ * minutes) so an agent that takes one screenshot does not leave a browser
+ * resident on the machine.
+ */
+
+import { createServer } from "node:net";
+import { existsSync, unlinkSync } from "node:fs";
+import { capture, engine, session, shutdown } from "./api.mjs";
+import { ensureMockServer, mockStatus, stopMockServer } from "./app.mjs";
+import { socketPath, sourceStamp } from "./ipc.mjs";
+
+const IDLE_MS = Number(process.env.SHOTKIT_IDLE_MS ?? 15 * 60 * 1000);
+/** Stamped once at boot; the client restarts this daemon when it moves. */
+const STAMP = sourceStamp();
+const startedAt = Date.now();
+let shots = 0;
+let idleTimer = null;
+let stopping = false;
+
+const path = socketPath();
+if (existsSync(path)) {
+  try {
+    unlinkSync(path);
+  } catch {
+    /* fall through: listen() will report the real problem */
+  }
+}
+
+function touchIdle() {
+  if (idleTimer) clearTimeout(idleTimer);
+  if (IDLE_MS <= 0) return;
+  idleTimer = setTimeout(() => stop("idle"), IDLE_MS);
+  idleTimer.unref?.();
+}
+
+/**
+ * @param {string} reason
+ * @param {boolean} [keepMock] leave the dev server running for the next daemon
+ */
+async function stop(reason, keepMock = false) {
+  if (stopping) return;
+  stopping = true;
+  // A restart to pick up edited source should not cost a Next dev server that
+  // took seconds to boot: it is spawned in its own process group, so leaving it
+  // alone lets the replacement daemon adopt it from `.next/dev/lock`.
+  if (!keepMock) stopMockServer();
+  await shutdown().catch(() => {});
+  server.close();
+  try {
+    unlinkSync(path);
+  } catch {
+    /* already gone */
+  }
+  process.exit(reason === "idle" ? 0 : 0);
+}
+
+const OPS = {
+  async ping() {
+    return { pid: process.pid, uptimeMs: Date.now() - startedAt, shots, socket: path, sourceStamp: STAMP };
+  },
+  async status() {
+    const eng = engine();
+    return {
+      pid: process.pid,
+      uptimeMs: Date.now() - startedAt,
+      shots,
+      idleMs: IDLE_MS,
+      socket: path,
+      sourceStamp: STAMP,
+      browser: eng.browser ? { channel: eng.channel, contexts: eng.contexts.size } : null,
+      mock: mockStatus(),
+      sessions: eng.listSessions(),
+    };
+  },
+  async warm(msg) {
+    await engine().start();
+    if (msg.mock) await ensureMockServer({ log: () => {} });
+    return this.status();
+  },
+  async shot(msg) {
+    shots += 1;
+    return capture(msg.spec, { mode: "daemon", log: () => {} });
+  },
+  async session(msg) {
+    if (msg.spec.op === "shoot") shots += 1;
+    return session(msg.spec, { mode: "daemon", log: () => {} });
+  },
+  async stop(msg) {
+    setTimeout(() => stop("requested", Boolean(msg.keepMock)), 10).unref?.();
+    return { stopping: true, pid: process.pid };
+  },
+};
+
+const server = createServer((sock) => {
+  touchIdle();
+  let buffer = "";
+  sock.on("data", async (chunk) => {
+    buffer += chunk;
+    let nl;
+    while ((nl = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, nl);
+      buffer = buffer.slice(nl + 1);
+      let reply;
+      try {
+        const msg = JSON.parse(line);
+        const handler = OPS[msg.op];
+        if (!handler) throw new Error(`unknown op: ${msg.op}`);
+        reply = { ok: true, ...(await handler.call(OPS, msg)) };
+      } catch (err) {
+        reply = { ok: false, error: err?.stack ?? String(err) };
+      }
+      touchIdle();
+      sock.write(`${JSON.stringify(reply)}\n`);
+    }
+  });
+  sock.on("error", () => {});
+});
+
+server.listen(path, () => {
+  touchIdle();
+  // Warm the browser behind whatever request arrives first, so the client that
+  // just started this daemon overlaps its own work with the launch.
+  engine().start().catch(() => {});
+  if (process.env.SHOTKIT_DAEMON_VERBOSE) process.stdout.write(`[shotkit] listening on ${path}\n`);
+});
+
+process.on("SIGTERM", () => stop("signal"));
+process.on("SIGINT", () => stop("signal"));

--- a/shotkit/src/doctor.mjs
+++ b/shotkit/src/doctor.mjs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * `shot doctor` and `shot bench`.
+ *
+ * The failures this tool can hit are all environmental — no browser downloaded,
+ * no pty, no app listening — and each produces a different unhelpful error deep
+ * in a capture. Doctor checks them up front and says which one is missing.
+ */
+
+import { existsSync } from "node:fs";
+import { platform, release } from "node:os";
+import { DEFAULT_OUT_DIR } from "./api.mjs";
+import { FRONTEND_DIR } from "./app.mjs";
+import { loadPlaywright, REPO_ROOT } from "./engine.mjs";
+import { candidates, launchChromium } from "./browser.mjs";
+import { ptyAvailable } from "./run.mjs";
+import { ping, socketPath } from "./ipc.mjs";
+
+const ok = (m) => process.stdout.write(`  \x1b[32m✓\x1b[0m ${m}\n`);
+const warn = (m) => process.stdout.write(`  \x1b[33m!\x1b[0m ${m}\n`);
+const bad = (m) => process.stdout.write(`  \x1b[31m✗\x1b[0m ${m}\n`);
+const head = (m) => process.stdout.write(`\n\x1b[1m${m}\x1b[0m\n`);
+
+export async function doctor() {
+  head("host");
+  ok(`node ${process.version} on ${platform()} ${release()}`);
+  ok(`repo ${REPO_ROOT}`);
+  ok(`output ${DEFAULT_OUT_DIR}`);
+
+  head("browser");
+  let pw = null;
+  try {
+    pw = await loadPlaywright();
+    ok("playwright resolved");
+  } catch (e) {
+    bad(e.message);
+  }
+  if (pw) {
+    try {
+      const { browser, channel } = await launchChromium(pw, { args: [] });
+      ok(`launches ${channel} (${browser.version()})`);
+      await browser.close();
+    } catch (e) {
+      bad(e.message.split("\n")[0]);
+    }
+    const found = candidates();
+    if (found.length) ok(`${found.length} browser binary(ies) on disk, best: ${found[0]}`);
+    if (process.env.PLAYWRIGHT_BROWSERS_PATH) ok(`PLAYWRIGHT_BROWSERS_PATH=${process.env.PLAYWRIGHT_BROWSERS_PATH}`);
+  }
+
+  head("terminal capture");
+  if (ptyAvailable) ok("script(1) present — commands run under a real pty, so Rich keeps its color");
+  else warn("script(1) missing — falling back to FORCE_COLOR; box drawing and widths may differ");
+  try {
+    await import("highlight.js/lib/common");
+    ok("highlight.js present — `shot code` highlights");
+  } catch {
+    warn("highlight.js missing — `shot code` renders plain. Run `npm install` in shotkit/");
+  }
+
+  head("app");
+  if (existsSync(`${FRONTEND_DIR}/node_modules`)) ok("mycelium-frontend deps installed — --mock can boot dev:mock");
+  else warn("mycelium-frontend/node_modules missing — run `pnpm install` there before --mock");
+  for (const port of [3000, 3001, 3002]) {
+    try {
+      const res = await fetch(`http://localhost:${port}/`, { redirect: "manual", signal: AbortSignal.timeout(600) });
+      if (res.status > 0) ok(`app answering on :${port}`);
+    } catch {
+      /* nothing there, which is the normal case */
+    }
+  }
+
+  head("daemon");
+  const alive = await ping();
+  if (alive) ok(`running · pid ${alive.pid} · ${alive.shots} shots · ${Math.round(alive.uptimeMs / 1000)}s up`);
+  else warn(`not running (starts on first shot) · socket ${socketPath()}`);
+  process.stdout.write("\n");
+}
+
+/**
+ * Time the two paths that matter: one capture from nothing, then repeated
+ * captures against a daemon that is already holding the browser.
+ */
+export async function bench(argv = []) {
+  const n = Number(argv[0] ?? 5);
+  const spec = { op: "term", argv: ["printf", "shotkit bench\\n"], name: "bench", backdrop: "ink" };
+
+  const { capture, shutdown } = await import("./api.mjs");
+  const t0 = Date.now();
+  await capture(spec, { mode: "direct" });
+  const cold = Date.now() - t0;
+  await shutdown();
+
+  const { ensureDaemon, send } = await import("./ipc.mjs");
+  await ensureDaemon();
+  await send("warm", {});
+
+  const warm = [];
+  for (let i = 0; i < n; i++) {
+    const t = Date.now();
+    await send("shot", { spec });
+    warm.push(Date.now() - t);
+  }
+  warm.sort((a, b) => a - b);
+  const median = warm[Math.floor(warm.length / 2)];
+
+  process.stdout.write(
+    `cold (no daemon, includes browser launch): ${cold}ms\n` +
+      `warm x${n}: min ${warm[0]}ms · median ${median}ms · max ${warm[warm.length - 1]}ms\n` +
+      `speedup: ${(cold / median).toFixed(1)}x\n`,
+  );
+}

--- a/shotkit/src/engine.mjs
+++ b/shotkit/src/engine.mjs
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The capture engine: one browser, pooled contexts, and the three things a
+ * caller can ask for — a card, a one-shot page, or a page held open.
+ *
+ * Everything here is written to be *held*. The engine is a long-lived object the
+ * daemon keeps between requests, so the costs that dominate a naive screenshot
+ * script — launching Chromium, opening a context, loading fonts — are paid once
+ * and amortized over every later shot. `--no-daemon` runs the same code with a
+ * lifetime of one capture, which is why a cold shot is slow and a warm one is
+ * not.
+ *
+ * Card renders reuse a single page per pool key and only swap its content:
+ * no navigation, no network, so the marginal cost is a layout and a rasterize.
+ * Sessions go further and hold the page itself, which is what makes a multi-step
+ * flow cheap — the alternative is replaying every click from a cold load before
+ * each shot in the sequence.
+ */
+
+import { createRequire } from "node:module";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { launchChromium } from "./browser.mjs";
+import { runActions } from "./actions.mjs";
+import { policyArgs, policyKey } from "./network.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const SHOTKIT_ROOT = resolve(HERE, "..");
+export const REPO_ROOT = resolve(SHOTKIT_ROOT, "..");
+
+/**
+ * Playwright is resolved rather than plainly imported: a checkout that has run
+ * `pnpm install` in mycelium-frontend already has a matching copy, and borrowing
+ * it means `shotkit/` needs no install of its own.
+ */
+export async function loadPlaywright() {
+  const require_ = createRequire(import.meta.url);
+  const candidates = ["playwright", resolve(REPO_ROOT, "mycelium-frontend/node_modules/playwright/index.js")];
+  for (const spec of candidates) {
+    try {
+      const path = spec.startsWith("/") ? spec : require_.resolve(spec);
+      const mod = await import(`file://${path}`);
+      // Playwright is CommonJS: the ESM namespace of a CJS module carries the
+      // exports object on `default`, and only sometimes re-exports its keys.
+      return mod.chromium ? mod : (mod.default ?? mod);
+    } catch {
+      // try the next candidate
+    }
+  }
+  throw new Error("playwright not found. Run `npm install` in shotkit/, or `pnpm install` in mycelium-frontend/.");
+}
+
+/** Width/height straight out of the PNG IHDR — cheaper than decoding. */
+export function pngSize(buf) {
+  if (buf.length < 24 || buf.readUInt32BE(0) !== 0x89504e47) return { width: 0, height: 0 };
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+const LAUNCH_ARGS = [
+  "--hide-scrollbars",
+  "--disable-dev-shm-usage",
+  "--force-color-profile=srgb",
+  // Subpixel antialiasing tints glyph edges red/blue, which reads as fringing
+  // once the PNG lands on a background other than the one it was rendered on.
+  "--disable-lcd-text",
+  "--disable-background-timer-throttling",
+  "--mute-audio",
+];
+
+export class Engine {
+  constructor() {
+    /** @type {Map<string, any>} browsers, one per distinct network policy */
+    this.browsers = new Map();
+    this.browser = null;
+    this.playwright = null;
+    /** @type {Map<string, any>} */
+    this.contexts = new Map();
+    /** @type {Map<string, any>} */
+    this.staticPages = new Map();
+    /** @type {Map<string, {page:any, context:any, meta:Record<string,any>}>} */
+    this.sessions = new Map();
+    this.launching = new Map();
+    this.channel = null;
+  }
+
+  /**
+   * The browser enforcing `policy`. The default policy's browser is the one
+   * `shot warm` opens; a second is launched only if some shot asks for a
+   * different network policy, since the policy is a launch flag.
+   */
+  async start(policy) {
+    const key = policyKey(policy);
+    const existing = this.browsers.get(key);
+    if (existing) return existing;
+    if (this.launching.has(key)) return this.launching.get(key);
+
+    const pending = (async () => {
+      const pw = this.playwright ?? (this.playwright = await loadPlaywright());
+      const { browser, channel } = await launchChromium(pw, { args: [...LAUNCH_ARGS, ...policyArgs(policy)] });
+      this.browsers.set(key, browser);
+      this.channel = channel;
+      if (key === "open") this.browser = browser;
+      return browser;
+    })();
+    this.launching.set(key, pending);
+    return pending;
+  }
+
+  contextOptions({ width, height, scale, theme, reducedMotion = true }) {
+    return {
+      viewport: { width, height },
+      deviceScaleFactor: scale,
+      colorScheme: theme,
+      reducedMotion: reducedMotion ? "reduce" : "no-preference",
+      // A stable frame: the same shot on macOS and in CI should differ only in
+      // font rasterization, not in locale-formatted dates or timezone.
+      locale: "en-US",
+      timezoneId: "UTC",
+    };
+  }
+
+  /** A pooled context. Shared between one-shot captures; sessions get their own. */
+  async context(frame, policy) {
+    const browser = await this.start(policy);
+    const key = `${policyKey(policy)}:${frame.width}x${frame.height}@${frame.scale}:${frame.theme}:${frame.reducedMotion !== false}`;
+    let ctx = this.contexts.get(key);
+    if (ctx) return ctx;
+    ctx = await browser.newContext(this.contextOptions(frame));
+    this.contexts.set(key, ctx);
+    return ctx;
+  }
+
+  /**
+   * Render a self-contained HTML document and shoot one element from it.
+   * @param {{html:string, selector?:string, theme?:string, scale?:number,
+   *          format?:string, quality?:number, transparent?:boolean,
+   *          width?:number, height?:number}} opts
+   */
+  async captureStatic(opts) {
+    const theme = opts.theme ?? "dark";
+    const scale = opts.scale ?? 2;
+    // Generous enough that a card is rarely larger than the frame; Playwright
+    // still stitches if it is, this just avoids the slow path.
+    const width = opts.width ?? 2200;
+    const height = opts.height ?? 1600;
+    const key = `${width}x${height}@${scale}:${theme}:static`;
+
+    let page = this.staticPages.get(key);
+    if (!page || page.isClosed()) {
+      const ctx = await this.context({ width, height, scale, theme });
+      page = await ctx.newPage();
+      this.staticPages.set(key, page);
+    }
+
+    await page.setContent(opts.html, { waitUntil: "load" });
+    await page.evaluate(() => document.fonts.ready);
+    return page.locator(opts.selector ?? "#canvas").first().screenshot({
+      type: opts.format === "jpeg" ? "jpeg" : "png",
+      ...(opts.format === "jpeg" ? { quality: opts.quality ?? 92 } : {}),
+      omitBackground: Boolean(opts.transparent),
+      animations: "disabled",
+      scale: "device",
+    });
+  }
+
+  /** Navigate, drive, and shoot — the one-shot page path. */
+  async capturePage(opts) {
+    const frame = frameOf(opts);
+    const ctx = await this.context(frame, policyOf(opts));
+    if (opts.storage) await seedStorage(ctx, opts.storage);
+    const page = await ctx.newPage();
+    try {
+      await page.goto(opts.url, { waitUntil: opts.waitUntil ?? "domcontentloaded", timeout: opts.timeout ?? 30_000 });
+      const trace = await preparePage(page, opts);
+      const buf = await shootPage(page, opts);
+      return { buf, trace };
+    } finally {
+      await page.close();
+    }
+  }
+
+  /**
+   * Open a page and keep it. The returned handle is addressed by name on later
+   * requests, so an agent can click, look, click again, and look again without
+   * paying for a reload — and without the daemon having to guess which of
+   * several open flows a request belongs to.
+   */
+  async openSession(name, opts) {
+    await this.closeSession(name);
+    const frame = frameOf(opts);
+    const browser = await this.start(policyOf(opts));
+    const context = await browser.newContext(this.contextOptions(frame));
+    if (opts.storage) await seedStorage(context, opts.storage);
+    const page = await context.newPage();
+    await page.goto(opts.url, { waitUntil: opts.waitUntil ?? "domcontentloaded", timeout: opts.timeout ?? 30_000 });
+    const trace = await preparePage(page, opts);
+    const meta = {
+      name,
+      url: page.url(),
+      frame,
+      openedAt: Date.now(),
+      actions: trace.length,
+    };
+    this.sessions.set(name, { page, context, meta });
+    return meta;
+  }
+
+  session(name) {
+    const s = this.sessions.get(name);
+    if (!s || s.page.isClosed()) {
+      throw new Error(`no open session "${name}". Start one with: shot open <route> --session ${name}`);
+    }
+    return s;
+  }
+
+  /** Run actions against a held page, without shooting. */
+  async actOnSession(name, opts) {
+    const s = this.session(name);
+    const trace = await runActions(s.page, opts.do ?? [], { baseUrl: opts.baseUrl, timeout: opts.timeout });
+    s.meta.actions += trace.length;
+    s.meta.url = s.page.url();
+    return { trace, meta: s.meta };
+  }
+
+  /** Change a held page's frame in place — the responsive path for a session. */
+  async resizeSession(name, frame) {
+    const s = this.session(name);
+    await s.page.setViewportSize({ width: frame.width, height: frame.height });
+    // deviceScaleFactor is fixed at context creation, so a scale change is the
+    // one resize that genuinely needs the page rebuilt; reload keeps the URL.
+    s.meta.frame = { ...s.meta.frame, width: frame.width, height: frame.height };
+    return s.meta;
+  }
+
+  async shootSession(name, opts) {
+    const s = this.session(name);
+    const trace = opts.do?.length
+      ? await runActions(s.page, opts.do, { baseUrl: opts.baseUrl, timeout: opts.timeout })
+      : [];
+    if (opts.hide || opts.css || opts.settle) await preparePage(s.page, { ...opts, do: [] });
+    const buf = await shootPage(s.page, opts);
+    s.meta.actions += trace.length;
+    s.meta.url = s.page.url();
+    return { buf, trace, meta: s.meta };
+  }
+
+  async closeSession(name) {
+    const s = this.sessions.get(name);
+    if (!s) return false;
+    this.sessions.delete(name);
+    await s.context.close().catch(() => {});
+    return true;
+  }
+
+  listSessions() {
+    return [...this.sessions.values()].map((s) => ({ ...s.meta, closed: s.page.isClosed() }));
+  }
+
+  async close() {
+    for (const name of [...this.sessions.keys()]) await this.closeSession(name);
+    for (const ctx of this.contexts.values()) await ctx.close().catch(() => {});
+    this.contexts.clear();
+    this.staticPages.clear();
+    for (const browser of this.browsers.values()) await browser.close().catch(() => {});
+    this.browsers.clear();
+    this.browser = null;
+    this.launching.clear();
+  }
+}
+
+/** @param {Record<string, any>} opts */
+export function policyOf(opts) {
+  return { offline: Boolean(opts.offline), block: opts.block ?? [] };
+}
+
+/** @param {Record<string, any>} opts */
+export function frameOf(opts) {
+  return {
+    width: opts.width ?? 1440,
+    height: opts.height ?? 900,
+    scale: opts.scale ?? 2,
+    theme: opts.theme ?? "dark",
+    reducedMotion: opts.reducedMotion !== false,
+  };
+}
+
+async function seedStorage(context, storage) {
+  await context.addInitScript((entries) => {
+    for (const [k, v] of entries) {
+      try {
+        window.localStorage.setItem(k, v);
+      } catch {
+        /* storage may be blocked; the shot is still worth taking */
+      }
+    }
+  }, Object.entries(storage));
+}
+
+/** Waits, ordered actions, and the cosmetic fixes every shot wants. */
+async function preparePage(page, opts) {
+  const timeout = opts.timeout ?? 30_000;
+  if (opts.waitFor) await page.waitForSelector(opts.waitFor, { state: "visible", timeout });
+  if (opts.waitForText) {
+    await page.waitForFunction((t) => document.body.innerText.includes(t), opts.waitForText, { timeout });
+  }
+  if (opts.settle && opts.settle !== "none") await settle(page, opts.settle);
+
+  const trace = await runActions(page, opts.do ?? [], { baseUrl: opts.baseUrl, timeout: opts.actionTimeout });
+  if (trace.length && opts.settle && opts.settle !== "none") await settle(page, "fast");
+
+  // Dev-mode chrome is not product UI, and dev mode is the only way to run the
+  // mock server the app shots come from.
+  const hide = ["nextjs-portal", ...(opts.hide ?? [])];
+  await page.addStyleTag({ content: `${hide.join(",")} { display:none !important }` });
+  if (opts.css) await page.addStyleTag({ content: opts.css });
+  if (opts.delay) await page.waitForTimeout(opts.delay);
+  await page.evaluate(() => document.fonts.ready);
+  return trace;
+}
+
+async function shootPage(page, opts) {
+  const shotOpts = {
+    type: opts.format === "jpeg" ? "jpeg" : "png",
+    ...(opts.format === "jpeg" ? { quality: opts.quality ?? 92 } : {}),
+    animations: "disabled",
+    caret: "hide",
+    ...(opts.mask?.length ? { mask: opts.mask.map((m) => page.locator(m)) } : {}),
+    ...(opts.transparent ? { omitBackground: true } : {}),
+  };
+  if (opts.element) return page.locator(opts.element).first().screenshot(shotOpts);
+  return page.screenshot({ ...shotOpts, fullPage: Boolean(opts.fullPage) });
+}
+
+/**
+ * Wait for a *populated* frame, not merely a mounted one.
+ *
+ * The shell renders before its fetches resolve, so gating on the ready hook
+ * alone reliably captures loading skeletons and a "Reconnecting…" badge. Every
+ * placeholder in the app is the same `.animate-pulse` Skeleton, which makes
+ * their absence a dependable "content is in" signal.
+ *
+ * Each step is best-effort: this also runs against a real backend, where a rail
+ * may legitimately stay empty, and an empty rail is not a reason to fail a shot.
+ */
+async function settle(page, level) {
+  const soft = (p) => p.catch(() => {});
+  await soft(page.waitForSelector('[data-app-shell="ready"]', { state: "visible", timeout: 15_000 }));
+  await soft(
+    page.waitForFunction(() => document.querySelectorAll(".animate-pulse").length === 0, null, {
+      timeout: level === "full" ? 15_000 : 4_000,
+    }),
+  );
+  if (level === "full") {
+    await soft(page.waitForFunction(() => document.body.innerText.includes("Live"), null, { timeout: 8_000 }));
+  }
+  await soft(page.evaluate(() => document.fonts.ready));
+}
+
+/** Write a capture to disk, creating parents. */
+export async function writeShot(path, buf) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, buf);
+  return { path, bytes: buf.length, ...pngSize(buf) };
+}

--- a/shotkit/src/ipc.mjs
+++ b/shotkit/src/ipc.mjs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Client side of the daemon: find the socket, start one if it isn't there, send
+ * newline-delimited JSON.
+ *
+ * A Unix socket rather than a TCP port because it needs no port allocation, no
+ * collision handling between two checkouts, and no listener reachable from off
+ * the machine. The path is keyed by both the protocol version and the checkout,
+ * so upgrading shotkit or working in a second clone starts a fresh daemon
+ * instead of talking to a stale one.
+ */
+
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { connect } from "node:net";
+import { existsSync, readdirSync, statSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const PROTOCOL = 1;
+
+/**
+ * Newest mtime under `src/`. A daemon holds its modules in memory for its whole
+ * life, so editing shotkit and taking a shot would otherwise silently run the
+ * old code — the kind of bug that looks like the fix not working.
+ */
+export function sourceStamp() {
+  let newest = 0;
+  try {
+    for (const f of readdirSync(HERE)) {
+      if (f.endsWith(".mjs")) newest = Math.max(newest, statSync(join(HERE, f)).mtimeMs);
+    }
+  } catch {
+    /* unreadable source: fall back to "unchanged" rather than restart-looping */
+  }
+  return Math.round(newest);
+}
+
+export function socketPath() {
+  if (process.env.SHOTKIT_SOCKET) return process.env.SHOTKIT_SOCKET;
+  const key = createHash("sha1").update(resolve(HERE, "..")).digest("hex").slice(0, 8);
+  return join(tmpdir(), `shotkit-${PROTOCOL}-${key}.sock`);
+}
+
+/** One request, one response. Rejects if the socket is absent or dead. */
+export function send(op, payload = {}, { timeout = 180_000 } = {}) {
+  const path = socketPath();
+  return new Promise((resolvePromise, reject) => {
+    const sock = connect(path);
+    let buffer = "";
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error(`daemon timed out after ${timeout}ms`));
+    }, timeout);
+
+    sock.on("connect", () => sock.write(`${JSON.stringify({ op, ...payload })}\n`));
+    sock.on("data", (chunk) => {
+      buffer += chunk;
+      const nl = buffer.indexOf("\n");
+      if (nl === -1) return;
+      clearTimeout(timer);
+      sock.end();
+      try {
+        const msg = JSON.parse(buffer.slice(0, nl));
+        if (msg.ok === false) reject(Object.assign(new Error(msg.error), { remote: true }));
+        else resolvePromise(msg);
+      } catch (err) {
+        reject(err);
+      }
+    });
+    sock.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+export async function ping({ timeout = 1500 } = {}) {
+  try {
+    return await send("ping", {}, { timeout });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return once a daemon is answering, starting one if needed.
+ *
+ * The daemon binds its socket before it launches Chromium, so this resolves in
+ * a few hundred milliseconds and the browser warms up underneath the first
+ * request rather than in front of it.
+ */
+export async function ensureDaemon({ idleMs, quiet = true } = {}) {
+  const alive = await ping();
+  if (alive && alive.sourceStamp === sourceStamp()) return alive;
+  if (alive) {
+    await send("stop", { keepMock: true }).catch(() => {});
+    for (let i = 0; i < 60 && (await ping({ timeout: 200 })); i++) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  }
+
+  const path = socketPath();
+  // A socket file left behind by a killed daemon refuses connections forever.
+  if (existsSync(path)) {
+    try {
+      unlinkSync(path);
+    } catch {
+      /* another process may have just cleaned it up */
+    }
+  }
+
+  const child = spawn(process.execPath, [join(HERE, "daemon.mjs")], {
+    detached: true,
+    stdio: quiet ? "ignore" : "inherit",
+    env: { ...process.env, ...(idleMs ? { SHOTKIT_IDLE_MS: String(idleMs) } : {}) },
+  });
+  child.unref();
+
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const pong = await ping({ timeout: 500 });
+    if (pong) return pong;
+    await new Promise((r) => setTimeout(r, 60));
+  }
+  throw new Error("daemon did not come up; retry with --no-daemon to see the error");
+}

--- a/shotkit/src/network.mjs
+++ b/shotkit/src/network.mjs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * What the page is allowed to reach.
+ *
+ * A local app is fast; the CDNs it references are not necessarily reachable.
+ * The frontend links Google Fonts, and behind a proxy that cannot reach them
+ * each navigation spent about thirteen seconds waiting before giving up — two
+ * orders of magnitude more than the capture itself. `--offline` turns that wait
+ * into an instant, deterministic failure, and the app renders with its fallback
+ * fonts.
+ *
+ * This is done with Chromium's own host-resolver rules rather than Playwright's
+ * request interception, which is the more obvious tool. Interception is a CDP
+ * feature and it silently stops completing requests when the driver and the
+ * browser build disagree — a mismatch this tool deliberately tolerates, since it
+ * runs against whatever Chromium the host already has. A launch flag has no such
+ * coupling: it is read by the browser, and either the browser starts or it does
+ * not.
+ *
+ * The cost is that the policy belongs to a browser process, not a page, so the
+ * engine keeps one browser per distinct policy.
+ */
+
+/**
+ * @typedef {object} NetworkPolicy
+ * @property {boolean} [offline] resolve nothing but localhost
+ * @property {string[]} [block] additional hosts to fail immediately
+ */
+
+/** A stable key for one policy, used to pick the browser that enforces it. */
+export function policyKey(policy = {}) {
+  const blocked = [...(policy.block ?? [])].sort();
+  if (!policy.offline && blocked.length === 0) return "open";
+  return `${policy.offline ? "offline" : "open"}|${blocked.join(",")}`;
+}
+
+/**
+ * Launch args implementing a policy.
+ *
+ * `~NOTFOUND` makes the resolver fail the lookup outright, so a blocked request
+ * ends in milliseconds instead of a connect timeout.
+ *
+ * Only `localhost` is excluded, and deliberately: EXCLUDE takes hostname
+ * patterns, and adding an IP literal such as `EXCLUDE 127.0.0.1` makes Chromium
+ * reject the entire rule string *silently* — every rule stops applying and the
+ * slow fetches quietly come back. The loopback address needs no exclusion
+ * anyway, since a numeric host never reaches the resolver.
+ * @param {NetworkPolicy} policy
+ * @returns {string[]}
+ */
+export function policyArgs(policy = {}) {
+  const rules = (policy.block ?? []).map((host) => `MAP ${host} ~NOTFOUND`);
+  if (policy.offline) rules.push("MAP * ~NOTFOUND", "EXCLUDE localhost");
+  if (rules.length === 0) return [];
+  return [`--host-resolver-rules=${rules.join(", ")}`];
+}
+
+/** Human-readable summary for `--json` and the status line. */
+export function describePolicy(policy = {}) {
+  if (policy.offline) return "offline (localhost only)";
+  if (policy.block?.length) return `blocking ${policy.block.join(", ")}`;
+  return "open";
+}

--- a/shotkit/src/run.mjs
+++ b/shotkit/src/run.mjs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Run a command the way a terminal would, and keep the escape codes.
+ *
+ * A screenshot of `mycelium memory ls` is worth taking only if it looks like
+ * the real thing, and Rich decides that from the process it finds itself in: no
+ * tty means no color, no box-drawing, no columns. So the command is run under
+ * `script(1)`, which allocates a real pty on both supported hosts — that is the
+ * whole reason this module exists rather than a bare `spawn`.
+ *
+ * `COLUMNS` is set as well as the pty being allocated. `script` gives the child
+ * the size of *our* terminal, which under an agent is either absent or wrong,
+ * and Rich reads `COLUMNS` ahead of the ioctl — so the env var is what actually
+ * decides the width of the output in the image.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { platform } from "node:os";
+
+const SCRIPT_BIN = ["/usr/bin/script", "/bin/script"].find((p) => existsSync(p));
+
+/** Shell-quote one argv entry for the single command string `script` takes. */
+export function shellQuote(arg) {
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(arg)) return arg;
+  return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * @typedef {object} RunOptions
+ * @property {string[]} argv command and arguments; joined into one shell line
+ * @property {string} [cwd]
+ * @property {number} [cols] width handed to the child (default 100)
+ * @property {number} [rows]
+ * @property {number} [timeout] ms before SIGKILL (default 60000)
+ * @property {Record<string,string>} [env] extra environment
+ * @property {boolean} [pty] allocate a pty (default true when `script` exists)
+ */
+
+/**
+ * @param {RunOptions} opts
+ * @returns {Promise<{output:string, exitCode:number, ms:number, command:string, pty:boolean, timedOut:boolean}>}
+ */
+export function runCommand(opts) {
+  const cols = opts.cols ?? 100;
+  const rows = opts.rows ?? 50;
+  const line = opts.argv.map(shellQuote).join(" ");
+  const usePty = (opts.pty ?? true) && Boolean(SCRIPT_BIN);
+
+  const env = {
+    ...process.env,
+    TERM: "xterm-256color",
+    COLUMNS: String(cols),
+    LINES: String(rows),
+    FORCE_COLOR: "1",
+    CLICOLOR_FORCE: "1",
+    PYTHONIOENCODING: "utf-8",
+    PYTHONUNBUFFERED: "1",
+    ...opts.env,
+  };
+  delete env.NO_COLOR;
+
+  let file;
+  let args;
+  if (usePty && platform() === "darwin") {
+    // BSD script: the typescript path comes first, then the command argv.
+    file = SCRIPT_BIN;
+    args = ["-q", "/dev/null", "/bin/sh", "-c", line];
+  } else if (usePty) {
+    // util-linux script: -e propagates the child's exit status, -c takes the
+    // command, and the typescript is discarded.
+    file = SCRIPT_BIN;
+    args = ["-qec", line, "/dev/null"];
+  } else {
+    file = "/bin/sh";
+    args = ["-c", line];
+  }
+
+  const started = Date.now();
+  return new Promise((resolve) => {
+    const child = spawn(file, args, { cwd: opts.cwd ?? process.cwd(), env, stdio: ["ignore", "pipe", "pipe"] });
+    /** @type {Buffer[]} */
+    const chunks = [];
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, opts.timeout ?? 60_000);
+
+    child.stdout.on("data", (d) => chunks.push(d));
+    child.stderr.on("data", (d) => chunks.push(d));
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({
+        output: `\x1b[31m${err.message}\x1b[0m`,
+        exitCode: 127,
+        ms: Date.now() - started,
+        command: line,
+        pty: usePty,
+        timedOut,
+      });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        output: Buffer.concat(chunks).toString("utf8"),
+        exitCode: code ?? 0,
+        ms: Date.now() - started,
+        command: line,
+        pty: usePty,
+        timedOut,
+      });
+    });
+  });
+}
+
+export const ptyAvailable = Boolean(SCRIPT_BIN);

--- a/shotkit/src/sheet.mjs
+++ b/shotkit/src/sheet.mjs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The contact sheet: every breakpoint of one screen, in one image.
+ *
+ * Written for the reader rather than the archive. Checking a responsive layout
+ * means comparing four captures, and four files is four separate looks with the
+ * previous one already out of view — so the frames are composed side by side at
+ * their true relative widths, which is also what makes a phone beside a
+ * 1920 monitor say something. The captures go in as data URIs, so composing
+ * needs no image library and no second trip to disk.
+ */
+
+import { UI_STACK, backdrop, palette } from "./theme.mjs";
+
+/** Widest sheet before everything is scaled down to fit. */
+const MAX_SHEET_WIDTH = 2400;
+
+/**
+ * @param {{label:string, base64:string, width:number, height:number, scale:number}[]} frames
+ * @param {{theme?:"dark"|"light", backdrop?:string, title?:string, gap?:number, padding?:number}} opts
+ */
+export function sheetDocument(frames, opts = {}) {
+  const theme = opts.theme ?? "dark";
+  const pal = palette(theme);
+  const gap = opts.gap ?? 32;
+  const pad = opts.padding ?? 44;
+
+  // Lay out in CSS pixels: a 390-wide phone must read as narrower than a
+  // 1920-wide desktop, which it would not if each were normalized to fit.
+  const cssWidths = frames.map((f) => f.width / (f.scale || 1));
+  const total = cssWidths.reduce((a, b) => a + b, 0) + gap * (frames.length - 1);
+  const k = Math.min(1, (MAX_SHEET_WIDTH - pad * 2) / total);
+
+  const cards = frames
+    .map((f, i) => {
+      const w = Math.round(cssWidths[i] * k);
+      return `<figure style="width:${w}px">
+      <img src="data:image/png;base64,${f.base64}" width="${w}">
+      <figcaption>${escapeHtml(f.label)}</figcaption>
+    </figure>`;
+    })
+    .join("");
+
+  const heading = opts.title
+    ? `<h1>${escapeHtml(opts.title)}</h1>`
+    : "";
+
+  return `<!doctype html><html><head><meta charset="utf-8"><style>
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;background:transparent}
+#canvas{
+  display:inline-block;width:max-content;padding:${pad}px;
+  background:${backdrop(opts.backdrop ?? "mycelium", theme)};
+  font-family:${UI_STACK};
+}
+h1{
+  margin:0 0 22px;font-size:15px;font-weight:600;letter-spacing:.01em;
+  color:${pal.text};
+}
+.row{display:flex;align-items:flex-start;gap:${gap}px}
+figure{margin:0;display:flex;flex-direction:column;gap:9px}
+img{
+  display:block;height:auto;border-radius:8px;
+  border:1px solid ${pal.border2};
+  box-shadow:0 18px 40px -14px rgba(0,0,0,${theme === "dark" ? ".7" : ".25"});
+}
+figcaption{
+  font-size:11.5px;letter-spacing:.02em;color:${pal.muted};text-align:center;
+}
+</style></head><body><div id="canvas">${heading}<div class="row">${cards}</div></div></body></html>`;
+}
+
+const escapeHtml = (s) =>
+  String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");

--- a/shotkit/src/terminal.mjs
+++ b/shotkit/src/terminal.mjs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/** The terminal card: a replayed ANSI stream under an optional prompt line. */
+
+import { ansiToHtml } from "./ansi.mjs";
+import { cardDocument, escapeHtml } from "./card.mjs";
+import { palette } from "./theme.mjs";
+
+/**
+ * @typedef {import("./card.mjs").CardOptions & {
+ *   output: string,
+ *   command?: string,
+ *   prompt?: string,
+ *   exitCode?: number,
+ *   showExit?: boolean,
+ * }} TerminalOptions
+ */
+
+/**
+ * @param {TerminalOptions} opts
+ * @returns {{html:string, rows:number, cols:number}}
+ */
+export function terminalDocument(opts) {
+  const theme = opts.theme ?? "dark";
+  const pal = palette(theme);
+  const rendered = ansiToHtml(opts.output ?? "", pal);
+
+  const parts = [];
+  if (opts.command) {
+    const sigil = opts.prompt ?? "❯";
+    parts.push(
+      `<span class="sigil">${escapeHtml(sigil)}</span> <span class="cmd">${escapeHtml(opts.command)}</span>`,
+    );
+  }
+  parts.push(rendered.html);
+  if (opts.showExit && opts.exitCode) {
+    parts.push(`<span class="exit">exit ${opts.exitCode}</span>`);
+  }
+
+  const extraCss = `
+.sigil{color:${pal.accent};font-weight:600}
+.cmd{color:${pal.text};font-weight:600}
+.exit{color:${pal.red};opacity:.85}
+`;
+
+  // The prompt line adds a row; the command adds to the widest line.
+  const promptCols = opts.command ? opts.command.length + 2 : 0;
+  return {
+    html: cardDocument(parts.join("\n"), { ...opts, theme }, extraCss),
+    rows: rendered.rows + (opts.command ? 1 : 0) + (opts.showExit && opts.exitCode ? 1 : 0),
+    cols: Math.max(rendered.cols, promptCols),
+  };
+}

--- a/shotkit/src/theme.mjs
+++ b/shotkit/src/theme.mjs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The look. Surfaces, text and the 16 ANSI slots, in both themes.
+ *
+ * Values track `mycelium-frontend/src/app/globals.css` so a terminal card sits
+ * next to an app screenshot without clashing: same canvas, same hairlines, same
+ * accent. The ANSI slots reuse the frontend's semantic and categorical hues
+ * rather than the stock VGA palette, which is why `mycelium memory ls` shades
+ * the same teal in a screenshot as it does in the product.
+ */
+
+/** @typedef {"dark"|"light"} ThemeName */
+
+/** @type {Record<ThemeName, Record<string, string>>} */
+export const THEMES = {
+  dark: {
+    bg: "#0c0e11",
+    surface: "#14171c",
+    paper: "#191d22",
+    elevated: "#21262d",
+    text: "#e8ebee",
+    muted: "#a7adb5",
+    faint: "#565d65",
+    border: "rgba(255, 255, 255, 0.08)",
+    border2: "rgba(255, 255, 255, 0.16)",
+    accent: "#5cc7d2",
+    accentFg: "#06181b",
+    accentSoft: "rgba(92, 199, 210, 0.13)",
+    green: "#4fc296",
+    yellow: "#d9a94e",
+    red: "#e6746f",
+    // 0-7 then bright 8-15.
+    ansi: [
+      "#21262d", "#e6746f", "#4fc296", "#d9a94e",
+      "#656fe2", "#e265ae", "#5cc7d2", "#e8ebee",
+      "#565d65", "#f0918c", "#6fd6ae", "#e6c274",
+      "#8a92ea", "#ea8cc2", "#7fd9e2", "#ffffff",
+    ],
+  },
+  light: {
+    bg: "#ffffff",
+    surface: "#f2f4f6",
+    paper: "#ffffff",
+    elevated: "#ffffff",
+    text: "#14171b",
+    muted: "#545c65",
+    faint: "#9198a0",
+    border: "rgba(17, 20, 24, 0.10)",
+    border2: "rgba(17, 20, 24, 0.17)",
+    accent: "#0c7d8f",
+    accentFg: "#ffffff",
+    accentSoft: "rgba(12, 125, 143, 0.10)",
+    green: "#0d8a63",
+    yellow: "#8a6410",
+    red: "#bd3f3a",
+    ansi: [
+      "#14171b", "#bd3f3a", "#0d8a63", "#8a6410",
+      "#212fca", "#ca2183", "#0c7d8f", "#545c65",
+      "#9198a0", "#d4615b", "#12a87b", "#a87d1b",
+      "#4450d8", "#d84a9f", "#1298ad", "#14171b",
+    ],
+  },
+};
+
+/**
+ * Backdrops the card floats on. `none` leaves the canvas transparent, which is
+ * what you want when the image is going into a page that has its own
+ * background; everything else pads the card so the drop shadow has room.
+ */
+export const BACKDROPS = {
+  mycelium: {
+    dark: "radial-gradient(120% 120% at 12% 0%, #17323a 0%, #101a20 45%, #0a0c0f 100%)",
+    light: "radial-gradient(120% 120% at 12% 0%, #dff1f4 0%, #eef2f4 45%, #e4e8ec 100%)",
+  },
+  dusk: {
+    dark: "linear-gradient(135deg, #2b2140 0%, #1b1930 55%, #101019 100%)",
+    light: "linear-gradient(135deg, #efe7fb 0%, #e6e9f7 55%, #dfe2ee 100%)",
+  },
+  ink: { dark: "#08090b", light: "#eceef1" },
+  paper: { dark: "#14171c", light: "#f2f4f6" },
+  none: { dark: "transparent", light: "transparent" },
+};
+
+/**
+ * Font stacks, not webfonts: the renderer must not touch the network, so each
+ * stack lists the macOS face first and the face that ships on this repo's Linux
+ * images second. Editing these is how you retarget the tool at a new host.
+ */
+export const MONO_STACK =
+  'ui-monospace, "SF Mono", SFMono-Regular, Menlo, "JetBrains Mono", ' +
+  '"IBM Plex Mono", "DejaVu Sans Mono", "Liberation Mono", Consolas, monospace';
+
+export const UI_STACK =
+  '-apple-system, BlinkMacSystemFont, "Inter", "IBM Plex Sans", ' +
+  '"DejaVu Sans", "Liberation Sans", system-ui, sans-serif';
+
+/** @param {ThemeName} name */
+export function palette(name) {
+  return THEMES[name] ?? THEMES.dark;
+}
+
+/**
+ * Resolve `--backdrop`: a preset name, or any CSS the caller wants to drop in
+ * verbatim (`"#111"`, `"linear-gradient(...)"`).
+ * @param {string} value
+ * @param {ThemeName} theme
+ */
+export function backdrop(value, theme) {
+  const preset = BACKDROPS[value];
+  if (preset) return preset[theme];
+  return value;
+}

--- a/shotkit/src/viewports.mjs
+++ b/shotkit/src/viewports.mjs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Named frames, so "does this look right on a phone" is one word rather than
+ * three numbers. Sizes are CSS pixels at each device's real pixel ratio, which
+ * is what the app's media queries respond to.
+ */
+
+/** @typedef {{width:number, height:number, scale:number, label:string}} Viewport */
+
+/** @type {Record<string, Viewport>} */
+export const VIEWPORTS = {
+  phone: { width: 390, height: 844, scale: 3, label: "iPhone 15 · 390×844" },
+  "phone-sm": { width: 360, height: 780, scale: 3, label: "Small Android · 360×780" },
+  tablet: { width: 834, height: 1112, scale: 2, label: "iPad Air · 834×1112" },
+  laptop: { width: 1280, height: 800, scale: 2, label: "Laptop · 1280×800" },
+  desktop: { width: 1440, height: 900, scale: 2, label: "Desktop · 1440×900" },
+  wide: { width: 1920, height: 1080, scale: 2, label: "Wide · 1920×1080" },
+};
+
+/** The ladder `--responsive` walks: one frame either side of every breakpoint. */
+export const RESPONSIVE_SET = ["phone", "tablet", "laptop", "wide"];
+
+/**
+ * Resolve `--viewport`: a preset name, or `WIDTHxHEIGHT[@SCALE]`.
+ * @param {string} name
+ * @returns {Viewport}
+ */
+export function resolveViewport(name) {
+  const preset = VIEWPORTS[name];
+  if (preset) return preset;
+  const m = /^(\d+)x(\d+)(?:@([\d.]+))?$/.exec(String(name).trim());
+  if (!m) {
+    throw new Error(`unknown viewport "${name}". Presets: ${Object.keys(VIEWPORTS).join(", ")}, or 1280x800@2`);
+  }
+  const width = Number(m[1]);
+  const height = Number(m[2]);
+  const scale = m[3] ? Number(m[3]) : 2;
+  return { width, height, scale, label: `${width}×${height}` };
+}
+
+/**
+ * Expand `--viewports a,b,c` / `--responsive` into the list to shoot.
+ * @param {{viewport?:string, viewports?:string, responsive?:boolean}} spec
+ * @returns {{name:string, viewport:Viewport}[]}
+ */
+export function viewportList(spec) {
+  let names;
+  if (spec.viewports) names = String(spec.viewports).split(",").map((s) => s.trim()).filter(Boolean);
+  else if (spec.responsive) names = RESPONSIVE_SET;
+  else if (spec.viewport) names = [spec.viewport];
+  else return [];
+  return names.map((name) => ({ name, viewport: resolveViewport(name) }));
+}

--- a/shotkit/test/selftest.mjs
+++ b/shotkit/test/selftest.mjs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * A smoke test for the parts that hold real logic and no browser: the ANSI
+ * screen buffer, the highlight-line splitter, the argument parser and the
+ * network policy. These are where the subtle bugs live — a `\r` that stacks two
+ * frames into one image, a resolver rule that silently disables itself — and
+ * they are all pure functions, so they can be checked without a Chromium.
+ *
+ *   node test/selftest.mjs
+ */
+
+import assert from "node:assert/strict";
+import { ansiToHtml, parseAnsi, stripAnsi } from "../src/ansi.mjs";
+import { splitHighlightedLines, guessLanguage } from "../src/code.mjs";
+import { parse } from "../src/args.mjs";
+import { policyArgs, policyKey } from "../src/network.mjs";
+import { resolveViewport, viewportList } from "../src/viewports.mjs";
+import { parseAction } from "../src/actions.mjs";
+import { palette } from "../src/theme.mjs";
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+  } catch (err) {
+    failures += 1;
+    process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+  }
+}
+
+const text = (input) => parseAnsi(input).map((r) => r.runs.map((x) => x.text).join(""));
+
+test("carriage return overwrites the line rather than appending", () => {
+  assert.deepEqual(text("first\rsecond"), ["second"]);
+});
+
+test("erase-to-end clears the tail a shorter repaint leaves behind", () => {
+  assert.deepEqual(text("aaaaaaa\rbb\x1b[K"), ["bb"]);
+});
+
+test("cursor-up repaints the row instead of adding one", () => {
+  assert.deepEqual(text("one\ntwo\n\x1b[2A\x1b[Kuno"), ["uno", "two"]);
+});
+
+test("a trailing newline does not add a blank row", () => {
+  assert.equal(parseAnsi("only\n").length, 1);
+});
+
+test("tabs advance to the next 8-column stop", () => {
+  assert.deepEqual(text("ab\tc"), ["ab      c"]);
+});
+
+test("SGR colors resolve against the theme, bold picks the bright slot", () => {
+  const pal = palette("dark");
+  const { html } = ansiToHtml("\x1b[31mred\x1b[0m \x1b[1;31mbright\x1b[0m", pal);
+  assert.ok(html.includes(pal.ansi[1]), "expected the red slot");
+  assert.ok(html.includes(pal.ansi[9]), "expected the bright red slot");
+});
+
+test("256-color and truecolor become rgb", () => {
+  const { html } = ansiToHtml("\x1b[38;5;208morange\x1b[0m\x1b[38;2;1;2;3mexact\x1b[0m", palette("dark"));
+  assert.ok(html.includes("rgb(255,135,0)"));
+  assert.ok(html.includes("rgb(1,2,3)"));
+});
+
+test("html is escaped, so output cannot inject markup", () => {
+  const { html } = ansiToHtml("<script>alert(1)</script>", palette("dark"));
+  assert.ok(!html.includes("<script>"));
+  assert.ok(html.includes("&lt;script&gt;"));
+});
+
+test("OSC 8 hyperlinks are dropped but keep their text", () => {
+  assert.deepEqual(text("\x1b]8;;https://example.com\x07label\x1b]8;;\x07"), ["label"]);
+});
+
+test("stripAnsi leaves plain text", () => {
+  assert.equal(stripAnsi("\x1b[1;36mhi\x1b[0m"), "hi");
+});
+
+test("splitting highlighted lines reopens spans across the break", () => {
+  const lines = splitHighlightedLines('<span class="hljs-comment">a\nb</span>c');
+  assert.equal(lines.length, 2);
+  assert.equal(lines[0], '<span class="hljs-comment">a</span>');
+  assert.ok(lines[1].startsWith('<span class="hljs-comment">b</span>'));
+});
+
+test("language is guessed from the extension", () => {
+  assert.equal(guessLanguage("src/api.mjs"), "javascript");
+  assert.equal(guessLanguage("app/services/l9.py"), "python");
+  assert.equal(guessLanguage("config.toml"), "ini");
+});
+
+test("term stops parsing its own flags at the command", () => {
+  const { flags, rest } = parse(
+    ["--cols", "84", "mycelium", "memory", "ls", "--room", "atlas"],
+    { cols: { type: "number" }, room: { type: "string" } },
+    { stopAtPositional: true },
+  );
+  assert.equal(flags.cols, 84);
+  assert.equal(flags.room, undefined, "--room belongs to the child command");
+  assert.deepEqual(rest, ["mycelium", "memory", "ls", "--room", "atlas"]);
+});
+
+test("--no-<flag> negates a boolean", () => {
+  const { flags } = parse(["--no-shadow"], { shadow: { type: "boolean" } });
+  assert.equal(flags.shadow, false);
+});
+
+test("repeatable and key=value flags accumulate", () => {
+  const { flags } = parse(
+    ["--do", "click:A", "--do", "wait:.b", "--env", "K=V"],
+    { do: { type: "list" }, env: { type: "map" } },
+  );
+  assert.deepEqual(flags.do, ["click:A", "wait:.b"]);
+  assert.deepEqual(flags.env, { K: "V" });
+});
+
+test("an unknown option is an error, not a silent drop", () => {
+  assert.throws(() => parse(["--nope"], {}), /unknown option/);
+});
+
+test("an open policy adds no launch args", () => {
+  assert.deepEqual(policyArgs({}), []);
+  assert.equal(policyKey({}), "open");
+});
+
+test("offline excludes localhost by name and never by IP literal", () => {
+  const [arg] = policyArgs({ offline: true });
+  assert.ok(arg.includes("MAP * ~NOTFOUND"));
+  assert.ok(arg.includes("EXCLUDE localhost"));
+  // An IP literal here makes Chromium reject the whole rule string silently.
+  assert.ok(!arg.includes("127.0.0.1"), "an IP literal would disable every rule");
+});
+
+test("blocked hosts become resolver failures", () => {
+  assert.deepEqual(policyArgs({ block: ["fonts.googleapis.com"] }), [
+    "--host-resolver-rules=MAP fonts.googleapis.com ~NOTFOUND",
+  ]);
+});
+
+test("viewports accept presets and explicit sizes", () => {
+  assert.equal(resolveViewport("phone").width, 390);
+  assert.deepEqual(
+    { ...resolveViewport("1280x800@1.5"), label: undefined },
+    { width: 1280, height: 800, scale: 1.5, label: undefined },
+  );
+  assert.throws(() => resolveViewport("enormous"), /unknown viewport/);
+});
+
+test("--responsive expands to the breakpoint ladder", () => {
+  assert.deepEqual(viewportList({ responsive: true }).map((v) => v.name), [
+    "phone",
+    "tablet",
+    "laptop",
+    "wide",
+  ]);
+  assert.deepEqual(viewportList({}), []);
+});
+
+test("an action splits on its first colon only", () => {
+  assert.deepEqual(parseAction("fill:#q=a:b"), { verb: "fill", arg: "#q=a:b" });
+  assert.deepEqual(parseAction("reload"), { verb: "reload", arg: "" });
+});
+
+process.stdout.write(failures ? `\n${failures} failing\n` : "\nall passing\n");
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## Summary

A new top-level `shotkit/` — the repo's camera. Screenshots of the running app
and of CLI output, fast enough for an agent to take one mid-thought: one line
in, an absolute PNG path out, ready to read back.

The speed comes from holding things open. A background daemon keeps the
browser, the mock dev server and the card-rendering page alive between
invocations, so the costs that dominate a naive screenshot script are paid once
rather than per shot:

```
$ shot bench
cold (no daemon, includes browser launch): 2142ms
warm x6: min 134ms · median 163ms · max 486ms
speedup: 13.1x
```

`pnpm screenshots`, which publishes the committed docs assets, now runs on this
engine instead of its own Playwright boot. Booting the mock server, finding a
usable Chromium, waiting for a populated frame and driving the page are the same
problems whether the caller is that pipeline or an agent at a terminal, and they
were solved twice.

## Changes

**Capture surfaces, one card renderer**

- `shot app` / `shot url` drive a page. `--mock` boots `pnpm dev:mock` inside the
  daemon so repeated shots reuse it; an already-running dev server is found from
  `.next/dev/lock` whatever port it is on.
- `shot term` runs a command under a pty so Rich keeps its colors and box
  drawing, replays the stream through a small screen buffer, and renders it as a
  Carbon-style card in the frontend's own palette. The replay is load-bearing: a
  spinner redraws with `\r` and a Live region repaints by moving the cursor up,
  so concatenating the raw stream stacks every intermediate frame into one image.
- `shot code` (highlight.js, themed to the frontend's tokens) and `shot html`
  share that chrome. `shot text` renders an ANSI log you already have.
- `--chrome` re-renders a page capture inside the same window frame with an
  address bar, so a framed app screenshot and a framed terminal card match.
  `--theme` drives the app's own theme, not just `prefers-color-scheme` —
  next-themes reads `localStorage` before first paint and would otherwise win.

**Responsivity**

- `--responsive` / `--viewports phone,wide` / `--viewport 1280x800@2`.
- `--sheet` composes the frames into one contact sheet at their true relative
  widths, so checking a layout is one image to look at rather than four.

**Navigation control**

- `--do <verb:arg>` runs ordered steps before a shot — order is the point, since
  a tab three clicks deep isn't expressible as an unordered set of flags.
- For longer flows the daemon holds a named page: `open` / `do` / `shoot` /
  `close`, ~250ms a frame, so you can look, decide, then act without replaying
  from a cold load. Element arguments take any Playwright selector engine; a bare
  word resolves by accessible name, then visible text.

**Two environment problems handled rather than assumed away**

- Playwright pins an exact browser build and refuses others. Launch falls back to
  `executablePath` for whatever Chromium is on disk, so a driver/browser skew is
  not a re-download.
- A page linking an unreachable CDN spends ~13s *per navigation* waiting on it —
  more than everything else combined. `--offline` applies Chromium host-resolver
  rules, via a launch flag rather than request interception, which stops
  completing requests when driver and browser builds disagree.

**Discovery**

- A `screenshot` skill, so agents reach for this instead of hand-rolling
  Playwright, and a short note in `CLAUDE.md`.
- Captures land in gitignored `.shotkit/`; committed docs assets keep their own
  pipeline.

## Testing

`shotkit/test/selftest.mjs` — 22 browserless assertions over the parts that hold
real logic and where the subtle bugs live: the ANSI screen buffer (`\r`
overwrite, `ESC[K` erase, cursor-up repaint, 256/truecolor, HTML escaping), the
highlight-line splitter, the argument parser's passthrough rule, the network
policy, viewport resolution.

That policy test is not decorative. `EXCLUDE 127.0.0.1` in a host-resolver rule
makes Chromium reject the entire rule string *silently* — every rule stops
applying and the slow fetches quietly come back. It cost an hour to find, so it
is pinned.

Manually exercised on Linux against the mock frontend: every command surface
(`app`, `url`, `term`, `text`, `code`, `html`, `open`/`do`/`shoot`/`close`,
`warm`/`status`/`stop`, `doctor`, `bench`), both themes, `--responsive --sheet`,
`--chrome`, and `pnpm screenshots` end to end. macOS paths (BSD `script(1)`
argument order, the Playwright cache location, `open`) are written but not
exercised — no macOS host in this environment.

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`) — untouched; this PR adds no Python
- [ ] Linting passes (`uv run ruff check .`) — untouched
- [ ] Format check passes (`uv run ruff format --check .`) — untouched
- [x] `node shotkit/test/selftest.mjs` — 22 passing
- [x] `pnpm screenshots room-plan --offline` publishes the same four files, in 2.7s

Regenerated docs PNGs were reverted rather than committed: this environment has
no webfonts, so they would have been a downgrade of the published assets.

## Related Issues

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwMZzsVJawEdEQoAusNyZe)_