### PR TITLE
shotkit: render the mycelial network as a backdrop

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -101,9 +101,15 @@ and `shot code <file> --range 40:80` makes a syntax-highlighted code card.
 ```bash
 node shotkit/bin/shot.mjs app /room/atlas --chrome --offline          # browser window frame
 node shotkit/bin/shot.mjs app / --chrome --theme light --backdrop dusk
+node shotkit/bin/shot.mjs app / --chrome --backdrop mycelial --padding 90
 ```
 
 `--theme` switches the app itself, not just the browser's media query.
+
+`--backdrop mycelial` is the desktop behind the window: the docs site's own
+mycelial network, the same one `docs/banner.png` is cut from. Give it padding to
+show — and prefer a quiet backdrop (`mycelium`, `ink`, `paper`) when the screen
+itself is busy.
 
 ## Rules
 

--- a/shotkit/README.md
+++ b/shotkit/README.md
@@ -49,6 +49,9 @@ speedup: 13.1x
 | `shot warm` / `status` / `stop` / `serve` | the daemon |
 | `shot doctor` / `bench` | check and time this machine |
 
+`--backdrop` takes `mycelial` (the site's network — see **The desktop**),
+`mycelium`, `dusk`, `ink`, `paper`, `none`, or any CSS.
+
 `shot help <command>` lists every flag. stdout carries the path and nothing
 else, so it composes: `open "$(shot app / --mock)"`.
 
@@ -120,6 +123,33 @@ shot app / --chrome --theme dark --chrome-theme light
 
 `--theme` drives the app's own theme, not just the browser's `prefers-color-scheme`:
 next-themes reads `localStorage` before first paint and would otherwise ignore it.
+
+## The desktop
+
+`--backdrop mycelial` puts the docs site's own hypha network behind the window,
+so a framed screenshot sits on the product's background rather than a gradient:
+
+```bash
+shot app /room/atlas --chrome --backdrop mycelial --padding 90
+shot term --backdrop mycelial -- mycelium memory ls --room atlas
+```
+
+It is the same network in both senses. The algorithm is the one the live site
+runs — read from `scripts/banner-assets/mycelial-canvas.js`, the copy
+`docs/banner.png` is already cut from, rather than a third transcription of it
+— and the colors are the site's `--canvas-*` values, cream and quiet in light,
+near-black and teal in dark.
+
+One network is grown per theme and held for the life of the daemon, so a run of
+shots shares one desktop and only the first pays to grow it — about 150ms once,
+after which a framed shot costs what any other does. It grows from a fixed seed,
+so the same command gives the same background tomorrow and a committed asset
+does not churn on every re-render; `--backdrop-seed <n>` asks for a different
+one.
+
+The other backdrops (`mycelium`, `dusk`, `ink`, `paper`, `none`, or any CSS you
+pass) are unchanged, and are what to reach for when a shot wants quiet behind
+it: the network is texture, and texture competes with a busy screen.
 
 ## The library
 

--- a/shotkit/README.md
+++ b/shotkit/README.md
@@ -140,6 +140,12 @@ runs — read from `scripts/banner-assets/mycelial-canvas.js`, the copy
 — and the colors are the site's `--canvas-*` values, cream and quiet in light,
 near-black and teal in dark.
 
+A vignette in the ground's own color veils it, lightly in the middle and
+heavily at the edges. The site can run the network at full strength because
+prose sits on near-solid paper above it; a screenshot has no such pane, and an
+unveiled network pulls the eye into the corners and away from the window. Light
+is veiled less than dark, since the site already runs it quieter.
+
 One network is grown per theme and held for the life of the daemon, so a run of
 shots shares one desktop and only the first pays to grow it — about 150ms once,
 after which a framed shot costs what any other does. It grows from a fixed seed,

--- a/shotkit/bin/shot.mjs
+++ b/shotkit/bin/shot.mjs
@@ -46,7 +46,8 @@ const CHROME = {
   chrome: { type: "boolean", help: "wrap the capture in browser window chrome" },
   address: { type: "string", help: "address-bar text (default: the route)" },
   "chrome-theme": { type: "string", value: "dark|light", help: "frame theme, when it differs from the app's" },
-  backdrop: { type: "string", value: "<preset|css>", help: "mycelium|dusk|ink|paper|none, or any CSS" },
+  backdrop: { type: "string", value: "<preset|css>", help: "mycelial|mycelium|dusk|ink|paper|none, or any CSS" },
+  "backdrop-seed": { type: "number", help: "which network --backdrop mycelial grows" },
   padding: { type: "number", help: "gutter around the frame (default 40)" },
   radius: { type: "number", help: "corner radius (default 12)" },
   shadow: { type: "boolean", help: "drop shadow (default on)" },
@@ -68,7 +69,8 @@ const DAEMON = {
 
 const CARD = {
   title: { type: "string", help: "title bar text" },
-  backdrop: { type: "string", value: "<preset|css>", help: "mycelium|dusk|ink|paper|none, or any CSS" },
+  backdrop: { type: "string", value: "<preset|css>", help: "mycelial|mycelium|dusk|ink|paper|none, or any CSS" },
+  "backdrop-seed": { type: "number", help: "which network --backdrop mycelial grows" },
   padding: { type: "number", help: "gutter around the card (default 40)" },
   radius: { type: "number", help: "corner radius (default 12)" },
   shadow: { type: "boolean", help: "drop shadow (default on)" },

--- a/shotkit/src/api.mjs
+++ b/shotkit/src/api.mjs
@@ -21,6 +21,7 @@ import { codeDocument } from "./code.mjs";
 import { terminalDocument } from "./terminal.mjs";
 import { cardDocument, imageCardDocument } from "./card.mjs";
 import { sheetDocument } from "./sheet.mjs";
+import { mycelialArt } from "./mycelial.mjs";
 import { resolveBaseUrl } from "./app.mjs";
 import { runCommand } from "./run.mjs";
 import { stripAnsi } from "./ansi.mjs";
@@ -50,6 +51,7 @@ import { viewportList } from "./viewports.mjs";
  * @property {string} [address] address-bar text when `chrome` is set
  * @property {"dark"|"light"} [chromeTheme] frame theme, when it should differ
  *   from the app's — a light frame around a dark app, say
+ * @property {number} [backdropSeed] which network `--backdrop mycelial` grows
  */
 
 export const DEFAULT_OUT_DIR = process.env.SHOTKIT_OUT ?? resolve(REPO_ROOT, ".shotkit");
@@ -85,6 +87,23 @@ export async function shutdown() {
 
 const CARD_KEYS = ["theme", "backdrop", "padding", "radius", "shadow", "window", "title", "fontSize", "lineHeight", "font", "cols", "maxWidth"];
 const pickCard = (spec) => Object.fromEntries(CARD_KEYS.filter((k) => spec[k] !== undefined).map((k) => [k, spec[k]]));
+
+/**
+ * The artwork layer behind the card, for the backdrops that have one.
+ *
+ * Only `mycelial` does. It is a backdrop rather than a flag of its own because
+ * that is where a caller looks for what the image sits on, but growing the
+ * network is a render and not a CSS lookup, so it resolves here — where the
+ * engine is — instead of in the string table.
+ *
+ * @param {any} eng @param {Record<string,any>} spec @param {string} theme
+ * @returns {Promise<string|undefined>}
+ */
+async function artFor(eng, spec, theme) {
+  if (spec.backdrop !== "mycelial") return undefined;
+  return mycelialArt(eng, { theme: theme === "light" ? "light" : "dark", seed: spec.backdropSeed });
+}
+
 const pickStatic = (spec) => ({
   theme: spec.theme,
   scale: spec.scale,
@@ -165,20 +184,15 @@ async function wrapChrome(eng, buf, spec, address) {
   if (!spec.chrome) return buf;
   const scale = spec.scale ?? 2;
   const { width } = pngSize(buf);
+  const theme = spec.chromeTheme ?? spec.theme ?? "dark";
   const html = imageCardDocument(buf.toString("base64"), Math.round(width / scale), {
     ...pickCard(spec),
-    theme: spec.chromeTheme ?? spec.theme ?? "dark",
+    theme,
+    art: await artFor(eng, spec, theme),
     address: spec.address ?? address,
   });
   // Same scale as the capture, so one image pixel lands on one device pixel.
-  return eng.captureStatic({
-    html,
-    ...pickStatic(spec),
-    theme: spec.chromeTheme ?? spec.theme ?? "dark",
-    scale,
-    width: 2600,
-    height: 2000,
-  });
+  return eng.captureStatic({ html, ...pickStatic(spec), theme, scale, width: 2600, height: 2000 });
 }
 
 /** app/url/session ops all need to know where the app is. */
@@ -218,6 +232,7 @@ async function captureResponsive({ base, spec, pageSpec, frames, fallbackName, e
   const html = sheetDocument(composed, {
     theme: spec.theme ?? "dark",
     backdrop: spec.backdrop,
+    art: await artFor(eng, spec, spec.theme ?? "dark"),
     title: spec.sheetTitle ?? `${spec.route ?? url} — ${frames.map((f) => f.name).join(" · ")}`,
   });
   const buf = await eng.captureStatic({ html, ...pickStatic(spec), scale: 1, width: 2600, height: 2000 });
@@ -233,6 +248,7 @@ async function renderCard(spec, eng) {
   let html;
   let selector;
   let fallbackName;
+  const card = { ...pickCard(spec), art: await artFor(eng, spec, spec.theme ?? "dark") };
 
   if (spec.op === "term") {
     let output = spec.text;
@@ -256,7 +272,7 @@ async function renderCard(spec, eng) {
       if (spec.echo) meta.plain = stripAnsi(output);
     }
     const doc = terminalDocument({
-      ...pickCard(spec),
+      ...card,
       output,
       command: spec.prompt === false ? undefined : command,
       prompt: typeof spec.prompt === "string" ? spec.prompt : undefined,
@@ -269,14 +285,14 @@ async function renderCard(spec, eng) {
     meta.cols = doc.cols;
     fallbackName = `term-${slug(command ?? "text")}`;
   } else if (spec.op === "code") {
-    const doc = await codeDocument({ ...pickCard(spec), ...pickCode(spec) });
+    const doc = await codeDocument({ ...card, ...pickCode(spec) });
     html = doc.html;
     meta.lang = doc.lang;
     meta.rows = doc.rows;
     fallbackName = `code-${slug(spec.file ? basename(spec.file) : (spec.lang ?? "snippet"))}`;
   } else {
     const source = spec.html ?? (await readFile(resolve(spec.file), "utf8"));
-    html = spec.raw === false ? cardDocument(source, pickCard(spec)) : source;
+    html = spec.raw === false ? cardDocument(source, card) : source;
     selector = spec.element ?? (html.includes('id="canvas"') ? "#canvas" : "body");
     fallbackName = spec.file ? `html-${slug(basename(spec.file))}` : "html";
   }

--- a/shotkit/src/card.mjs
+++ b/shotkit/src/card.mjs
@@ -23,6 +23,8 @@ const escapeHtml = (s) =>
  * @typedef {object} CardOptions
  * @property {"dark"|"light"} [theme]
  * @property {string} [backdrop] preset name or literal CSS
+ * @property {string} [art] a CSS background painted over the backdrop, behind
+ *   the card — the mycelial network arrives this way
  * @property {number} [padding] gutter between backdrop edge and card
  * @property {number} [radius]
  * @property {boolean} [shadow]
@@ -83,10 +85,17 @@ export function cardDocument(bodyHtml, opts = {}, extraCss = "") {
 html,body{margin:0;padding:0;background:transparent}
 body{-webkit-font-smoothing:antialiased;text-rendering:geometricPrecision}
 #canvas{
+  position:relative;
   display:inline-block;width:max-content;padding:${pad}px;
   background:${backdrop(opts.backdrop ?? "mycelium", theme)};
 }
+/* Artwork is its own layer rather than a second background on #canvas, so that
+   image-rendering reaches the network and nothing else: the card body holds a
+   page capture placed at 1:1, and pixelating that would undo the point of it. */
+#art{position:absolute;inset:0;image-rendering:pixelated;background:${opts.art ?? "none"}}
 #card{
+  /* Lifted over #art, which is positioned and would otherwise paint on top. */
+  position:relative;
   width:max-content;${maxWidth}
   background:${pal.paper};
   border:1px solid ${pal.border2};
@@ -130,7 +139,7 @@ body{-webkit-font-smoothing:antialiased;text-rendering:geometricPrecision}
   white-space:pre;tab-size:8;
 }
 ${extraCss}
-</style></head><body><div id="canvas"><div id="card">${titleBar}<div class="body">${bodyHtml}</div></div></div></body></html>`;
+</style></head><body><div id="canvas">${opts.art ? '<div id="art"></div>' : ""}<div id="card">${titleBar}<div class="body">${bodyHtml}</div></div></div></body></html>`;
 }
 
 /**

--- a/shotkit/src/doctor.mjs
+++ b/shotkit/src/doctor.mjs
@@ -14,6 +14,7 @@ import { platform, release } from "node:os";
 import { DEFAULT_OUT_DIR } from "./api.mjs";
 import { FRONTEND_DIR } from "./app.mjs";
 import { loadPlaywright, REPO_ROOT } from "./engine.mjs";
+import { CANVAS_SOURCE } from "./mycelial.mjs";
 import { candidates, launchChromium } from "./browser.mjs";
 import { ptyAvailable } from "./run.mjs";
 import { ping, socketPath } from "./ipc.mjs";
@@ -59,6 +60,10 @@ export async function doctor() {
   } catch {
     warn("highlight.js missing — `shot code` renders plain. Run `npm install` in shotkit/");
   }
+
+  head("backdrop");
+  if (existsSync(`${REPO_ROOT}/${CANVAS_SOURCE}`)) ok(`${CANVAS_SOURCE} present — \`--backdrop mycelial\` grows the site's network`);
+  else warn(`${CANVAS_SOURCE} missing — \`--backdrop mycelial\` errors; the other presets are unaffected`);
 
   head("app");
   if (existsSync(`${FRONTEND_DIR}/node_modules`)) ok("mycelium-frontend deps installed — --mock can boot dev:mock");

--- a/shotkit/src/mycelial.mjs
+++ b/shotkit/src/mycelial.mjs
@@ -37,9 +37,42 @@ export const CANVAS_SOURCE = "scripts/banner-assets/mycelial-canvas.js";
  * site's, kept rather than re-tuned.
  */
 export const CANVAS_VARS = {
-  dark: { bg: "#0c0e11", ink: "92, 199, 210", alpha: 1 },
-  light: { bg: "#f4ecda", ink: "12, 125, 143", alpha: 0.72 },
+  dark: { bg: "#0c0e11", rgb: "12, 14, 17", ink: "92, 199, 210", alpha: 1 },
+  light: { bg: "#f4ecda", rgb: "244, 236, 218", ink: "12, 125, 143", alpha: 0.72 },
 };
+
+/**
+ * How hard the vignette veils the network, per theme: center, midpoint, edge.
+ *
+ * Light is veiled less than dark, not more. The site already runs light at
+ * `--canvas-alpha: 0.72` against dark's 1, so an equal veil quiets it twice and
+ * the network disappears into the cream — the same asymmetry the site tunes for,
+ * applied on this side of it.
+ */
+export const VEIL = {
+  dark: [0.3, 0.58, 0.9],
+  light: [0.12, 0.32, 0.68],
+};
+
+/**
+ * A vignette over the network, in the ground's own color.
+ *
+ * The site can run the network at full strength because prose sits on near-solid
+ * paper above it. A screenshot has no such pane: the network is next to the
+ * window rather than under it, and at full strength the corners pull the eye off
+ * the thing being shown. So it is veiled a little everywhere and a lot at the
+ * edges — enough to read as a desktop, not enough to compete with one.
+ *
+ * @param {"dark"|"light"} theme
+ */
+function vignette(theme) {
+  const g = CANVAS_VARS[theme].rgb;
+  const [center, mid, edge] = VEIL[theme];
+  return (
+    `radial-gradient(125% 125% at 50% 40%, rgba(${g},${center}) 0%, ` +
+    `rgba(${g},${mid}) 45%, rgba(${g},${edge}) 100%)`
+  );
+}
 
 /**
  * Hero-page proportions, the same ones `gen-banner-network.py` renders at. The
@@ -141,7 +174,11 @@ export async function mycelialArt(eng, opts = {}) {
       width: RENDER_W,
       height: RENDER_H,
     });
-    return `url("data:image/png;base64,${buf.toString("base64")}") center/cover no-repeat`;
+    // One value, two background layers: CSS paints the first over the second, so
+    // the vignette rides on the network without a second element to position.
+    // `image-rendering` leaves a gradient alone — nothing is being rescaled —
+    // so the veil stays smooth while the cells below it stay hard-edged.
+    return `${vignette(theme)}, url("data:image/png;base64,${buf.toString("base64")}") center/cover no-repeat`;
   })();
   // A failed render must not become the cached answer for the rest of the
   // process — the next shot should get another go at it.

--- a/shotkit/src/mycelial.mjs
+++ b/shotkit/src/mycelial.mjs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The mycelial network, as something a card can sit on.
+ *
+ * The docs site paints a growing hypha network behind the page, and
+ * `docs/banner.png` is a still frame of that same canvas, cropped and upscaled.
+ * A framed app screenshot wants the same thing behind the window — a desktop,
+ * not a gradient — so this renders the network once and hands back a CSS
+ * background the card renderer can drop into its backdrop layer.
+ *
+ * The algorithm is not reimplemented here. `scripts/banner-assets/mycelial-canvas.js`
+ * is already the repo's shared copy of the live site's canvas IIFE, kept there
+ * so the banner looks like the site; this reads that file rather than adding a
+ * third copy to keep in step.
+ *
+ * Two things make it cheap enough to put on every shot. The render is one small
+ * PNG — one image pixel per cell, a couple of hundred pixels across, upscaled
+ * with `image-rendering: pixelated`, which is where the chunky cells come from
+ * — and it is cached per theme for the life of the process, so the daemon grows
+ * a network on the first framed shot and every later one reuses it. A run of
+ * shots therefore shares one desktop instead of each inventing its own.
+ */
+
+import { readFile, stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { REPO_ROOT } from "./engine.mjs";
+
+/** The shared canvas algorithm, relative to the repo root. */
+export const CANVAS_SOURCE = "scripts/banner-assets/mycelial-canvas.js";
+
+/**
+ * The docs site's `--canvas-*` values (docs/mycelium.css), which is what makes
+ * this the site's network rather than a lookalike. Dark ink on a light ground
+ * reads heavier at equal alpha, so light runs quieter — that asymmetry is the
+ * site's, kept rather than re-tuned.
+ */
+export const CANVAS_VARS = {
+  dark: { bg: "#0c0e11", ink: "92, 199, 210", alpha: 1 },
+  light: { bg: "#f4ecda", ink: "12, 125, 143", alpha: 0.72 },
+};
+
+/**
+ * Hero-page proportions, the same ones `gen-banner-network.py` renders at. The
+ * colony count in the algorithm is fixed, so the render size *is* the density:
+ * grow the network on a larger page and it thins out. Matching the banner keeps
+ * it looking like the site.
+ */
+const RENDER_W = 1600;
+const RENDER_H = 900;
+
+/**
+ * Any constant would do; the point is that it is one. Every network the
+ * algorithm grows is plausible, so a random one per shot would only mean a docs
+ * asset whose diff is noise. `--backdrop-seed` picks a different one.
+ */
+export const DEFAULT_SEED = 4271;
+
+/** @type {Map<string, Promise<string>>} */
+const cache = new Map();
+
+/** The canvas IIFE, and when it last changed. */
+export async function canvasSource() {
+  const path = resolve(REPO_ROOT, CANVAS_SOURCE);
+  try {
+    const [script, info] = await Promise.all([readFile(path, "utf8"), stat(path)]);
+    return { script, version: info.mtimeMs };
+  } catch (e) {
+    throw new Error(
+      `the mycelial backdrop needs the shared canvas algorithm at ${path} (${e.code ?? e.message}). ` +
+        "Use --backdrop mycelium for the gradient instead.",
+    );
+  }
+}
+
+/**
+ * Replace `Math.random` before the algorithm runs, so one seed grows one
+ * network. mulberry32: short, and good enough for artwork.
+ * @param {number} seed
+ */
+function seedScript(seed) {
+  return `<script>(function(){var s=${seed >>> 0};Math.random=function(){s=s+0x6D2B79F5|0;` +
+    `var t=Math.imul(s^s>>>15,1|s);t=t+Math.imul(t^t>>>7,61|t)^t;` +
+    `return((t^t>>>14)>>>0)/4294967296};})();</script>`;
+}
+
+/**
+ * A standalone page that grows the network and stops.
+ *
+ * The canvas is left at its natural size — one CSS pixel per cell — so the
+ * capture is the raw cell grid and the upscaling happens later, in the card,
+ * where the final size is known. Under reduced motion (which every shotkit
+ * context sets) the algorithm paints its grown network once instead of
+ * animating, so there is nothing to wait for.
+ *
+ * @param {string} script the canvas algorithm
+ * @param {{theme?:"dark"|"light", seed?:number}} [opts]
+ */
+export function networkDocument(script, opts = {}) {
+  const theme = opts.theme === "light" ? "light" : "dark";
+  const v = CANVAS_VARS[theme];
+  // `</script>` cannot appear in the algorithm today; inlining it is still the
+  // one place where that would end the block early.
+  const inline = script.replace(/<\/script/gi, "<\\/script");
+  return `<!doctype html><html class="${theme}"><head><meta charset="utf-8"><style>
+html,body{margin:0;padding:0;background:${v.bg}}
+html{--canvas-bg:${v.bg};--canvas-ink:${v.ink};--canvas-alpha:${v.alpha}}
+canvas{display:block;image-rendering:pixelated}
+</style></head><body>${seedScript(opts.seed ?? DEFAULT_SEED)}<canvas id="mycelium-bg"></canvas><script>${inline}</script></body></html>`;
+}
+
+/**
+ * The network as a CSS background value, grown on first use and cached after.
+ *
+ * `cover` rather than a fixed cell size: a card's width is whatever its content
+ * shrink-wraps to, and a fixed size would leave bands of flat ground beside a
+ * wide one. The cells scale with the card the way the banner's do.
+ *
+ * @param {import("./engine.mjs").Engine} eng
+ * @param {{theme?:"dark"|"light", seed?:number}} [opts]
+ * @returns {Promise<string>}
+ */
+export async function mycelialArt(eng, opts = {}) {
+  const theme = opts.theme === "light" ? "light" : "dark";
+  const seed = opts.seed ?? DEFAULT_SEED;
+  // The algorithm lives outside src/, so editing it does not restart the daemon
+  // the way editing shotkit does. Keying on its mtime is what stops a long-lived
+  // daemon from serving a network grown by a version of it that is gone.
+  const { script, version } = await canvasSource();
+  const key = `${theme}:${seed}:${version}`;
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  const pending = (async () => {
+    const buf = await eng.captureStatic({
+      html: networkDocument(script, { theme, seed }),
+      selector: "#mycelium-bg",
+      theme,
+      scale: 1,
+      width: RENDER_W,
+      height: RENDER_H,
+    });
+    return `url("data:image/png;base64,${buf.toString("base64")}") center/cover no-repeat`;
+  })();
+  // A failed render must not become the cached answer for the rest of the
+  // process — the next shot should get another go at it.
+  pending.catch(() => cache.delete(key));
+  cache.set(key, pending);
+  return pending;
+}

--- a/shotkit/src/sheet.mjs
+++ b/shotkit/src/sheet.mjs
@@ -19,7 +19,7 @@ const MAX_SHEET_WIDTH = 2400;
 
 /**
  * @param {{label:string, base64:string, width:number, height:number, scale:number}[]} frames
- * @param {{theme?:"dark"|"light", backdrop?:string, title?:string, gap?:number, padding?:number}} opts
+ * @param {{theme?:"dark"|"light", backdrop?:string, art?:string, title?:string, gap?:number, padding?:number}} opts
  */
 export function sheetDocument(frames, opts = {}) {
   const theme = opts.theme ?? "dark";
@@ -51,10 +51,14 @@ export function sheetDocument(frames, opts = {}) {
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;background:transparent}
 #canvas{
+  position:relative;
   display:inline-block;width:max-content;padding:${pad}px;
   background:${backdrop(opts.backdrop ?? "mycelium", theme)};
   font-family:${UI_STACK};
 }
+/* The backdrop artwork, if there is any; see card.mjs for why it is a layer. */
+#art{position:absolute;inset:0;image-rendering:pixelated;background:${opts.art ?? "none"}}
+h1,.row{position:relative}
 h1{
   margin:0 0 22px;font-size:15px;font-weight:600;letter-spacing:.01em;
   color:${pal.text};
@@ -69,7 +73,7 @@ img{
 figcaption{
   font-size:11.5px;letter-spacing:.02em;color:${pal.muted};text-align:center;
 }
-</style></head><body><div id="canvas">${heading}<div class="row">${cards}</div></div></body></html>`;
+</style></head><body><div id="canvas">${opts.art ? '<div id="art"></div>' : ""}${heading}<div class="row">${cards}</div></div></body></html>`;
 }
 
 const escapeHtml = (s) =>

--- a/shotkit/src/theme.mjs
+++ b/shotkit/src/theme.mjs
@@ -68,6 +68,12 @@ export const THEMES = {
  * Backdrops the card floats on. `none` leaves the canvas transparent, which is
  * what you want when the image is going into a page that has its own
  * background; everything else pads the card so the drop shadow has room.
+ *
+ * `mycelial` is the ground the docs site paints its hypha network on. Asking
+ * for it also asks for the network itself, which is not a CSS value and so
+ * arrives separately (see mycelial.mjs); this entry is what shows if that
+ * render is unavailable, which is why it is the site's canvas color and not a
+ * gradient of its own.
  */
 export const BACKDROPS = {
   mycelium: {
@@ -78,6 +84,7 @@ export const BACKDROPS = {
     dark: "linear-gradient(135deg, #2b2140 0%, #1b1930 55%, #101019 100%)",
     light: "linear-gradient(135deg, #efe7fb 0%, #e6e9f7 55%, #dfe2ee 100%)",
   },
+  mycelial: { dark: "#0c0e11", light: "#f4ecda" },
   ink: { dark: "#08090b", light: "#eceef1" },
   paper: { dark: "#14171c", light: "#f2f4f6" },
   none: { dark: "transparent", light: "transparent" },

--- a/shotkit/test/selftest.mjs
+++ b/shotkit/test/selftest.mjs
@@ -18,7 +18,9 @@ import { parse } from "../src/args.mjs";
 import { policyArgs, policyKey } from "../src/network.mjs";
 import { resolveViewport, viewportList } from "../src/viewports.mjs";
 import { parseAction } from "../src/actions.mjs";
-import { palette } from "../src/theme.mjs";
+import { backdrop, palette } from "../src/theme.mjs";
+import { CANVAS_VARS, networkDocument } from "../src/mycelial.mjs";
+import { cardDocument } from "../src/card.mjs";
 
 let failures = 0;
 function test(name, fn) {
@@ -163,6 +165,33 @@ test("--responsive expands to the breakpoint ladder", () => {
 test("an action splits on its first colon only", () => {
   assert.deepEqual(parseAction("fill:#q=a:b"), { verb: "fill", arg: "#q=a:b" });
   assert.deepEqual(parseAction("reload"), { verb: "reload", arg: "" });
+});
+
+test("a backdrop preset resolves per theme, and unknown values pass through", () => {
+  assert.equal(backdrop("mycelial", "dark"), CANVAS_VARS.dark.bg);
+  assert.equal(backdrop("mycelial", "light"), CANVAS_VARS.light.bg);
+  assert.equal(backdrop("#123456", "dark"), "#123456");
+});
+
+test("the network harness carries the theme's canvas vars", () => {
+  const html = networkDocument("/* algorithm */", { theme: "light" });
+  assert.ok(html.includes(`--canvas-ink:${CANVAS_VARS.light.ink}`));
+  assert.ok(html.includes(`--canvas-alpha:${CANVAS_VARS.light.alpha}`));
+  assert.ok(html.includes('id="mycelium-bg"'), "the algorithm looks the canvas up by id");
+});
+
+test("one seed grows one network", () => {
+  const a = networkDocument("/* algorithm */", { seed: 7 });
+  assert.ok(a.includes("var s=7;"), "the seed replaces Math.random before the algorithm runs");
+  assert.notEqual(a, networkDocument("/* algorithm */", { seed: 8 }));
+  assert.equal(a, networkDocument("/* algorithm */", { seed: 7 }));
+});
+
+test("a card grows an artwork layer only when there is artwork", () => {
+  assert.ok(!cardDocument("hi", { backdrop: "ink" }).includes('id="art"'));
+  const art = cardDocument("hi", { backdrop: "mycelial", art: "url(data:image/png;base64,AA) center/cover" });
+  assert.ok(art.includes('id="art"'));
+  assert.ok(art.includes("image-rendering:pixelated"), "the cells must not blur when upscaled");
 });
 
 process.stdout.write(failures ? `\n${failures} failing\n` : "\nall passing\n");

--- a/shotkit/test/selftest.mjs
+++ b/shotkit/test/selftest.mjs
@@ -19,7 +19,7 @@ import { policyArgs, policyKey } from "../src/network.mjs";
 import { resolveViewport, viewportList } from "../src/viewports.mjs";
 import { parseAction } from "../src/actions.mjs";
 import { backdrop, palette } from "../src/theme.mjs";
-import { CANVAS_VARS, networkDocument } from "../src/mycelial.mjs";
+import { CANVAS_VARS, VEIL, networkDocument } from "../src/mycelial.mjs";
 import { cardDocument } from "../src/card.mjs";
 
 let failures = 0;
@@ -185,6 +185,13 @@ test("one seed grows one network", () => {
   assert.ok(a.includes("var s=7;"), "the seed replaces Math.random before the algorithm runs");
   assert.notEqual(a, networkDocument("/* algorithm */", { seed: 8 }));
   assert.equal(a, networkDocument("/* algorithm */", { seed: 7 }));
+});
+
+test("the vignette veils light less than dark", () => {
+  // The site already runs light at a lower canvas alpha; veiling both equally
+  // washes the network out of the cream entirely.
+  assert.ok(CANVAS_VARS.light.alpha < CANVAS_VARS.dark.alpha);
+  for (const [i, stop] of VEIL.light.entries()) assert.ok(stop < VEIL.dark[i], `stop ${i}`);
 });
 
 test("a card grows an artwork layer only when there is artwork", () => {


### PR DESCRIPTION
## Summary

`shot --chrome` frames a page capture in a window, and that window has been floating on a gradient. This adds `--backdrop mycelial`: the docs site's own hypha network as the desktop behind the frame, so a framed screenshot sits on the product's background rather than a generic one.

![--backdrop mycelium vs --backdrop mycelial](https://raw.githubusercontent.com/mycelium-io/mycelium/ca83fc95319596506e42915a4bd1decb2914b467/backdrop-compare.png)

It is the same network in both senses that matter. The algorithm is the one the live site runs — read from `scripts/banner-assets/mycelial-canvas.js`, the shared copy `docs/banner.png` is already cut from, rather than a third transcription of it — and the colors are the site's own `--canvas-*` values.

A vignette in the ground's color veils it, lightly in the middle and heavily at the edges. The site can run the network at full strength because prose sits on near-solid paper above it; a screenshot has no such pane, and unveiled the corners pull the eye away from the thing being shown. Light is veiled less than dark, since the site already runs light at `--canvas-alpha: 0.72` against dark's `1` — an equal veil quiets it twice and it disappears into the cream.

![a light-theme terminal card on the mycelial ground](https://raw.githubusercontent.com/mycelium-io/mycelium/ca83fc95319596506e42915a4bd1decb2914b467/backdrop-light.png)

It is a backdrop preset rather than a chrome-only flag, so it works anywhere a backdrop does — terminal and code cards, `--chrome`-wrapped page shots, and contact sheets. The README notes that the network is texture and competes with a busy screen, so `mycelium` / `ink` / `paper` stay the right reach for a dense app screenshot.

## Changes

- **`shotkit/src/mycelial.mjs`** (new) grows the network in a headless page at the same 1600×900 hero proportions `gen-banner-network.py` uses — the colony count in the algorithm is fixed, so render size *is* density — and returns a CSS background. The capture is one small PNG at one pixel per cell; the card upscales it with `image-rendering: pixelated`, which is where the chunky cells come from. The vignette rides as a second background layer on the same value, so no extra element has to be positioned.
- **`card.mjs` / `sheet.mjs`** gained an `art` layer behind the card. It is its own element rather than a second background on `#canvas` so that `image-rendering` reaches the network and nothing else — the card body holds a page capture placed at 1:1, and pixelating that would undo the point of it.
- **`api.mjs`** resolves the artwork where the engine is, for the card, chrome and sheet paths. One network per theme is cached for the life of the process, keyed on the algorithm's mtime: it lives outside the `src/` tree the daemon watches, so without that key a long-lived daemon would keep serving a network grown by a version of the algorithm that is gone.
- **`--backdrop-seed`** picks a different network. A seeded `Math.random` replaces the global before the algorithm runs, so by default the same command gives the same background — these images get committed, and a random one per shot would mean a diff that is pure noise.
- **`theme.mjs`** gains the `mycelial` ground color, which is what shows if the render is unavailable.
- **`doctor.mjs`** gains a `backdrop` check; a missing algorithm file gives a named error pointing at `--backdrop mycelium` rather than silently drawing something else.
- **`README.md`** and the `screenshot` skill document it.

## Testing

Nothing outside `shotkit/` is touched, so the Python gates are unaffected and were not run.

- `node shotkit/test/selftest.mjs` — all passing, including 5 new cases: preset resolution per theme, the harness carrying the theme's canvas vars, seed determinism, the light-veiled-less-than-dark asymmetry, and the art layer appearing only when there is art.
- Rendered and eyeballed every surface: terminal card, code card, `--chrome`-wrapped page, and contact sheet, in both themes.
- Determinism verified across separate processes — byte-identical PNGs for the same seed, different under `--backdrop-seed 99`.
- Caching verified: first shot of a theme ~230ms capture, later shots 85–120ms, unchanged from any other backdrop.
- Missing-algorithm path verified by moving the file aside; the error names the path and the fallback.

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`) — not run; no backend code changed
- [ ] Linting passes (`uv run ruff check .`) — not run; no Python changed
- [ ] Format check passes (`uv run ruff format --check .`) — not run; no Python changed

## Related Issues

None.

## Note for the reviewer

The two images above are hosted on a detached `assets/shotkit-mycelial-backdrop` branch rather than committed here, so the PR diff stays code-only and nothing from `.shotkit/` lands on `main`. Delete that branch once this is merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01819mUVb77SSjk1YN2yNu2L)_