### PR TITLE
Wait for the room to connect, and prefer labels over tag names

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -24,8 +24,13 @@ node shotkit/bin/shot.mjs doctor
 ```
 
 It reports the browser, `script(1)`, whether the frontend's deps are installed,
-and whether an app is already listening. Fix anything it marks `✗` before
-capturing. Terminal and code cards need no app at all.
+whether an app is already listening, and whether webfonts load here. Fix
+anything it marks `✗` before capturing. Terminal and code cards need no app at
+all.
+
+**If the webfont check warns, add `--offline` to every app capture** and don't
+publish shots taken on this machine — they will render in fallback fonts. A
+capture that takes more than a few seconds prints the same hint.
 
 ## Screenshot the app
 
@@ -76,9 +81,11 @@ node shotkit/bin/shot.mjs shoot --session r --name negotiate   # ~250ms
 node shotkit/bin/shot.mjs close --session r
 ```
 
-A bare word (`click:Negotiate`) matches an accessible name, then visible text.
-For anything else use a Playwright selector: `#id`, `.class`,
-`role=button[name="Save"]`, `text=Save`. `shot help shoot` lists every verb.
+A bare word (`click:Negotiate`) matches an accessible name, then visible text —
+including words that are also tag names, so `click:table` finds a button
+labelled "table" before it considers a `<table>`. For anything else use a
+Playwright selector: `#id`, `.class`, `role=button[name="Save"]`, `text=Save`.
+`shot help shoot` lists every verb.
 
 ## Screenshot CLI output
 

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -198,6 +198,10 @@ function RoomWorkspace() {
   const statusLeft = (
     <>
       <span
+        // A stable hook for anything that has to wait until the room is
+        // actually connected — the screenshot pipeline gates on this rather
+        // than on the label text, which is a translation away from breaking.
+        data-connection={connected ? "live" : "reconnecting"}
         className="rounded px-1.5 py-0.5 text-micro font-medium"
         style={{
           color: connected ? "var(--green)" : "var(--yellow)",

--- a/shotkit/README.md
+++ b/shotkit/README.md
@@ -26,7 +26,7 @@ seconds doing the same three things every time. shotkit pays them once:
 | **A daemon holds the browser.** | First shot ~2s, every later shot ~150ms. It starts itself, and shuts down after 15 idle minutes. |
 | **Cards never touch the network.** | `term`, `code` and `html` render a self-contained document into a page that stays open. No navigation, no fetches. |
 | **`--mock` boots the app once.** | The Next dev server is held by the daemon, not by the request, so six shots of six routes boot it once. |
-| **`--offline` skips dead CDNs.** | The frontend links Google Fonts. Where those are unreachable, waiting on them costs ~13s *per navigation* — more than everything else combined. |
+| **`--offline` skips dead CDNs.** | The frontend links Google Fonts. Where those are unreachable, waiting on them costs ~13s *per navigation* — more than everything else combined. `shot doctor` probes for this, and a slow capture says so. |
 
 ```
 $ shot bench
@@ -108,7 +108,9 @@ shot sessions ; shot close --session r
 Element arguments accept any Playwright selector engine (`text=`,
 `role=button[name="Save"]`, `#id`, `//xpath`). A bare word is matched by
 accessible name, then by visible text — `click:Save` means the button labelled
-Save, not a `<save>` element.
+Save, not a `<save>` element. Words that are also tag names are no exception:
+`click:table` prefers a control labelled "table", and only falls back to the
+`<table>` element when nothing carries that label.
 
 ## Browser chrome
 
@@ -171,6 +173,17 @@ r.shots;     // one entry per breakpoint
 the committed docs assets and uses this engine for the browser work, keeping
 only what is publication's business — the shot manifest, the `sharp` pass, and
 where files land.
+
+## Waiting
+
+An app capture waits for a *populated* frame, not a mounted one: the shell hook,
+then the loading skeletons clearing, then the room's `data-connection` badge
+reading live. That last step is the difference between a screenshot and a
+publishable one — a shot taken a moment early catches the status bar mid
+"Reconnecting…", which reads as a broken app.
+
+`--settle full` raises every budget for a slow backend; `--settle none` skips the
+lot when you want the frame exactly as it loads.
 
 ## Notes
 

--- a/shotkit/bin/shot.mjs
+++ b/shotkit/bin/shot.mjs
@@ -236,6 +236,7 @@ function report(result, flags) {
   const size = result.width ? ` · ${result.width}x${result.height}` : "";
   err(`[shot] ${result.op} · ${bits.join(" · ")} · ${result.mode ?? "daemon"}${size}`);
   if (result.meta?.exitCode) err(`[shot] command exited ${result.meta.exitCode}`);
+  if (result.meta?.hint) err(`[shot] ${result.meta.hint}`);
   for (const step of result.trace ?? []) err(`[shot]   ${step.action} (${step.ms}ms)`);
   for (const shot of result.shots ?? []) err(`[shot]   ${shot.viewport} · ${shot.ms}ms · ${shot.width}x${shot.height}`);
 

--- a/shotkit/src/actions.mjs
+++ b/shotkit/src/actions.mjs
@@ -21,38 +21,52 @@ const ENGINE_PREFIX = /^(css|text|role|xpath|id|data-testid|internal:[a-z-]+)[=:
 /** Punctuation that only appears in a CSS selector, never in a visible label. */
 const CSS_PUNCTUATION = /[.#\[\]>+~*]|::/;
 
-/**
- * Resolve one element argument.
- *
- * Order matters, and the interesting case is the bare word. `--do click:Save`
- * means the button labelled Save, but "Save" is also a syntactically valid CSS
- * type selector, so handing it to `locator()` silently looks for a `<save>`
- * element and times out. A bare word is therefore matched by what it is on
- * screen: its accessible name first — buttons, links and tabs are what
- * navigation actually targets — and its visible text as the fallback.
- *
- * @param {import("playwright").Page} page
- */
-export function locate(page, spec) {
-  if (ENGINE_PREFIX.test(spec) || spec.startsWith("//") || spec.startsWith("(")) return page.locator(spec).first();
-  if (CSS_PUNCTUATION.test(spec) || /\s/.test(spec) === false && /^[a-z]+$/.test(spec) && HTML_TAGS.has(spec)) {
-    return page.locator(spec).first();
-  }
-  return page
+/** Lowercase bare words that could plausibly be meant as element selectors. */
+const HTML_TAGS = new Set([
+  "a", "article", "aside", "body", "button", "canvas", "code", "dialog", "div", "footer",
+  "form", "h1", "h2", "h3", "header", "img", "input", "li", "main", "nav", "ol", "p", "pre",
+  "section", "select", "span", "svg", "table", "tbody", "td", "textarea", "th", "tr", "ul", "video",
+]);
+
+/** A bare word, matched the way a person means it: by what it says on screen. */
+const byLabel = (page, spec) =>
+  page
     .getByRole("button", { name: spec })
     .or(page.getByRole("link", { name: spec }))
     .or(page.getByRole("tab", { name: spec }))
     .or(page.getByRole("menuitem", { name: spec }))
     .or(page.getByText(spec, { exact: true }))
     .first();
-}
 
-/** Lowercase bare words that really are element selectors rather than labels. */
-const HTML_TAGS = new Set([
-  "a", "article", "aside", "body", "button", "canvas", "code", "dialog", "div", "footer",
-  "form", "h1", "h2", "h3", "header", "img", "input", "li", "main", "nav", "ol", "p", "pre",
-  "section", "select", "span", "svg", "table", "tbody", "td", "textarea", "th", "tr", "ul", "video",
-]);
+/**
+ * Resolve one element argument.
+ *
+ * The interesting case is the bare word. `--do click:Save` means the button
+ * labelled Save, but "Save" is also a syntactically valid CSS type selector, so
+ * handing it to `locator()` looks for a `<save>` element and times out. Labels
+ * win: a word is matched by accessible name, then by visible text.
+ *
+ * Some labels collide with real tag names — "table", "select", "code", "header",
+ * "form", "nav" are all things a button might say — so the tag reading is a
+ * fallback rather than a rule. It is used only when the word names a tag, no
+ * label matches it, and an element of that tag is actually on the page. When
+ * neither matches (the usual "not there yet" case) the label locator is
+ * returned, so Playwright's auto-waiting applies and any error names the label
+ * the caller actually typed.
+ *
+ * @param {import("playwright").Page} page
+ * @returns {Promise<import("playwright").Locator>}
+ */
+export async function locate(page, spec) {
+  if (ENGINE_PREFIX.test(spec) || spec.startsWith("//") || spec.startsWith("(")) return page.locator(spec).first();
+  if (CSS_PUNCTUATION.test(spec) || /\s/.test(spec)) return page.locator(spec).first();
+
+  const label = byLabel(page, spec);
+  if (!HTML_TAGS.has(spec.toLowerCase())) return label;
+  if ((await label.count()) > 0) return label;
+  const tag = page.locator(spec).first();
+  return (await tag.count()) > 0 ? tag : label;
+}
 
 /** Split `verb:rest` on the first colon. `back` and `reload` take no argument. */
 export function parseAction(raw) {
@@ -81,31 +95,31 @@ export async function runActions(page, actions, ctx = {}) {
     const { verb, arg } = parseAction(raw);
     switch (verb) {
       case "click":
-        await locate(page, arg).click({ timeout });
+        await (await locate(page, arg)).click({ timeout });
         break;
       case "dblclick":
-        await locate(page, arg).dblclick({ timeout });
+        await (await locate(page, arg)).dblclick({ timeout });
         break;
       case "hover":
-        await locate(page, arg).hover({ timeout });
+        await (await locate(page, arg)).hover({ timeout });
         break;
       case "focus":
-        await locate(page, arg).focus({ timeout });
+        await (await locate(page, arg)).focus({ timeout });
         break;
       case "check":
-        await locate(page, arg).check({ timeout });
+        await (await locate(page, arg)).check({ timeout });
         break;
       case "uncheck":
-        await locate(page, arg).uncheck({ timeout });
+        await (await locate(page, arg)).uncheck({ timeout });
         break;
       case "fill": {
         const [sel, value] = splitPair(arg);
-        await locate(page, sel).fill(value, { timeout });
+        await (await locate(page, sel)).fill(value, { timeout });
         break;
       }
       case "select": {
         const [sel, value] = splitPair(arg);
-        await locate(page, sel).selectOption(value, { timeout });
+        await (await locate(page, sel)).selectOption(value, { timeout });
         break;
       }
       case "press":
@@ -133,7 +147,7 @@ export async function runActions(page, actions, ctx = {}) {
         if (arg === "bottom") await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
         else if (arg === "top") await page.evaluate(() => window.scrollTo(0, 0));
         else if (/^-?\d+$/.test(arg)) await page.evaluate((y) => window.scrollBy(0, y), Number(arg));
-        else await locate(page, arg).scrollIntoViewIfNeeded({ timeout });
+        else await (await locate(page, arg)).scrollIntoViewIfNeeded({ timeout });
         break;
       case "wait":
         await page.locator(arg).first().waitFor({ state: "visible", timeout });

--- a/shotkit/src/api.mjs
+++ b/shotkit/src/api.mjs
@@ -145,7 +145,15 @@ export async function capture(spec, ctx = {}) {
       const tCap = Date.now();
       const raw = await eng.capturePage({ ...pageSpec, ...(frame ?? {}) });
       const buf = await wrapChrome(eng, raw.buf, spec, prettyAddress(spec, url));
-      const meta = { url, baseUrl, viewport: frames[0]?.name, trace: raw.trace, chrome: Boolean(spec.chrome) };
+      const captureMs = Date.now() - tCap;
+      const meta = {
+        url,
+        baseUrl,
+        viewport: frames[0]?.name,
+        trace: raw.trace,
+        chrome: Boolean(spec.chrome),
+        hint: slowCaptureHint(spec, captureMs),
+      };
       return finish(
         { ...base, meta, ms: { total: Date.now() - t0, capture: Date.now() - tCap } },
         spec,
@@ -193,6 +201,19 @@ async function wrapChrome(eng, buf, spec, address) {
   });
   // Same scale as the capture, so one image pixel lands on one device pixel.
   return eng.captureStatic({ html, ...pickStatic(spec), theme, scale, width: 2600, height: 2000 });
+}
+
+/**
+ * A capture this slow is almost always a page waiting on an unreachable CDN,
+ * which is silent by construction: the shot still succeeds, just late and in
+ * fallback fonts. Surfaced through the result rather than a log because the
+ * daemon does the work in another process, where stderr goes nowhere useful.
+ */
+const SLOW_CAPTURE_MS = 6000;
+
+function slowCaptureHint(spec, ms) {
+  if (spec.offline || ms < SLOW_CAPTURE_MS) return undefined;
+  return `capture took ${(ms / 1000).toFixed(1)}s — if the app links a CDN this host cannot reach, --offline skips the wait (shot doctor checks)`;
 }
 
 /** app/url/session ops all need to know where the app is. */
@@ -278,7 +299,10 @@ async function renderCard(spec, eng) {
       prompt: typeof spec.prompt === "string" ? spec.prompt : undefined,
       exitCode: meta.exitCode,
       showExit: spec.showExit !== false,
-      title: spec.title ?? (spec.argv ? spec.argv[0] : "terminal"),
+      // The title names what the card claims to show. With --command relabelling
+      // the prompt (`mycelium …` for a line that really ran `uv run mycelium …`),
+      // taking it from argv would caption the card with the wrong binary.
+      title: spec.title ?? binaryOf(command) ?? "terminal",
     });
     html = doc.html;
     meta.rows = doc.rows;
@@ -310,6 +334,12 @@ async function renderCard(spec, eng) {
 function prettyAddress(spec, url) {
   if (spec.op === "app" && spec.route) return spec.route;
   return url;
+}
+
+/** The program name from a shell line, for use as a card title. */
+function binaryOf(commandLine) {
+  const first = String(commandLine ?? "").trim().split(/\s+/)[0];
+  return first ? first.replace(/^.*\//, "").replace(/^['"]|['"]$/g, "") : null;
 }
 
 const pickCode = (spec) => ({

--- a/shotkit/src/doctor.mjs
+++ b/shotkit/src/doctor.mjs
@@ -24,6 +24,59 @@ const warn = (m) => process.stdout.write(`  \x1b[33m!\x1b[0m ${m}\n`);
 const bad = (m) => process.stdout.write(`  \x1b[31m✗\x1b[0m ${m}\n`);
 const head = (m) => process.stdout.write(`\n\x1b[1m${m}\x1b[0m\n`);
 
+/** The host the frontend's own `<link>` points at, so the probe tests the real dependency. */
+const FONT_PROBE_HOST = "fonts.googleapis.com";
+const FONT_PROBE_URL = `https://${FONT_PROBE_HOST}/css2?family=IBM+Plex+Sans:wght@400`;
+const FONT_PROBE_BUDGET_MS = 4000;
+
+/**
+ * Can this machine actually load a webfont?
+ *
+ * This is the failure that degrades a published screenshot silently. The
+ * frontend links Google Fonts; where that host is unreachable the page still
+ * renders — in fallback fonts, several seconds later — so nothing looks broken
+ * except the image, and only to someone who knows what it should look like.
+ * Nothing else doctor checks can be wrong without an obvious symptom, which is
+ * why this one is worth a real network probe rather than an inference.
+ */
+async function probeWebfonts(pw) {
+  if (!pw) {
+    warn("skipped — no usable browser");
+    return;
+  }
+  let browser;
+  try {
+    const launched = await launchChromium(pw, { args: [] });
+    browser = launched.browser;
+    const page = await (await browser.newContext()).newPage();
+    // fetch() needs a real origin; about:blank is opaque and rejects outright.
+    await page.goto("data:text/html,<title>probe</title>");
+    const started = Date.now();
+    // Bounded, because the answer is the same either way: a host that needs
+    // longer than this is one every capture would be waiting on.
+    const reachable = await page.evaluate(async ([url, budget]) => {
+      try {
+        const res = await fetch(url, { mode: "no-cors", signal: AbortSignal.timeout(budget) });
+        return res.type === "opaque" || res.ok;
+      } catch {
+        return false;
+      }
+    }, [`${FONT_PROBE_URL}?_=shotkit`, FONT_PROBE_BUDGET_MS]);
+    const ms = Date.now() - started;
+
+    if (reachable) ok(`${FONT_PROBE_HOST} reachable in ${ms}ms — captures render with the real fonts`);
+    else {
+      warn(`${FONT_PROBE_HOST} unreachable (gave up after ${ms}ms)`);
+      warn("  every app capture will wait on it, then fall back. Pass --offline to skip the wait.");
+      warn("  published screenshots taken here will use fallback fonts — regenerate on a connected host.");
+    }
+  } catch (e) {
+    warn(`probe failed: ${e.message.split("\n")[0]}`);
+  } finally {
+    await browser?.close().catch(() => {});
+  }
+}
+
 export async function doctor() {
   head("host");
   ok(`node ${process.version} on ${platform()} ${release()}`);
@@ -64,6 +117,9 @@ export async function doctor() {
   head("backdrop");
   if (existsSync(`${REPO_ROOT}/${CANVAS_SOURCE}`)) ok(`${CANVAS_SOURCE} present — \`--backdrop mycelial\` grows the site's network`);
   else warn(`${CANVAS_SOURCE} missing — \`--backdrop mycelial\` errors; the other presets are unaffected`);
+
+  head("webfonts");
+  await probeWebfonts(pw);
 
   head("app");
   if (existsSync(`${FRONTEND_DIR}/node_modules`)) ok("mycelium-frontend deps installed — --mock can boot dev:mock");

--- a/shotkit/src/engine.mjs
+++ b/shotkit/src/engine.mjs
@@ -340,22 +340,45 @@ async function shootPage(page, opts) {
  * The shell renders before its fetches resolve, so gating on the ready hook
  * alone reliably captures loading skeletons and a "Reconnecting…" badge. Every
  * placeholder in the app is the same `.animate-pulse` Skeleton, which makes
- * their absence a dependable "content is in" signal.
+ * their absence a dependable "content is in" signal, and the status bar carries
+ * a `data-connection` hook for the stream.
+ *
+ * The connection wait is not an extra: a shot taken a moment early shows the
+ * room mid-"Reconnecting…", which reads as a broken app in a published image.
+ * It costs a second or two when the stream is coming up and nothing at all on a
+ * page that has no indicator, so both levels wait — `full` just waits longer.
  *
  * Each step is best-effort: this also runs against a real backend, where a rail
  * may legitimately stay empty, and an empty rail is not a reason to fail a shot.
  */
+const SETTLE_BUDGET = {
+  fast: { shell: 15_000, skeleton: 4_000, connection: 6_000 },
+  full: { shell: 15_000, skeleton: 15_000, connection: 12_000 },
+};
+
 async function settle(page, level) {
   const soft = (p) => p.catch(() => {});
-  await soft(page.waitForSelector('[data-app-shell="ready"]', { state: "visible", timeout: 15_000 }));
+  const budget = SETTLE_BUDGET[level] ?? SETTLE_BUDGET.fast;
+
+  await soft(page.waitForSelector('[data-app-shell="ready"]', { state: "visible", timeout: budget.shell }));
   await soft(
     page.waitForFunction(() => document.querySelectorAll(".animate-pulse").length === 0, null, {
-      timeout: level === "full" ? 15_000 : 4_000,
+      timeout: budget.skeleton,
     }),
   );
-  if (level === "full") {
-    await soft(page.waitForFunction(() => document.body.innerText.includes("Live"), null, { timeout: 8_000 }));
-  }
+  await soft(
+    page.waitForFunction(
+      () => {
+        const badge = document.querySelector("[data-connection]");
+        // No indicator on this route means there is no stream to wait for; the
+        // text check is the fallback for a page that predates the hook.
+        if (!badge) return !document.body.innerText.includes("Reconnecting");
+        return badge.getAttribute("data-connection") === "live";
+      },
+      null,
+      { timeout: budget.connection },
+    ),
+  );
   await soft(page.evaluate(() => document.fonts.ready));
 }
 

--- a/shotkit/test/selftest.mjs
+++ b/shotkit/test/selftest.mjs
@@ -17,7 +17,7 @@ import { splitHighlightedLines, guessLanguage } from "../src/code.mjs";
 import { parse } from "../src/args.mjs";
 import { policyArgs, policyKey } from "../src/network.mjs";
 import { resolveViewport, viewportList } from "../src/viewports.mjs";
-import { parseAction } from "../src/actions.mjs";
+import { locate, parseAction } from "../src/actions.mjs";
 import { backdrop, palette } from "../src/theme.mjs";
 import { CANVAS_VARS, VEIL, networkDocument } from "../src/mycelial.mjs";
 import { cardDocument } from "../src/card.mjs";
@@ -200,6 +200,71 @@ test("a card grows an artwork layer only when there is artwork", () => {
   assert.ok(art.includes('id="art"'));
   assert.ok(art.includes("image-rendering:pixelated"), "the cells must not blur when upscaled");
 });
+
+/**
+ * A stand-in for a Playwright page. Each locator records how it was built and
+ * reports a count from `present`, whose entries are `"<kind>:<arg>"` — `label`
+ * for the accessible-name/text chain, `css` for a plain selector. Counts are all
+ * `locate` consults.
+ */
+function fakePage(present) {
+  const mk = (kind, arg) => ({
+    kind,
+    arg,
+    first: () => mk(kind, arg),
+    or: (other) => ({ ...mk("label", arg), alternatives: [kind, other.kind], first: () => mk("label", arg) }),
+    count: async () => (present.includes(`${kind}:${arg}`) ? 1 : 0),
+  });
+  return {
+    locator: (sel) => mk("css", sel),
+    getByRole: (role, o) => mk("role", o.name),
+    getByText: (t) => mk("text", t),
+  };
+}
+
+await (async () => {
+  const acount = async (name, fn) => {
+    try {
+      await fn();
+      process.stdout.write(`  \x1b[32m✓\x1b[0m ${name}\n`);
+    } catch (err) {
+      failures += 1;
+      process.stdout.write(`  \x1b[31m✗\x1b[0m ${name}\n    ${err.message}\n`);
+    }
+  };
+
+  await acount("a selector with punctuation stays CSS", async () => {
+    const r = await locate(fakePage([]), ".offer-grid");
+    assert.equal(r.kind, "css");
+  });
+
+  await acount("a selector-engine prefix is passed through", async () => {
+    const r = await locate(fakePage([]), 'role=button[name="Save"]');
+    assert.equal(r.kind, "css");
+  });
+
+  await acount("a bare word that is not a tag name resolves by label", async () => {
+    const r = await locate(fakePage([]), "Negotiate");
+    assert.equal(r.kind, "label");
+  });
+
+  await acount("a label wins over the same word as a tag name", async () => {
+    // A button labelled "table" and a <table> both on the page: the label is
+    // what the caller typed and what they meant.
+    const r = await locate(fakePage(["label:table", "css:table"]), "table");
+    assert.equal(r.kind, "label");
+  });
+
+  await acount("the tag is used only when no label matches it", async () => {
+    const r = await locate(fakePage(["css:select"]), "select");
+    assert.equal(r.kind, "css");
+  });
+
+  await acount("neither present falls back to the label, for a legible error", async () => {
+    const r = await locate(fakePage([]), "form");
+    assert.equal(r.kind, "label");
+  });
+})();
 
 process.stdout.write(failures ? `\n${failures} failing\n` : "\nall passing\n");
 process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## Summary

Four fixes from using shotkit in anger. Two are correctness (a shot taken too
early, a click resolving to the wrong element), one closes a silent failure, one
is a caption nit.

## Changes

**The default settle returned before the room was connected.** An app shot caught
the status bar mid-"Reconnecting…", which reads as a broken app in a published
image, and was only avoidable by knowing to pass `--wait-text Live`. Both settle
levels now wait for the connection.

Gated on a new `data-connection` hook on the status badge rather than on its
label text — the same pattern as the existing `[data-app-shell="ready"]`, and one
translation away from not breaking. It costs ~1s while the stream comes up and
nothing at all on a route with no indicator, so it isn't worth making optional;
`--settle full` stays the same behavior with longer budgets.

**A bare-word click resolved against `HTML_TAGS` before labels.** `--do
click:table` found the `<table>` element, not the button labelled "table" — and
that list reserves ~30 words, most of them plausible UI labels (`select`, `code`,
`header`, `form`, `nav`, `main`). It also made the skill's documented behavior
false for exactly those words.

Labels now win outright. The tag reading survives as a fallback, used only when
the word names a tag, nothing carries it as a label, and such an element is
actually on the page. When neither matches — the ordinary "not there yet" case —
the label locator is returned, so Playwright's auto-waiting still applies and the
error names what the caller typed.

**`doctor` didn't check webfonts.** It covered the browser, `script(1)`, deps and
the app, but not the one failure here that degrades a published screenshot
*silently*: the page renders either way, just seconds later and in the wrong
fonts. It now probes the host the frontend actually links, on a 4s budget, and
says what to do — `--offline` for speed, and don't publish shots taken here.

I did not flip `--offline` on by default when the probe fails. It changes what
the image shows, and a capture tool that quietly renders something other than the
app is the same class of problem this fix is about. Instead the detection is
wired to where it's noticed: a capture slow enough to imply the CDN problem
carries the hint in its result, so it reaches people who never run `doctor`.

**Nit: `--command` relabelled the prompt but not the title.** A card reading
`mycelium memory --help` was captioned `uv`. The title follows the command being
shown.

## Testing

- `node shotkit/test/selftest.mjs` — 34 passing, including six new cases pinning
  label-vs-tag resolution against a fake page: punctuation stays CSS, an engine
  prefix passes through, a label beats the same word as a tag, the tag is used
  only when no label matches, and neither-present falls back to the label.
- Verified against the running mock frontend: three consecutive `shot app` runs
  all render the status bar as **Live** with no flag, at ~2.3s warm (unchanged).
  Confirmed by eye, not just by the wait returning.
- `--do click:Negotiate` (bare word) and `--do click:[data-connection]` (CSS)
  both still resolve.
- `shot term --command "mycelium memory --help" -- uv run mycelium memory --help`
  now titles the card `mycelium`.
- Frontend gate for the `page.tsx` change: `npx tsc --noEmit`, `npx eslint .`
  (0 errors), `npx vitest run` (370 passing), `npx next build` — all clean.

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`) — untouched; no Python in this PR
- [ ] Linting passes (`uv run ruff check .`) — untouched
- [ ] Format check passes (`uv run ruff format --check .`) — untouched

## Related Issues

Follow-up to #760.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwMZzsVJawEdEQoAusNyZe)_