### PR TITLE
Match a multi-word action argument as a label, not a selector

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -81,11 +81,12 @@ node shotkit/bin/shot.mjs shoot --session r --name negotiate   # ~250ms
 node shotkit/bin/shot.mjs close --session r
 ```
 
-A bare word (`click:Negotiate`) matches an accessible name, then visible text —
-including words that are also tag names, so `click:table` finds a button
-labelled "table" before it considers a `<table>`. For anything else use a
-Playwright selector: `#id`, `.class`, `role=button[name="Save"]`, `text=Save`.
-`shot help shoot` lists every verb.
+Anything without CSS punctuation is matched by accessible name, then visible
+text — `click:Negotiate`, and phrases too: `click:Install CLI` is a button, not a
+descendant selector. Words that are also tag names are no exception, so
+`click:table` finds a button labelled "table" before it considers a `<table>`.
+For a selector use `#id`, `.class`, `role=button[name="Save"]`, `text=Save`, or
+`css=` when it is only tag names and spaces. `shot help shoot` lists every verb.
 
 ## Screenshot CLI output
 

--- a/shotkit/README.md
+++ b/shotkit/README.md
@@ -110,7 +110,9 @@ Element arguments accept any Playwright selector engine (`text=`,
 accessible name, then by visible text — `click:Save` means the button labelled
 Save, not a `<save>` element. Words that are also tag names are no exception:
 `click:table` prefers a control labelled "table", and only falls back to the
-`<table>` element when nothing carries that label.
+`<table>` element when nothing carries that label. Phrases are labels too —
+`click:Save changes` is a button, not a descendant selector — so a selector made
+only of tag names and spaces needs saying explicitly: `css=nav button`.
 
 ## Browser chrome
 

--- a/shotkit/src/actions.mjs
+++ b/shotkit/src/actions.mjs
@@ -48,7 +48,8 @@ const byLabel = (page, spec) =>
  *
  * Some labels collide with real tag names — "table", "select", "code", "header",
  * "form", "nav" are all things a button might say — so the tag reading is a
- * fallback rather than a rule. It is used only when the word names a tag, no
+ * fallback rather than a rule, and it applies to single words only: a phrase
+ * with a space in it is a label, not a descendant selector. It is used only when the word names a tag, no
  * label matches it, and an element of that tag is actually on the page. When
  * neither matches (the usual "not there yet" case) the label locator is
  * returned, so Playwright's auto-waiting applies and any error names the label
@@ -59,10 +60,14 @@ const byLabel = (page, spec) =>
  */
 export async function locate(page, spec) {
   if (ENGINE_PREFIX.test(spec) || spec.startsWith("//") || spec.startsWith("(")) return page.locator(spec).first();
-  if (CSS_PUNCTUATION.test(spec) || /\s/.test(spec)) return page.locator(spec).first();
+  if (CSS_PUNCTUATION.test(spec)) return page.locator(spec).first();
 
+  // Everything left is punctuation-free, which on a UI means a label far more
+  // often than a selector: `click:Save changes` is a button, not a `<changes>`
+  // inside a `<Save>`. A space-separated selector of bare tag names is the one
+  // thing this reading loses, and `css=nav button` still says it explicitly.
   const label = byLabel(page, spec);
-  if (!HTML_TAGS.has(spec.toLowerCase())) return label;
+  if (/\s/.test(spec) || !HTML_TAGS.has(spec.toLowerCase())) return label;
   if ((await label.count()) > 0) return label;
   const tag = page.locator(spec).first();
   return (await tag.count()) > 0 ? tag : label;
@@ -195,5 +200,7 @@ export const ACTION_HELP = `
   eval:<js>            run JS in the page
 
   Selectors take any Playwright engine: text=Save, role=button[name="Save"],
-  #id, .class, //xpath. A bare word is matched by accessible name, then by
-  visible text — click:Save means the button labelled Save.`;
+  #id, .class, //xpath. Anything without CSS punctuation is matched by
+  accessible name, then visible text — click:Save changes means the button
+  labelled "Save changes". For a selector that is only tag names and spaces,
+  say so: css=nav button.`;

--- a/shotkit/test/selftest.mjs
+++ b/shotkit/test/selftest.mjs
@@ -255,6 +255,23 @@ await (async () => {
     assert.equal(r.kind, "label");
   });
 
+  await acount("a multi-word label is a label, not a descendant selector", async () => {
+    // `page.locator("Save changes")` is valid CSS — a <changes> inside a <Save>
+    // — so getting this wrong fails silently rather than throwing.
+    const r = await locate(fakePage([]), "Save changes");
+    assert.equal(r.kind, "label");
+  });
+
+  await acount("a phrase of tag names is still a label", async () => {
+    const r = await locate(fakePage(["css:nav button"]), "nav button");
+    assert.equal(r.kind, "label");
+  });
+
+  await acount("an explicit css= prefix still reaches the selector engine", async () => {
+    const r = await locate(fakePage([]), "css=nav button");
+    assert.equal(r.kind, "css");
+  });
+
   await acount("the tag is used only when no label matches it", async () => {
     const r = await locate(fakePage(["css:select"]), "select");
     assert.equal(r.kind, "css");


### PR DESCRIPTION
## Summary

Fixes a regression I introduced in #762. Reordering the bare-word branch
inverted a guard:

```js
// before — "no whitespace" was a restriction on the TAG path
if (CSS_PUNCTUATION.test(spec) || /\s/.test(spec) === false && /^[a-z]+$/.test(spec) && HTML_TAGS.has(spec))

// after — whitespace now routes INTO the CSS path
if (CSS_PUNCTUATION.test(spec) || /\s/.test(spec))
```

So any action argument containing a space became a CSS selector. `click:Save
changes` parses as a perfectly valid descendant selector — a `<changes>` inside a
`<Save>` — which is why it fails silently rather than throwing: zero matches,
then a fifteen-second timeout with nothing explaining it.

Against the running app, `Install CLI` matched **0** elements as a selector and
**1** as a label.

## Changes

Punctuation alone decides now. Anything without CSS punctuation goes to the label
path — phrases included, which is what a phrase on a UI almost always is — and
the tag-name fallback keeps the single-word restriction it originally had.

```js
if (CSS_PUNCTUATION.test(spec)) return page.locator(spec).first();
const label = byLabel(page, spec);
if (/\s/.test(spec) || !HTML_TAGS.has(spec.toLowerCase())) return label;
```

The one reading this loses is a selector made only of tag names and spaces
(`nav button`). That stays available as `css=nav button`, which is worth the
explicitness: the ambiguity is real, and resolving it toward labels is the same
call the rest of this function makes.

Docs updated in three places that all described the old single-word framing:
`ACTION_HELP`, the README, and the skill.

## Testing

- Three new cases in `shotkit/test/selftest.mjs` (37 passing): a multi-word label
  resolves as a label, a phrase made of tag names still resolves as a label, and
  an explicit `css=` prefix still reaches the selector engine.
- Against the running mock frontend: `click:Install CLI` (multi-word label),
  `click:Negotiate` (single word), and `click:css=nav a` (explicit selector with a
  space) all resolve and act.
- Direct comparison on the live page, confirming the regression rather than
  assuming it: `page.locator("Install CLI").count()` → 0;
  `getByRole/getByText` → 1.
- `npx tsc --noEmit` clean (shotkit's JSDoc is checked through the frontend's
  `allowJs`).

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`) — untouched; no Python in this PR
- [ ] Linting passes (`uv run ruff check .`) — untouched
- [ ] Format check passes (`uv run ruff format --check .`) — untouched

## Related Issues

Fixes a regression from #762.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwMZzsVJawEdEQoAusNyZe)_