### PR TITLE
Record short videos with a cursor, click rings and a camera

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: screenshot
-description: Take a screenshot of the running Mycelium app, or of CLI output rendered as a terminal card. Use when you need to SEE the UI — verifying a frontend change, checking a layout at phone/tablet/desktop widths, driving a multi-step flow and looking at each step, or producing an image of a `mycelium` command's output for a doc or PR. Triggers on "screenshot", "show me the app", "what does it look like", "check the layout", "responsive", "capture the terminal".
+description: Take a screenshot of the running Mycelium app, or of CLI output rendered as a terminal card, or record a short video of a flow with a visible cursor and click/zoom animations. Use when you need to SEE the UI — verifying a frontend change, checking a layout at phone/tablet/desktop widths, driving a multi-step flow and looking at each step, producing an image of a `mycelium` command's output for a doc or PR, or showing a flow in motion. Triggers on "screenshot", "show me the app", "what does it look like", "check the layout", "responsive", "capture the terminal", "record a video", "screen recording", "demo clip", "show it in motion".
 ---
 
 # Screenshot the app or the CLI
@@ -79,6 +79,27 @@ node shotkit/bin/shot.mjs close --session r
 A bare word (`click:Negotiate`) matches an accessible name, then visible text.
 For anything else use a Playwright selector: `#id`, `.class`,
 `role=button[name="Save"]`, `text=Save`. `shot help shoot` lists every verb.
+
+## Record a short video
+
+When the thing to show is a *flow* rather than a state — a demo clip for a PR or
+a doc, or checking that an interaction feels right:
+
+```bash
+node shotkit/bin/shot.mjs video /room/atlas-migration --mock --offline \
+  --do click:Negotiate --do wait:.offer-grid --auto-zoom
+```
+
+Same `--do` verbs as a screenshot. The recording adds what a still does not
+need: the pointer travels to each target (moving the real mouse, so hover states
+fire), a ring marks each click, and `--auto-zoom` pushes the camera in on what is
+being pressed and back out after. `zoom:<sel>`, `zoom:<sel>@2.2` and `zoomout`
+place the camera by hand.
+
+The output path on stdout is an **.mp4 where the machine has a full ffmpeg, and
+a .webm otherwise** — Playwright's bundled build is webm-only. `shot doctor`
+says which. You cannot watch it: hand the path to the user, or pull a frame out
+of it to look at. Keep takes short (a few actions); `--max-seconds` caps one.
 
 ## Screenshot CLI output
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,11 @@ shotkit/            The repo's camera: fast screenshots of the running app and o
                     — `app` (a route, with --mock booting dev:mock), `term` (a
                     command under a pty, so Rich keeps its colors, rendered as a
                     Carbon-style card), `code`, plus --responsive/--sheet for
-                    breakpoints and open/do/shoot for driving a held page. See the
+                    breakpoints and open/do/shoot for driving a held page. `video`
+                    records the same `--do` flow as a short clip with a drawn
+                    cursor, click rings and a camera that pushes in (--auto-zoom),
+                    encoded by whatever ffmpeg is on the machine — mp4 with a full
+                    one, webm off the build Playwright ships. See the
                     `screenshot` skill. Captures land in gitignored `.shotkit/`;
                     the committed docs assets are still `pnpm screenshots`, which
                     now runs on this engine.

--- a/shotkit/README.md
+++ b/shotkit/README.md
@@ -12,6 +12,7 @@ shot term mycelium memory ls --room atlas     # a terminal card, real ANSI color
 shot app /room/atlas-migration --mock         # the running frontend
 shot app / --responsive --sheet               # every breakpoint in one image
 shot code src/services/aligner.py --range 40:80
+shot video /room/atlas --click Negotiate --auto-zoom   # a short take, cursor and all
 ```
 
 Nothing here is on the install path or in the runtime. A user never executes it.
@@ -45,6 +46,7 @@ speedup: 13.1x
 | `shot text <file\|->` | render an existing ANSI capture |
 | `shot code <file>` | a syntax-highlighted code card |
 | `shot html <file\|->` | render an HTML document |
+| `shot video [route]` | record a short take — see **Video** |
 | `shot open` / `do` / `shoot` / `close` | drive a page held open — see **Navigation** |
 | `shot warm` / `status` / `stop` / `serve` | the daemon |
 | `shot doctor` / `bench` | check and time this machine |
@@ -107,6 +109,50 @@ Element arguments accept any Playwright selector engine (`text=`,
 accessible name, then by visible text — `click:Save` means the button labelled
 Save, not a `<save>` element.
 
+## Video
+
+`shot video` records the same flow a screenshot would take, as a short clip with
+a pointer in it:
+
+```bash
+shot video /room/atlas --do click:Negotiate --do wait:.offer-grid --auto-zoom
+shot video / --mock --do 'fill:#search=aligner' --do press:Enter --format mp4
+shot video https://example.com --do 'zoom:.pricing@2' --do zoomout --fps 24
+```
+
+The action vocabulary is the one `--do` already speaks — a recording is not a
+second script format. What changes is how each verb is performed:
+
+| | |
+|---|---|
+| **The pointer travels.** | It eases to each target and the real mouse goes with it, so hover states, tooltips and drag affordances light up on the way. |
+| **The click reads.** | A ring expands where the press lands, and the cursor dips — at 30fps a click is otherwise a frame with nothing in it. |
+| **The camera pushes in.** | `zoom:<sel>` frames an element; `--auto-zoom` does it for every click and pulls back after. It is a transform on the page, so the type is re-rasterized sharper, not scaled up. |
+| **Typing is typed.** | `fill:` clicks the field and enters the text a character at a time. |
+
+Two extra verbs, ignored outside a recording, so one action list can serve both
+a take and the stills pulled from the same flow:
+
+```
+zoom:<sel>  zoom:<sel>@2.2  zoom:2  zoomout   hold:<ms>
+```
+
+The camera crops into the frame as it stands, so it never asks the page for
+content it has not painted; a push-in near an edge slides back inside instead of
+panning off. While it is pushed in, a `position: fixed` element travels with the
+page rather than sticking, and an element the crop has cut off is brought back by
+pulling the camera out before acting on it.
+
+**Format.** `--format mp4|webm|gif`, defaulting to the best the machine's ffmpeg
+can write. Playwright ships one with its browsers — always present, but built
+webm-only — so mp4 and gif need a full ffmpeg on PATH (or `SHOTKIT_FFMPEG`).
+`shot doctor` says which you have.
+
+**Timing.** `--fps` (30), `--move-ms` (620), `--dwell` (620), `--zoom-ms` (620),
+`--lead-in` (500), `--tail` (1000), and `--max-seconds` (90) to stop a runaway
+take. Frames come from a CDP screencast — real time, the app's own transitions
+included; `--capture shots` falls back to a screenshot loop.
+
 ## Browser chrome
 
 `--chrome` re-renders a page capture inside the same window frame the terminal
@@ -147,3 +193,5 @@ where files land.
   the client replaces it when that moves, so a fix never silently runs stale.
 - **Captures land in `.shotkit/`** (gitignored) and overwrite by name; `--unique`
   timestamps instead.
+- **A take costs about what it lasts.** Encoding keeps up with capture, so a
+  ten-second video takes about ten seconds plus the flow's own waits.

--- a/shotkit/bin/shot.mjs
+++ b/shotkit/bin/shot.mjs
@@ -61,6 +61,28 @@ const RESPONSIVE = {
   "sheet-title": { type: "string", help: "heading on the contact sheet" },
 };
 
+const VIDEO = {
+  fps: { type: "number", help: "frames per second (default 30)" },
+  format: { type: "string", value: "mp4|webm|gif", help: "container (default: the best this ffmpeg writes)" },
+  quality: { type: "number", help: "frame jpeg quality, 1-100 (default 92)" },
+  crf: { type: "number", help: "encoder quality; lower is better" },
+  zoom: { type: "number", help: "push-in factor for zoom: and --auto-zoom (default 1.6)" },
+  "auto-zoom": { type: "boolean", help: "push in on every click, and back out after" },
+  cursor: { type: "boolean", help: "draw the pointer (default on)" },
+  "cursor-size": { type: "number", help: "pointer height in px (default 30)" },
+  accent: { type: "string", value: "<css>", help: "click-ring color (default: the theme's accent)" },
+  "move-ms": { type: "number", help: "how long the pointer takes to travel (default 620)" },
+  dwell: { type: "number", value: "<ms>", help: "beat after each action (default 620)" },
+  "zoom-ms": { type: "number", help: "push-in duration (default 620)" },
+  "lead-in": { type: "number", value: "<ms>", help: "still frames before the first action (default 500)" },
+  tail: { type: "number", value: "<ms>", help: "still frames after the last one (default 1000)" },
+  "max-seconds": { type: "number", help: "stop the take at N seconds (default 90)" },
+  capture: { type: "string", value: "screencast|shots", help: "frame source (default screencast)" },
+  scale: { type: "number", help: "device pixel ratio (default 1, even for a preset that implies 2)" },
+  viewport: { type: "string", value: "<preset|WxH@S>", help: "phone|tablet|laptop|desktop|wide, or 1280x800@2" },
+};
+
+
 const DAEMON = {
   daemon: { type: "boolean", help: "use the warm background browser (default on)" },
   idle: { type: "number", value: "<ms>", help: "daemon idle timeout when starting one" },
@@ -127,6 +149,11 @@ const APP = {
   mock: { type: "boolean", help: "boot pnpm dev:mock and keep it warm in the daemon" },
 };
 
+// A take has no still-image business: nothing is clipped to an element, masked,
+// or made transparent, so those flags stay out of `shot help video`.
+const { "full-page": _fullPage, element: _element, mask: _mask, ...VIDEO_PAGE } = PAGE;
+const { transparent: _transparent, ...VIDEO_FRAME } = FRAME;
+
 const err = (m) => process.stderr.write(`${m}\n`);
 
 const USAGE = `shot — fast screenshots of the app and of CLI output
@@ -138,6 +165,9 @@ one-shot
   shot text <file|->      render an existing text/ANSI capture as a terminal
   shot code <file>        a syntax-highlighted code card
   shot html <file|->      render an HTML document
+
+video
+  shot video [route] --do click:X --auto-zoom      a short take, cursor and all
 
 responsive
   shot app / --responsive --sheet     every breakpoint, plus one image of all of them
@@ -169,9 +199,16 @@ const COMMAND_HELP = {
   open: ["shot open <route|url> [options]   — hold a page open under a name", { ...SESSION, ...APP, ...PAGE, ...RESPONSIVE, ...FRAME, ...DAEMON }],
   do: ["shot do <verb:arg…> [options]       — drive the held page", { ...SESSION, ...PAGE, ...DAEMON }],
   shoot: ["shot shoot [verb:arg…] [options]   — shoot the held page as it stands", { ...SESSION, ...PAGE, ...CHROME, ...FRAME, ...OUTPUT, ...DAEMON }],
+  video: [
+    "shot video [route|url] [options]   — a recorded take, with a visible cursor",
+    { ...APP, ...VIDEO_PAGE, ...VIDEO_FRAME, ...OUTPUT, ...DAEMON, ...VIDEO },
+  ],
   resize: ["shot resize --viewport <v> [options] — reframe the held page in place", { ...SESSION, ...RESPONSIVE, ...DAEMON }],
   close: ["shot close [options]", { ...SESSION, ...DAEMON }],
 };
+
+/** `/room/atlas` is a route; anything with a scheme is a URL. */
+const isUrl = (s) => /^[a-z][a-z0-9+.-]*:\/\//i.test(s);
 
 async function readStdin() {
   const chunks = [];
@@ -204,7 +241,10 @@ async function runSpec(spec, flags) {
     try {
       const { ensureDaemon, send } = await import("../src/ipc.mjs");
       await ensureDaemon({ idleMs: flags.idle });
-      return await send(isSession ? "session" : "shot", { spec });
+      // A take runs for as long as it runs; the default request timeout is
+      // sized for a screenshot and would cut one short.
+      const timeout = spec.op === "video" ? Math.max(180_000, (spec.maxSeconds ?? 90) * 1000 + 120_000) : undefined;
+      return await send(isSession ? "session" : "shot", { spec }, timeout ? { timeout } : {});
     } catch (e) {
       // A failure the daemon reported is this shot's failure — retrying it in
       // this process would only lose the daemon's state (a booted mock server,
@@ -232,6 +272,10 @@ function report(result, flags) {
   if (t.command) bits.push(`cmd ${t.command}ms`);
   if (t.capture) bits.push(`capture ${t.capture}ms`);
   const size = result.width ? ` · ${result.width}x${result.height}` : "";
+  if (result.op === "video") {
+    bits.push(`${(result.durationMs / 1000).toFixed(1)}s`, `${result.frames} frames @ ${result.fps}fps`);
+    if (result.meta?.truncated) bits.push("truncated at --max-seconds");
+  }
   err(`[shot] ${result.op} · ${bits.join(" · ")} · ${result.mode ?? "daemon"}${size}`);
   if (result.meta?.exitCode) err(`[shot] command exited ${result.meta.exitCode}`);
   for (const step of result.trace ?? []) err(`[shot]   ${step.action} (${step.ms}ms)`);
@@ -342,7 +386,7 @@ async function main() {
   } else if (command === "open") {
     spec = toSpec("open", flags);
     const target = rest[0] ?? "/";
-    if (target.startsWith("http")) spec.url = target;
+    if (isUrl(target)) spec.url = target;
     else spec.route = target;
   } else if (command === "do" || command === "shoot") {
     spec = toSpec(command === "do" ? "act" : "shoot", flags);
@@ -370,6 +414,11 @@ async function main() {
     spec = toSpec("html", flags);
     if (src === "-") spec.html = await readStdin();
     else spec.file = resolve(src);
+  } else if (command === "video") {
+    spec = toSpec("video", flags);
+    const target = rest[0] ?? "/";
+    if (isUrl(target)) spec.url = target;
+    else spec.route = target;
   } else if (command === "url") {
     if (!rest[0]) throw new Error("shot url needs a URL");
     spec = toSpec("url", flags);

--- a/shotkit/src/actions.mjs
+++ b/shotkit/src/actions.mjs
@@ -68,26 +68,48 @@ const splitPair = (arg) => {
 };
 
 /**
+ * The recorder's hook into this vocabulary. When one is present the same verbs
+ * are performed *cinematically* — the pointer travels to the target, the press
+ * is visible, the camera can follow — so a take and a screenshot are driven by
+ * one script rather than two. See video.mjs.
+ *
+ * @typedef {object} Cursor
+ * @property {number} typeDelay per-character delay for visible typing
+ * @property {(l:any, o?:any) => Promise<any>} glide move to a target
+ * @property {(l:any, o?:any) => Promise<any>} click travel, press, release
+ * @property {(arg:string, o?:any) => Promise<any>} zoom push in
+ * @property {() => Promise<any>} zoomOut pull back to 1x
+ * @property {(ms?:number) => Promise<void>} dwell a beat, so the result reads
+ */
+
+/** Verbs that are already a wait; a recording must not pad them further. */
+const SELF_PACED = new Set(["sleep", "hold", "wait", "wait-hidden", "wait-text", "wait-url"]);
+
+/**
  * @param {import("playwright").Page} page
  * @param {string[]} actions
- * @param {{baseUrl?:string, timeout?:number, log?:(m:string)=>void}} ctx
+ * @param {{baseUrl?:string, timeout?:number, log?:(m:string)=>void, cursor?:Cursor}} ctx
  * @returns {Promise<{action:string, ms:number}[]>}
  */
 export async function runActions(page, actions, ctx = {}) {
   const timeout = ctx.timeout ?? 15_000;
+  const cursor = ctx.cursor;
   const trace = [];
   for (const raw of actions ?? []) {
     const started = Date.now();
     const { verb, arg } = parseAction(raw);
     switch (verb) {
       case "click":
-        await locate(page, arg).click({ timeout });
+        if (cursor) await cursor.click(locate(page, arg), { timeout });
+        else await locate(page, arg).click({ timeout });
         break;
       case "dblclick":
-        await locate(page, arg).dblclick({ timeout });
+        if (cursor) await cursor.click(locate(page, arg), { timeout, dblclick: true });
+        else await locate(page, arg).dblclick({ timeout });
         break;
       case "hover":
-        await locate(page, arg).hover({ timeout });
+        if (cursor) await cursor.glide(locate(page, arg), { timeout });
+        else await locate(page, arg).hover({ timeout });
         break;
       case "focus":
         await locate(page, arg).focus({ timeout });
@@ -100,11 +122,21 @@ export async function runActions(page, actions, ctx = {}) {
         break;
       case "fill": {
         const [sel, value] = splitPair(arg);
-        await locate(page, sel).fill(value, { timeout });
+        const field = locate(page, sel);
+        if (!cursor) {
+          await field.fill(value, { timeout });
+          break;
+        }
+        // A field that fills in one frame reads as a glitch. On camera the
+        // pointer goes to it, it is cleared, and the text is typed.
+        await cursor.click(field, { timeout });
+        await field.fill("", { timeout });
+        await field.pressSequentially(value, { delay: cursor.typeDelay, timeout });
         break;
       }
       case "select": {
         const [sel, value] = splitPair(arg);
+        if (cursor) await cursor.glide(locate(page, sel), { timeout });
         await locate(page, sel).selectOption(value, { timeout });
         break;
       }
@@ -112,7 +144,7 @@ export async function runActions(page, actions, ctx = {}) {
         await page.keyboard.press(arg);
         break;
       case "typekeys":
-        await page.keyboard.type(arg, { delay: 20 });
+        await page.keyboard.type(arg, { delay: cursor?.typeDelay ?? 20 });
         break;
       case "goto":
         await page.goto(arg.startsWith("http") ? arg : `${ctx.baseUrl ?? ""}${arg}`, {
@@ -130,6 +162,9 @@ export async function runActions(page, actions, ctx = {}) {
         await page.reload({ waitUntil: "domcontentloaded" });
         break;
       case "scroll":
+        // Scrolling is done at 1x: the camera is a crop of the painted frame,
+        // and the page repaints for the scroll, not for the crop.
+        if (cursor) await cursor.zoomOut();
         if (arg === "bottom") await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
         else if (arg === "top") await page.evaluate(() => window.scrollTo(0, 0));
         else if (/^-?\d+$/.test(arg)) await page.evaluate((y) => window.scrollBy(0, y), Number(arg));
@@ -148,7 +183,16 @@ export async function runActions(page, actions, ctx = {}) {
         await page.waitForURL(arg.includes("*") ? arg : `**${arg}`, { timeout });
         break;
       case "sleep":
+      case "hold":
         await page.waitForTimeout(Number(arg) || 0);
+        break;
+      case "zoom":
+        // Camera work is a no-op outside a recording, so one action list can
+        // serve both a take and the stills pulled from the same flow.
+        await cursor?.zoom(arg, { timeout, locate: (sel) => locate(page, sel) });
+        break;
+      case "zoomout":
+        await cursor?.zoomOut();
         break;
       case "eval":
         await page.evaluate(arg);
@@ -161,6 +205,7 @@ export async function runActions(page, actions, ctx = {}) {
       default:
         throw new Error(`unknown action "${verb}" in "${raw}"`);
     }
+    if (cursor && !SELF_PACED.has(verb)) await cursor.dwell();
     trace.push({ action: raw, ms: Date.now() - started });
     ctx.log?.(`${raw} (${Date.now() - started}ms)`);
   }
@@ -175,10 +220,14 @@ export const ACTION_HELP = `
   press:<key>          keyboard key            typekeys:<text>    type into focus
   goto:<url|route>     navigate                back / forward     history
   reload               reload the page         emulate:<scheme>   dark | light
-  scroll:<px|top|bottom|sel>                    sleep:<ms>
+  scroll:<px|top|bottom|sel>                    sleep:<ms> / hold:<ms>
   wait:<sel>           until visible           wait-hidden:<sel>  until gone
   wait-text:<text>     until text appears      wait-url:<glob>    until routed
   eval:<js>            run JS in the page
+
+  Recording only (\`shot video\`), and ignored elsewhere:
+  zoom:<sel>           push in on it        zoom:2             push in on the cursor
+  zoom:<sel>@2.2       both                 zoomout            pull back out
 
   Selectors take any Playwright engine: text=Save, role=button[name="Save"],
   #id, .class, //xpath. A bare word is matched by accessible name, then by

--- a/shotkit/src/api.mjs
+++ b/shotkit/src/api.mjs
@@ -25,6 +25,7 @@ import { resolveBaseUrl } from "./app.mjs";
 import { runCommand } from "./run.mjs";
 import { stripAnsi } from "./ansi.mjs";
 import { viewportList } from "./viewports.mjs";
+import { record, resolveFormat } from "./video.mjs";
 
 /**
  * @typedef {object} PageSpec
@@ -50,6 +51,9 @@ import { viewportList } from "./viewports.mjs";
  * @property {string} [address] address-bar text when `chrome` is set
  * @property {"dark"|"light"} [chromeTheme] frame theme, when it should differ
  *   from the app's — a light frame around a dark app, say
+ * @property {number} [fps] `op: "video"` — frames per second (default 30)
+ * @property {number} [zoom] push-in factor for `zoom:` and `--auto-zoom`
+ * @property {boolean} [autoZoom] push in on every click, and back out after
  */
 
 export const DEFAULT_OUT_DIR = process.env.SHOTKIT_OUT ?? resolve(REPO_ROOT, ".shotkit");
@@ -59,12 +63,18 @@ const slug = (s) =>
 
 const stamp = () => new Date().toISOString().replace(/[-:]/g, "").replace(/\..+/, "").replace("T", "-");
 
+/** The extension a spec's output wants: an image format, or a video container. */
+function outputExt(spec) {
+  if (spec.op === "video") return spec.format ?? "webm";
+  return spec.format === "jpeg" ? "jpg" : "png";
+}
+
 /** Where this shot lands, given `--out` / `--out-dir` / `--name` / `--unique`. */
 function outputPath(spec, fallbackName, suffix = "") {
-  const ext = spec.format === "jpeg" ? "jpg" : "png";
+  const ext = outputExt(spec);
   if (spec.out && !suffix) return resolve(spec.out);
   if (spec.out) {
-    const base = resolve(spec.out).replace(/\.(png|jpg|jpeg)$/i, "");
+    const base = resolve(spec.out).replace(/\.(png|jpg|jpeg|mp4|webm|gif)$/i, "");
     return `${base}${suffix}.${ext}`;
   }
   const dir = spec.outDir ? resolve(spec.outDir) : DEFAULT_OUT_DIR;
@@ -109,6 +119,43 @@ export async function capture(spec, ctx = {}) {
     return finish({ ...base, meta, ms: { total: Date.now() - t0, ...timings } }, spec, buf, fallbackName);
   }
 
+  if (spec.op === "video") {
+    const { url, baseUrl } = await resolvePageUrl({ ...spec, op: spec.url ? "url" : "app" }, log);
+    const { format } = await resolveFormat(spec);
+    const frame = viewportList(spec)[0];
+    const isApp = Boolean(spec.route);
+    const name = `video-${slug(spec.route ?? new URL(url).pathname)}`;
+    const out = outputPath({ ...spec, format }, name);
+    const take = await record(
+      eng,
+      {
+        ...spec,
+        // A preset's own pixel ratio is for stills; a take is a viewport-sized
+        // file unless --scale asks for more, since doubling it doubles every
+        // frame for detail a video does not keep.
+        ...(frame ? { width: frame.viewport.width, height: frame.viewport.height } : {}),
+        format,
+        url,
+        baseUrl,
+        settle: spec.settle ?? (isApp ? "fast" : "none"),
+        storage: themedStorage(spec, isApp),
+      },
+      { log, out },
+    );
+    // Everything about *how* the take was made is meta; the file and its shape
+    // stay at the top level, where every other op puts them.
+    const { capture: source, encoder, truncated, ...rest } = take;
+    const result = {
+      ...base,
+      ...rest,
+      meta: { url, baseUrl, viewport: frame?.name, capture: source, encoder, truncated },
+      ms: { total: Date.now() - t0, ...take.ms },
+    };
+    if (!spec.stdout) return result;
+    const bytes = await readFile(take.path);
+    return { ...result, base64: bytes.toString("base64"), bytes: bytes.length };
+  }
+
   if (spec.op === "url" || spec.op === "app") {
     const { url, baseUrl } = await resolvePageUrl(spec, log);
     const fallbackName = spec.op === "app" ? `app-${slug(spec.route ?? "home")}` : `url-${slug(new URL(url).pathname)}`;
@@ -149,8 +196,8 @@ export async function capture(spec, ctx = {}) {
  * or it produces a light frame around an unchanged dark app. An explicit
  * `--storage theme=…` still takes precedence.
  */
-function themedStorage(spec) {
-  if (spec.op !== "app") return spec.storage;
+function themedStorage(spec, isApp = spec.op === "app") {
+  if (!isApp) return spec.storage;
   return { theme: spec.theme ?? "dark", ...(spec.storage ?? {}) };
 }
 

--- a/shotkit/src/browser.mjs
+++ b/shotkit/src/browser.mjs
@@ -19,7 +19,7 @@ import { existsSync, readdirSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 
-const BROWSERS_DIR = process.env.PLAYWRIGHT_BROWSERS_PATH ||
+export const BROWSERS_DIR = process.env.PLAYWRIGHT_BROWSERS_PATH ||
   (platform() === "darwin" ? join(homedir(), "Library/Caches/ms-playwright") : join(homedir(), ".cache/ms-playwright"));
 
 /** Per-platform binary path inside one downloaded browser directory. */

--- a/shotkit/src/cursor.mjs
+++ b/shotkit/src/cursor.mjs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * What a recording adds to a page: a cursor you can see, a click you can see,
+ * and a camera that can push in.
+ *
+ * Headless Chromium draws no pointer, and a screen recording without one is
+ * unreadable — things happen and nothing says why. So the cursor is drawn by
+ * the page itself, as an overlay that follows the *real* mouse. That direction
+ * matters: the recorder moves Playwright's actual mouse, hover states light up
+ * under it for real, and the drawn arrow is downstream of the same events the
+ * app sees rather than a second animation that has to be kept in step with it.
+ *
+ * The camera is a transform on the document, not a crop in the encoder. A page
+ * the browser zooms re-rasterizes its text at the new size, so a push-in lands
+ * on type sharper than the frame it started from; cropping the video afterwards
+ * could only make the same pixels bigger.
+ *
+ * `installOverlay` is serialized into the page by `addInitScript`, so it closes
+ * over nothing and reads nothing from this module — every constant it needs
+ * arrives in its one argument.
+ */
+
+/** Where the arrow's tip sits inside its own 26x30 box. */
+export const HOTSPOT = { x: 5, y: 3 };
+
+/**
+ * @typedef {object} OverlayOptions
+ * @property {boolean} [cursor] draw the pointer at all
+ * @property {number} [startX] @property {number} [startY] where it starts
+ * @property {number} [follow] 0-1, how hard the drawn cursor chases the real one
+ * @property {string} [accent] ripple color
+ * @property {number} [size] arrow height in CSS px
+ */
+
+/** @type {Required<OverlayOptions> & {hotspotX:number, hotspotY:number}} */
+export const OVERLAY_DEFAULTS = {
+  cursor: true,
+  startX: 40,
+  startY: 40,
+  follow: 0.42,
+  accent: "#5cc7d2",
+  size: 30,
+  hotspotX: HOTSPOT.x,
+  hotspotY: HOTSPOT.y,
+};
+
+/**
+ * Runs in the page, on every document. Installs `window.__shotkit`:
+ *
+ *   at(x, y)                aim the drawn cursor (real mouse events do this too;
+ *                           the recorder calls it to seed and to land exactly)
+ *   snap(x, y)              teleport, no easing
+ *   camera(z, x, y, ms)     push in to `z` around viewport point (x, y)
+ *   press(down) / show(on)  force the pressed look; hide the pointer
+ *   state()                 what the recorder asserts against
+ *
+ * @param {Required<OverlayOptions> & {hotspotX:number, hotspotY:number}} opts
+ */
+export function installOverlay(opts) {
+  if (window.__shotkit) return;
+
+  const st = {
+    x: opts.startX,
+    y: opts.startY,
+    tx: opts.startX,
+    ty: opts.startY,
+    anim: null,
+    down: false,
+    ticking: false,
+    lastPress: -Infinity,
+    visible: opts.cursor,
+    cam: { z: 1, tx: 0, ty: 0 },
+    mounted: false,
+  };
+  let root = null;
+  let arrow = null;
+
+  const CSS = `
+    #__shotkit-overlay, #__shotkit-overlay * { pointer-events: none !important; }
+    #__shotkit-overlay {
+      position: fixed; inset: 0; margin: 0; padding: 0; border: 0;
+      width: 100%; height: 100%; max-width: none; max-height: none;
+      background: transparent; overflow: visible; z-index: 2147483647;
+    }
+    #__shotkit-overlay::backdrop { background: transparent; }
+    #__shotkit-cursor {
+      position: absolute; left: 0; top: 0;
+      width: ${(opts.size * 26) / 30}px; height: ${opts.size}px;
+      transform-origin: ${(opts.hotspotX / 26) * 100}% ${(opts.hotspotY / 30) * 100}%;
+      filter: drop-shadow(0 2px 5px rgba(0,0,0,.42));
+      transition: opacity 160ms linear;
+      will-change: transform;
+    }
+    #__shotkit-cursor svg { display: block; width: 100%; height: 100%; }
+    .__shotkit-ripple {
+      position: absolute; border-radius: 50%;
+      border: 2.5px solid ${opts.accent};
+      background: ${opts.accent}33;
+      box-shadow: 0 0 12px ${opts.accent}66;
+    }
+  `;
+
+  const ARROW = `<svg viewBox="0 0 26 30" xmlns="http://www.w3.org/2000/svg">
+      <path d="M5 2.6 L5 24.4 L10.7 18.8 L14.2 26.8 L17.9 25.1 L14.4 17.3 L21.8 17.1 Z"
+            fill="#ffffff" stroke="rgba(12,14,17,.62)" stroke-width="1.5" stroke-linejoin="round"/>
+    </svg>`;
+
+  function mount() {
+    if (!document.documentElement) return;
+    // A page that replaces its body (setContent, a client-side route change)
+    // takes the overlay with it, so "mounted" means *still attached*.
+    if (st.mounted && root && root.isConnected) return;
+    if (!document.getElementById("__shotkit-style")) {
+      const style = document.createElement("style");
+      style.id = "__shotkit-style";
+      style.textContent = CSS;
+      (document.head ?? document.documentElement).appendChild(style);
+    }
+
+    root = document.createElement("div");
+    root.id = "__shotkit-overlay";
+    root.setAttribute("aria-hidden", "true");
+    arrow = document.createElement("div");
+    arrow.id = "__shotkit-cursor";
+    arrow.innerHTML = ARROW;
+    root.appendChild(arrow);
+    (document.body ?? document.documentElement).appendChild(root);
+
+    // The top layer is the one place a fixed element ignores an ancestor
+    // transform, which is exactly what the camera does to the document: the
+    // cursor has to stay the size of a cursor while the page is pushed in.
+    try {
+      root.setAttribute("popover", "manual");
+      root.showPopover();
+    } catch {
+      /* no popover here: the cursor rides the zoom, which is survivable */
+    }
+    st.mounted = true;
+    draw();
+    // One loop for the life of the document, however often the overlay has to
+    // be put back: remounting is not a reason to start a second one.
+    if (!st.ticking) {
+      st.ticking = true;
+      requestAnimationFrame(tick);
+    }
+  }
+
+  function draw() {
+    if (!arrow) return;
+    const x = st.x - opts.hotspotX;
+    const y = st.y - opts.hotspotY;
+    arrow.style.transform = `translate(${x}px, ${y}px) scale(${st.down ? 0.86 : 1})`;
+    arrow.style.opacity = st.visible ? "1" : "0";
+  }
+
+  /** Ease in and out, the same curve the recorder walks the real mouse along. */
+  function ease(t) {
+    return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
+  }
+
+  /**
+   * Two ways the pointer moves, and the reason for both.
+   *
+   * A travel the recorder asked for is animated here, in the page, off rAF: it
+   * is smooth at the display's rate whatever the round-trip cost of driving the
+   * browser from outside, and it does not depend on input events reaching this
+   * script at all — headless Chromium coalesces mouse moves and flushes them
+   * with its frames, which is a thin thread to hang a recording on.
+   *
+   * Anything else that moves the mouse — a stray `locator.click()`, a real
+   * pointer — is chased with a light lerp, which irons out sparse events and
+   * gives the cursor a little weight.
+   */
+  function tick() {
+    requestAnimationFrame(tick);
+    if (st.anim) {
+      const p = Math.min(1, (performance.now() - st.anim.t0) / st.anim.ms);
+      const e = ease(p);
+      st.x = st.anim.fx + (st.anim.x - st.anim.fx) * e;
+      st.y = st.anim.fy + (st.anim.y - st.anim.fy) * e;
+      if (p >= 1) st.anim = null;
+      draw();
+      return;
+    }
+    const dx = st.tx - st.x;
+    const dy = st.ty - st.y;
+    if (Math.abs(dx) < 0.05 && Math.abs(dy) < 0.05) {
+      if (st.x === st.tx && st.y === st.ty) return;
+      st.x = st.tx;
+      st.y = st.ty;
+    } else {
+      st.x += dx * opts.follow;
+      st.y += dy * opts.follow;
+    }
+    draw();
+  }
+
+  function ripple() {
+    if (!root) return;
+    const el = document.createElement("div");
+    const size = 18;
+    el.className = "__shotkit-ripple";
+    el.style.left = `${st.tx - size / 2}px`;
+    el.style.top = `${st.ty - size / 2}px`;
+    el.style.width = `${size}px`;
+    el.style.height = `${size}px`;
+    root.appendChild(el);
+    const done = () => el.remove();
+    try {
+      // Held bright for the first third: a ring that fades on the way out is
+      // gone by the second frame at 30fps, which reads as no click at all.
+      const anim = el.animate(
+        [
+          { transform: "scale(.4)", opacity: 1, offset: 0 },
+          { transform: "scale(1.5)", opacity: 0.9, offset: 0.35 },
+          { transform: "scale(3.4)", opacity: 0, offset: 1 },
+        ],
+        { duration: 540, easing: "cubic-bezier(.22,.7,.3,1)" },
+      );
+      anim.addEventListener("finish", done);
+    } catch {
+      done();
+    }
+  }
+
+  /**
+   * Push in to `z` around viewport point (x, y).
+   *
+   * The transform is `translate(t) scale(z)` off a `0 0` origin, so aiming it is
+   * arithmetic rather than origin bookkeeping: a point `u` in the unzoomed
+   * viewport renders at `t + z*u`. `t` is then clamped so the frame only ever
+   * crops into what is already on screen — a push-in near an edge slides back
+   * inside instead of panning off the page.
+   *
+   * The clamp is not politeness: a page paints what its layout viewport covers
+   * and nothing else, so a camera that wandered outside the frame would be
+   * pointed at document nobody has drawn.
+   */
+  function camera(z, x, y, ms) {
+    const de = document.documentElement;
+    const W = window.innerWidth;
+    const H = window.innerHeight;
+    const zoom = Math.max(1, Number(z) || 1);
+    const ux = (x - st.cam.tx) / st.cam.z;
+    const uy = (y - st.cam.ty) / st.cam.z;
+    const tx = Math.min(0, Math.max(W * (1 - zoom), W / 2 - zoom * ux));
+    const ty = Math.min(0, Math.max(H * (1 - zoom), H / 2 - zoom * uy));
+    st.cam = { z: zoom, tx, ty };
+    de.style.transformOrigin = "0 0";
+    de.style.willChange = zoom === 1 ? "" : "transform";
+    de.style.transition = ms > 0 ? `transform ${ms}ms cubic-bezier(.33,.1,.24,1)` : "none";
+    // The scroll offset is applied after the transform, so it has to come back
+    // out of the translate for the arithmetic above to hold on a scrolled page.
+    const sx = window.scrollX * (zoom - 1);
+    const sy = window.scrollY * (zoom - 1);
+    de.style.transform = zoom === 1 ? "" : `translate(${tx - sx}px, ${ty - sy}px) scale(${zoom})`;
+    return { z: zoom, tx, ty };
+  }
+
+  addEventListener("mousemove", (e) => {
+    st.tx = e.clientX;
+    st.ty = e.clientY;
+  }, { capture: true, passive: true });
+  addEventListener("mousedown", () => {
+    st.down = true;
+    // A press the recorder announced has already drawn its ring; the real event
+    // arrives a moment later and must not stack a second one on top of it.
+    if (performance.now() - st.lastPress > 400) ripple();
+    draw();
+  }, { capture: true, passive: true });
+  addEventListener("mouseup", () => {
+    st.down = false;
+    draw();
+  }, { capture: true, passive: true });
+
+  window.__shotkit = {
+    mount,
+    at(x, y) {
+      st.tx = x;
+      st.ty = y;
+    },
+    /** Travel there over `ms`, on the page's own clock. */
+    glide(x, y, ms) {
+      if (!(ms > 0)) return this.snap(x, y);
+      st.anim = { fx: st.x, fy: st.y, x, y, t0: performance.now(), ms };
+      st.tx = x;
+      st.ty = y;
+      return undefined;
+    },
+    snap(x, y) {
+      st.anim = null;
+      st.x = x;
+      st.tx = x;
+      st.y = y;
+      st.ty = y;
+      draw();
+    },
+    press(down) {
+      st.down = Boolean(down);
+      if (down) {
+        st.lastPress = performance.now();
+        ripple();
+      }
+      draw();
+    },
+    show(on) {
+      st.visible = Boolean(on);
+      draw();
+    },
+    camera,
+    state: () => ({ ...st, cam: { ...st.cam } }),
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", mount, { once: true });
+  } else {
+    mount();
+  }
+  // A client-side route change that replaces the tree we appended to would
+  // otherwise lose the cursor mid-take; remounting is cheap and idempotent.
+  setInterval(mount, 500);
+}

--- a/shotkit/src/doctor.mjs
+++ b/shotkit/src/doctor.mjs
@@ -17,6 +17,7 @@ import { loadPlaywright, REPO_ROOT } from "./engine.mjs";
 import { candidates, launchChromium } from "./browser.mjs";
 import { ptyAvailable } from "./run.mjs";
 import { ping, socketPath } from "./ipc.mjs";
+import { findEncoder } from "./encode.mjs";
 
 const ok = (m) => process.stdout.write(`  \x1b[32m✓\x1b[0m ${m}\n`);
 const warn = (m) => process.stdout.write(`  \x1b[33m!\x1b[0m ${m}\n`);
@@ -58,6 +59,16 @@ export async function doctor() {
     ok("highlight.js present — `shot code` highlights");
   } catch {
     warn("highlight.js missing — `shot code` renders plain. Run `npm install` in shotkit/");
+  }
+
+  head("video");
+  try {
+    const caps = await findEncoder();
+    ok(`ffmpeg (${caps.source}) ${caps.path}`);
+    if (caps.formats.includes("mp4")) ok(`writes ${caps.formats.join(", ")}`);
+    else warn(`writes ${caps.formats.join(", ") || "nothing"} — install a full ffmpeg for mp4 and gif`);
+  } catch (e) {
+    bad(e.message.split("\n")[0]);
   }
 
   head("app");

--- a/shotkit/src/encode.mjs
+++ b/shotkit/src/encode.mjs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Frames in, one video file out.
+ *
+ * The recorder never holds a take in memory: JPEG frames go down ffmpeg's stdin
+ * as they are captured, so a minute of 1280x800 costs a pipe rather than a
+ * gigabyte, and the encode finishes about when the recording does.
+ *
+ * Which ffmpeg is a real question on this machine and not a detail. Playwright
+ * ships one for its own video recording, and it is always there once browsers
+ * are installed — but it is built `--disable-everything` with VP8 and WebM
+ * enabled and nothing else. So H.264 and GIF depend on a full ffmpeg being on
+ * PATH, and the format list is probed rather than assumed: better to say "this
+ * ffmpeg can only write webm" up front than to hand back a broken mp4.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { platform } from "node:os";
+import { join } from "node:path";
+import { BROWSERS_DIR } from "./browser.mjs";
+
+/** Playwright's own build, wherever its browsers live. */
+function bundledFfmpeg() {
+  const inner = { linux: "ffmpeg-linux", darwin: "ffmpeg-mac", win32: "ffmpeg-win64.exe" }[platform()];
+  if (!inner || !existsSync(BROWSERS_DIR)) return null;
+  const dirs = readdirSync(BROWSERS_DIR)
+    .filter((d) => d.startsWith("ffmpeg-"))
+    .sort((a, b) => Number(b.split("-").pop()) - Number(a.split("-").pop()));
+  for (const d of dirs) {
+    const p = join(BROWSERS_DIR, d, inner);
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+const run = (cmd, args) =>
+  new Promise((resolve) => {
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let out = "";
+    child.stdout.on("data", (c) => (out += c));
+    child.stderr.on("data", (c) => (out += c));
+    child.on("error", () => resolve(null));
+    child.on("close", (code) => resolve(code === 0 ? out : null));
+  });
+
+/** @type {{path:string, source:string, encoders:string[], formats:string[]}|null} */
+let cached = null;
+
+/**
+ * The ffmpeg this machine will use, and what it can actually write.
+ * Probed once and held — the daemon asks on every recording.
+ * @param {{force?: boolean}} [opts]
+ */
+export async function findEncoder(opts = {}) {
+  if (cached && !opts.force) return cached;
+  const candidates = [process.env.SHOTKIT_FFMPEG, "ffmpeg", bundledFfmpeg()].filter(Boolean);
+  for (const path of candidates) {
+    const listing = await run(path, ["-hide_banner", "-encoders"]);
+    if (!listing) continue;
+    const encoders = ["libx264", "libx265", "libvpx", "libvpx-vp9", "gif"].filter((e) =>
+      new RegExp(`^\\s*\\S+\\s+${e}\\s`, "m").test(listing),
+    );
+    const formats = [];
+    if (encoders.includes("libx264")) formats.push("mp4");
+    if (encoders.includes("libvpx") || encoders.includes("libvpx-vp9")) formats.push("webm");
+    if (encoders.includes("gif")) formats.push("gif");
+    const source = path === process.env.SHOTKIT_FFMPEG ? "SHOTKIT_FFMPEG" : path === "ffmpeg" ? "PATH" : "playwright";
+    cached = { path, source, encoders, formats };
+    return cached;
+  }
+  throw new Error(
+    "no ffmpeg. Install one (brew install ffmpeg / apt install ffmpeg), point SHOTKIT_FFMPEG at a binary, " +
+      "or run `npx playwright install` — Playwright ships a webm-only build shotkit can borrow.",
+  );
+}
+
+/** Reset the probe; for tests and for `shot doctor` after an install. */
+export function forgetEncoder() {
+  cached = null;
+}
+
+/** The best container this ffmpeg can write, most useful first. */
+export function defaultFormat(caps) {
+  return caps.formats[0] ?? "webm";
+}
+
+/**
+ * ffmpeg's argument list for one take.
+ *
+ * `scale` is pinned to the first frame's size rounded to even numbers: the
+ * screencast can hand back an odd or off-by-one frame when a page resizes
+ * itself, and both H.264 and VP8 refuse odd dimensions in 4:2:0.
+ *
+ * @param {{format:string, fps:number, width:number, height:number,
+ *          crf?:number, out:string}} opts
+ */
+export function encodeArgs({ format, fps, width, height, crf, out }) {
+  const w = width - (width % 2);
+  const h = height - (height % 2);
+  // `pipe:0` rather than `-`: Playwright's stripped build registers the pipe
+  // protocol but not the bare-dash spelling of it, and both work everywhere.
+  const input = ["-hide_banner", "-loglevel", "error", "-y", "-f", "image2pipe",
+    "-vcodec", "mjpeg", "-framerate", String(fps), "-i", "pipe:0"];
+  if (format === "mp4") {
+    return [...input, "-vf", `scale=${w}:${h}`, "-c:v", "libx264", "-preset", "veryfast",
+      "-crf", String(crf ?? 20), "-pix_fmt", "yuv420p", "-movflags", "+faststart", out];
+  }
+  if (format === "webm") {
+    return [...input, "-vf", `scale=${w}:${h}`, "-c:v", "libvpx", "-b:v", "0",
+      "-crf", String(crf ?? 30), "-deadline", "good", "-cpu-used", "3", "-pix_fmt", "yuv420p", out];
+  }
+  if (format === "gif") {
+    const rate = Math.min(fps, 18);
+    return [...input, "-vf",
+      `fps=${rate},scale=${w}:-1:flags=lanczos,split[a][b];[a]palettegen=stats_mode=diff[p];[b][p]paletteuse=dither=bayer:bayer_scale=4`,
+      "-loop", "0", out];
+  }
+  throw new Error(`unknown video format "${format}"`);
+}
+
+/**
+ * Start an encoder. Write JPEG frames to `write()`, then `await finish()`.
+ *
+ * @param {{format:string, fps:number, width:number, height:number, crf?:number,
+ *          out:string, ffmpeg:string}} opts
+ */
+export function startEncoder(opts) {
+  const args = encodeArgs(opts);
+  const child = spawn(opts.ffmpeg, args, { stdio: ["pipe", "ignore", "pipe"] });
+  let stderr = "";
+  let failed = null;
+  child.stderr.on("data", (c) => (stderr += c));
+  child.on("error", (err) => (failed = err));
+  // A dead encoder must not take the recorder down with an EPIPE mid-take; the
+  // failure is reported when the take ends, with ffmpeg's own diagnostics.
+  child.stdin.on("error", (err) => (failed ??= err));
+
+  let frames = 0;
+  /** @type {Promise<{frames:number}>|null} */
+  let ending = null;
+  return {
+    args,
+    get frames() {
+      return frames;
+    },
+    write(buf) {
+      if (failed || child.stdin.destroyed) return false;
+      frames += 1;
+      return child.stdin.write(buf);
+    },
+    /** Close the pipe and wait for the file. Safe to call twice. */
+    finish() {
+      ending ??= new Promise((resolve) => {
+        child.on("close", (code) => {
+          if (code !== 0 && !failed) failed = new Error(`ffmpeg exited ${code}\n${stderr.trim()}`);
+          resolve();
+        });
+        child.stdin.end();
+      }).then(() => {
+        if (failed) throw failed;
+        if (!frames) throw new Error("no frames were captured");
+        return { frames };
+      });
+      return ending;
+    },
+    kill() {
+      child.kill("SIGKILL");
+    },
+  };
+}
+
+/** Width/height out of a JPEG's SOF marker, without decoding it. */
+export function jpegSize(buf) {
+  let i = 2;
+  while (i < buf.length - 9) {
+    if (buf[i] !== 0xff) {
+      i += 1;
+      continue;
+    }
+    const marker = buf[i + 1];
+    // SOF0-SOF15, minus the four markers in that range that are not frame headers.
+    if (marker >= 0xc0 && marker <= 0xcf && ![0xc4, 0xc8, 0xcc].includes(marker)) {
+      return { height: buf.readUInt16BE(i + 5), width: buf.readUInt16BE(i + 7) };
+    }
+    i += 2 + buf.readUInt16BE(i + 2);
+  }
+  return { width: 0, height: 0 };
+}

--- a/shotkit/src/engine.mjs
+++ b/shotkit/src/engine.mjs
@@ -287,7 +287,7 @@ export function frameOf(opts) {
   };
 }
 
-async function seedStorage(context, storage) {
+export async function seedStorage(context, storage) {
   await context.addInitScript((entries) => {
     for (const [k, v] of entries) {
       try {
@@ -300,7 +300,7 @@ async function seedStorage(context, storage) {
 }
 
 /** Waits, ordered actions, and the cosmetic fixes every shot wants. */
-async function preparePage(page, opts) {
+export async function preparePage(page, opts) {
   const timeout = opts.timeout ?? 30_000;
   if (opts.waitFor) await page.waitForSelector(opts.waitFor, { state: "visible", timeout });
   if (opts.waitForText) {

--- a/shotkit/src/video.mjs
+++ b/shotkit/src/video.mjs
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Short videos: the same page, the same actions, but recorded.
+ *
+ * A screenshot answers "what does it look like"; a take answers "what happens
+ * when you use it". The difference is entirely in the parts a still does not
+ * need — a pointer that travels to the thing it is about to press, a click you
+ * can see land, and a camera that pushes in so the detail being demonstrated is
+ * legible at the size a README embeds.
+ *
+ * Three pieces, kept apart on purpose:
+ *
+ *   cursor.mjs   what the page draws (pointer, ripple, camera transform)
+ *   this file    the take: a frame pump, and a cinematic reading of the actions
+ *   encode.mjs   frames to a file
+ *
+ * The action vocabulary is the one `--do` already speaks. A recording does not
+ * get its own script format: `click:Negotiate` is a click in a screenshot and a
+ * glide-press-settle in a take, because the difference between those is the
+ * recorder's business and not the caller's.
+ *
+ * Frames come from a CDP screencast — the browser pushing what it composites,
+ * which is a real recording of real timing, including the app's own transitions.
+ * A screenshot loop is the fallback where that is unavailable; it produces the
+ * same file, more slowly and with the page's animation sampled coarsely.
+ */
+
+import { OVERLAY_DEFAULTS, installOverlay } from "./cursor.mjs";
+import { defaultFormat, findEncoder, jpegSize, startEncoder } from "./encode.mjs";
+import { frameOf, policyOf, preparePage, seedStorage } from "./engine.mjs";
+import { runActions } from "./actions.mjs";
+import { palette } from "./theme.mjs";
+
+/** Timing, in ms. Beats a viewer can follow rather than the fastest that works. */
+export const TIMING = {
+  moveMs: 620,
+  dwellMs: 620,
+  zoomMs: 620,
+  leadInMs: 500,
+  tailMs: 1000,
+  typeDelayMs: 55,
+  settleMs: 130,
+};
+
+export const VIDEO_DEFAULTS = {
+  fps: 30,
+  scale: 1,
+  width: 1280,
+  height: 800,
+  quality: 92,
+  zoom: 1.6,
+  maxSeconds: 90,
+};
+
+/**
+ * The container this take will land in, and the ffmpeg that can write it.
+ *
+ * Resolved before the file name is chosen, because the default is whatever the
+ * machine can actually do — an mp4 where a full ffmpeg is installed, webm off
+ * Playwright's bundled build — and the extension has to agree with it.
+ * @param {Record<string, any>} spec
+ */
+export async function resolveFormat(spec) {
+  const caps = await findEncoder();
+  const format = spec.format ?? defaultFormat(caps);
+  if (!caps.formats.includes(format)) {
+    throw new Error(
+      `this ffmpeg cannot write ${format} (it offers ${caps.formats.join(", ") || "nothing"}). ` +
+        `It is ${caps.source === "playwright" ? "Playwright's bundled build, which is webm-only" : caps.path}. ` +
+        `Install a full ffmpeg, or pass --format ${caps.formats[0] ?? "webm"}.`,
+    );
+  }
+  return { caps, format };
+}
+
+/**
+ * Read a `zoom:` argument: `out` | `2` | `<sel>` | `<sel>@2.2`.
+ *
+ * A bare number is a factor on the pointer, anything else is a target — and a
+ * selector can hold digits and colons, so the factor is only ever the tail
+ * after the last `@`.
+ *
+ * @param {string} arg @param {number} fallback the configured `--zoom`
+ * @returns {{target: string, z: number}}
+ */
+export function parseZoom(arg, fallback) {
+  const text = String(arg ?? "").trim();
+  if (!text || text === "out" || text === "1") return { target: "", z: 1 };
+  const cut = text.lastIndexOf("@");
+  const tail = cut > 0 ? Number(text.slice(cut + 1)) : Number(text);
+  const numeric = Number.isFinite(tail) && tail > 0;
+  return {
+    target: cut > 0 ? text.slice(0, cut) : numeric ? "" : text,
+    z: numeric ? tail : fallback,
+  };
+}
+
+const clamp = (n, lo, hi) => Math.min(hi, Math.max(lo, n));
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+/** Ease in and out — a pointer that starts and stops, rather than teleports. */
+const easeInOut = (t) => (t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2);
+
+/**
+ * Record one take.
+ *
+ * @param {import("./engine.mjs").Engine} eng
+ * @param {Record<string, any>} spec
+ * @param {{log?: (m:string) => void, out: string}} ctx `out` is the file to write
+ */
+export async function record(eng, spec, ctx) {
+  const log = ctx.log ?? (() => {});
+  const { caps, format } = await resolveFormat(spec);
+
+  const fps = clamp(Math.round(spec.fps ?? VIDEO_DEFAULTS.fps), 5, 60);
+  const timing = {
+    ...TIMING,
+    ...(spec.moveMs !== undefined ? { moveMs: spec.moveMs } : {}),
+    ...(spec.dwell !== undefined ? { dwellMs: spec.dwell } : {}),
+    ...(spec.zoomMs !== undefined ? { zoomMs: spec.zoomMs } : {}),
+    ...(spec.leadIn !== undefined ? { leadInMs: spec.leadIn } : {}),
+    ...(spec.tail !== undefined ? { tailMs: spec.tail } : {}),
+  };
+
+  // Motion is the point here, so two still-capture defaults invert: the app's
+  // own transitions have to run, and one device pixel per video pixel keeps the
+  // file a size a README can hold.
+  const frame = frameOf({
+    ...spec,
+    width: spec.width ?? VIDEO_DEFAULTS.width,
+    height: spec.height ?? VIDEO_DEFAULTS.height,
+    scale: spec.scale ?? VIDEO_DEFAULTS.scale,
+    reducedMotion: false,
+  });
+
+  const browser = await eng.start(policyOf(spec));
+  const context = await browser.newContext(eng.contextOptions(frame));
+  const start = { x: Math.round(frame.width * 0.14), y: Math.round(frame.height * 0.2) };
+  await context.addInitScript(installOverlay, {
+    ...OVERLAY_DEFAULTS,
+    cursor: spec.cursor !== false,
+    accent: spec.accent ?? palette(frame.theme).accent,
+    startX: start.x,
+    startY: start.y,
+    ...(spec.cursorSize ? { size: spec.cursorSize } : {}),
+  });
+  if (spec.storage) await seedStorage(context, spec.storage);
+
+  const t0 = Date.now();
+  const page = await context.newPage();
+  let pump = null;
+  try {
+    await page.goto(spec.url, { waitUntil: spec.waitUntil ?? "domcontentloaded", timeout: spec.timeout ?? 30_000 });
+    // Waits, hidden selectors and extra CSS, but not the actions: those are the
+    // take, and they have to happen with the camera rolling.
+    await preparePage(page, { ...spec, do: [] });
+    await page.mouse.move(start.x, start.y);
+    await page.evaluate(([x, y]) => window.__shotkit?.snap(x, y), [start.x, start.y]).catch(() => {});
+
+    pump = await startPump(page, context, {
+      fps,
+      quality: spec.quality ?? VIDEO_DEFAULTS.quality,
+      frame,
+      capture: spec.capture,
+      maxFrames: fps * clamp(spec.maxSeconds ?? VIDEO_DEFAULTS.maxSeconds, 1, 600),
+      encoder: (size) =>
+        startEncoder({ ...size, format, fps, crf: spec.crf, out: ctx.out, ffmpeg: caps.path }),
+      log,
+    });
+
+    const cursor = makeCursor(page, { ...spec, log, timing, zoom: spec.zoom ?? VIDEO_DEFAULTS.zoom });
+    // The cap has to be a timer this take can cancel: an outstanding one would
+    // hold the process open long after the file is written.
+    let capTimer = null;
+    const cap = new Promise((r) => {
+      capTimer = setTimeout(() => r("over"), pump.budgetMs);
+    });
+    const trace = await Promise.race([drive(page, spec, cursor, timing), cap]);
+    clearTimeout(capTimer);
+    if (trace === "over") log("stopped at --max-seconds; the take is what fit");
+    await sleep(timing.tailMs);
+
+    const { frames, width, height } = await pump.stop();
+    return {
+      path: ctx.out,
+      format,
+      fps,
+      frames,
+      width,
+      height,
+      durationMs: Math.round((frames / fps) * 1000),
+      encoder: caps.source,
+      capture: pump.mode,
+      truncated: trace === "over" || pump.truncated,
+      trace: Array.isArray(trace) ? trace : [],
+      url: page.url(),
+      ms: { total: Date.now() - t0 },
+    };
+  } finally {
+    if (pump) await pump.abort();
+    await context.close().catch(() => {});
+  }
+}
+
+/** The take: lead-in, the actions, and whatever the tail catches. */
+async function drive(page, spec, cursor, timing) {
+  await sleep(timing.leadInMs);
+  return runActions(page, spec.do ?? [], {
+    baseUrl: spec.baseUrl,
+    timeout: spec.actionTimeout,
+    cursor,
+  });
+}
+
+/* ── The cinematic cursor ───────────────────────────────────────────────────
+ * `runActions` calls into this when a recording is running: same verbs, but a
+ * pointer that travels, a press that reads, and a camera that can follow.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * @param {import("playwright").Page} page
+ * @param {Record<string, any>} opts
+ * @returns {import("./actions.mjs").Cursor}
+ */
+export function makeCursor(page, opts) {
+  const timing = opts.timing ?? TIMING;
+  let at = { x: 0, y: 0 };
+
+  /**
+   * Where a click on this locator would land, in viewport coordinates.
+   *
+   * A push-in crops the frame, and the next thing the script asks for may be
+   * outside what is left of it — a button at the edge of the card the camera
+   * just framed. Pulling back first is what a person would do, and it keeps the
+   * press on something the viewer can see.
+   */
+  async function pointOf(locator, { timeout }) {
+    await locator.waitFor({ state: "visible", timeout });
+    await locator.scrollIntoViewIfNeeded({ timeout }).catch(() => {});
+    let box = await locator.boundingBox({ timeout });
+    if (!box) throw new Error("target has no box on screen");
+    const frame = page.viewportSize() ?? { width: 1280, height: 800 };
+    const outside = (b) =>
+      b.x + b.width < 8 || b.y + b.height < 8 || b.x > frame.width - 8 || b.y > frame.height - 8;
+    if (outside(box)) {
+      await zoomOut();
+      box = (await locator.boundingBox({ timeout })) ?? box;
+    }
+    return { x: box.x + box.width / 2, y: box.y + box.height / 2, box };
+  }
+
+  /**
+   * Travel there — twice over, and both halves matter.
+   *
+   * The page animates the drawn pointer along the curve, off its own rAF, so
+   * the motion in the file is smooth however the driving process is scheduled.
+   * The real mouse walks the same curve more coarsely, because that is what
+   * lights up hover states, tooltips and drag affordances on the way — most of
+   * what a UI has to say for itself while a pointer crosses it.
+   */
+  async function glideTo(x, y, ms = timing.moveMs) {
+    const from = at;
+    const distance = Math.hypot(x - from.x, y - from.y);
+    if (distance < 2) {
+      at = { x, y };
+      return;
+    }
+    // A short hop should not take as long as a trip across the frame.
+    const duration = Math.round(clamp(ms * (0.35 + distance / 900), 140, ms * 1.4));
+    await page.evaluate(([px, py, d]) => window.__shotkit?.glide(px, py, d), [x, y, duration]).catch(() => {});
+    const steps = Math.max(2, Math.round(duration / 40));
+    const startedAt = Date.now();
+    for (let i = 1; i <= steps; i++) {
+      const p = easeInOut(i / steps);
+      await page.mouse.move(from.x + (x - from.x) * p, from.y + (y - from.y) * p);
+      const behind = startedAt + (duration * i) / steps - Date.now();
+      if (behind > 0) await sleep(behind);
+    }
+    at = { x, y };
+    await sleep(timing.settleMs);
+  }
+
+  /**
+   * Press and release, and tell the page so it draws it.
+   *
+   * The overlay listens for real mouse events too, but headless Chromium only
+   * flushes those alongside its frames — an animation that has to land on the
+   * frame of the press cannot wait for that.
+   */
+  async function press() {
+    await page.evaluate(() => window.__shotkit?.press(true)).catch(() => {});
+    await page.mouse.down();
+    await sleep(110);
+    await page.mouse.up();
+    await page.evaluate(() => window.__shotkit?.press(false)).catch(() => {});
+  }
+
+  async function camera(z, x, y, ms = timing.zoomMs) {
+    const applied = await page
+      .evaluate(([zz, xx, yy, mm]) => window.__shotkit?.camera(zz, xx, yy, mm), [z, x, y, ms])
+      .catch(() => null);
+    await sleep(ms);
+    return applied;
+  }
+
+  function zoomOut() {
+    const size = page.viewportSize() ?? { width: 1280, height: 800 };
+    return camera(1, size.width / 2, size.height / 2);
+  }
+
+  return {
+    typeDelay: timing.typeDelayMs,
+
+    async glide(locator, o = {}) {
+      const p = await pointOf(locator, o);
+      await glideTo(p.x, p.y);
+      return p;
+    },
+
+    async click(locator, o = {}) {
+      let p = await pointOf(locator, o);
+      await glideTo(p.x, p.y);
+      if (opts.autoZoom) {
+        await camera(opts.zoom, p.x, p.y);
+        // The push-in moved the target under the pointer; follow it to where it
+        // now is, so the press lands on the thing the viewer is looking at.
+        p = await pointOf(locator, o);
+        await glideTo(p.x, p.y, timing.moveMs * 0.5);
+      }
+      await press();
+      if (o.dblclick) {
+        await sleep(90);
+        await press();
+      }
+      if (opts.autoZoom) {
+        // Hold on what the press did, then pull back out — the shape of every
+        // demo beat, and the reason auto-zoom does not need a script.
+        await sleep(timing.dwellMs);
+        await zoomOut();
+      }
+      return p;
+    },
+
+    /**
+     * `zoom:out` | `zoom:2` (on the pointer) | `zoom:<sel>[@factor]`.
+     * `o.locate` resolves a selector the way the rest of the action list does.
+     */
+    async zoom(arg, o = {}) {
+      const { target, z } = parseZoom(arg, opts.zoom);
+      if (z === 1) return zoomOut();
+      if (!target) return camera(z, at.x, at.y);
+      const p = await pointOf(o.locate(target), o);
+      return camera(z, p.x, p.y);
+    },
+
+    zoomOut,
+
+    /** A beat after an action, so the viewer sees the result of it. */
+    dwell(ms) {
+      return sleep(ms ?? timing.dwellMs);
+    },
+  };
+}
+
+/* ── The frame pump ────────────────────────────────────────────────────────
+ * Frames arrive when the page changes; the file needs one every 1/fps whether
+ * anything changed or not. So the pump holds the newest frame and a
+ * self-correcting timer writes it on the beat — a still page costs repeats of
+ * one JPEG, and no drift accumulates over a long take.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+async function startPump(page, context, opts) {
+  const period = 1000 / opts.fps;
+  let latest = null;
+  let encoder = null;
+  let size = { width: 0, height: 0 };
+  let stopped = false;
+  let truncated = false;
+  let timer = null;
+  let failure = null;
+  let mode = opts.capture === "shots" ? "shots" : "screencast";
+  let shooter = null;
+
+  // Nothing in here may throw: it runs on a timer, where a throw is an uncaught
+  // exception in whatever process hosts the daemon rather than a failed shot.
+  // Anything that goes wrong is held and raised when the take ends.
+  const beat = (n, startedAt) => {
+    if (stopped) return;
+    try {
+      if (latest) {
+        if (!encoder) {
+          size = jpegSize(latest);
+          if (!size.width) throw new Error("the first frame was not a readable JPEG");
+          encoder = opts.encoder(size);
+          opts.log(`encoding ${size.width}x${size.height} @ ${opts.fps}fps`);
+        }
+        if (encoder.frames >= opts.maxFrames) truncated = true;
+        else encoder.write(latest);
+      }
+    } catch (err) {
+      failure ??= err;
+    }
+    const next = startedAt + (n + 1) * period - Date.now();
+    timer = setTimeout(() => beat(n + 1, startedAt), Math.max(0, next));
+  };
+
+  if (mode === "screencast") {
+    const cdp = await context.newCDPSession(page).catch(() => null);
+    if (cdp) {
+      cdp.on("Page.screencastFrame", (f) => {
+        latest = Buffer.from(f.data, "base64");
+        cdp.send("Page.screencastFrameAck", { sessionId: f.sessionId }).catch(() => {});
+      });
+      await cdp.send("Page.startScreencast", {
+        format: "jpeg",
+        quality: opts.quality,
+        maxWidth: Math.round(opts.frame.width * opts.frame.scale),
+        maxHeight: Math.round(opts.frame.height * opts.frame.scale),
+        everyNthFrame: 1,
+      });
+      for (let i = 0; i < 40 && !latest; i++) await sleep(50);
+      shooter = { stop: () => cdp.send("Page.stopScreencast").catch(() => {}) };
+    }
+    if (!latest) {
+      opts.log("no screencast frames; falling back to a screenshot loop");
+      mode = "shots";
+      await shooter?.stop();
+      shooter = null;
+    }
+  }
+
+  if (mode === "shots") {
+    // Slower and coarser, but it depends on nothing but `page.screenshot`.
+    let running = true;
+    const loop = (async () => {
+      while (running && !stopped) {
+        try {
+          latest = await page.screenshot({ type: "jpeg", quality: opts.quality, animations: "allow", caret: "hide" });
+        } catch {
+          if (!stopped) await sleep(100);
+        }
+      }
+    })();
+    shooter = {
+      stop: async () => {
+        running = false;
+        await loop.catch(() => {});
+      },
+    };
+    for (let i = 0; i < 60 && !latest; i++) await sleep(50);
+  }
+
+  const startedAt = Date.now();
+  beat(0, startedAt);
+
+  const halt = async () => {
+    if (stopped) return;
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    await shooter?.stop();
+  };
+
+  return {
+    mode,
+    get truncated() {
+      return truncated;
+    },
+    /** How long the take may run before the frame cap bites. */
+    budgetMs: (opts.maxFrames / opts.fps) * 1000,
+    async stop() {
+      await halt();
+      if (failure) throw failure;
+      if (!encoder) throw new Error("nothing was captured — the page never produced a frame");
+      const { frames } = await encoder.finish();
+      return { frames, ...size };
+    },
+    /**
+     * Give up, but close the file properly: a take that failed on its third
+     * action is still the most useful thing to look at, and a half-written
+     * container is not playable.
+     */
+    async abort() {
+      await halt();
+      if (!encoder) return;
+      await Promise.race([encoder.finish().catch(() => {}), sleep(5_000).then(() => encoder.kill())]);
+    },
+  };
+}

--- a/shotkit/test/selftest.mjs
+++ b/shotkit/test/selftest.mjs
@@ -19,6 +19,8 @@ import { policyArgs, policyKey } from "../src/network.mjs";
 import { resolveViewport, viewportList } from "../src/viewports.mjs";
 import { parseAction } from "../src/actions.mjs";
 import { palette } from "../src/theme.mjs";
+import { encodeArgs, jpegSize } from "../src/encode.mjs";
+import { parseZoom } from "../src/video.mjs";
 
 let failures = 0;
 function test(name, fn) {
@@ -163,6 +165,37 @@ test("--responsive expands to the breakpoint ladder", () => {
 test("an action splits on its first colon only", () => {
   assert.deepEqual(parseAction("fill:#q=a:b"), { verb: "fill", arg: "#q=a:b" });
   assert.deepEqual(parseAction("reload"), { verb: "reload", arg: "" });
+});
+
+test("a zoom argument splits into a target and a factor", () => {
+  assert.deepEqual(parseZoom("out", 1.6), { target: "", z: 1 });
+  assert.deepEqual(parseZoom("2", 1.6), { target: "", z: 2 });
+  assert.deepEqual(parseZoom("#panel", 1.6), { target: "#panel", z: 1.6 });
+  assert.deepEqual(parseZoom("#panel@2.2", 1.6), { target: "#panel", z: 2.2 });
+  // A selector may hold digits and colons; only the tail after @ is a factor.
+  assert.deepEqual(parseZoom("text=Save 2", 1.6), { target: "text=Save 2", z: 1.6 });
+});
+
+test("the encoder is fed frames on a pipe and writes even dimensions", () => {
+  const args = encodeArgs({ format: "mp4", fps: 30, width: 1281, height: 801, out: "/tmp/a.mp4" });
+  // A bare "-" is not a protocol Playwright's stripped ffmpeg registers.
+  assert.ok(args.includes("pipe:0"));
+  assert.ok(args.includes("scale=1280:800"), "4:2:0 refuses odd dimensions");
+  assert.ok(args.includes("libx264"));
+  assert.equal(encodeArgs({ format: "webm", fps: 30, width: 640, height: 400, out: "/tmp/a.webm" })
+    .includes("libvpx"), true);
+  assert.throws(() => encodeArgs({ format: "mov", fps: 30, width: 2, height: 2, out: "x" }), /unknown video format/);
+});
+
+test("a jpeg's size comes out of its frame header", () => {
+  // SOI, an APP0 whose length must be skipped, then SOF0 carrying 200x100.
+  const jpeg = Buffer.from([
+    0xff, 0xd8,
+    0xff, 0xe0, 0x00, 0x04, 0x00, 0x00,
+    0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x64, 0x00, 0xc8, 0x03, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  ]);
+  assert.deepEqual(jpegSize(jpeg), { width: 200, height: 100 });
+  assert.deepEqual(jpegSize(Buffer.from([0xff, 0xd8])), { width: 0, height: 0 });
 });
 
 process.stdout.write(failures ? `\n${failures} failing\n` : "\nall passing\n");


### PR DESCRIPTION
shotkit could show what the app looks like, not what using it looks like. `shot
video` records the same `--do` flow a screenshot would take, as a short clip.

The action vocabulary is unchanged — a recording does not get its own script
format. What changes is how each verb is performed: the pointer travels to its
target and the real mouse goes with it, so hover states fire on the way; a ring
marks each press, because at 30fps a click is otherwise a frame with nothing in
it; `fill:` types a character at a time; and `zoom:<sel>` / `--auto-zoom` push
the camera in on what is being demonstrated and pull back after.

Three new modules, kept apart:

- cursor.mjs, injected into the page: the drawn pointer, the click ring, and the
  camera. The pointer follows the real mouse rather than replacing it, and the
  camera is a transform on the document, so a push-in re-rasterizes type sharper
  instead of scaling pixels up. Its travel is animated in the page off rAF —
  headless Chromium flushes coalesced mouse moves with its frames, which is too
  thin a thread to hang the motion in the file on.
- video.mjs: the take. Frames come from a CDP screencast and a self-correcting
  timer writes the newest one on the beat, so a still page costs repeats of one
  JPEG and no drift accumulates; `--capture shots` falls back to a screenshot
  loop. Nothing on that timer may throw, so failures are held and raised when
  the take ends, and a take that dies mid-flow still closes its file.
- encode.mjs: frames stream down ffmpeg's stdin as they are captured. Which
  ffmpeg is a real question and not a detail: Playwright ships one with its
  browsers, always present but built webm-only, so the format list is probed and
  mp4/gif depend on a full ffmpeg. `shot doctor` now says which you have.

The camera crops into the frame as it stands, so it never asks the page for
content it has not painted, and an element a push-in has cut off brings the
camera back out before it is acted on.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BAEu8S3RytXEiR5E6s8UK5