### PR TITLE
Make CI report its own timing, check its own hygiene, and publish screenshots

### DIFF
--- a/.github/ci-budgets.json
+++ b/.github/ci-budgets.json
@@ -1,0 +1,31 @@
+{
+  "_comment": [
+    "Duration budgets for the CI workflow, in seconds. These do not gate a merge:",
+    "the timing job reports every job's duration into the run summary and raises a",
+    "::warning:: when one is over, so a slowdown is visible in the run that caused",
+    "it rather than noticed months later. A fast CI is a feature; this is how it",
+    "stays one.",
+    "",
+    "Budgets are roughly 2x the observed steady-state duration, so ordinary noise",
+    "(a cold cache, a slow runner) doesn't warn but a real regression does. Raise",
+    "one deliberately, in the PR that makes the job slower, with a reason.",
+    "",
+    "wall_clock_seconds budgets the critical path across jobs — the number a human",
+    "waits on. It is deliberately near the no-image-build baseline (~95s), so a PR",
+    "that triggers the frontend image build is expected to trip it; the warning",
+    "names the job that owns the tail, which is the useful part.",
+    "",
+    "scripts/check_workflows.py asserts this file and ci.yml name the same jobs."
+  ],
+  "wall_clock_seconds": 150,
+  "jobs": {
+    "Repo hygiene": 60,
+    "Backend tests": 75,
+    "CLI lint + tests": 75,
+    "Live-node integration slices (SLIM)": 75,
+    "Collector docker build": 120,
+    "Frontend typecheck + lint + build": 180,
+    "Frontend docker build": 300,
+    "CI timing": 60
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,32 @@ on:
   pull_request:
     branches: [main]
 
+# Read-only by default; the timing job asks for `actions: read` on top of this.
+permissions:
+  contents: read
+
+# A branch only needs its newest commit checked. Superseded runs are cancelled
+# rather than left to finish, which keeps queue time (and therefore the wall
+# clock a human waits on) from backing up behind a push that no longer matters.
+# Never on main: those runs are the record of what landed.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  hygiene:
+    # Repo-level contracts that have no other home: actions pinned to SHAs,
+    # workflows declaring their permissions, budgets that still name real jobs.
+    # No toolchain install — it's stdlib Python over the workflow files, so it
+    # finishes long before the jobs that build something.
+    name: Repo hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Workflow contracts
+        run: python3 scripts/check_workflows.py
+
   test-backend:
     name: Backend tests
     runs-on: ubuntu-latest
@@ -326,3 +351,33 @@ jobs:
       - name: SLIM node logs (on failure)
         if: failure()
         run: docker logs mycelium-slim || true
+
+  timing:
+    # Reports what the run cost, per job, against .github/ci-budgets.json. It
+    # runs last because it reads the other jobs' durations back from the API,
+    # and `always()` so a red run still gets its timing (a job that fails slowly
+    # is the interesting case). It never fails: timing is information, not a
+    # gate, and a warning that can block a merge stops being read.
+    name: CI timing
+    runs-on: ubuntu-latest
+    # Not `always()`: a run cancelled by the concurrency group above has nothing
+    # worth timing, and shouldn't spend a runner saying so.
+    if: ${{ !cancelled() }}
+    needs:
+      - hygiene
+      - test-backend
+      - test-cli
+      - build-collector
+      - build-frontend
+      - build-frontend-image
+      - integration-slim
+    permissions:
+      contents: read
+      actions: read   # list this run's jobs
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Report job durations
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/ci_timing.py

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,134 @@
+name: Screenshots
+
+# Publishes the committed app screenshots by running the real capture pipeline
+# (`pnpm screenshots` -> shotkit -> the frontend in mock mode) on a runner.
+#
+# The pipeline itself is not new; operationalizing it is. Until now the docs
+# assets and the splash repo's hero images were only refreshed when somebody
+# remembered to run the capture locally, which means they drift behind the UI
+# they are supposed to show, and the drift is invisible until someone looks at
+# a screenshot and notices it is a version old.
+#
+# Entirely additive, in two ways. It is manual (`workflow_dispatch`) — nothing
+# on the PR path gets slower. And the splash half is optional: with no
+# SPLASH_REPO_TOKEN configured the docs/ assets still refresh and the splash
+# step reports that it was skipped, rather than failing the run.
+#
+# It opens pull requests rather than pushing to a default branch. A screenshot
+# rendered on a runner is not byte-identical to one rendered on a laptop (font
+# hinting, GPU rasterization), so the diff wants a human eye before it lands.
+#
+# Setup for the splash half: a fine-grained PAT scoped to
+# mycelium-io/mycelium-io.github.io alone, with Contents: read/write and Pull
+# requests: read/write, stored as the SPLASH_REPO_TOKEN secret. That is the
+# whole grant — it can reach no other repository.
+
+on:
+  workflow_dispatch:
+    inputs:
+      shots:
+        description: "Shot ids to capture (space-separated); empty captures all"
+        required: false
+        default: ""
+      dry_run:
+        description: "Capture and upload the artifact, but open no pull requests"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: screenshots
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    name: Capture and publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push the branch this repo's PR is opened from
+      pull-requests: write   # open that PR
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Secrets are not available to job-level `if:`, so the optional half is
+      # gated on a step output instead.
+      - name: Check splash repo credentials
+        id: creds
+        env:
+          SPLASH_TOKEN: ${{ secrets.SPLASH_REPO_TOKEN }}
+        run: |
+          if [ -n "$SPLASH_TOKEN" ]; then
+            echo "splash=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "splash=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::SPLASH_REPO_TOKEN is not configured — capturing docs/ assets only."
+          fi
+
+      - name: Check out the splash repo
+        if: steps.creds.outputs.splash == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: mycelium-io/mycelium-io.github.io
+          token: ${{ secrets.SPLASH_REPO_TOKEN }}
+          path: splash
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: |
+            mycelium-frontend/package-lock.json
+            shotkit/package-lock.json
+
+      # shotkit boots the mock server with `pnpm dev:mock`; the dependency tree
+      # itself comes from the committed npm lockfiles.
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Install frontend dependencies
+        working-directory: mycelium-frontend
+        run: npm ci --no-audit --no-fund
+
+      - name: Install shotkit dependencies
+        working-directory: shotkit
+        run: npm ci --no-audit --no-fund
+
+      - name: Install Chromium
+        working-directory: mycelium-frontend
+        run: npx playwright install --with-deps chromium
+
+      # Shots whose target is the splash repo are still captured without it;
+      # send them to a scratch directory so the run stays honest about what it
+      # published rather than writing outside the workspace.
+      - name: Capture
+        working-directory: mycelium-frontend
+        env:
+          MYCELIUM_SPLASH_DIR: >-
+            ${{ steps.creds.outputs.splash == 'true'
+                && format('{0}/splash', github.workspace)
+                || format('{0}/splash-unpublished', runner.temp) }}
+          # Through the environment, never interpolated into the command line:
+          # a dispatch input is untrusted text.
+          SHOTS: ${{ inputs.shots }}
+        run: |
+          if ! printf '%s' "$SHOTS" | grep -qE '^[a-z0-9 _-]*$'; then
+            echo "::error::shot ids may only contain lowercase letters, digits, '-', '_' and spaces"
+            exit 1
+          fi
+          npm run screenshots -- $SHOTS
+
+      - name: Open the docs pull request
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/publish-screenshots.sh . docs "the docs site"
+
+      - name: Open the splash pull request
+        if: ${{ !inputs.dry_run && steps.creds.outputs.splash == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.SPLASH_REPO_TOKEN }}
+        run: bash scripts/publish-screenshots.sh splash . "the splash site"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,6 +330,23 @@ is no litellm dependency.
   `openclaw` and `hermes` are **gone**, not deprecated — they rode the removed
   SSE/coordination-tick model and their packages were deleted (#503). Don't
   reintroduce them as adapter options.
+- **CI is fast on purpose; timing is reported, never enforced.** A PR run's
+  critical path is ~95s, and that is a property worth defending — it erodes
+  twenty seconds at a time, invisibly. The `timing` job reads the run's own job
+  durations back from the Actions API, writes them into the run summary, and
+  warns against the budgets in `.github/ci-budgets.json`. It cannot fail a run:
+  a slow PR should merge and say it was slow. Raise a budget deliberately, in
+  the PR that makes the job slower. `scripts/check_workflows.py` (the `hygiene`
+  job) keeps the budgets naming real jobs, every `uses:` pinned to a commit SHA,
+  and every workflow declaring its own `permissions:`.
+- **Screenshots publish through a workflow, and it is additive.** The capture
+  pipeline (`pnpm screenshots`) is the same one that runs locally; the
+  `Screenshots` workflow runs it on a runner on manual dispatch and opens PRs
+  against `docs/` and the splash repo rather than pushing. The splash half needs
+  `SPLASH_REPO_TOKEN`, a PAT scoped to `mycelium-io/mycelium-io.github.io`
+  alone; without it the docs half still runs. Nothing on the PR path gets
+  slower, and a runner-rendered PNG differs subtly from a laptop-rendered one —
+  which is exactly why it lands as a reviewable diff.
 
 ## Local development
 

--- a/mycelium-frontend/src/lib/api-contract.test.ts
+++ b/mycelium-frontend/src/lib/api-contract.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * The frontend↔backend route contract.
+ *
+ * Every `/api/...` the UI fetches is served by exactly one of two things: a
+ * local Next route handler under `src/app/api/`, or a backend endpoint reached
+ * through the catch-all proxy. The proxy is untyped by construction — it
+ * forwards whatever path it is handed — so a renamed or deleted backend route
+ * fails at runtime with a 404 in a panel, not at build time.
+ *
+ * This closes that seam against the committed `openapi.json` (the same spec the
+ * OpenAPI client is generated from, and the same one CI asserts is current), so
+ * a backend route change that strands a fetch fails here instead.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC_DIR = resolve(HERE, "..");
+const FRONTEND_DIR = resolve(SRC_DIR, "..");
+const OPENAPI = resolve(FRONTEND_DIR, "..", "openapi.json");
+
+/** A used segment whose value is only known at runtime: `${roomName}`, `[name]`. */
+const PARAM = "{}";
+
+/**
+ * Backend params declared with FastAPI's `:path` converter, which swallow
+ * slashes. A memory key is namespaced by design (`decisions/cutover`), so
+ * `/memory/{key}` is one declared segment against two or more used ones.
+ */
+const SLASHY_PARAMS = new Set(["{key}"]);
+
+/** Mirrors the one alias the proxy applies (src/app/api/[...path]/route.ts). */
+const PROXY_ALIASES: Record<string, string> = { "/api/health": "/health" };
+
+/** Recursively list files under `dir`. */
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) return e.name === "node_modules" ? [] : walk(full);
+    return [full];
+  });
+}
+
+/**
+ * Replace `${...}` interpolations with the param marker, balancing braces so a
+ * nested template (`${a ? `${b}` : c}`) collapses to a single marker.
+ */
+function collapseInterpolations(path: string): string {
+  let out = "";
+  for (let i = 0; i < path.length; i++) {
+    if (path[i] === "$" && path[i + 1] === "{") {
+      let depth = 1;
+      i += 2;
+      while (i < path.length && depth > 0) {
+        if (path[i] === "{") depth++;
+        else if (path[i] === "}") depth--;
+        i++;
+      }
+      i--;
+      out += PARAM;
+    } else {
+      out += path[i];
+    }
+  }
+  return out;
+}
+
+/** `/api/rooms/${name}/memory?x=1` -> `["api", "rooms", "{}", "memory"]`. */
+function usedSegments(path: string): string[] {
+  return collapseInterpolations(path).split("?")[0].split("#")[0].split("/").filter(Boolean);
+}
+
+/** `/api/rooms/{room_name}/memory` -> `["api", "rooms", "{room_name}", "memory"]`. */
+function declaredSegments(path: string): string[] {
+  return path
+    .split("/")
+    .filter(Boolean)
+    .map((s) => (s.startsWith("[") ? `{${s}}` : s));
+}
+
+const isParam = (segment: string): boolean => /^\{.*\}$/.test(segment);
+
+/**
+ * A used path satisfies a declared one when every segment lines up: a concrete
+ * value fills a declared param, and an interpolated value fills anything (the
+ * UI can't know at build time that `${decision}` is only ever `accept` or
+ * `decline`). Literal-against-literal is exact — that's what catches a renamed
+ * or dropped route.
+ */
+function matches(used: string[], declared: string[]): boolean {
+  const last = declared.length - 1;
+  if (last >= 0 && SLASHY_PARAMS.has(declared[last])) {
+    if (used.length < declared.length) return false;
+  } else if (used.length !== declared.length) {
+    return false;
+  }
+  return declared.every((d, i) => isParam(d) || used[i] === PARAM || d === used[i]);
+}
+
+/** Route handlers this app serves itself, from the `src/app/api` tree. */
+function localHandlers(): string[][] {
+  const apiDir = join(SRC_DIR, "app", "api");
+  return walk(apiDir)
+    .filter((f) => /[/\\]route\.tsx?$/.test(f))
+    .map((f) => dirname(f).slice(apiDir.length).split(/[/\\]/).filter(Boolean))
+    // The catch-all IS the proxy to the backend. Counting it as a local handler
+    // would make every path under /api/ valid and this test vacuous.
+    .filter((segs) => !segs.some((s) => s.startsWith("[...")))
+    .map((segs) => declaredSegments(["api", ...segs].join("/")));
+}
+
+/** Paths the backend declares, from the committed spec. */
+function backendPaths(): string[][] {
+  const spec = JSON.parse(readFileSync(OPENAPI, "utf8")) as { paths: Record<string, unknown> };
+  return Object.keys(spec.paths).map(declaredSegments);
+}
+
+/** Every `/api/...` string or template literal in the frontend source. */
+function usedPaths(): { path: string; file: string }[] {
+  const found: { path: string; file: string }[] = [];
+  for (const file of walk(SRC_DIR)) {
+    if (!/\.tsx?$/.test(file)) continue;
+    const text = readFileSync(file, "utf8");
+    for (const m of text.matchAll(/(["'`])(\/api\/[^"'`\n]*)\1/g)) {
+      const path = m[2];
+      // `/api/*`, `/api/[...path]` and `/api/…` name the proxy itself in prose
+      // and route definitions; they are not fetches.
+      if (/[*[\s…]|\.\./.test(path)) continue;
+      found.push({ path, file: file.slice(FRONTEND_DIR.length + 1) });
+    }
+  }
+  return found;
+}
+
+describe("frontend /api routes", () => {
+  const local = localHandlers();
+  const backend = backendPaths();
+  const used = usedPaths();
+
+  it("finds the fetch surface to check", () => {
+    // Guards the scanner itself: a refactor that moves every fetch behind a
+    // path builder would silently empty this suite rather than fail it.
+    expect(used.length).toBeGreaterThan(20);
+    expect(local.length).toBeGreaterThan(0);
+  });
+
+  it.each(used)("$path ($file) is served by a local handler or the backend spec", ({ path }) => {
+    const target = usedSegments(PROXY_ALIASES[path.split("?")[0]] ?? path);
+    const served =
+      local.some((declared) => matches(target, declared)) ||
+      backend.some((declared) => matches(target, declared));
+    expect(served, `${path} matches no local route handler and no path in openapi.json`).toBe(true);
+  });
+});

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,7 @@
 Maintainer utilities, run by hand. Nothing here is on the install path or in the
 runtime — a user never executes these, and a broken one can sit unnoticed.
 
-Two kinds live here:
+Three kinds live here:
 
 - **Regenerators.** They refresh a committed artifact from a live source: the
   OpenAPI snapshot from a running backend, and the typed client from that
@@ -13,6 +13,10 @@ Two kinds live here:
 - **Asset builders.** They render the banner and social images from fonts and
   ImageMagick. Their output is committed too, so you only need the toolchain if
   you're changing the image.
+- **CI helpers.** `check_workflows.py` is the exception to "run by hand" — it is
+  a gate, and it runs locally the same way it runs in CI (stdlib only, no
+  install). `ci_timing.py` and `publish-screenshots.sh` read the Actions
+  environment and only make sense on a runner.
 
 Each script's header comment states its prerequisites and where its output
 lands. Read that before running — several need a running backend or a font

--- a/scripts/check_workflows.py
+++ b/scripts/check_workflows.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+"""Contract checks over .github/workflows — the CI that checks CI.
+
+Three properties, each of which has a way of eroding quietly:
+
+  1. Every `uses:` is pinned to a full commit SHA. A moving tag is a supply
+     chain hole: the tag can be repointed at new code that runs with our
+     GITHUB_TOKEN, and nothing in the diff shows it moved.
+  2. Every workflow declares `permissions:`. Without one the job inherits the
+     repository default, which can be write-all — so the blast radius of a
+     compromised step is a repo setting rather than something reviewable here.
+  3. Every job in ci.yml has a duration budget in .github/ci-budgets.json, and
+     every budget names a real job. The budgets are only useful if they can't
+     drift away from the jobs they describe.
+
+Pure stdlib and line-oriented so it needs no install step: it reads the
+workflow files as text rather than parsing YAML.
+
+    uv run python scripts/check_workflows.py     # exits 1 on any violation
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+BUDGETS_FILE = REPO_ROOT / ".github" / "ci-budgets.json"
+
+USES = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<ref>\S+)")
+SHA_PINNED = re.compile(r"^[^@\s]+@[0-9a-f]{40}$")
+TOP_LEVEL_KEY = re.compile(r"^(?P<key>[a-zA-Z_][a-zA-Z0-9_-]*):")
+JOB_KEY = re.compile(r"^  (?P<job>[a-zA-Z_][a-zA-Z0-9_-]*):\s*$")
+JOB_NAME = re.compile(r"^    name:\s*(?P<name>.+?)\s*$")
+
+
+def problems_in(path: Path) -> list[str]:
+    """Pinning + permissions violations in one workflow file."""
+    found: list[str] = []
+    lines = path.read_text().splitlines()
+
+    for lineno, line in enumerate(lines, start=1):
+        match = USES.match(line)
+        if not match:
+            continue
+        ref = match.group("ref").strip("\"'")
+        # A local composite action (./.github/actions/x) and a digest-pinned
+        # container image are already immutable.
+        if ref.startswith(("./", "docker://")):
+            continue
+        if not SHA_PINNED.match(ref):
+            found.append(
+                f"{path.name}:{lineno}: `uses: {ref}` is not pinned to a "
+                f"40-character commit SHA (add `# vN` after it for readability)",
+            )
+
+    if not any(TOP_LEVEL_KEY.match(line) and line.startswith("permissions:") for line in lines):
+        found.append(
+            f"{path.name}: no top-level `permissions:` block — the workflow "
+            f"inherits the repository default instead of declaring its own",
+        )
+
+    return found
+
+
+def declared_jobs(path: Path) -> list[str]:
+    """Display names of the jobs in a workflow (the `name:`, else the job key).
+
+    These are the names the Actions API reports, which is what ties a budget to
+    the job it measures.
+    """
+    names: list[str] = []
+    in_jobs = False
+    pending: str | None = None
+
+    for line in path.read_text().splitlines():
+        top = TOP_LEVEL_KEY.match(line)
+        if top:
+            if pending:
+                names.append(pending)
+                pending = None
+            in_jobs = top.group("key") == "jobs"
+            continue
+        if not in_jobs:
+            continue
+        job = JOB_KEY.match(line)
+        if job:
+            if pending:
+                names.append(pending)
+            pending = job.group("job")
+            continue
+        named = JOB_NAME.match(line)
+        if named and pending:
+            names.append(named.group("name").strip("\"'"))
+            pending = None
+
+    if pending:
+        names.append(pending)
+    return names
+
+
+def budget_problems() -> list[str]:
+    """Budgets and CI jobs must name the same set of jobs."""
+    budgets = json.loads(BUDGETS_FILE.read_text())
+    jobs = set(declared_jobs(WORKFLOW_DIR / "ci.yml"))
+    budgeted = set(budgets["jobs"])
+
+    found = [
+        f"ci-budgets.json: no budget for CI job {name!r} — add one (the "
+        f"timing report can't flag a job it has no baseline for)"
+        for name in sorted(jobs - budgeted)
+    ]
+    found += [
+        f"ci-budgets.json: budget for {name!r} matches no job in ci.yml"
+        for name in sorted(budgeted - jobs)
+    ]
+    return found
+
+
+def main() -> int:
+    problems = [p for path in sorted(WORKFLOW_DIR.glob("*.yml")) for p in problems_in(path)]
+    problems += budget_problems()
+
+    for problem in problems:
+        # `::error` renders as an annotation under Actions, plain text locally.
+        print(f"::error::{problem}")
+
+    if problems:
+        print(f"\n{len(problems)} workflow hygiene problem(s).")
+        return 1
+
+    checked = len(list(WORKFLOW_DIR.glob("*.yml")))
+    print(f"{checked} workflow(s): actions SHA-pinned, permissions declared, budgets aligned.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_timing.py
+++ b/scripts/ci_timing.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+"""Report how long this CI run took, per job, against committed budgets.
+
+CI being fast is a property worth keeping, and the way it erodes is invisible:
+nobody notices twenty seconds, and a year of twenty seconds is a coffee break
+per PR. This reads the run's own jobs back from the Actions API, writes a table
+into the run summary, and raises a ::warning:: for anything over budget.
+
+It never fails the run. Timing is information, not a gate — a slow PR should
+merge, it should just say it was slow. Budgets live in .github/ci-budgets.json.
+
+Reads GITHUB_TOKEN, GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_RUN_ATTEMPT and
+appends to GITHUB_STEP_SUMMARY; run under Actions, not locally.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BUDGETS_FILE = REPO_ROOT / ".github" / "ci-budgets.json"
+API = "https://api.github.com"
+
+# This job is still running while it reports, so it has no end time of its own
+# and cannot be part of the critical path it measures.
+SELF = os.environ.get("CI_TIMING_JOB_NAME", "CI timing")
+
+
+def fetch_jobs() -> list[dict]:
+    """Every job of this run attempt, from the Actions API."""
+    repo = os.environ["GITHUB_REPOSITORY"]
+    run_id = os.environ["GITHUB_RUN_ID"]
+    attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "1")
+    url = f"{API}/repos/{repo}/actions/runs/{run_id}/attempts/{attempt}/jobs?per_page=100"
+
+    request = urllib.request.Request(url)  # noqa: S310 — fixed https API host
+    request.add_header("Accept", "application/vnd.github+json")
+    request.add_header("Authorization", f"Bearer {os.environ['GITHUB_TOKEN']}")
+    with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+        return json.load(response)["jobs"]
+
+
+def parse(stamp: str | None) -> datetime | None:
+    return datetime.fromisoformat(stamp.replace("Z", "+00:00")) if stamp else None
+
+
+def duration(job: dict) -> int | None:
+    """Wall-clock seconds the job ran, or None if it never finished."""
+    started, completed = parse(job.get("started_at")), parse(job.get("completed_at"))
+    if not started or not completed:
+        return None
+    return max(0, round((completed - started).total_seconds()))
+
+
+def emit(lines: list[str]) -> None:
+    """Append markdown to the run summary (and echo it into the log)."""
+    body = "\n".join(lines) + "\n"
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with Path(summary).open("a") as handle:
+            handle.write(body)
+    print(body)
+
+
+def main() -> int:
+    budgets = json.loads(BUDGETS_FILE.read_text())
+    job_budgets: dict[str, int] = budgets["jobs"]
+
+    try:
+        jobs = [job for job in fetch_jobs() if job["name"] != SELF]
+    except (urllib.error.URLError, KeyError, TimeoutError) as err:
+        # The report is a courtesy; losing it must not colour the run.
+        print(f"::notice::CI timing report unavailable: {err}")
+        return 0
+
+    rows: list[str] = []
+    warnings: list[str] = []
+    slowest: tuple[int, str] | None = None
+
+    for job in sorted(jobs, key=lambda j: -(duration(j) or 0)):
+        name = job["name"]
+        seconds = duration(job)
+        budget = job_budgets.get(name)
+
+        if job["conclusion"] == "skipped" or seconds is None:
+            rows.append(f"| {name} | — | {budget or '—'}s | skipped |")
+            continue
+
+        if slowest is None or seconds > slowest[0]:
+            slowest = (seconds, name)
+
+        if budget is None:
+            verdict = "no budget"
+        elif seconds > budget:
+            verdict = f"**over by {seconds - budget}s**"
+            warnings.append(f"{name} took {seconds}s (budget {budget}s)")
+        else:
+            verdict = f"{round(100 * seconds / budget)}% of budget"
+        rows.append(f"| {name} | {seconds}s | {budget or '—'}s | {verdict} |")
+
+    starts = [parse(job.get("started_at")) for job in jobs]
+    ends = [parse(job.get("completed_at")) for job in jobs]
+    known = [(s, e) for s, e in zip(starts, ends, strict=True) if s and e]
+    wall = round((max(e for _, e in known) - min(s for s, _ in known)).total_seconds()) if known else 0
+    wall_budget = budgets["wall_clock_seconds"]
+
+    tail = f" — {slowest[1]} owns the tail at {slowest[0]}s" if slowest else ""
+    verdict = (
+        f"⚠️ **{wall}s**, over the {wall_budget}s baseline{tail}"
+        if wall > wall_budget
+        else f"✅ **{wall}s**, within the {wall_budget}s baseline{tail}"
+    )
+
+    emit(
+        [
+            "## CI timing",
+            "",
+            f"Critical path: {verdict}",
+            "",
+            "| Job | Duration | Budget | |",
+            "| --- | --- | --- | --- |",
+            *rows,
+            "",
+            "_Budgets are in `.github/ci-budgets.json` and never fail a run._",
+        ],
+    )
+
+    if wall > wall_budget:
+        print(f"::warning::CI critical path was {wall}s, over the {wall_budget}s baseline{tail}")
+    for warning in warnings:
+        print(f"::warning::{warning}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/publish-screenshots.sh
+++ b/scripts/publish-screenshots.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+#
+# Open a pull request for whatever the screenshot capture just rewrote, in one
+# repository. Both sinks the pipeline writes to — docs/ here, the PNGs at the
+# root of the splash repo — are published the same way, so this takes the
+# checkout and the paths to look at:
+#
+#   scripts/publish-screenshots.sh <repo-dir> <pathspec> <label>
+#
+# Needs GH_TOKEN in the environment, with push and pull-request rights on that
+# checkout's remote. A no-op (exit 0) when the capture reproduced the committed
+# assets byte for byte, which is the expected result on a UI that hasn't moved.
+set -euo pipefail
+
+repo_dir=$1
+pathspec=$2
+label=$3
+
+cd "$repo_dir"
+
+if [ -z "$(git status --porcelain -- "$pathspec")" ]; then
+  echo "::notice::$label: screenshots already match the running UI — nothing to publish."
+  exit 0
+fi
+
+base=$(git rev-parse --abbrev-ref HEAD)
+branch="screenshots/run-${GITHUB_RUN_ID}"
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+git checkout -b "$branch"
+git add -- "$pathspec"
+git commit -m "Refresh app screenshots from the running UI"
+
+# Retry the push: a transient network failure on a manual, idempotent workflow
+# should not cost a re-run of the whole capture.
+for delay in 2 4 8 0; do
+  if git push -u origin "$branch"; then
+    break
+  fi
+  if [ "$delay" = 0 ]; then
+    echo "::error::$label: could not push $branch"
+    exit 1
+  fi
+  sleep "$delay"
+done
+
+gh pr create \
+  --base "$base" \
+  --head "$branch" \
+  --title "Refresh app screenshots" \
+  --body "$(
+    cat <<EOF
+Captured from the frontend in mock mode by the \`Screenshots\` workflow
+([run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})),
+which regenerates $label's committed assets the same way \`pnpm screenshots\`
+does locally.
+
+Worth an eye on the rendered diff before merging: a runner and a laptop do not
+rasterize identically, so a small visual delta here is expected and a large one
+means the UI actually changed.
+EOF
+  )"


### PR DESCRIPTION
## Summary

CI is fast — ~95s critical path on a normal PR — and that is a property worth
defending rather than a happy accident. This keeps it fast *and* makes it say
more, by adding only things that either run in parallel with the existing jobs
or don't run on the PR path at all.

Four additions:

1. **Timing is reported, never enforced.** The run tells you what it cost, per
   job, against committed budgets.
2. **Repo hygiene is a gate.** Actions pinned to SHAs, workflows declaring their
   own permissions, budgets that still name real jobs.
3. **A frontend↔backend route contract**, closing the one seam the `/api/*`
   proxy leaves untyped.
4. **The screenshot pipeline gets operationalized** — the manual-dispatch
   workflow with an optional token scoped to the splash repo.

Measured on the last 30 runs of `ci.yml`: median 93s, and the two runs that
touched the frontend image took 228s and 234s. The per-job floor is Backend
tests 34s / CLI 27s / SLIM 24s / collector 27s; the tail is Frontend
typecheck+lint+build at 90s and Frontend docker build at 230s. Budgets are set
from those numbers.

## Changes

**`timing` job + `.github/ci-budgets.json`.** Runs last (`needs:` every other
job), reads the run's own job durations back from the Actions API, and writes a
table into the run summary:

| Job | Duration | Budget | |
| --- | --- | --- | --- |
| Frontend docker build | 230s | 300s | 77% of budget |
| Frontend typecheck + lint + build | 90s | 180s | 50% of budget |
| Backend tests | 34s | 75s | 45% of budget |
| … | | | |

It raises a `::warning::` when a job or the critical path is over budget, naming
the job that owns the tail — the actionable half. It **cannot fail a run**: a
slow PR should merge and say it was slow, and a warning that can block a merge
stops being read. `wall_clock_seconds` is set at 150s, deliberately near the
no-image-build baseline, so a frontend-image PR is *expected* to trip it and
report why. Budgets are ~2× observed, so ordinary runner noise is quiet and a
real regression isn't. Raising one is a deliberate edit in the PR that makes the
job slower. `if: !cancelled()` rather than `always()`, so a superseded run
doesn't spend a runner on a report nobody reads.

**`hygiene` job + `scripts/check_workflows.py`.** Three properties that each
erode invisibly: every `uses:` pinned to a 40-char commit SHA (a moving tag can
be repointed at code that runs with our `GITHUB_TOKEN`, and nothing in a diff
shows it moved); every workflow declaring `permissions:` rather than inheriting
a repo-wide default; and the budgets file and `ci.yml` naming the same set of
jobs, so the budgets can't drift away from what they describe. Stdlib-only and
line-oriented — no toolchain install, no YAML dependency, ~10s in parallel, so
zero wall clock. Runs locally the same way: `python3 scripts/check_workflows.py`.

**`mycelium-frontend/src/lib/api-contract.test.ts`.** The `/api/*` catch-all
proxy is untyped by construction — it forwards whatever path it is handed — so a
renamed or deleted backend route strands a fetch and surfaces as a 404 inside a
panel, at runtime, in the browser. This scans the frontend for `/api/...`
literals and requires each to resolve either to a local Next route handler
(derived by walking `src/app/api/`, with the catch-all itself excluded so the
test can't go vacuous) or to a path in the committed `openapi.json`. 68 paths,
6ms, inside the vitest job that already runs. It models the two real quirks
rather than special-casing around them: the proxy's `/api/health` → `/health`
alias, and FastAPI's `{key:path}` converter for namespaced memory keys.

**`.github/workflows/screenshots.yml` + `scripts/publish-screenshots.sh`.** The
capture pipeline already existed and was already good; what was missing was
anything that ran it, so `docs/` and the splash repo's hero images drift behind
the UI until somebody happens to look at one. This runs `pnpm screenshots` on a
runner (Chromium + the frontend in mock mode) and **opens PRs** against `docs/`
here and `mycelium-io/mycelium-io.github.io` there. Additive in two senses:
manual dispatch, so nothing on the PR path gets slower; and the splash half is
gated on a `SPLASH_REPO_TOKEN` step output — with no token configured the docs
half still runs and the run reports that the other was skipped. PRs rather than
pushes because a runner and a laptop don't rasterize identically (font hinting,
GPU), so the diff wants an eye. Setup is one fine-grained PAT scoped to
`mycelium-io.github.io` alone, Contents + Pull requests read/write.

**Also:** top-level `permissions: contents: read` on `ci.yml`, and `concurrency`
with `cancel-in-progress` on PR branches only (never on `main` — those runs are
the record of what landed), so a superseded run stops occupying the queue the
next push is waiting in.

## Testing

- Frontend: `npx tsc --noEmit` clean, `npx eslint .` 0 errors, `npx vitest run`
  **438 passed** (68 of them the new contract cases). Mutation-checked: renaming
  `/api/rooms/${roomName}/skills` → `/skillz` fails the test with the path named.
- `scripts/check_workflows.py` passes on the three real workflows, and was run
  against fixtures for each failure mode: an unpinned `uses:`, a missing
  `permissions:` block, a budget for a job that doesn't exist, and a job with no
  budget.
- `scripts/ci_timing.py` exercised against the real job timings of run
  [32591048457](https://github.com/mycelium-io/mycelium/actions/runs/32591048457),
  including the over-budget and skipped-job branches. Output is the table above.
- The screenshot pipeline was run end-to-end in a container equivalent to a
  runner (`npm ci` in `mycelium-frontend` + `shotkit`, Chromium, mock server
  boot): captured `room-empty` in 9.5s, wrote both the 1x and @2x assets, and
  the rendered image is correct. The captured PNGs were reverted — refreshing
  the committed assets is the workflow's job, not this PR's.
- `bash -n` on the publish script; both new workflows parse as YAML and the
  `timing` job's `needs:` was verified to cover every other job.
- Backend and CLI are untouched, so their gates are unaffected.

---

# Ideation: where else GitHub Actions could earn their place

Asked for separately — this is the survey, not a commitment. The organizing
question is *what does this repo already do well, and what does CI not know
about it?*

## The principle worth keeping

Mycelium's own hygiene idea is **derived artifacts with a regenerate-and-diff
gate**: `openapi.json` vs the live app, `docs/*.html` vs its markdown sources,
`contracts/slim-l9-wire.json` vs both copies of the SLIM/L9 primitives, the link
index vs the markdown. Every one of those is "the truth is computed, so CI
recomputes it and fails on drift." Almost every idea below is that same shape
pointed at something we haven't pointed it at yet. That's the hygiene story: not
more checks, more *derivations*.

## Tiering, so the fast baseline survives

The thing that would ruin CI is putting good ideas in the wrong tier.

- **Tier 0 — per PR, must stay under ~95s.** Nothing that needs a network
  service, an LLM, or a docker build of an image the PR didn't touch. Everything
  in this PR is Tier 0 or cheaper.
- **Tier 1 — per PR, path-filtered.** Already how the two image builds work.
  Costs nothing on PRs that don't touch them.
- **Tier 2 — nightly / weekly on `main`.** Anything slow, flaky-by-nature, or
  paid. Failures open an issue rather than blocking a person.
- **Tier 3 — manual dispatch.** Publishing actions (the screenshots workflow),
  release dry-runs.

A rule of thumb worth adopting: **a new Tier 0 job must be parallel and under
60s, or it isn't Tier 0.**

## The gaps, roughly by value

**1. The backend image is never built in CI.** The collector and frontend images
get smoke builds; the backend — the image that ships `pi`, `slim-bindings`, and
the whole moderator — is only ever built at release. A broken backend Dockerfile
is currently discovered on release day. Tier 1, path-filtered on
`fastapi-backend/**`, same shape as the collector job: build, then
`docker run --rm … pi --version` and an import probe for `slim_bindings`. Highest
value-per-second on this list.

**2. Cognition has no CI at all.** The aligner's Pi brain, `plan_compiler.py`
and the doctor's completion probe are the product's core and are exercised only
against fakes, because live-LLM tests cost tokens (`MYCELIUM_LLM_TESTS=1`).
Tier 2, nightly, with a hard cap: one negotiation to convergence, one plan
compile, assert `plan/tasks.md` materializes with `@handle` owners and NEGMAS
terminated at unanimity rather than the step cap (the anti-theatre property is
exactly the kind of thing that regresses silently). Needs an API key secret —
same optional-secret pattern as `SPLASH_REPO_TOKEN`, skip-with-a-notice when
absent so forks aren't broken by it.

**3. The install path is never tested.** `install.sh` → `mycelium install` →
compose up → `/health` → `mycelium doctor` → create a room → `memory set/get` →
`mycelium down`. The `e2e` skill already scripts this by hand. Tier 2 nightly.
This is the one that catches the class of bug #765 was: the compose topology
changed and the CLI's view of it didn't.

**4. compose.yml ↔ CLI service-name drift.** Cheaper, narrower version of #3 and
genuinely Tier 0: `mycelium up/down/logs/status` name services; assert every
service the CLI references exists in `compose.yml` and vice versa. Pure static
check, milliseconds. Now that the UI is part of the stack rather than a profile,
this drift has one fewer guard rail than it looks like it has.

**5. Mock fixtures vs the OpenAPI schemas.** The natural sequel to the route
contract in this PR. `src/mocks/` fixtures are what the UI is *developed*
against; when they drift from the real response shapes, the app is built against
a fiction and the divergence shows up in production, not in a test. Validate
each mock payload against the `openapi.json` component schema for its route.
Tier 0, inside the existing vitest job.

**6. OpenAPI *breaking-change* detection.** Today CI proves the spec is current;
it doesn't notice that a change is breaking. Diff the PR's `openapi.json`
against `main`'s and warn on removed paths, removed/newly-required params, and
removed response fields — the three that break the generated client and the
frontend. Warn-only, Tier 0, seconds. Pairs with the route contract: one catches
the frontend's side, this catches the client's.

**7. Config schema → `.env` mapping coverage.** `mycelium config apply`
regenerates `~/.mycelium/.env` from `config.toml`, and the containers read only
that. A config field with no mapping is a setting that silently does nothing —
a bad failure mode, since it looks like it worked. Assert every field in the
pydantic schema either maps to an env var or is explicitly marked local-only.
Tier 0.

**8. Docs link checking.** `docs/*.html` and the READMEs, including the anchors
the docs generator emits. Regeneration moves anchors; nothing notices. Warn-only,
Tier 1 on `docs/**`.

**9. Release dry-run.** On PRs touching `release.yml`, the Dockerfiles, or
packaging metadata: build the wheel and one binary without publishing. Same
argument as #1 — release-day failures are the expensive kind. Tier 1.

**10. Adapter e2e (`claude_code`).** The `claude-code-e2e` skill already
defines it: the resident loop picks up an `@`-mention and posts a reply through a
real negotiation. `claude_code` is the one adapter we call proven; nothing in CI
proves it. Tier 2 nightly, needs a `claude` CLI + key secret.

**11. Screenshot visual diff on frontend PRs.** A non-publishing mode of the
workflow this PR adds: capture, compare against the committed assets, and post
the delta as a summary. Turns "we changed the UI and forgot the docs images"
into a visible number. Tier 1, and only worth it once #12's cost is understood.

**12. Frontend bundle-size budget.** Exactly the timing philosophy applied to
`next build` output: report route sizes into the summary, warn over budget,
never block. Free — the build already runs.

**13. Accessibility smoke.** shotkit already drives the mock routes; running
axe-core against four of them costs seconds. Warn-only.

**14. Dependency review + secret scanning on PRs.** `dependency-review-action`
on the PR diff (new CVEs, license surprises) and diff-scoped secret scanning.
Dependabot already covers the update half; neither of these is covered.

**15. Timing as a trend, not a threshold.** The natural evolution of the job in
this PR: store the last N `main` durations and compare against the rolling
median rather than a hand-set number, so budgets stop being a thing anyone edits.
Worth doing only once the fixed budgets have proven they warn on the right
things — a trend line built on the wrong signal is worse than a threshold.

**16. `scripts/` is outside every lint root.** `ruff`/`ty` cover
`fastapi-backend` and `mycelium-cli`; the maintainer scripts — including the two
this PR adds — are checked by nobody. Cheap to fold into the CLI job.

## What I'd deliberately not do

- **Blocking timing budgets.** A timing gate that can fail a merge gets raised
  until it's meaningless, and then it's a slow CI job that also lies.
- **A per-PR full-stack e2e.** It's the most valuable check on this list and the
  worst possible Tier 0 job. Nightly, or it eats the baseline this PR exists to
  protect.
- **Coverage thresholds.** They ratchet toward tests written to move a number.
  The contract-style checks above catch the failures we actually have.
- **Auto-merging Dependabot PRs.** With actions pinned by SHA (now enforced),
  the bot's action bumps are exactly the diffs that most deserve a human glance.

## Related Issues

None — new work.

---
_Generated by [Claude Code](https://claude.ai/code/session_017UYx4JKN9z9YVztfzPaV5V)_