### PR TITLE
Highlight one install tab at a time

### DIFF
--- a/mycelium-frontend/src/components/install-panel.test.tsx
+++ b/mycelium-frontend/src/components/install-panel.test.tsx
@@ -91,16 +91,35 @@ describe("<InstallPanel />", () => {
     expect(screen.queryByDisplayValue(PROMPT_COMMAND)).not.toBeInTheDocument();
   });
 
-  it("preselects the platform it detects, underneath the default Prompt tab", async () => {
+  it("highlights one tab at a time, and drops into the detected OS when Prompt is switched off", async () => {
+    const user = userEvent.setup();
     stubHub(false);
     vi.spyOn(navigator, "userAgent", "get").mockReturnValue(
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
     );
     renderWithSWR(<InstallPanel />);
 
-    expect(screen.getByRole("button", { name: "Prompt" })).toHaveAttribute("aria-pressed", "true");
-    await waitFor(() =>
-      expect(screen.getByRole("button", { name: "macOS" })).toHaveAttribute("aria-pressed", "true"),
-    );
+    const prompt = screen.getByRole("button", { name: "Prompt" });
+    const macos = screen.getByRole("button", { name: "macOS" });
+    expect(prompt).toHaveAttribute("aria-pressed", "true");
+    expect(macos).toHaveAttribute("aria-pressed", "false");
+
+    // Switching Prompt off lands on the detected OS, and only that one.
+    await user.click(prompt);
+    await waitFor(() => expect(macos).toHaveAttribute("aria-pressed", "true"));
+    expect(prompt).toHaveAttribute("aria-pressed", "false");
+    expect(commandField(CLI_INSTALL_COMMAND)).toBeInTheDocument();
+  });
+
+  it("deselects Prompt when an OS tab is picked", async () => {
+    const user = userEvent.setup();
+    stubHub(false);
+    renderWithSWR(<InstallPanel />);
+
+    await user.click(screen.getByRole("button", { name: "Linux" }));
+
+    expect(screen.getByRole("button", { name: "Prompt" })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: "Linux" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "macOS" })).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/mycelium-frontend/src/components/install-panel.tsx
+++ b/mycelium-frontend/src/components/install-panel.tsx
@@ -96,9 +96,12 @@ export function InstallPanel({ className }: Props) {
   // "Prompt" is a fourth tab alongside the OS ones, not a fifth platform: it
   // swaps the manual steps for one line to hand a coding agent instead, same
   // as the landing page's prompt/curl toggle. Selected by default, same as
-  // there. The detected OS tab stays highlighted underneath it (its own
-  // independent toggle), so it's already right the moment you switch off Prompt.
+  // there. Pressing it again drops into the manual steps for the detected OS,
+  // which is what makes the detection above worth doing.
   const [usePrompt, setUsePrompt] = useState(true);
+
+  // One row, one selection: an OS tab reads as active only while Prompt isn't.
+  const osSelected = (id: Platform) => !usePrompt && platform === id;
 
   return (
     <section className={cn("rounded-xl border border-border bg-paper p-5", className)}>
@@ -121,7 +124,7 @@ export function InstallPanel({ className }: Props) {
         <button
           type="button"
           aria-pressed={usePrompt}
-          onClick={() => setUsePrompt(true)}
+          onClick={() => setUsePrompt(prev => !prev)}
           className={cn(
             "rounded-md border px-2.5 py-1 text-micro font-medium transition-colors",
             usePrompt
@@ -135,14 +138,14 @@ export function InstallPanel({ className }: Props) {
           <button
             key={p.id}
             type="button"
-            aria-pressed={platform === p.id}
+            aria-pressed={osSelected(p.id)}
             onClick={() => {
               setUsePrompt(false);
               setPlatform(p.id);
             }}
             className={cn(
               "rounded-md border px-2.5 py-1 text-micro font-medium transition-colors",
-              platform === p.id
+              osSelected(p.id)
                 ? "border-border2 bg-surface text-text"
                 : "border-transparent text-muted-foreground hover:bg-hairline hover:text-text",
             )}


### PR DESCRIPTION
## Summary

On "Connect your CLI to this hub", two tabs looked selected at once — **Prompt** and the viewer's OS (macOS on a Mac, Linux on Linux). The row is a single segmented control, but it was driven by two independent pieces of state: `usePrompt` (default `true`) and `platform` (detected on mount). Both rendered their active styling, and both carried `aria-pressed="true"` inside one `role="group"`.

The old comment framed the OS highlight as deliberate — "already right the moment you switch off Prompt" — but there was no way to switch Prompt off except by clicking a specific OS tab, which sets `platform` itself. So the detection never actually showed through; it only produced the double highlight.

## Changes

- `install-panel.tsx`: an OS tab reads as selected (styling and `aria-pressed`) only while Prompt isn't — one active tab in the row, in either state.
- `install-panel.tsx`: the Prompt tab is now a real toggle. Pressing it while active drops into the manual steps for the detected OS, which is what makes the mount-time detection worth doing.
- `install-panel.test.tsx`: replaced the test that asserted the double-pressed state with one covering single selection plus the toggle-off path, and added a case asserting Prompt deselects when an OS tab is picked.

## Testing

Frontend gate (this repo's CI steps for `mycelium-frontend`):

- `npx tsc --noEmit` — clean
- `npx eslint .` — 0 errors (49 pre-existing warnings, one of them on this file's untouched mount effect)
- `npx vitest run` — 39 files, 371 tests passing

Visually confirmed in the running app (shotkit, `app / --mock`): Prompt alone highlighted on open; after pressing Prompt, the detected OS tab alone highlighted with the three manual steps showing.

The Python checks in this template don't apply — no backend files changed.

## Related Issues

None.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqtDT2fSTGma1PU3PR9tNw)_