### PR TITLE
Replace native title tooltips with a themed Tooltip primitive

### DIFF
--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { LoginGate } from "@/components/login-gate";
 import { KeymapProvider } from "@/components/keymap-provider";
 import { NotificationsProvider } from "@/components/notifications-provider";
 import { SWRProvider } from "@/components/swr-provider";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 export const metadata: Metadata = {
   title: "mycelium",
@@ -39,10 +40,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     the gate is off. */}
                 <LoginGate>
                   <NotificationsProvider>
-                    {/* Above the pages, not inside a page's shell: a page
-                        registers its own bindings, so it has to sit under the
-                        provider. */}
-                    <KeymapProvider>{children}</KeymapProvider>
+                    {/* Tooltips group their delay app-wide, so moving along a
+                        toolbar doesn't re-wait per control. */}
+                    <TooltipProvider>
+                      {/* Above the pages, not inside a page's shell: a page
+                          registers its own bindings, so it has to sit under
+                          the provider. */}
+                      <KeymapProvider>{children}</KeymapProvider>
+                    </TooltipProvider>
                   </NotificationsProvider>
                 </LoginGate>
               </AuthSessionProvider>

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -16,6 +16,7 @@ import { RoomChatBox } from "@/components/room-chat-box";
 import { RoomInspector, type Tab } from "@/components/room-inspector";
 import { RoomTour } from "@/components/room-tour";
 import { GlobalStatusItems, StatusButton } from "@/components/status-items";
+import { Tooltip } from "@/components/ui/tooltip";
 import { useCommands, useKeyAction, useKeyScope } from "@/components/keymap-provider";
 import type { PaletteCommand } from "@/lib/commands";
 import { useRoomStatus } from "@/lib/use-status";
@@ -213,7 +214,7 @@ function RoomWorkspace() {
         {connected ? "Live" : "Reconnecting…"}
       </span>
       {episodeLabel && (
-        <StatusButton onClick={() => openTab("episodes")} title="View episodes">
+        <StatusButton onClick={() => openTab("episodes")} tooltip="View episodes">
           <span style={{ color: episodeLabel.color }}>{episodeLabel.text}</span>
         </StatusButton>
       )}
@@ -226,7 +227,7 @@ function RoomWorkspace() {
   const statusRight = (
     <>
       {agents !== null && (
-        <StatusButton onClick={() => openTab("agents")} title="View agents">
+        <StatusButton onClick={() => openTab("agents")} tooltip="View agents">
           <span className="tabular">{agents} agent{agents === 1 ? "" : "s"}</span>
         </StatusButton>
       )}
@@ -238,7 +239,9 @@ function RoomWorkspace() {
     <>
       <span className="text-ui font-semibold text-text truncate">{roomName}</span>
       {room?.mas_id && (
-        <span className="font-mono text-micro text-faint truncate" title="MAS id">{room.mas_id}</span>
+        <Tooltip content="MAS id" side="bottom">
+          <span className="font-mono text-micro text-faint truncate">{room.mas_id}</span>
+        </Tooltip>
       )}
     </>
   );

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -18,6 +18,7 @@ import { useCommands } from "@/components/keymap-provider";
 import type { PaletteCommand } from "@/lib/commands";
 import { useAuthSession } from "@/components/auth-session";
 import { Monogram } from "@/components/ui/monogram";
+import { Tooltip } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { TagInput } from "@/components/ui/tag-input";
@@ -174,43 +175,51 @@ export function ActingAsPicker({ compact = false }: Props) {
     form.isNew ? users.find((u) => u.handle === normHandle(form.handle)) : undefined;
 
   const teamSuggestions = teams.map((t) => t.team);
+  const actingLabel = principal
+    ? `Acting as @${principal}`
+    : "Choose the user you're acting as";
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger
-        title={principal ? `Acting as @${principal}` : "Choose the user you're acting as"}
-        className={
-          compact
-            ? "group flex size-8 items-center justify-center rounded-md transition-colors hover:bg-hairline"
-            : "group flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-hairline"
-        }
-      >
-        {principal ? (
-          <Monogram handle={principal} color="var(--muted-foreground)" className="size-7" />
-        ) : (
-          <span
-            aria-hidden
-            className="flex size-7 flex-shrink-0 items-center justify-center rounded-full bg-surface text-muted-foreground"
-          >
-            <UserRound className="size-3.5" />
-          </span>
-        )}
-        {/* The handle and the switcher affordance are what the 48px strip
-            can't hold; the avatar carries the identity on its own there. */}
-        {!compact && (
-          <>
-            <span className="min-w-0 flex-1">
-              <span className="block truncate font-mono text-label text-text">
-                {principal ? `@${principal}` : "Anonymous"}
-              </span>
-              <span className="block truncate text-micro text-muted-foreground">
-                {principal ? (signedIn ? "signed in" : "acting as") : "pick a user"}
-              </span>
+      {/* Collapsed to an avatar, the trigger has no text of its own, so
+          the label does the naming there and the tooltip only ever
+          restates it. */}
+      <Tooltip content={actingLabel} side="right">
+        <DialogTrigger
+          aria-label={compact ? actingLabel : undefined}
+          className={
+            compact
+              ? "group flex size-8 items-center justify-center rounded-md transition-colors hover:bg-hairline"
+              : "group flex min-w-0 flex-1 items-center gap-2 rounded-md px-1.5 py-1 text-left transition-colors hover:bg-hairline"
+          }
+        >
+          {principal ? (
+            <Monogram handle={principal} color="var(--muted-foreground)" className="size-7" />
+          ) : (
+            <span
+              aria-hidden
+              className="flex size-7 flex-shrink-0 items-center justify-center rounded-full bg-surface text-muted-foreground"
+            >
+              <UserRound className="size-3.5" />
             </span>
-            <ChevronsUpDown className="size-3.5 flex-shrink-0 text-faint transition-colors group-hover:text-muted-foreground" />
-          </>
-        )}
-      </DialogTrigger>
+          )}
+          {/* The handle and the switcher affordance are what the 48px strip
+              can't hold; the avatar carries the identity on its own there. */}
+          {!compact && (
+            <>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate font-mono text-label text-text">
+                  {principal ? `@${principal}` : "Anonymous"}
+                </span>
+                <span className="block truncate text-micro text-muted-foreground">
+                  {principal ? (signedIn ? "signed in" : "acting as") : "pick a user"}
+                </span>
+              </span>
+              <ChevronsUpDown className="size-3.5 flex-shrink-0 text-faint transition-colors group-hover:text-muted-foreground" />
+            </>
+          )}
+        </DialogTrigger>
+      </Tooltip>
 
       <DialogContent className="sm:max-w-sm">
         {view === "switch" && (

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Monogram } from "@/components/ui/monogram";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip } from "@/components/ui/tooltip";
 import { useCurrentUser } from "@/components/current-user";
 import {
   Dialog,
@@ -317,18 +318,25 @@ export function AgentsPanel({
                     {a.handle}
                   </span>
                   {a.owner && (
-                    <span
-                      className="truncate font-mono text-micro"
-                      style={{ color: mine ? "var(--accent)" : "var(--muted-foreground)" }}
-                      title={`owner: @${a.owner}`}
-                    >
-                      @{a.owner}
-                    </span>
+                    <Tooltip content={`owner: @${a.owner}`}>
+                      <span
+                        className="truncate font-mono text-micro"
+                        style={{ color: mine ? "var(--accent)" : "var(--muted-foreground)" }}
+                        aria-description={`owner: @${a.owner}`}
+                      >
+                        @{a.owner}
+                      </span>
+                    </Tooltip>
                   )}
                   {a.team && (
-                    <span className="truncate text-micro text-muted-foreground" title={`team: ${a.team}`}>
-                      · {a.team}
-                    </span>
+                    <Tooltip content={`team: ${a.team}`}>
+                      <span
+                        className="truncate text-micro text-muted-foreground"
+                        aria-description={`team: ${a.team}`}
+                      >
+                        · {a.team}
+                      </span>
+                    </Tooltip>
                   )}
                 </div>
                 <div className="mt-0.5 truncate text-micro text-muted-foreground">

--- a/mycelium-frontend/src/components/episode-detail.tsx
+++ b/mycelium-frontend/src/components/episode-detail.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useState } from "react";
 import { fetchEpisode, type EpisodeDetail as EpisodeDetailT, type L9Envelope } from "@/lib/api";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip } from "@/components/ui/tooltip";
 
 function outcomeColor(state: string | null): string {
   if (state === "converged" || state === "resolved") return "var(--green)";
@@ -22,12 +23,20 @@ function Meta({ label, children }: { label: string; children: React.ReactNode })
   );
 }
 
-function Stat({ label, value, title }: { label: string; value: string; title?: string }) {
+/** A quality metric tile. The label is an acronym, so the tooltip spelling it
+ *  out is the tile's only explanation — `aria-description` keeps it for readers
+ *  that never hover. */
+function Stat({ label, value, hint }: { label: string; value: string; hint?: string }) {
   return (
-    <div className="flex flex-col gap-0.5 rounded-lg border border-border bg-surface px-3 py-2" title={title}>
-      <span className="text-micro uppercase tracking-wide text-faint">{label}</span>
-      <span className="font-mono text-label tabular text-text">{value}</span>
-    </div>
+    <Tooltip content={hint}>
+      <div
+        aria-description={hint}
+        className="flex flex-col gap-0.5 rounded-lg border border-border bg-surface px-3 py-2"
+      >
+        <span className="text-micro uppercase tracking-wide text-faint">{label}</span>
+        <span className="font-mono text-label tabular text-text">{value}</span>
+      </div>
+    </Tooltip>
   );
 }
 
@@ -108,9 +117,9 @@ export function EpisodeDetail({ roomName, shortId }: { roomName: string; shortId
 
       {m && (
         <div className="grid grid-cols-3 gap-2 border-b border-border px-5 py-4">
-          <Stat label="MPC" value={m.mpc.toFixed(2)} title="Mutual proposal coherence" />
-          <Stat label="GAR" value={m.gar.toFixed(2)} title="Genuine agreement ratio" />
-          <Stat label="SCR" value={m.scr.toFixed(2)} title="Self-consistency ratio" />
+          <Stat label="MPC" value={m.mpc.toFixed(2)} hint="Mutual proposal coherence" />
+          <Stat label="GAR" value={m.gar.toFixed(2)} hint="Genuine agreement ratio" />
+          <Stat label="SCR" value={m.scr.toFixed(2)} hint="Self-consistency ratio" />
         </div>
       )}
 

--- a/mycelium-frontend/src/components/episodes-rail.tsx
+++ b/mycelium-frontend/src/components/episodes-rail.tsx
@@ -10,6 +10,7 @@ import { useRoomEpisodes } from "@/lib/room-data";
 import { DetailDrawer } from "@/components/detail-drawer";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip } from "@/components/ui/tooltip";
 import { EpisodeDetail } from "@/components/episode-detail";
 
 // The room's episodes at a glance: each convening of the aligner is one episode
@@ -113,12 +114,14 @@ export function EpisodesRail({ roomName, focusShortId = null, onFocusConsumed }:
                     className={`inline-block size-1.5 flex-shrink-0 rounded-full ${live ? "" : "opacity-60"}`}
                     style={{ background: color }}
                   />
-                  <span
-                    className="font-mono text-micro text-muted-foreground truncate"
-                    title={ep.episode || ep.short_id}
-                  >
-                    {ep.short_id}
-                  </span>
+                  <Tooltip content={ep.episode || ep.short_id} side="left">
+                    <span
+                      className="font-mono text-micro text-muted-foreground truncate"
+                      aria-description={ep.episode || ep.short_id}
+                    >
+                      {ep.short_id}
+                    </span>
+                  </Tooltip>
                   <span className="ml-auto text-micro text-muted-foreground tabular">{ep.message_count} msg</span>
                 </div>
                 <div className="flex items-center gap-2 pl-3.5">

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -24,6 +24,7 @@ import { KeyBadge } from "@/components/key-badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Monogram } from "@/components/ui/monogram";
+import { Tooltip } from "@/components/ui/tooltip";
 import { Bot, MessagesSquare } from "lucide-react";
 
 interface Event {
@@ -639,7 +640,9 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                   >
                     <span>in</span>
                     {shortId ? (
-                      <span className="font-mono text-accent" title={episodeUrn}>{shortId}</span>
+                      <Tooltip content={episodeUrn}>
+                        <span className="font-mono text-accent" aria-description={episodeUrn}>{shortId}</span>
+                      </Tooltip>
                     ) : (
                       <span className="font-mono">episode</span>
                     )}
@@ -649,9 +652,14 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                       <>
                         <span>· {issueCount} issue{issueCount === 1 ? "" : "s"} agreed</span>
                         {gar !== undefined ? (
-                          <span className="font-mono" title="genuine agreement ratio: how many agents actually moved toward the outcome">
-                            · GAR {gar.toFixed(2)}
-                          </span>
+                          <Tooltip content="Genuine agreement ratio: how many agents actually moved toward the outcome">
+                            <span
+                              className="font-mono"
+                              aria-description="Genuine agreement ratio: how many agents actually moved toward the outcome"
+                            >
+                              · GAR {gar.toFixed(2)}
+                            </span>
+                          </Tooltip>
                         ) : null}
                         {planFile ? (
                           <span>→ <span className="font-mono text-accent">{planFile}</span></span>
@@ -671,7 +679,9 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                     <span className="font-medium text-muted-foreground">@{handle}</span>
                     <span>joined</span>
                     {shortId ? (
-                      <span className="font-mono text-accent" title={episodeUrn}>{shortId}</span>
+                      <Tooltip content={episodeUrn}>
+                        <span className="font-mono text-accent" aria-description={episodeUrn}>{shortId}</span>
+                      </Tooltip>
                     ) : null}
                     {intent ? <span>· &ldquo;{intent}&rdquo;</span> : null}
                   </SystemNotice>
@@ -705,9 +715,11 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
 
                   <div className="w-7 flex-shrink-0">
                     {!grouped && (
-                      <span title={owner ? `@${ev.sender} · owned by @${owner}` : ev.sender}>
-                        <Monogram handle={ev.sender} color={color} className="size-7 text-micro" />
-                      </span>
+                      <Tooltip content={owner ? `@${ev.sender} · owned by @${owner}` : ev.sender}>
+                        <span role="img" aria-label={owner ? `@${ev.sender} · owned by @${owner}` : ev.sender}>
+                          <Monogram handle={ev.sender} color={color} className="size-7 text-micro" />
+                        </span>
+                      </Tooltip>
                     )}
                   </div>
                   <div className="min-w-0 flex-1">

--- a/mycelium-frontend/src/components/global-search.tsx
+++ b/mycelium-frontend/src/components/global-search.tsx
@@ -6,6 +6,7 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { SearchPalette } from "@/components/search-palette";
+import { Tooltip } from "@/components/ui/tooltip";
 import { useKeyAction } from "@/components/keymap-provider";
 import { searchEverything } from "@/lib/api";
 import { isMacPlatform } from "@/lib/keymap";
@@ -60,13 +61,14 @@ export function GlobalSearchButton() {
   const openSearch = useContext(OpenSearchContext);
   if (!openSearch) return null;
   return (
-    <button
-      type="button"
-      onClick={openSearch}
-      title="Search everything"
-      className="rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
-    >
-      <kbd className="font-sans">/</kbd> search
-    </button>
+    <Tooltip content="Search everything" side="top">
+      <button
+        type="button"
+        onClick={openSearch}
+        className="rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
+      >
+        <kbd className="font-sans">/</kbd> search
+      </button>
+    </Tooltip>
   );
 }

--- a/mycelium-frontend/src/components/keymap-provider.tsx
+++ b/mycelium-frontend/src/components/keymap-provider.tsx
@@ -14,6 +14,7 @@ import {
   type ReactNode,
 } from "react";
 import { CommandPalette } from "@/components/command-palette";
+import { Tooltip } from "@/components/ui/tooltip";
 import { KeymapCheatsheet } from "@/components/keymap-cheatsheet";
 import { loadRecent, pushRecent, saveRecent, type PaletteCommand } from "@/lib/commands";
 import {
@@ -376,14 +377,15 @@ export function KeymapHelpButton() {
   const api = useContext(KeymapContext);
   if (!api) return null;
   return (
-    <button
-      type="button"
-      onClick={api.openHelp}
-      title="Keyboard shortcuts"
-      className="rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
-    >
-      <kbd className="font-sans">?</kbd> keys
-    </button>
+    <Tooltip content="Keyboard shortcuts" side="top">
+      <button
+        type="button"
+        onClick={api.openHelp}
+        className="rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
+      >
+        <kbd className="font-sans">?</kbd> keys
+      </button>
+    </Tooltip>
   );
 }
 
@@ -392,14 +394,15 @@ export function CommandPaletteButton() {
   const mac = useIsMac();
   if (!api) return null;
   return (
-    <button
-      type="button"
-      onClick={api.openPalette}
-      title="Command palette"
-      className="rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
-    >
-      <kbd className="font-sans">{formatChord(chordFor("palette.open") ?? "", mac)}</kbd> commands
-    </button>
+    <Tooltip content="Command palette" side="top">
+      <button
+        type="button"
+        onClick={api.openPalette}
+        className="rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
+      >
+        <kbd className="font-sans">{formatChord(chordFor("palette.open") ?? "", mac)}</kbd> commands
+      </button>
+    </Tooltip>
   );
 }
 

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tooltip } from "@/components/ui/tooltip";
 import {
   fetchL9History,
   getSSEUrl,
@@ -257,15 +258,18 @@ function frameIcon(kind: string, subkind?: string | null): LucideIcon {
 }
 
 export function KindBadge({ kind, subkind }: { kind: string; subkind?: string | null }) {
+  const full = `${kind}${subkind ? ":" + subkind : ""}`;
   return (
-    <span
-      className="block min-w-0 truncate font-mono text-label font-semibold uppercase tracking-[0.02em]"
-      style={{ color: frameTone(kind, subkind) }}
-      title={`${kind}${subkind ? ":" + subkind : ""}`}
-    >
-      {kind.toUpperCase()}
-      {subkind ? <span className="text-muted-foreground">:{subkind}</span> : null}
-    </span>
+    <Tooltip content={full}>
+      <span
+        className="block min-w-0 truncate font-mono text-label font-semibold uppercase tracking-[0.02em]"
+        style={{ color: frameTone(kind, subkind) }}
+        aria-description={full}
+      >
+        {kind.toUpperCase()}
+        {subkind ? <span className="text-muted-foreground">:{subkind}</span> : null}
+      </span>
+    </Tooltip>
   );
 }
 
@@ -277,10 +281,12 @@ export function MetricsRow({ metrics }: { metrics: EpisodeMetrics }) {
   ];
   return (
     <span className="flex items-center gap-2 font-mono text-micro tabular">
-      {items.map(([label, value, title]) => (
-        <span key={label} title={title} className="text-muted-foreground">
-          <span className="text-muted-foreground">{label}</span> {Number(value).toFixed(2)}
-        </span>
+      {items.map(([label, value, expansion]) => (
+        <Tooltip key={label} content={expansion}>
+          <span aria-description={expansion} className="text-muted-foreground">
+            <span className="text-muted-foreground">{label}</span> {Number(value).toFixed(2)}
+          </span>
+        </Tooltip>
       ))}
     </span>
   );
@@ -314,7 +320,10 @@ function FrameRow({
         type="button"
         aria-expanded={expanded}
         onClick={() => setExpanded((prev) => !prev)}
-        title={expanded ? "Collapse envelope" : "Expand full envelope JSON"}
+        // No visual tooltip: the trigger is a full-width feed row, so a bubble
+        // anchored to it would sit over its neighbours. The chevron and
+        // aria-expanded already carry the affordance.
+        aria-description={expanded ? "Collapse envelope" : "Expand full envelope JSON"}
         // Fixed columns so kind / actor / summary line up down the feed, one text
         // size throughout; timestamp + metrics ride a right-aligned meta cluster.
         className="group grid w-full cursor-pointer grid-cols-[14px_16px_176px_120px_minmax(0,1fr)_auto] items-center gap-x-2.5 px-4 py-1.5 text-left text-label transition-colors hover:bg-hairline"
@@ -333,14 +342,18 @@ function FrameRow({
         <span className="flex items-center justify-end gap-2.5 text-micro text-muted-foreground">
           {frame.metrics ? <MetricsRow metrics={frame.metrics} /> : null}
           {frame.parents.length > 0 ? (
-            <span className="font-mono tabular" title={frame.parents.join("\n")}>
-              ←{frame.parents.length}
-            </span>
+            <Tooltip content={frame.parents.join("\n")}>
+              <span className="font-mono tabular" aria-description={`parents: ${frame.parents.join(", ")}`}>
+                ←{frame.parents.length}
+              </span>
+            </Tooltip>
           ) : null}
           {frame.episode ? (
-            <span className="font-mono text-accent" title={frame.episode}>
-              {shortEpisode(frame.episode)}
-            </span>
+            <Tooltip content={frame.episode}>
+              <span className="font-mono text-accent" aria-description={frame.episode}>
+                {shortEpisode(frame.episode)}
+              </span>
+            </Tooltip>
           ) : null}
           <span className="font-mono tabular">{frame.time}</span>
         </span>

--- a/mycelium-frontend/src/components/markdown-content.test.tsx
+++ b/mycelium-frontend/src/components/markdown-content.test.tsx
@@ -43,7 +43,7 @@ describe("<MarkdownContent /> memory links", () => {
     );
 
     expect(screen.queryByRole("button", { name: /gone/ })).not.toBeInTheDocument();
-    expect(screen.getByTitle("gone — no such memory")).toBeInTheDocument();
+    expect(screen.getByText("gone")).toHaveAttribute("aria-description", "gone — no such memory");
   });
 
   it("renders links inert when no click handler is supplied", () => {
@@ -93,7 +93,7 @@ describe("<MarkdownContent /> memory links", () => {
     const onLinkClick = vi.fn();
     render(<MarkdownContent onLinkClick={onLinkClick}>{"![[glossary/slim]]"}</MarkdownContent>);
 
-    expect(screen.getByTitle("Embeds glossary/slim")).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveAttribute("aria-description", "Embeds glossary/slim");
   });
 
   it("renders a /skill reference as a chip that opens its skills/ memory", async () => {

--- a/mycelium-frontend/src/components/markdown-content.tsx
+++ b/mycelium-frontend/src/components/markdown-content.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { Tooltip } from "@/components/ui/tooltip";
 
 // Mentions, memory links, transclusions, and skill references, in one pass so a
 // body is split once. `![[…]]` is listed before `[[…]]` so the transclusion form
@@ -86,13 +87,15 @@ function MemoryLinkChip({ link, broken, onClick }: LinkProps) {
 
   if (broken) {
     return (
-      <span
-        title={`${link.target} — no such memory`}
-        className={`${base} text-muted-foreground line-through decoration-red/60`}
-      >
-        {link.transclusion && <span aria-hidden className="not-italic">⧉</span>}
-        {text}
-      </span>
+      <Tooltip content={`${link.target} — no such memory`}>
+        <span
+          aria-description={`${link.target} — no such memory`}
+          className={`${base} text-muted-foreground line-through decoration-red/60`}
+        >
+          {link.transclusion && <span aria-hidden className="not-italic">⧉</span>}
+          {text}
+        </span>
+      </Tooltip>
     );
   }
 
@@ -106,15 +109,18 @@ function MemoryLinkChip({ link, broken, onClick }: LinkProps) {
   if (!onClick) {
     return <span className={`${base} text-accent`}>{body}</span>;
   }
+  const action = link.transclusion ? `Embeds ${link.target}` : `Open ${link.target}`;
   return (
-    <button
-      type="button"
-      onClick={() => onClick(link.target)}
-      title={link.transclusion ? `Embeds ${link.target}` : `Open ${link.target}`}
-      className={`${base} text-accent hover:bg-accent-soft hover:underline`}
-    >
-      {body}
-    </button>
+    <Tooltip content={action}>
+      <button
+        type="button"
+        onClick={() => onClick(link.target)}
+        aria-description={action}
+        className={`${base} text-accent hover:bg-accent-soft hover:underline`}
+      >
+        {body}
+      </button>
+    </Tooltip>
   );
 }
 

--- a/mycelium-frontend/src/components/memory-graph.tsx
+++ b/mycelium-frontend/src/components/memory-graph.tsx
@@ -17,6 +17,7 @@ import { AlertTriangle, ChevronDown, ChevronUp, ExternalLink, Filter, Link2, Rot
 import type { MemoryGraph as MemoryGraphData, MemoryGraphNode } from "@/lib/api";
 import { computeForceLayout, type GraphLayoutEdge, type GraphLayoutNode } from "@/lib/memory-graph-layout";
 import { isBrokenLinkError, linkErrorLabel, LINK_ERRORS } from "@/lib/memory-links";
+import { Tooltip } from "@/components/ui/tooltip";
 import {
   loadPlacements,
   savePlacements,
@@ -521,20 +522,35 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
           {linkCount === 1 ? "" : "s"}
         </span>
         {orphanCount > 0 && (
-          <span className="flex items-center gap-1 text-yellow" title="Fully isolated — no inbound or outbound links">
-            <Unlink className="size-3.5" />
-            <span className="font-semibold tabular">{orphanCount}</span> orphan{orphanCount === 1 ? "" : "s"}
-          </span>
+          <Tooltip content="Fully isolated — no inbound or outbound links" side="bottom">
+            <span
+              className="flex items-center gap-1 text-yellow"
+              aria-description="Fully isolated — no inbound or outbound links"
+            >
+              <Unlink className="size-3.5" />
+              <span className="font-semibold tabular">{orphanCount}</span> orphan{orphanCount === 1 ? "" : "s"}
+            </span>
+          </Tooltip>
         )}
         {rootCount > 0 && (
-          <span className="flex items-center gap-1 text-muted-foreground" title="Entry points — nothing links here yet">
-            <span className="font-semibold tabular">{rootCount}</span> root{rootCount === 1 ? "" : "s"}
-          </span>
+          <Tooltip content="Entry points — nothing links here yet" side="bottom">
+            <span
+              className="flex items-center gap-1 text-muted-foreground"
+              aria-description="Entry points — nothing links here yet"
+            >
+              <span className="font-semibold tabular">{rootCount}</span> root{rootCount === 1 ? "" : "s"}
+            </span>
+          </Tooltip>
         )}
         {leafCount > 0 && (
-          <span className="flex items-center gap-1 text-muted-foreground" title="Dead ends — links arrive but go no further">
-            <span className="font-semibold tabular">{leafCount}</span> lea{leafCount === 1 ? "f" : "ves"}
-          </span>
+          <Tooltip content="Dead ends — links arrive but go no further" side="bottom">
+            <span
+              className="flex items-center gap-1 text-muted-foreground"
+              aria-description="Dead ends — links arrive but go no further"
+            >
+              <span className="font-semibold tabular">{leafCount}</span> lea{leafCount === 1 ? "f" : "ves"}
+            </span>
+          </Tooltip>
         )}
         {brokenCount > 0 && (
           <span className="flex items-center gap-1 text-red">
@@ -543,37 +559,45 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
           </span>
         )}
         {crossRoomCount > 0 && (
-          <span
-            className="flex items-center gap-1 text-muted-foreground"
-            title={LINK_ERRORS.cross_room}
-          >
-            <ExternalLink className="size-3.5" />
-            <span className="font-semibold tabular">{crossRoomCount}</span> cross-room
-          </span>
+          <Tooltip content={LINK_ERRORS.cross_room} side="bottom">
+            <span
+              className="flex items-center gap-1 text-muted-foreground"
+              aria-description={LINK_ERRORS.cross_room}
+            >
+              <ExternalLink className="size-3.5" />
+              <span className="font-semibold tabular">{crossRoomCount}</span> cross-room
+            </span>
+          </Tooltip>
         )}
         <div className="ml-auto flex items-center gap-1">
           {filtered && (
-            <button
-              onClick={clearFilters}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
-              title="Show every namespace and link type again"
-            >
-              <Filter className="size-3.5" />
-              Clear filters
-            </button>
+            <Tooltip content="Show every namespace and link type again" side="bottom" align="end">
+              <button
+                onClick={clearFilters}
+                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+              >
+                <Filter className="size-3.5" />
+                Clear filters
+              </button>
+            </Tooltip>
           )}
           {hasPlacements && (
-            <button
-              onClick={() => {
-                dirty.current = true;
-                setPlaced({});
-              }}
-              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
-              title="Put every hand-moved memory back where the force layout placed it, and forget the saved arrangement"
+            <Tooltip
+              content="Put every hand-moved memory back where the force layout placed it, and forget the saved arrangement"
+              side="bottom"
+              align="end"
             >
-              <RotateCcw className="size-3.5" />
-              Reset layout
-            </button>
+              <button
+                onClick={() => {
+                  dirty.current = true;
+                  setPlaced({});
+                }}
+                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+              >
+                <RotateCcw className="size-3.5" />
+                Reset layout
+              </button>
+            </Tooltip>
           )}
         </div>
       </div>
@@ -647,22 +671,22 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
               {namespaces.map(ns => {
                 const hidden = hiddenNamespaces.has(ns);
                 return (
-                  <button
-                    key={ns}
-                    onClick={() => toggle(setHiddenNamespaces, ns)}
-                    aria-pressed={!hidden}
-                    aria-label={hidden ? `Show ${ns}` : `Hide ${ns}`}
-                    title={hidden ? `Show ${ns}` : `Hide ${ns}`}
-                    className={`flex items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-hairline ${
-                      hidden ? "opacity-40" : ""
-                    }`}
-                  >
-                    <span
-                      className="size-2 flex-shrink-0 rounded-full"
-                      style={{ background: hidden ? "transparent" : colorFor(ns), boxShadow: `inset 0 0 0 1px ${colorFor(ns)}` }}
-                    />
-                    <span className={`font-mono ${hidden ? "line-through" : ""}`}>{ns}</span>
-                  </button>
+                  <Tooltip key={ns} content={hidden ? `Show ${ns}` : `Hide ${ns}`} side="right">
+                    <button
+                      onClick={() => toggle(setHiddenNamespaces, ns)}
+                      aria-pressed={!hidden}
+                      aria-label={hidden ? `Show ${ns}` : `Hide ${ns}`}
+                      className={`flex items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-hairline ${
+                        hidden ? "opacity-40" : ""
+                      }`}
+                    >
+                      <span
+                        className="size-2 flex-shrink-0 rounded-full"
+                        style={{ background: hidden ? "transparent" : colorFor(ns), boxShadow: `inset 0 0 0 1px ${colorFor(ns)}` }}
+                      />
+                      <span className={`font-mono ${hidden ? "line-through" : ""}`}>{ns}</span>
+                    </button>
+                  </Tooltip>
                 );
               })}
 
@@ -672,19 +696,23 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
                   {edgeTypes.map(type => {
                     const hidden = hiddenTypes.has(type);
                     return (
-                      <button
+                      <Tooltip
                         key={type}
-                        onClick={() => toggle(setHiddenTypes, type)}
-                        aria-pressed={!hidden}
-                        aria-label={hidden ? `Show ${type} edges` : `Hide ${type} edges`}
-                        title={hidden ? `Show ${type} edges` : `Hide ${type} edges`}
-                        className={`flex items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-hairline ${
-                          hidden ? "opacity-40" : ""
-                        }`}
+                        content={hidden ? `Show ${type} edges` : `Hide ${type} edges`}
+                        side="right"
                       >
-                        <Link2 className="size-3 flex-shrink-0" />
-                        <span className={`font-mono ${hidden ? "line-through" : ""}`}>{type}</span>
-                      </button>
+                        <button
+                          onClick={() => toggle(setHiddenTypes, type)}
+                          aria-pressed={!hidden}
+                          aria-label={hidden ? `Show ${type} edges` : `Hide ${type} edges`}
+                          className={`flex items-center gap-1.5 rounded px-1 py-0.5 text-left transition-colors hover:bg-hairline ${
+                            hidden ? "opacity-40" : ""
+                          }`}
+                        >
+                          <Link2 className="size-3 flex-shrink-0" />
+                          <span className={`font-mono ${hidden ? "line-through" : ""}`}>{type}</span>
+                        </button>
+                      </Tooltip>
                     );
                   })}
                 </>

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -33,6 +33,7 @@ import { memoryValueText } from "@/lib/memory-preview";
 import { DetailDrawer } from "@/components/detail-drawer";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip } from "@/components/ui/tooltip";
 import { MemoryDetail } from "@/components/memory-detail";
 import { MemoryEditor } from "@/components/memory-editor";
 import { useCurrentUser } from "@/components/current-user";
@@ -379,14 +380,15 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
           <span className="text-faint px-1">·</span>
           <span className="text-text font-semibold tabular">{contributors.length}</span>
           <span>contributors</span>
-          <Link
-            href={memoryGraphHref(roomName)}
-            className="ml-auto inline-flex flex-shrink-0 items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
-            title="Open the memory link graph"
-          >
-            <Network className="size-3.5" />
-            Graph
-          </Link>
+          <Tooltip content="Open the memory link graph">
+            <Link
+              href={memoryGraphHref(roomName)}
+              className="ml-auto inline-flex flex-shrink-0 items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+            >
+              <Network className="size-3.5" />
+              Graph
+            </Link>
+          </Tooltip>
         </div>
         {contributors.length > 0 && (
           <div className="flex flex-wrap gap-1.5 mt-2.5">
@@ -504,25 +506,27 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
         actions={
           selected ? (
             <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={() =>
-                  isEditing ? guard(() => setIsEditing(false)) : setIsEditing(true)
-                }
-                title={isEditing ? "View" : "Edit"}
-                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
-              >
-                {isEditing ? <Eye className="size-3.5" /> : <Pencil className="size-3.5" />}
-                {isEditing ? "View" : "Edit"}
-              </button>
-              <Link
-                href={memoryHref(roomName, selected.key)}
-                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
-                title="Open full page"
-              >
-                <ExternalLink className="size-3.5" />
-                Full page
-              </Link>
+              <Tooltip content={isEditing ? "Back to the rendered memory" : "Edit this memory"}>
+                <button
+                  type="button"
+                  onClick={() =>
+                    isEditing ? guard(() => setIsEditing(false)) : setIsEditing(true)
+                  }
+                  className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+                >
+                  {isEditing ? <Eye className="size-3.5" /> : <Pencil className="size-3.5" />}
+                  {isEditing ? "View" : "Edit"}
+                </button>
+              </Tooltip>
+              <Tooltip content="Open full page">
+                <Link
+                  href={memoryHref(roomName, selected.key)}
+                  className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+                >
+                  <ExternalLink className="size-3.5" />
+                  Full page
+                </Link>
+              </Tooltip>
             </div>
           ) : undefined
         }

--- a/mycelium-frontend/src/components/negotiation-view.tsx
+++ b/mycelium-frontend/src/components/negotiation-view.tsx
@@ -6,6 +6,7 @@
 import { useMemo } from "react";
 import { Scale, X } from "lucide-react";
 import { EmptyState } from "@/components/empty-state";
+import { Tooltip } from "@/components/ui/tooltip";
 
 // The Negotiation instrument: the aligner's NEGMAS Stacked Alternating Offers
 // mechanism made visible. It reconstructs, purely from the coordination_tick /
@@ -119,18 +120,28 @@ function derive(events: readonly NegEvent[]): Negotiation {
   };
 }
 
+/** The SAO move as a bare shape. It carries no text, so `role="img"` +
+ *  `aria-label` is the glyph's whole accessible name; the tooltip is the
+ *  sighted reader's copy of it. */
 function MoveGlyph({ action }: { action?: MoveAction }) {
-  if (action === "propose")
-    return <span title="propose" className="inline-block size-2.5 border-[1.5px] border-accent" />;
-  if (action === "counter")
-    return <span title="counter" className="inline-block size-2.5 rotate-45 border-[1.5px] border-accent" />;
-  if (action === "accept")
-    return <span title="accept" className="inline-block size-2.5 bg-green" />;
   if (action === "reject")
     return <X className="size-3 text-yellow" strokeWidth={2.5} aria-label="reject" />;
-  if (action)
-    return <span title={action} className="inline-block size-1.5 rounded-full bg-muted-foreground" />;
-  return <span className="inline-block size-1 rounded-full bg-faint/40" aria-hidden />;
+  if (!action) return <span className="inline-block size-1 rounded-full bg-faint/40" aria-hidden />;
+
+  const shape =
+    action === "propose"
+      ? "size-2.5 border-[1.5px] border-accent"
+      : action === "counter"
+        ? "size-2.5 rotate-45 border-[1.5px] border-accent"
+        : action === "accept"
+          ? "size-2.5 bg-green"
+          : "size-1.5 rounded-full bg-muted-foreground";
+
+  return (
+    <Tooltip content={action}>
+      <span role="img" aria-label={action} className={`inline-block ${shape}`} />
+    </Tooltip>
+  );
 }
 
 const STATE_TONE: Record<Negotiation["state"], string> = {

--- a/mycelium-frontend/src/components/notification-bell.test.tsx
+++ b/mycelium-frontend/src/components/notification-bell.test.tsx
@@ -99,7 +99,7 @@ describe("<NotificationBell />", () => {
 
     await user.click(screen.getByLabelText("1 unread notifications"));
     const panel = await screen.findByText("Notifications");
-    await user.click(within(panel.closest("[data-slot=popover-content]")!).getByTitle("Mark all read"));
+    await user.click(within(panel.closest("[data-slot=popover-content]")!).getByLabelText("Mark all read"));
 
     expect(screen.getByLabelText("Notifications")).toBeInTheDocument();
   });
@@ -117,7 +117,7 @@ describe("<NotificationBell />", () => {
     await user.click(await screen.findByLabelText("1 unread notifications"));
     expect(await screen.findByText("sprint")).toBeInTheDocument();
 
-    await user.click(screen.getByTitle("Dismiss"));
+    await user.click(screen.getByLabelText("Dismiss"));
     expect(screen.queryByText("hey @bob take a look")).not.toBeInTheDocument();
   });
 });

--- a/mycelium-frontend/src/components/notification-bell.tsx
+++ b/mycelium-frontend/src/components/notification-bell.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { Bell, BellOff, Check, Settings, VolumeX, X } from "lucide-react";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { EmptyState } from "@/components/empty-state";
+import { Tooltip } from "@/components/ui/tooltip";
 import { useNotifications } from "@/components/notifications-provider";
 import { NotificationSettingsDialog } from "@/components/notification-settings";
 import type { NotificationKind } from "@/lib/notifications";
@@ -54,49 +55,65 @@ export function NotificationBell() {
   const loud = notifications.filter((n) => n.alert !== false);
   const items = [...loud].reverse();
 
+  // One string names the trigger and fills its tooltip, so the do-not-disturb
+  // dot — too small to anchor a bubble of its own — is still readable and
+  // announced.
+  const bellLabel = [
+    unreadCount > 0 ? `${unreadCount} unread notifications` : "Notifications",
+    settings.dnd ? "do not disturb is on" : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
   return (
     <>
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger
-          className="relative flex size-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
-          aria-label={unreadCount > 0 ? `${unreadCount} unread notifications` : "Notifications"}
-        >
-          <Bell className="size-4" />
-          {unreadCount > 0 && (
-            <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold tabular text-accent-fg">
-              {unreadCount > 99 ? "99+" : unreadCount}
-            </span>
-          )}
-          {settings.dnd && (
-            <span
-              className="absolute -bottom-0.5 -right-0.5 flex size-3 items-center justify-center rounded-full bg-surface text-muted-foreground"
-              title="Do not disturb is on"
-            >
-              <VolumeX className="size-2.5" />
-            </span>
-          )}
-        </PopoverTrigger>
+        <Tooltip content={bellLabel}>
+          <PopoverTrigger
+            className="relative flex size-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+            aria-label={bellLabel}
+          >
+            <Bell className="size-4" />
+            {unreadCount > 0 && (
+              <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold tabular text-accent-fg">
+                {unreadCount > 99 ? "99+" : unreadCount}
+              </span>
+            )}
+            {settings.dnd && (
+              <span
+                aria-hidden
+                className="absolute -bottom-0.5 -right-0.5 flex size-3 items-center justify-center rounded-full bg-surface text-muted-foreground"
+              >
+                <VolumeX className="size-2.5" />
+              </span>
+            )}
+          </PopoverTrigger>
+        </Tooltip>
         <PopoverContent className="flex max-h-[28rem] w-80 flex-col p-0">
           <div className="flex items-center gap-2 border-b border-border px-3 py-2.5">
             <span className="text-label font-semibold text-text">Notifications</span>
             <span className="text-micro tabular text-faint">{loud.length}</span>
             <div className="ml-auto flex items-center gap-1">
               {loud.length > 0 && (
+                <Tooltip content="Mark all read">
+                  <button
+                    onClick={markAllRead}
+                    aria-label="Mark all read"
+                    className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+                  >
+                    <Check className="size-3.5" />
+                  </button>
+                </Tooltip>
+              )}
+              <Tooltip content="Notification settings">
                 <button
-                  onClick={markAllRead}
-                  title="Mark all read"
+                  onClick={() => setShowSettings(true)}
+                  aria-label="Notification settings"
                   className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
                 >
-                  <Check className="size-3.5" />
+                  <Settings className="size-3.5" />
                 </button>
-              )}
-              <button
-                onClick={() => setShowSettings(true)}
-                title="Notification settings"
-                className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
-              >
-                <Settings className="size-3.5" />
-              </button>
+              </Tooltip>
             </div>
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto">
@@ -142,26 +159,30 @@ export function NotificationBell() {
                     <p className="mt-0.5 truncate text-label text-text">{n.summary || n.sender}</p>
                   </Link>
                   <div className="flex flex-shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        muteRoom(n.room);
-                      }}
-                      title={`Mute ${n.room}`}
-                      className="mt-0.5 flex size-5 items-center justify-center rounded text-faint hover:bg-hairline hover:text-text"
-                    >
-                      <BellOff className="size-3" />
-                    </button>
-                    <button
-                      onClick={(e) => {
-                        e.preventDefault();
-                        dismiss(n.id);
-                      }}
-                      title="Dismiss"
-                      className="mt-0.5 flex size-5 items-center justify-center rounded text-faint hover:bg-hairline hover:text-text"
-                    >
-                      <X className="size-3" />
-                    </button>
+                    <Tooltip content={`Mute ${n.room}`}>
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          muteRoom(n.room);
+                        }}
+                        aria-label={`Mute ${n.room}`}
+                        className="mt-0.5 flex size-5 items-center justify-center rounded text-faint hover:bg-hairline hover:text-text"
+                      >
+                        <BellOff className="size-3" />
+                      </button>
+                    </Tooltip>
+                    <Tooltip content="Dismiss">
+                      <button
+                        onClick={(e) => {
+                          e.preventDefault();
+                          dismiss(n.id);
+                        }}
+                        aria-label="Dismiss"
+                        className="mt-0.5 flex size-5 items-center justify-center rounded text-faint hover:bg-hairline hover:text-text"
+                      >
+                        <X className="size-3" />
+                      </button>
+                    </Tooltip>
                   </div>
                 </div>
               ))

--- a/mycelium-frontend/src/components/room-inspector.tsx
+++ b/mycelium-frontend/src/components/room-inspector.tsx
@@ -15,6 +15,7 @@ import {
 import { AgentsPanel } from "@/components/agents-panel";
 import { EpisodesRail } from "@/components/episodes-rail";
 import { KeyBadge } from "@/components/key-badge";
+import { Tooltip } from "@/components/ui/tooltip";
 import { MemoryPanel } from "@/components/memory-panel";
 import { chordFor, chordKey } from "@/lib/keymap";
 import { TAB_LABELS_MIN_WIDTH } from "@/lib/panel-layout";
@@ -110,28 +111,29 @@ export function RoomInspector({
   if (!open) {
     return (
       <aside className="flex w-full min-w-0 flex-col items-center gap-1 overflow-hidden bg-surface/40 pt-3">
-        <button
-          onClick={() => setOpen(true)}
-          aria-label={railToggleTitle(false)}
-          title={railToggleTitle(false)}
-          className="flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface hover:text-text"
-        >
-          <PanelRightOpen className="size-[18px]" />
-        </button>
+        <Tooltip content={railToggleTitle(false)} side="left">
+          <button
+            onClick={() => setOpen(true)}
+            aria-label={railToggleTitle(false)}
+            className="flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+          >
+            <PanelRightOpen className="size-[18px]" />
+          </button>
+        </Tooltip>
         <div className="mt-1 h-px w-5 bg-border" />
         {TABS.map(({ id, label, icon: Icon }) => (
-          <button
-            key={id}
-            onClick={() => { setTab(id); setOpen(true); }}
-            aria-label={label}
-            title={label}
-            className={`relative flex size-9 items-center justify-center rounded-lg transition-colors hover:bg-surface hover:text-text ${
-              tab === id ? "text-accent" : "text-muted-foreground"
-            }`}
-          >
-            <Icon className="size-[18px]" />
-            <KeyBadge action={`rail.${id}`} overlay />
-          </button>
+          <Tooltip key={id} content={label} side="left">
+            <button
+              onClick={() => { setTab(id); setOpen(true); }}
+              aria-label={label}
+              className={`relative flex size-9 items-center justify-center rounded-lg transition-colors hover:bg-surface hover:text-text ${
+                tab === id ? "text-accent" : "text-muted-foreground"
+              }`}
+            >
+              <Icon className="size-[18px]" />
+              <KeyBadge action={`rail.${id}`} overlay />
+            </button>
+          </Tooltip>
         ))}
       </aside>
     );
@@ -144,33 +146,34 @@ export function RoomInspector({
           {TABS.map(({ id, label, icon: Icon }) => {
             const active = tab === id;
             return (
-              <button
-                key={id}
-                data-tour={`inspector-${id}`}
-                onClick={() => setTab(id)}
-                aria-label={label}
-                title={compact ? label : undefined}
-                className={`relative flex items-center gap-1.5 rounded-md py-1 text-label font-medium transition-colors ${
-                  compact ? "px-2" : "px-2.5"
-                } ${
-                  active ? "bg-elevated text-text shadow-sm ring-1 ring-border" : "text-muted-foreground hover:text-text"
-                }`}
-              >
-                <Icon className="size-3.5 flex-shrink-0" />
-                {!compact && label}
-                <KeyBadge action={`rail.${id}`} overlay={compact} />
-              </button>
+              <Tooltip key={id} content={compact ? label : undefined} side="bottom">
+                <button
+                  data-tour={`inspector-${id}`}
+                  onClick={() => setTab(id)}
+                  aria-label={label}
+                  className={`relative flex items-center gap-1.5 rounded-md py-1 text-label font-medium transition-colors ${
+                    compact ? "px-2" : "px-2.5"
+                  } ${
+                    active ? "bg-elevated text-text shadow-sm ring-1 ring-border" : "text-muted-foreground hover:text-text"
+                  }`}
+                >
+                  <Icon className="size-3.5 flex-shrink-0" />
+                  {!compact && label}
+                  <KeyBadge action={`rail.${id}`} overlay={compact} />
+                </button>
+              </Tooltip>
             );
           })}
         </div>
-        <button
-          onClick={() => setOpen(false)}
-          aria-label={railToggleTitle(true)}
-          title={railToggleTitle(true)}
-          className="ml-auto flex size-7 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
-        >
-          <PanelRightClose className="size-4" />
-        </button>
+        <Tooltip content={railToggleTitle(true)} side="bottom">
+          <button
+            onClick={() => setOpen(false)}
+            aria-label={railToggleTitle(true)}
+            className="ml-auto flex size-7 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+          >
+            <PanelRightClose className="size-4" />
+          </button>
+        </Tooltip>
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">

--- a/mycelium-frontend/src/components/room-plan-header.tsx
+++ b/mycelium-frontend/src/components/room-plan-header.tsx
@@ -13,6 +13,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Chip } from "@/components/ui/chip";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Tooltip } from "@/components/ui/tooltip";
 
 interface Props {
   roomName: string;
@@ -122,20 +123,21 @@ export function RoomPlanHeader({ roomName }: Props) {
             }}
           />
         ) : (
-          <button
-            onClick={startEditTitle}
-            className="w-full text-left leading-[1.05] transition-colors hover:text-accent"
-            style={{
-              fontFamily: "var(--font-serif, 'Cormorant Garamond', Georgia, serif)",
-              fontStyle: "italic",
-              fontWeight: 600,
-              fontSize: "2.5rem",
-              color: titleText ? "var(--text)" : "var(--muted-foreground)",
-            }}
-            title="click to edit"
-          >
-            {titleText || "name this plan…"}
-          </button>
+          <Tooltip content="Click to rename the plan" side="bottom" align="start">
+            <button
+              onClick={startEditTitle}
+              className="w-full text-left leading-[1.05] transition-colors hover:text-accent"
+              style={{
+                fontFamily: "var(--font-serif, 'Cormorant Garamond', Georgia, serif)",
+                fontStyle: "italic",
+                fontWeight: 600,
+                fontSize: "2.5rem",
+                color: titleText ? "var(--text)" : "var(--muted-foreground)",
+              }}
+            >
+              {titleText || "name this plan…"}
+            </button>
+          </Tooltip>
         )}
       </div>
 

--- a/mycelium-frontend/src/components/room-slim.tsx
+++ b/mycelium-frontend/src/components/room-slim.tsx
@@ -6,6 +6,7 @@
 import { type AuthStatus, type CoordinationRoom, type IdentityStatus } from "@/lib/api";
 import { useNetworkStatus } from "@/lib/room-data";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip } from "@/components/ui/tooltip";
 
 /** This room's SLIM channel status — the node it rides, who is present (SLIM
  *  members plus server-held `await` participants), episode state, and
@@ -56,10 +57,14 @@ export function RoomSlimView({
             {coord ? `${coord.provisions_ok}✓ / ${coord.provisions_failed}✗` : "—"}
           </RailStat>
           <RailStat dot={identity ? identityDot(identity) : undefined} label="identity">
-            <span title={identity?.message}>{identity?.mode ?? "—"}</span>
+            <Tooltip content={identity?.message} side="bottom">
+              <span aria-description={identity?.message}>{identity?.mode ?? "—"}</span>
+            </Tooltip>
           </RailStat>
           <RailStat dot={auth?.enabled ? "var(--green)" : undefined} label="auth">
-            <span title={authDetail(auth)}>{auth ? (auth.enabled ? "on" : "off") : "—"}</span>
+            <Tooltip content={authDetail(auth)} side="bottom">
+              <span aria-description={authDetail(auth)}>{auth ? (auth.enabled ? "on" : "off") : "—"}</span>
+            </Tooltip>
           </RailStat>
           <span className="h-3 w-px bg-border" aria-hidden />
           <RailStat

--- a/mycelium-frontend/src/components/rooms-sidebar.tsx
+++ b/mycelium-frontend/src/components/rooms-sidebar.tsx
@@ -30,6 +30,7 @@ import { ActingAsPicker } from "@/components/acting-as-picker";
 import { useNotifications } from "@/components/notifications-provider";
 import { EmptyState } from "@/components/empty-state";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tooltip } from "@/components/ui/tooltip";
 import { KeyBadge } from "@/components/key-badge";
 import { useCommands, useKeyAction } from "@/components/keymap-provider";
 import { useOpenInstallModal } from "@/components/install-modal";
@@ -194,24 +195,26 @@ export function RoomsSidebar({ activeRoom = null, collapsed = false, onCollapsed
   if (collapsed) {
     return (
       <aside data-tour="rooms" className="flex w-full min-w-0 flex-col items-center overflow-hidden bg-surface/50">
-        <Link
-          href="/"
-          title="Command center"
-          className="relative flex h-[52px] w-full flex-shrink-0 items-center justify-center border-b border-border transition-colors hover:bg-hairline"
-        >
-          <Image src="/logo.png" alt="Mycelium" width={20} height={20} className="opacity-90" />
-          <KeyBadge action="nav.home" />
-        </Link>
+        <Tooltip content="Command center" side="right">
+          <Link
+            href="/"
+            className="relative flex h-[52px] w-full flex-shrink-0 items-center justify-center border-b border-border transition-colors hover:bg-hairline"
+          >
+            <Image src="/logo.png" alt="Mycelium" width={20} height={20} className="opacity-90" />
+            <KeyBadge action="nav.home" />
+          </Link>
+        </Tooltip>
 
-        <button
-          onClick={() => onCollapsedChange?.(false)}
-          aria-label={railToggleTitle(false)}
-          title={railToggleTitle(false)}
-          className="relative mt-2 flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface hover:text-text"
-        >
-          <PanelLeftOpen className="size-[18px]" />
-          <KeyBadge action="rooms.toggle" overlay />
-        </button>
+        <Tooltip content={railToggleTitle(false)} side="right">
+          <button
+            onClick={() => onCollapsedChange?.(false)}
+            aria-label={railToggleTitle(false)}
+            className="relative mt-2 flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+          >
+            <PanelLeftOpen className="size-[18px]" />
+            <KeyBadge action="rooms.toggle" overlay />
+          </button>
+        </Tooltip>
         <div className="mt-1 h-px w-5 bg-border" />
 
         <ScrollArea className="min-h-0 w-full flex-1">
@@ -220,39 +223,44 @@ export function RoomsSidebar({ activeRoom = null, collapsed = false, onCollapsed
               const active = room.name === activeRoom;
               const unread = active ? 0 : unreadByRoom.get(room.name) ?? 0;
               return (
-                <Link
+                <Tooltip
                   key={room.name}
-                  href={`/room/${encodeURIComponent(room.name)}`}
-                  title={unread > 0 ? `${room.name} — ${unread} unread` : room.name}
-                  className={`relative flex size-8 flex-shrink-0 items-center justify-center rounded-md font-mono text-micro font-semibold transition-colors ${
-                    active
-                      ? "bg-accent text-accent-fg"
-                      : "bg-surface text-muted-foreground hover:text-text"
-                  }`}
+                  content={unread > 0 ? `${room.name} — ${unread} unread` : room.name}
+                  side="right"
                 >
-                  <span aria-hidden>{monogram(room.name)}</span>
-                  <span className="sr-only">{room.name}</span>
-                  {unread > 0 && (
-                    <span
-                      aria-label={`${unread} unread`}
-                      className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-accent ring-2 ring-surface"
-                    />
-                  )}
-                  {i < 9 && <KeyBadge chord={`alt+${i + 1}`} overlay />}
-                </Link>
+                  <Link
+                    href={`/room/${encodeURIComponent(room.name)}`}
+                    className={`relative flex size-8 flex-shrink-0 items-center justify-center rounded-md font-mono text-micro font-semibold transition-colors ${
+                      active
+                        ? "bg-accent text-accent-fg"
+                        : "bg-surface text-muted-foreground hover:text-text"
+                    }`}
+                  >
+                    <span aria-hidden>{monogram(room.name)}</span>
+                    <span className="sr-only">{room.name}</span>
+                    {unread > 0 && (
+                      <span
+                        aria-label={`${unread} unread`}
+                        className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-accent ring-2 ring-surface"
+                      />
+                    )}
+                    {i < 9 && <KeyBadge chord={`alt+${i + 1}`} overlay />}
+                  </Link>
+                </Tooltip>
               );
             })}
           </nav>
         </ScrollArea>
 
-        <button
-          onClick={() => setShowCreate(true)}
-          aria-label="New room"
-          title="New room"
-          className="mb-1 flex size-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
-        >
-          <Plus className="size-4" />
-        </button>
+        <Tooltip content="New room" side="right">
+          <button
+            onClick={() => setShowCreate(true)}
+            aria-label="New room"
+            className="mb-1 flex size-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+          >
+            <Plus className="size-4" />
+          </button>
+        </Tooltip>
         <div className="flex w-full flex-col items-center gap-1 border-t border-border py-2">
           <ActingAsPicker compact />
           <NotificationBell />
@@ -286,23 +294,25 @@ export function RoomsSidebar({ activeRoom = null, collapsed = false, onCollapsed
       <div className="flex items-center gap-2 px-3 pt-3 pb-2">
         <span className="text-micro font-semibold uppercase tracking-wide text-muted-foreground">Rooms</span>
         <span className="text-micro tabular text-muted-foreground">{rooms.length}</span>
-        <button
-          onClick={() => setShowCreate(true)}
-          aria-label="New room"
-          title="New room"
-          className="ml-auto flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
-        >
-          <Plus className="size-4" />
-        </button>
-        <button
-          onClick={() => onCollapsedChange?.(true)}
-          aria-label={railToggleTitle(true)}
-          title={railToggleTitle(true)}
-          className="relative flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
-        >
-          <PanelLeftClose className="size-4" />
-          <KeyBadge action="rooms.toggle" overlay />
-        </button>
+        <Tooltip content="New room">
+          <button
+            onClick={() => setShowCreate(true)}
+            aria-label="New room"
+            className="ml-auto flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+          >
+            <Plus className="size-4" />
+          </button>
+        </Tooltip>
+        <Tooltip content={railToggleTitle(true)}>
+          <button
+            onClick={() => onCollapsedChange?.(true)}
+            aria-label={railToggleTitle(true)}
+            className="relative flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+          >
+            <PanelLeftClose className="size-4" />
+            <KeyBadge action="rooms.toggle" overlay />
+          </button>
+        </Tooltip>
       </div>
       <div className="px-3 pb-2">
         <div className="flex items-center gap-2 rounded-lg border border-border bg-bg px-2.5 py-1.5 focus-within:border-accent">

--- a/mycelium-frontend/src/components/status-items.tsx
+++ b/mycelium-frontend/src/components/status-items.tsx
@@ -8,31 +8,35 @@ import { usePathname } from "next/navigation";
 import { BarChart3 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useGlobalStatus } from "@/lib/use-status";
+import { Tooltip } from "@/components/ui/tooltip";
 
-/** A status-bar cell that navigates somewhere on click (editor footer style). */
-export function StatusLink({ href, title, children }: { href: string; title?: string; children: ReactNode }) {
+/** A status-bar cell that navigates somewhere on click (editor footer style).
+ *  The bar sits at the bottom of the viewport, so its tooltips open upward. */
+export function StatusLink({ href, tooltip, children }: { href: string; tooltip?: string; children: ReactNode }) {
   return (
-    <Link
-      href={href}
-      title={title}
-      className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text"
-    >
-      {children}
-    </Link>
+    <Tooltip content={tooltip} side="top">
+      <Link
+        href={href}
+        className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text"
+      >
+        {children}
+      </Link>
+    </Tooltip>
   );
 }
 
 /** A status-bar cell that fires an action on click. */
-export function StatusButton({ onClick, title, children }: { onClick: () => void; title?: string; children: ReactNode }) {
+export function StatusButton({ onClick, tooltip, children }: { onClick: () => void; tooltip?: string; children: ReactNode }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text"
-    >
-      {children}
-    </button>
+    <Tooltip content={tooltip} side="top">
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text"
+      >
+        {children}
+      </button>
+    </Tooltip>
   );
 }
 
@@ -44,18 +48,18 @@ export function GlobalStatusItems() {
   return (
     <>
       {shortModel && (
-        <StatusLink href="/metrics" title={model ?? undefined}>
+        <StatusLink href="/metrics" tooltip={model ?? undefined}>
           <span className="font-mono">{shortModel}</span>
         </StatusLink>
       )}
       {spend !== null && (
-        <StatusLink href="/metrics" title="Spend (session)">
+        <StatusLink href="/metrics" tooltip="Spend (session)">
           <span className="tabular">${spend.toFixed(2)}</span>
         </StatusLink>
       )}
       {/* Health only shows when unhealthy. */}
       {healthy === false && (
-        <StatusLink href="/metrics" title="Backend unreachable">
+        <StatusLink href="/metrics" tooltip="Backend unreachable">
           <span className="flex items-center gap-1.5 text-red">
             <span className="inline-block size-1.5 rounded-full bg-red" />
             backend
@@ -73,16 +77,17 @@ export function MetricsStatusLink() {
   const pathname = usePathname();
   const active = pathname === "/metrics";
   return (
-    <Link
-      href="/metrics"
-      title="Metrics"
-      aria-current={active ? "page" : undefined}
-      className={`flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text ${
-        active ? "text-text" : ""
-      }`}
-    >
-      <BarChart3 className="size-3.5" />
-      metrics
-    </Link>
+    <Tooltip content="Metrics" side="top">
+      <Link
+        href="/metrics"
+        aria-current={active ? "page" : undefined}
+        className={`flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text ${
+          active ? "text-text" : ""
+        }`}
+      >
+        <BarChart3 className="size-3.5" />
+        metrics
+      </Link>
+    </Tooltip>
   );
 }

--- a/mycelium-frontend/src/components/ui/monogram.tsx
+++ b/mycelium-frontend/src/components/ui/monogram.tsx
@@ -2,6 +2,7 @@
 // Copyright 2026 Mycelium Contributors
 
 import { cn } from "@/lib/utils";
+import { Tooltip } from "@/components/ui/tooltip";
 
 /** Two-letter monogram from a handle: "backend-lead" → BL, "oc-test2" → OT,
  *  "main" → MA. Splits on non-alphanumerics, else first two chars. */
@@ -46,17 +47,23 @@ export function Monogram({ handle, color = "var(--accent)", className, presence 
   );
 }
 
-/** Presence badge: solid for live socket, pulsing for server lease. */
+/** Presence badge: solid for live socket, pulsing for server lease. The dot is
+ *  the only carrier of the tier, so it names itself for screen readers rather
+ *  than leaning on the tooltip a pointer reveals. */
 function PresenceBadge({ presence }: { presence: Presence }) {
   const slim = presence === "slim";
+  const label = slim ? "SLIM connected" : "server-held lease (awaiting)";
   return (
-    <span
-      className={cn(
-        "absolute -bottom-0.5 -right-0.5 block size-2.5 rounded-full ring-2 ring-paper",
-        !slim && "animate-pulse",
-      )}
-      style={{ background: slim ? "var(--accent)" : "var(--muted-foreground)" }}
-      title={slim ? "SLIM connected" : "server-held lease (awaiting)"}
-    />
+    <Tooltip content={label}>
+      <span
+        role="img"
+        aria-label={label}
+        className={cn(
+          "absolute -bottom-0.5 -right-0.5 block size-2.5 rounded-full ring-2 ring-paper",
+          !slim && "animate-pulse",
+        )}
+        style={{ background: slim ? "var(--accent)" : "var(--muted-foreground)" }}
+      />
+    </Tooltip>
   );
 }

--- a/mycelium-frontend/src/components/ui/tooltip.test.tsx
+++ b/mycelium-frontend/src/components/ui/tooltip.test.tsx
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
+
+function renderTooltip(content?: string) {
+  return render(
+    <TooltipProvider>
+      <Tooltip content={content}>
+        <button type="button" aria-label="Dismiss">
+          ×
+        </button>
+      </Tooltip>
+    </TooltipProvider>,
+  );
+}
+
+describe("<Tooltip />", () => {
+  it("renders the trigger as its own element rather than wrapping it", () => {
+    renderTooltip("Dismiss this notification");
+
+    const trigger = screen.getByRole("button", { name: "Dismiss" });
+    expect(trigger.tagName).toBe("BUTTON");
+    expect(trigger).not.toHaveAttribute("title");
+  });
+
+  it("shows the content on hover and describes the trigger while open", async () => {
+    const user = userEvent.setup();
+    renderTooltip("Dismiss this notification");
+    const trigger = screen.getByRole("button", { name: "Dismiss" });
+
+    expect(screen.queryByText("Dismiss this notification")).not.toBeInTheDocument();
+
+    await user.hover(trigger);
+
+    const popup = await screen.findByText("Dismiss this notification");
+    expect(trigger).toHaveAttribute("aria-describedby", popup.id);
+  });
+
+  it("opens on keyboard focus, so the hint is not pointer-only", async () => {
+    const user = userEvent.setup();
+    renderTooltip("Dismiss this notification");
+
+    await user.tab();
+
+    expect(await screen.findByText("Dismiss this notification")).toBeInTheDocument();
+  });
+
+  it("passes the trigger through untouched when there is nothing to say", async () => {
+    const user = userEvent.setup();
+    renderTooltip(undefined);
+    const trigger = screen.getByRole("button", { name: "Dismiss" });
+
+    await user.hover(trigger);
+
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+    expect(trigger).not.toHaveAttribute("data-base-ui-tooltip-trigger");
+  });
+});

--- a/mycelium-frontend/src/components/ui/tooltip.tsx
+++ b/mycelium-frontend/src/components/ui/tooltip.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useId, useState, type ReactElement, type ReactNode } from "react";
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+
+import { cn } from "@/lib/utils";
+
+type Side = "top" | "bottom" | "left" | "right";
+type Align = "start" | "center" | "end";
+
+interface Props {
+  /** Tooltip body. Nullish or empty renders the trigger bare, so a call site
+   *  can keep passing a conditional label without branching on it. */
+  content?: ReactNode;
+  /** The element the tooltip describes; rendered as-is, not wrapped. */
+  children: ReactElement;
+  side?: Side;
+  align?: Align;
+  sideOffset?: number;
+  className?: string;
+}
+
+/** Hover/focus tooltip in the app's own idiom — an elevated card on the
+ *  surface ladder rather than the browser's OS-chrome `title` bubble.
+ *
+ *  The trigger is rendered through Base UI's `render` prop, so the child keeps
+ *  its own tag, classes and refs; only tooltip wiring is merged in.
+ *
+ *  Base UI wires no ARIA of its own, so this does: the popup is a `tooltip`
+ *  the open trigger points at, making the bubble the control's *description*
+ *  the way `title` was. When the text is also the control's only name (an
+ *  icon-only button, a bare glyph), the call site still supplies `aria-label`. */
+export function Tooltip({
+  content,
+  children,
+  side = "top",
+  align = "center",
+  sideOffset = 6,
+  className,
+}: Props) {
+  const popupId = useId();
+  const [open, setOpen] = useState(false);
+
+  if (content === undefined || content === null || content === "") return children;
+
+  return (
+    <TooltipPrimitive.Root open={open} onOpenChange={setOpen}>
+      {/* Only while the popup is mounted — a dangling id describes nothing. */}
+      <TooltipPrimitive.Trigger
+        render={children}
+        aria-describedby={open ? popupId : undefined}
+      />
+      <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Positioner
+          side={side}
+          align={align}
+          sideOffset={sideOffset}
+          collisionPadding={8}
+        >
+          <TooltipPrimitive.Popup
+            id={popupId}
+            role="tooltip"
+            data-slot="tooltip"
+            className={cn(
+              "z-50 max-w-64 origin-[var(--transform-origin)] rounded-md border border-border2",
+              "bg-elevated px-2 py-1 text-micro leading-snug text-text shadow-lg outline-none",
+              // Some content is a newline-joined list (an envelope's parents).
+              "whitespace-pre-line",
+              "duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+              "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+              className,
+            )}
+          >
+            {content}
+          </TooltipPrimitive.Popup>
+        </TooltipPrimitive.Positioner>
+      </TooltipPrimitive.Portal>
+    </TooltipPrimitive.Root>
+  );
+}
+
+/** Shared open/close delay for every tooltip in the tree. Grouping means the
+ *  first tooltip waits, then moving along a toolbar shows its neighbours
+ *  immediately instead of re-waiting per control. */
+export function TooltipProvider({ children }: { children: ReactNode }) {
+  return (
+    <TooltipPrimitive.Provider delay={400} closeDelay={80}>
+      {children}
+    </TooltipPrimitive.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

Every hover hint in the GUI was a browser `title`, which renders as OS chrome — unstyled, slow to appear, and untouched by the app's design tokens. This sweeps the frontend and replaces them with a first-party tooltip that sits on the app's own surface ladder in both themes.

Accessibility is preserved rather than traded away. Base UI wires no ARIA of its own, so the primitive does: the popup is a `role="tooltip"` that the open trigger points at with `aria-describedby` — the role `title` actually played. Where the hint was also the control's only name (icon-only buttons, the presence dot, the SAO move glyphs), the call site carries `aria-label`. Where it explains visible text, it carries `aria-description`, so the text survives with no pointer at all.

## Changes

- **New `src/components/ui/tooltip.tsx`** — an elevated card (`bg-elevated`, `border-border2`, `text-micro`) built on Base UI's tooltip. Renders the trigger through the `render` prop, so a child keeps its own tag, classes and refs. `content` that is nullish or empty passes the trigger through untouched, so conditional hints (`compact ? label : undefined`) need no branching at the call site.
- **`TooltipProvider` in the root layout** — one grouped delay app-wide, so moving along a toolbar shows neighbours instantly instead of re-waiting per control.
- **~60 call sites converted** across the rails, status bar, chat stream, memory panel and graph, L9 inspector, notification bell, episodes rail and plan header. Each picks a `side` that suits its edge: the status bar opens up, the rooms rail right, the inspector rail left.
- **Two hints stay AT-only, deliberately.** The L9 frame row is a full-width feed line whose bubble would cover its neighbours; the do-not-disturb dot is a 12px badge too small to anchor one, so its state joins the bell's own label. Both keep the information via ARIA.
- **Component props named `title` are untouched** — `EmptyState`, `DiagTile`, `SectionHeader`, `Step`, `DetailDrawer`, `LinkGroup` take a heading, not a hover.
- **`src/components/ui/tooltip.test.tsx`** covers trigger pass-through, hover, keyboard focus, and the `aria-describedby` wiring.
- Two existing tests moved off `getByTitle` to the attributes that now carry the same meaning.

## Testing

The gates here are the frontend's, not the backend's:

- [x] Unit tests pass — `pnpm test`, 374 passed (40 files), up from 370
- [x] Typecheck + lint pass — `pnpm lint` (`tsc --noEmit && eslint .`), 0 errors; the 51 warnings are pre-existing and unrelated
- [x] Verified visually with shotkit against the mock app: tooltip placement in the status bar, room header, collapsed rooms rail, and chat stream; long-content wrapping; both light and dark themes

## Related Issues

<!-- none -->

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9LSybKyERBThmuMqGgefT)_