### PR TITLE
docs(frontend): tidy the comments added with the react-hooks fixes

### DIFF
--- a/mycelium-frontend/src/app/layout.tsx
+++ b/mycelium-frontend/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className="dark" suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        {/* App Router uses layout.tsx, not pages/_document.js — false positive. */}
+        {/* The rule wants fonts in pages/_document.js, which the App Router has no equivalent of. */}
         {/* eslint-disable-next-line @next/next/no-page-custom-font */}
         <link
           href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,600&family=IBM+Plex+Sans:wght@400;500;600&family=Geist+Mono:wght@400;500;600;700&display=swap"

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -52,11 +52,9 @@ function RoomWorkspace() {
   const [inspectorOpen, setInspectorOpen] = useState(true);
   const [editorView, setEditorView] = useState<View>("channel");
   const [negPhase, setNegPhase] = useState<NegotiationPhase>("idle");
-  // useSearchParams is read here before the hook is declared later on line 97;
-  // moved forward so tourActive can be initialized from the URL in one render.
+  // Hoisted above the state below so the tour flag can be seeded from the URL.
   const searchParamsEarly = useSearchParams();
-  // Lazy initializer reads the URL once on mount; setTourActive(false) in the
-  // exit handler still works. No effect needed — the param is client-only state.
+  // `?tour=1` seeds the tour once on mount; exiting is client-only state after that.
   const [tourActive, setTourActive] = useState(() => searchParamsEarly.get("tour") === "1");
   const [inviteEngine, setInviteEngine] = useState(false);
   const [focusMemory, setFocusMemory] = useState<{ key: string; nonce: number } | null>(null);
@@ -110,9 +108,8 @@ function RoomWorkspace() {
       router.replace(memoryHref(roomName, target.id));
       return;
     }
-    // Focus-dispatch: the effect consumes one URL parameter and translates it
-    // into the appropriate panel open + item selected. Lifting this into the
-    // caller would require threading focus state through every page entry point.
+    // The focus target is consumed here rather than derived: it has to outlive
+    // the parameter, which is cleared as soon as it has been acted on.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setFocus(target);
     if (target.type === "episode") openTab("episodes");

--- a/mycelium-frontend/src/components/acting-as-picker.tsx
+++ b/mycelium-frontend/src/components/acting-as-picker.tsx
@@ -93,7 +93,7 @@ export function ActingAsPicker() {
   useEffect(() => {
     if (open) {
       refresh(); // async fetch; setState only in its .then() callback
-      // setView/setError reset picker state on open — one logical unit with refresh.
+      // Opening resets the picker to its default view.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setView("switch");
       setError(null);

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -89,8 +89,7 @@ export function AgentsPanel({
 
   useEffect(() => {
     if (!engineInvite) return;
-    // Prop-triggered one-shot: parent signals "open the engine tab" by flipping
-    // engineInvite; the handler clears it after this effect fires.
+    // One-shot: the parent flips engineInvite, and clears it once the tab is shown.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setAddTab("engines");
     setAddOpen(true);
@@ -104,9 +103,7 @@ export function AgentsPanel({
   const highlightRow = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!focusHandle) return;
-    // Focus-consumed pattern: parent supplies a handle to highlight, then this
-    // effect marks the request consumed. The highlight state must persist past
-    // the parameter being cleared, so it cannot be derived from the prop alone.
+    // The highlight outlives focusHandle, which is cleared as soon as it is consumed.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setHighlight(focusHandle);
     onFocusConsumed?.();

--- a/mycelium-frontend/src/components/auth-session.tsx
+++ b/mycelium-frontend/src/components/auth-session.tsx
@@ -69,8 +69,7 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
   }, [setPrincipal]);
 
   useEffect(() => {
-    // refresh() is an async fetch; setState is called only inside its .then()
-    // callback, not synchronously in the effect body.
+    // Async fetch; setState happens in refresh()'s .then(), not the effect body.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     refresh();
   }, [refresh]);
@@ -85,8 +84,7 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
 
   const login = useCallback(() => {
     const returnTo = window.location.pathname + window.location.search;
-    // Full-page navigation is required: the server sets auth cookies on the
-    // callback URL, and router.push() would not trigger that round-trip.
+    // Full-page navigation: the server sets the auth cookies on the callback URL.
     // eslint-disable-next-line @next/next/no-location-assign-relative-destination
     window.location.href = `/api/auth/login?return_to=${encodeURIComponent(returnTo)}`;
   }, []);
@@ -94,8 +92,7 @@ export function AuthSessionProvider({ children }: { children: ReactNode }) {
   const logout = useCallback(async () => {
     await fetch("/api/auth/logout", { method: "POST" });
     setPrincipal("");
-    // Full-page reload clears all React state after the session cookie is
-    // cleared server-side — router.push("/") would leave stale state behind.
+    // Full-page reload, so no React state survives the cleared session cookie.
     // eslint-disable-next-line @next/next/no-location-assign-relative-destination
     window.location.href = "/";
   }, [setPrincipal]);

--- a/mycelium-frontend/src/components/command-palette.tsx
+++ b/mycelium-frontend/src/components/command-palette.tsx
@@ -48,9 +48,8 @@ export function CommandPalette({ open, onClose, commands, recent, onRun, mac }: 
 
   useEffect(() => {
     if (!open) return;
-    // Reset query and capture the element to restore focus to on close. These
-    // must run in an effect because restoreTo reads document.activeElement (a
-    // DOM side effect) and ran.current + setQuery reset the palette together.
+    // Capturing what to restore focus to reads document.activeElement, so the
+    // rest of the on-open reset stays here with it.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setQuery("");
     ran.current = false;

--- a/mycelium-frontend/src/components/current-user.tsx
+++ b/mycelium-frontend/src/components/current-user.tsx
@@ -34,8 +34,8 @@ export function CurrentUserProvider({ children }: { children: ReactNode }) {
     if (typeof window === "undefined") return;
     const saved = window.localStorage.getItem(STORAGE_KEY);
     if (saved) {
-      // SSR hydration: localStorage unavailable on server; lazy init would produce
-      // a hydration mismatch (server "" ≠ client stored value) on the first render.
+      // localStorage is client-only: seeding this at init would mismatch the
+      // SSR render, where the principal is always "".
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setPrincipalState(saved);
     }

--- a/mycelium-frontend/src/components/episode-detail.tsx
+++ b/mycelium-frontend/src/components/episode-detail.tsx
@@ -61,8 +61,8 @@ export function EpisodeDetail({ roomName, shortId }: { roomName: string; shortId
 
   useEffect(() => {
     let cancelled = false;
-    // Async fetch: setState calls are all inside .then()/.catch() callbacks, not
-    // synchronously in the effect body. setLoading(true) is a loading-gate reset.
+    // Async fetch; the other setState calls are in its callbacks. This one is
+    // the loading gate, which has to be raised before the fetch starts.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setLoading(true);
     fetchEpisode(roomName, shortId)

--- a/mycelium-frontend/src/components/episodes-rail.tsx
+++ b/mycelium-frontend/src/components/episodes-rail.tsx
@@ -48,8 +48,7 @@ export function EpisodesRail({ roomName, focusShortId = null, onFocusConsumed }:
     if (!focusShortId) return;
     const known = episodes.find((ep) => ep.short_id === focusShortId);
     if (known) {
-      // Focus-consumed: parent provides a short_id to select; the handler clears
-      // it. The selection must outlive the parameter, so it can't be derived.
+      // The selection outlives focusShortId, which is cleared once consumed.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelected(known);
       onFocusConsumed?.();

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -403,8 +403,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   const highlightRow = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!focusMessageId) return;
-    // Focus-consumed: parent supplies a message ID to highlight; the handler
-    // clears it. Highlight must outlive the cleared prop, so it can't be derived.
+    // The highlight outlives focusMessageId, which is cleared once consumed.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setHighlight(focusMessageId);
     onFocusConsumed?.();

--- a/mycelium-frontend/src/components/install-panel.tsx
+++ b/mycelium-frontend/src/components/install-panel.tsx
@@ -80,12 +80,11 @@ interface Props {
 export function InstallPanel({ className }: Props) {
   const healthy = useBackendHealth(WAITING_POLL);
 
-  // Server-rendered markup can't know the OS or this page's own origin, so
-  // both land after mount to avoid a hydration mismatch. Until then, no
-  // useSyncExternalStore gives a server snapshot of "unknown"/"<this-hub-url>"
-  // and the real browser values on the client, so the hydration pass updates
-  // the component without a useEffect. Platform is also mutable (user tab clicks),
-  // so an override layer sits on top of the detected value.
+  // Server-rendered markup can't know the OS or this page's own origin: until
+  // the client snapshot arrives, no platform tab is preselected and the config
+  // command shows a placeholder host. The origin is only a first guess, since
+  // some deployments front the API on a different port than the UI, so it's
+  // there to edit — and the OS tabs override the detected platform.
   const noSubscribe = () => () => {};
   const detectedPlatform = useSyncExternalStore(
     noSubscribe,

--- a/mycelium-frontend/src/components/keymap-provider.tsx
+++ b/mycelium-frontend/src/components/keymap-provider.tsx
@@ -86,12 +86,12 @@ export function KeymapProvider({ children }: { children: ReactNode }) {
   const [scopeCounts, setScopeCounts] = useState<Partial<Record<KeyScope, number>>>({ global: 1 });
   const [helpOpen, setHelpOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
-  // Which commands ran, most recent first. Hydrated from localStorage after mount
-  // so that SSR and the first hydration render both produce [] (no mismatch).
+  // Which commands ran, most recent first. Seeded from localStorage after mount,
+  // so SSR and the first client render agree on an empty list.
   const [recent, setRecent] = useState<string[]>([]);
   useEffect(() => {
-    // SSR hydration: localStorage unavailable on server; useSyncExternalStore would
-    // still need a separate setRecent for command-use writes, so this is simpler.
+    // localStorage is client-only, and runCommand writes this list back, so it
+    // stays ordinary state rather than an external-store snapshot.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setRecent(loadRecent());
   }, []);
@@ -203,15 +203,13 @@ export function KeymapProvider({ children }: { children: ReactNode }) {
 
   const commands = useMemo(
     () => {
-      // collectCommands reads commandSources.current and handlers.current (refs).
-      // Moving this into useEffect + setState would introduce set-state-in-effect;
-      // the refs are intentionally stable mutable registries — reading them here is safe.
+      // collectCommands reads the registration refs, which are stable mutable
+      // registries: commandEpoch below is what says when to read them again.
       // eslint-disable-next-line react-hooks/refs
       return paletteOpen ? collectCommands(scopes) : [];
     },
-    // commandEpoch is a cache-bust epoch that increments on registration changes;
-    // it is not referenced in the callback body (refs are read via collectCommands)
-    // but IS required so the list recomputes when registrations change.
+    // commandEpoch never appears in the body — it is here to recompute the list
+    // when registrations change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [paletteOpen, commandEpoch, scopes, collectCommands],
   );
@@ -372,10 +370,8 @@ export function useKeyCapture(): KeymapApi["captureKeys"] {
  *  never reveals. */
 export function useKeyReveal(): boolean {
   const api = useContext(KeymapContext);
-  // useSyncExternalStore is the idiomatic fit: subscribe to an external signal
-  // (the hold/release of the reveal modifier) and snapshot its current value.
-  // Stabilise subscribe/getSnapshot with useCallback so React doesn't
-  // unsubscribe and resubscribe on every render.
+  // Reveal lives outside React, so it is subscribed to rather than mirrored in
+  // state. Both callbacks are memoized so React doesn't resubscribe every render.
   const subscribe = useCallback(
     (listener: () => void) => api?.subscribeReveal(listener) ?? (() => {}),
     [api],

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -323,8 +323,7 @@ function FrameRow({
           aria-hidden
           className={`size-3.5 text-faint transition-transform group-hover:text-muted-foreground ${expanded ? "rotate-90" : ""}`}
         />
-        {/* frameIcon picks from a fixed table of imported Lucide components,
-            so nothing is defined here — the rule cannot see through the call. */}
+        {/* frameIcon returns one of a fixed table of imported Lucide components. */}
         {/* eslint-disable-next-line react-hooks/static-components */}
         <Icon aria-hidden className="size-3.5" style={{ color: tone }} />
         <KindBadge kind={frame.kind} subkind={frame.subkind} />
@@ -391,8 +390,8 @@ export function L9Inspector({ roomName }: Props) {
   useEffect(() => {
     let cancelled = false;
     seenIds.current = new Set();
-    // Async fetch: setState calls are in the .then() callback. setFrames([]) here
-    // is a guard reset before the fetch resolves — intentional, not cascading.
+    // Async fetch; the rest of the setState calls are in its .then(). Clearing
+    // here drops the previous room's frames before the new ones arrive.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setFrames([]);
     fetchL9History(roomName).then((rows) => {
@@ -454,8 +453,7 @@ export function L9Inspector({ roomName }: Props) {
     () => Array.from(new Set(frames.map((f) => f.episode).filter((e): e is string => Boolean(e)))),
     [frames],
   );
-  // Fall back to "all" when the selected episode scrolls out of the MAX_FRAMES
-  // window; derive rather than resetting in an effect so there is no extra render.
+  // Fall back to "all" once the selected episode scrolls out of the MAX_FRAMES window.
   const effectiveEpisodeFilter =
     episodeFilter === "all" || episodesPresent.includes(episodeFilter) ? episodeFilter : "all";
 

--- a/mycelium-frontend/src/components/login-gate.tsx
+++ b/mycelium-frontend/src/components/login-gate.tsx
@@ -61,8 +61,8 @@ function useAuthError(): string | null {
     const url = new URL(window.location.href);
     const e = url.searchParams.get("auth_error");
     if (e) {
-      // URL cleanup side effect (history.replaceState) must co-locate with the
-      // state update — a lazy initializer can't call history.replaceState safely.
+      // The error is read and the parameter consumed in one step, so the
+      // replaceState that clears it stays beside the state update.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setErr(e);
       url.searchParams.delete("auth_error");

--- a/mycelium-frontend/src/components/memory-detail.tsx
+++ b/mycelium-frontend/src/components/memory-detail.tsx
@@ -226,7 +226,7 @@ export function MemoryDetail({
   const text = memory.content_text ?? formatValue(memory.value);
   const displayText = !raw && renderedBody ? renderedBody : text;
   const rawIsJson = useMemo(() => isJsonRawText(text), [text]);
-  // jsonView is meaningful only when raw is true; derive instead of resetting in an effect.
+  // jsonView only means anything in raw mode.
   const effectiveJsonView = raw && jsonView;
   const rawDisplay =
     effectiveJsonView && rawIsJson ? (prettyPrintJsonRawText(text) ?? text) : text;

--- a/mycelium-frontend/src/components/memory-editor.tsx
+++ b/mycelium-frontend/src/components/memory-editor.tsx
@@ -79,8 +79,8 @@ function WikilinkDropdown({
   onSelect: (key: string) => void;
   onDismiss: () => void;
 }) {
-  // React's idiomatic "reset when prop changes" — store previous candidates and
-  // update in-render (a second render pass fires immediately, no layout effect).
+  // A fresh candidate list starts the highlight at the top. Comparing in render
+  // rather than resetting in an effect, so no stale row is ever painted.
   const [prevCandidates, setPrevCandidates] = useState(candidates);
   const [activeIdx, setActiveIdx] = useState(0);
   if (prevCandidates !== candidates) {

--- a/mycelium-frontend/src/components/memory-graph.tsx
+++ b/mycelium-frontend/src/components/memory-graph.tsx
@@ -151,10 +151,8 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
   const [legendOpen, setLegendOpen] = useState(false);
   const filtered = hiddenNamespaces.size > 0 || hiddenTypes.size > 0;
 
-  // Reset filters when the graph changes. Guard preserves the same Set identity
-  // when nothing was filtered, avoiding a spurious re-render of every node.
-  // Uses the derived-state-during-render pattern (React fires a second pass
-  // immediately, like getDerivedStateFromProps).
+  // Reset the filters when the graph changes. The guard keeps the same Set
+  // identity when nothing was filtered, so every node doesn't re-render.
   const [prevGraph, setPrevGraph] = useState(graph);
   if (prevGraph !== graph) {
     setPrevGraph(graph);
@@ -299,9 +297,8 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
   useLayoutEffect(() => {
     dirty.current = false;
     if (!roomName) {
-      // Placement load/clear is a storage-read side effect tied to the graph
-      // identity changing; it belongs in a layout effect because it must run
-      // before the first paint of the new graph layout.
+      // Placements are read from storage, so they land in a layout effect —
+      // before the new layout's first paint.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setPlaced({});
       return;

--- a/mycelium-frontend/src/components/memory-page-view.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.tsx
@@ -38,8 +38,8 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
 
   useEffect(() => {
     let live = true;
-    // Async fetch: remaining setState calls are in .then() callbacks. The two
-    // resets here are pre-fetch guard clears, not cascading renders from props.
+    // Async fetch; the rest of the setState calls are in its .then(). Clearing
+    // here keeps the previous memory from showing under the new key.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setMemory(undefined);
     setRenderedBody(null);

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -232,9 +232,8 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
   const memoriesRef = useRef(memories);
   useLayoutEffect(() => { memoriesRef.current = memories; }, [memories]);
 
-  // Exit edit mode whenever the selected memory changes. Derived-state-during-render
-  // (the React alternative to getDerivedStateFromProps) fires a second pass immediately
-  // so the new selection never flashes in edit mode.
+  // Exit edit mode whenever the selection changes. Compared in render rather
+  // than reset in an effect, so the new selection never flashes in edit mode.
   const [prevSelectedKey, setPrevSelectedKey] = useState(selected?.key);
   if (prevSelectedKey !== selected?.key) {
     setPrevSelectedKey(selected?.key);
@@ -246,8 +245,8 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
   // unexpanded chips (#599).
   useEffect(() => {
     if (!selected) {
-      // Async fetch guard: clear the rendered body when selection clears so the
-      // previous memory's body never flashes during the next fetch.
+      // Clear the body when the selection clears, so the previous memory's
+      // never shows under the next one.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setRenderedBody(null);
       return;

--- a/mycelium-frontend/src/components/notifications-provider.tsx
+++ b/mycelium-frontend/src/components/notifications-provider.tsx
@@ -72,9 +72,8 @@ export function NotificationsProvider({ children }: { children: ReactNode }) {
   const isLeader = useRef(false);
   const channelRef = useRef<ReturnType<typeof openCrossTabChannel> | null>(null);
 
-  // Hydrate from localStorage once the DOM is available (SSR has none). The three
-  // setStates are one logical "hydrate from client storage" step. Lazy initializers
-  // would mismatch the SSR render (server "" ≠ client stored value on first pass).
+  // Load from localStorage once the DOM is there to read it: on the server
+  // there is none, and seeding at init would mismatch the SSR render.
   useEffect(() => {
     const stored = loadNotifications();
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/mycelium-frontend/src/components/search-palette.tsx
+++ b/mycelium-frontend/src/components/search-palette.tsx
@@ -72,9 +72,8 @@ export function SearchPalette({ open, onClose, onPick, search, mac }: Props) {
 
   useEffect(() => {
     if (!open) return;
-    // On-open reset: clears query/results/error and captures the element to
-    // restore focus to on close. restoreTo reads document.activeElement (DOM
-    // side effect), so the resets must stay co-located in the same effect.
+    // Capturing what to restore focus to reads document.activeElement, so the
+    // rest of the on-open reset stays here with it.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setQuery("");
     setResults([]);
@@ -106,8 +105,7 @@ export function SearchPalette({ open, onClose, onPick, search, mac }: Props) {
     if (!open) return;
     const trimmed = query.trim();
     if (!trimmed) {
-      // Empty query clears results synchronously so the palette goes blank rather
-      // than keeping stale rows while the user deletes their input.
+      // Emptying the box blanks the palette rather than leaving stale rows up.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setResults([]);
       setScope(EMPTY_SCOPE);

--- a/mycelium-frontend/src/lib/client-hooks.ts
+++ b/mycelium-frontend/src/lib/client-hooks.ts
@@ -2,37 +2,23 @@
 // Copyright 2026 Mycelium Contributors
 
 /**
- * Client-only React hooks that use useSyncExternalStore to provide a
- * server snapshot that matches the SSR render (avoiding hydration mismatches)
- * and a client snapshot that reflects the real browser environment.
- *
- * These replace the useEffect(() => setState(browserValue), []) pattern that
- * react-hooks/set-state-in-effect flags. useSyncExternalStore is the
- * recommended React 18+ primitive for this class of "read once from the
- * browser, never subscribe" state.
+ * Client-only hooks that read the browser once. Each returns a server snapshot
+ * matching the SSR render and a client snapshot reflecting the real browser,
+ * so there is no hydration mismatch and no extra render pass.
  */
 
 import { useSyncExternalStore } from "react";
 import { isMacPlatform } from "@/lib/keymap";
 
-/** No-op subscribe function for values that never change after mount. */
+/** No-op subscribe: these values never change after mount. */
 const noSubscribe = () => () => {};
 
-/**
- * Returns true on the client, false during SSR and the server hydration
- * snapshot. Replaces: `const [mounted, setMounted] = useState(false);
- * useEffect(() => setMounted(true), []);`
- */
+/** True on the client, false during SSR and the hydration snapshot. */
 export function useIsClient(): boolean {
   return useSyncExternalStore(noSubscribe, () => true, () => false);
 }
 
-/**
- * Returns true when running on a Mac (⌘ key platform), false otherwise.
- * Server snapshot is false to avoid hydrating ⌘ labels on non-Mac servers.
- * Replaces: `const [mac, setMac] = useState(false);
- * useEffect(() => setMac(isMacPlatform()), []);`
- */
+/** True on a Mac (⌘ key platform); false in the server snapshot, so ⌘ labels never hydrate on non-Mac. */
 export function useIsMac(): boolean {
   return useSyncExternalStore(noSubscribe, () => isMacPlatform(), () => false);
 }


### PR DESCRIPTION
## Summary

Comment-only pass over #711. The hook fixes themselves are right; the prose that came with them mostly argues with the lint rule instead of describing the code. This rewrites those comments so they say what the code does and why, and restores one that was left truncated mid-sentence.

Every `eslint-disable` directive stays exactly where it was — only the explanations around them changed. 22 files, 104 lines removed / 64 added, no behaviour change.

## Changes

- **Lint-defence narration → plain description.** Most suppressions explained why some *other* refactor would be worse ("moving this into useEffect + setState would introduce set-state-in-effect", "lifting this into the caller would require threading focus state through every page entry point"). They now state the actual constraint — e.g. `agents-panel`'s three-line "Focus-consumed pattern" block becomes `// The highlight outlives focusHandle, which is cleared as soon as it is consumed.`
- **Dropped the pattern names.** "Uses the derived-state-during-render pattern (React fires a second pass immediately, like getDerivedStateFromProps)" appeared in `memory-graph`, `memory-panel` and `memory-editor`. The code is four lines and reads plainly; the comments now say what the reset achieves (no flash of the previous selection).
- **`client-hooks.ts` docs.** Each hook documented itself by quoting the `useState` + `useEffect` it replaced. That's review context, not API documentation — the two exports now carry one-line doc comments.
- **`install-panel.tsx` truncation.** The comment was left mid-sentence ("Until then, no") followed by a new sentence about `useSyncExternalStore`, losing the original explanation of the placeholder host and the editable origin guess. Restored as coherent prose.
- **Removed the line-number reference** in `room/[name]/page.tsx` ("read here before the hook is declared later on line 97"), which goes stale on the next edit.

## Testing

- [x] `pnpm run lint` (tsc + eslint) clean — still **0** `react-hooks/` warnings, so no suppression lost its anchor
- [x] `pnpm vitest run` — 327 tests across 35 files pass
- [x] Diff verified to touch comment lines only

The Python checks in the template don't apply: nothing outside `mycelium-frontend/` is touched.

## Related Issues

Targets #711 — merge into that branch before it lands on `main`.

## Note

One thing deliberately left alone: `page.tsx` still has `const searchParams = searchParamsEarly;`, an alias left over from hoisting the `useSearchParams()` call. It's dead indirection worth collapsing, but it's code rather than a comment, so it stayed out of a comment-only pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PTNYTRGoLFM7bJWARgrFK

---
_Generated by [Claude Code](https://claude.ai/code/session_015PTNYTRGoLFM7bJWARgrFK)_