### PR TITLE
Add AGENTS.md link to documentation navigation

### DIFF
--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -38,7 +38,7 @@
     <span class="brand-word">mycelium</span>
   </a>
   <nav class="sectionnav">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
   </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
@@ -187,6 +187,7 @@
     </div>
     <div class="nav-external">
       <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
     </div>
   </nav>
   <div class="nav-backdrop" id="nav-backdrop" onclick="closeDrawer()"></div>

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -968,6 +968,11 @@ SKILL_MD_URL = (
     "mycelium/SKILL.md"
 )
 
+AGENTS_MD_URL = (
+    "https://raw.githubusercontent.com/mycelium-io/mycelium/main/"
+    "mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md"
+)
+
 # Every markdown-backed section links back to the file it was rendered from, so
 # a reader who spots a mistake can fix it where the source of truth lives.
 EDIT_BASE_URL = (
@@ -1069,7 +1074,7 @@ def _topnav() -> str:
     <span class="brand-word">mycelium</span>
   </a>
   <nav class="sectionnav">
-    <a href="{SKILL_MD_URL}" target="_blank" rel="noopener">SKILL.md ↗</a>
+    <a href="{AGENTS_MD_URL}" target="_blank" rel="noopener">AGENTS.md ↗</a>
   </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
@@ -1140,6 +1145,9 @@ def _sidebar(nav: list[NavPage], active_page_id: str) -> str:
     out.append('    <div class="nav-external">')
     out.append(
         f'      <a href="{SKILL_MD_URL}" target="_blank" rel="noopener">SKILL.md ↗</a>'
+    )
+    out.append(
+        f'      <a href="{AGENTS_MD_URL}" target="_blank" rel="noopener">AGENTS.md ↗</a>'
     )
     out.append("    </div>")
     out.append("  </nav>")

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <span class="brand-word">mycelium</span>
   </a>
   <nav class="sectionnav">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
   </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
@@ -187,6 +187,7 @@
     </div>
     <div class="nav-external">
       <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
     </div>
   </nav>
   <div class="nav-backdrop" id="nav-backdrop" onclick="closeDrawer()"></div>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -38,7 +38,7 @@
     <span class="brand-word">mycelium</span>
   </a>
   <nav class="sectionnav">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
   </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
@@ -187,6 +187,7 @@
     </div>
     <div class="nav-external">
       <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
+      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
     </div>
   </nav>
   <div class="nav-backdrop" id="nav-backdrop" onclick="closeDrawer()"></div>


### PR DESCRIPTION
## Summary

Updates the documentation site navigation to link to the Cursor integration's AGENTS.md file alongside the existing SKILL.md link. This adds a new external documentation reference in both the top navigation and sidebar.

## Changes

- Added `AGENTS_MD_URL` constant pointing to the Cursor integration's AGENTS.md asset
- Updated top navigation to link to AGENTS.md instead of SKILL.md
- Added AGENTS.md link to the sidebar's external links section (keeping SKILL.md)
- Regenerated HTML documentation files (index.html, reference.html, adapters.html) to reflect the navigation changes

## Testing

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Format check passes (`uv run ruff format --check .`)

## Related Issues

<!-- Closes #XXX -->

https://claude.ai/code/session_012e3Y9FNEdqvKAUKxpvWdss