### PR TITLE
test(cli): isolate suite from ambient MYCELIUM_AGENT_AUTH_* env

### DIFF
--- a/mycelium-cli/tests/conftest.py
+++ b/mycelium-cli/tests/conftest.py
@@ -280,6 +280,36 @@ def backend(monkeypatch: pytest.MonkeyPatch) -> Callable[..., None]:
 # ── environment isolation ─────────────────────────────────────────────────────
 
 
+#: Agent-credential and agent-identity vars, from ``agent_credentials.py`` and the
+#: ``[agent_auth]`` env overrides in ``config.py``. A machine configured to talk to
+#: a hosted hub as an agent exports these, and the CLI's auth seam honours them:
+#: ``agent_credentials.resolve()`` would mint a real bearer mid-suite, so a test
+#: asserting an unauthenticated request would fail on that machine and pass on a
+#: bare one. The suite owns its environment, so every test starts without them.
+AGENT_AUTH_ENV_VARS = (
+    "MYCELIUM_AGENT_AUTH_TOKEN",
+    "MYCELIUM_AGENT_AUTH_CLIENT_ID",
+    "MYCELIUM_AGENT_AUTH_CLIENT_SECRET",
+    "MYCELIUM_AGENT_AUTH_ISSUER",
+    "MYCELIUM_AGENT_AUTH_SCOPES",
+    "MYCELIUM_AGENT_AUTH_AUDIENCE",
+    "MYCELIUM_AGENT_HANDLE",
+    "MYCELIUM_AGENT_CREDENTIALS_FILE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_ambient_agent_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip ambient agent credentials so no test inherits a real identity.
+
+    Autouse and function-scoped: the tests that exercise the agent-auth path set
+    what they need themselves, so they keep their coverage; everything else runs
+    as an anonymous caller whether or not the host is logged in as an agent.
+    """
+    for name in AGENT_AUTH_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
 @pytest.fixture
 def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point ``Path.home()`` (and thus ``get_mycelium_dir``) at a temp dir.


### PR DESCRIPTION
## Summary

The CLI test suite inherited the host's agent credentials. On any machine configured to talk to a hosted hub as an agent, the environment exports `MYCELIUM_AGENT_AUTH_CLIENT_ID` / `..._CLIENT_SECRET` / `..._ISSUER` / `MYCELIUM_AGENT_HANDLE`. `agent_credentials.resolve()` reads exactly those, `access_token()` mints a real bearer from them, and the CLI's auth-header seam then returns a populated `Authorization` header. Tests that assert an unauthenticated request fail there and pass on a bare machine.

That is a test-isolation gap, not a product bug: the same class as #785. The suite should own its environment rather than depend on how the host happens to be logged in.

Test-only change. No production code touched, no assertion weakened.

## Changes

- Add `AGENT_AUTH_ENV_VARS` and an autouse, function-scoped `_no_ambient_agent_auth` fixture to `mycelium-cli/tests/conftest.py`, clearing each name with `monkeypatch.delenv(name, raising=False)`.
- The eight names are taken from source, not guessed: `STATIC_TOKEN_ENV`, `CLIENT_ID_ENV`, `CLIENT_SECRET_ENV`, `AGENT_HANDLE_ENV` and `CREDENTIAL_STORE_ENV` in `agent_credentials.py`, plus the `[agent_auth]` overrides `MYCELIUM_AGENT_AUTH_ISSUER` / `_SCOPES` / `_AUDIENCE` read by `MyceliumConfig` in `config.py`.

## Testing

Reproduced first, with the ambient vars present on the runner: 7 failed, 511 passed, 2 skipped.

```
FAILED tests/test_engine_config.py::test_save_roundtrips_auth_even_with_project_config
FAILED tests/test_login.py::test_logged_out_clients_send_no_authorization_header
FAILED tests/test_login.py::test_every_client_carries_the_bearer_once_signed_in
FAILED tests/test_login.py::test_an_expired_token_is_refreshed_transparently_and_re_cached
FAILED tests/test_login.py::test_an_expired_token_with_no_refresh_token_sends_nothing
FAILED tests/test_login.py::test_logout_drops_the_session
FAILED tests/test_plan_commands.py::test_fetch_plan_hits_room_scoped_endpoint
```

With the fixture applied, the full gate from `mycelium-cli/` is green in the same environment: `518 passed, 2 skipped`. The count of passing tests is up by exactly the seven that were failing, and nothing regressed.

The agent-auth path keeps its coverage. `tests/test_agent_credentials.py` already clears these vars in its own fixture and then sets what each case needs via `monkeypatch.setenv` (`CLIENT_ID_ENV`, `CLIENT_SECRET_ENV`, `AGENT_HANDLE_ENV`, `STATIC_TOKEN_ENV`), so clearing globally cannot mask a regression there. `test_agent_credentials.py` plus `test_login.py`: 54 passed.

No generated docs touched, so there is no docs drift to regenerate.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)

## Related Issues

Same class as #785 (ambient env leaking into tests), and resolves the CLI half of it. This also unblocks other branches that were seeing false-red CLI runs from the same cause: any branch built or tested on an agent-configured machine hit these seven failures regardless of its own diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vcnwa6g5DpMooqVzg1ZxFL)_