### PR TITLE
Let the hub-facing commands run on an env-only config

### DIFF
--- a/mycelium-cli/src/mycelium/commands/instance.py
+++ b/mycelium-cli/src/mycelium/commands/instance.py
@@ -24,7 +24,6 @@ from mycelium.client import hub_error_detail
 from mycelium.config import MyceliumConfig, ServerConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
-from mycelium.exceptions import ConfigNotFoundError
 from mycelium.http_client import MyceliumHTTPClient  # kept for health check
 from mycelium.ui_status import (
     CheckResult,
@@ -614,9 +613,6 @@ def status(ctx: typer.Context) -> None:
         json_output = ctx.obj.get("json", False) if ctx.obj else False
 
         config_path = MyceliumConfig.get_config_path()
-        if not config_path.exists():
-            raise ConfigNotFoundError(str(config_path))
-
         config = MyceliumConfig.load()
 
         from mycelium import __version__ as cli_version
@@ -688,6 +684,7 @@ def status(ctx: typer.Context) -> None:
                 },
                 "config": {
                     "path": str(config_path),
+                    "file_present": config_path.exists(),
                     "api_url": config.server.api_url,
                     "active_room": config.get_active_room(),
                 },
@@ -813,7 +810,8 @@ def status(ctx: typer.Context) -> None:
             # ── Configuration ─────────────────────────────────────────
             # Informational block (no checks): path + active room.
             print_section("Configuration")
-            print_kv("Path", str(config_path))
+            path_note = "" if config_path.exists() else "  (absent — settings from environment)"
+            print_kv("Path", f"{config_path}{path_note}")
             active_room = config.get_active_room()
             if active_room:
                 print_kv("Active Room", active_room)

--- a/mycelium-cli/src/mycelium/commands/network.py
+++ b/mycelium-cli/src/mycelium/commands/network.py
@@ -30,7 +30,6 @@ import typer
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
-from mycelium.exceptions import ConfigNotFoundError
 from mycelium.http_client import MyceliumHTTPClient
 from mycelium.ui_status import print_title
 
@@ -138,9 +137,6 @@ def network(
     try:
         json_output = ctx.obj.get("json", False) if ctx.obj else False
 
-        config_path = MyceliumConfig.get_config_path()
-        if not config_path.exists():
-            raise ConfigNotFoundError(str(config_path))
         config = MyceliumConfig.load()
 
         with MyceliumHTTPClient(config=config) as client:
@@ -208,8 +204,6 @@ def network(
             _print_a2a(name, a2a[name])
 
     except (typer.Exit, typer.Abort):
-        raise
-    except ConfigNotFoundError:
         raise
     except httpx.HTTPError as exc:
         cfg = MyceliumConfig.load()

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -28,7 +28,7 @@ from mycelium.client import typed_client as _typed_client
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
 from mycelium.error_handler import print_error
-from mycelium.exceptions import ConfigNotFoundError, MyceliumError
+from mycelium.exceptions import MyceliumError
 
 # The L9 "raise-up" whitelist: message types promoted onto the primary channel
 # surface (here, `room watch`'s live stream) rather than staying inspector-only.
@@ -120,10 +120,6 @@ def list_rooms(
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
         json_output = ctx.obj.get("json", False) if ctx.obj else False
 
-        config_path = MyceliumConfig.get_config_path()
-        if not config_path.exists():
-            raise ConfigNotFoundError(str(config_path))
-
         config = MyceliumConfig.load()
 
         params: dict[str, str | int] = {"limit": limit}
@@ -185,10 +181,6 @@ def create(
     try:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
         json_output = ctx.obj.get("json", False) if ctx.obj else False
-
-        config_path = MyceliumConfig.get_config_path()
-        if not config_path.exists():
-            raise ConfigNotFoundError(str(config_path))
 
         config = MyceliumConfig.load()
 
@@ -291,10 +283,6 @@ def delete(
     """Delete one or more rooms."""
     try:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
-        config_path = MyceliumConfig.get_config_path()
-        if not config_path.exists():
-            raise ConfigNotFoundError(str(config_path))
-
         config = MyceliumConfig.load()
 
         if not force:

--- a/mycelium-cli/src/mycelium/exceptions.py
+++ b/mycelium-cli/src/mycelium/exceptions.py
@@ -19,17 +19,6 @@ class ConfigError(MyceliumError):
     pass
 
 
-class ConfigNotFoundError(ConfigError):
-    """Configuration file not found."""
-
-    def __init__(self, config_path: str) -> None:
-        super().__init__(
-            message=f"Configuration file not found: {config_path}",
-            suggestion="Run 'mycelium init' to create a new configuration file",
-        )
-        self.config_path = config_path
-
-
 class ConfigValidationError(ConfigError):
     """Configuration validation failed."""
 

--- a/mycelium-cli/tests/test_client_only_config.py
+++ b/mycelium-cli/tests/test_client_only_config.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The hub-facing commands must work with no config file at all.
+
+A ``--client-only`` install is the CLI on PATH plus environment variables and
+nothing else: no ``~/.mycelium/config.toml``, no data dir. ``MyceliumConfig.load()``
+already produces a usable config from env alone, so any command whose work is a
+plain HTTP call to the hub has to run on that config. These tests point ``HOME``
+at an empty temp dir, put the hub settings in the environment, and drive each
+command with only its transport stubbed — the real loader runs.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, Mock
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from mycelium.commands import instance as instance_cmd
+from mycelium.commands import network as net_cmd
+from mycelium.commands import room as room_cmd
+from mycelium.config import MyceliumConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+HUB_URL = "http://hub.test:8000"
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def env_only(isolated_home: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An empty ``HOME`` plus the hub settings in the environment."""
+    monkeypatch.setenv("MYCELIUM_API_URL", HUB_URL)
+    monkeypatch.setenv("MYCELIUM_ACTIVE_ROOM", "a2a-test")
+    assert not MyceliumConfig.get_config_path().exists()
+    return isolated_home
+
+
+def _no_op_typed_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    cm = MagicMock()
+    cm.__enter__.return_value = Mock(name="client")
+    cm.__exit__.return_value = None
+    monkeypatch.setattr(room_cmd, "_typed_client", lambda _c: cm)
+
+
+def _fake_http(monkeypatch: pytest.MonkeyPatch, module: object, health: dict) -> Mock:
+    """Stand in for ``MyceliumHTTPClient`` on ``module``, answering ``/health``."""
+    client = Mock()
+    client.get.side_effect = lambda path, **_kw: SimpleNamespace(
+        json=lambda: health if path == "/health" else {}
+    )
+    cm = MagicMock()
+    cm.__enter__.return_value = client
+    cm.__exit__.return_value = None
+    monkeypatch.setattr(module, "MyceliumHTTPClient", lambda **_kw: cm)
+    return client
+
+
+def test_config_loads_from_env_with_no_file() -> None:
+    assert MyceliumConfig.load().server.api_url == HUB_URL
+
+
+def test_room_ls_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mycelium_backend_client.models import RoomRead
+
+    _no_op_typed_client(monkeypatch)
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.rooms.list_rooms_api_rooms_get.sync",
+        lambda **_kw: [
+            RoomRead(
+                id=1,
+                name="a2a-test",
+                is_public=True,
+                created_at=datetime.datetime(2026, 6, 1),  # noqa: DTZ001
+            )
+        ],
+    )
+    result = runner.invoke(room_cmd.app, ["ls"])
+    assert result.exit_code == 0, result.output
+    assert "a2a-test" in result.output
+    assert "config.toml" not in result.output
+
+
+def test_room_create_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mycelium_backend_client.models import RoomRead
+
+    _no_op_typed_client(monkeypatch)
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.rooms.create_room_api_rooms_post.sync",
+        lambda **_kw: RoomRead(
+            id=2,
+            name="fresh",
+            is_public=True,
+            created_at=datetime.datetime(2026, 6, 1),  # noqa: DTZ001
+        ),
+    )
+    result = runner.invoke(room_cmd.app, ["create", "fresh"])
+    assert result.exit_code == 0, result.output
+    assert "config.toml" not in result.output
+
+
+def test_room_delete_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    _no_op_typed_client(monkeypatch)
+    monkeypatch.setattr(
+        "mycelium_backend_client.api.rooms.delete_room_api_rooms_room_name_delete.sync_detailed",
+        lambda **_kw: SimpleNamespace(status_code=204),
+    )
+    result = runner.invoke(room_cmd.app, ["delete", "doomed", "--force"])
+    assert result.exit_code == 0, result.output
+    assert "deleted" in result.output
+    assert "config.toml" not in result.output
+
+
+def _network_app() -> typer.Typer:
+    app = typer.Typer()
+
+    @app.callback()
+    def _root(ctx: typer.Context) -> None:
+        ctx.obj = {"json": False}
+
+    app.command(name="network")(net_cmd.network)
+    return app
+
+
+def test_network_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_http(
+        monkeypatch,
+        net_cmd,
+        {
+            "status": "ok",
+            "coordination": {
+                "endpoint": "http://slim:46357",
+                "slim_enabled": True,
+                "channels_live": 0,
+                "provisions_ok": 0,
+                "provisions_failed": 0,
+                "invite_failures": 0,
+                "rooms": [],
+            },
+        },
+    )
+    result = runner.invoke(_network_app(), ["network"])
+    assert result.exit_code == 0, result.output
+    assert "Mycelium Network" in result.output
+    assert "config.toml" not in result.output
+
+
+def _status_app(json_flag: bool = False) -> typer.Typer:
+    app = typer.Typer()
+
+    @app.callback()
+    def _root(ctx: typer.Context) -> None:
+        ctx.obj = {"json": json_flag}
+
+    app.command(name="status")(instance_cmd.status)
+    return app
+
+
+@pytest.fixture
+def _no_docker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        instance_cmd,
+        "_check_docker_containers",
+        lambda: {"available": False, "message": "Docker not available"},
+    )
+
+
+@pytest.mark.usefixtures("_no_docker")
+def test_status_runs_and_reports_the_absent_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_http(monkeypatch, instance_cmd, {"status": "ok", "version": "3.0.1"})
+    result = runner.invoke(_status_app(), ["status"])
+    assert result.exit_code == 0, result.output
+    assert "All systems operational" in result.output
+    # The missing file is reported as context, never as a failure.
+    assert "absent" in result.output
+
+
+@pytest.mark.usefixtures("_no_docker")
+def test_status_json_marks_the_file_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_http(monkeypatch, instance_cmd, {"status": "ok", "version": "3.0.1"})
+    result = runner.invoke(_status_app(json_flag=True), ["status"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["config"]["file_present"] is False
+    assert payload["config"]["api_url"] == HUB_URL

--- a/mycelium-cli/tests/test_room_commands.py
+++ b/mycelium-cli/tests/test_room_commands.py
@@ -24,9 +24,9 @@ runner = CliRunner()
 def _isolate(isolated_home, monkeypatch: pytest.MonkeyPatch) -> None:
     """A real (empty) config on a temp home, plus a no-op typed client.
 
-    ``room`` reads ``config.get_active_room()`` and requires a config file to
-    exist, so it needs the real ``MyceliumConfig`` (not the SimpleNamespace the
-    shared ``backend`` fixture installs) — only the typed client is stubbed.
+    ``room`` reads ``config.get_active_room()``, so it needs the real
+    ``MyceliumConfig`` (not the SimpleNamespace the shared ``backend`` fixture
+    installs) — only the typed client is stubbed.
     """
     from unittest.mock import MagicMock, Mock
 


### PR DESCRIPTION
## Summary

`room ls`, `room create`, `room delete`, `status` and `network` checked that `~/.mycelium/config.toml` existed *before* calling the loader that would have handled its absence. `MyceliumConfig.load()` already guards every file read with `.exists()` and then layers `_load_from_env()` over the result — so the guard rejected a config the loader is perfectly capable of producing.

That is exactly the shape of a `--client-only` install (#758): the CLI on PATH plus `MYCELIUM_API_URL` and friends, nothing else. In that environment `memory ls`, `room send`, `room messages`, `skill ls`, `plan ls` and `engine ls` all worked, and these five refused. A client-only agent could read and post but could not list the rooms it could see, nor create the room it would post into.

Each site's work after the guard is a plain HTTP call to the hub, so the fix is to drop the precondition and let the loader resolve config from file + env.

## Changes

- Drop the `config_path.exists()` → `ConfigNotFoundError` guard at all five sites: `commands/room.py` (`ls`, `create`, `delete`), `commands/instance.py` (`status`), `commands/network.py` (`network`).
- Decided per-command for the two the issue flagged as possibly needing a real precondition instead:
  - **`network`** only reads the backend's `/health` coordination block — it has no local Docker dependency at all, so the guard is removed outright with nothing to replace it.
  - **`status`** does shell out to Docker, but every one of those checks already degrades gracefully (`docker_info.get("available")`, the disk/data-dir checks, the backend-unreachable verdict). Reporting is the whole job, so the missing file becomes context rather than a gate: the rendered Configuration block appends `(absent — settings from environment)` to the path, and `--json` carries a new `config.file_present`.
- Remove `ConfigNotFoundError` from `exceptions.py`. Nothing else in the repo references it, and its suggestion (`Run 'mycelium init'`) encodes the precondition this change says is wrong. Per the issue's own guidance, a command that genuinely needs a file-only setting should fail on *that setting*, naming it. `ConfigError` and `ConfigValidationError` are untouched and still cover real config failures.
- Drop the now-dead `except ConfigNotFoundError: raise` re-raise in `network`, and the stale "requires a config file to exist" line from the `test_room_commands.py` fixture docstring.

## Testing

New `mycelium-cli/tests/test_client_only_config.py` — `HOME` pointed at an empty temp dir (the existing `isolated_home` fixture, which also chdirs so a project-local `.mycelium/` can't leak in), hub settings in the environment, and the **real** `MyceliumConfig.load()` running with only the transport stubbed. It asserts the loader resolves the hub from env with no file, then drives `room ls` / `room create` / `room delete` / `network` / `status` and checks each exits 0 without a `config.toml` complaint, plus `status --json` reporting `config.file_present: false`.

Verified the test actually bites rather than passing vacuously: re-applying the guard to `room.py` turns the three room cases red on `exit_code == 1`, and reverting turns them green again.

Full gate from `mycelium-cli/`: **525 passed, 2 skipped** — up by exactly the seven new cases from the 518 on `main`, nothing regressed. Branch is rebased on `main` at #790, so the run is clean of the ambient `MYCELIUM_AGENT_AUTH_*` failures.

No `@doc_ref` metadata, docs markdown or config schema touched; regenerating the docs site left `docs/` byte-identical, so there is no drift to commit.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] Type check passes (`uv run ty check .`)

## Related Issues

Fixes #788. Unblocks the `--client-only` install story from #758.


---
_Generated by [Claude Code](https://claude.ai/code/session_015z87rVv3YPENsqCVktK3qA)_