### PR TITLE
docs: point the AGENTS.md nav links at the published runbook

### DIFF
--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -38,7 +38,7 @@
     <span class="brand-word">mycelium</span>
   </a>
   <nav class="sectionnav">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
+    <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
   </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
@@ -189,7 +189,7 @@
     </div>
     <div class="nav-external">
       <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
-      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
+      <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
     </div>
   </nav>
   <div class="nav-backdrop" id="nav-backdrop" onclick="closeDrawer()"></div>

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -970,10 +970,9 @@ SKILL_MD_URL = (
     "mycelium/SKILL.md"
 )
 
-AGENTS_MD_URL = (
-    "https://raw.githubusercontent.com/mycelium-io/mycelium/main/"
-    "mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md"
-)
+# The setup runbook the site publishes for agents, served from docs/ alongside
+# the generated pages.
+AGENTS_MD_URL = "https://mycelium-io.github.io/mycelium/agents.md"
 
 # Every markdown-backed section links back to the file it was rendered from, so
 # a reader who spots a mistake can fix it where the source of truth lives.
@@ -1065,8 +1064,8 @@ def _topnav() -> str:
     The brand cell is sidebar-width so the rail reads as one column, matching
     RoomsSidebar sitting under the workspace header in the app. Page navigation
     lives in the persistent rail, which carries every page at every width, so the
-    bar holds only what the rail cannot: search, the page actions, and the one
-    link that leaves the site.
+    bar holds only what the rail cannot: search, the page actions, and the
+    agent-facing runbook.
     """
     return f"""<!-- TOP BAR -->
 <nav class="topnav">

--- a/docs/index.html
+++ b/docs/index.html
@@ -38,7 +38,7 @@
     <span class="brand-word">mycelium</span>
   </a>
   <nav class="sectionnav">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
+    <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
   </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
@@ -189,7 +189,7 @@
     </div>
     <div class="nav-external">
       <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
-      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
+      <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
     </div>
   </nav>
   <div class="nav-backdrop" id="nav-backdrop" onclick="closeDrawer()"></div>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -38,7 +38,7 @@
     <span class="brand-word">mycelium</span>
   </a>
   <nav class="sectionnav">
-    <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
+    <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
   </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
@@ -189,7 +189,7 @@
     </div>
     <div class="nav-external">
       <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
-      <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/cursor/assets/AGENTS.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
+      <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
     </div>
   </nav>
   <div class="nav-backdrop" id="nav-backdrop" onclick="closeDrawer()"></div>


### PR DESCRIPTION
## Summary

Follow-up to #784. That PR added the `AGENTS.md ↗` nav links but pointed them at the Cursor adapter's workspace brief (`integrations/cursor/assets/AGENTS.md`) — the wrong file. The site already publishes `agents.md` at its root: the setup runbook the README tells an agent to curl. Both links now go there.

## Changes

- `AGENTS_MD_URL` → `https://mycelium-io.github.io/mycelium/agents.md`
- Regenerated `index.html`, `adapters.html`, `reference.html`; the only diff is the two link hrefs
- Refreshed the `_topnav()` docstring, which described the bar's extra link as "the one link that leaves the site" — it now points within the site

## Testing

- [x] `docs/generate_docs.py` reruns clean; generated HTML diff is exactly the two hrefs, no other drift
- [ ] Unit tests pass (`uv run pytest tests/ -x -q`) — docs-only change, no test surface touched
- [ ] Linting passes (`uv run ruff check .`) — `docs/` is outside the backend/CLI lint scope; the file's one pre-existing F541 is unrelated and untouched
- [ ] Format check passes (`uv run ruff format --check .`)

## Related Issues

Follows up #784

---
_Generated by [Claude Code](https://claude.ai/code/session_012e3Y9FNEdqvKAUKxpvWdss)_