### PR TITLE
docs: swap the docs-cmd button for a Copy agents.md button

### DIFF
--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -37,9 +37,6 @@
     <img src="logo.png" alt="Mycelium">
     <span class="brand-word">mycelium</span>
   </a>
-  <nav class="sectionnav">
-    <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
-  </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
       <button class="docsearch-toggle" id="docsearch-toggle" type="button"
@@ -60,7 +57,7 @@
         </div>
       </div>
     </div>
-    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal"></i>Copy docs cmd</button>
+    <button class="copy-agents-btn" onclick="copyAgentsMd()"><i data-lucide="file-text"></i>Copy agents.md</button>
     <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy"></i>Copy page</button>
     <div class="theme-toggle">
       <button class="theme-btn" id="theme-btn" aria-label="Theme" onclick="toggleThemeMenu(event)">
@@ -189,7 +186,6 @@
     </div>
     <div class="nav-external">
       <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
-      <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
     </div>
   </nav>
   <div class="nav-backdrop" id="nav-backdrop" onclick="closeDrawer()"></div>

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -970,10 +970,6 @@ SKILL_MD_URL = (
     "mycelium/SKILL.md"
 )
 
-# The setup runbook the site publishes for agents, served from docs/ alongside
-# the generated pages.
-AGENTS_MD_URL = "https://mycelium-io.github.io/mycelium/agents.md"
-
 # Every markdown-backed section links back to the file it was rendered from, so
 # a reader who spots a mistake can fix it where the source of truth lives.
 EDIT_BASE_URL = (
@@ -1064,8 +1060,7 @@ def _topnav() -> str:
     The brand cell is sidebar-width so the rail reads as one column, matching
     RoomsSidebar sitting under the workspace header in the app. Page navigation
     lives in the persistent rail, which carries every page at every width, so the
-    bar holds only what the rail cannot: search, the page actions, and the
-    agent-facing runbook.
+    bar holds only what the rail cannot: search and the page actions.
     """
     return f"""<!-- TOP BAR -->
 <nav class="topnav">
@@ -1074,9 +1069,6 @@ def _topnav() -> str:
     <img src="logo.png" alt="Mycelium">
     <span class="brand-word">mycelium</span>
   </a>
-  <nav class="sectionnav">
-    <a href="{AGENTS_MD_URL}" target="_blank" rel="noopener">AGENTS.md ↗</a>
-  </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
       <button class="docsearch-toggle" id="docsearch-toggle" type="button"
@@ -1097,7 +1089,7 @@ def _topnav() -> str:
         </div>
       </div>
     </div>
-    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal"></i>Copy docs cmd</button>
+    <button class="copy-agents-btn" onclick="copyAgentsMd()"><i data-lucide="file-text"></i>Copy agents.md</button>
     <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy"></i>Copy page</button>
 {_theme_toggle()}
     <a href="https://github.com/mycelium-io/mycelium" aria-label="GitHub">{GITHUB_SVG}</a>
@@ -1146,9 +1138,6 @@ def _sidebar(nav: list[NavPage], active_page_id: str) -> str:
     out.append('    <div class="nav-external">')
     out.append(
         f'      <a href="{SKILL_MD_URL}" target="_blank" rel="noopener">SKILL.md ↗</a>'
-    )
-    out.append(
-        f'      <a href="{AGENTS_MD_URL}" target="_blank" rel="noopener">AGENTS.md ↗</a>'
     )
     out.append("    </div>")
     out.append("  </nav>")

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,9 +37,6 @@
     <img src="logo.png" alt="Mycelium">
     <span class="brand-word">mycelium</span>
   </a>
-  <nav class="sectionnav">
-    <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
-  </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
       <button class="docsearch-toggle" id="docsearch-toggle" type="button"
@@ -60,7 +57,7 @@
         </div>
       </div>
     </div>
-    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal"></i>Copy docs cmd</button>
+    <button class="copy-agents-btn" onclick="copyAgentsMd()"><i data-lucide="file-text"></i>Copy agents.md</button>
     <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy"></i>Copy page</button>
     <div class="theme-toggle">
       <button class="theme-btn" id="theme-btn" aria-label="Theme" onclick="toggleThemeMenu(event)">
@@ -189,7 +186,6 @@
     </div>
     <div class="nav-external">
       <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
-      <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
     </div>
   </nav>
   <div class="nav-backdrop" id="nav-backdrop" onclick="closeDrawer()"></div>

--- a/docs/mycelium.css
+++ b/docs/mycelium.css
@@ -327,7 +327,7 @@ a.topnav-page:hover { color: var(--text); text-decoration: none; }
  * One primary accent exists in the app; docs chrome has no primary action, so
  * every button here is the quiet variant. */
 .copy-page-btn,
-.copy-docs-btn,
+.copy-agents-btn,
 .resources-btn,
 .install-tab {
   display: inline-flex;
@@ -347,37 +347,15 @@ a.topnav-page:hover { color: var(--text); text-decoration: none; }
   transition: color 0.15s, background 0.15s, border-color 0.15s;
 }
 .copy-page-btn svg,
-.copy-docs-btn svg,
+.copy-agents-btn svg,
 .install-tab svg { width: 13px; height: 13px; stroke: currentColor; flex-shrink: 0; }
 .copy-page-btn:hover,
-.copy-docs-btn:hover,
+.copy-agents-btn:hover,
 .resources-btn:hover,
 .install-tab:hover { color: var(--text); background: var(--surface); border-color: var(--border2); }
 .copy-page-btn.copied,
-.copy-docs-btn.copied { color: var(--green); border-color: var(--green); }
-
-/* ── TOP BAR LINK ──
- * Page navigation lives in the persistent rail, so the only thing left in the
- * bar's left half is the one link that leaves the site. */
-.sectionnav {
-  display: flex;
-  align-items: center;
-  margin-left: 12px;
-}
-.sectionnav a {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 10px;
-  border-radius: var(--radius-md);
-  color: var(--muted-foreground);
-  text-decoration: none;
-  font-family: var(--font-sans);
-  font-size: var(--text-label);
-  font-weight: 500;
-  white-space: nowrap;
-  transition: color 0.15s, background 0.15s;
-}
-.sectionnav a:hover { color: var(--text); background: var(--hairline); text-decoration: none; }
+.copy-agents-btn.copied { color: var(--green); border-color: var(--green); }
+.copy-agents-btn.failed { color: var(--red); border-color: var(--red); }
 
 .caps-mono {
   font-family: var(--font-mono);
@@ -1344,7 +1322,7 @@ h3:hover .header-anchor,
   :root { --statusbar-total: 0px; }
   .main { margin-left: 0; }
   .topnav-brand { width: auto; }
-  .copy-page-btn, .copy-docs-btn { display: none; }
+  .copy-page-btn, .copy-agents-btn { display: none; }
   .docsearch-field input { width: 150px; }
   .docs-footer .tagline { display: none; }
   .nav-toggle { display: inline-flex; }
@@ -1366,7 +1344,6 @@ h3:hover .header-anchor,
 }
 @media (max-width: 640px) {
   body { overflow-x: hidden; }
-  .sectionnav { display: none; }
   .topnav-cell { padding: 0 12px; }
   /* There is no room for a live text field beside the brand at these widths, so
      the bar carries only a search icon and the field drops to a row of its own

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -37,9 +37,6 @@
     <img src="logo.png" alt="Mycelium">
     <span class="brand-word">mycelium</span>
   </a>
-  <nav class="sectionnav">
-    <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
-  </nav>
   <div class="topnav-right">
     <div class="docsearch" id="docsearch">
       <button class="docsearch-toggle" id="docsearch-toggle" type="button"
@@ -60,7 +57,7 @@
         </div>
       </div>
     </div>
-    <button class="copy-docs-btn" onclick="copyDocsCmd()"><i data-lucide="terminal"></i>Copy docs cmd</button>
+    <button class="copy-agents-btn" onclick="copyAgentsMd()"><i data-lucide="file-text"></i>Copy agents.md</button>
     <button class="copy-page-btn" onclick="copyPage()"><i data-lucide="copy"></i>Copy page</button>
     <div class="theme-toggle">
       <button class="theme-btn" id="theme-btn" aria-label="Theme" onclick="toggleThemeMenu(event)">
@@ -189,7 +186,6 @@
     </div>
     <div class="nav-external">
       <a href="https://raw.githubusercontent.com/mycelium-io/mycelium/main/mycelium-cli/src/mycelium/integrations/claude_code/assets/skills/mycelium/SKILL.md" target="_blank" rel="noopener">SKILL.md ↗</a>
-      <a href="https://mycelium-io.github.io/mycelium/agents.md" target="_blank" rel="noopener">AGENTS.md ↗</a>
     </div>
   </nav>
   <div class="nav-backdrop" id="nav-backdrop" onclick="closeDrawer()"></div>

--- a/docs/site.js
+++ b/docs/site.js
@@ -379,38 +379,35 @@
     heading.appendChild(anchor);
   });
 
-  // ── Section ID to docs command mapping ──
-  const SECTION_DOCS_MAP = {
-    'overview': 'mycelium docs overview',
-    'quickstart': 'mycelium docs quickstart',
-    'rooms': 'mycelium docs rooms',
-    'memory': 'mycelium docs memory',
-    'cognitive-engine': 'mycelium docs cognitive-engine',
-    'knowledge-graph': 'mycelium docs knowledge-graph',
-    'cli-reference': 'mycelium docs cli-reference',
-    'architecture': 'mycelium docs architecture',
-    'adapters': 'mycelium docs adapters',
-    'adapter-claude-code': 'mycelium docs adapters claude-code',
-    'adapter-cursor': 'mycelium docs adapters cursor',
-    'adapter-api': 'mycelium docs adapters api',
-  };
 
-  // Track current visible section for the docs cmd button
-  var currentDocsSection = 'overview';
-
-  function copyDocsCmd() {
-    const cmd = SECTION_DOCS_MAP[currentDocsSection] || 'mycelium docs --full';
-    navigator.clipboard.writeText(cmd).then(() => {
-      const btn = document.querySelector('.copy-docs-btn');
-      btn.innerHTML = '<i data-lucide="check"></i>' + cmd;
-      btn.classList.add('copied');
+  // agents.md is the setup runbook, meant to be handed to an agent whole. The
+  // token estimate matches copyPage's: characters over four, close enough to
+  // tell a reader whether it fits their context.
+  function copyAgentsMd() {
+    const btn = document.querySelector('.copy-agents-btn');
+    const reset = () => {
+      btn.innerHTML = '<i data-lucide="file-text"></i>Copy agents.md';
+      btn.classList.remove('copied', 'failed');
       icons();
-      setTimeout(() => {
-        btn.innerHTML = '<i data-lucide="terminal"></i>Copy docs cmd';
-        btn.classList.remove('copied');
+    };
+    fetch('agents.md')
+      .then(r => {
+        if (!r.ok) throw new Error(r.status);
+        return r.text();
+      })
+      .then(text => navigator.clipboard.writeText(text).then(() => {
+        const tokens = Math.round(text.length / 4).toLocaleString();
+        btn.innerHTML = '<i data-lucide="check"></i>Copied (~' + tokens + ' tokens)';
+        btn.classList.add('copied');
         icons();
-      }, 2000);
-    });
+        setTimeout(reset, 2000);
+      }))
+      .catch(() => {
+        btn.innerHTML = '<i data-lucide="x"></i>Copy failed';
+        btn.classList.add('failed');
+        icons();
+        setTimeout(reset, 2000);
+      });
   }
 
   // Active nav link tracking
@@ -424,8 +421,6 @@
         navLinks.forEach(l => l.classList.remove('active'));
         const active = document.querySelector(`.nav-link[href="#${id}"]`);
         if (active) active.classList.add('active');
-        // Track for copy docs cmd button
-        if (SECTION_DOCS_MAP[id]) currentDocsSection = id;
       }
     });
   }, { rootMargin: '-20% 0px -70% 0px' });


### PR DESCRIPTION
## Summary

The top bar's **Copy docs cmd** button copied a `mycelium docs <section>` string, picked by whichever section was in view. It's now **Copy agents.md**: it fetches the setup runbook the site publishes at its root and copies the file itself, so a reader can hand the whole thing to an agent in one click. On success it reports a token estimate the way **Copy page** already does — characters over four.

For `agents.md` as it stands today that reads `Copied (~1,971 tokens)`.

With the button carrying the file, the two `AGENTS.md ↗` links added in #784/#793 are redundant, so both come out.

## Changes

- `copyDocsCmd()` → `copyAgentsMd()` in `site.js`: `fetch('agents.md')` → clipboard → `Copied (~N tokens)`, reverting after 2s. Adds a `Copy failed` state, since a fetch can fail where copying in-page text cannot.
- `.copy-docs-btn` → `.copy-agents-btn`, plus a `.failed` rule using the existing `--red` token.
- Removed the `AGENTS.md` link from the top bar and from the sidebar's external block; `SKILL.md` stays in the sidebar.
- Removed `SECTION_DOCS_MAP` / `currentDocsSection` and the IntersectionObserver line feeding them — dead once the old button went.
- Removed the `.sectionnav` rules and their 640px media rule; the element they styled no longer renders.

## Testing

Served `docs/` and drove `index.html` in Chromium:

- Button renders `Copy agents.md`
- Click copies all 7,882 chars of `agents.md` (clipboard verified against the file), label becomes `Copied (~1,971 tokens)`, class `copied`
- Reverts to `Copy agents.md` after 2s
- `.sectionnav` count 0; `.nav-external` holds only `SKILL.md ↗`
- No page errors from the change — the only failed requests are external CDNs blocked by the sandbox (unpkg lucide, Google Fonts, the promo video)

- [x] `generate_docs.py` reruns clean; generated HTML matches
- [ ] Unit tests pass (`uv run pytest tests/ -x -q`) — docs-only change, no test surface touched
- [ ] Linting passes (`uv run ruff check .`) — `docs/` is outside the backend/CLI lint scope
- [ ] Format check passes (`uv run ruff format --check .`)

## Related Issues

Follows up #784, #793

---
_Generated by [Claude Code](https://claude.ai/code/session_012e3Y9FNEdqvKAUKxpvWdss)_