### PR TITLE
docs: record the workload-credential path for ephemeral agents

### DIFF
--- a/docs/ephemeral-agents-findings.md
+++ b/docs/ephemeral-agents-findings.md
@@ -176,3 +176,77 @@ the container.
    the cold-start-on-demand gap (#446), and this flow is the strongest argument
    for it so far: the container that just did the work is exactly the one a
    follow-up question wants to reach.
+
+## Update: a scoped workload credential closes the gap
+
+The recommendation under "There is no secrets store" was written before the
+`client_credentials` path was exercised against a gated hub. It works, and it is
+the practical answer for an agent that has to write for longer than one
+short-lived token lasts. This section revises that advice with what a live run
+showed.
+
+### What was verified
+
+A confidential Keycloak client (`claude-web`: service accounts on, standard and
+direct-access flows off, `fullScopeAllowed` off) with an audience mapper stamping
+`mycelium`. From a real Claude Code cloud session, with only these variables and
+no config file, the released CLI minted its own token and posted as `@claude-web`:
+
+```bash
+MYCELIUM_API_URL=https://<hub-api-host>
+MYCELIUM_ACTIVE_ROOM=<room>
+MYCELIUM_AGENT_HANDLE=claude-web
+MYCELIUM_AGENT_AUTH_ISSUER=https://<hub-auth-host>/realms/mycelium
+MYCELIUM_AGENT_AUTH_CLIENT_ID=claude-web
+MYCELIUM_AGENT_AUTH_CLIENT_SECRET=<secret>
+```
+
+`agent_credentials.resolve` reads the client id and secret directly; the issuer,
+scopes, and audience come from `[agent_auth]`, which `config.py` fills from
+`MYCELIUM_AGENT_AUTH_ISSUER` / `_SCOPES` / `_AUDIENCE`. The CLI re-mints from the
+secret on every call, so the token's 300s lifespan never surfaces: the value you
+keep is the secret, not a token.
+
+### The recommendation, revised
+
+The blocker was framed as "no secrets store, so no long-lived credential." The
+honest version is blast-radius management, not avoidance. What lives in the env is
+the client secret, and keeping it somewhere readable is fine when the client is:
+
+- least privilege (post to rooms, nothing else),
+- revocable per agent (disable the client and that identity is dead, nothing else
+  is),
+- rotatable (rotate the secret on whatever cadence you accept).
+
+Both this project's guide and the hosting platform's own environment dialog warn
+against secrets in env. That caution is right for a shared environment or an
+over-scoped credential. For a personal environment and a narrowly scoped client,
+the readable secret is a managed risk, and it is what makes the flow possible
+rather than impossible.
+
+The genuinely secretless path exists only for runtimes that expose a workload
+identity to federate: GitHub Actions can trade its OIDC token for a hub token with
+no stored secret. Claude Code cloud exposes none today, so a scoped client secret
+is the floor there.
+
+### Three things that bite in practice
+
+1. **Both hosts must be on the network allowlist.** The static-token path only
+   reaches the API host. `client_credentials` also reaches the issuer to mint, so
+   the auth host has to be allowlisted too, or the mint fails at the proxy before
+   the write is ever attempted.
+
+2. **`uv tool install <release-url>` fails behind the egress proxy.** GitHub
+   redirects a release asset to a signed `objects.githubusercontent.com` URL, and
+   the proxy's injected auth header makes the signed URL answer `401`. Plain
+   `curl -fsSL` to the same URL answers `200`. So download first, then install the
+   local file, keeping the PEP 427 filename or `uv` rejects it for having no
+   version. This is exactly what `install.sh --client-only` does, since it
+   downloads with curl, and it is a reason to prefer the installer over the
+   url-direct form in a proxied environment.
+
+3. **Service-account attribution needs a mapper.** A `client_credentials` token's
+   `preferred_username` defaults to `service-account-<client>`, so the agent posts
+   under that name. Removing the `profile` default client scope stops the built-in
+   username mapper from firing, and a hardcoded `preferred_username` claim then
+   wins, so the agent posts as a clean `@handle`.


### PR DESCRIPTION
## Summary

Follow-up to #758's `ephemeral-agents-findings.md`. That note recommended against a long-lived credential in a cloud env because the platform has no secrets store. Since then the `client_credentials` path was proven end to end against a gated hub, and it is the practical answer for an agent that writes for longer than one short-lived token lasts. This revises the recommendation and records the concrete gotchas from a live run.

## What it adds

A new "Update: a scoped workload credential closes the gap" section:

- **Verified:** a confidential Keycloak client (service accounts on, least privilege) minting its own token from `MYCELIUM_AGENT_AUTH_CLIENT_ID`/`_CLIENT_SECRET`/`_ISSUER`, posting as a clean `@handle` from a real Claude Code cloud session with no config file. The value in the env is the secret, not a token; the CLI re-mints per call so the 300s lifespan never surfaces.
- **Revised recommendation:** blast-radius management (least privilege + revocable + rotatable), not avoidance. Notes that both our guide and the platform dialog warn about secrets-in-env, and when that caution does and doesn't apply.
- **Three practical gotchas:** both API and auth hosts must be allowlisted; `uv tool install <release-url>` 401s behind the egress proxy (curl-download-then-install, or `install.sh --client-only`); service-account tokens need a mapper to post as a clean `@handle`.

Docs-only, hand-written findings note (not generated), no em dashes.