### PR TITLE
feat(messages): room send honors owner/allow_from delegation

### DIFF
--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -55,10 +55,16 @@ async def send_message(room_name: str, payload: MessageCreate, request: Request)
     channel, coord = _resolve_channel(room_name)
 
     # Token-verified sender; fall back to payload handle if unauthenticated.
-    sender_handle = actor.bind_actor(request, payload.sender_handle, field="sender_handle")
+    # Delegation-aware, like /reply: a principal may announce as a handle that
+    # granted it access via owner/allow_from, which is how one shared workload
+    # credential posts under a distinct per-agent handle. The grant is explicit on
+    # the target manifest, so this is authorized delegation, not impersonation.
+    base_room = channel.split(":session:", 1)[0]
+    sender_handle = actor.bind_delegated_actor(
+        request, base_room, payload.sender_handle, field="sender_handle"
+    )
 
     # Prevent impersonation: only engines post as engine handles.
-    base_room = channel.split(":session:", 1)[0]
     reason = principals.post_rejection_reason(base_room, sender_handle, allow_unregistered=True)
     if reason:
         raise HTTPException(status_code=403, detail=reason)

--- a/fastapi-backend/tests/test_handle_authorization.py
+++ b/fastapi-backend/tests/test_handle_authorization.py
@@ -235,3 +235,44 @@ async def test_delegates_to_reads_only_explicit_grants(client: AsyncClient):
     assert not principals.delegates_to(ROOM, "loner", "alice")
     assert not principals.delegates_to(ROOM, "unregistered", "alice")
     assert not principals.delegates_to(ROOM, "bot", "")
+
+
+# ── room send (POST /messages) honors delegation, like /reply ─────────────────
+
+
+async def _send_as(client: AsyncClient, handle: str, *, room: str = ROOM):
+    return await client.post(
+        f"/api/rooms/{room}/messages",
+        json={"sender_handle": handle, "content": "hi", "message_type": "broadcast"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_room_send_as_own_handle(client: AsyncClient, as_principal):
+    await _make_room(client)
+    as_principal("alice", role="user")
+    resp = await _send_as(client, "alice")
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["sender_handle"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_room_send_allow_from_lets_a_shared_credential_announce(
+    client: AsyncClient, as_principal
+):
+    """One shared workload credential may announce under a distinct per-agent
+    handle that granted it access — the self-claimed ephemeral-agent path."""
+    await _make_room(client)
+    _seed_agent("cc-demo", owner="alice", allow_from=["claude-web"])
+    as_principal("claude-web")
+    resp = await _send_as(client, "cc-demo")
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["sender_handle"] == "cc-demo"
+
+
+@pytest.mark.asyncio
+async def test_room_send_rejects_an_ungranted_handle(client: AsyncClient, as_principal):
+    await _make_room(client)
+    _seed_agent("cc-demo", owner="alice", allow_from=["claude-web"])
+    as_principal("mallory")
+    assert (await _send_as(client, "cc-demo")).status_code == 403


### PR DESCRIPTION
## Summary

`POST /rooms/{room}/messages` (`room send`) used the strict `bind_actor` — the sender had to be the token's own handle. `/reply` already uses the delegation-aware `bind_delegated_actor` (honoring `owner`/`allow_from`). This aligns the two.

**Why:** it's the enabler for **self-claimed ephemeral-agent identity**. One shared workload credential (e.g. a `claude-web` service account) can now *announce* under a distinct per-agent handle that granted it access — so concurrent cloud agents are distinguishable in the room instead of all collapsing to the shared credential's handle, while still rotating/revoking one secret.

The grant is explicit on the target manifest (`mycelium agent create <h> --allow-from <cred>`), so this is authorized delegation, not impersonation. An ungranted handle is still `403`, and the gate-off path is unchanged.

## Change

- `messages.py`: compute `base_room` first, then `bind_actor` → `bind_delegated_actor(request, base_room, …)`.

## Tests

`test_handle_authorization.py` gains three cases on the `room send` path:
- posts as own handle (201)
- a shared credential announces under a delegated handle it was `allow_from`'d on (201)
- an ungranted handle is refused (403)

Full backend suite green (756 passed).

_Found while wiring self-claimed identities for remote ephemeral agents against the live Keycloak-gated hub: delegation worked on `/reply` but not on the announce path they actually use._