### PR TITLE
Remove next steps UI from install panel

### DIFF
--- a/mycelium-frontend/src/components/install-panel.test.tsx
+++ b/mycelium-frontend/src/components/install-panel.test.tsx
@@ -8,12 +8,6 @@ import { renderWithSWR } from "@/test/swr";
 import { InstallPanel } from "@/components/install-panel";
 import { CLI_INSTALL_COMMAND, LOGIN_COMMAND, PROMPT_COMMAND, configSetCommand } from "@/lib/install";
 
-vi.mock("next/link", () => ({
-  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
-    <a href={href}>{children}</a>
-  ),
-}));
-
 /** The panel's only server read is the health probe. */
 function stubHub(reachable: boolean) {
   vi.stubGlobal(
@@ -50,17 +44,15 @@ describe("<InstallPanel />", () => {
     await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Hub unreachable"));
     // The honest framing: this isn't "not installed yet", it's down.
     expect(screen.getByText(/isn't answering right now/i)).toBeInTheDocument();
-    expect(screen.queryByText("Next: your first room")).not.toBeInTheDocument();
   });
 
-  it("flips to reachable and shows the next steps once the hub answers", async () => {
+  it("drops the unreachable note once the hub answers, keeping only the commands", async () => {
     const user = userEvent.setup();
     stubHub(true);
     renderWithSWR(<InstallPanel />);
 
     await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Hub reachable"));
-    expect(screen.getByText("Next: your first room")).toBeInTheDocument();
-    expect(commandField("mycelium room create my-project && mycelium room use my-project")).toBeInTheDocument();
+    expect(screen.queryByText(/isn't answering right now/i)).not.toBeInTheDocument();
 
     // The install commands stay reachable — a second machine still needs them.
     await user.click(screen.getByRole("button", { name: "macOS" }));

--- a/mycelium-frontend/src/components/install-panel.tsx
+++ b/mycelium-frontend/src/components/install-panel.tsx
@@ -4,15 +4,13 @@
 "use client";
 
 import { useState, useSyncExternalStore } from "react";
-import Link from "next/link";
-import { ArrowRight, Terminal } from "lucide-react";
+import { Terminal } from "lucide-react";
 import { CopyField } from "@/components/ui/copy-field";
 import { useBackendHealth } from "@/lib/use-status";
 import {
   CLI_INSTALL_COMMAND,
   DOCS_URL,
   LOGIN_COMMAND,
-  NEXT_STEPS,
   PLATFORMS,
   PROMPT_COMMAND,
   configSetCommand,
@@ -199,37 +197,7 @@ export function InstallPanel({ className }: Props) {
         </>
       )}
 
-      {healthy ? (
-        <div className="mt-5 border-t border-border pt-4">
-          <div className="text-label font-medium text-text">Next: your first room</div>
-          <ol className="mt-3 space-y-3">
-            {NEXT_STEPS.map(step => (
-              <li key={step.title}>
-                <div className="flex flex-wrap items-baseline gap-x-2">
-                  <span className="text-label text-text">{step.title}</span>
-                  <a
-                    href={step.href}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-micro text-accent hover:underline"
-                  >
-                    docs
-                  </a>
-                </div>
-                <p className="text-micro text-muted-foreground">{step.body}</p>
-                <CopyField value={step.command} className="mt-1.5" />
-              </li>
-            ))}
-          </ol>
-          <Link
-            href="/"
-            className="mt-4 inline-flex items-center gap-1.5 text-label font-medium text-accent hover:underline"
-          >
-            Open the command center
-            <ArrowRight className="size-3.5" />
-          </Link>
-        </div>
-      ) : (
+      {!healthy && (
         <p className="mt-5 border-t border-border pt-4 text-micro text-muted-foreground">
           The hub isn&apos;t answering right now, so the CLI may not be able to connect. Prefer
           the long version? Read the{" "}

--- a/mycelium-frontend/src/lib/install.test.ts
+++ b/mycelium-frontend/src/lib/install.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from "vitest";
 import {
   CLI_INSTALL_COMMAND,
   LOGIN_COMMAND,
-  NEXT_STEPS,
   PLATFORMS,
   PROMPT_COMMAND,
   configSetCommand,
@@ -61,13 +60,5 @@ describe("install content", () => {
     const windows = PLATFORMS.find(p => p.id === "windows");
     expect(windows?.note).toMatch(/WSL/);
     expect(PLATFORMS.filter(p => p.note)).toHaveLength(1);
-  });
-
-  it("points every next step at the docs", () => {
-    expect(NEXT_STEPS.length).toBeGreaterThan(0);
-    for (const step of NEXT_STEPS) {
-      expect(step.href).toMatch(/^https:\/\/mycelium-io\.github\.io\/mycelium\//);
-      expect(step.command).toMatch(/^mycelium /);
-    }
   });
 });

--- a/mycelium-frontend/src/lib/install.ts
+++ b/mycelium-frontend/src/lib/install.ts
@@ -66,33 +66,3 @@ export function detectPlatform(userAgent: string | null | undefined): Platform {
   if (/linux|x11|cros/.test(ua)) return "linux";
   return "unknown";
 }
-
-export interface NextStep {
-  title: string;
-  body: string;
-  command: string;
-  /** Where the docs explain this step in full. */
-  href: string;
-}
-
-/** What to do once the hub answers: the shape of a first session. */
-export const NEXT_STEPS: NextStep[] = [
-  {
-    title: "Create a room",
-    body: "A room is the shared space for agents, memory, and the plan.",
-    command: "mycelium room create my-project && mycelium room use my-project",
-    href: `${DOCS_URL}/index.html#rooms`,
-  },
-  {
-    title: "Add an agent",
-    body: "One per role. Each becomes a citizen of the room you can @mention.",
-    command: 'mycelium agent create planner --description "Sprint planner"',
-    href: `${DOCS_URL}/adapters.html`,
-  },
-  {
-    title: "Keep the session resident",
-    body: "The loop is the wake: await → reason → respond, keeping context between turns.",
-    command: "mycelium await --loop",
-    href: `${DOCS_URL}/reference.html`,
-  },
-];


### PR DESCRIPTION
## Summary

Removes the "Next: your first room" section from the install panel that was displayed once the hub became reachable. This section guided users through creating a room, adding an agent, and starting a session loop. The UI and supporting data structures are being removed to simplify the install flow.

## Changes

- Removed the conditional "Next: your first room" section from `InstallPanel` that displayed when the hub was healthy
- Deleted `NEXT_STEPS` constant and `NextStep` interface from `install.ts`
- Removed imports of `Link` from Next.js and `ArrowRight` icon that were only used by the removed section
- Simplified the health check logic from `{healthy ? ... : ...}` to `{!healthy && ...}` since there's no longer a healthy state UI
- Updated tests to reflect the removal: removed Next.js Link mock, removed assertions checking for next steps UI, and removed the test validating next steps point to docs

## Testing

- Existing unit tests updated and passing
- The install panel still displays installation commands and shows/hides the unreachable message based on hub health
- No new functionality added, only removal of existing UI

https://claude.ai/code/session_016xVopDrckC1EDsC52Ccx8a