### PR TITLE
Add documentation link to app header

### DIFF
--- a/mycelium-frontend/src/components/app-shell.tsx
+++ b/mycelium-frontend/src/components/app-shell.tsx
@@ -10,6 +10,7 @@ import { RoomsSidebar } from "@/components/rooms-sidebar";
 import { GlobalSearch, GlobalSearchButton } from "@/components/global-search";
 import { CommandPaletteButton, KeymapHelpButton } from "@/components/keymap-provider";
 import { InstallModalProvider, useOpenInstallModal } from "@/components/install-modal";
+import { DocsLink } from "@/components/docs-link";
 import { MetricsStatusLink } from "@/components/status-items";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
@@ -154,6 +155,7 @@ export function AppShell({
                   <div className="ml-auto flex flex-shrink-0 items-center gap-3">
                     {headerRight}
                     <InstallCliButton />
+                    <DocsLink />
                     <ThemeToggle />
                   </div>
                 </header>

--- a/mycelium-frontend/src/components/docs-link.tsx
+++ b/mycelium-frontend/src/components/docs-link.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useMemo } from "react";
+import { BookOpen } from "lucide-react";
+import { useCommands } from "@/components/keymap-provider";
+import { Tooltip } from "@/components/ui/tooltip";
+import { DOCS_URL } from "@/lib/install";
+import type { PaletteCommand } from "@/lib/commands";
+
+/** The docs site, one icon along from the theme toggle. The header corner is
+ *  already where the app keeps the things that are about the app rather than
+ *  about the room, and the docs are hosted elsewhere, so this opens in its own
+ *  tab rather than taking the workspace with it. */
+export function DocsLink() {
+  const commands = useMemo<PaletteCommand[]>(
+    () => [
+      {
+        id: "docs.open",
+        title: "Open documentation",
+        group: "Help",
+        keywords: ["docs", "documentation", "guide", "reference", "help"],
+        run: () => window.open(DOCS_URL, "_blank", "noreferrer"),
+      },
+    ],
+    [],
+  );
+  useCommands(commands);
+
+  return (
+    <Tooltip content="Documentation" side="bottom">
+      <a
+        href={DOCS_URL}
+        target="_blank"
+        rel="noreferrer"
+        aria-label="Documentation"
+        className="flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface hover:text-text"
+      >
+        <BookOpen className="size-4" />
+      </a>
+    </Tooltip>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a documentation link to the app shell header, positioned next to the theme toggle. The link opens the docs site in a new tab and is also accessible via the command palette.

## Changes

- Created new `DocsLink` component that renders a documentation icon button in the header
- Integrated the docs link into the app shell header's top-right corner
- Added a command palette entry (`docs.open`) to open documentation via keyboard shortcut
- Uses the existing `DOCS_URL` constant from the install module

## Testing

No testing needed — this is a straightforward UI component addition that follows existing patterns in the codebase (similar to `ThemeToggle` and `InstallCliButton`).

https://claude.ai/code/session_01G5VHqLuLcd2VhfAUo2ffCk