### PR TITLE
docs: point L9 outbound links at the Outshift semantic-gap post

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,7 +9,7 @@
 
 - [Internet of Cognition](https://outshift.cisco.com) — Outshift by Cisco
 - [AGNTCY SLIM](https://github.com/agntcy/slim) — AGNTCY
-- [IOC L9 protocol models](https://github.com/outshift-open/ioc-protocols-models) — Outshift by Cisco
+- [IOC Layer 9](https://outshift.cisco.com/blog/ai-ml/mind-the-semantic-gap-osi-model) — Outshift by Cisco
 - [NegMAS](https://negmas.readthedocs.io/) — Yasser Mohammad
 - [FastAPI](https://fastapi.tiangolo.com/) — Sebastian Ramirez
 - [fastembed](https://github.com/qdrant/fastembed) — Qdrant

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ mycelium plan tasks   # the shared - [ ] checklist the team executes against
 
 **Sharing is the live channel.** Two machines share a room by sharing the fabric: one runs `mycelium hub host`, the other runs `mycelium connect`, and both talk to the same room channel and the same memory store. Git can version or back up the hub's `~/.mycelium/` files, but it is not the sharing path — no room flow pushes or pulls over git. For a point-in-time copy, `mycelium room clone --from <api-url>` takes an HTTP snapshot.
 
-**Mycelium speaks IOC L9.** Coordination rides SLIM as additive [Layer 9](https://github.com/outshift-open/ioc-protocols-models) epistemic envelopes (`exchange` for ticks/replies, `commit:converged|resolved|rejected`, `knowledge`) with episodes and causal message threading. Summoning the aligner opens an **episode**: a tagged, membership-scoped negotiation on the room's channel with its own record at `log/episodes/{id}.md` (the full causally-linked envelope chain), surfaced live in the UI protocol inspector. Agents can state confidence, cite evidence, and flag deference on replies; consensus gets measurable quality metrics. All of it is optional; agents never need to speak L9.
+**Mycelium speaks IOC L9.** Coordination rides SLIM as additive [Layer 9](https://outshift.cisco.com/blog/ai-ml/mind-the-semantic-gap-osi-model) epistemic envelopes (`exchange` for ticks/replies, `commit:converged|resolved|rejected`, `knowledge`) with episodes and causal message threading. Summoning the aligner opens an **episode**: a tagged, membership-scoped negotiation on the room's channel with its own record at `log/episodes/{id}.md` (the full causally-linked envelope chain), surfaced live in the UI protocol inspector. Agents can state confidence, cite evidence, and flag deference on replies; consensus gets measurable quality metrics. All of it is optional; agents never need to speak L9.
 
 **Deployment modes.** By default everything runs on a single device (your laptop): backend, SLIM node, agents, and CLI all on `localhost`. That's the primary target and what `mycelium install` sets up out of the box. For small teams that want to share memory and coordination state, Mycelium supports a hub-and-spoke mode: one machine runs `mycelium hub host` to stand up the SLIM node and prints its address; teammates run `mycelium connect http://<hub-ip>:<port>` to point their CLI + agents at it. `mycelium doctor` auto-detects which mode you're in.
 
@@ -219,7 +219,7 @@ Interactive API docs at `http://localhost:8000/docs` when the backend is running
 Mycelium builds on OSS projects we found invaluable in this space:
 
 - [AGNTCY SLIM](https://github.com/agntcy/slim): the encrypted group-messaging transport agents coordinate over
-- [IOC L9 protocol models](https://github.com/outshift-open/ioc-protocols-models): the epistemic envelope layer that rides SLIM
+- [IOC Layer 9](https://outshift.cisco.com/blog/ai-ml/mind-the-semantic-gap-osi-model): the epistemic envelope layer that rides SLIM
 - [NegMAS](https://negmas.readthedocs.io/): multi-issue negotiation, the aligner's engine
 - [FastAPI](https://fastapi.tiangolo.com/) + [fastembed](https://github.com/qdrant/fastembed): the moderator backend and on-device embeddings
 - [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mycelium-io/mycelium)

--- a/docs/index.html
+++ b/docs/index.html
@@ -852,7 +852,7 @@ Review 1
     <section class="doc-section" id="l9-protocol">
       <h1>L9 Protocol</h1>
       <p>Every negotiation ends in &quot;accept,&quot; but an accept can mean <em>&quot;you convinced me&quot;</em> or <em>&quot;fine, whatever, let&#x27;s move on.&quot;</em> If you can&#x27;t tell those apart, you can&#x27;t tell a real team decision from one agent steamrolling the rest, and the plan your agents execute inherits that blind spot.</p>
-      <p>L9 (the epistemic layer of the <a href="https://github.com/outshift-open/ioc-protocols-models">Internet of Cognition</a>) fixes this by making <em>how</em> the team decided as inspectable as <em>what</em> it decided. Agents say how sure they are and why; every consensus gets a quality score; every negotiation leaves a causal paper trail.</p>
+      <p>L9 (the epistemic layer of the <a href="https://outshift.cisco.com/blog/ai-ml/mind-the-semantic-gap-osi-model">Internet of Cognition</a>) fixes this by making <em>how</em> the team decided as inspectable as <em>what</em> it decided. Agents say how sure they are and why; every consensus gets a quality score; every negotiation leaves a causal paper trail.</p>
       <p>L9 rides the room&#x27;s SLIM channel as additive JSON envelopes on the coordination messages: ticks are <code>exchange</code>, agreement commits as <code>commit:converged</code>, failure as <code>commit:rejected</code>, and shared knowledge as <code>knowledge</code>. The backend synthesizes reply envelopes from what agents say, so agents never need to speak L9 themselves.</p>
       <div class="callout callout-note">
         <div class="callout-bar"></div>

--- a/docs/l9-integration.html
+++ b/docs/l9-integration.html
@@ -117,7 +117,7 @@
 
       <h1>How mycelium integrates L9</h1>
       <p>
-        L9 is the epistemic layer of the <a href="https://github.com/outshift-open/ioc-protocols-models">Internet of Cognition</a>:
+        L9 is the epistemic layer of the <a href="https://outshift.cisco.com/blog/ai-ml/mind-the-semantic-gap-osi-model">Internet of Cognition</a>:
         a fixed message <em>envelope</em> (kind/subkind, participants, episode URN, causal
         <code>message.parents</code>, typed payload) that carries cognition between agents and
         engines. Mycelium is one producer of those envelopes.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1093,7 +1093,7 @@ can't tell a real team decision from one agent steamrolling the rest, and the
 plan your agents execute inherits that blind spot.
 
 L9 (the epistemic layer of the [Internet of
-Cognition](https://github.com/outshift-open/ioc-protocols-models)) fixes this
+Cognition](https://outshift.cisco.com/blog/ai-ml/mind-the-semantic-gap-osi-model)) fixes this
 by making *how* the team decided as inspectable as *what* it decided. Agents
 say how sure they are and why; every consensus gets a quality score; every
 negotiation leaves a causal paper trail.

--- a/mycelium-cli/src/mycelium/docs/concepts/l9-protocol.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/l9-protocol.md
@@ -6,7 +6,7 @@ can't tell a real team decision from one agent steamrolling the rest, and the
 plan your agents execute inherits that blind spot.
 
 L9 (the epistemic layer of the [Internet of
-Cognition](https://github.com/outshift-open/ioc-protocols-models)) fixes this
+Cognition](https://outshift.cisco.com/blog/ai-ml/mind-the-semantic-gap-osi-model)) fixes this
 by making *how* the team decided as inspectable as *what* it decided. Agents
 say how sure they are and why; every consensus gets a quality score; every
 negotiation leaves a causal paper trail.


### PR DESCRIPTION
## Summary

Every outbound "what is L9 / Internet of Cognition" link pointed at `github.com/outshift-open/ioc-protocols-models` — the binding source, which is where the code came from but not where a reader learns what Layer 9 is. All five now point at https://outshift.cisco.com/blog/ai-ml/mind-the-semantic-gap-osi-model, the post that introduces the layer.

The vendoring provenance comments in `l9.py` / `l9_models.py` / `slim/l9.py` (and the `ioc-protocols-models` rows in the component/version tables on `l9-integration.html`) still name the repo — those describe where the vendored binding actually came from, so swapping them for a blog URL would make them wrong.

## Changes

- `README.md` — the "Mycelium speaks IOC L9" Layer 9 link, and the "Built on" entry (relabelled `IOC Layer 9`, since it no longer points at the models repo)
- `CONTRIBUTORS.md` — same "Built On" entry
- `mycelium-cli/src/mycelium/docs/concepts/l9-protocol.md` — the Internet of Cognition link
- `docs/l9-integration.html` — the Internet of Cognition link (hand-maintained page, not generated)
- `docs/index.html`, `docs/llms-full.txt` — regenerated from the markdown source via `docs/generate_docs.py`

## Testing

- Regenerated the docs site (`uv run python ../docs/generate_docs.py`); the only diff in the generated output is the intended link, so there is no drift for CI to catch.
- `curl -I` on the new URL returns 200.
- Docs-only change; no Python touched.

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`) — n/a, no code changed
- [ ] Linting passes (`uv run ruff check .`) — n/a
- [ ] Format check passes (`uv run ruff format --check .`) — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01K36qDar8A4SjA44Qy6BzNC)_