### PR TITLE
Draw every key through one keycap component, and give the status rail the affordance it lacked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,15 @@ is no litellm dependency.
   popover; `[[` is matched before `/` and `@` since a memory key can contain
   slashes. Skills insert a reference token — the resident agent/engine interprets
   it; the composer never runs the skill.
+- **One keycap, sized by where it sits.** Every surface that names a key draws it
+  through `ui/kbd.tsx` — `Kbd` for a literal, `KbdChord` for a chord the keymap
+  owns (platform-spelled, and silent when nothing binds the action). Three sizes,
+  picked by context rather than emphasis: `xs` is the one that fits the 24px
+  status rail, `sm` for palettes and hint rows, `md` for the `?` cheatsheet. The
+  rail is where this matters most: it is the only strip every screen shows, so a
+  cell a key already reaches names that key (in its tooltip, via `action=`) and
+  the way in teaches the way past. `key-badge.tsx` stays separate — that is the
+  ⌥-reveal badge drawn *on* a target, not a cap set in copy.
 - **The synthesizer distills messages into memory (#808).** Its input is the
   room's transcript — the ephemeral half, where a decision is argued and settled
   and nothing indexes it for meaning — and its output is a `knowledge` memory at

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -221,7 +221,7 @@ function RoomWorkspace() {
         {connected ? "Live" : "Reconnecting…"}
       </span>
       {episodeLabel && (
-        <StatusButton onClick={() => openTab("episodes")} tooltip="View episodes">
+        <StatusButton onClick={() => openTab("episodes")} tooltip="View episodes" action="rail.episodes">
           <span style={{ color: episodeLabel.color }}>{episodeLabel.text}</span>
         </StatusButton>
       )}
@@ -234,7 +234,7 @@ function RoomWorkspace() {
   const statusRight = (
     <>
       {agents !== null && (
-        <StatusButton onClick={() => openTab("agents")} tooltip="View agents">
+        <StatusButton onClick={() => openTab("agents")} tooltip="View agents" action="rail.agents">
           <span className="tabular">{agents} agent{agents === 1 ? "" : "s"}</span>
         </StatusButton>
       )}

--- a/mycelium-frontend/src/components/command-palette.tsx
+++ b/mycelium-frontend/src/components/command-palette.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/command";
 import { paletteFilter, paletteSections, type PaletteCommand } from "@/lib/commands";
 import { eventToChord, formatChord, matchBinding } from "@/lib/keymap";
+import { Kbd } from "@/components/ui/kbd";
 
 interface Props {
   open: boolean;
@@ -122,14 +123,14 @@ export function CommandPalette({ open, onClose, commands, recent, onRun, mac }: 
         </Command>
 
         <footer className="flex flex-shrink-0 items-center gap-3 border-t border-border px-4 py-2 text-micro text-muted-foreground">
-          <span>
-            <kbd className="font-sans">↑↓</kbd> navigate
+          <span className="flex items-center gap-1.5">
+            <Kbd size="xs" tone="muted">↑↓</Kbd> navigate
           </span>
-          <span>
-            <kbd className="font-sans">↵</kbd> run
+          <span className="flex items-center gap-1.5">
+            <Kbd size="xs" tone="muted">↵</Kbd> run
           </span>
-          <span>
-            <kbd className="font-sans">esc</kbd> close
+          <span className="flex items-center gap-1.5">
+            <Kbd size="xs" tone="muted">Esc</Kbd> close
           </span>
         </footer>
       </div>

--- a/mycelium-frontend/src/components/global-search.tsx
+++ b/mycelium-frontend/src/components/global-search.tsx
@@ -8,6 +8,7 @@ import { useIsMac } from "@/lib/client-hooks";
 import { useRouter } from "next/navigation";
 import { SearchPalette } from "@/components/search-palette";
 import { Tooltip } from "@/components/ui/tooltip";
+import { KbdChord } from "@/components/ui/kbd";
 import { useKeyAction } from "@/components/keymap-provider";
 import { searchEverything } from "@/lib/api";
 import { resultHref, type SearchHit } from "@/lib/search";
@@ -64,9 +65,9 @@ export function GlobalSearchButton() {
       <button
         type="button"
         onClick={openSearch}
-        className="rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
+        className="flex items-center gap-1.5 rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
       >
-        <kbd className="font-sans">/</kbd> search
+        <KbdChord size="xs" tone="muted" action="search.open" /> search
       </button>
     </Tooltip>
   );

--- a/mycelium-frontend/src/components/keymap-cheatsheet.tsx
+++ b/mycelium-frontend/src/components/keymap-cheatsheet.tsx
@@ -5,15 +5,8 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import { X } from "lucide-react";
-import { bindingsInScope, formatChord, type Binding, type KeyScope } from "@/lib/keymap";
-
-function Keycap({ children }: { children: string }) {
-  return (
-    <kbd className="rounded border border-border bg-surface px-1.5 py-0.5 font-mono text-micro text-text">
-      {children}
-    </kbd>
-  );
-}
+import { bindingsInScope, type Binding, type KeyScope } from "@/lib/keymap";
+import { Kbd, KbdChord } from "@/components/ui/kbd";
 
 interface Props {
   open: boolean;
@@ -80,9 +73,9 @@ export function KeymapCheatsheet({ open, onClose, scopes, mac }: Props) {
         <header className="flex items-center gap-3 border-b border-border px-5 py-3.5">
           <h2 className="text-ui font-semibold text-text">Keyboard shortcuts</h2>
           <span className="text-micro text-muted-foreground">
-            Hold <kbd className="font-sans">{mac ? "⌥" : "Alt"}</kbd>{" "}
+            Hold <Kbd size="xs">{mac ? "⌥" : "Alt"}</Kbd>{" "}
             to see each key on the thing it selects. Keys are inert while you&apos;re typing —{" "}
-            <kbd className="font-sans">Esc</kbd> returns to command mode.
+            <Kbd size="xs">Esc</Kbd> returns to command mode.
           </span>
           <button
             type="button"
@@ -102,15 +95,18 @@ export function KeymapCheatsheet({ open, onClose, scopes, mac }: Props) {
                 {bindings.map((b) => (
                   <div key={b.id} className="flex items-baseline gap-3">
                     <dt className="flex flex-shrink-0 items-baseline gap-1">
-                      <Keycap>{formatChord(b.keys[0], mac)}</Keycap>
+                      <KbdChord size="md" chord={b.keys[0]} mac={mac} />
                       {b.abbreviate ? (
                         <>
                           <span className="text-micro text-faint">…</span>
-                          <Keycap>{formatChord(b.keys[b.keys.length - 1], mac)}</Keycap>
+                          <KbdChord size="md" chord={b.keys[b.keys.length - 1]} mac={mac} />
                         </>
                       ) : (
                         b.keys.length > 1 && (
-                          <span className="text-micro text-faint">or {formatChord(b.keys[1], mac)}</span>
+                          <>
+                            <span className="text-micro text-faint">or</span>
+                            <KbdChord size="md" tone="muted" chord={b.keys[1]} mac={mac} />
+                          </>
                         )
                       )}
                     </dt>

--- a/mycelium-frontend/src/components/keymap-provider.tsx
+++ b/mycelium-frontend/src/components/keymap-provider.tsx
@@ -17,12 +17,12 @@ import {
 import { useIsMac } from "@/lib/client-hooks";
 import { CommandPalette } from "@/components/command-palette";
 import { Tooltip } from "@/components/ui/tooltip";
+import { KbdChord } from "@/components/ui/kbd";
 import { KeymapCheatsheet } from "@/components/keymap-cheatsheet";
 import { loadRecent, pushRecent, saveRecent, type PaletteCommand } from "@/lib/commands";
 import {
   chordFor,
   eventToChord,
-  formatChord,
   isCommandChord,
   isModifierKey,
   matchBinding,
@@ -392,9 +392,9 @@ export function KeymapHelpButton() {
       <button
         type="button"
         onClick={api.openHelp}
-        className="rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
+        className="flex items-center gap-1.5 rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
       >
-        <kbd className="font-sans">?</kbd> keys
+        <KbdChord size="xs" tone="muted" action="help.keys" /> keys
       </button>
     </Tooltip>
   );
@@ -409,9 +409,9 @@ export function CommandPaletteButton() {
       <button
         type="button"
         onClick={api.openPalette}
-        className="rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
+        className="flex items-center gap-1.5 rounded px-1 text-micro text-muted-foreground transition-colors hover:text-text"
       >
-        <kbd className="font-sans">{formatChord(chordFor("palette.open") ?? "", mac)}</kbd> commands
+        <KbdChord size="xs" tone="muted" action="palette.open" mac={mac} /> commands
       </button>
     </Tooltip>
   );

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -10,6 +10,7 @@ import { SendPlaneIcon } from "@/components/send-plane-icon";
 import { useRoomMemories, useRoomRoster, useRoomSkills } from "@/lib/room-data";
 import { useKeyAction } from "@/components/keymap-provider";
 import { useCurrentUser } from "@/components/current-user";
+import { Kbd } from "@/components/ui/kbd";
 
 interface Props {
   roomName: string;
@@ -305,9 +306,10 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
             </button>
           </div>
         </div>
-        <div className="mt-1.5 px-1 text-micro text-muted-foreground">
-          <kbd className="font-sans">Enter</kbd> to send · <kbd className="font-sans">Shift+Enter</kbd> for newline ·{" "}
-          <kbd className="font-sans">Esc</kbd> for command mode
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-1.5 gap-y-1 px-1 text-micro text-muted-foreground">
+          <Kbd size="xs" tone="muted">Enter</Kbd> to send ·
+          <Kbd size="xs" tone="muted">Shift+Enter</Kbd> for newline ·
+          <Kbd size="xs" tone="muted">Esc</Kbd> for command mode
         </div>
       </div>
     </div>

--- a/mycelium-frontend/src/components/search-palette.tsx
+++ b/mycelium-frontend/src/components/search-palette.tsx
@@ -24,6 +24,7 @@ import {
   type SearchScope,
 } from "@/lib/search";
 import { eventToChord, matchBinding } from "@/lib/keymap";
+import { Kbd } from "@/components/ui/kbd";
 
 const ICONS: Record<SearchResultType, LucideIcon> = {
   room: Boxes,
@@ -224,14 +225,14 @@ export function SearchPalette({ open, onClose, onPick, search, mac }: Props) {
         </Command>
 
         <footer className="flex flex-shrink-0 items-center gap-3 border-t border-border px-4 py-2 text-micro text-muted-foreground">
-          <span>
-            <kbd className="font-sans">↑↓</kbd> navigate
+          <span className="flex items-center gap-1.5">
+            <Kbd size="xs" tone="muted">↑↓</Kbd> navigate
           </span>
-          <span>
-            <kbd className="font-sans">↵</kbd> open
+          <span className="flex items-center gap-1.5">
+            <Kbd size="xs" tone="muted">↵</Kbd> open
           </span>
-          <span>
-            <kbd className="font-sans">esc</kbd> close
+          <span className="flex items-center gap-1.5">
+            <Kbd size="xs" tone="muted">Esc</Kbd> close
           </span>
           {pending && <span className="ml-auto">searching…</span>}
         </footer>

--- a/mycelium-frontend/src/components/status-items.test.tsx
+++ b/mycelium-frontend/src/components/status-items.test.tsx
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { StatusButton } from "@/components/status-items";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+vi.mock("next/navigation", () => ({ usePathname: () => "/" }));
+
+function renderCell(action?: string) {
+  return render(
+    <TooltipProvider>
+      <StatusButton onClick={() => {}} tooltip="View agents" action={action}>
+        <span>3 agents</span>
+      </StatusButton>
+    </TooltipProvider>,
+  );
+}
+
+describe("<StatusButton />", () => {
+  it("names the key that does the same thing, so the rail teaches the shortcut", async () => {
+    const user = userEvent.setup();
+    const { container } = renderCell("rail.agents");
+
+    await user.hover(screen.getByRole("button"));
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("View agents");
+    // Portaled out of `container`, so the cap is looked for in the document.
+    expect(tooltip.querySelector("kbd")?.textContent).toBe("Alt+A");
+    expect(container.querySelector("kbd")).toBeNull();
+  });
+
+  it("keeps the bare label for a cell no key reaches", async () => {
+    const user = userEvent.setup();
+    renderCell();
+
+    await user.hover(screen.getByRole("button"));
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("View agents");
+    expect(tooltip.querySelector("kbd")).toBeNull();
+  });
+});

--- a/mycelium-frontend/src/components/status-items.tsx
+++ b/mycelium-frontend/src/components/status-items.tsx
@@ -9,16 +9,38 @@ import { BarChart3 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useGlobalStatus } from "@/lib/use-status";
 import { Tooltip } from "@/components/ui/tooltip";
+import { KbdChord } from "@/components/ui/kbd";
+
+const CELL = "flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text";
+
+interface CellProps {
+  tooltip?: string;
+  /** Keymap action this cell duplicates. Its chord is drawn as a keycap beside
+   *  the tooltip label, so the cheap way in teaches the fast one — the rail is
+   *  the one place every screen shows, and a cell that a key already reaches
+   *  had no way of saying so. Silent when the keymap doesn't bind the action. */
+  action?: string;
+  children: ReactNode;
+}
+
+/** The tooltip body for a cell: its label, plus the key that does the same
+ *  thing. A cell with no binding keeps the bare string. */
+function cellTooltip(tooltip: string | undefined, action: string | undefined): ReactNode {
+  if (!tooltip || !action) return tooltip;
+  return (
+    <span className="flex items-center gap-1.5">
+      {tooltip}
+      <KbdChord size="xs" action={action} />
+    </span>
+  );
+}
 
 /** A status-bar cell that navigates somewhere on click (editor footer style).
  *  The bar sits at the bottom of the viewport, so its tooltips open upward. */
-export function StatusLink({ href, tooltip, children }: { href: string; tooltip?: string; children: ReactNode }) {
+export function StatusLink({ href, tooltip, action, children }: CellProps & { href: string }) {
   return (
-    <Tooltip content={tooltip} side="top">
-      <Link
-        href={href}
-        className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text"
-      >
+    <Tooltip content={cellTooltip(tooltip, action)} side="top">
+      <Link href={href} className={CELL}>
         {children}
       </Link>
     </Tooltip>
@@ -26,14 +48,10 @@ export function StatusLink({ href, tooltip, children }: { href: string; tooltip?
 }
 
 /** A status-bar cell that fires an action on click. */
-export function StatusButton({ onClick, tooltip, children }: { onClick: () => void; tooltip?: string; children: ReactNode }) {
+export function StatusButton({ onClick, tooltip, action, children }: CellProps & { onClick: () => void }) {
   return (
-    <Tooltip content={tooltip} side="top">
-      <button
-        type="button"
-        onClick={onClick}
-        className="flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text"
-      >
+    <Tooltip content={cellTooltip(tooltip, action)} side="top">
+      <button type="button" onClick={onClick} className={CELL}>
         {children}
       </button>
     </Tooltip>
@@ -81,9 +99,7 @@ export function MetricsStatusLink() {
       <Link
         href="/metrics"
         aria-current={active ? "page" : undefined}
-        className={`flex items-center gap-1.5 rounded px-1.5 py-0.5 -my-0.5 transition-colors hover:bg-hairline hover:text-text ${
-          active ? "text-text" : ""
-        }`}
+        className={`${CELL} ${active ? "text-text" : ""}`}
       >
         <BarChart3 className="size-3.5" />
         metrics

--- a/mycelium-frontend/src/components/ui/command.tsx
+++ b/mycelium-frontend/src/components/ui/command.tsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import { Command as CommandPrimitive } from "cmdk";
 import { SearchIcon } from "lucide-react";
 
+import { Kbd } from "@/components/ui/kbd";
 import { cn } from "@/lib/utils";
 
 /** shadcn's `command` (cmdk), restyled onto the app's tokens: the stock recipe
@@ -109,15 +110,15 @@ function CommandItem({ className, ...props }: React.ComponentProps<typeof Comman
   );
 }
 
-/** The chord an item answers to, drawn like a keycap on the cheatsheet. */
+/** The chord an item answers to, drawn as the same keycap the cheatsheet and
+ *  the status rail use — only pushed to the row's right edge and lit with the
+ *  selection. */
 function CommandShortcut({ className, ...props }: React.ComponentProps<"kbd">) {
   return (
-    <kbd
+    <Kbd
       data-slot="command-shortcut"
-      className={cn(
-        "ml-auto flex-shrink-0 rounded border border-border bg-surface px-1.5 py-0.5 font-mono text-micro text-muted-foreground group-data-[selected=true]/command-item:text-text",
-        className,
-      )}
+      tone="muted"
+      className={cn("ml-auto group-data-[selected=true]/command-item:text-text", className)}
       {...props}
     />
   );

--- a/mycelium-frontend/src/components/ui/kbd.test.tsx
+++ b/mycelium-frontend/src/components/ui/kbd.test.tsx
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { Kbd, KbdChord } from "@/components/ui/kbd";
+import { KEYMAP } from "@/lib/keymap";
+
+describe("<Kbd />", () => {
+  it("renders a kbd element, so a key is marked up as one", () => {
+    render(<Kbd>Esc</Kbd>);
+    expect(screen.getByText("Esc").tagName).toBe("KBD");
+  });
+
+  it("draws every size at a height the 24px status rail can hold", () => {
+    for (const size of ["xs", "sm", "md"] as const) {
+      const { unmount } = render(<Kbd size={size}>K</Kbd>);
+      const cap = screen.getByText("K");
+      const height = /h-\[?(\d+)(?:px)?\]?/.exec(cap.className);
+      expect(height, `${size} declares no height`).not.toBeNull();
+      // Tailwind's bare scale is quarter-rems; an arbitrary value is px.
+      const px = height![0].includes("[") ? Number(height![1]) : Number(height![1]) * 4;
+      expect(px, `${size} is too tall for the status rail`).toBeLessThanOrEqual(24);
+      unmount();
+    }
+  });
+});
+
+describe("<KbdChord />", () => {
+  it("spells a chord for the platform it is told about", () => {
+    const { unmount } = render(<KbdChord chord="mod+k" mac />);
+    expect(screen.getByText("⌘K")).toBeInTheDocument();
+    unmount();
+
+    render(<KbdChord chord="mod+k" mac={false} />);
+    expect(screen.getByText("Ctrl+K")).toBeInTheDocument();
+  });
+
+  it("reads the chord off the keymap when given an action", () => {
+    render(<KbdChord action="palette.open" mac />);
+    expect(screen.getByText("⌘K")).toBeInTheDocument();
+  });
+
+  it("renders nothing for an action the keymap does not bind, rather than an empty cap", () => {
+    const { container } = render(<KbdChord action="does.not.exist" mac />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("defaults to the platform the browser reports", () => {
+    vi.spyOn(navigator, "userAgent", "get").mockReturnValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)");
+    render(<KbdChord chord="mod+k" />);
+    expect(screen.getByText("⌘K")).toBeInTheDocument();
+    vi.restoreAllMocks();
+  });
+
+  it("draws a legible cap for every binding, so the cheatsheet has no blanks", () => {
+    for (const binding of KEYMAP) {
+      const { container, unmount } = render(<KbdChord chord={binding.keys[0]} mac={false} />);
+      expect(container.querySelector("kbd")?.textContent, binding.id).toBeTruthy();
+      unmount();
+    }
+  });
+});

--- a/mycelium-frontend/src/components/ui/kbd.tsx
+++ b/mycelium-frontend/src/components/ui/kbd.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
+
+import { useIsMac } from "@/lib/client-hooks";
+import { chordFor, formatChord } from "@/lib/keymap";
+import { cn } from "@/lib/utils";
+
+/** One keycap language for the whole app. Every surface that names a key —
+ *  the cheatsheet, the palettes' shortcut column and their footers, the
+ *  composer hint, the status rail — draws it through this, so a key reads the
+ *  same wherever it appears and no surface can quietly go back to plain text.
+ *
+ *  Mono, because a key is a glyph you press rather than a word you read. The
+ *  cap is sized by where it sits, not by emphasis: `xs` is the one that fits
+ *  the 24px status rail, `sm` is the default for palettes and hint rows, `md`
+ *  for the cheatsheet's own two-column list. */
+const kbdVariants = cva(
+  "inline-flex flex-shrink-0 select-none items-center justify-center rounded border font-mono font-medium leading-none",
+  {
+    variants: {
+      size: {
+        xs: "h-4 min-w-4 gap-0.5 px-1 text-[10px]",
+        sm: "h-5 min-w-5 gap-0.5 px-1.5 text-[11px]",
+        md: "h-[22px] min-w-[22px] gap-1 px-1.5 text-micro",
+      },
+      tone: {
+        /** The cap as an object: a raised key on the surface ladder. */
+        default: "border-border bg-surface text-text",
+        /** A cap inside already-quiet copy — a palette footer, a hint row. */
+        muted: "border-border bg-surface text-muted-foreground",
+      },
+    },
+    defaultVariants: { size: "sm", tone: "default" },
+  },
+);
+
+type KbdProps = ComponentProps<"kbd"> & VariantProps<typeof kbdVariants>;
+
+/** A literal key, spelled by the caller: `<Kbd>Esc</Kbd>`, `<Kbd>↵</Kbd>`. */
+export function Kbd({ className, size, tone, ...props }: KbdProps) {
+  return <kbd data-slot="kbd" className={cn(kbdVariants({ size, tone }), className)} {...props} />;
+}
+
+interface ChordProps extends Omit<KbdProps, "children"> {
+  /** A chord in the keymap's notation ("mod+k", "alt+c", "?"). */
+  chord?: string;
+  /** An action id, for the chord the keymap currently binds it to. */
+  action?: string;
+  /** Platform override; defaults to what the browser reports. Call sites that
+   *  already carry `mac` (the palettes take it as a prop) pass it through so
+   *  one render can't disagree with itself about ⌘ versus Ctrl. */
+  mac?: boolean;
+}
+
+/** The cap for a chord, spelled for the platform: ⌘K on a Mac, Ctrl+K
+ *  elsewhere. Renders nothing when the action has no binding, so a call site
+ *  can name an action without first proving the keymap still binds it. */
+export function KbdChord({ chord, action, mac, ...props }: ChordProps) {
+  const detected = useIsMac();
+  const resolved = chord ?? (action ? chordFor(action) : undefined);
+  if (!resolved) return null;
+  return <Kbd {...props}>{formatChord(resolved, mac ?? detected)}</Kbd>;
+}
+
+export { kbdVariants };


### PR DESCRIPTION
## Summary

The app named keys four different ways. The `?` cheatsheet had a local `Keycap`. `ui/command.tsx` had `CommandShortcut`, styled almost but not quite the same. And ten call sites were bare `<kbd className="font-sans">` — no border, no mono, no cap. That third group is what the **bottom status rail** was made of, so the strip every screen shows rendered `/ search`, `Ctrl+K commands` and `? keys` in the same sans as their own labels: keys set as prose, indistinguishable from the words beside them.

`src/components/ui/kbd.tsx` is now the one keycap language, with three sizes picked by **where a cap sits** rather than by emphasis — `xs` is the one that fits the 24px rail, `sm` the palettes and hint rows, `md` the cheatsheet's two-column list.

## Changes

**New — `ui/kbd.tsx`**
- `Kbd` — a literal key: `<Kbd size="xs">Esc</Kbd>`. `cva` variants for `size` (`xs` / `sm` / `md`) and `tone` (`default` / `muted`), following `ui/button.tsx`.
- `KbdChord` — the cap for a chord the keymap owns, taken either as a chord or as an **action id**, and spelled for the platform (⌘K on a Mac, Ctrl+K elsewhere). It renders **nothing** when the keymap doesn't bind the action, so a call site can name an action without first proving the binding survives a keymap edit. `mac` is overridable, because the palettes already carry it as a prop and one render must not disagree with itself.

**Migrated every keycap in the tree** — the exploration turned up ten, in seven files:
- `keymap-cheatsheet.tsx` — the local `Keycap` is gone; the header's ⌥/Esc are caps now instead of unstyled `<kbd>`, and so is the *alternate* chord (`] or J`), which was plain text.
- `ui/command.tsx` — `CommandShortcut` is `Kbd` plus the two things that are actually its own: `ml-auto`, and lighting up with the row selection.
- `command-palette.tsx`, `search-palette.tsx` — the shortcut column and both `↑↓ / ↵ / Esc` footers.
- `room-chat-box.tsx` — the composer's `Enter` / `Shift+Enter` / `Esc` hint.
- `keymap-provider.tsx`, `global-search.tsx` — the three rail buttons.

**The rail gains the affordance it had none of.** `StatusLink` / `StatusButton` take an `action`, and draw that binding's key beside the tooltip label. Wired where a cell and a key already do the same thing — the episodes and agents cells against `rail.episodes` / `rail.agents`, both of which those cells' own `openTab` calls already answer — so the discoverable way in teaches the fast one. A cell with no binding keeps its bare string, unchanged.

**Deliberately untouched:** `key-badge.tsx`. The ⌥-reveal badge is drawn *on* a target and positioned out of flow; it shares the word "key" with a keycap and nothing else. Folding it in would have made one component answer to two shapes.

## Testing

Frontend gate, matching CI (`ci.yml` → *Frontend typecheck + lint + build*):

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint .` — 0 errors (the 5 warnings are pre-existing, in files this PR doesn't touch: `episodes-rail`, `l9-inspector`, `markdown-content`, `sse.test`, `use-collapsible-rail`)
- [x] `npx vitest run` — 577 passed (568 before; 9 new)
- [x] `npx next build` — clean

New tests, both mutation-checked:
- `ui/kbd.test.tsx` — platform spelling both ways, action → chord off the keymap, nothing rendered for an unbound action, a legible cap for **every** binding in `KEYMAP`, and that no size is too tall for the 24px rail. Widening `xs` to `h-8` turns that last one red.
- `status-items.test.tsx` — a cell with an `action` puts the key in its tooltip; one without keeps the bare label. Dropping the keycap from `cellTooltip` turns the first one red.

Looked at with `shotkit`: the rail (dark + light), the `?` cheatsheet, the command palette, the search palette, the composer hint. I have not attached the captures — this session can only reach GitHub through the API, which has no image upload, and a rendered-inline screenshot needs the web drag-drop path (the same constraint `CLAUDE.md` records for the promo video). Reproduce them with `node shotkit/bin/shot.mjs app /room/atlas-migration --mock --offline`.

The phone breakpoint was checked against a stashed baseline: the rail already overflows at 390px on `main`, and this change does not move it — a cap adds a few px to cells that were already drawing the same glyph as text.

## Related Issues

None — this came out of reading the rail.
