### PR TITLE
Clarify docs generation dependency on version pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,11 +149,15 @@ jobs:
       # config schema. Same contract as the openapi.json check above: regenerate,
       # fail if the tree moves. Without it the committed output drifts silently and
       # the backlog lands as unrelated diff in whichever PR next runs the generator.
+      #
+      # The error names the version pins because they are the input nobody expects:
+      # the dependency table resolves them at generate time, so a bump reddens this
+      # check in a change that never touched a doc.
       - name: Docs site is current
         run: |
           (cd mycelium-cli && uv run python ../docs/generate_docs.py)
           if [ -n "$(git status --porcelain -- docs/)" ]; then
-            echo "::error file=docs/llms-full.txt::Generated docs are stale — run 'cd mycelium-cli && uv run python ../docs/generate_docs.py' and commit docs/."
+            echo "::error file=docs/llms-full.txt::Generated docs are stale — run 'cd mycelium-cli && uv run python ../docs/generate_docs.py' and commit docs/. The dependency table reads its versions live from both pyproject files and the compose.yml image tags, so bumping a dependency makes docs/ stale on its own — no doc has to have been edited."
             git status --porcelain -- docs/
             git diff --stat -- docs/
             exit 1


### PR DESCRIPTION
## Summary

Expands the error message in the docs staleness check to explain why bumping dependencies alone (without editing docs) causes the check to fail. This addresses a common source of confusion where developers don't realize that the dependency table is read live from `pyproject.toml` files and `compose.yml` image tags during doc generation.

## Changes

- Added explanatory comment block above the "Docs site is current" CI job describing why version pins matter
- Expanded the error message to clarify that dependency bumps automatically stale the docs, even without doc edits

## Testing

N/A — documentation and error message only; no functional changes to code paths.

https://claude.ai/code/session_01J8amkhr4wKahXV35aPdbtE