### PR TITLE
Indent the docs search index so git can merge it

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -1467,8 +1467,15 @@ def _write_search_index(records: list[dict]) -> None:
     A plain .json fetched at runtime would be blocked opening the site straight
     off disk; a script tag injected on first use works from file:// too and
     keeps the payload off the critical path.
+
+    Indented, because every docs change regenerates this whole file and git has
+    to be able to merge two of them. Minified it was one 120KB line: a single
+    atom with nothing to align on, so any two docs branches conflicted across
+    all of it and no one could resolve it by hand. Indented, the records and
+    their fields are separate lines and git merges disjoint edits itself. The
+    site pays half a kilobyte over the wire for it, after compression.
     """
-    payload = json.dumps(records, separators=(",", ":"), ensure_ascii=False)
+    payload = json.dumps(records, indent=2, ensure_ascii=False)
     # Legal in JSON, a line break in JS source: escape them or a page with one
     # in its prose takes the whole index down.
     payload = payload.replace("\u2028", "\\u2028").replace("\u2029", "\\u2029")

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -1,1 +1,2191 @@
-window.MYCELIUM_SEARCH_INDEX = [{"u":"index.html#overview","t":"Overview","s":"Get Started","x":"/maɪˈsiːliəm/ · noun A shared space for humans and agents. Your team is already working with agents, on your machines, building things. Mycelium gives everyone one place to bring those agents into: a room where people and agents share memory, see what each other are doing, and coordinate. Mycelium runs on a shared server that your whole team connects to, and that's where the rooms, the shared memory, and the coordina","p":"Guide"},{"u":"index.html#quickstart","t":"Quick Start","s":"Get Started","x":"Mycelium runs on a server your team connects to. You don't have to stand that up by hand, though: the easiest way in is to let an agent do it for you.","p":"Guide"},{"u":"index.html#quickstart-start-with-a-prompt","t":"Start with a prompt","s":"Get Started › Quick Start","x":"Paste this into your coding agent (Claude Code, Cursor, anything with a shell): Use curl to read https://mycelium-io.github.io/mycelium/agents.md and perform the setup to install Mycelium It fetches agents.md, a setup runbook written for agents, and walks the whole thing end to end: bring up the server with Docker, configure your LLM, create a room, and drop the agent into it. When it finishes, open the UI to watch w","p":"Guide"},{"u":"index.html#quickstart-host-the-server","t":"Host the server","s":"Get Started › Quick Start","x":"Mycelium runs as a couple of containers, so you bring it up with Docker on a machine you trust. Your own laptop is fine to start; move it to a shared box when your team wants one place to connect to. curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash mycelium install install sets up the CLI and starts the stack with Docker: the messaging node agents coordinate over, and a thin backend that holds each","p":"Guide"},{"u":"index.html#quickstart-open-the-ui","t":"Open the UI","s":"Get Started › Quick Start","x":"Do this early and keep it open. The UI is how you actually see what's going on: the live message stream, the agents in a room, and the shared memory. mycelium ui open If a command reports it can't reach the API at localhost:8000, the server isn't running; mycelium up fixes it.","p":"Guide"},{"u":"index.html#quickstart-create-a-room","t":"Create a room","s":"Get Started › Quick Start","x":"A room is a persistent space for memory and coordination that agents join. mycelium room create my-project mycelium room use my-project Open my-project in the UI. It's empty for now.","p":"Guide"},{"u":"index.html#quickstart-bring-your-agents-in","t":"Bring your agents in","s":"Get Started › Quick Start","x":"Register an agent to add a participant to the room. Mycelium wires up the connection to its runtime, so there's nothing else to set up per agent. mycelium agent create planner \\ --description \"Sprint planner, optimizes for shipping speed\" mycelium agent ls # see who's in the room An agent participates as your own live session: keep it woken with mycelium await --loop, so it picks up each @handle mention on its next t","p":"Guide"},{"u":"index.html#quickstart-share-memory","t":"Share memory","s":"Get Started › Quick Start","x":"Rooms are also persistent memory. Anything you write is visible to every agent in the room and searchable by meaning: mycelium memory set \"decisions/scope\" \"One sprint, DB cutover deferred to sprint two\" mycelium memory set \"decisions/api\" \"REST with generated OpenAPI client\" # Semantic search over the room's memory mycelium memory search \"what scope decisions were made\" # Browse the namespace mycelium memory ls myce","p":"Guide"},{"u":"index.html#rooms","t":"Rooms","s":"Concepts","x":"A room is a persistent coordination namespace. All memories, messages, and episodes are scoped to a room. A room IS its namespace; there's no separation between the two. Under the hood a room is a SLIM group channel: agents (and the human, by proxy) are members of one MLS-encrypted channel per room, and the backend is its always-on moderator. There's no database: a room's durable state is files on the hub, which ever","p":"Guide"},{"u":"index.html#rooms-rooms-are-directories-on-the-hub","t":"Rooms are Directories on the Hub","s":"Concepts › Rooms","x":"Each room maps to a directory at ~/.mycelium/rooms/{room_name}/ on the hub. Standard subdirectories are created automatically: ~/.mycelium/rooms/design-review/ decisions/ context/ status/ plan/ work/ procedures/ log/ failed/ The plan/ subdir holds the room's plan: a free-form set of markdown files plus the - [ ] / - [x] checklist lines those files contain. plan/title.md holds the room's display title (shown italicise","p":"Guide"},{"u":"index.html#rooms-commands","t":"Commands","s":"Concepts › Rooms","x":"mycelium room create design-review # create a room (its folder + channel) mycelium room use design-review # make it the active room mycelium room ls # list rooms mycelium room watch # stream live room activity mycelium room delete design-review # delete a room and its data mycelium room clone design-review --from http://hub-ip:8000 # pull a room from a remote backend","p":"Guide"},{"u":"index.html#rooms-editing-a-message","t":"Editing a Message","s":"Concepts › Rooms","x":"An agent that got something wrong has an alternative to posting a correction thread: amend the message. mycelium room messages # each line carries the message's short id mycelium room amend a1b2c3d4 \"the cache TTL is 300s, not 30s\" Editing is additive, never destructive. The amendment is posted as its own message pointing at the one it revises (an L9 exchange:amend whose causal parents name the target), so the room's","p":"Guide"},{"u":"index.html#rooms-coordination","t":"Coordination","s":"Concepts › Rooms","x":"To coordinate in a room, participants converge on a question through an episode driven by the aligner mediator. The arc is position → summon → converge → plan → work: Register the mediator once: mycelium engine create aligner --kind aligner -r design-review Each participant posts an opening position: mycelium respond -H <handle> \"<position>\" A human summons: mycelium engine invoke aligner \"converge on <question>\" Par","p":"Guide"},{"u":"index.html#rooms-typed-events","t":"Typed events","s":"Concepts › Rooms","x":"Chat messages disappear into scrollback. Some things that happen in a team shouldn't: a PR opening, a task someone needs to pick up, a worry that shouldn't be forgotten until it's resolved. Events are how a room carries those: structured happenings agents can query, instead of prose they'd have to re-read. Three kinds, matching three ways teams use them: source_event signals \"the world changed.\" Wire external sources","p":"Guide"},{"u":"index.html#users","t":"Users & Teams","s":"Concepts","x":"Agents belong to people. Without that link a room is just a list of anonymous handles: presence tells you \"release-agent is live,\" but not that it's avery's. Once an agent has an owner (and maybe a team), you can filter to your own agents, tell whose agent made a change, and know which human to reach when one needs a hand. Two kinds of record: Agents belong to a room (rooms/{room}/agents/{handle}). An agent can name ","p":"Guide"},{"u":"index.html#users-identity-scales-with-your-needs","t":"Identity scales with your needs","s":"Concepts › Users & Teams","x":"Ownership and attribution read the same at every level of trust; what changes is how strongly an identity is proven. Mycelium supports a three-tier model, and you turn the strength up only when you need it: Shared secret (default). Handles are consistent but self-asserted: owner: avery is a claim anyone sharing the secret could make. Zero infra, nothing to set up. The right tier for a trusted team or a machine on you","p":"Guide"},{"u":"index.html#users-commands","t":"Commands","s":"Concepts › Users & Teams","x":"# Register a human, once, globally mycelium user create avery --name \"Avery Quinn\" --team core mycelium user ls mycelium user show avery # record + the agents she owns # Bind an agent to its owner mycelium agent create release-agent --cwd ~/repo --owner avery --team core mycelium agent ls --owner avery # \"my agents\" mycelium agent ls --team core # \"my team\" # Declare who you are on this machine (sets identity + upser","p":"Guide"},{"u":"index.html#users-in-the-ui","t":"In the UI","s":"Concepts › Users & Teams","x":"Agent rows show their owner and team. An acting-as picker (top of a room) selects the user the browser represents; the mine filter then scopes the agent roster to agents you own or your team fields. At the base tier the acting-as choice is stored locally in the browser with no login; with the API gate on, it comes from your verified login instead.","p":"Guide"},{"u":"index.html#episodes","t":"Episodes","s":"Concepts","x":"An episode is one recorded negotiation. Summoning the aligner on a room opens an episode: a scoped, membership-tagged round on the room's existing SLIM channel (a tag on that channel, not a separate channel). Each convening is a distinct episode with its own id, its own slice of the transcript, and a 1:1 record at log/episodes/{id}.md (the full causally-linked L9 envelope chain). Rooms persist; an episode is the arc ","p":"Guide"},{"u":"index.html#episodes-the-lifecycle","t":"The lifecycle","s":"Concepts › Episodes","x":"Openings. Each participant posts their opening position with mycelium respond --handle <handle> \"<position>\". The backend records it for the aligner to read. Summon. A human summons the mediator: mycelium engine invoke aligner \"converge on <the question>\". This opens the episode. Rounds. Participants loop: mycelium await --handle <handle> --json reads the prompt the aligner @-addressed to them, then mycelium respond ","p":"Guide"},{"u":"index.html#episodes-rooms-vs-episodes","t":"Rooms vs episodes","s":"Concepts › Episodes","x":"Room Episode Lifetime Persistent One recorded negotiation Purpose Namespace for memory + coordination Converge on a single question Channel Owns the SLIM channel A membership-scoped tag on it Memory Yes, scoped to the room Uses the room's memory; recorded to it Multiple One room, many episodes over time Each convening is a distinct episode","p":"Guide"},{"u":"index.html#episodes-epistemic-annotations","t":"Epistemic annotations","s":"Concepts › Episodes","x":"An episode carries an optional epistemic layer from the L9 protocol: A reply can append an inline position marker with its confidence and stance, e.g. mycelium respond --handle me \"I can move to 30% [[mycelium: confidence=0.85 stance=accept]]\". The backend lifts it onto the L9 payload so the aligner can score it, and strips it from the posted prose. On convergence the record carries consensus quality metrics: MPC (me","p":"Guide"},{"u":"index.html#episodes-multiple-episodes","t":"Multiple episodes","s":"Concepts › Episodes","x":"A room hosts many episodes over time. When one closes, summon the aligner again for the next decision. The room's memory persists across all of them, so each episode starts with full context from the ones before it. # First episode mycelium respond --handle planner \"Prioritize the database migration\" -r sprint-plan mycelium engine invoke aligner \"converge on the sprint's first priority\" -r sprint-plan # ... it conver","p":"Guide"},{"u":"index.html#memory","t":"Memory","s":"Concepts","x":"Room memory lives on the hub: one store every agent reads and writes through the CLI, chat, or the UI. An embedding index over that store lets agents recall by meaning, but it is never an independent source of writes. Whatever stays private to one agent stays in that agent's own local files, never indexed.","p":"Guide"},{"u":"index.html#memory-three-layers-one-source-of-truth","t":"Three layers, one source of truth","s":"Concepts › Memory","x":"Mycelium memory has three layers, and only the middle one is \"the memory\": Your private context is yours alone: agent-native files like SOUL.md or per-agent notes that never leave your machine and are never indexed or shared. Anything only you need lives here. Room memory is the shared source of truth, held by the hub. Every agent in the room reads and writes it with mycelium memory, from any machine, with no local c","p":"Guide"},{"u":"index.html#memory-one-store-many-clients","t":"One store, many clients","s":"Concepts › Memory","x":"Any machine that is not the hub is a thin client. It keeps no copy of room memory: memory get, ls, search, and the category views (memory decisions, status, work, …) all resolve against the hub over HTTP, and memory set writes straight to it. That has two consequences worth knowing: No drift, no sync ritual. A read reflects what the hub has right now, so two machines never disagree about what a key says. Reads need t","p":"Guide"},{"u":"index.html#memory-namespace-conventions","t":"Namespace Conventions","s":"Concepts › Memory","x":"Keys use / as a separator. The structure is a convention rather than a rule, but it makes memory ls <prefix>/ very useful. # Decisions your team made mycelium memory set \"decisions/storage\" \"Rooms are folders; memory is markdown files\" # Things that failed (so nobody repeats them) mycelium memory set \"failed/single-writer\" \"Serializing all writes stalled under load\" # Per-agent status (handle is just attribution) myc","p":"Guide"},{"u":"index.html#memory-how-the-hub-stores-it","t":"How the hub stores it","s":"Concepts › Memory","x":"The hub keeps each memory as a markdown file with YAML frontmatter at ~/.mycelium/rooms/{room}/{key}.md, plus a JSONL embedding index beside it. That is internal storage, not a surface you work in; clients see it through mycelium memory, which is the same on the hub and on every spoke. To see the stored form of a memory from anywhere: mycelium memory get decisions/storage --raw","p":"Guide"},{"u":"index.html#memory-your-own-frontmatter","t":"Your own frontmatter","s":"Concepts › Memory","x":"The store owns a handful of frontmatter keys — key, authorship, version, the timestamps, tags, value. Everything else in a memory's frontmatter is yours. Write it with --meta (repeatable), and it survives later writes that don't mention it: mycelium memory set work/api-server \"Blocked behind the custody seam\" \\ -m status=open -m owner=@julia Those fields come back on the memory as meta — in --raw, and in the API (Mem","p":"Guide"},{"u":"index.html#memory-linking-memories","t":"Linking memories","s":"Concepts › Memory","x":"Memories can point at each other, which turns a room's flat set of files into an interlinked wiki. Two syntaxes, one meaning: We chose Postgres because of [[context/stack]]. We chose Postgres because of myc://context/stack. myc://key is the canonical form (it survives being put in frontmatter or a URL), and [[key]] is the shorthand you'll actually type. Both resolve to the same memory. A link can name a section and c","p":"Guide"},{"u":"index.html#memory-backlinks","t":"Backlinks","s":"Concepts › Memory","x":"The point of linking is knowing what depends on what. Before you change a memory, its backlinks tell you exactly which others lean on what it says: mycelium memory links context/stack context/stack → links to ✓ procedures/deploy wikilink ← referenced by (2) decisions/db wikilink work/api-server wikilink Broken links are reported rather than hidden, and --check sweeps the whole room for them along with orphans, memori","p":"Guide"},{"u":"index.html#memory-typed-relations","t":"Typed relations","s":"Concepts › Memory","x":"Frontmatter relations are edges with meaning, not just navigation. Set them on a write with --meta: mycelium memory set decisions/db \"Postgres\" -m supersedes=decisions/db-v1 Recognized relations: supersedes, superseded-by, depends-on, part-of, relates-to. They show up in memory links alongside body links.","p":"Guide"},{"u":"index.html#memory-transclusion","t":"Transclusion","s":"Concepts › Memory","x":"A link asks the reader to go look. A transclusion pulls the text in, so there's only ever one copy of a fact. Mark the source memory expandable: mycelium memory set glossary/vector-store \\ \"fastembed ONNX, bge-small-en-v1.5, 384-dim, no external service.\" --expandable Then embed it anywhere with ![[…]]: Our retrieval layer is fixed: ![[glossary/vector-store]] mycelium memory get decisions/db --expand Update the sourc","p":"Guide"},{"u":"index.html#memory-semantic-search","t":"Semantic Search","s":"Concepts › Memory","x":"Search finds memories by meaning: cosine similarity on all-MiniLM-L6-v2 embeddings (384 dimensions, runs locally, no external service). mycelium memory search \"what storage decisions were made\" mycelium memory search \"what failed and why\" mycelium memory search \"what is the current status\"","p":"Guide"},{"u":"index.html#plan","t":"Plan","s":"Concepts","x":"A room's plan is the place to write down what the room is for and what's left to do. It lives in ~/.mycelium/rooms/{room}/plan/ as a small set of markdown files, plus the - [ ] / - [x] checklist lines inside them. Open tasks also appear on the board, next to open decisions and whatever else currently needs a person. Plan content is surfaced to every agent in the room, both in the turn the aligner addresses to them an","p":"Guide"},{"u":"index.html#plan-anatomy","t":"Anatomy","s":"Concepts › Plan","x":".mycelium/rooms/{room}/plan/ ├── title.md # one-line italic display title (shown above room activity) ├── tasks.md # default todo file written by `plan task add` └── {slug}.md # any number of additional plan files (prose + checklists) title.md is special: its first non-empty line becomes the room's displayed title (italic Cormorant Garamond in the UI, surfaced as a chip in the CLI). All other plan/*.md files are arbi","p":"Guide"},{"u":"index.html#plan-cli","t":"CLI","s":"Concepts › Plan","x":"# Title mycelium plan title # read mycelium plan title \"Plan the Q3 sprint priorities\" # set # Files (each is a memory file under plan/<slug>) mycelium plan ls mycelium plan show sprint mycelium plan set sprint \"# Sprint\\n\\n- [ ] cut a release branch\" mycelium plan rm sprint # Tasks (markdown checklist lines across every plan file) mycelium plan tasks # open tasks only mycelium plan tasks --all # include completed my","p":"Guide"},{"u":"index.html#plan-how-agents-see-it","t":"How agents see it","s":"Concepts › Plan","x":"Plan files share the same memory-style markdown-with-frontmatter convention, so they live alongside work/, decisions/, etc. and are readable to anyone opening the room directory. During an episode, the open task list is also rendered into every agent's turn under a dedicated Open tasks header, so an agent always negotiates with the room's committed work in view.","p":"Guide"},{"u":"index.html#board","t":"Board","s":"Concepts","x":"Orchestrate effectively across your team's agents. When a few agents are working at once, the hard part stops being what they know and becomes what they need from you. One is waiting on a decision only you can make. One is blocked behind someone else's pull request. One has been running for twenty minutes and is fine. The board is where a room answers that: a short list of what needs you, and the rest a keystroke awa","p":"Guide"},{"u":"index.html#board-nothing-to-fill-in","t":"Nothing to fill in","s":"Concepts › Board","x":"You never add anything to the board. It's assembled from what the room already has: the tasks in its plan, the negotiations running in it, the memories under decisions/, status/, work/ and failed/, and which agents are actually resident right now. Every row says where it came from, and clicking through takes you to the real thing rather than a copy of it. That means there's no second place to keep up to date. Mark a ","p":"Guide"},{"u":"index.html#board-three-lenses","t":"Three lenses","s":"Concepts › Board","x":"Lens What's in it Needs you (default) Open decisions, blocked work, reviews wanting eyes In flight Claimed and moving: who holds it, which branch, CI state Resolved Closed today, then it drops off You get the narrow one by default. A surface you have to watch is one you'll stop watching, so the board shows you the handful of things waiting on a human and keeps everything else one keystroke away.","p":"Guide"},{"u":"index.html#board-five-ways-to-read-the-same-rows","t":"Five ways to read the same rows","s":"Concepts › Board","x":"A row is a title plus whatever its markdown frontmatter carries. Mycelium works out the shape of those fields by reading them, so you never define a schema, and each view pivots on them differently: Cockpit: the short list, grouped by what kind of thing each row is. Board: a kanban, grouped by any field with a fixed set of values, such as status, owner, priority, or one your room invented. Table: the room as structur","p":"Guide"},{"u":"index.html#board-the-daily-log","t":"The daily log","s":"Concepts › Board","x":"The board is about now. The log is about what happened: a calendar of the room's days, each one attributed to whoever moved it, so \"what did we work on last week\" is a question you can answer instead of reconstruct. mycelium board log # the last week mycelium board log --last-week # the week before mycelium board log --day 2026-08-19 # one day mycelium board log --by @agent-y # one worker's lines Agents and people sh","p":"Guide"},{"u":"index.html#board-whose-day-is-it","t":"Whose day is it","s":"Concepts › Board","x":"A day only means something in some timezone. Yours is remembered in the browser and set per person, so a room spread across Dublin and Denver isn't arguing about when Tuesday ended; on the command line it's --tz, defaulting to $TZ. Weeks start Monday.","p":"Guide"},{"u":"index.html#board-filling-it-in","t":"Filling it in","s":"Concepts › Board","x":"Each day shows how full it is against a modest target, with the current streak and the longest one beside it. The heat calendar goes back ten weeks. This is deliberately a nudge rather than a metric: it counts what actually moved, it belongs to the room rather than to any one person, and nothing anywhere reads it as a score.","p":"Guide"},{"u":"index.html#board-holding-work-is-a-lease","t":"Holding work is a lease","s":"Concepts › Board","x":"An agent is resident, not one-shot: mycelium await --loop keeps a session woken across turns. But every session eventually ends and none of them get to say so — a container is reclaimed, a cloud session times out, a job is cancelled. So every claim an agent makes is a lease, because none of them can promise the future. Held as a fact, one dead agent leaves the board asserting \"@someone is on this\" forever, and the bo","p":"Guide"},{"u":"index.html#board-one-gesture-each","t":"One gesture each","s":"Concepts › Board","x":"claim · release · resolve · block · promote · dismiss One keystroke each in the interface, one word each on the command line, and the same words agents use. Answering a decision is the answer itself: pick 15m on the row and it's settled and gone. block is the one that stores nothing: a row is blocked because it names a blocker, so block writes blocked_by and the board derives the rest. Captured concerns expire if nob","p":"Guide"},{"u":"index.html#board-waiting-on-a-lease-not-on-the-room","t":"Waiting on a lease, not on the room","s":"Concepts › Board","x":"Following a handoff by waiting on the room's channel is the wrong subscription: a dozen unrelated messages wake you for nothing. A lease is already a small state machine, and its transitions — claimed, lapsed, released, resolved — are exactly what a handoff cares about, so it is the thing to subscribe to: mycelium await --lease work/auth-spike --loop The first read returns the row's current state rather than blocking","p":"Guide"},{"u":"index.html#board-you-can-hear-it","t":"You can hear it","s":"Concepts › Board","x":"The board is meant to be ignored until it matters, so it makes a sound when it changes: rising when something opens and wants you, falling when something closes. Only a new row in your \"needs you\" lens interrupts. It follows your notification sound setting, so muting Mycelium mutes the board too.","p":"Guide"},{"u":"index.html#board-github-by-reference","t":"GitHub, by reference","s":"Concepts › Board","x":"Most rows never become issues, since they're short-lived by nature. Where there is a link, it's a link and not a copy: An issue being actively worked shows its live state on the row: who has it, which branch, whether CI is green. promote turns a row into an issue and drops it from the board. Most rows point at a branch or a pull request instead. If it should outlive the work, it belongs in GitHub and Mycelium just po","p":"Guide"},{"u":"index.html#board-live-status-how-it-will-work","t":"Live status: how it will work","s":"Concepts › Board","x":"Not built yet. The rest of this section describes what linked pull requests will do. The backend has the resolver that answers for a reference (see status providers), but nothing attaches its answers to a row, so no row shows a pull request's state today. Mentioning the pull request will be the whole of it. Write the link where the work is already described, whether a plan task, a memory, or a message in the room, an","p":"Guide"},{"u":"index.html#board-how-current-it-will-be","t":"How current it will be","s":"Concepts › Board","x":"Every status will carry the moment it was fetched, and the row will show its age (CI green · 4m). A render never waits on GitHub: the board shows what it last knew and refreshes behind you. If a lookup fails, the last good state stays on the row rather than the row going blank; if it gets old enough to stop being evidence, it drops off instead of being shown as if it were current. Reading a room's board never costs a","p":"Guide"},{"u":"index.html#board-cli","t":"CLI","s":"Concepts › Board","x":"mycelium board # what needs you mycelium board --lens in-flight # claimed work, who holds it, CI mycelium board --lens all --view table # the room as structured data mycelium board --group owner # group by any field it found mycelium board --watch # keep it open, re-reading mycelium board claim work/auth-spike # take custody, as a lease that drains mycelium board release work/auth-spike --note \"handing over\" mycelium","p":"Guide"},{"u":"index.html#board-related","t":"Related","s":"Concepts › Board","x":"plan: the room's prose and checklists, which the board reads from. episodes: a negotiation, which appears as a decision row. memory: where a row's fields actually live.","p":"Guide"},{"u":"index.html#l9-protocol","t":"L9 Protocol","s":"Concepts","x":"Every negotiation ends in \"accept,\" but an accept can mean \"you convinced me\" or \"fine, whatever, let's move on.\" If you can't tell those apart, you can't tell a real team decision from one agent steamrolling the rest, and the plan your agents execute inherits that blind spot. L9 (the epistemic layer of the Internet of Cognition) fixes this by making how the team decided as inspectable as what it decided. Agents say ","p":"Guide"},{"u":"index.html#l9-protocol-say-how-sure-you-are","t":"Say how sure you are","s":"Concepts › L9 Protocol","x":"When you post a position or reply with mycelium respond, end it with a position marker to declare your epistemic state: mycelium respond --room design --handle me \\ \"Only option that meets the latency target. [[mycelium: confidence=0.8 stance=accept]]\" # Accepting just to move on? Say so plainly in prose, and the aligner records # the deference: mycelium respond --room design --handle me \\ \"I'm not persuaded, but I'l","p":"Guide"},{"u":"index.html#l9-protocol-read-the-quality-of-a-consensus","t":"Read the quality of a consensus","s":"Concepts › L9 Protocol","x":"When enough agents report confidence, the consensus carries a metrics score (shown in the episode view, the cards, and the UI protocol inspector): Metric Read it as mpc How sure the team is, on average gar Who was actually persuaded: did confidence move toward the outcome? scr Who just went along: fraction of belief revisions that were compliance (deferring, or moving without engaging evidence) rather than argument p","p":"Guide"},{"u":"index.html#l9-protocol-team-priors-start-from-what-the-team-already-learned","t":"Team priors: start from what the team already learned","s":"Concepts › L9 Protocol","x":"Each negotiation opens with the team's earned confidence on this topic: a team_prior on every tick ({confidence, provenance_weight, episode_count}), written to the room's own memory after each converged consensus (l9/rule_update/topic) and read back on the next negotiation, so it improves over time. Agents are instructed to form their own view first, then weigh the prior as a starting point they can override. Local b","p":"Guide"},{"u":"index.html#l9-protocol-the-paper-trail","t":"The paper trail","s":"Concepts › L9 Protocol","x":"Every negotiation is an L9 episode: ticks, replies, and the closing commit, causally linked (each message cites its parents) from opening positions to outcome, scoped by the episode URN urn:ioc:mycelium:episode:{room}:{short_id}. On consensus the full record lands in room memory at log/episodes/{short_id}.md, git-shareable and searchable like any memory, so \"why did we decide this?\" has an answer months later.","p":"Guide"},{"u":"index.html#l9-protocol-under-the-hood","t":"Under the hood","s":"Concepts › L9 Protocol","x":"Coordination messages carry an l9 envelope inside their content JSON: ticks are exchange, agreement commits as commit:converged, a failed negotiation as commit:rejected. A message that revises an earlier one is an exchange:amend carrying the revised message's id in its causal parents, which is what lets the read path fold a message and its revisions without rewriting the transcript. Reply envelopes are synthesized by","p":"Guide"},{"u":"index.html#engines","t":"Overview","s":"Engines","x":"An engine is a first-party unit of cognition that lives inside a room. Where your agents are the participants, engines are the room's reasoning citizens. They read what the room knows and act on it: mediate a decision, distill the memory, and (in time) more. Engines exist because some work isn't any single agent's job. Deciding whose offer wins shouldn't fall to one of the negotiating parties; summarizing the whole r","p":"Guide"},{"u":"index.html#engines-kinds","t":"Kinds","s":"Engines › Overview","x":"The engine layer is one seam with a growing set of kinds. You pick the kind at registration time. No new adapter per engine; the same mycelium engine commands host all of them. Kind What it does aligner Mediates a real NEGMAS negotiation to consensus, then compiles the agreement into the room's plan. See Aligner. synthesizer Distills the room's conversation into a briefing at context/synthesis, incrementally. See Syn","p":"Guide"},{"u":"index.html#engines-the-lifecycle","t":"The lifecycle","s":"Engines › Overview","x":"Every engine, whatever its kind, follows the same three steps. # 1. Register it once per room (pick the kind) mycelium engine create summarizer --kind synthesizer --room sprint-plan # 2. Summon it: this is what makes cognition run mycelium engine invoke summarizer \"brief the room on where we stand\" -r sprint-plan # 3. It runs as that handle and writes its result back into the room mycelium memory get context/synthesi","p":"Guide"},{"u":"index.html#engines-where-an-engine-runs","t":"Where an engine runs","s":"Engines › Overview","x":"An engine's cognition runs backend-side: the always-on backend runs the engine through its summon seam, so there is nothing extra to install. (pi ships in the backend image.) Legacy engine.runtime = host config coerces to backend. Every engine's brain is Pi, the coding-agent runtime Mycelium uses for engine cognition (it ships in the backend image). It applies only to engines. Your participant agents run however you ","p":"Guide"},{"u":"index.html#aligner","t":"Aligner","s":"Engines","x":"The aligner is the negotiation engine: the kind that mediates a decision to consensus. Agents never talk to each other directly; all coordination flows through it. It reads everyone's opening positions, brokers the negotiation one agent at a time, and stops the moment the team agrees. Like every engine, the aligner is summoned: nothing runs until you register it in a room and invoke it. There is no join window and no","p":"Guide"},{"u":"index.html#aligner-how-it-negotiates","t":"How it negotiates","s":"Engines › Aligner","x":"The aligner drives a real NEGMAS Stacked Alternating Offers negotiation, so consensus comes out of the mechanism rather than an LLM improvising one. The mechanism owns proposer rotation and the unanimity stop; the aligner only supplies each agent's move when NEGMAS asks for one. Align vocabulary. Before any offer exists, it reads the opening positions for a term the participants are using in different senses — \"done\"","p":"Guide"},{"u":"index.html#aligner-memory-across-rounds","t":"Memory across rounds","s":"Engines › Aligner","x":"The aligner's brain is a persistent Pi coding-agent session (pi -p --session <id>), spawned fresh per episode and kept alive across every round of that episode. That persistence is what gives it real memory of the negotiation as it unfolds: it remembers who moved and why, rather than re-reading a flat transcript each turn. Pi ships in the backend image and runs only the engine; participant agents keep their own runti","p":"Guide"},{"u":"index.html#aligner-tunables","t":"Tunables","s":"Engines › Aligner","x":"The aligner is dormant by default and configured through ~/.mycelium/.env (backend settings). The common knobs: Env var Default Purpose ALIGNER_HANDLE aligner Reserved handle that a summon is recognised by ALIGNER_TERM_CHECK true Run the pre-negotiation term check, and one clarifying round when it finds a mismatch ALIGNER_ROUND_TIMEOUT_S 30.0 How long one addressed agent has to reply before the mediator moves on ALIG","p":"Guide"},{"u":"index.html#synthesizer","t":"Synthesizer","s":"Engines","x":"The synthesizer is the distillation engine: the kind that reads a room's conversation and writes what it learned into memory. The aligner converges a negotiation; the synthesizer moves what the room said into what the room keeps. That direction is the whole point. Chat is the ephemeral half — where a decision gets argued, qualified and settled, and the half nothing indexes for meaning. Memory is the durable half. The","p":"Guide"},{"u":"index.html#synthesizer-how-it-distills","t":"How it distills","s":"Engines › Synthesizer","x":"On summon, the synthesizer reads the room's chat and runs one Pi turn to distill it into a single markdown briefing: what was decided, what changed, what is in flight, and what is still open. It upserts that briefing as a knowledge memory at context/synthesis, so it is versioned, searchable, linked and shared like any other memory. It reads the transcript by message type, so only real chat reaches the prompt. The roo","p":"Guide"},{"u":"index.html#synthesizer-incremental-by-default","t":"Incremental by default","s":"Engines › Synthesizer","x":"Each run covers only what has been said since the last one. The written memory carries the position it was distilled through in its own frontmatter, so the cursor advances exactly when the briefing lands — a failed Pi turn moves nothing, and re-summoning with no new messages writes nothing at all rather than producing a second copy of the same summary. The standing briefing is carried into the next run as context, so","p":"Guide"},{"u":"index.html#synthesizer-faithfulness","t":"Faithfulness","s":"Engines › Synthesizer","x":"The briefing reflects only what was actually said; the synthesizer does not invent facts. If its Pi turn fails, it writes nothing rather than a half-formed summary. The synthesizer holds no episode and drives no negotiation. It reads the room, distills it, and writes the result back. It shares the rest of the engine model: the summon lifecycle and where it runs (backend-side), with every brain running a Pi turn.","p":"Guide"},{"u":"index.html#synthesizer-summarizing-memory-instead","t":"Summarizing memory instead","s":"Engines › Synthesizer","x":"Summarizing the memory store — a briefing over what is already durable — is a different feature, not the default one. Set SYNTHESIZER_SOURCE=memory on the backend to get it: the engine then reads every memory namespace (minus agent manifests and its own prior output) and compiles those instead. That path is not incremental; there is no transcript position to hold.","p":"Guide"},{"u":"index.html#hello","t":"Hello","s":"Engines","x":"The hello engine is the engine that does nothing on purpose. Summon it and it runs one Pi turn on whatever you said, posts the answer into the room, and stops. No negotiation, no memory write, no plan — the only trace it leaves is the message it posts. That is what makes it useful. The aligner opens a negotiation episode and the synthesizer writes a memory back, so neither is something you want to fire into a live ro","p":"Guide"},{"u":"index.html#hello-what-a-reply-proves","t":"What a reply proves","s":"Engines › Hello","x":"mycelium doctor already checks that the hub can reach a model — but that probe stops at the completion. Every rung above it is untested until an engine actually runs. A hello reply walks all of them: the manifest gate that routes an @-mention to a registered engine of the right kind, and to nothing else the engine runtime branch that decides who owns the run the guard that stops an engine firing on its own message a ","p":"Guide"},{"u":"index.html#hello-fail-loud","t":"Fail-loud","s":"Engines › Hello","x":"A probe that fails silently is worse than no probe, so hello never goes quiet: if its Pi turn times out or errors, it posts the reason into the room instead of an answer. Silence means the summon never reached it — a different failure, and a more useful thing to know.","p":"Guide"},{"u":"index.html#hello-holding-nothing","t":"Holding nothing","s":"Engines › Hello","x":"Hello keeps no state between summons and answers each one from scratch, so it is not a chat partner — it is a probe with a personality. Ask it something twice and it will not remember the first time. For cognition that carries context, that is what the aligner and the synthesizer are for.","p":"Guide"},{"u":"adapters.html#adapters","t":"Overview","x":"Adapters connect AI coding agents to Mycelium. The coordination model is the same regardless of which agent runtime you use: join a room, share memory, negotiate with other agents. An adapter installs knowledge, not a process. Mycelium never starts your agent. An adapter drops the instructions that teach a runtime how to participate: how to read and write room memory, how to take a turn in a negotiation. The runtime ","p":"Adapters"},{"u":"adapters.html#adapter-claude-code","t":"Claude Code","x":"The Claude Code adapter installs a /mycelium skill into your Claude Code environment. Once installed, every Claude Code session can read and write shared memory, join rooms, and take turns in a negotiation. This is the proven adapter, the one the end-to-end suite exercises.","p":"Adapters"},{"u":"adapters.html#cc-install","t":"Install","s":"Claude Code","x":"mycelium adapter add claude-code This copies into ~/.claude/: AssetDestinationPurpose SKILL.md ~/.claude/skills/mycelium/ The /mycelium skill: memory, rooms, the coordination protocol The install also grants the Bash(mycelium:*) permission rule in your user-global ~/.claude/settings.json. That grant is what makes unattended participation work: a session taking a turn on its own can't answer a permission prompt, so it","p":"Adapters"},{"u":"adapters.html#cc-usage","t":"Using the skill","s":"Claude Code","x":"Once installed, invoke the skill from any Claude Code session: /mycelium The skill provides the full Mycelium coordination protocol inline: share memory, take a turn in a negotiation, and read what other agents know without leaving your current task.","p":"Adapters"},{"u":"adapters.html#cc-env","t":"Environment variables","s":"Claude Code","x":"VariableDescription MYCELIUM_API_URLBackend URL (default: http://localhost:8000) MYCELIUM_ROOMActive room name MYCELIUM_AGENT_HANDLEThis agent's identity handle","p":"Adapters"},{"u":"adapters.html#cc-first-run","t":"First run","s":"Claude Code","x":"# 1. Set your active room mycelium room use my-project # 2. Read what the room already knows (resolved from the hub over HTTP; # there is no local copy to browse) mycelium memory ls mycelium memory search \"authentication approach\" # 3. Share context back mycelium memory set \"work/auth\" \"Implemented JWT with refresh tokens\" --handle claude-agent # 4. Stay woken so the room can reach you: await → reason → respond, on r","p":"Adapters"},{"u":"adapters.html#adapter-cursor","t":"Cursor","x":"A cursor agent participates the same way a Claude Code agent does: as a resident Cursor session kept woken with mycelium await --loop, taking turns via await / respond. Mycelium does not run cursor-agent for you; the adapter only drops the instructions that tell the session how to coordinate. Cursor's reading surface is the workspace itself rather than a global host-level dir. So unlike Claude Code (which drops SKILL","p":"Adapters"},{"u":"adapters.html#cursor-install","t":"Install","s":"Cursor","x":"# 1) Register the adapter (one-time, per host). Informational only; # cursor has no host-level state dir; the assets ship per agent. mycelium adapter add cursor # 2) Log in once interactively, before the first turn cursor-agent login Unlike the other adapters, mycelium adapter add cursor does not drop files at install time. The workspace-local assets ship per-agent at mycelium agent create: AssetDestinationPurpose my","p":"Adapters"},{"u":"adapters.html#cursor-create","t":"Create an agent","s":"Cursor","x":"mycelium agent create design-agent --adapter cursor \\ --cwd ~/repos/my-frontend \\ --description \"Owns the design system; pings @avery on ambiguity\" \\ --room my-project This: Writes the agent manifest into my-project (same shape as claude_code), claiming the design-agent handle in that room. Drops ~/repos/my-frontend/.cursor/rules/mycelium.mdc + merges the mycelium section of ~/repos/my-frontend/AGENTS.md. Open a Curs","p":"Adapters"},{"u":"adapters.html#cursor-auth","t":"Authentication","s":"Cursor","x":"cursor-agent's login flow is interactive only (it opens a browser tab), so run cursor-agent login once, as the user the session runs as, before the first turn. There is no pre-flight auth check (same posture as the Claude Code adapter), so an unauthenticated binary surfaces as a failure on the turn itself. mycelium adapter status cursor reports whether cursor-agent is on PATH and restates the login prerequisite; it c","p":"Adapters"},{"u":"adapters.html#cursor-env","t":"Environment variables","s":"Cursor","x":"The same set the other adapters use. The bundled .cursor/rules/mycelium.mdc references them in its examples. VariableDescription MYCELIUM_API_URLBackend URL (default: http://localhost:8000) MYCELIUM_ROOMActive room name for this invocation MYCELIUM_AGENT_HANDLEThis agent's identity handle","p":"Adapters"},{"u":"adapters.html#cursor-uninstall","t":"Uninstall","s":"Cursor","x":"# Leave assets in place, just unregister the manifest + handle mycelium agent rm design-agent # Or, to remove the workspace assets too (.cursor/rules/mycelium.mdc + the # mycelium section of AGENTS.md; surrounding AGENTS.md content preserved) mycelium agent rm design-agent --full","p":"Adapters"},{"u":"adapters.html#adapter-a2a","t":"A2A Bridge","x":"Mycelium speaks Agent2Agent (A2A), the open agent-interop protocol, in both directions. You can pull any A2A agent into a room and talk to it like a teammate, and you can hand a whole room to an outside A2A client as if the room itself were an agent. Unlike the Claude Code and Cursor adapters, there is nothing to install on your machine and no resident session to keep woken. A bridged agent is a remote HTTP endpoint;","p":"Adapters"},{"u":"adapters.html#adapter-a2a-bring-an-a2a-agent-into-a-room","t":"Bring an A2A agent into a room","s":"A2A Bridge","x":"Register a remote A2A endpoint as a room member. The hub resolves its Agent Card at registration, so a bad or unreachable URL fails right away instead of at the first mention. mycelium agent create researcher --adapter a2a \\ --card https://research.example.com \\ --room my-room Now @researcher is on the roster. Mention it in normal chat and it answers: @researcher what did last quarter's numbers say about churn? The b","p":"Adapters"},{"u":"adapters.html#adapter-a2a-expose-a-room-as-an-a2a-agent","t":"Expose a room as an A2A agent","s":"A2A Bridge","x":"Every room is discoverable and callable as an A2A agent, with no per-room route wiring. Its Agent Card is served at: GET /api/rooms/{room}/.well-known/agent-card.json The card advertises the room's name and its skills, drawn from the room's skills/ namespace. An external A2A client then sends the room a message with A2A JSON-RPC (message/send) at: POST /api/rooms/{room}/a2a The message lands in the room like any othe","p":"Adapters"},{"u":"adapters.html#adapter-a2a-watch-the-bridge","t":"Watch the bridge","s":"A2A Bridge","x":"The bridge is the one hop that doesn't ride SLIM, so it gets its own place in the coordination views instead of being folded into the channel telemetry. From the CLI, mycelium network [room] prints a bridge block per room under the fabric table: the bridged agents with their endpoint and advertised skills, the room's own card and how often it has been read, and the last exchanges either way — an answered call with wh","p":"Adapters"},{"u":"adapters.html#adapter-a2a-what-the-bridge-is-and-what-it-is-not","t":"What the bridge is, and what it is not","s":"A2A Bridge","x":"A bridged A2A agent is a member of the room in the coordination sense: it is on the roster, it answers when mentioned, and its replies are attributed to its handle. It is not a member of the room's end-to-end-encrypted MLS group. It never holds a group key. The backend is a translation boundary: it reads the room's plaintext and calls the remote agent out-of-band. Today that call is plain HTTPS. It can be moved onto ","p":"Adapters"},{"u":"adapters.html#adapter-api","t":"REST API","x":"Any agent or tool that can make HTTP requests can use the Mycelium API directly, with no adapter required. The API is the same one the CLI wraps.","p":"Adapters"},{"u":"adapters.html#api-docs","t":"Interactive docs","s":"REST API","x":"When the backend is running, interactive API docs are available at: http://localhost:8000/docs","p":"Adapters"},{"u":"adapters.html#api-example","t":"Quick example","s":"REST API","x":"Memory is scoped by room, so the room name is part of the path. Writes are batched: items takes 1–100 memories per call. # Write a memory curl -X POST http://localhost:8000/api/rooms/my-project/memory \\ -H \"Content-Type: application/json\" \\ -d '{\"items\": [{\"key\": \"work/api\", \"value\": \"REST with OpenAPI client\", \"created_by\": \"avery-agent\"}]}' # Read it back curl http://localhost:8000/api/rooms/my-project/memory/work/","p":"Adapters"},{"u":"adapters.html#api-a2a","t":"A2A endpoints","s":"REST API","x":"A room is also reachable over Agent2Agent, so an external A2A client can discover and message it without knowing anything about the Mycelium API. See the A2A bridge for what happens to the message once it lands. # Discover the room as an A2A agent (public: discovery is unauthenticated by spec) curl http://localhost:8000/api/rooms/my-project/.well-known/agent-card.json # Send it a message (A2A JSON-RPC; gated by the h","p":"Adapters"},{"u":"reference.html#architecture","t":"Architecture","s":"Architecture","x":"","p":"Reference"},{"u":"reference.html#architecture-deployment-modes","t":"Deployment Modes","s":"Architecture","x":"Mycelium supports two deployment modes. The stack is identical in both; what differs is where the agents run and how they reach the room.","p":"Reference"},{"u":"reference.html#architecture-1-single-device-default","t":"1. Single-device (default)","s":"Architecture","x":"Everything (the backend, the SLIM node, agents, and CLI) runs on one machine, typically a developer's laptop. This is what mycelium install sets up out of the box. No network configuration, no remote services to point at, no shared infrastructure required. This is the primary deployment target. Use it when one person (or one machine) owns the whole agent workflow.","p":"Reference"},{"u":"reference.html#architecture-2-hub-and-spoke-small-teams","t":"2. Hub-and-spoke (small teams)","s":"Architecture","x":"A second, optional mode for small teams that want to share memory, rooms, and coordination across machines. One machine runs the SLIM node and backend (the hub); other machines run only the CLI + agents (spokes) as thin HTTP clients to the hub API. Role What runs locally When to use Hub The SLIM node, the thin FastAPI backend (room moderator), and the UI. The team's shared coordination server. One per team. Spoke CLI","p":"Reference"},{"u":"reference.html#architecture-reading-a-remote-room-spoke","t":"Reading a remote room (spoke)","s":"Architecture","x":"When the backend runs on a remote server (EC2, Raspberry Pi, a hub), a spoke is a thin client: mycelium memory and mycelium room resolve against the hub over HTTP, so reads are always fresh and there is no sync step: nothing is mirrored locally to fall out of date. room clone / mycelium sync remain only as an explicit export: a point-in-time local snapshot for backup or offline reference, not part of the normal flow.","p":"Reference"},{"u":"reference.html#architecture-stack","t":"Stack","s":"Architecture","x":"Mycelium runs on one SLIM node and a thin backend: no database, no message broker, no vector store. The hub backend moderates an AGNTCY SLIM group channel per room (MLS-encrypted; PSK or SignerJwt on the SLIM plane). Turn-based agents on spokes (and humans by proxy) participate over HTTP — the backend holds server-side presence and serves turns from the durable transcript. Room state lives on the hub as markdown file","p":"Reference"},{"u":"reference.html#architecture-adapters","t":"Adapters","s":"Architecture","x":"Mycelium integrates with AI coding agents via adapters. The coordination model is the same regardless of adapter: join, await, respond. Adapter How it connects claude_code Skill + resident await/respond loop cursor Workspace rules + the same resident loop a2a A remote Agent2Agent endpoint the hub calls; no local runtime","p":"Reference"},{"u":"reference.html#architecture-claude-code","t":"Claude Code","s":"Architecture","x":"The Mycelium skill installs as a Claude Code skill (~/.claude/skills/mycelium/SKILL.md), invoked via the /mycelium slash command for memory and coordination commands. The adapter is skill-only. # The skill is invoked automatically in Claude Code sessions # or explicitly via the slash command /mycelium A Claude Code session participates as a resident runtime: it loops mycelium await → reason → mycelium respond, pickin","p":"Reference"},{"u":"reference.html#architecture-cursor","t":"Cursor","s":"Architecture","x":"Same resident model as Claude Code: a Cursor session loops await → reason → respond. mycelium adapter add cursor # installs the workspace rule + AGENTS.md assets cursor-agent login # one-time, interactive # Per agent: --cwd is the session's workspace root (optional) mycelium agent create design-agent --adapter cursor \\ --cwd ~/repos/my-frontend --room my-project","p":"Reference"},{"u":"reference.html#architecture-a2a","t":"A2A","s":"Architecture","x":"An a2a agent has no local runtime at all: it is a remote Agent2Agent endpoint the hub calls on its behalf. The card is resolved at registration, so a bad URL fails immediately. mycelium agent create researcher --adapter a2a \\ --card https://research.example.com --room my-project The same bridge runs inbound: every room is served as an A2A agent, discoverable at GET /api/rooms/{room}/.well-known/agent-card.json (publi","p":"Reference"},{"u":"reference.html#architecture-backend-api","t":"Backend API","s":"Architecture","x":"Any agent that can make HTTP requests can use the REST API directly. Interactive API docs are available at http://localhost:8000/docs when the backend is running.","p":"Reference"},{"u":"reference.html#architecture-status-providers","t":"Status providers","s":"Architecture","x":"Adapters connect agents to a room. Status providers connect the tools your work already lives in, so that a board row pointing at a pull request can report whether it's approved, blocked or failing instead of someone copying that state into Mycelium. Experimental. This works end to end: give the hub a token, write a pull request into a plan task, and the board row for that task carries the pull request's state, in bo","p":"Reference"},{"u":"reference.html#architecture-asking-what-the-tools-say","t":"Asking what the tools say","s":"Architecture","x":"GET /api/rooms/{room}/status You never tell Mycelium which pull requests to watch. Write a plan task that says land the custody seam: mycelium-io/mycelium#504 and the reference is already there; the hub reads the room's own plan tasks and its decisions/, status/, work/ and failed/ memories, and asks each provider what it recognises. Nothing in the hub matches #504: a provider is the only thing that knows its own shap","p":"Reference"},{"u":"reference.html#architecture-giving-the-hub-a-credential","t":"Giving the hub a credential","s":"Architecture","x":"Resolving pull requests takes a GitHub token; read-only is enough, plus repo scope for private repositories. A provider declares which credential it needs and how it is presented (a scheme: bearer token, basic auth, a raw key in a header), and never handles the value. The runtime resolves it and hands back a transport that already carries it. You give the hub the value by name, on the machine the backend runs on: # T","p":"Reference"},{"u":"reference.html#architecture-teaching-mycelium-another-tracker","t":"Teaching Mycelium another tracker","s":"Architecture","x":"A provider is one small class in app/services/status/providers/; providers/github.py is written to be copied. It declares its batching and freshness, then implements two methods: class JiraProvider: name = \"jira\" base_url = \"https://your-org.atlassian.net\" # ctx.http is bound to this host auth = Basic(\"JIRA_EMAIL\", \"JIRA_TOKEN\") # a scheme, not a value; the runtime resolves both names max_batch = 50 # most references","p":"Reference"},{"u":"reference.html#cli-reference","t":"CLI Reference","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-setup","t":"setup","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium doctor [--fix] [--json] [--mode auto|hub|spoke]","s":"CLI Reference","x":"Diagnose and fix common configuration issues (workspace sync, LLM, containers).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium init [--api-url <url>] [--force]","s":"CLI Reference","x":"Initialize CLI configuration. Creates ~/.mycelium/config.toml.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium up [--build] [--metrics]","s":"CLI Reference","x":"Start the Mycelium stack via docker compose up.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium down [--volumes]","s":"CLI Reference","x":"Stop the Mycelium stack. Pass --volumes to also delete data.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium status","s":"CLI Reference","x":"Show running service health (backend connectivity, room count).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium logs [service] [--follow] [--tail N]","s":"CLI Reference","x":"Tail container logs via docker compose logs.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium pull [--version <tag>] [--no-restart]","s":"CLI Reference","x":"Pull Mycelium Docker images and restart services. Pass --version to pin a preview/specific build.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium hub host","s":"CLI Reference","x":"Start the SLIM node and print the address peers connect to.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium connect <address>","s":"CLI Reference","x":"Store the SLIM node endpoint to connect to (self- or mycelium-hosted).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium install [--yes] [--non-interactive] [--force]","s":"CLI Reference","x":"Interactive installer: Docker check, LLM config, docker compose up, provision workspace.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium upgrade [--check] [--version <version>]","s":"CLI Reference","x":"Upgrade (or pin) the Mycelium CLI. Pass --version to install a specific release.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium login [--issuer URL] [--device] [--no-browser] [--client-id ID]","s":"CLI Reference","x":"Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium logout","s":"CLI Reference","x":"Drop the cached OIDC session; the CLI goes back to sending no token.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium ui open [-y]","s":"CLI Reference","x":"Open the frontend in your default browser.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-setup","t":"mycelium ui status","s":"CLI Reference","x":"Show whether the frontend container is running.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-room","t":"room","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-room","t":"mycelium room ls","s":"CLI Reference","x":"List all rooms with state and member count.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-room","t":"mycelium room create <name>","s":"CLI Reference","x":"Create a new persistent coordination room.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-room","t":"mycelium room use <name>","s":"CLI Reference","x":"Switch active room. Subsequent memory and message commands use this room by default.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-room","t":"mycelium room delete <name> [<name> ...] [--force]","s":"CLI Reference","x":"Delete one or more rooms and all their data (memories, sessions, messages).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-room","t":"mycelium room clone <room-name> [--from <api-url>]","s":"CLI Reference","x":"Clone a room from a remote backend: fetches all memories via HTTP and writes them locally.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-room","t":"mycelium room send \"<content>\" [--room <room>] [--handle <handle>]","s":"CLI Reference","x":"Send an addressed chat message into a room. Use @handle mentions to direct it to specific agents.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-room","t":"mycelium room amend <message-id> \"<new content>\" [--room <room>] [--handle <handle>]","s":"CLI Reference","x":"Revise a message you sent. The amendment is posted as its own message; the room reads the newest text, marked edited.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-room","t":"mycelium room messages [<room>] [--limit N] [--sender <handle>] [--type <type>]","s":"CLI Reference","x":"Read recent messages in a room (point-in-time, newest first). Filter with --sender / --type.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-room","t":"mycelium room delegate <room> --to <handle> --task <description>","s":"CLI Reference","x":"Delegate a task to another agent in a room.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"agent","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent create <handle> --adapter <name> [--cwd <path>] [--card <url>] [--card-auth-env <var>]","s":"CLI Reference","x":"Create a new, Mycelium-controlled agent in a room. claude_code and cursor agents are resident sessions the user keeps woken with mycelium await --loop. --adapter a2a instead registers a remote Agent2Agent endpoint given by --card (its Agent Card host, resolved at registration); --card-auth-env names a backend env var holding its bearer token, so only the var name is stored in the room.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent ls [--room <room>]","s":"CLI Reference","x":"List all registered agents in a room.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent show <handle> [--room <room>]","s":"CLI Reference","x":"Show an agent's manifest, notes, and most recent invocation log.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent invoke <handle> \"<prompt>\" [--room <room>]","s":"CLI Reference","x":"Send an addressed message to a registered agent. Desugars to mycelium room send \"@handle <prompt>\".","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent rm <handle> [--room <room>] [--full] [--force]","s":"CLI Reference","x":"Unregister an agent. Default keeps the underlying runtime; --full also tears down the underlying runtime (requires confirmation unless -y).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent credential set <handle> [--client-id ID] [--secret-stdin] [--issuer URL]","s":"CLI Reference","x":"Give an agent its own service-account credential, stored 0600 outside config.toml. Only meaningful once a hub enables auth.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent credential show <handle>","s":"CLI Reference","x":"Show which credential an agent resolves to. Never prints the secret.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent credential ls","s":"CLI Reference","x":"List the agents on this machine that have their own credential.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent credential rm <handle>","s":"CLI Reference","x":"Forget an agent's credential on this machine.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-agent","t":"mycelium agent credential slim-key <handle>","s":"CLI Reference","x":"Mint an agent's SignerJwt SLIM channel identity: a local ES256 keypair (0600) whose public JWK is registered on the room roster. The floor for slim.identity = signerjwt (#476); the PSK default needs none.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"memory","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory set <key> [<value>] [--file <path>] [--handle <handle>]","s":"CLI Reference","x":"Write a memory (upsert). The value comes from the positional argument or --file (- reads stdin): one or the other, not both. Structured category keys (work/, decisions/, status/, context/) are auto-validated. Always upserts; the backend handles versioning.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory get <key>","s":"CLI Reference","x":"Read a memory by exact key from the hub.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory ls [prefix/]","s":"CLI Reference","x":"List memories from the hub. Optional prefix filters by namespace.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory search <query>","s":"CLI Reference","x":"Semantic search: finds memories by meaning using cosine similarity on local embeddings. Requires the backend API.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory links <key> [--check]","s":"CLI Reference","x":"Show a memory's links: what it points at and what points back at it. Links are myc://key or [[key]] in the body, plus typed frontmatter relations (supersedes, depends-on, part-of, relates-to). --check reports broken links, orphans (no connections), roots (no inbound), and leaves (no outbound) across the whole room.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory rm <key> [--force]","s":"CLI Reference","x":"Delete a memory: removes the markdown file and search index entry.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory reindex","s":"CLI Reference","x":"Re-index the room into the local JSONL search index. Run after editing memory files outside the CLI.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory subscribe <pattern> [-H <handle>]","s":"CLI Reference","x":"Subscribe to memory change notifications matching a glob pattern.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory status","s":"CLI Reference","x":"Show current status: filters to status/* memories as a table.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory work","s":"CLI Reference","x":"Show what's been built: filters to work/* memories as a table.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory decisions","s":"CLI Reference","x":"Show why choices were made: filters to decisions/* memories as a table.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory context","s":"CLI Reference","x":"Show background and preferences: filters to context/* memories as a table.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-memory","t":"mycelium memory procedures","s":"CLI Reference","x":"Show reusable how-to steps: filters to procedures/* memories as a table.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-skill","t":"skill","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-skill","t":"mycelium skill set <name> [<body>] [--file <path>] [--desc <text>]","s":"CLI Reference","x":"Create or update a skill (upsert) in a room's skills/ namespace. The body comes from the positional argument or --file (- reads stdin).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-skill","t":"mycelium skill ls","s":"CLI Reference","x":"List a room's skills, newest-updated first.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-skill","t":"mycelium skill get <name>","s":"CLI Reference","x":"Read a skill by name from a room.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-skill","t":"mycelium skill rm <name>","s":"CLI Reference","x":"Delete a skill from a room.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-skill","t":"mycelium skill adapter-def","s":"CLI Reference","x":"Print the Mycelium SKILL.md: the Claude Code adapter's skill definition (the participation protocol the resident agent follows).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-plan","t":"plan","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-plan","t":"mycelium plan ls","s":"CLI Reference","x":"List plan files in the active room.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-plan","t":"mycelium plan show <slug>","s":"CLI Reference","x":"Print a plan file's body.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-plan","t":"mycelium plan set <slug> <body>","s":"CLI Reference","x":"Create or overwrite a plan file. Body is the full markdown.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-plan","t":"mycelium plan rm <slug>","s":"CLI Reference","x":"Delete a plan file.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-plan","t":"mycelium plan title [<text>]","s":"CLI Reference","x":"Read or set the room's plan title: the italic display line shown above room activity. Pass no text to print the current title.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-plan","t":"mycelium plan tasks","s":"CLI Reference","x":"List every checkbox task across plan files. Open first, done last.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-plan","t":"mycelium plan task add <text> [--file <slug>]","s":"CLI Reference","x":"Append a new - [ ] line to a plan file (defaults to tasks).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-plan","t":"mycelium plan task done [<id>...]","s":"CLI Reference","x":"Mark task(s) complete. Run without IDs to pick from open tasks interactively.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-plan","t":"mycelium plan task undo [<id>...]","s":"CLI Reference","x":"Reopen completed task(s). Run without IDs to pick interactively.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-adapter","t":"adapter","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-adapter","t":"mycelium adapter add <type> [--dry-run]","s":"CLI Reference","x":"Install an agent framework adapter (claude-code, cursor).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-adapter","t":"mycelium adapter remove <type> [--force]","s":"CLI Reference","x":"Unregister and uninstall an adapter.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-adapter","t":"mycelium adapter ls","s":"CLI Reference","x":"List available and registered adapters.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-adapter","t":"mycelium adapter status [type]","s":"CLI Reference","x":"Check adapter health and installation status.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-config","t":"config","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-config","t":"mycelium config show","s":"CLI Reference","x":"Print current configuration (API URL, identity, active room).","k":"cmd","p":"Reference"},{"u":"reference.html#cli-config","t":"mycelium config set <key> <value> [--env <preset>]","s":"CLI Reference","x":"Set a configuration value or switch environment preset.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-config","t":"mycelium config get <key>","s":"CLI Reference","x":"Read a configuration value.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-config","t":"mycelium config apply [--restart] [--migrate-env]","s":"CLI Reference","x":"Regenerate .env from config.toml and optionally restart containers.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-other","t":"watch","s":"CLI Reference","x":"","p":"Reference"},{"u":"reference.html#cli-other","t":"mycelium sync [--no-reindex]","s":"CLI Reference","x":"Sync the active room with the backend: fetch all memories from the API and write them locally.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-other","t":"mycelium watch [room]","s":"CLI Reference","x":"Stream live room activity via SSE. Messages appear in real time as other agents write.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-other","t":"mycelium await --room <room> [--handle <handle> | --lease <key>] [--loop] [--exec CMD] [--timeout N] [--json]","s":"CLI Reference","x":"Long-poll a room until a message is addressed to the handle — or until a named lease changes hands.","k":"cmd","p":"Reference"},{"u":"reference.html#cli-other","t":"mycelium respond --room <room> --handle <handle> \"<text>\"","s":"CLI Reference","x":"Publish a reply as the handle; the backend records it as a position for the aligner.","k":"cmd","p":"Reference"},{"u":"reference.html#configuration","t":"Configuration","s":"Configuration","x":"Settings live in ~/.mycelium/config.toml. Change a value with mycelium config set <key> <value> (for example, mycelium config set llm.model anthropic/claude-sonnet-4-6), then run mycelium config apply to regenerate ~/.mycelium/.env. If the change affects a service running in a container, restart with mycelium up for it to take effect. # Agent identity configuration. [identity] # Display name chosen by user name = \"\" ","p":"Reference"},{"u":"reference.html#dependencies","t":"Dependencies","s":"Dependencies","x":"Mycelium is assembled from a small set of upstream components. This page lists every notable runtime dependency, the version pinned, what it's for, and where to check what changed upstream. The versions are read from the pins in pyproject.toml and compose.yml, so they match what ships.","p":"Reference"},{"u":"reference.html#dependencies-messaging-fabric-agntcy-slim","t":"Messaging fabric (AGNTCY SLIM)","s":"Dependencies","x":"Mycelium is SLIM-native: rooms are SLIM group channels and the node forwards only MLS ciphertext. This is the one deep coupling in the stack, so it comes first. Component Pinned version Role Upstream slim-bindings >=2.1,<2.2 The client the CLI and backend use to join channels agntcy/slim releases ghcr.io/agntcy/slim 2.1.0 The messaging node itself, a blind ciphertext forwarder ghcr.io/agntcy/slim Version lockstep. Th","p":"Reference"},{"u":"reference.html#dependencies-memory-and-search","t":"Memory and search","s":"Dependencies","x":"Component Pinned version Role Upstream fastembed >=0.8.0 Local ONNX embeddings (BAAI/bge-small-en-v1.5, 384-dim); no external service qdrant/fastembed tiktoken >=0.12.0 Token counting for context budgeting openai/tiktoken rapidfuzz >=3.14.5 Fuzzy key matching over memory rapidfuzz/RapidFuzz","p":"Reference"},{"u":"reference.html#dependencies-cognition","t":"Cognition","s":"Dependencies","x":"Component Pinned version Role Upstream negmas >=0.15.7 backend / >=0.11 CLI engine extra The Stacked Alternating Offers mechanism the aligner runs yasserfarouk/negmas anthropic >=0.40.0 LLM client for backend cognition stages anthropic-sdk-python Pi (pi binary) shipped in the backend image The aligner's brain and every one-shot cognition turn external binary, not a Python dependency","p":"Reference"},{"u":"reference.html#dependencies-identity-and-crypto","t":"Identity and crypto","s":"Dependencies","x":"Component Pinned version Role Upstream pyjwt[crypto] >=2.10,<3 JWT validation for the auth gate and SignerJwt identity jpadilla/pyjwt cryptography >=42,<47 ES256 keypair and JWK for SLIM channel identity pyca/cryptography The rest of the stack is standard, widely used building blocks with no special version constraint beyond their pins: fastapi[standard], httpx, pydantic / pydantic-settings, typer, rich, and question","p":"Reference"},{"u":"reference.html#structured-memory","t":"Structured Memory","s":"Guides","x":"This guide shows how to use Mycelium's structured memory conventions to give agents continuity across separate runs.","p":"Reference"},{"u":"reference.html#structured-memory-the-problem","t":"The Problem","s":"Guides › Structured Memory","x":"An agent helps build something over a long stretch of work, then goes away. When the user (or another agent) comes back, there's no memory of what happened. The next agent starts from scratch.","p":"Reference"},{"u":"reference.html#structured-memory-the-solution-category-conventions","t":"The Solution: Category Conventions","s":"Guides › Structured Memory","x":"Instead of writing memories with arbitrary keys, use structured prefixes: work/ What was built or changed decisions/ Why choices were made context/ User preferences and background status/ Current state of ongoing work procedures/ Reusable how-to steps (do this again later) memory set validates these automatically: when the key starts with a known category prefix, it checks the slug format and auto-timestamps the cont","p":"Reference"},{"u":"reference.html#structured-memory-workflow","t":"Workflow","s":"Guides › Structured Memory","x":"","p":"Reference"},{"u":"reference.html#structured-memory-1-set-up-a-room","t":"1. Set up a room","s":"Guides › Structured Memory","x":"mycelium room create project-x mycelium room use project-x","p":"Reference"},{"u":"reference.html#structured-memory-2-write-structured-memories-as-you-work","t":"2. Write structured memories as you work","s":"Guides › Structured Memory","x":"# Record what you built mycelium memory set work/api-server \"Set up FastAPI with auth endpoints\" mycelium memory set work/database \"Created PostgreSQL schema, 3 tables\" # Record why you made choices mycelium memory set decisions/framework \"FastAPI over Flask: async + type hints\" mycelium memory set decisions/auth \"JWT tokens, 1hr expiry, refresh via cookie\" # Record user context mycelium memory set context/goal \"Buil","p":"Reference"},{"u":"reference.html#structured-memory-3-check-status-at-a-glance","t":"3. Check status at a glance","s":"Guides › Structured Memory","x":"mycelium memory status # Table of all status/* memories mycelium memory work # What's been built mycelium memory decisions # Why things are the way they are mycelium memory procedures # How to do things again","p":"Reference"},{"u":"reference.html#structured-memory-4-update-status-as-things-change","t":"4. Update status as things change","s":"Guides › Structured Memory","x":"# memory set always upserts, so just set the new value mycelium memory set status/deploy \"ACTIVE: deployed to vps.example.com\"","p":"Reference"},{"u":"reference.html#structured-memory-type-safety","t":"Type Safety","s":"Guides › Structured Memory","x":"memory set validates category keys against the MemoryLogEntry type (defined in mycelium.protocol). This is the same pattern used for the negotiation reply payload (RespondReply): Pydantic validation before the API call, so malformed slugs fail fast on the client side. Valid slugs: lowercase alphanumeric, hyphens, dots, underscores. work/api-server (valid) status/v2.deploy (valid) decisions/Why We Chose X (invalid: up","p":"Reference"},{"u":"reference.html#hub-and-spoke","t":"Hub & Spoke","s":"Guides","x":"Run Mycelium across two or more machines so a small team shares rooms, memory, and coordination from one hub. One machine is the hub: it runs the SLIM node and the always-on FastAPI backend (room moderator + memory store). Every other machine is a spoke: CLI + agents only, talking to the hub over HTTP. There is no database and no separate channel server. Two planes. Spokes use the HTTP API (:8000) for memory and part","p":"Reference"},{"u":"reference.html#hub-and-spoke-when-to-use-this","t":"When to use this","s":"Guides › Hub & Spoke","x":"Use hub-and-spoke when people on different machines need to join the same rooms, see the same memories, and run negotiations together. If everything runs on one machine, the default single-device install already does this; see the Quick Start.","p":"Reference"},{"u":"reference.html#hub-and-spoke-topology","t":"Topology","s":"Guides › Hub & Spoke","x":"┌─────────────────────────────────────────────┐ │ Hub (one machine) │ │ │ │ mycelium install │ │ mycelium hub host │ │ ├─ SLIM node :46357 (MLS fabric) │ │ └─ FastAPI backend :8000 (HTTP API) │ │ moderator + memory store │ └──────────────────┬──────────────────────────┘ │ HTTP :8000 (memory, await, respond) │ ┌─────────────┴─────────────┐ │ │ ┌────┴──────┐ ┌─────┴─────┐ │ Spoke A │ │ Spoke B │ │ CLI │ │ CLI │ │ + age","p":"Reference"},{"u":"reference.html#hub-and-spoke-step-1-stand-up-the-hub","t":"Step 1: Stand up the hub","s":"Guides › Hub & Spoke","x":"On the hub machine, install the stack and start the SLIM node: mycelium install mycelium hub host mycelium hub host starts the slim node container and prints addresses: SLIM node running. local → http://127.0.0.1:46357 (this machine, saved to config) for peers → http://192.168.1.20:46357 Ensure the backend is up as well (mycelium up or the full install stack). Verify with: mycelium doctor doctor auto-detects hub vs s","p":"Reference"},{"u":"reference.html#hub-and-spoke-hub-only-slim-master-secret","t":"Hub-only: SLIM master secret","s":"Guides › Hub & Spoke","x":"The hub SLIM PSK lives in config.toml, not as a hand-edited .env entry. On first mycelium install or mycelium config apply, Mycelium generates [slim].master_secret when unset and renders it to MYCELIUM_SLIM_MASTER_SECRET in ~/.mycelium/.env for the backend container. mycelium config apply # generates [slim].master_secret if missing mycelium config show # SLIM PSK shown masked To rotate: mycelium config set slim.maste","p":"Reference"},{"u":"reference.html#hub-and-spoke-open-ports","t":"Open ports","s":"Guides › Hub & Spoke","x":"Port Service Spokes need it? Purpose 8000 FastAPI backend Yes Memory, await/respond, room ops 46357 SLIM node No (default) Native SLIM on hub; optional for slim send Restrict :8000 on the hub when the team shares a network. Enable the HTTP JWT gate — that is what protects spokes, not the SLIM PSK.","p":"Reference"},{"u":"reference.html#hub-and-spoke-step-2-connect-each-spoke","t":"Step 2: Connect each spoke","s":"Guides › Hub & Spoke","x":"On each spoke, install the CLI: curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash Point the spoke at the hub backend (required): mycelium config set server.api_url http://192.168.1.20:8000 Or during init: mycelium init --api-url http://192.168.1.20:8000 Optional: store the hub's SLIM node address (only needed for native SLIM tooling such as mycelium slim send, not for normal participation): mycelium","p":"Reference"},{"u":"reference.html#hub-and-spoke-secure-a-shared-hub","t":"Secure a shared hub","s":"Guides › Hub & Spoke","x":"When spokes reach the hub over a LAN or VPN, turn on HTTP authentication on the hub. See Authentication. Without it, any peer on the network can read/write memory and post as any @handle — independent of SLIM PSK.","p":"Reference"},{"u":"reference.html#hub-and-spoke-behind-a-tls-terminating-proxy","t":"Behind a TLS-terminating proxy","s":"Guides › Hub & Spoke","x":"A public hub usually sits behind a reverse proxy (Caddy, nginx, a cloud load balancer) that terminates HTTPS and forwards plain HTTP to the backend container. The backend then sees an http request and builds every absolute URL with that scheme, so an external client reading the A2A agent card is pointed at http:// for a hub that is only served over https://. The proxy says what the original request was in X-Forwarded","p":"Reference"},{"u":"reference.html#hub-and-spoke-step-3-use-a-room-from-a-spoke","t":"Step 3: Use a room from a spoke","s":"Guides › Hub & Spoke","x":"There is one store: the hub's. Create the room on the hub, then use it from anywhere. # On the hub mycelium room create portfolio mycelium room use portfolio On a spoke, just make it the active room: mycelium room use portfolio Every memory command resolves against the hub over HTTP: mycelium memory ls mycelium memory get decisions/allocation mycelium memory set decisions/allocation \"60/40 equities to bonds\" mycelium","p":"Reference"},{"u":"reference.html#hub-and-spoke-step-4-run-a-negotiation-across-machines","t":"Step 4: Run a negotiation across machines","s":"Guides › Hub & Spoke","x":"Register the aligner once in the room, post opening positions, and loop on participation. The aligner runs on the hub over the SLIM fabric; spoke agents use HTTP await/respond. mycelium engine create aligner --kind aligner --room portfolio Each participant posts an opening position: # Spoke A's agent mycelium respond --room portfolio --handle alice \"I want 60% equities.\" # Spoke B's agent mycelium respond --room port","p":"Reference"},{"u":"reference.html#hub-and-spoke-agent-identity","t":"Agent identity","s":"Guides › Hub & Spoke","x":"Each agent needs a unique handle across the deployment. The handle is resolved from, in order: identity.name in ~/.mycelium/config.toml The MYCELIUM_AGENT_HANDLE environment variable The --handle flag on await / respond On a shared hub with auth enabled, the token — not the body alone — is the actor of record. Configure agent credentials for unattended spokes.","p":"Reference"},{"u":"reference.html#hub-and-spoke-troubleshooting","t":"Troubleshooting","s":"Guides › Hub & Spoke","x":"","p":"Reference"},{"u":"reference.html#hub-and-spoke-spoke-cant-reach-the-hub","t":"Spoke can't reach the hub","s":"Guides › Hub & Spoke","x":"Check the backend first (the path spokes actually use): curl http://192.168.1.20:8000/health If this fails, check firewall rules, VPN connectivity, or security groups. The backend must be reachable on port 8000. The SLIM node (:46357) is only required on the hub for coordination fabric; spokes do not need it for memory or await/respond.","p":"Reference"},{"u":"reference.html#hub-and-spoke-doctor-reports-spoke-mode-unexpectedly","t":"doctor reports \"spoke mode\" unexpectedly","s":"Guides › Hub & Spoke","x":"mycelium doctor infers mode from server.api_url. If it points at a non-local address, doctor assumes spoke mode. If you're running the backend locally on a non-default address, set server.api_url to http://localhost:8000 in ~/.mycelium/config.toml, or force hub mode: mycelium doctor --mode hub See Troubleshooting for the full runbook and Security Planes for HTTP vs SLIM protection.","p":"Reference"},{"u":"reference.html#ephemeral-agents","t":"Ephemeral Agents","s":"Guides","x":"An ephemeral agent is a runtime that exists for one task and then disappears: a Claude Code cloud session, a CI job, a docker run that ends when the command does. It has no .mycelium/ directory, no config.toml, usually no Docker, and nobody sitting at a terminal to run mycelium login. It should still be able to say what it did. This guide covers the thinnest possible spoke: a container that installs the CLI, reads it","p":"Reference"},{"u":"reference.html#ephemeral-agents-the-shape-of-it","t":"The shape of it","s":"Guides › Ephemeral Agents","x":"┌──────────────────────────────┐ │ Ephemeral container │ │ │ │ env: MYCELIUM_API_URL │ HTTPS │ MYCELIUM_ACTIVE_ROOM │ ─────────────► Hub (backend :8000) │ MYCELIUM_AGENT_HANDLE │ room + memory + transcript │ │ │ curl install.sh | bash │ │ mycelium room send \"…\" │ └──────────────────────────────┘ no config.toml, no .mycelium/, no Docker Nothing is written to disk that matters. The room is on the hub, and every call is","p":"Reference"},{"u":"reference.html#ephemeral-agents-what-the-container-needs","t":"What the container needs","s":"Guides › Ephemeral Agents","x":"Four environment variables, no config file: Variable What it sets Needed MYCELIUM_API_URL The hub's backend URL, e.g. https://mycelium.example.com Always MYCELIUM_ACTIVE_ROOM The room to post into (MYCELIUM_ROOM_ID also works) Unless you pass --room MYCELIUM_AGENT_HANDLE Who the message is from Always MYCELIUM_AGENT_AUTH_TOKEN Bearer token for the hub Only if the hub's auth gate is on MYCELIUM_AGENT_HANDLE does doubl","p":"Reference"},{"u":"reference.html#ephemeral-agents-install-without-docker","t":"Install without Docker","s":"Guides › Ephemeral Agents","x":"The normal installer sets up the whole stack, which needs Docker. An ephemeral agent only talks to a hub that already exists, so it wants the CLI alone: curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash -s -- --client-only Client-only mode skips the Docker check entirely, and when the container's python3 is older than 3.12 it installs a managed 3.12 for the CLI rather than failing. Both are what an ","p":"Reference"},{"u":"reference.html#ephemeral-agents-announce-something","t":"Announce something","s":"Guides › Ephemeral Agents","x":"mycelium room send \"Migrated the session store to Redis. Tests green, PR #412 up.\" That is the whole flow. The message lands in the room's stream, where every other member and the UI sees it. @handle mentions inside the text address specific agents, and a mentioned resident agent picks it up on its next await: mycelium room send \"@avery-agent the retry backoff is in — worth a look before you re-run the bench.\" Read t","p":"Reference"},{"u":"reference.html#ephemeral-agents-beyond-announcing","t":"Beyond announcing","s":"Guides › Ephemeral Agents","x":"Announcing is one-way. To let the container take a turn in a negotiation — receive an addressed tick and reply as a position — use await and respond instead (see Rooms): mycelium await --handle ci-runner --timeout 120 mycelium respond --handle ci-runner \"I can hold the deploy until the bench lands.\" respond posts as an agent, so unlike a broadcast the handle must be a registered principal — an agent or a user. Regist","p":"Reference"},{"u":"reference.html#ephemeral-agents-claude-code-on-the-web","t":"Claude Code on the web","s":"Guides › Ephemeral Agents","x":"A Claude Code cloud session is the case this guide was written for: an agent working in someone's repository, in a container you never touch, that should report back into a room when it is done. Cloud sessions read their configuration from a cloud environment, which is where the environment variables above go.","p":"Reference"},{"u":"reference.html#ephemeral-agents-1-configure-the-environment","t":"1. Configure the environment","s":"Guides › Ephemeral Agents","x":"On claude.ai/code, select the cloud icon above the message box, then Add cloud environment (or the settings icon on an existing one). The dialog holds the name, network access, environment variables, and setup script. Put this in Environment variables (.env format, one KEY=value per line): MYCELIUM_API_URL=https://mycelium.example.com MYCELIUM_ACTIVE_ROOM=build MYCELIUM_AGENT_HANDLE=claude-web Sessions copy these onc","p":"Reference"},{"u":"reference.html#ephemeral-agents-2-let-the-session-reach-the-hub","t":"2. Let the session reach the hub","s":"Guides › Ephemeral Agents","x":"Cloud sessions get Trusted network access by default: package registries and GitHub, and nothing else. Your hub is not on that list, so set Network access to Custom and add its host to Allowed domains: mycelium.example.com Leave Also include default list of common package managers checked, or the installer itself cannot reach PyPI and GitHub releases. Two constraints follow from the session's egress proxy, and neithe","p":"Reference"},{"u":"reference.html#ephemeral-agents-3-install-the-cli-once-per-environment","t":"3. Install the CLI once per environment","s":"Guides › Ephemeral Agents","x":"Put the client-only install in the Setup script, the Bash script that runs before Claude Code starts: curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash -s -- --client-only The filesystem is snapshotted after the setup script runs and reused for later sessions, so the CLI is already on disk at the start of every session in that environment rather than being reinstalled each time.","p":"Reference"},{"u":"reference.html#ephemeral-agents-4-tell-the-agent-to-use-it","t":"4. Tell the agent to use it","s":"Guides › Ephemeral Agents","x":"Nothing so far tells Claude to announce anything. Commit that instruction to the repository, in CLAUDE.md or a skill, so it applies to every session: ## Reporting When you finish a piece of work, announce it in the Mycelium room: mycelium room send \"<what changed, what's left, links>\" The room, handle, and hub are already in the environment. Address teammates with @handle when they need to act.","p":"Reference"},{"u":"reference.html#ephemeral-agents-5-link-the-announcement-back-to-the-session","t":"5. Link the announcement back to the session","s":"Guides › Ephemeral Agents","x":"A cloud session knows its own transcript URL, which makes an announcement traceable to the run that produced it: mycelium room send \"$(cat <<EOF @team Retry backoff landed — PR #412, CI green. Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID/#cse_/session_} EOF )\" CLAUDE_CODE_REMOTE_SESSION_ID is set by the platform; the substitution turns its cse_ prefix into the session_ prefix the transcript URL exp","p":"Reference"},{"u":"reference.html#ephemeral-agents-other-ephemeral-runtimes","t":"Other ephemeral runtimes","s":"Guides › Ephemeral Agents","x":"Nothing above is specific to Claude Code. Any container that can set environment variables and reach the hub works the same way — a GitHub Actions job, a Nomad batch task, a docker run: docker run --rm \\ -e MYCELIUM_API_URL=https://mycelium.example.com \\ -e MYCELIUM_ACTIVE_ROOM=build \\ -e MYCELIUM_AGENT_HANDLE=nightly-bench \\ python:3.12-slim bash -c ' curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | ba","p":"Reference"},{"u":"reference.html#ephemeral-agents-troubleshooting","t":"Troubleshooting","s":"Guides › Ephemeral Agents","x":"Symptom Cause Failed to connect to the Mycelium API MYCELIUM_API_URL unreachable: not public, not HTTPS, or not on the session's allowlist 502 Bad Gateway / ProxyError from a hub that is up The hub's domain is not on the environment's Allowed domains; the refusal is the egress proxy's, not the hub's No room context found Neither MYCELIUM_ACTIVE_ROOM / MYCELIUM_ROOM_ID nor --room is set 403 … is not a registered agent","p":"Reference"},{"u":"reference.html#security-planes","t":"Security Planes","s":"Guides","x":"Mycelium has two enforcement planes. They protect different things, use different credentials, and apply to different machines. Conflating them is the most common hub-and-spoke misconfiguration.","p":"Reference"},{"u":"reference.html#security-planes-the-two-planes","t":"The two planes","s":"Guides › Security Planes","x":"Plane Port (default) Who uses it What it protects Default Upgrade HTTP API 8000 Spokes, humans, agents (memory, await, respond) Memory, participation, handle attribution Open (no token) Authentication (auth.enabled) SLIM / MLS 46357 Hub backend (moderator); dev slim send; future native connectors Native SLIM group membership on the coordination fabric Shared-secret PSK (hub only) SignerJwt (slim.identity) Spokes do n","p":"Reference"},{"u":"reference.html#security-planes-what-psk-actually-protects","t":"What PSK actually protects","s":"Guides › Security Planes","x":"PSK (MYCELIUM_SLIM_MASTER_SECRET → HMAC per workspace/room → create_app_with_secret) is the SLIM-plane room gate: It decides who may authenticate as a SLIM app and join a room's MLS group. It is scoped per room, not per agent — every member with the secret is cryptographically indistinguishable under the psk tier. It does not encrypt message bodies; MLS performs group key agreement once members are admitted. It does ","p":"Reference"},{"u":"reference.html#security-planes-what-protects-spokes","t":"What protects spokes","s":"Guides › Security Planes","x":"For hub-and-spoke, the urgent control is the HTTP API gate, not PSK: mycelium config set auth.enabled true mycelium config set auth.audience mycelium # … configure [[auth.issuers]] … mycelium config apply See Authentication for humans and agent service accounts. Without the gate, anyone who can reach :8000 can read/write memory and post as any @handle — even if the hub uses a private SLIM master secret.","p":"Reference"},{"u":"reference.html#security-planes-deployment-profiles","t":"Deployment profiles","s":"Guides › Security Planes","x":"Profile HTTP API SLIM (hub) Spoke config Solo dev Open Dev PSK literal (fallback if no config secret) N/A (all-in-one) LAN team JWT on Auto-generated [slim].master_secret on hub server.api_url → hub:8000 only Hosted JWT required Private hub secret + SignerJwt Same; no master secret on spokes mycelium doctor reports HTTP auth status from the hub's /health endpoint. In hub mode it also warns when [slim].master_secret i","p":"Reference"},{"u":"reference.html#security-planes-slim-identity-ladder-hub-native-clients","t":"SLIM identity ladder (hub native clients)","s":"Guides › Security Planes","x":"Tier Plane Spoke needs it? psk SLIM No (hub backend only today) signerjwt SLIM Only if the spoke runs a native SLIM connector mycelium config set slim.identity signerjwt changes SLIM channel identity on machines that open native SLIM connections. It does not turn on HTTP API auth. Configure [auth] separately.","p":"Reference"},{"u":"reference.html#security-planes-related-guides","t":"Related guides","s":"Guides › Security Planes","x":"Hub & Spoke Setup — topology and spoke checklist Authentication — HTTP JWT gate (spokes and hub API)","p":"Reference"},{"u":"reference.html#auth","t":"Authentication","s":"Guides","x":"Mycelium's backend can require a signed bearer token on every HTTP API call, validated against an OIDC issuer you configure. It is off by default and nothing about the default install changes until you turn it on. This is the HTTP API plane — what protects spokes in hub-and-spoke deployments. It is separate from SLIM/MLS PSK or SignerJwt on the coordination fabric; see Security Planes.","p":"Reference"},{"u":"reference.html#auth-off-by-default-on-purpose","t":"Off by default, on purpose","s":"Guides › Authentication","x":"Auth must never be a wall between someone and trying Mycelium. A fresh install runs with no issuer, no tokens, and no extra containers: memory, rooms, and coordination all work exactly as they do today. Turn it on when a team shares a hub over a network. Until then, leaving it off is the supported configuration, not a shortcut. Without the gate, anyone who can reach the backend's port can read and write every room an","p":"Reference"},{"u":"reference.html#auth-turning-it-on","t":"Turning it on","s":"Guides › Authentication","x":"mycelium config set auth.enabled true mycelium config set auth.audience mycelium mycelium config apply Then declare at least one trust root in ~/.mycelium/config.toml: [auth] enabled = true audience = \"mycelium\" [[auth.issuers]] issuer = \"https://sso.example.com/realms/mycelium\" jwks_url = \"https://sso.example.com/realms/mycelium/protocol/openid-connect/certs\" role = \"user\" Re-run mycelium config apply and recreate t","p":"Reference"},{"u":"reference.html#auth-always-set-an-audience","t":"Always set an audience","s":"Guides › Authentication","x":"audience is optional but you should always set it when enabling auth. Without one, any token your issuer has ever minted is accepted, including a token a user obtained for a completely unrelated application on the same identity provider. That token's holder was never authorized against your hub. Setting an audience is what makes \"a valid token\" mean \"a token meant for this hub\". The backend logs a warning at startup ","p":"Reference"},{"u":"reference.html#auth-configuration","t":"Configuration","s":"Guides › Authentication","x":"Key Default What it does auth.enabled false Enforce bearer-token auth on the HTTP API. auth.issuers (none) Trust roots, as repeatable [[auth.issuers]] blocks. auth.audience (unset) Required aud claim. Set this whenever auth is on. auth.localhost_bypass true Let loopback callers through without a token. auth.handle_claim sub Claim carrying the canonical @handle. auth.role_claim mycelium_role Claim distinguishing a use","p":"Reference"},{"u":"reference.html#auth-signing-in-from-the-cli","t":"Signing in from the CLI","s":"Guides › Authentication","x":"The gate above is the hub's half. mycelium login is yours: it obtains an OIDC token for you, caches it, and every later command sends it. mycelium config set login.issuer https://sso.example.com/realms/mycelium mycelium config set login.audience mycelium # match the hub's auth.audience mycelium login Your browser opens, you sign in at your identity provider, and the CLI takes it from there: mycelium memory, mycelium ","p":"Reference"},{"u":"reference.html#auth-login-is-opt-in-like-the-gate","t":"Login is opt-in, like the gate","s":"Guides › Authentication","x":"Never running mycelium login changes nothing: with no cached session the CLI sends no Authorization header, exactly as before this existed. That is what keeps it safe against an ungated hub, which is the default one.","p":"Reference"},{"u":"reference.html#auth-where-the-token-lives","t":"Where the token lives","s":"Guides › Authentication","x":"In ~/.mycelium/token.json, created mode 0600, not in config.toml. Config is printed, copied between machines, and mirrored to config.json for the frontend; a token in there would leak by routine. Set MYCELIUM_TOKEN_FILE to cache it somewhere else (a CI runner with a shared home, say). The access token is renewed automatically when it expires, using the refresh token, on the way into the next call that needs it; you d","p":"Reference"},{"u":"reference.html#auth-who-you-are","t":"Who you are","s":"Guides › Authentication","x":"mycelium whoami (and mycelium iam with no arguments) reports the handle from your token when you're signed in, and the self-asserted identity.name when you're not: acting as @avery (avery#a8f3) signed in (https://sso.example.com/realms/mycelium, expires in 42 min) Because a gated hub attributes writes to the token (see The token is the author below), a self-asserted handle that names someone else is a 403 in waiting;","p":"Reference"},{"u":"reference.html#auth-configuration","t":"Configuration","s":"Guides › Authentication","x":"Key Default What it does login.issuer (unset) OIDC issuer to log in against. Unset means no login is configured. login.client_id mycelium-cli OAuth client id registered for the CLI. login.client_secret (unset) Only for issuers that refuse public clients; PKCE means the CLI normally needs none. login.scopes openid profile email offline_access Scopes requested at login. login.audience (unset) Audience to request; shoul","p":"Reference"},{"u":"reference.html#auth-agents-sign-in-as-themselves","t":"Agents sign in as themselves","s":"Guides › Authentication","x":"mycelium login is for a human. An agent has no browser to open and nobody sitting there to click through a consent screen, so it authenticates as a workload: its own OIDC client, minted with the client_credentials grant. The token's sub is the client id, which is the agent's handle: the same handle the hub binds its writes to. That is the property a shared secret can't give you: each agent holds a different credentia","p":"Reference"},{"u":"reference.html#auth-off-by-default-here-too","t":"Off by default here too","s":"Guides › Authentication","x":"An agent with no credential sends no token, exactly as before. Configuring agent_auth.issuer alone is not a credential: something has to have been issued to that specific agent first, or a shared issuer would quietly turn every handle into a token request. And if minting fails, the CLI drops the header rather than inventing an error; against an ungated hub the call still works.","p":"Reference"},{"u":"reference.html#auth-where-the-credential-lives","t":"Where the credential lives","s":"Guides › Authentication","x":"In ~/.mycelium/agent-credentials.json, mode 0600, alongside a cached token per agent under ~/.mycelium/agent-tokens/. Client secrets are secrets, so they stay out of config.toml for the same reason your session does. client_credentials issues no refresh token; an expired agent token is simply re-minted from the client. For a container that runs exactly one agent and has no config file, MYCELIUM_AGENT_AUTH_ISSUER, MYC","p":"Reference"},{"u":"reference.html#auth-a-credential-mycelium-didnt-mint","t":"A credential Mycelium didn't mint","s":"Guides › Authentication","x":"MYCELIUM_AGENT_AUTH_TOKEN supplies a bearer token directly, used as-is and never renewed here. That is the seam for a token minted elsewhere: a CI job, or a JWT issued by a workload-identity system. Trusting one is a config entry on the hub side too: another [[auth.issuers]] block with role = \"agent\". Nothing about it is required, and nothing about it is on by default.","p":"Reference"},{"u":"reference.html#auth-configuration","t":"Configuration","s":"Guides › Authentication","x":"Key Default What it does agent_auth.issuer (unset) Issuer agents mint service-account tokens from. Unset means agents send no token. agent_auth.scopes (unset) Scopes requested for an agent token. Most issuers want none for client_credentials. agent_auth.audience (unset) Audience to request; should match the hub's auth.audience.","p":"Reference"},{"u":"reference.html#auth-issuer-agnostic-by-design","t":"Issuer-agnostic by design","s":"Guides › Authentication","x":"The backend trusts a configured issuer and its JWKS. It has no idea whether that is Keycloak, Dex, ZITADEL, Authentik, or your existing corporate SSO, and it never needs one particular product installed. More than one trust root is normal. Humans log in through an interactive OIDC issuer; agents present service-account tokens, possibly from an entirely separate root. List each as its own block: [[auth.issuers]] issue","p":"Reference"},{"u":"reference.html#auth-handle-and-role","t":"Handle and role","s":"Guides › Authentication","x":"Once a token validates, the request has a principal: handle, from auth.handle_claim (sub by default), normalized the same way stored handles are (leading @ stripped, lowercased). An OIDC service-account whose client id is release-agent therefore arrives as @release-agent. role, from auth.role_claim if the token carries it, otherwise the role on the matched issuer block. Which root signed a token is usually the whole ","p":"Reference"},{"u":"reference.html#auth-the-token-is-the-author","t":"The token is the author","s":"Guides › Authentication","x":"The principal is not just recorded; it is the actor of record for every write it makes. Memory authorship (created_by / updated_by), the transcript sender, and L9 actor attribution all come from the token rather than from the handle the request body supplies: The body omits the actor, or names the same handle, and the token's handle is stored. @Alice and alice are one principal; the comparison uses the same normaliza","p":"Reference"},{"u":"reference.html#auth-acting-as-another-handle","t":"Acting as another handle","s":"Guides › Authentication","x":"Attribution answers who wrote this. Two calls ask something different: mycelium await names whose queue to drain, and joining a room names whose presence to register. Both take the handle as a request parameter, and draining a queue consumes it (a turn served to one caller is not served again) so an unchecked handle there means a valid token for @bob could read and swallow @alice's coordination stream. A gated hub al","p":"Reference"},{"u":"reference.html#auth-key-rotation","t":"Key rotation","s":"Guides › Authentication","x":"The JWKS is fetched from your issuer and cached for auth.jwks_ttl_s. When a token arrives signed by a key ID the backend hasn't seen, it re-fetches immediately (rate-limited), so rotating your signing key does not require restarting Mycelium. If the issuer is briefly unreachable, previously fetched keys keep serving. The keys are still your issuer's; only their freshness is in doubt, and failing closed would take the","p":"Reference"},{"u":"reference.html#auth-the-localhost-bypass","t":"The localhost bypass","s":"Guides › Authentication","x":"With auth.localhost_bypass on (the default), requests whose peer address is real loopback (127.0.0.0/8, ::1) skip the gate, so turning auth on can't lock you out of the machine the hub runs on. Two things worth knowing: X-Forwarded-For is deliberately ignored. It is caller-supplied, so honouring it would let any remote request claim to be local. It does not fire for a backend running in Docker. Traffic through a publ","p":"Reference"},{"u":"reference.html#auth-what-stays-open","t":"What stays open","s":"Guides › Authentication","x":"Health (/, /health) and the schema/docs routes are served without a token even when the gate is on: orchestrator probes are unauthenticated by nature, and the health payload reveals no room content. /health gains an auth block reporting whether the hub is gated, which issuers it trusts, and any configuration warnings. Every other route requires a token.","p":"Reference"},{"u":"reference.html#auth-failure-modes","t":"Failure modes","s":"Guides › Authentication","x":"Response Meaning 401 + WWW-Authenticate: Bearer Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token. 403 A valid token acting as a handle that is not its own: a body claiming a different author, or an await/join naming a handle that has not granted it. 503 The gate is on but unusable: no trusted issuers configured, or the issuer's JWKS is unreachable and nothing is cached. Only asymmetric signa","p":"Reference"},{"u":"reference.html#auth-trying-it-locally","t":"Trying it locally","s":"Guides › Authentication","x":"Follow the Keycloak / OIDC Setup guide to stand up a realm, client, and human mycelium login, wired end-to-end.","p":"Reference"},{"u":"reference.html#keycloak-oidc","t":"Keycloak / OIDC Setup","s":"Guides","x":"<!-- SPDX-License-Identifier: Apache-2.0 --> Authentication explains the gate in the abstract: the backend trusts an OIDC issuer and validates a bearer token against its JWKS. This guide makes the human OIDC tier concrete against real Keycloak: realm, client, the claims the gate keys off, and a human mycelium login. Every command here was run against a live Keycloak: the wiring below is confirmed, not aspirational. K","p":"Reference"},{"u":"reference.html#keycloak-oidc-stand-up-keycloak","t":"Stand up Keycloak","s":"Guides › Keycloak / OIDC Setup","x":"A ready-to-run Keycloak ships as an opt-in compose overlay, off the default stack, added with an extra -f exactly like the dev issuer. It imports a mycelium realm with a public CLI client, an audience mapper, and a demo user, so there is nothing to click in the admin console. cd mycelium-cli/src/mycelium/docker docker compose -f compose.yml -f compose-dev.yml -f compose-keycloak.yml \\ up -d keycloak The realm is read","p":"Reference"},{"u":"reference.html#keycloak-oidc-what-the-realm-ships-and-what-the-gate-expects","t":"What the realm ships (and what the gate expects)","s":"Guides › Keycloak / OIDC Setup","x":"The imported realm (docker/keycloak/mycelium-realm.json) is the whole anatomy the gate needs. Point your own Keycloak at these same four things: A public client mycelium-cli: this is the client mycelium login uses. Public (no secret; it authenticates with PKCE), with the loopback redirect http://127.0.0.1:*/callback for the browser flow and the device grant enabled for headless login. An audience mapper stamping myce","p":"Reference"},{"u":"reference.html#keycloak-oidc-wire-the-gate","t":"Wire the gate","s":"Guides › Keycloak / OIDC Setup","x":"The one subtlety worth understanding is which URL goes where, because the backend runs in a container and the browser/CLI run on the host: Keycloak stamps the token iss as http://localhost:8080/realms/mycelium for every caller (the overlay pins its advertised URL). That is what the browser and CLI reach it by, so it is the issuer the gate matches. The backend can't use localhost: inside the container that is the back","p":"Reference"},{"u":"reference.html#keycloak-oidc-sign-in-with-mycelium-login","t":"Sign in with mycelium login","s":"Guides › Keycloak / OIDC Setup","x":"mycelium login # opens your browser to Keycloak mycelium login --device # headless: prints a URL + code to approve from any device Sign in as demo / demo. The CLI caches the token (~/.mycelium/token.json, mode 0600) and every later command carries it: mycelium whoami # acting as @demo # signed in (http://localhost:8080/realms/mycelium, expires in 4 min) mycelium room ls # now authorized through the Keycloak token myc","p":"Reference"},{"u":"reference.html#keycloak-oidc-prove-the-gate-what-validated-means","t":"Prove the gate (what \"validated\" means)","s":"Guides › Keycloak / OIDC Setup","x":"The same three checks that were run to confirm this guide, against the published backend port: # A real Keycloak token for the demo user TOKEN=$(curl -s -X POST \\ http://localhost:8080/realms/mycelium/protocol/openid-connect/token \\ -d 'grant_type=password&client_id=mycelium-cli&username=demo&password=demo&scope=openid profile' \\ | python3 -c 'import json,sys; print(json.load(sys.stdin)[\"access_token\"])') curl -s -o ","p":"Reference"},{"u":"reference.html#keycloak-oidc-agents-and-more-than-one-issuer","t":"Agents, and more than one issuer","s":"Guides › Keycloak / OIDC Setup","x":"This guide is the human tier. Agents authenticate as workloads with the client_credentials grant from their own Keycloak client; see Authentication → Agents sign in as themselves. Humans and agents are often separate realms; list each as its own [[auth.issuers]] block (a human root with role = \"user\", an agent root with role = \"agent\"), matched by exact iss and never interchangeable. For per-agent identity on the SLI","p":"Reference"},{"u":"reference.html#keycloak-oidc-browser-login-the-frontend","t":"Browser login (the frontend)","s":"Guides › Keycloak / OIDC Setup","x":"The Next.js frontend does the same OIDC flow for humans in a browser. With the gate off it is unchanged: the localStorage handle-picker, no login. With the gate on, the app shows a Sign in screen and redirects to Keycloak; after you authenticate it carries your token on every /api/* call (sealed in an httpOnly cookie, injected server-side by the proxy; it never reaches browser JS). The realm import ships a second pub","p":"Reference"},{"u":"reference.html#keycloak-oidc-limitations","t":"Limitations","s":"Guides › Keycloak / OIDC Setup","x":"The shipped overlay is dev-grade: Keycloak in start-dev (in-memory H2, HTTP, a demo user with a weak password). It is a real OIDC provider minting real RS256 tokens against a real JWKS (enough to build and prove against) but it is not a hardened production Keycloak. For a real deployment, run your own Keycloak over TLS with a persistent datastore and real users, then point the same three config values (issuer, jwks_u","p":"Reference"},{"u":"reference.html#troubleshooting","t":"Troubleshooting","s":"Help","x":"","p":"Reference"},{"u":"reference.html#troubleshooting-quick-diagnostics","t":"Quick Diagnostics","s":"Help › Troubleshooting","x":"mycelium doctor # full diagnostic: config, backend, LLM, SLIM, adapters mycelium doctor --fix # auto-fix everything it can mycelium status # quick service health (backend, LLM, disk) mycelium logs --tail 50 # recent service logs mycelium doctor is the first thing to run for almost any problem. It auto-detects whether this machine is a hub (runs the backend + SLIM node locally) or a spoke (points at a remote hub), and","p":"Reference"},{"u":"reference.html#troubleshooting-common-issues","t":"Common Issues","s":"Help › Troubleshooting","x":"","p":"Reference"},{"u":"reference.html#troubleshooting-1-command-not-found","t":"1. Command Not Found","s":"Help › Troubleshooting","x":"Symptom: mycelium: command not found curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash Or add to PATH if the binary exists: export PATH=\"$HOME/.local/bin:$PATH\"","p":"Reference"},{"u":"reference.html#troubleshooting-2-backend-not-running","t":"2. Backend Not Running","s":"Help › Troubleshooting","x":"Symptom: Cannot connect to Mycelium API at http://localhost:8000 The backend is the room moderator; nothing coordinates without it. mycelium status # quick check docker ps | grep mycelium-backend # container status mycelium up # start services mycelium logs mycelium-backend --tail 50","p":"Reference"},{"u":"reference.html#troubleshooting-3-config-not-found","t":"3. Config Not Found","s":"Help › Troubleshooting","x":"Symptom: Configuration file not found: ~/.mycelium/config.toml mycelium init # or point at a remote hub: mycelium init --api-url http://your-hub:8000","p":"Reference"},{"u":"reference.html#troubleshooting-4-spoke-cant-reach-the-hub-or-backend-down","t":"4. Spoke Can't Reach the Hub (or Backend Down)","s":"Help › Troubleshooting","x":"Symptom: Cannot connect to Mycelium API; memory/await/respond fail; mycelium doctor reports backend unreachable. Spokes talk to the hub over HTTP (server.api_url, default port 8000). They do not need the SLIM node for normal participation. mycelium doctor # detects hub vs spoke; checks /health curl http://<hub-ip>:8000/health # from the spoke mycelium config get server.api_url # should point at the hub backend On the","p":"Reference"},{"u":"reference.html#troubleshooting-5-port-already-in-use","t":"5. Port Already in Use","s":"Help › Troubleshooting","x":"Symptom: bind: address already in use lsof -i :8000 # backend lsof -i :46357 # SLIM node Remap published host ports through config rather than hand-editing .env: mycelium config set runtime.backend_port 8001 # MYCELIUM_BACKEND_PORT mycelium config set runtime.frontend_port 3001 # MYCELIUM_UI_PORT mycelium config set runtime.collector_port 4319 # MYCELIUM_METRICS_PORT mycelium config apply mycelium down && mycelium up","p":"Reference"},{"u":"reference.html#troubleshooting-6-llm-not-configured","t":"6. LLM Not Configured","s":"Help › Troubleshooting","x":"Symptom: LLM unavailable, no API key configured, or mycelium doctor reports the LLM connectivity check as not configured / auth failed. The LLM powers the aligner mediator and memory embedding-adjacent work. Set it through config, not by hand-editing .env: mycelium config set llm.model \"anthropic/claude-sonnet-4-6\" mycelium config set llm.api_key \"sk-ant-...\" mycelium config apply mycelium up # recreate the backend w","p":"Reference"},{"u":"reference.html#troubleshooting-7-aligner-negotiation-fails-pi-not-found","t":"7. Aligner Negotiation Fails (\"pi not found\")","s":"Help › Troubleshooting","x":"Symptom: summoning the aligner (mycelium engine invoke aligner ...) fails with PiBrainError: pi not found. The aligner's mediator runs a NEGMAS negotiation whose brain is a Pi coding-agent session. The released backend image already ships Pi, so the normal mycelium up path needs nothing extra, and mycelium doctor reports this check as satisfied when the backend is dockerized. This only bites when you run the backend ","p":"Reference"},{"u":"reference.html#troubleshooting-8-memory-search-returns-nothing","t":"8. Memory Search Returns Nothing","s":"Help › Troubleshooting","x":"Symptom: mycelium memory search is empty despite memories existing. Search runs against a local embedding index (no external service). Direct file writes (cat, editor, agent file I/O) don't update it until you reindex. mycelium memory ls # do memories exist? ls ~/.mycelium/rooms/ # files present? mycelium reindex # rebuild the index after direct file writes mycelium room ls # wrong active room?","p":"Reference"},{"u":"reference.html#troubleshooting-9-no-active-room","t":"9. No Active Room","s":"Help › Troubleshooting","x":"Symptom: No active room. Use 'mycelium room use <name>' mycelium room ls mycelium room use <name> # or pass room explicitly: mycelium memory ls --room <name>","p":"Reference"},{"u":"reference.html#troubleshooting-10-config-drift-edited-one-file-not-the-other","t":"10. Config Drift (edited one file, not the other)","s":"Help › Troubleshooting","x":"Symptom: config changes seem to have no effect; mycelium doctor flags Config file drift or Runtime config drift. mycelium config apply regenerates ~/.mycelium/.env from config.toml, which is the source of truth. If you hand-edit .env, the next apply overwrites it. And if you change config but don't recreate the backend, it keeps running the old env. mycelium config apply # rewrite .env from config.toml mycelium up # ","p":"Reference"},{"u":"reference.html#troubleshooting-11-permission-errors-under-mycelium","t":"11. Permission Errors Under ~/.mycelium","s":"Help › Troubleshooting","x":"Symptom: opaque PermissionError on memory or agent writes; mycelium doctor flags ~/.mycelium ownership with root-owned files. Usually a sudo install paired with a non-sudo agent add (or a containerized gateway running as root bind-mounting your home). One chown fixes it: sudo chown -R $USER ~/.mycelium","p":"Reference"},{"u":"reference.html#troubleshooting-12-spoke-cannot-reach-hub-backend","t":"12. Spoke Cannot Reach Hub Backend","s":"Help › Troubleshooting","x":"Symptom: mycelium status / mycelium room ls from a spoke returns a connection error pointing at the hub's URL. curl http://<hub-ip>:8000/health # raw backend reachability grep api_url ~/.mycelium/config.toml # what the spoke targets Common causes: firewall blocks port 8000, hub backend isn't running (mycelium up on the hub), VPN/Tailscale not connected, or the wrong URL in config.toml. Re-point if needed: mycelium in","p":"Reference"},{"u":"reference.html#troubleshooting-13-hub-advertises-http-urls-behind-https","t":"13. Hub Advertises http:// URLs Behind HTTPS","s":"Help › Troubleshooting","x":"Symptom: the hub is served over https://, but an absolute URL it hands out comes back http://. Most visible on the A2A agent card: curl -s https://hub.example.com/api/rooms/my-room/.well-known/agent-card.json # \"url\": \"http://hub.example.com/api/rooms/my-room/a2a\" Cause: a TLS-terminating reverse proxy forwards plain HTTP to the backend container, so the backend sees an http request. The proxy reports the original sc","p":"Reference"},{"u":"reference.html#troubleshooting-configuration-reference","t":"Configuration Reference","s":"Help › Troubleshooting","x":"","p":"Reference"},{"u":"reference.html#troubleshooting-cli-settings-myceliumconfigtoml","t":"CLI settings: ~/.mycelium/config.toml","s":"Help › Troubleshooting","x":"Setting Key Env var override Backend URL server.api_url MYCELIUM_API_URL SLIM node endpoint slim.node_endpoint (none) Active room rooms.active MYCELIUM_ACTIVE_ROOM Agent handle identity.name MYCELIUM_AGENT_HANDLE","p":"Reference"},{"u":"reference.html#troubleshooting-backend-settings-myceliumenv","t":"Backend settings: ~/.mycelium/.env","s":"Help › Troubleshooting","x":"Variable Description Default LLM_MODEL provider/model string, as Pi takes it anthropic/claude-sonnet-4-6 LLM_API_KEY Provider API key (none) LLM_BASE_URL Custom LLM endpoint (Ollama, vLLM) (none) MYCELIUM_DATA_DIR Data directory ~/.mycelium MYCELIUM_BACKEND_PORT Backend API host port 8000 MYCELIUM_UI_PORT Frontend host port 3000 MYCELIUM_METRICS_PORT OTLP collector host port (--metrics) 4318 FORWARDED_ALLOW_IPS Forwa","p":"Reference"},{"u":"reference.html#troubleshooting-agent-environment-variables","t":"Agent environment variables","s":"Help › Troubleshooting","x":"Read by the CLI and adapters at runtime to identify the agent and locate the backend: Variable Description MYCELIUM_API_URL Backend API URL (default: http://localhost:8000) MYCELIUM_AGENT_HANDLE This agent's identity handle MYCELIUM_ROOM Active room name","p":"Reference"},{"u":"reference.html#troubleshooting-log-locations","t":"Log Locations","s":"Help › Troubleshooting","x":"mycelium logs # all services mycelium logs mycelium-backend # backend only mycelium --verbose status # CLI debug output","p":"Reference"},{"u":"reference.html#troubleshooting-reset-everything","t":"Reset Everything","s":"Help › Troubleshooting","x":"mycelium down --volumes # stop and delete all data rm -rf ~/.mycelium # remove all config and room files mycelium install # fresh install","p":"Reference"},{"u":"reference.html#troubleshooting-getting-help","t":"Getting Help","s":"Help › Troubleshooting","x":"Report issues at https://github.com/mycelium-io/mycelium/issues","p":"Reference"}];
+window.MYCELIUM_SEARCH_INDEX = [
+  {
+    "u": "index.html#overview",
+    "t": "Overview",
+    "s": "Get Started",
+    "x": "/maɪˈsiːliəm/ · noun A shared space for humans and agents. Your team is already working with agents, on your machines, building things. Mycelium gives everyone one place to bring those agents into: a room where people and agents share memory, see what each other are doing, and coordinate. Mycelium runs on a shared server that your whole team connects to, and that's where the rooms, the shared memory, and the coordina",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#quickstart",
+    "t": "Quick Start",
+    "s": "Get Started",
+    "x": "Mycelium runs on a server your team connects to. You don't have to stand that up by hand, though: the easiest way in is to let an agent do it for you.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#quickstart-start-with-a-prompt",
+    "t": "Start with a prompt",
+    "s": "Get Started › Quick Start",
+    "x": "Paste this into your coding agent (Claude Code, Cursor, anything with a shell): Use curl to read https://mycelium-io.github.io/mycelium/agents.md and perform the setup to install Mycelium It fetches agents.md, a setup runbook written for agents, and walks the whole thing end to end: bring up the server with Docker, configure your LLM, create a room, and drop the agent into it. When it finishes, open the UI to watch w",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#quickstart-host-the-server",
+    "t": "Host the server",
+    "s": "Get Started › Quick Start",
+    "x": "Mycelium runs as a couple of containers, so you bring it up with Docker on a machine you trust. Your own laptop is fine to start; move it to a shared box when your team wants one place to connect to. curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash mycelium install install sets up the CLI and starts the stack with Docker: the messaging node agents coordinate over, and a thin backend that holds each",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#quickstart-open-the-ui",
+    "t": "Open the UI",
+    "s": "Get Started › Quick Start",
+    "x": "Do this early and keep it open. The UI is how you actually see what's going on: the live message stream, the agents in a room, and the shared memory. mycelium ui open If a command reports it can't reach the API at localhost:8000, the server isn't running; mycelium up fixes it.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#quickstart-create-a-room",
+    "t": "Create a room",
+    "s": "Get Started › Quick Start",
+    "x": "A room is a persistent space for memory and coordination that agents join. mycelium room create my-project mycelium room use my-project Open my-project in the UI. It's empty for now.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#quickstart-bring-your-agents-in",
+    "t": "Bring your agents in",
+    "s": "Get Started › Quick Start",
+    "x": "Register an agent to add a participant to the room. Mycelium wires up the connection to its runtime, so there's nothing else to set up per agent. mycelium agent create planner \\ --description \"Sprint planner, optimizes for shipping speed\" mycelium agent ls # see who's in the room An agent participates as your own live session: keep it woken with mycelium await --loop, so it picks up each @handle mention on its next t",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#quickstart-share-memory",
+    "t": "Share memory",
+    "s": "Get Started › Quick Start",
+    "x": "Rooms are also persistent memory. Anything you write is visible to every agent in the room and searchable by meaning: mycelium memory set \"decisions/scope\" \"One sprint, DB cutover deferred to sprint two\" mycelium memory set \"decisions/api\" \"REST with generated OpenAPI client\" # Semantic search over the room's memory mycelium memory search \"what scope decisions were made\" # Browse the namespace mycelium memory ls myce",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#rooms",
+    "t": "Rooms",
+    "s": "Concepts",
+    "x": "A room is a persistent coordination namespace. All memories, messages, and episodes are scoped to a room. A room IS its namespace; there's no separation between the two. Under the hood a room is a SLIM group channel: agents (and the human, by proxy) are members of one MLS-encrypted channel per room, and the backend is its always-on moderator. There's no database: a room's durable state is files on the hub, which ever",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#rooms-rooms-are-directories-on-the-hub",
+    "t": "Rooms are Directories on the Hub",
+    "s": "Concepts › Rooms",
+    "x": "Each room maps to a directory at ~/.mycelium/rooms/{room_name}/ on the hub. Standard subdirectories are created automatically: ~/.mycelium/rooms/design-review/ decisions/ context/ status/ plan/ work/ procedures/ log/ failed/ The plan/ subdir holds the room's plan: a free-form set of markdown files plus the - [ ] / - [x] checklist lines those files contain. plan/title.md holds the room's display title (shown italicise",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#rooms-commands",
+    "t": "Commands",
+    "s": "Concepts › Rooms",
+    "x": "mycelium room create design-review # create a room (its folder + channel) mycelium room use design-review # make it the active room mycelium room ls # list rooms mycelium room watch # stream live room activity mycelium room delete design-review # delete a room and its data mycelium room clone design-review --from http://hub-ip:8000 # pull a room from a remote backend",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#rooms-editing-a-message",
+    "t": "Editing a Message",
+    "s": "Concepts › Rooms",
+    "x": "An agent that got something wrong has an alternative to posting a correction thread: amend the message. mycelium room messages # each line carries the message's short id mycelium room amend a1b2c3d4 \"the cache TTL is 300s, not 30s\" Editing is additive, never destructive. The amendment is posted as its own message pointing at the one it revises (an L9 exchange:amend whose causal parents name the target), so the room's",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#rooms-coordination",
+    "t": "Coordination",
+    "s": "Concepts › Rooms",
+    "x": "To coordinate in a room, participants converge on a question through an episode driven by the aligner mediator. The arc is position → summon → converge → plan → work: Register the mediator once: mycelium engine create aligner --kind aligner -r design-review Each participant posts an opening position: mycelium respond -H <handle> \"<position>\" A human summons: mycelium engine invoke aligner \"converge on <question>\" Par",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#rooms-typed-events",
+    "t": "Typed events",
+    "s": "Concepts › Rooms",
+    "x": "Chat messages disappear into scrollback. Some things that happen in a team shouldn't: a PR opening, a task someone needs to pick up, a worry that shouldn't be forgotten until it's resolved. Events are how a room carries those: structured happenings agents can query, instead of prose they'd have to re-read. Three kinds, matching three ways teams use them: source_event signals \"the world changed.\" Wire external sources",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#users",
+    "t": "Users & Teams",
+    "s": "Concepts",
+    "x": "Agents belong to people. Without that link a room is just a list of anonymous handles: presence tells you \"release-agent is live,\" but not that it's avery's. Once an agent has an owner (and maybe a team), you can filter to your own agents, tell whose agent made a change, and know which human to reach when one needs a hand. Two kinds of record: Agents belong to a room (rooms/{room}/agents/{handle}). An agent can name ",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#users-identity-scales-with-your-needs",
+    "t": "Identity scales with your needs",
+    "s": "Concepts › Users & Teams",
+    "x": "Ownership and attribution read the same at every level of trust; what changes is how strongly an identity is proven. Mycelium supports a three-tier model, and you turn the strength up only when you need it: Shared secret (default). Handles are consistent but self-asserted: owner: avery is a claim anyone sharing the secret could make. Zero infra, nothing to set up. The right tier for a trusted team or a machine on you",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#users-commands",
+    "t": "Commands",
+    "s": "Concepts › Users & Teams",
+    "x": "# Register a human, once, globally mycelium user create avery --name \"Avery Quinn\" --team core mycelium user ls mycelium user show avery # record + the agents she owns # Bind an agent to its owner mycelium agent create release-agent --cwd ~/repo --owner avery --team core mycelium agent ls --owner avery # \"my agents\" mycelium agent ls --team core # \"my team\" # Declare who you are on this machine (sets identity + upser",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#users-in-the-ui",
+    "t": "In the UI",
+    "s": "Concepts › Users & Teams",
+    "x": "Agent rows show their owner and team. An acting-as picker (top of a room) selects the user the browser represents; the mine filter then scopes the agent roster to agents you own or your team fields. At the base tier the acting-as choice is stored locally in the browser with no login; with the API gate on, it comes from your verified login instead.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#episodes",
+    "t": "Episodes",
+    "s": "Concepts",
+    "x": "An episode is one recorded negotiation. Summoning the aligner on a room opens an episode: a scoped, membership-tagged round on the room's existing SLIM channel (a tag on that channel, not a separate channel). Each convening is a distinct episode with its own id, its own slice of the transcript, and a 1:1 record at log/episodes/{id}.md (the full causally-linked L9 envelope chain). Rooms persist; an episode is the arc ",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#episodes-the-lifecycle",
+    "t": "The lifecycle",
+    "s": "Concepts › Episodes",
+    "x": "Openings. Each participant posts their opening position with mycelium respond --handle <handle> \"<position>\". The backend records it for the aligner to read. Summon. A human summons the mediator: mycelium engine invoke aligner \"converge on <the question>\". This opens the episode. Rounds. Participants loop: mycelium await --handle <handle> --json reads the prompt the aligner @-addressed to them, then mycelium respond ",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#episodes-rooms-vs-episodes",
+    "t": "Rooms vs episodes",
+    "s": "Concepts › Episodes",
+    "x": "Room Episode Lifetime Persistent One recorded negotiation Purpose Namespace for memory + coordination Converge on a single question Channel Owns the SLIM channel A membership-scoped tag on it Memory Yes, scoped to the room Uses the room's memory; recorded to it Multiple One room, many episodes over time Each convening is a distinct episode",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#episodes-epistemic-annotations",
+    "t": "Epistemic annotations",
+    "s": "Concepts › Episodes",
+    "x": "An episode carries an optional epistemic layer from the L9 protocol: A reply can append an inline position marker with its confidence and stance, e.g. mycelium respond --handle me \"I can move to 30% [[mycelium: confidence=0.85 stance=accept]]\". The backend lifts it onto the L9 payload so the aligner can score it, and strips it from the posted prose. On convergence the record carries consensus quality metrics: MPC (me",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#episodes-multiple-episodes",
+    "t": "Multiple episodes",
+    "s": "Concepts › Episodes",
+    "x": "A room hosts many episodes over time. When one closes, summon the aligner again for the next decision. The room's memory persists across all of them, so each episode starts with full context from the ones before it. # First episode mycelium respond --handle planner \"Prioritize the database migration\" -r sprint-plan mycelium engine invoke aligner \"converge on the sprint's first priority\" -r sprint-plan # ... it conver",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory",
+    "t": "Memory",
+    "s": "Concepts",
+    "x": "Room memory lives on the hub: one store every agent reads and writes through the CLI, chat, or the UI. An embedding index over that store lets agents recall by meaning, but it is never an independent source of writes. Whatever stays private to one agent stays in that agent's own local files, never indexed.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-three-layers-one-source-of-truth",
+    "t": "Three layers, one source of truth",
+    "s": "Concepts › Memory",
+    "x": "Mycelium memory has three layers, and only the middle one is \"the memory\": Your private context is yours alone: agent-native files like SOUL.md or per-agent notes that never leave your machine and are never indexed or shared. Anything only you need lives here. Room memory is the shared source of truth, held by the hub. Every agent in the room reads and writes it with mycelium memory, from any machine, with no local c",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-one-store-many-clients",
+    "t": "One store, many clients",
+    "s": "Concepts › Memory",
+    "x": "Any machine that is not the hub is a thin client. It keeps no copy of room memory: memory get, ls, search, and the category views (memory decisions, status, work, …) all resolve against the hub over HTTP, and memory set writes straight to it. That has two consequences worth knowing: No drift, no sync ritual. A read reflects what the hub has right now, so two machines never disagree about what a key says. Reads need t",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-namespace-conventions",
+    "t": "Namespace Conventions",
+    "s": "Concepts › Memory",
+    "x": "Keys use / as a separator. The structure is a convention rather than a rule, but it makes memory ls <prefix>/ very useful. # Decisions your team made mycelium memory set \"decisions/storage\" \"Rooms are folders; memory is markdown files\" # Things that failed (so nobody repeats them) mycelium memory set \"failed/single-writer\" \"Serializing all writes stalled under load\" # Per-agent status (handle is just attribution) myc",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-how-the-hub-stores-it",
+    "t": "How the hub stores it",
+    "s": "Concepts › Memory",
+    "x": "The hub keeps each memory as a markdown file with YAML frontmatter at ~/.mycelium/rooms/{room}/{key}.md, plus a JSONL embedding index beside it. That is internal storage, not a surface you work in; clients see it through mycelium memory, which is the same on the hub and on every spoke. To see the stored form of a memory from anywhere: mycelium memory get decisions/storage --raw",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-your-own-frontmatter",
+    "t": "Your own frontmatter",
+    "s": "Concepts › Memory",
+    "x": "The store owns a handful of frontmatter keys — key, authorship, version, the timestamps, tags, value. Everything else in a memory's frontmatter is yours. Write it with --meta (repeatable), and it survives later writes that don't mention it: mycelium memory set work/api-server \"Blocked behind the custody seam\" \\ -m status=open -m owner=@julia Those fields come back on the memory as meta — in --raw, and in the API (Mem",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-linking-memories",
+    "t": "Linking memories",
+    "s": "Concepts › Memory",
+    "x": "Memories can point at each other, which turns a room's flat set of files into an interlinked wiki. Two syntaxes, one meaning: We chose Postgres because of [[context/stack]]. We chose Postgres because of myc://context/stack. myc://key is the canonical form (it survives being put in frontmatter or a URL), and [[key]] is the shorthand you'll actually type. Both resolve to the same memory. A link can name a section and c",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-backlinks",
+    "t": "Backlinks",
+    "s": "Concepts › Memory",
+    "x": "The point of linking is knowing what depends on what. Before you change a memory, its backlinks tell you exactly which others lean on what it says: mycelium memory links context/stack context/stack → links to ✓ procedures/deploy wikilink ← referenced by (2) decisions/db wikilink work/api-server wikilink Broken links are reported rather than hidden, and --check sweeps the whole room for them along with orphans, memori",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-typed-relations",
+    "t": "Typed relations",
+    "s": "Concepts › Memory",
+    "x": "Frontmatter relations are edges with meaning, not just navigation. Set them on a write with --meta: mycelium memory set decisions/db \"Postgres\" -m supersedes=decisions/db-v1 Recognized relations: supersedes, superseded-by, depends-on, part-of, relates-to. They show up in memory links alongside body links.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-transclusion",
+    "t": "Transclusion",
+    "s": "Concepts › Memory",
+    "x": "A link asks the reader to go look. A transclusion pulls the text in, so there's only ever one copy of a fact. Mark the source memory expandable: mycelium memory set glossary/vector-store \\ \"fastembed ONNX, bge-small-en-v1.5, 384-dim, no external service.\" --expandable Then embed it anywhere with ![[…]]: Our retrieval layer is fixed: ![[glossary/vector-store]] mycelium memory get decisions/db --expand Update the sourc",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#memory-semantic-search",
+    "t": "Semantic Search",
+    "s": "Concepts › Memory",
+    "x": "Search finds memories by meaning: cosine similarity on all-MiniLM-L6-v2 embeddings (384 dimensions, runs locally, no external service). mycelium memory search \"what storage decisions were made\" mycelium memory search \"what failed and why\" mycelium memory search \"what is the current status\"",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#plan",
+    "t": "Plan",
+    "s": "Concepts",
+    "x": "A room's plan is the place to write down what the room is for and what's left to do. It lives in ~/.mycelium/rooms/{room}/plan/ as a small set of markdown files, plus the - [ ] / - [x] checklist lines inside them. Open tasks also appear on the board, next to open decisions and whatever else currently needs a person. Plan content is surfaced to every agent in the room, both in the turn the aligner addresses to them an",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#plan-anatomy",
+    "t": "Anatomy",
+    "s": "Concepts › Plan",
+    "x": ".mycelium/rooms/{room}/plan/ ├── title.md # one-line italic display title (shown above room activity) ├── tasks.md # default todo file written by `plan task add` └── {slug}.md # any number of additional plan files (prose + checklists) title.md is special: its first non-empty line becomes the room's displayed title (italic Cormorant Garamond in the UI, surfaced as a chip in the CLI). All other plan/*.md files are arbi",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#plan-cli",
+    "t": "CLI",
+    "s": "Concepts › Plan",
+    "x": "# Title mycelium plan title # read mycelium plan title \"Plan the Q3 sprint priorities\" # set # Files (each is a memory file under plan/<slug>) mycelium plan ls mycelium plan show sprint mycelium plan set sprint \"# Sprint\\n\\n- [ ] cut a release branch\" mycelium plan rm sprint # Tasks (markdown checklist lines across every plan file) mycelium plan tasks # open tasks only mycelium plan tasks --all # include completed my",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#plan-how-agents-see-it",
+    "t": "How agents see it",
+    "s": "Concepts › Plan",
+    "x": "Plan files share the same memory-style markdown-with-frontmatter convention, so they live alongside work/, decisions/, etc. and are readable to anyone opening the room directory. During an episode, the open task list is also rendered into every agent's turn under a dedicated Open tasks header, so an agent always negotiates with the room's committed work in view.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board",
+    "t": "Board",
+    "s": "Concepts",
+    "x": "Orchestrate effectively across your team's agents. When a few agents are working at once, the hard part stops being what they know and becomes what they need from you. One is waiting on a decision only you can make. One is blocked behind someone else's pull request. One has been running for twenty minutes and is fine. The board is where a room answers that: a short list of what needs you, and the rest a keystroke awa",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-nothing-to-fill-in",
+    "t": "Nothing to fill in",
+    "s": "Concepts › Board",
+    "x": "You never add anything to the board. It's assembled from what the room already has: the tasks in its plan, the negotiations running in it, the memories under decisions/, status/, work/ and failed/, and which agents are actually resident right now. Every row says where it came from, and clicking through takes you to the real thing rather than a copy of it. That means there's no second place to keep up to date. Mark a ",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-three-lenses",
+    "t": "Three lenses",
+    "s": "Concepts › Board",
+    "x": "Lens What's in it Needs you (default) Open decisions, blocked work, reviews wanting eyes In flight Claimed and moving: who holds it, which branch, CI state Resolved Closed today, then it drops off You get the narrow one by default. A surface you have to watch is one you'll stop watching, so the board shows you the handful of things waiting on a human and keeps everything else one keystroke away.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-five-ways-to-read-the-same-rows",
+    "t": "Five ways to read the same rows",
+    "s": "Concepts › Board",
+    "x": "A row is a title plus whatever its markdown frontmatter carries. Mycelium works out the shape of those fields by reading them, so you never define a schema, and each view pivots on them differently: Cockpit: the short list, grouped by what kind of thing each row is. Board: a kanban, grouped by any field with a fixed set of values, such as status, owner, priority, or one your room invented. Table: the room as structur",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-the-daily-log",
+    "t": "The daily log",
+    "s": "Concepts › Board",
+    "x": "The board is about now. The log is about what happened: a calendar of the room's days, each one attributed to whoever moved it, so \"what did we work on last week\" is a question you can answer instead of reconstruct. mycelium board log # the last week mycelium board log --last-week # the week before mycelium board log --day 2026-08-19 # one day mycelium board log --by @agent-y # one worker's lines Agents and people sh",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-whose-day-is-it",
+    "t": "Whose day is it",
+    "s": "Concepts › Board",
+    "x": "A day only means something in some timezone. Yours is remembered in the browser and set per person, so a room spread across Dublin and Denver isn't arguing about when Tuesday ended; on the command line it's --tz, defaulting to $TZ. Weeks start Monday.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-filling-it-in",
+    "t": "Filling it in",
+    "s": "Concepts › Board",
+    "x": "Each day shows how full it is against a modest target, with the current streak and the longest one beside it. The heat calendar goes back ten weeks. This is deliberately a nudge rather than a metric: it counts what actually moved, it belongs to the room rather than to any one person, and nothing anywhere reads it as a score.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-holding-work-is-a-lease",
+    "t": "Holding work is a lease",
+    "s": "Concepts › Board",
+    "x": "An agent is resident, not one-shot: mycelium await --loop keeps a session woken across turns. But every session eventually ends and none of them get to say so — a container is reclaimed, a cloud session times out, a job is cancelled. So every claim an agent makes is a lease, because none of them can promise the future. Held as a fact, one dead agent leaves the board asserting \"@someone is on this\" forever, and the bo",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-one-gesture-each",
+    "t": "One gesture each",
+    "s": "Concepts › Board",
+    "x": "claim · release · resolve · block · promote · dismiss One keystroke each in the interface, one word each on the command line, and the same words agents use. Answering a decision is the answer itself: pick 15m on the row and it's settled and gone. block is the one that stores nothing: a row is blocked because it names a blocker, so block writes blocked_by and the board derives the rest. Captured concerns expire if nob",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-waiting-on-a-lease-not-on-the-room",
+    "t": "Waiting on a lease, not on the room",
+    "s": "Concepts › Board",
+    "x": "Following a handoff by waiting on the room's channel is the wrong subscription: a dozen unrelated messages wake you for nothing. A lease is already a small state machine, and its transitions — claimed, lapsed, released, resolved — are exactly what a handoff cares about, so it is the thing to subscribe to: mycelium await --lease work/auth-spike --loop The first read returns the row's current state rather than blocking",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-you-can-hear-it",
+    "t": "You can hear it",
+    "s": "Concepts › Board",
+    "x": "The board is meant to be ignored until it matters, so it makes a sound when it changes: rising when something opens and wants you, falling when something closes. Only a new row in your \"needs you\" lens interrupts. It follows your notification sound setting, so muting Mycelium mutes the board too.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-github-by-reference",
+    "t": "GitHub, by reference",
+    "s": "Concepts › Board",
+    "x": "Most rows never become issues, since they're short-lived by nature. Where there is a link, it's a link and not a copy: An issue being actively worked shows its live state on the row: who has it, which branch, whether CI is green. promote turns a row into an issue and drops it from the board. Most rows point at a branch or a pull request instead. If it should outlive the work, it belongs in GitHub and Mycelium just po",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-live-status-how-it-will-work",
+    "t": "Live status: how it will work",
+    "s": "Concepts › Board",
+    "x": "Not built yet. The rest of this section describes what linked pull requests will do. The backend has the resolver that answers for a reference (see status providers), but nothing attaches its answers to a row, so no row shows a pull request's state today. Mentioning the pull request will be the whole of it. Write the link where the work is already described, whether a plan task, a memory, or a message in the room, an",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-how-current-it-will-be",
+    "t": "How current it will be",
+    "s": "Concepts › Board",
+    "x": "Every status will carry the moment it was fetched, and the row will show its age (CI green · 4m). A render never waits on GitHub: the board shows what it last knew and refreshes behind you. If a lookup fails, the last good state stays on the row rather than the row going blank; if it gets old enough to stop being evidence, it drops off instead of being shown as if it were current. Reading a room's board never costs a",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-cli",
+    "t": "CLI",
+    "s": "Concepts › Board",
+    "x": "mycelium board # what needs you mycelium board --lens in-flight # claimed work, who holds it, CI mycelium board --lens all --view table # the room as structured data mycelium board --group owner # group by any field it found mycelium board --watch # keep it open, re-reading mycelium board claim work/auth-spike # take custody, as a lease that drains mycelium board release work/auth-spike --note \"handing over\" mycelium",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#board-related",
+    "t": "Related",
+    "s": "Concepts › Board",
+    "x": "plan: the room's prose and checklists, which the board reads from. episodes: a negotiation, which appears as a decision row. memory: where a row's fields actually live.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#l9-protocol",
+    "t": "L9 Protocol",
+    "s": "Concepts",
+    "x": "Every negotiation ends in \"accept,\" but an accept can mean \"you convinced me\" or \"fine, whatever, let's move on.\" If you can't tell those apart, you can't tell a real team decision from one agent steamrolling the rest, and the plan your agents execute inherits that blind spot. L9 (the epistemic layer of the Internet of Cognition) fixes this by making how the team decided as inspectable as what it decided. Agents say ",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#l9-protocol-say-how-sure-you-are",
+    "t": "Say how sure you are",
+    "s": "Concepts › L9 Protocol",
+    "x": "When you post a position or reply with mycelium respond, end it with a position marker to declare your epistemic state: mycelium respond --room design --handle me \\ \"Only option that meets the latency target. [[mycelium: confidence=0.8 stance=accept]]\" # Accepting just to move on? Say so plainly in prose, and the aligner records # the deference: mycelium respond --room design --handle me \\ \"I'm not persuaded, but I'l",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#l9-protocol-read-the-quality-of-a-consensus",
+    "t": "Read the quality of a consensus",
+    "s": "Concepts › L9 Protocol",
+    "x": "When enough agents report confidence, the consensus carries a metrics score (shown in the episode view, the cards, and the UI protocol inspector): Metric Read it as mpc How sure the team is, on average gar Who was actually persuaded: did confidence move toward the outcome? scr Who just went along: fraction of belief revisions that were compliance (deferring, or moving without engaging evidence) rather than argument p",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#l9-protocol-team-priors-start-from-what-the-team-already-learned",
+    "t": "Team priors: start from what the team already learned",
+    "s": "Concepts › L9 Protocol",
+    "x": "Each negotiation opens with the team's earned confidence on this topic: a team_prior on every tick ({confidence, provenance_weight, episode_count}), written to the room's own memory after each converged consensus (l9/rule_update/topic) and read back on the next negotiation, so it improves over time. Agents are instructed to form their own view first, then weigh the prior as a starting point they can override. Local b",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#l9-protocol-the-paper-trail",
+    "t": "The paper trail",
+    "s": "Concepts › L9 Protocol",
+    "x": "Every negotiation is an L9 episode: ticks, replies, and the closing commit, causally linked (each message cites its parents) from opening positions to outcome, scoped by the episode URN urn:ioc:mycelium:episode:{room}:{short_id}. On consensus the full record lands in room memory at log/episodes/{short_id}.md, git-shareable and searchable like any memory, so \"why did we decide this?\" has an answer months later.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#l9-protocol-under-the-hood",
+    "t": "Under the hood",
+    "s": "Concepts › L9 Protocol",
+    "x": "Coordination messages carry an l9 envelope inside their content JSON: ticks are exchange, agreement commits as commit:converged, a failed negotiation as commit:rejected. A message that revises an earlier one is an exchange:amend carrying the revised message's id in its causal parents, which is what lets the read path fold a message and its revisions without rewriting the transcript. Reply envelopes are synthesized by",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#engines",
+    "t": "Overview",
+    "s": "Engines",
+    "x": "An engine is a first-party unit of cognition that lives inside a room. Where your agents are the participants, engines are the room's reasoning citizens. They read what the room knows and act on it: mediate a decision, distill the memory, and (in time) more. Engines exist because some work isn't any single agent's job. Deciding whose offer wins shouldn't fall to one of the negotiating parties; summarizing the whole r",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#engines-kinds",
+    "t": "Kinds",
+    "s": "Engines › Overview",
+    "x": "The engine layer is one seam with a growing set of kinds. You pick the kind at registration time. No new adapter per engine; the same mycelium engine commands host all of them. Kind What it does aligner Mediates a real NEGMAS negotiation to consensus, then compiles the agreement into the room's plan. See Aligner. synthesizer Distills the room's conversation into a briefing at context/synthesis, incrementally. See Syn",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#engines-the-lifecycle",
+    "t": "The lifecycle",
+    "s": "Engines › Overview",
+    "x": "Every engine, whatever its kind, follows the same three steps. # 1. Register it once per room (pick the kind) mycelium engine create summarizer --kind synthesizer --room sprint-plan # 2. Summon it: this is what makes cognition run mycelium engine invoke summarizer \"brief the room on where we stand\" -r sprint-plan # 3. It runs as that handle and writes its result back into the room mycelium memory get context/synthesi",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#engines-where-an-engine-runs",
+    "t": "Where an engine runs",
+    "s": "Engines › Overview",
+    "x": "An engine's cognition runs backend-side: the always-on backend runs the engine through its summon seam, so there is nothing extra to install. (pi ships in the backend image.) Legacy engine.runtime = host config coerces to backend. Every engine's brain is Pi, the coding-agent runtime Mycelium uses for engine cognition (it ships in the backend image). It applies only to engines. Your participant agents run however you ",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#aligner",
+    "t": "Aligner",
+    "s": "Engines",
+    "x": "The aligner is the negotiation engine: the kind that mediates a decision to consensus. Agents never talk to each other directly; all coordination flows through it. It reads everyone's opening positions, brokers the negotiation one agent at a time, and stops the moment the team agrees. Like every engine, the aligner is summoned: nothing runs until you register it in a room and invoke it. There is no join window and no",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#aligner-how-it-negotiates",
+    "t": "How it negotiates",
+    "s": "Engines › Aligner",
+    "x": "The aligner drives a real NEGMAS Stacked Alternating Offers negotiation, so consensus comes out of the mechanism rather than an LLM improvising one. The mechanism owns proposer rotation and the unanimity stop; the aligner only supplies each agent's move when NEGMAS asks for one. Align vocabulary. Before any offer exists, it reads the opening positions for a term the participants are using in different senses — \"done\"",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#aligner-memory-across-rounds",
+    "t": "Memory across rounds",
+    "s": "Engines › Aligner",
+    "x": "The aligner's brain is a persistent Pi coding-agent session (pi -p --session <id>), spawned fresh per episode and kept alive across every round of that episode. That persistence is what gives it real memory of the negotiation as it unfolds: it remembers who moved and why, rather than re-reading a flat transcript each turn. Pi ships in the backend image and runs only the engine; participant agents keep their own runti",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#aligner-tunables",
+    "t": "Tunables",
+    "s": "Engines › Aligner",
+    "x": "The aligner is dormant by default and configured through ~/.mycelium/.env (backend settings). The common knobs: Env var Default Purpose ALIGNER_HANDLE aligner Reserved handle that a summon is recognised by ALIGNER_TERM_CHECK true Run the pre-negotiation term check, and one clarifying round when it finds a mismatch ALIGNER_ROUND_TIMEOUT_S 30.0 How long one addressed agent has to reply before the mediator moves on ALIG",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#synthesizer",
+    "t": "Synthesizer",
+    "s": "Engines",
+    "x": "The synthesizer is the distillation engine: the kind that reads a room's conversation and writes what it learned into memory. The aligner converges a negotiation; the synthesizer moves what the room said into what the room keeps. That direction is the whole point. Chat is the ephemeral half — where a decision gets argued, qualified and settled, and the half nothing indexes for meaning. Memory is the durable half. The",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#synthesizer-how-it-distills",
+    "t": "How it distills",
+    "s": "Engines › Synthesizer",
+    "x": "On summon, the synthesizer reads the room's chat and runs one Pi turn to distill it into a single markdown briefing: what was decided, what changed, what is in flight, and what is still open. It upserts that briefing as a knowledge memory at context/synthesis, so it is versioned, searchable, linked and shared like any other memory. It reads the transcript by message type, so only real chat reaches the prompt. The roo",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#synthesizer-incremental-by-default",
+    "t": "Incremental by default",
+    "s": "Engines › Synthesizer",
+    "x": "Each run covers only what has been said since the last one. The written memory carries the position it was distilled through in its own frontmatter, so the cursor advances exactly when the briefing lands — a failed Pi turn moves nothing, and re-summoning with no new messages writes nothing at all rather than producing a second copy of the same summary. The standing briefing is carried into the next run as context, so",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#synthesizer-faithfulness",
+    "t": "Faithfulness",
+    "s": "Engines › Synthesizer",
+    "x": "The briefing reflects only what was actually said; the synthesizer does not invent facts. If its Pi turn fails, it writes nothing rather than a half-formed summary. The synthesizer holds no episode and drives no negotiation. It reads the room, distills it, and writes the result back. It shares the rest of the engine model: the summon lifecycle and where it runs (backend-side), with every brain running a Pi turn.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#synthesizer-summarizing-memory-instead",
+    "t": "Summarizing memory instead",
+    "s": "Engines › Synthesizer",
+    "x": "Summarizing the memory store — a briefing over what is already durable — is a different feature, not the default one. Set SYNTHESIZER_SOURCE=memory on the backend to get it: the engine then reads every memory namespace (minus agent manifests and its own prior output) and compiles those instead. That path is not incremental; there is no transcript position to hold.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#hello",
+    "t": "Hello",
+    "s": "Engines",
+    "x": "The hello engine is the engine that does nothing on purpose. Summon it and it runs one Pi turn on whatever you said, posts the answer into the room, and stops. No negotiation, no memory write, no plan — the only trace it leaves is the message it posts. That is what makes it useful. The aligner opens a negotiation episode and the synthesizer writes a memory back, so neither is something you want to fire into a live ro",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#hello-what-a-reply-proves",
+    "t": "What a reply proves",
+    "s": "Engines › Hello",
+    "x": "mycelium doctor already checks that the hub can reach a model — but that probe stops at the completion. Every rung above it is untested until an engine actually runs. A hello reply walks all of them: the manifest gate that routes an @-mention to a registered engine of the right kind, and to nothing else the engine runtime branch that decides who owns the run the guard that stops an engine firing on its own message a ",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#hello-fail-loud",
+    "t": "Fail-loud",
+    "s": "Engines › Hello",
+    "x": "A probe that fails silently is worse than no probe, so hello never goes quiet: if its Pi turn times out or errors, it posts the reason into the room instead of an answer. Silence means the summon never reached it — a different failure, and a more useful thing to know.",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#hello-holding-nothing",
+    "t": "Holding nothing",
+    "s": "Engines › Hello",
+    "x": "Hello keeps no state between summons and answers each one from scratch, so it is not a chat partner — it is a probe with a personality. Ask it something twice and it will not remember the first time. For cognition that carries context, that is what the aligner and the synthesizer are for.",
+    "p": "Guide"
+  },
+  {
+    "u": "adapters.html#adapters",
+    "t": "Overview",
+    "x": "Adapters connect AI coding agents to Mycelium. The coordination model is the same regardless of which agent runtime you use: join a room, share memory, negotiate with other agents. An adapter installs knowledge, not a process. Mycelium never starts your agent. An adapter drops the instructions that teach a runtime how to participate: how to read and write room memory, how to take a turn in a negotiation. The runtime ",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#adapter-claude-code",
+    "t": "Claude Code",
+    "x": "The Claude Code adapter installs a /mycelium skill into your Claude Code environment. Once installed, every Claude Code session can read and write shared memory, join rooms, and take turns in a negotiation. This is the proven adapter, the one the end-to-end suite exercises.",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#cc-install",
+    "t": "Install",
+    "s": "Claude Code",
+    "x": "mycelium adapter add claude-code This copies into ~/.claude/: AssetDestinationPurpose SKILL.md ~/.claude/skills/mycelium/ The /mycelium skill: memory, rooms, the coordination protocol The install also grants the Bash(mycelium:*) permission rule in your user-global ~/.claude/settings.json. That grant is what makes unattended participation work: a session taking a turn on its own can't answer a permission prompt, so it",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#cc-usage",
+    "t": "Using the skill",
+    "s": "Claude Code",
+    "x": "Once installed, invoke the skill from any Claude Code session: /mycelium The skill provides the full Mycelium coordination protocol inline: share memory, take a turn in a negotiation, and read what other agents know without leaving your current task.",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#cc-env",
+    "t": "Environment variables",
+    "s": "Claude Code",
+    "x": "VariableDescription MYCELIUM_API_URLBackend URL (default: http://localhost:8000) MYCELIUM_ROOMActive room name MYCELIUM_AGENT_HANDLEThis agent's identity handle",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#cc-first-run",
+    "t": "First run",
+    "s": "Claude Code",
+    "x": "# 1. Set your active room mycelium room use my-project # 2. Read what the room already knows (resolved from the hub over HTTP; # there is no local copy to browse) mycelium memory ls mycelium memory search \"authentication approach\" # 3. Share context back mycelium memory set \"work/auth\" \"Implemented JWT with refresh tokens\" --handle claude-agent # 4. Stay woken so the room can reach you: await → reason → respond, on r",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#adapter-cursor",
+    "t": "Cursor",
+    "x": "A cursor agent participates the same way a Claude Code agent does: as a resident Cursor session kept woken with mycelium await --loop, taking turns via await / respond. Mycelium does not run cursor-agent for you; the adapter only drops the instructions that tell the session how to coordinate. Cursor's reading surface is the workspace itself rather than a global host-level dir. So unlike Claude Code (which drops SKILL",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#cursor-install",
+    "t": "Install",
+    "s": "Cursor",
+    "x": "# 1) Register the adapter (one-time, per host). Informational only; # cursor has no host-level state dir; the assets ship per agent. mycelium adapter add cursor # 2) Log in once interactively, before the first turn cursor-agent login Unlike the other adapters, mycelium adapter add cursor does not drop files at install time. The workspace-local assets ship per-agent at mycelium agent create: AssetDestinationPurpose my",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#cursor-create",
+    "t": "Create an agent",
+    "s": "Cursor",
+    "x": "mycelium agent create design-agent --adapter cursor \\ --cwd ~/repos/my-frontend \\ --description \"Owns the design system; pings @avery on ambiguity\" \\ --room my-project This: Writes the agent manifest into my-project (same shape as claude_code), claiming the design-agent handle in that room. Drops ~/repos/my-frontend/.cursor/rules/mycelium.mdc + merges the mycelium section of ~/repos/my-frontend/AGENTS.md. Open a Curs",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#cursor-auth",
+    "t": "Authentication",
+    "s": "Cursor",
+    "x": "cursor-agent's login flow is interactive only (it opens a browser tab), so run cursor-agent login once, as the user the session runs as, before the first turn. There is no pre-flight auth check (same posture as the Claude Code adapter), so an unauthenticated binary surfaces as a failure on the turn itself. mycelium adapter status cursor reports whether cursor-agent is on PATH and restates the login prerequisite; it c",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#cursor-env",
+    "t": "Environment variables",
+    "s": "Cursor",
+    "x": "The same set the other adapters use. The bundled .cursor/rules/mycelium.mdc references them in its examples. VariableDescription MYCELIUM_API_URLBackend URL (default: http://localhost:8000) MYCELIUM_ROOMActive room name for this invocation MYCELIUM_AGENT_HANDLEThis agent's identity handle",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#cursor-uninstall",
+    "t": "Uninstall",
+    "s": "Cursor",
+    "x": "# Leave assets in place, just unregister the manifest + handle mycelium agent rm design-agent # Or, to remove the workspace assets too (.cursor/rules/mycelium.mdc + the # mycelium section of AGENTS.md; surrounding AGENTS.md content preserved) mycelium agent rm design-agent --full",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#adapter-a2a",
+    "t": "A2A Bridge",
+    "x": "Mycelium speaks Agent2Agent (A2A), the open agent-interop protocol, in both directions. You can pull any A2A agent into a room and talk to it like a teammate, and you can hand a whole room to an outside A2A client as if the room itself were an agent. Unlike the Claude Code and Cursor adapters, there is nothing to install on your machine and no resident session to keep woken. A bridged agent is a remote HTTP endpoint;",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#adapter-a2a-bring-an-a2a-agent-into-a-room",
+    "t": "Bring an A2A agent into a room",
+    "s": "A2A Bridge",
+    "x": "Register a remote A2A endpoint as a room member. The hub resolves its Agent Card at registration, so a bad or unreachable URL fails right away instead of at the first mention. mycelium agent create researcher --adapter a2a \\ --card https://research.example.com \\ --room my-room Now @researcher is on the roster. Mention it in normal chat and it answers: @researcher what did last quarter's numbers say about churn? The b",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#adapter-a2a-expose-a-room-as-an-a2a-agent",
+    "t": "Expose a room as an A2A agent",
+    "s": "A2A Bridge",
+    "x": "Every room is discoverable and callable as an A2A agent, with no per-room route wiring. Its Agent Card is served at: GET /api/rooms/{room}/.well-known/agent-card.json The card advertises the room's name and its skills, drawn from the room's skills/ namespace. An external A2A client then sends the room a message with A2A JSON-RPC (message/send) at: POST /api/rooms/{room}/a2a The message lands in the room like any othe",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#adapter-a2a-watch-the-bridge",
+    "t": "Watch the bridge",
+    "s": "A2A Bridge",
+    "x": "The bridge is the one hop that doesn't ride SLIM, so it gets its own place in the coordination views instead of being folded into the channel telemetry. From the CLI, mycelium network [room] prints a bridge block per room under the fabric table: the bridged agents with their endpoint and advertised skills, the room's own card and how often it has been read, and the last exchanges either way — an answered call with wh",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#adapter-a2a-what-the-bridge-is-and-what-it-is-not",
+    "t": "What the bridge is, and what it is not",
+    "s": "A2A Bridge",
+    "x": "A bridged A2A agent is a member of the room in the coordination sense: it is on the roster, it answers when mentioned, and its replies are attributed to its handle. It is not a member of the room's end-to-end-encrypted MLS group. It never holds a group key. The backend is a translation boundary: it reads the room's plaintext and calls the remote agent out-of-band. Today that call is plain HTTPS. It can be moved onto ",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#adapter-api",
+    "t": "REST API",
+    "x": "Any agent or tool that can make HTTP requests can use the Mycelium API directly, with no adapter required. The API is the same one the CLI wraps.",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#api-docs",
+    "t": "Interactive docs",
+    "s": "REST API",
+    "x": "When the backend is running, interactive API docs are available at: http://localhost:8000/docs",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#api-example",
+    "t": "Quick example",
+    "s": "REST API",
+    "x": "Memory is scoped by room, so the room name is part of the path. Writes are batched: items takes 1–100 memories per call. # Write a memory curl -X POST http://localhost:8000/api/rooms/my-project/memory \\ -H \"Content-Type: application/json\" \\ -d '{\"items\": [{\"key\": \"work/api\", \"value\": \"REST with OpenAPI client\", \"created_by\": \"avery-agent\"}]}' # Read it back curl http://localhost:8000/api/rooms/my-project/memory/work/",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#api-a2a",
+    "t": "A2A endpoints",
+    "s": "REST API",
+    "x": "A room is also reachable over Agent2Agent, so an external A2A client can discover and message it without knowing anything about the Mycelium API. See the A2A bridge for what happens to the message once it lands. # Discover the room as an A2A agent (public: discovery is unauthenticated by spec) curl http://localhost:8000/api/rooms/my-project/.well-known/agent-card.json # Send it a message (A2A JSON-RPC; gated by the h",
+    "p": "Adapters"
+  },
+  {
+    "u": "reference.html#architecture",
+    "t": "Architecture",
+    "s": "Architecture",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-deployment-modes",
+    "t": "Deployment Modes",
+    "s": "Architecture",
+    "x": "Mycelium supports two deployment modes. The stack is identical in both; what differs is where the agents run and how they reach the room.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-1-single-device-default",
+    "t": "1. Single-device (default)",
+    "s": "Architecture",
+    "x": "Everything (the backend, the SLIM node, agents, and CLI) runs on one machine, typically a developer's laptop. This is what mycelium install sets up out of the box. No network configuration, no remote services to point at, no shared infrastructure required. This is the primary deployment target. Use it when one person (or one machine) owns the whole agent workflow.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-2-hub-and-spoke-small-teams",
+    "t": "2. Hub-and-spoke (small teams)",
+    "s": "Architecture",
+    "x": "A second, optional mode for small teams that want to share memory, rooms, and coordination across machines. One machine runs the SLIM node and backend (the hub); other machines run only the CLI + agents (spokes) as thin HTTP clients to the hub API. Role What runs locally When to use Hub The SLIM node, the thin FastAPI backend (room moderator), and the UI. The team's shared coordination server. One per team. Spoke CLI",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-reading-a-remote-room-spoke",
+    "t": "Reading a remote room (spoke)",
+    "s": "Architecture",
+    "x": "When the backend runs on a remote server (EC2, Raspberry Pi, a hub), a spoke is a thin client: mycelium memory and mycelium room resolve against the hub over HTTP, so reads are always fresh and there is no sync step: nothing is mirrored locally to fall out of date. room clone / mycelium sync remain only as an explicit export: a point-in-time local snapshot for backup or offline reference, not part of the normal flow.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-stack",
+    "t": "Stack",
+    "s": "Architecture",
+    "x": "Mycelium runs on one SLIM node and a thin backend: no database, no message broker, no vector store. The hub backend moderates an AGNTCY SLIM group channel per room (MLS-encrypted; PSK or SignerJwt on the SLIM plane). Turn-based agents on spokes (and humans by proxy) participate over HTTP — the backend holds server-side presence and serves turns from the durable transcript. Room state lives on the hub as markdown file",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-adapters",
+    "t": "Adapters",
+    "s": "Architecture",
+    "x": "Mycelium integrates with AI coding agents via adapters. The coordination model is the same regardless of adapter: join, await, respond. Adapter How it connects claude_code Skill + resident await/respond loop cursor Workspace rules + the same resident loop a2a A remote Agent2Agent endpoint the hub calls; no local runtime",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-claude-code",
+    "t": "Claude Code",
+    "s": "Architecture",
+    "x": "The Mycelium skill installs as a Claude Code skill (~/.claude/skills/mycelium/SKILL.md), invoked via the /mycelium slash command for memory and coordination commands. The adapter is skill-only. # The skill is invoked automatically in Claude Code sessions # or explicitly via the slash command /mycelium A Claude Code session participates as a resident runtime: it loops mycelium await → reason → mycelium respond, pickin",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-cursor",
+    "t": "Cursor",
+    "s": "Architecture",
+    "x": "Same resident model as Claude Code: a Cursor session loops await → reason → respond. mycelium adapter add cursor # installs the workspace rule + AGENTS.md assets cursor-agent login # one-time, interactive # Per agent: --cwd is the session's workspace root (optional) mycelium agent create design-agent --adapter cursor \\ --cwd ~/repos/my-frontend --room my-project",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-a2a",
+    "t": "A2A",
+    "s": "Architecture",
+    "x": "An a2a agent has no local runtime at all: it is a remote Agent2Agent endpoint the hub calls on its behalf. The card is resolved at registration, so a bad URL fails immediately. mycelium agent create researcher --adapter a2a \\ --card https://research.example.com --room my-project The same bridge runs inbound: every room is served as an A2A agent, discoverable at GET /api/rooms/{room}/.well-known/agent-card.json (publi",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-backend-api",
+    "t": "Backend API",
+    "s": "Architecture",
+    "x": "Any agent that can make HTTP requests can use the REST API directly. Interactive API docs are available at http://localhost:8000/docs when the backend is running.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-status-providers",
+    "t": "Status providers",
+    "s": "Architecture",
+    "x": "Adapters connect agents to a room. Status providers connect the tools your work already lives in, so that a board row pointing at a pull request can report whether it's approved, blocked or failing instead of someone copying that state into Mycelium. Experimental. This works end to end: give the hub a token, write a pull request into a plan task, and the board row for that task carries the pull request's state, in bo",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-asking-what-the-tools-say",
+    "t": "Asking what the tools say",
+    "s": "Architecture",
+    "x": "GET /api/rooms/{room}/status You never tell Mycelium which pull requests to watch. Write a plan task that says land the custody seam: mycelium-io/mycelium#504 and the reference is already there; the hub reads the room's own plan tasks and its decisions/, status/, work/ and failed/ memories, and asks each provider what it recognises. Nothing in the hub matches #504: a provider is the only thing that knows its own shap",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-giving-the-hub-a-credential",
+    "t": "Giving the hub a credential",
+    "s": "Architecture",
+    "x": "Resolving pull requests takes a GitHub token; read-only is enough, plus repo scope for private repositories. A provider declares which credential it needs and how it is presented (a scheme: bearer token, basic auth, a raw key in a header), and never handles the value. The runtime resolves it and hands back a transport that already carries it. You give the hub the value by name, on the machine the backend runs on: # T",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#architecture-teaching-mycelium-another-tracker",
+    "t": "Teaching Mycelium another tracker",
+    "s": "Architecture",
+    "x": "A provider is one small class in app/services/status/providers/; providers/github.py is written to be copied. It declares its batching and freshness, then implements two methods: class JiraProvider: name = \"jira\" base_url = \"https://your-org.atlassian.net\" # ctx.http is bound to this host auth = Basic(\"JIRA_EMAIL\", \"JIRA_TOKEN\") # a scheme, not a value; the runtime resolves both names max_batch = 50 # most references",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-reference",
+    "t": "CLI Reference",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "setup",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium doctor [--fix] [--json] [--mode auto|hub|spoke]",
+    "s": "CLI Reference",
+    "x": "Diagnose and fix common configuration issues (workspace sync, LLM, containers).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium init [--api-url <url>] [--force]",
+    "s": "CLI Reference",
+    "x": "Initialize CLI configuration. Creates ~/.mycelium/config.toml.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium up [--build] [--metrics]",
+    "s": "CLI Reference",
+    "x": "Start the Mycelium stack via docker compose up.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium down [--volumes]",
+    "s": "CLI Reference",
+    "x": "Stop the Mycelium stack. Pass --volumes to also delete data.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium status",
+    "s": "CLI Reference",
+    "x": "Show running service health (backend connectivity, room count).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium logs [service] [--follow] [--tail N]",
+    "s": "CLI Reference",
+    "x": "Tail container logs via docker compose logs.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium pull [--version <tag>] [--no-restart]",
+    "s": "CLI Reference",
+    "x": "Pull Mycelium Docker images and restart services. Pass --version to pin a preview/specific build.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium hub host",
+    "s": "CLI Reference",
+    "x": "Start the SLIM node and print the address peers connect to.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium connect <address>",
+    "s": "CLI Reference",
+    "x": "Store the SLIM node endpoint to connect to (self- or mycelium-hosted).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium install [--yes] [--non-interactive] [--force]",
+    "s": "CLI Reference",
+    "x": "Interactive installer: Docker check, LLM config, docker compose up, provision workspace.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium upgrade [--check] [--version <version>]",
+    "s": "CLI Reference",
+    "x": "Upgrade (or pin) the Mycelium CLI. Pass --version to install a specific release.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium login [--issuer URL] [--device] [--no-browser] [--client-id ID]",
+    "s": "CLI Reference",
+    "x": "Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium logout",
+    "s": "CLI Reference",
+    "x": "Drop the cached OIDC session; the CLI goes back to sending no token.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium ui open [-y]",
+    "s": "CLI Reference",
+    "x": "Open the frontend in your default browser.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium ui status",
+    "s": "CLI Reference",
+    "x": "Show whether the frontend container is running.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "room",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "mycelium room ls",
+    "s": "CLI Reference",
+    "x": "List all rooms with state and member count.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "mycelium room create <name>",
+    "s": "CLI Reference",
+    "x": "Create a new persistent coordination room.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "mycelium room use <name>",
+    "s": "CLI Reference",
+    "x": "Switch active room. Subsequent memory and message commands use this room by default.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "mycelium room delete <name> [<name> ...] [--force]",
+    "s": "CLI Reference",
+    "x": "Delete one or more rooms and all their data (memories, sessions, messages).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "mycelium room clone <room-name> [--from <api-url>]",
+    "s": "CLI Reference",
+    "x": "Clone a room from a remote backend: fetches all memories via HTTP and writes them locally.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "mycelium room send \"<content>\" [--room <room>] [--handle <handle>]",
+    "s": "CLI Reference",
+    "x": "Send an addressed chat message into a room. Use @handle mentions to direct it to specific agents.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "mycelium room amend <message-id> \"<new content>\" [--room <room>] [--handle <handle>]",
+    "s": "CLI Reference",
+    "x": "Revise a message you sent. The amendment is posted as its own message; the room reads the newest text, marked edited.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "mycelium room messages [<room>] [--limit N] [--sender <handle>] [--type <type>]",
+    "s": "CLI Reference",
+    "x": "Read recent messages in a room (point-in-time, newest first). Filter with --sender / --type.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-room",
+    "t": "mycelium room delegate <room> --to <handle> --task <description>",
+    "s": "CLI Reference",
+    "x": "Delegate a task to another agent in a room.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "agent",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent create <handle> --adapter <name> [--cwd <path>] [--card <url>] [--card-auth-env <var>]",
+    "s": "CLI Reference",
+    "x": "Create a new, Mycelium-controlled agent in a room. claude_code and cursor agents are resident sessions the user keeps woken with mycelium await --loop. --adapter a2a instead registers a remote Agent2Agent endpoint given by --card (its Agent Card host, resolved at registration); --card-auth-env names a backend env var holding its bearer token, so only the var name is stored in the room.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent ls [--room <room>]",
+    "s": "CLI Reference",
+    "x": "List all registered agents in a room.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent show <handle> [--room <room>]",
+    "s": "CLI Reference",
+    "x": "Show an agent's manifest, notes, and most recent invocation log.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent invoke <handle> \"<prompt>\" [--room <room>]",
+    "s": "CLI Reference",
+    "x": "Send an addressed message to a registered agent. Desugars to mycelium room send \"@handle <prompt>\".",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent rm <handle> [--room <room>] [--full] [--force]",
+    "s": "CLI Reference",
+    "x": "Unregister an agent. Default keeps the underlying runtime; --full also tears down the underlying runtime (requires confirmation unless -y).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent credential set <handle> [--client-id ID] [--secret-stdin] [--issuer URL]",
+    "s": "CLI Reference",
+    "x": "Give an agent its own service-account credential, stored 0600 outside config.toml. Only meaningful once a hub enables auth.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent credential show <handle>",
+    "s": "CLI Reference",
+    "x": "Show which credential an agent resolves to. Never prints the secret.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent credential ls",
+    "s": "CLI Reference",
+    "x": "List the agents on this machine that have their own credential.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent credential rm <handle>",
+    "s": "CLI Reference",
+    "x": "Forget an agent's credential on this machine.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-agent",
+    "t": "mycelium agent credential slim-key <handle>",
+    "s": "CLI Reference",
+    "x": "Mint an agent's SignerJwt SLIM channel identity: a local ES256 keypair (0600) whose public JWK is registered on the room roster. The floor for slim.identity = signerjwt (#476); the PSK default needs none.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "memory",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory set <key> [<value>] [--file <path>] [--handle <handle>]",
+    "s": "CLI Reference",
+    "x": "Write a memory (upsert). The value comes from the positional argument or --file (- reads stdin): one or the other, not both. Structured category keys (work/, decisions/, status/, context/) are auto-validated. Always upserts; the backend handles versioning.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory get <key>",
+    "s": "CLI Reference",
+    "x": "Read a memory by exact key from the hub.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory ls [prefix/]",
+    "s": "CLI Reference",
+    "x": "List memories from the hub. Optional prefix filters by namespace.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory search <query>",
+    "s": "CLI Reference",
+    "x": "Semantic search: finds memories by meaning using cosine similarity on local embeddings. Requires the backend API.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory links <key> [--check]",
+    "s": "CLI Reference",
+    "x": "Show a memory's links: what it points at and what points back at it. Links are myc://key or [[key]] in the body, plus typed frontmatter relations (supersedes, depends-on, part-of, relates-to). --check reports broken links, orphans (no connections), roots (no inbound), and leaves (no outbound) across the whole room.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory rm <key> [--force]",
+    "s": "CLI Reference",
+    "x": "Delete a memory: removes the markdown file and search index entry.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory reindex",
+    "s": "CLI Reference",
+    "x": "Re-index the room into the local JSONL search index. Run after editing memory files outside the CLI.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory subscribe <pattern> [-H <handle>]",
+    "s": "CLI Reference",
+    "x": "Subscribe to memory change notifications matching a glob pattern.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory status",
+    "s": "CLI Reference",
+    "x": "Show current status: filters to status/* memories as a table.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory work",
+    "s": "CLI Reference",
+    "x": "Show what's been built: filters to work/* memories as a table.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory decisions",
+    "s": "CLI Reference",
+    "x": "Show why choices were made: filters to decisions/* memories as a table.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory context",
+    "s": "CLI Reference",
+    "x": "Show background and preferences: filters to context/* memories as a table.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-memory",
+    "t": "mycelium memory procedures",
+    "s": "CLI Reference",
+    "x": "Show reusable how-to steps: filters to procedures/* memories as a table.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-skill",
+    "t": "skill",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-skill",
+    "t": "mycelium skill set <name> [<body>] [--file <path>] [--desc <text>]",
+    "s": "CLI Reference",
+    "x": "Create or update a skill (upsert) in a room's skills/ namespace. The body comes from the positional argument or --file (- reads stdin).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-skill",
+    "t": "mycelium skill ls",
+    "s": "CLI Reference",
+    "x": "List a room's skills, newest-updated first.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-skill",
+    "t": "mycelium skill get <name>",
+    "s": "CLI Reference",
+    "x": "Read a skill by name from a room.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-skill",
+    "t": "mycelium skill rm <name>",
+    "s": "CLI Reference",
+    "x": "Delete a skill from a room.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-skill",
+    "t": "mycelium skill adapter-def",
+    "s": "CLI Reference",
+    "x": "Print the Mycelium SKILL.md: the Claude Code adapter's skill definition (the participation protocol the resident agent follows).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "plan",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "mycelium plan ls",
+    "s": "CLI Reference",
+    "x": "List plan files in the active room.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "mycelium plan show <slug>",
+    "s": "CLI Reference",
+    "x": "Print a plan file's body.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "mycelium plan set <slug> <body>",
+    "s": "CLI Reference",
+    "x": "Create or overwrite a plan file. Body is the full markdown.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "mycelium plan rm <slug>",
+    "s": "CLI Reference",
+    "x": "Delete a plan file.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "mycelium plan title [<text>]",
+    "s": "CLI Reference",
+    "x": "Read or set the room's plan title: the italic display line shown above room activity. Pass no text to print the current title.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "mycelium plan tasks",
+    "s": "CLI Reference",
+    "x": "List every checkbox task across plan files. Open first, done last.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "mycelium plan task add <text> [--file <slug>]",
+    "s": "CLI Reference",
+    "x": "Append a new - [ ] line to a plan file (defaults to tasks).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "mycelium plan task done [<id>...]",
+    "s": "CLI Reference",
+    "x": "Mark task(s) complete. Run without IDs to pick from open tasks interactively.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-plan",
+    "t": "mycelium plan task undo [<id>...]",
+    "s": "CLI Reference",
+    "x": "Reopen completed task(s). Run without IDs to pick interactively.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-adapter",
+    "t": "adapter",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-adapter",
+    "t": "mycelium adapter add <type> [--dry-run]",
+    "s": "CLI Reference",
+    "x": "Install an agent framework adapter (claude-code, cursor).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-adapter",
+    "t": "mycelium adapter remove <type> [--force]",
+    "s": "CLI Reference",
+    "x": "Unregister and uninstall an adapter.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-adapter",
+    "t": "mycelium adapter ls",
+    "s": "CLI Reference",
+    "x": "List available and registered adapters.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-adapter",
+    "t": "mycelium adapter status [type]",
+    "s": "CLI Reference",
+    "x": "Check adapter health and installation status.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-config",
+    "t": "config",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-config",
+    "t": "mycelium config show",
+    "s": "CLI Reference",
+    "x": "Print current configuration (API URL, identity, active room).",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-config",
+    "t": "mycelium config set <key> <value> [--env <preset>]",
+    "s": "CLI Reference",
+    "x": "Set a configuration value or switch environment preset.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-config",
+    "t": "mycelium config get <key>",
+    "s": "CLI Reference",
+    "x": "Read a configuration value.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-config",
+    "t": "mycelium config apply [--restart] [--migrate-env]",
+    "s": "CLI Reference",
+    "x": "Regenerate .env from config.toml and optionally restart containers.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-other",
+    "t": "watch",
+    "s": "CLI Reference",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-other",
+    "t": "mycelium sync [--no-reindex]",
+    "s": "CLI Reference",
+    "x": "Sync the active room with the backend: fetch all memories from the API and write them locally.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-other",
+    "t": "mycelium watch [room]",
+    "s": "CLI Reference",
+    "x": "Stream live room activity via SSE. Messages appear in real time as other agents write.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-other",
+    "t": "mycelium await --room <room> [--handle <handle> | --lease <key>] [--loop] [--exec CMD] [--timeout N] [--json]",
+    "s": "CLI Reference",
+    "x": "Long-poll a room until a message is addressed to the handle — or until a named lease changes hands.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-other",
+    "t": "mycelium respond --room <room> --handle <handle> \"<text>\"",
+    "s": "CLI Reference",
+    "x": "Publish a reply as the handle; the backend records it as a position for the aligner.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#configuration",
+    "t": "Configuration",
+    "s": "Configuration",
+    "x": "Settings live in ~/.mycelium/config.toml. Change a value with mycelium config set <key> <value> (for example, mycelium config set llm.model anthropic/claude-sonnet-4-6), then run mycelium config apply to regenerate ~/.mycelium/.env. If the change affects a service running in a container, restart with mycelium up for it to take effect. # Agent identity configuration. [identity] # Display name chosen by user name = \"\" ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#dependencies",
+    "t": "Dependencies",
+    "s": "Dependencies",
+    "x": "Mycelium is assembled from a small set of upstream components. This page lists every notable runtime dependency, the version pinned, what it's for, and where to check what changed upstream. The versions are read from the pins in pyproject.toml and compose.yml, so they match what ships.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#dependencies-messaging-fabric-agntcy-slim",
+    "t": "Messaging fabric (AGNTCY SLIM)",
+    "s": "Dependencies",
+    "x": "Mycelium is SLIM-native: rooms are SLIM group channels and the node forwards only MLS ciphertext. This is the one deep coupling in the stack, so it comes first. Component Pinned version Role Upstream slim-bindings >=2.1,<2.2 The client the CLI and backend use to join channels agntcy/slim releases ghcr.io/agntcy/slim 2.1.0 The messaging node itself, a blind ciphertext forwarder ghcr.io/agntcy/slim Version lockstep. Th",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#dependencies-memory-and-search",
+    "t": "Memory and search",
+    "s": "Dependencies",
+    "x": "Component Pinned version Role Upstream fastembed >=0.8.0 Local ONNX embeddings (BAAI/bge-small-en-v1.5, 384-dim); no external service qdrant/fastembed tiktoken >=0.12.0 Token counting for context budgeting openai/tiktoken rapidfuzz >=3.14.5 Fuzzy key matching over memory rapidfuzz/RapidFuzz",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#dependencies-cognition",
+    "t": "Cognition",
+    "s": "Dependencies",
+    "x": "Component Pinned version Role Upstream negmas >=0.15.7 backend / >=0.11 CLI engine extra The Stacked Alternating Offers mechanism the aligner runs yasserfarouk/negmas anthropic >=0.40.0 LLM client for backend cognition stages anthropic-sdk-python Pi (pi binary) shipped in the backend image The aligner's brain and every one-shot cognition turn external binary, not a Python dependency",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#dependencies-identity-and-crypto",
+    "t": "Identity and crypto",
+    "s": "Dependencies",
+    "x": "Component Pinned version Role Upstream pyjwt[crypto] >=2.10,<3 JWT validation for the auth gate and SignerJwt identity jpadilla/pyjwt cryptography >=42,<47 ES256 keypair and JWK for SLIM channel identity pyca/cryptography The rest of the stack is standard, widely used building blocks with no special version constraint beyond their pins: fastapi[standard], httpx, pydantic / pydantic-settings, typer, rich, and question",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#structured-memory",
+    "t": "Structured Memory",
+    "s": "Guides",
+    "x": "This guide shows how to use Mycelium's structured memory conventions to give agents continuity across separate runs.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#structured-memory-the-problem",
+    "t": "The Problem",
+    "s": "Guides › Structured Memory",
+    "x": "An agent helps build something over a long stretch of work, then goes away. When the user (or another agent) comes back, there's no memory of what happened. The next agent starts from scratch.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#structured-memory-the-solution-category-conventions",
+    "t": "The Solution: Category Conventions",
+    "s": "Guides › Structured Memory",
+    "x": "Instead of writing memories with arbitrary keys, use structured prefixes: work/ What was built or changed decisions/ Why choices were made context/ User preferences and background status/ Current state of ongoing work procedures/ Reusable how-to steps (do this again later) memory set validates these automatically: when the key starts with a known category prefix, it checks the slug format and auto-timestamps the cont",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#structured-memory-workflow",
+    "t": "Workflow",
+    "s": "Guides › Structured Memory",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#structured-memory-1-set-up-a-room",
+    "t": "1. Set up a room",
+    "s": "Guides › Structured Memory",
+    "x": "mycelium room create project-x mycelium room use project-x",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#structured-memory-2-write-structured-memories-as-you-work",
+    "t": "2. Write structured memories as you work",
+    "s": "Guides › Structured Memory",
+    "x": "# Record what you built mycelium memory set work/api-server \"Set up FastAPI with auth endpoints\" mycelium memory set work/database \"Created PostgreSQL schema, 3 tables\" # Record why you made choices mycelium memory set decisions/framework \"FastAPI over Flask: async + type hints\" mycelium memory set decisions/auth \"JWT tokens, 1hr expiry, refresh via cookie\" # Record user context mycelium memory set context/goal \"Buil",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#structured-memory-3-check-status-at-a-glance",
+    "t": "3. Check status at a glance",
+    "s": "Guides › Structured Memory",
+    "x": "mycelium memory status # Table of all status/* memories mycelium memory work # What's been built mycelium memory decisions # Why things are the way they are mycelium memory procedures # How to do things again",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#structured-memory-4-update-status-as-things-change",
+    "t": "4. Update status as things change",
+    "s": "Guides › Structured Memory",
+    "x": "# memory set always upserts, so just set the new value mycelium memory set status/deploy \"ACTIVE: deployed to vps.example.com\"",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#structured-memory-type-safety",
+    "t": "Type Safety",
+    "s": "Guides › Structured Memory",
+    "x": "memory set validates category keys against the MemoryLogEntry type (defined in mycelium.protocol). This is the same pattern used for the negotiation reply payload (RespondReply): Pydantic validation before the API call, so malformed slugs fail fast on the client side. Valid slugs: lowercase alphanumeric, hyphens, dots, underscores. work/api-server (valid) status/v2.deploy (valid) decisions/Why We Chose X (invalid: up",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke",
+    "t": "Hub & Spoke",
+    "s": "Guides",
+    "x": "Run Mycelium across two or more machines so a small team shares rooms, memory, and coordination from one hub. One machine is the hub: it runs the SLIM node and the always-on FastAPI backend (room moderator + memory store). Every other machine is a spoke: CLI + agents only, talking to the hub over HTTP. There is no database and no separate channel server. Two planes. Spokes use the HTTP API (:8000) for memory and part",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-when-to-use-this",
+    "t": "When to use this",
+    "s": "Guides › Hub & Spoke",
+    "x": "Use hub-and-spoke when people on different machines need to join the same rooms, see the same memories, and run negotiations together. If everything runs on one machine, the default single-device install already does this; see the Quick Start.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-topology",
+    "t": "Topology",
+    "s": "Guides › Hub & Spoke",
+    "x": "┌─────────────────────────────────────────────┐ │ Hub (one machine) │ │ │ │ mycelium install │ │ mycelium hub host │ │ ├─ SLIM node :46357 (MLS fabric) │ │ └─ FastAPI backend :8000 (HTTP API) │ │ moderator + memory store │ └──────────────────┬──────────────────────────┘ │ HTTP :8000 (memory, await, respond) │ ┌─────────────┴─────────────┐ │ │ ┌────┴──────┐ ┌─────┴─────┐ │ Spoke A │ │ Spoke B │ │ CLI │ │ CLI │ │ + age",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-step-1-stand-up-the-hub",
+    "t": "Step 1: Stand up the hub",
+    "s": "Guides › Hub & Spoke",
+    "x": "On the hub machine, install the stack and start the SLIM node: mycelium install mycelium hub host mycelium hub host starts the slim node container and prints addresses: SLIM node running. local → http://127.0.0.1:46357 (this machine, saved to config) for peers → http://192.168.1.20:46357 Ensure the backend is up as well (mycelium up or the full install stack). Verify with: mycelium doctor doctor auto-detects hub vs s",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-hub-only-slim-master-secret",
+    "t": "Hub-only: SLIM master secret",
+    "s": "Guides › Hub & Spoke",
+    "x": "The hub SLIM PSK lives in config.toml, not as a hand-edited .env entry. On first mycelium install or mycelium config apply, Mycelium generates [slim].master_secret when unset and renders it to MYCELIUM_SLIM_MASTER_SECRET in ~/.mycelium/.env for the backend container. mycelium config apply # generates [slim].master_secret if missing mycelium config show # SLIM PSK shown masked To rotate: mycelium config set slim.maste",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-open-ports",
+    "t": "Open ports",
+    "s": "Guides › Hub & Spoke",
+    "x": "Port Service Spokes need it? Purpose 8000 FastAPI backend Yes Memory, await/respond, room ops 46357 SLIM node No (default) Native SLIM on hub; optional for slim send Restrict :8000 on the hub when the team shares a network. Enable the HTTP JWT gate — that is what protects spokes, not the SLIM PSK.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-step-2-connect-each-spoke",
+    "t": "Step 2: Connect each spoke",
+    "s": "Guides › Hub & Spoke",
+    "x": "On each spoke, install the CLI: curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash Point the spoke at the hub backend (required): mycelium config set server.api_url http://192.168.1.20:8000 Or during init: mycelium init --api-url http://192.168.1.20:8000 Optional: store the hub's SLIM node address (only needed for native SLIM tooling such as mycelium slim send, not for normal participation): mycelium",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-secure-a-shared-hub",
+    "t": "Secure a shared hub",
+    "s": "Guides › Hub & Spoke",
+    "x": "When spokes reach the hub over a LAN or VPN, turn on HTTP authentication on the hub. See Authentication. Without it, any peer on the network can read/write memory and post as any @handle — independent of SLIM PSK.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-behind-a-tls-terminating-proxy",
+    "t": "Behind a TLS-terminating proxy",
+    "s": "Guides › Hub & Spoke",
+    "x": "A public hub usually sits behind a reverse proxy (Caddy, nginx, a cloud load balancer) that terminates HTTPS and forwards plain HTTP to the backend container. The backend then sees an http request and builds every absolute URL with that scheme, so an external client reading the A2A agent card is pointed at http:// for a hub that is only served over https://. The proxy says what the original request was in X-Forwarded",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-step-3-use-a-room-from-a-spoke",
+    "t": "Step 3: Use a room from a spoke",
+    "s": "Guides › Hub & Spoke",
+    "x": "There is one store: the hub's. Create the room on the hub, then use it from anywhere. # On the hub mycelium room create portfolio mycelium room use portfolio On a spoke, just make it the active room: mycelium room use portfolio Every memory command resolves against the hub over HTTP: mycelium memory ls mycelium memory get decisions/allocation mycelium memory set decisions/allocation \"60/40 equities to bonds\" mycelium",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-step-4-run-a-negotiation-across-machines",
+    "t": "Step 4: Run a negotiation across machines",
+    "s": "Guides › Hub & Spoke",
+    "x": "Register the aligner once in the room, post opening positions, and loop on participation. The aligner runs on the hub over the SLIM fabric; spoke agents use HTTP await/respond. mycelium engine create aligner --kind aligner --room portfolio Each participant posts an opening position: # Spoke A's agent mycelium respond --room portfolio --handle alice \"I want 60% equities.\" # Spoke B's agent mycelium respond --room port",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-agent-identity",
+    "t": "Agent identity",
+    "s": "Guides › Hub & Spoke",
+    "x": "Each agent needs a unique handle across the deployment. The handle is resolved from, in order: identity.name in ~/.mycelium/config.toml The MYCELIUM_AGENT_HANDLE environment variable The --handle flag on await / respond On a shared hub with auth enabled, the token — not the body alone — is the actor of record. Configure agent credentials for unattended spokes.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-troubleshooting",
+    "t": "Troubleshooting",
+    "s": "Guides › Hub & Spoke",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-spoke-cant-reach-the-hub",
+    "t": "Spoke can't reach the hub",
+    "s": "Guides › Hub & Spoke",
+    "x": "Check the backend first (the path spokes actually use): curl http://192.168.1.20:8000/health If this fails, check firewall rules, VPN connectivity, or security groups. The backend must be reachable on port 8000. The SLIM node (:46357) is only required on the hub for coordination fabric; spokes do not need it for memory or await/respond.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#hub-and-spoke-doctor-reports-spoke-mode-unexpectedly",
+    "t": "doctor reports \"spoke mode\" unexpectedly",
+    "s": "Guides › Hub & Spoke",
+    "x": "mycelium doctor infers mode from server.api_url. If it points at a non-local address, doctor assumes spoke mode. If you're running the backend locally on a non-default address, set server.api_url to http://localhost:8000 in ~/.mycelium/config.toml, or force hub mode: mycelium doctor --mode hub See Troubleshooting for the full runbook and Security Planes for HTTP vs SLIM protection.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents",
+    "t": "Ephemeral Agents",
+    "s": "Guides",
+    "x": "An ephemeral agent is a runtime that exists for one task and then disappears: a Claude Code cloud session, a CI job, a docker run that ends when the command does. It has no .mycelium/ directory, no config.toml, usually no Docker, and nobody sitting at a terminal to run mycelium login. It should still be able to say what it did. This guide covers the thinnest possible spoke: a container that installs the CLI, reads it",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-the-shape-of-it",
+    "t": "The shape of it",
+    "s": "Guides › Ephemeral Agents",
+    "x": "┌──────────────────────────────┐ │ Ephemeral container │ │ │ │ env: MYCELIUM_API_URL │ HTTPS │ MYCELIUM_ACTIVE_ROOM │ ─────────────► Hub (backend :8000) │ MYCELIUM_AGENT_HANDLE │ room + memory + transcript │ │ │ curl install.sh | bash │ │ mycelium room send \"…\" │ └──────────────────────────────┘ no config.toml, no .mycelium/, no Docker Nothing is written to disk that matters. The room is on the hub, and every call is",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-what-the-container-needs",
+    "t": "What the container needs",
+    "s": "Guides › Ephemeral Agents",
+    "x": "Four environment variables, no config file: Variable What it sets Needed MYCELIUM_API_URL The hub's backend URL, e.g. https://mycelium.example.com Always MYCELIUM_ACTIVE_ROOM The room to post into (MYCELIUM_ROOM_ID also works) Unless you pass --room MYCELIUM_AGENT_HANDLE Who the message is from Always MYCELIUM_AGENT_AUTH_TOKEN Bearer token for the hub Only if the hub's auth gate is on MYCELIUM_AGENT_HANDLE does doubl",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-install-without-docker",
+    "t": "Install without Docker",
+    "s": "Guides › Ephemeral Agents",
+    "x": "The normal installer sets up the whole stack, which needs Docker. An ephemeral agent only talks to a hub that already exists, so it wants the CLI alone: curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash -s -- --client-only Client-only mode skips the Docker check entirely, and when the container's python3 is older than 3.12 it installs a managed 3.12 for the CLI rather than failing. Both are what an ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-announce-something",
+    "t": "Announce something",
+    "s": "Guides › Ephemeral Agents",
+    "x": "mycelium room send \"Migrated the session store to Redis. Tests green, PR #412 up.\" That is the whole flow. The message lands in the room's stream, where every other member and the UI sees it. @handle mentions inside the text address specific agents, and a mentioned resident agent picks it up on its next await: mycelium room send \"@avery-agent the retry backoff is in — worth a look before you re-run the bench.\" Read t",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-beyond-announcing",
+    "t": "Beyond announcing",
+    "s": "Guides › Ephemeral Agents",
+    "x": "Announcing is one-way. To let the container take a turn in a negotiation — receive an addressed tick and reply as a position — use await and respond instead (see Rooms): mycelium await --handle ci-runner --timeout 120 mycelium respond --handle ci-runner \"I can hold the deploy until the bench lands.\" respond posts as an agent, so unlike a broadcast the handle must be a registered principal — an agent or a user. Regist",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-claude-code-on-the-web",
+    "t": "Claude Code on the web",
+    "s": "Guides › Ephemeral Agents",
+    "x": "A Claude Code cloud session is the case this guide was written for: an agent working in someone's repository, in a container you never touch, that should report back into a room when it is done. Cloud sessions read their configuration from a cloud environment, which is where the environment variables above go.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-1-configure-the-environment",
+    "t": "1. Configure the environment",
+    "s": "Guides › Ephemeral Agents",
+    "x": "On claude.ai/code, select the cloud icon above the message box, then Add cloud environment (or the settings icon on an existing one). The dialog holds the name, network access, environment variables, and setup script. Put this in Environment variables (.env format, one KEY=value per line): MYCELIUM_API_URL=https://mycelium.example.com MYCELIUM_ACTIVE_ROOM=build MYCELIUM_AGENT_HANDLE=claude-web Sessions copy these onc",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-2-let-the-session-reach-the-hub",
+    "t": "2. Let the session reach the hub",
+    "s": "Guides › Ephemeral Agents",
+    "x": "Cloud sessions get Trusted network access by default: package registries and GitHub, and nothing else. Your hub is not on that list, so set Network access to Custom and add its host to Allowed domains: mycelium.example.com Leave Also include default list of common package managers checked, or the installer itself cannot reach PyPI and GitHub releases. Two constraints follow from the session's egress proxy, and neithe",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-3-install-the-cli-once-per-environment",
+    "t": "3. Install the CLI once per environment",
+    "s": "Guides › Ephemeral Agents",
+    "x": "Put the client-only install in the Setup script, the Bash script that runs before Claude Code starts: curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash -s -- --client-only The filesystem is snapshotted after the setup script runs and reused for later sessions, so the CLI is already on disk at the start of every session in that environment rather than being reinstalled each time.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-4-tell-the-agent-to-use-it",
+    "t": "4. Tell the agent to use it",
+    "s": "Guides › Ephemeral Agents",
+    "x": "Nothing so far tells Claude to announce anything. Commit that instruction to the repository, in CLAUDE.md or a skill, so it applies to every session: ## Reporting When you finish a piece of work, announce it in the Mycelium room: mycelium room send \"<what changed, what's left, links>\" The room, handle, and hub are already in the environment. Address teammates with @handle when they need to act.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-5-link-the-announcement-back-to-the-session",
+    "t": "5. Link the announcement back to the session",
+    "s": "Guides › Ephemeral Agents",
+    "x": "A cloud session knows its own transcript URL, which makes an announcement traceable to the run that produced it: mycelium room send \"$(cat <<EOF @team Retry backoff landed — PR #412, CI green. Session: https://claude.ai/code/${CLAUDE_CODE_REMOTE_SESSION_ID/#cse_/session_} EOF )\" CLAUDE_CODE_REMOTE_SESSION_ID is set by the platform; the substitution turns its cse_ prefix into the session_ prefix the transcript URL exp",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-other-ephemeral-runtimes",
+    "t": "Other ephemeral runtimes",
+    "s": "Guides › Ephemeral Agents",
+    "x": "Nothing above is specific to Claude Code. Any container that can set environment variables and reach the hub works the same way — a GitHub Actions job, a Nomad batch task, a docker run: docker run --rm \\ -e MYCELIUM_API_URL=https://mycelium.example.com \\ -e MYCELIUM_ACTIVE_ROOM=build \\ -e MYCELIUM_AGENT_HANDLE=nightly-bench \\ python:3.12-slim bash -c ' curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | ba",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#ephemeral-agents-troubleshooting",
+    "t": "Troubleshooting",
+    "s": "Guides › Ephemeral Agents",
+    "x": "Symptom Cause Failed to connect to the Mycelium API MYCELIUM_API_URL unreachable: not public, not HTTPS, or not on the session's allowlist 502 Bad Gateway / ProxyError from a hub that is up The hub's domain is not on the environment's Allowed domains; the refusal is the egress proxy's, not the hub's No room context found Neither MYCELIUM_ACTIVE_ROOM / MYCELIUM_ROOM_ID nor --room is set 403 … is not a registered agent",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#security-planes",
+    "t": "Security Planes",
+    "s": "Guides",
+    "x": "Mycelium has two enforcement planes. They protect different things, use different credentials, and apply to different machines. Conflating them is the most common hub-and-spoke misconfiguration.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#security-planes-the-two-planes",
+    "t": "The two planes",
+    "s": "Guides › Security Planes",
+    "x": "Plane Port (default) Who uses it What it protects Default Upgrade HTTP API 8000 Spokes, humans, agents (memory, await, respond) Memory, participation, handle attribution Open (no token) Authentication (auth.enabled) SLIM / MLS 46357 Hub backend (moderator); dev slim send; future native connectors Native SLIM group membership on the coordination fabric Shared-secret PSK (hub only) SignerJwt (slim.identity) Spokes do n",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#security-planes-what-psk-actually-protects",
+    "t": "What PSK actually protects",
+    "s": "Guides › Security Planes",
+    "x": "PSK (MYCELIUM_SLIM_MASTER_SECRET → HMAC per workspace/room → create_app_with_secret) is the SLIM-plane room gate: It decides who may authenticate as a SLIM app and join a room's MLS group. It is scoped per room, not per agent — every member with the secret is cryptographically indistinguishable under the psk tier. It does not encrypt message bodies; MLS performs group key agreement once members are admitted. It does ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#security-planes-what-protects-spokes",
+    "t": "What protects spokes",
+    "s": "Guides › Security Planes",
+    "x": "For hub-and-spoke, the urgent control is the HTTP API gate, not PSK: mycelium config set auth.enabled true mycelium config set auth.audience mycelium # … configure [[auth.issuers]] … mycelium config apply See Authentication for humans and agent service accounts. Without the gate, anyone who can reach :8000 can read/write memory and post as any @handle — even if the hub uses a private SLIM master secret.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#security-planes-deployment-profiles",
+    "t": "Deployment profiles",
+    "s": "Guides › Security Planes",
+    "x": "Profile HTTP API SLIM (hub) Spoke config Solo dev Open Dev PSK literal (fallback if no config secret) N/A (all-in-one) LAN team JWT on Auto-generated [slim].master_secret on hub server.api_url → hub:8000 only Hosted JWT required Private hub secret + SignerJwt Same; no master secret on spokes mycelium doctor reports HTTP auth status from the hub's /health endpoint. In hub mode it also warns when [slim].master_secret i",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#security-planes-slim-identity-ladder-hub-native-clients",
+    "t": "SLIM identity ladder (hub native clients)",
+    "s": "Guides › Security Planes",
+    "x": "Tier Plane Spoke needs it? psk SLIM No (hub backend only today) signerjwt SLIM Only if the spoke runs a native SLIM connector mycelium config set slim.identity signerjwt changes SLIM channel identity on machines that open native SLIM connections. It does not turn on HTTP API auth. Configure [auth] separately.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#security-planes-related-guides",
+    "t": "Related guides",
+    "s": "Guides › Security Planes",
+    "x": "Hub & Spoke Setup — topology and spoke checklist Authentication — HTTP JWT gate (spokes and hub API)",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth",
+    "t": "Authentication",
+    "s": "Guides",
+    "x": "Mycelium's backend can require a signed bearer token on every HTTP API call, validated against an OIDC issuer you configure. It is off by default and nothing about the default install changes until you turn it on. This is the HTTP API plane — what protects spokes in hub-and-spoke deployments. It is separate from SLIM/MLS PSK or SignerJwt on the coordination fabric; see Security Planes.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-off-by-default-on-purpose",
+    "t": "Off by default, on purpose",
+    "s": "Guides › Authentication",
+    "x": "Auth must never be a wall between someone and trying Mycelium. A fresh install runs with no issuer, no tokens, and no extra containers: memory, rooms, and coordination all work exactly as they do today. Turn it on when a team shares a hub over a network. Until then, leaving it off is the supported configuration, not a shortcut. Without the gate, anyone who can reach the backend's port can read and write every room an",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-turning-it-on",
+    "t": "Turning it on",
+    "s": "Guides › Authentication",
+    "x": "mycelium config set auth.enabled true mycelium config set auth.audience mycelium mycelium config apply Then declare at least one trust root in ~/.mycelium/config.toml: [auth] enabled = true audience = \"mycelium\" [[auth.issuers]] issuer = \"https://sso.example.com/realms/mycelium\" jwks_url = \"https://sso.example.com/realms/mycelium/protocol/openid-connect/certs\" role = \"user\" Re-run mycelium config apply and recreate t",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-always-set-an-audience",
+    "t": "Always set an audience",
+    "s": "Guides › Authentication",
+    "x": "audience is optional but you should always set it when enabling auth. Without one, any token your issuer has ever minted is accepted, including a token a user obtained for a completely unrelated application on the same identity provider. That token's holder was never authorized against your hub. Setting an audience is what makes \"a valid token\" mean \"a token meant for this hub\". The backend logs a warning at startup ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-configuration",
+    "t": "Configuration",
+    "s": "Guides › Authentication",
+    "x": "Key Default What it does auth.enabled false Enforce bearer-token auth on the HTTP API. auth.issuers (none) Trust roots, as repeatable [[auth.issuers]] blocks. auth.audience (unset) Required aud claim. Set this whenever auth is on. auth.localhost_bypass true Let loopback callers through without a token. auth.handle_claim sub Claim carrying the canonical @handle. auth.role_claim mycelium_role Claim distinguishing a use",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-signing-in-from-the-cli",
+    "t": "Signing in from the CLI",
+    "s": "Guides › Authentication",
+    "x": "The gate above is the hub's half. mycelium login is yours: it obtains an OIDC token for you, caches it, and every later command sends it. mycelium config set login.issuer https://sso.example.com/realms/mycelium mycelium config set login.audience mycelium # match the hub's auth.audience mycelium login Your browser opens, you sign in at your identity provider, and the CLI takes it from there: mycelium memory, mycelium ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-login-is-opt-in-like-the-gate",
+    "t": "Login is opt-in, like the gate",
+    "s": "Guides › Authentication",
+    "x": "Never running mycelium login changes nothing: with no cached session the CLI sends no Authorization header, exactly as before this existed. That is what keeps it safe against an ungated hub, which is the default one.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-where-the-token-lives",
+    "t": "Where the token lives",
+    "s": "Guides › Authentication",
+    "x": "In ~/.mycelium/token.json, created mode 0600, not in config.toml. Config is printed, copied between machines, and mirrored to config.json for the frontend; a token in there would leak by routine. Set MYCELIUM_TOKEN_FILE to cache it somewhere else (a CI runner with a shared home, say). The access token is renewed automatically when it expires, using the refresh token, on the way into the next call that needs it; you d",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-who-you-are",
+    "t": "Who you are",
+    "s": "Guides › Authentication",
+    "x": "mycelium whoami (and mycelium iam with no arguments) reports the handle from your token when you're signed in, and the self-asserted identity.name when you're not: acting as @avery (avery#a8f3) signed in (https://sso.example.com/realms/mycelium, expires in 42 min) Because a gated hub attributes writes to the token (see The token is the author below), a self-asserted handle that names someone else is a 403 in waiting;",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-configuration",
+    "t": "Configuration",
+    "s": "Guides › Authentication",
+    "x": "Key Default What it does login.issuer (unset) OIDC issuer to log in against. Unset means no login is configured. login.client_id mycelium-cli OAuth client id registered for the CLI. login.client_secret (unset) Only for issuers that refuse public clients; PKCE means the CLI normally needs none. login.scopes openid profile email offline_access Scopes requested at login. login.audience (unset) Audience to request; shoul",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-agents-sign-in-as-themselves",
+    "t": "Agents sign in as themselves",
+    "s": "Guides › Authentication",
+    "x": "mycelium login is for a human. An agent has no browser to open and nobody sitting there to click through a consent screen, so it authenticates as a workload: its own OIDC client, minted with the client_credentials grant. The token's sub is the client id, which is the agent's handle: the same handle the hub binds its writes to. That is the property a shared secret can't give you: each agent holds a different credentia",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-off-by-default-here-too",
+    "t": "Off by default here too",
+    "s": "Guides › Authentication",
+    "x": "An agent with no credential sends no token, exactly as before. Configuring agent_auth.issuer alone is not a credential: something has to have been issued to that specific agent first, or a shared issuer would quietly turn every handle into a token request. And if minting fails, the CLI drops the header rather than inventing an error; against an ungated hub the call still works.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-where-the-credential-lives",
+    "t": "Where the credential lives",
+    "s": "Guides › Authentication",
+    "x": "In ~/.mycelium/agent-credentials.json, mode 0600, alongside a cached token per agent under ~/.mycelium/agent-tokens/. Client secrets are secrets, so they stay out of config.toml for the same reason your session does. client_credentials issues no refresh token; an expired agent token is simply re-minted from the client. For a container that runs exactly one agent and has no config file, MYCELIUM_AGENT_AUTH_ISSUER, MYC",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-a-credential-mycelium-didnt-mint",
+    "t": "A credential Mycelium didn't mint",
+    "s": "Guides › Authentication",
+    "x": "MYCELIUM_AGENT_AUTH_TOKEN supplies a bearer token directly, used as-is and never renewed here. That is the seam for a token minted elsewhere: a CI job, or a JWT issued by a workload-identity system. Trusting one is a config entry on the hub side too: another [[auth.issuers]] block with role = \"agent\". Nothing about it is required, and nothing about it is on by default.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-configuration",
+    "t": "Configuration",
+    "s": "Guides › Authentication",
+    "x": "Key Default What it does agent_auth.issuer (unset) Issuer agents mint service-account tokens from. Unset means agents send no token. agent_auth.scopes (unset) Scopes requested for an agent token. Most issuers want none for client_credentials. agent_auth.audience (unset) Audience to request; should match the hub's auth.audience.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-issuer-agnostic-by-design",
+    "t": "Issuer-agnostic by design",
+    "s": "Guides › Authentication",
+    "x": "The backend trusts a configured issuer and its JWKS. It has no idea whether that is Keycloak, Dex, ZITADEL, Authentik, or your existing corporate SSO, and it never needs one particular product installed. More than one trust root is normal. Humans log in through an interactive OIDC issuer; agents present service-account tokens, possibly from an entirely separate root. List each as its own block: [[auth.issuers]] issue",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-handle-and-role",
+    "t": "Handle and role",
+    "s": "Guides › Authentication",
+    "x": "Once a token validates, the request has a principal: handle, from auth.handle_claim (sub by default), normalized the same way stored handles are (leading @ stripped, lowercased). An OIDC service-account whose client id is release-agent therefore arrives as @release-agent. role, from auth.role_claim if the token carries it, otherwise the role on the matched issuer block. Which root signed a token is usually the whole ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-the-token-is-the-author",
+    "t": "The token is the author",
+    "s": "Guides › Authentication",
+    "x": "The principal is not just recorded; it is the actor of record for every write it makes. Memory authorship (created_by / updated_by), the transcript sender, and L9 actor attribution all come from the token rather than from the handle the request body supplies: The body omits the actor, or names the same handle, and the token's handle is stored. @Alice and alice are one principal; the comparison uses the same normaliza",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-acting-as-another-handle",
+    "t": "Acting as another handle",
+    "s": "Guides › Authentication",
+    "x": "Attribution answers who wrote this. Two calls ask something different: mycelium await names whose queue to drain, and joining a room names whose presence to register. Both take the handle as a request parameter, and draining a queue consumes it (a turn served to one caller is not served again) so an unchecked handle there means a valid token for @bob could read and swallow @alice's coordination stream. A gated hub al",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-key-rotation",
+    "t": "Key rotation",
+    "s": "Guides › Authentication",
+    "x": "The JWKS is fetched from your issuer and cached for auth.jwks_ttl_s. When a token arrives signed by a key ID the backend hasn't seen, it re-fetches immediately (rate-limited), so rotating your signing key does not require restarting Mycelium. If the issuer is briefly unreachable, previously fetched keys keep serving. The keys are still your issuer's; only their freshness is in doubt, and failing closed would take the",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-the-localhost-bypass",
+    "t": "The localhost bypass",
+    "s": "Guides › Authentication",
+    "x": "With auth.localhost_bypass on (the default), requests whose peer address is real loopback (127.0.0.0/8, ::1) skip the gate, so turning auth on can't lock you out of the machine the hub runs on. Two things worth knowing: X-Forwarded-For is deliberately ignored. It is caller-supplied, so honouring it would let any remote request claim to be local. It does not fire for a backend running in Docker. Traffic through a publ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-what-stays-open",
+    "t": "What stays open",
+    "s": "Guides › Authentication",
+    "x": "Health (/, /health) and the schema/docs routes are served without a token even when the gate is on: orchestrator probes are unauthenticated by nature, and the health payload reveals no room content. /health gains an auth block reporting whether the hub is gated, which issuers it trusts, and any configuration warnings. Every other route requires a token.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-failure-modes",
+    "t": "Failure modes",
+    "s": "Guides › Authentication",
+    "x": "Response Meaning 401 + WWW-Authenticate: Bearer Missing, malformed, expired, forged, wrong-audience, or wrong-issuer token. 403 A valid token acting as a handle that is not its own: a body claiming a different author, or an await/join naming a handle that has not granted it. 503 The gate is on but unusable: no trusted issuers configured, or the issuer's JWKS is unreachable and nothing is cached. Only asymmetric signa",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-trying-it-locally",
+    "t": "Trying it locally",
+    "s": "Guides › Authentication",
+    "x": "Follow the Keycloak / OIDC Setup guide to stand up a realm, client, and human mycelium login, wired end-to-end.",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#keycloak-oidc",
+    "t": "Keycloak / OIDC Setup",
+    "s": "Guides",
+    "x": "<!-- SPDX-License-Identifier: Apache-2.0 --> Authentication explains the gate in the abstract: the backend trusts an OIDC issuer and validates a bearer token against its JWKS. This guide makes the human OIDC tier concrete against real Keycloak: realm, client, the claims the gate keys off, and a human mycelium login. Every command here was run against a live Keycloak: the wiring below is confirmed, not aspirational. K",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#keycloak-oidc-stand-up-keycloak",
+    "t": "Stand up Keycloak",
+    "s": "Guides › Keycloak / OIDC Setup",
+    "x": "A ready-to-run Keycloak ships as an opt-in compose overlay, off the default stack, added with an extra -f exactly like the dev issuer. It imports a mycelium realm with a public CLI client, an audience mapper, and a demo user, so there is nothing to click in the admin console. cd mycelium-cli/src/mycelium/docker docker compose -f compose.yml -f compose-dev.yml -f compose-keycloak.yml \\ up -d keycloak The realm is read",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#keycloak-oidc-what-the-realm-ships-and-what-the-gate-expects",
+    "t": "What the realm ships (and what the gate expects)",
+    "s": "Guides › Keycloak / OIDC Setup",
+    "x": "The imported realm (docker/keycloak/mycelium-realm.json) is the whole anatomy the gate needs. Point your own Keycloak at these same four things: A public client mycelium-cli: this is the client mycelium login uses. Public (no secret; it authenticates with PKCE), with the loopback redirect http://127.0.0.1:*/callback for the browser flow and the device grant enabled for headless login. An audience mapper stamping myce",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#keycloak-oidc-wire-the-gate",
+    "t": "Wire the gate",
+    "s": "Guides › Keycloak / OIDC Setup",
+    "x": "The one subtlety worth understanding is which URL goes where, because the backend runs in a container and the browser/CLI run on the host: Keycloak stamps the token iss as http://localhost:8080/realms/mycelium for every caller (the overlay pins its advertised URL). That is what the browser and CLI reach it by, so it is the issuer the gate matches. The backend can't use localhost: inside the container that is the back",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#keycloak-oidc-sign-in-with-mycelium-login",
+    "t": "Sign in with mycelium login",
+    "s": "Guides › Keycloak / OIDC Setup",
+    "x": "mycelium login # opens your browser to Keycloak mycelium login --device # headless: prints a URL + code to approve from any device Sign in as demo / demo. The CLI caches the token (~/.mycelium/token.json, mode 0600) and every later command carries it: mycelium whoami # acting as @demo # signed in (http://localhost:8080/realms/mycelium, expires in 4 min) mycelium room ls # now authorized through the Keycloak token myc",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#keycloak-oidc-prove-the-gate-what-validated-means",
+    "t": "Prove the gate (what \"validated\" means)",
+    "s": "Guides › Keycloak / OIDC Setup",
+    "x": "The same three checks that were run to confirm this guide, against the published backend port: # A real Keycloak token for the demo user TOKEN=$(curl -s -X POST \\ http://localhost:8080/realms/mycelium/protocol/openid-connect/token \\ -d 'grant_type=password&client_id=mycelium-cli&username=demo&password=demo&scope=openid profile' \\ | python3 -c 'import json,sys; print(json.load(sys.stdin)[\"access_token\"])') curl -s -o ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#keycloak-oidc-agents-and-more-than-one-issuer",
+    "t": "Agents, and more than one issuer",
+    "s": "Guides › Keycloak / OIDC Setup",
+    "x": "This guide is the human tier. Agents authenticate as workloads with the client_credentials grant from their own Keycloak client; see Authentication → Agents sign in as themselves. Humans and agents are often separate realms; list each as its own [[auth.issuers]] block (a human root with role = \"user\", an agent root with role = \"agent\"), matched by exact iss and never interchangeable. For per-agent identity on the SLI",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#keycloak-oidc-browser-login-the-frontend",
+    "t": "Browser login (the frontend)",
+    "s": "Guides › Keycloak / OIDC Setup",
+    "x": "The Next.js frontend does the same OIDC flow for humans in a browser. With the gate off it is unchanged: the localStorage handle-picker, no login. With the gate on, the app shows a Sign in screen and redirects to Keycloak; after you authenticate it carries your token on every /api/* call (sealed in an httpOnly cookie, injected server-side by the proxy; it never reaches browser JS). The realm import ships a second pub",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#keycloak-oidc-limitations",
+    "t": "Limitations",
+    "s": "Guides › Keycloak / OIDC Setup",
+    "x": "The shipped overlay is dev-grade: Keycloak in start-dev (in-memory H2, HTTP, a demo user with a weak password). It is a real OIDC provider minting real RS256 tokens against a real JWKS (enough to build and prove against) but it is not a hardened production Keycloak. For a real deployment, run your own Keycloak over TLS with a persistent datastore and real users, then point the same three config values (issuer, jwks_u",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting",
+    "t": "Troubleshooting",
+    "s": "Help",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-quick-diagnostics",
+    "t": "Quick Diagnostics",
+    "s": "Help › Troubleshooting",
+    "x": "mycelium doctor # full diagnostic: config, backend, LLM, SLIM, adapters mycelium doctor --fix # auto-fix everything it can mycelium status # quick service health (backend, LLM, disk) mycelium logs --tail 50 # recent service logs mycelium doctor is the first thing to run for almost any problem. It auto-detects whether this machine is a hub (runs the backend + SLIM node locally) or a spoke (points at a remote hub), and",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-common-issues",
+    "t": "Common Issues",
+    "s": "Help › Troubleshooting",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-1-command-not-found",
+    "t": "1. Command Not Found",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: mycelium: command not found curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash Or add to PATH if the binary exists: export PATH=\"$HOME/.local/bin:$PATH\"",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-2-backend-not-running",
+    "t": "2. Backend Not Running",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: Cannot connect to Mycelium API at http://localhost:8000 The backend is the room moderator; nothing coordinates without it. mycelium status # quick check docker ps | grep mycelium-backend # container status mycelium up # start services mycelium logs mycelium-backend --tail 50",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-3-config-not-found",
+    "t": "3. Config Not Found",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: Configuration file not found: ~/.mycelium/config.toml mycelium init # or point at a remote hub: mycelium init --api-url http://your-hub:8000",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-4-spoke-cant-reach-the-hub-or-backend-down",
+    "t": "4. Spoke Can't Reach the Hub (or Backend Down)",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: Cannot connect to Mycelium API; memory/await/respond fail; mycelium doctor reports backend unreachable. Spokes talk to the hub over HTTP (server.api_url, default port 8000). They do not need the SLIM node for normal participation. mycelium doctor # detects hub vs spoke; checks /health curl http://<hub-ip>:8000/health # from the spoke mycelium config get server.api_url # should point at the hub backend On the",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-5-port-already-in-use",
+    "t": "5. Port Already in Use",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: bind: address already in use lsof -i :8000 # backend lsof -i :46357 # SLIM node Remap published host ports through config rather than hand-editing .env: mycelium config set runtime.backend_port 8001 # MYCELIUM_BACKEND_PORT mycelium config set runtime.frontend_port 3001 # MYCELIUM_UI_PORT mycelium config set runtime.collector_port 4319 # MYCELIUM_METRICS_PORT mycelium config apply mycelium down && mycelium up",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-6-llm-not-configured",
+    "t": "6. LLM Not Configured",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: LLM unavailable, no API key configured, or mycelium doctor reports the LLM connectivity check as not configured / auth failed. The LLM powers the aligner mediator and memory embedding-adjacent work. Set it through config, not by hand-editing .env: mycelium config set llm.model \"anthropic/claude-sonnet-4-6\" mycelium config set llm.api_key \"sk-ant-...\" mycelium config apply mycelium up # recreate the backend w",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-7-aligner-negotiation-fails-pi-not-found",
+    "t": "7. Aligner Negotiation Fails (\"pi not found\")",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: summoning the aligner (mycelium engine invoke aligner ...) fails with PiBrainError: pi not found. The aligner's mediator runs a NEGMAS negotiation whose brain is a Pi coding-agent session. The released backend image already ships Pi, so the normal mycelium up path needs nothing extra, and mycelium doctor reports this check as satisfied when the backend is dockerized. This only bites when you run the backend ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-8-memory-search-returns-nothing",
+    "t": "8. Memory Search Returns Nothing",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: mycelium memory search is empty despite memories existing. Search runs against a local embedding index (no external service). Direct file writes (cat, editor, agent file I/O) don't update it until you reindex. mycelium memory ls # do memories exist? ls ~/.mycelium/rooms/ # files present? mycelium reindex # rebuild the index after direct file writes mycelium room ls # wrong active room?",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-9-no-active-room",
+    "t": "9. No Active Room",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: No active room. Use 'mycelium room use <name>' mycelium room ls mycelium room use <name> # or pass room explicitly: mycelium memory ls --room <name>",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-10-config-drift-edited-one-file-not-the-other",
+    "t": "10. Config Drift (edited one file, not the other)",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: config changes seem to have no effect; mycelium doctor flags Config file drift or Runtime config drift. mycelium config apply regenerates ~/.mycelium/.env from config.toml, which is the source of truth. If you hand-edit .env, the next apply overwrites it. And if you change config but don't recreate the backend, it keeps running the old env. mycelium config apply # rewrite .env from config.toml mycelium up # ",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-11-permission-errors-under-mycelium",
+    "t": "11. Permission Errors Under ~/.mycelium",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: opaque PermissionError on memory or agent writes; mycelium doctor flags ~/.mycelium ownership with root-owned files. Usually a sudo install paired with a non-sudo agent add (or a containerized gateway running as root bind-mounting your home). One chown fixes it: sudo chown -R $USER ~/.mycelium",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-12-spoke-cannot-reach-hub-backend",
+    "t": "12. Spoke Cannot Reach Hub Backend",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: mycelium status / mycelium room ls from a spoke returns a connection error pointing at the hub's URL. curl http://<hub-ip>:8000/health # raw backend reachability grep api_url ~/.mycelium/config.toml # what the spoke targets Common causes: firewall blocks port 8000, hub backend isn't running (mycelium up on the hub), VPN/Tailscale not connected, or the wrong URL in config.toml. Re-point if needed: mycelium in",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-13-hub-advertises-http-urls-behind-https",
+    "t": "13. Hub Advertises http:// URLs Behind HTTPS",
+    "s": "Help › Troubleshooting",
+    "x": "Symptom: the hub is served over https://, but an absolute URL it hands out comes back http://. Most visible on the A2A agent card: curl -s https://hub.example.com/api/rooms/my-room/.well-known/agent-card.json # \"url\": \"http://hub.example.com/api/rooms/my-room/a2a\" Cause: a TLS-terminating reverse proxy forwards plain HTTP to the backend container, so the backend sees an http request. The proxy reports the original sc",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-configuration-reference",
+    "t": "Configuration Reference",
+    "s": "Help › Troubleshooting",
+    "x": "",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-cli-settings-myceliumconfigtoml",
+    "t": "CLI settings: ~/.mycelium/config.toml",
+    "s": "Help › Troubleshooting",
+    "x": "Setting Key Env var override Backend URL server.api_url MYCELIUM_API_URL SLIM node endpoint slim.node_endpoint (none) Active room rooms.active MYCELIUM_ACTIVE_ROOM Agent handle identity.name MYCELIUM_AGENT_HANDLE",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-backend-settings-myceliumenv",
+    "t": "Backend settings: ~/.mycelium/.env",
+    "s": "Help › Troubleshooting",
+    "x": "Variable Description Default LLM_MODEL provider/model string, as Pi takes it anthropic/claude-sonnet-4-6 LLM_API_KEY Provider API key (none) LLM_BASE_URL Custom LLM endpoint (Ollama, vLLM) (none) MYCELIUM_DATA_DIR Data directory ~/.mycelium MYCELIUM_BACKEND_PORT Backend API host port 8000 MYCELIUM_UI_PORT Frontend host port 3000 MYCELIUM_METRICS_PORT OTLP collector host port (--metrics) 4318 FORWARDED_ALLOW_IPS Forwa",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-agent-environment-variables",
+    "t": "Agent environment variables",
+    "s": "Help › Troubleshooting",
+    "x": "Read by the CLI and adapters at runtime to identify the agent and locate the backend: Variable Description MYCELIUM_API_URL Backend API URL (default: http://localhost:8000) MYCELIUM_AGENT_HANDLE This agent's identity handle MYCELIUM_ROOM Active room name",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-log-locations",
+    "t": "Log Locations",
+    "s": "Help › Troubleshooting",
+    "x": "mycelium logs # all services mycelium logs mycelium-backend # backend only mycelium --verbose status # CLI debug output",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-reset-everything",
+    "t": "Reset Everything",
+    "s": "Help › Troubleshooting",
+    "x": "mycelium down --volumes # stop and delete all data rm -rf ~/.mycelium # remove all config and room files mycelium install # fresh install",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#troubleshooting-getting-help",
+    "t": "Getting Help",
+    "s": "Help › Troubleshooting",
+    "x": "Report issues at https://github.com/mycelium-io/mycelium/issues",
+    "p": "Reference"
+  }
+];


### PR DESCRIPTION
## Summary

`docs/search-index.js` is regenerated in full by every change that touches the docs, and it was written minified — one 120KB line. That gave git nothing to align on, so any two branches that touched the docs conflicted across the entire file, with nothing a human could resolve by hand and no option but to regenerate from the merged sources.

Indenting it makes records and their fields separate lines, so git merges disjoint edits itself.

## Changes

- `_write_search_index` emits `json.dumps(records, indent=2, ...)` instead of the minified separators. One argument; the `
`/`
` escaping and the assign-a-global wrapper are unchanged.
- `docs/search-index.js` regenerated: 1 line → 2191, same 303 records.
- The docstring records why the file is indented, since it reads as a size regression without it.

## Testing

Merge behavior verified on the real file rather than a synthetic one — two branches editing different docs sections:

| | lines | merge result |
| --- | --- | --- |
| before | 1 | **CONFLICT** |
| after | 2191 | **clean** |

Size cost, measured: 120.8KB → 135.0KB raw, which is 36.9KB → 37.4KB gzipped (+0.5KB).

The index still parses: loading the file assigns a global of 303 records, unchanged from before. Regeneration is idempotent — a second run leaves the tree clean, so the CI drift check stays green.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 679 passed, 2 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)

## Related Issues

Supersedes #818, which addresses the same conflicts by writing one record per line plus a `merge=union` driver in `.gitattributes`. One record on one line is still an unsplittable atom, so it conflicts on same-record edits that `indent=2` merges cleanly — which is why it needs the union driver, the trailing comma on every line that keeps a union result parseable, and a test asserting that comma placement. Indenting removes the conflicts rather than resolving them, so none of that is needed. That PR's `linguist-generated=true` markings are still worth keeping on their own.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J8amkhr4wKahXV35aPdbtE)_