### PR TITLE
Make a board verb write to the room, not to the browser (#825)

### DIFF
--- a/contracts/board-vocabulary.json
+++ b/contracts/board-vocabulary.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Frozen vocabulary for the coordination board (PoC). The GUI (mycelium-frontend/src/lib/board/) and the CLI (mycelium-cli/src/mycelium/board/) each carry their own copy of the projection rules \u2014 the thin `uv tool` CLI can't import the frontend and vice versa \u2014 so the words they must agree on live here, the same way contracts/slim-l9-wire.json freezes the SLIM+L9 constants. A unit test on each side asserts against this file, so neither copy can drift without a red gate.",
+  "_comment": "Frozen vocabulary for the coordination board. The GUI (mycelium-frontend/src/lib/board/) and the CLI (mycelium-cli/src/mycelium/board/) each carry their own copy of the projection rules \u2014 the thin `uv tool` CLI can't import the frontend and vice versa \u2014 so the words they must agree on live here, the same way contracts/slim-l9-wire.json freezes the SLIM+L9 constants. A unit test on each side asserts against this file, so neither copy can drift without a red gate.",
   "version": 1,
   "statuses": [
     "open",

--- a/contracts/board-vocabulary.json
+++ b/contracts/board-vocabulary.json
@@ -138,6 +138,19 @@
     },
     "blocked_field": "blocked_by"
   },
+  "fields": {
+    "_comment": "What a board verb writes when it is not custody: frontmatter on the row's memory, through the same upsert `memory set --meta` goes through. Only a memory carries frontmatter, so every other projected row refuses in its own terms rather than accepting a write that goes nowhere. The reserved set is deliberately NOT listed here \u2014 it is derived from `custody` (its field, its companion fields, and the holder), and each implementation asserts that derivation rather than a second copy that could drift.",
+    "writable_source_kinds": [
+      "memory"
+    ],
+    "refusals": {
+      "plan": "a plan task is a checklist line; there is no frontmatter on it to write",
+      "episode": "an episode is a recorded negotiation, not a row the room can edit",
+      "agent": "presence is what the runtime reports, not a field you set",
+      "capture": "this row is not in the room yet; capture it first",
+      "github": "this value belongs to the tool it came from; change it there"
+    }
+  },
   "schema": {
     "_comment": "Field types the two surfaces must infer identically, and the order options come back in. `cases` is a table both suites run through their own classifier: a field name, the values it holds, and the type both must call it. These drifted once (the GUI grew number-from-string and link rules the CLI never got, and sorted out-of-vocabulary options first where the CLI sorted them last), which is what a table asserted from both sides prevents.",
     "types": [

--- a/docs/index.html
+++ b/docs/index.html
@@ -690,10 +690,6 @@ Blocked 1
 Review 1
  ◉ 7c2   @agent-z opened PR #504, wants eyes on the custody seam
          @agent-z   feat/custody-seam   CI green   #504       12m</code></pre>
-      <div class="callout callout-note">
-        <div class="callout-bar"></div>
-        <div class="callout-body"><strong>Experimental.</strong> The board reads and writes real room state. A triage verb puts frontmatter on the row&#x27;s memory, through the same upsert a <code>memory set</code> goes through — so a card you move is a versioned, indexed change the room can read back, not a change to your own view. Rows projected from somewhere other than a memory say so instead of taking the write.</div>
-      </div>
       <h2 id="board-nothing-to-fill-in">Nothing to fill in</h2>
       <p>You never add anything to the board. It&#x27;s assembled from what the room already has: the tasks in its plan, the negotiations running in it, the memories under <code>decisions/</code>, <code>status/</code>, <code>work/</code> and <code>failed/</code>, and which agents are actually resident right now. Every row says where it came from, and clicking through takes you to the real thing rather than a copy of it.</p>
       <p>That means there&#x27;s no second place to keep up to date. Mark a plan task done and its row resolves. End a negotiation and its decision row closes. Nothing to groom, and nothing that can quietly disagree with the room it describes.</p>
@@ -759,7 +755,8 @@ Review 1
       <h2 id="board-one-gesture-each">One gesture each</h2>
       <p><code>claim</code> · <code>release</code> · <code>resolve</code> · <code>block</code> · <code>promote</code> · <code>dismiss</code></p>
       <p>One keystroke each in the interface, one word each on the command line, and the same words agents use. Answering a decision is the answer itself: pick <code>15m</code> on the row and it&#x27;s settled and gone.</p>
-      <p><code>block</code> is the one that stores nothing: a row is blocked because it <em>names</em> a blocker, so <code>block</code> writes <code>blocked_by</code> and the board derives the rest. Captured concerns expire if nobody claims them, so the board stays a picture of now instead of turning into a backlog. Anything that should outlive the work gets <code>promote</code>d into a GitHub issue and leaves, with a link left behind.</p>
+      <p>Every one of them writes. A verb puts frontmatter on the row&#x27;s memory, through the same upsert a <code>memory set</code> goes through, so a card you move is a versioned, indexed change the room reads back rather than a change to your own view. Custody is the exception, and only because it needs to be: who holds a row moves through a lease, under rules a plain write can&#x27;t check. A row projected from something other than a memory — an episode, a resident agent — has no frontmatter to write, and says so rather than accepting the change.</p>
+      <p><code>block</code> is the one that stores nothing: a row is blocked because it <em>names</em> a blocker, so <code>block</code> writes <code>blocked_by</code> and the board derives the rest. Captured concerns expire if nobody claims them, so the board stays a picture of now instead of turning into a backlog. <code>promote</code> marks a row as belonging somewhere more durable and resolves it; filing the GitHub issue itself is still yours to do, and the verb doesn&#x27;t invent a link it didn&#x27;t create.</p>
       <h2 id="board-waiting-on-a-lease-not-on-the-room">Waiting on a lease, not on the room</h2>
       <p>Following a handoff by waiting on the room&#x27;s channel is the wrong subscription: a dozen unrelated messages wake you for nothing. A lease is already a small state machine, and its transitions — claimed, lapsed, released, resolved — are exactly what a handoff cares about, so it is the thing to subscribe to:</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">await</span> <span class="flag">--lease</span> work/auth-spike <span class="flag">--loop</span></code></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -692,7 +692,7 @@ Review 1
          @agent-z   feat/custody-seam   CI green   #504       12m</code></pre>
       <div class="callout callout-note">
         <div class="callout-bar"></div>
-        <div class="callout-body"><strong>Experimental.</strong> The board reads real room state today. The triage verbs act on your own view: <code>resolve</code> writes through to a plan task, and the rest change what you see without yet writing back to the room.</div>
+        <div class="callout-body"><strong>Experimental.</strong> The board reads and writes real room state. A triage verb puts frontmatter on the row&#x27;s memory, through the same upsert a <code>memory set</code> goes through — so a card you move is a versioned, indexed change the room can read back, not a change to your own view. Rows projected from somewhere other than a memory say so instead of taking the write.</div>
       </div>
       <h2 id="board-nothing-to-fill-in">Nothing to fill in</h2>
       <p>You never add anything to the board. It&#x27;s assembled from what the room already has: the tasks in its plan, the negotiations running in it, the memories under <code>decisions/</code>, <code>status/</code>, <code>work/</code> and <code>failed/</code>, and which agents are actually resident right now. Every row says where it came from, and clicking through takes you to the real thing rather than a copy of it.</p>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -805,12 +805,6 @@ Review 1
          @agent-z   feat/custody-seam   CI green   #504       12m
 ```
 
-> **Experimental.** The board reads and writes real room state. A triage verb
-> puts frontmatter on the row's memory, through the same upsert a `memory set`
-> goes through — so a card you move is a versioned, indexed change the room can
-> read back, not a change to your own view. Rows projected from somewhere other
-> than a memory say so instead of taking the write.
-
 ## Nothing to fill in
 
 You never add anything to the board. It's assembled from what the room already
@@ -944,11 +938,20 @@ One keystroke each in the interface, one word each on the command line, and the
 same words agents use. Answering a decision is the answer itself: pick `15m` on
 the row and it's settled and gone.
 
+Every one of them writes. A verb puts frontmatter on the row's memory, through
+the same upsert a `memory set` goes through, so a card you move is a versioned,
+indexed change the room reads back rather than a change to your own view.
+Custody is the exception, and only because it needs to be: who holds a row moves
+through a lease, under rules a plain write can't check. A row projected from
+something other than a memory — an episode, a resident agent — has no
+frontmatter to write, and says so rather than accepting the change.
+
 `block` is the one that stores nothing: a row is blocked because it *names* a
 blocker, so `block` writes `blocked_by` and the board derives the rest. Captured
 concerns expire if nobody claims them, so the board stays a picture of now
-instead of turning into a backlog. Anything that should outlive the work gets
-`promote`d into a GitHub issue and leaves, with a link left behind.
+instead of turning into a backlog. `promote` marks a row as belonging somewhere
+more durable and resolves it; filing the GitHub issue itself is still yours to
+do, and the verb doesn't invent a link it didn't create.
 
 ## Waiting on a lease, not on the room
 
@@ -1879,12 +1882,11 @@ work already lives in**, so that a [board](#board) row pointing at a pull reques
 can report whether it's approved, blocked or failing instead of someone copying
 that state into Mycelium.
 
-> **Experimental.** This works end to end: give the hub a token, write a pull
-> request into a plan task, and the board row for that task carries the pull
-> request's state, in both the app and `mycelium board`. Nothing refreshes on a
-> schedule: a read reports what is known, starts a fetch for what is not, and
-> the surfaces show that plainly rather than pretending. Check the module before
-> writing a provider.
+This works end to end: give the hub a token, write a pull request into a row,
+and that row carries the pull request's state, in both the app and `mycelium
+board`. Nothing refreshes on a schedule: a read reports what is known, starts a
+fetch for what is not, and the surfaces show that plainly rather than
+pretending. Check the module before writing a provider.
 
 | Provider | Recognises | Reports |
 |----------|------------|---------|

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -805,9 +805,11 @@ Review 1
          @agent-z   feat/custody-seam   CI green   #504       12m
 ```
 
-> **Experimental.** The board reads real room state today. The triage verbs act
-> on your own view: `resolve` writes through to a plan task, and the rest change
-> what you see without yet writing back to the room.
+> **Experimental.** The board reads and writes real room state. A triage verb
+> puts frontmatter on the row's memory, through the same upsert a `memory set`
+> goes through — so a card you move is a versioned, indexed change the room can
+> read back, not a change to your own view. Rows projected from somewhere other
+> than a memory say so instead of taking the write.
 
 ## Nothing to fill in
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -375,10 +375,7 @@
       <p>Any agent that can make HTTP requests can use the REST API directly. Interactive API docs are available at <code>http://localhost:8000/docs</code> when the backend is running.</p>
       <h2 id="architecture-status-providers">Status providers</h2>
       <p>Adapters connect <strong>agents</strong> to a room. Status providers connect the <strong>tools your work already lives in</strong>, so that a <a href="index.html#board">board</a> row pointing at a pull request can report whether it&#x27;s approved, blocked or failing instead of someone copying that state into Mycelium.</p>
-      <div class="callout callout-note">
-        <div class="callout-bar"></div>
-        <div class="callout-body"><strong>Experimental.</strong> This works end to end: give the hub a token, write a pull request into a plan task, and the board row for that task carries the pull request&#x27;s state, in both the app and <code>mycelium board</code>. Nothing refreshes on a schedule: a read reports what is known, starts a fetch for what is not, and the surfaces show that plainly rather than pretending. Check the module before writing a provider.</div>
-      </div>
+      <p>This works end to end: give the hub a token, write a pull request into a row, and that row carries the pull request&#x27;s state, in both the app and <code>mycelium board</code>. Nothing refreshes on a schedule: a read reports what is known, starts a fetch for what is not, and the surfaces show that plainly rather than pretending. Check the module before writing a provider.</p>
       <div class="table-wrap">
         <table>
           <thead>

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -325,7 +325,7 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "index.html#board-one-gesture-each",
     "t": "One gesture each",
     "s": "Concepts › Board",
-    "x": "claim · release · resolve · block · promote · dismiss One keystroke each in the interface, one word each on the command line, and the same words agents use. Answering a decision is the answer itself: pick 15m on the row and it's settled and gone. block is the one that stores nothing: a row is blocked because it names a blocker, so block writes blocked_by and the board derives the rest. Captured concerns expire if nob",
+    "x": "claim · release · resolve · block · promote · dismiss One keystroke each in the interface, one word each on the command line, and the same words agents use. Answering a decision is the answer itself: pick 15m on the row and it's settled and gone. Every one of them writes. A verb puts frontmatter on the row's memory, through the same upsert a memory set goes through, so a card you move is a versioned, indexed change t",
     "p": "Guide"
   },
   {
@@ -761,7 +761,7 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "reference.html#architecture-status-providers",
     "t": "Status providers",
     "s": "Architecture",
-    "x": "Adapters connect agents to a room. Status providers connect the tools your work already lives in, so that a board row pointing at a pull request can report whether it's approved, blocked or failing instead of someone copying that state into Mycelium. Experimental. This works end to end: give the hub a token, write a pull request into a plan task, and the board row for that task carries the pull request's state, in bo",
+    "x": "Adapters connect agents to a room. Status providers connect the tools your work already lives in, so that a board row pointing at a pull request can report whether it's approved, blocked or failing instead of someone copying that state into Mycelium. This works end to end: give the hub a token, write a pull request into a row, and that row carries the pull request's state, in both the app and mycelium board. Nothing ",
     "p": "Reference"
   },
   {

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -35,6 +35,7 @@ from app.routes.a2a_state import router as a2a_state_router
 from app.routes.agents import router as agents_router
 from app.routes.engines import router as engines_router
 from app.routes.episodes import router as episodes_router
+from app.routes.fields import router as fields_router
 from app.routes.invites import router as invites_router
 from app.routes.leases import router as leases_router
 from app.routes.links import router as links_router
@@ -258,6 +259,7 @@ app.include_router(rooms_router, prefix="/api")
 app.include_router(messages_router, prefix="/api")
 app.include_router(invites_router, prefix="/api")
 app.include_router(leases_router, prefix="/api")
+app.include_router(fields_router, prefix="/api")
 app.include_router(episodes_router, prefix="/api")
 app.include_router(participate_router, prefix="/api")
 app.include_router(sessions_router, prefix="/api")

--- a/fastapi-backend/app/routes/fields.py
+++ b/fastapi-backend/app/routes/fields.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""
+Field API — the board's verbs, written down.
+
+GET  /rooms/{room}/fields/{key}   — a row's writable fields right now
+POST /rooms/{room}/fields         — put fields on a row
+
+A sibling router rather than routes under ``/memory``, for the same reason
+``leases`` and ``links`` sit beside it: the memory router ends in a
+``{key:path}`` catch-all, so a suffix hung off it is an ordering bug waiting to
+happen.
+
+A board that changed a row's status in the browser and nowhere else was a
+surface asserting something the room had never been told.  This is the write
+that makes a verb real, and it is deliberately the *same* upsert a ``memory
+set`` goes through — a human moving a card and an agent writing frontmatter are
+one operation, so they leave one kind of trace.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app.services import actor, fields
+from app.services.filesystem import room_exists
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/rooms/{room_name}/fields", tags=["fields"])
+
+
+def _require_room(room_name: str) -> None:
+    if not room_exists(room_name):
+        raise HTTPException(status_code=404, detail="Room not found")
+
+
+def _fail(error: fields.FieldError) -> HTTPException:
+    return HTTPException(
+        status_code=error.status, detail={"error": "field", "message": error.reason, **error.detail}
+    )
+
+
+class WriteBody(BaseModel):
+    key: str = Field(..., description="Memory key of the row being written")
+    handle: str = Field(..., description="Who is writing — recorded as the memory's author")
+    fields: dict[str, object] = Field(
+        ...,
+        description=(
+            "Frontmatter to merge onto the row. A null value clears its key. "
+            "Custody keys are refused: those move through /leases."
+        ),
+    )
+
+
+@router.post("")
+async def write_fields(room_name: str, body: WriteBody, request: Request):
+    """Put fields on a row, through the canonical memory upsert."""
+    _require_room(room_name)
+    handle = actor.bind_delegated_actor(request, room_name, body.handle, field="handle")
+    try:
+        return await fields.write(room_name, body.key, dict(body.fields), handle)
+    except fields.FieldError as e:
+        raise _fail(e) from e
+
+
+@router.get("/{key:path}")
+async def read_fields(room_name: str, key: str):
+    """A row's writable fields, without changing anything."""
+    _require_room(room_name)
+    try:
+        return fields.read(room_name, key)
+    except fields.FieldError as e:
+        raise _fail(e) from e

--- a/fastapi-backend/app/services/fields.py
+++ b/fastapi-backend/app/services/fields.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""A row's fields are its memory's frontmatter, and a verb writes them.
+
+The board projects a row as a title plus whatever frontmatter its memory
+carries, so every verb that is not custody — a status change, a priority, a
+block, a dismissal — is a frontmatter write and nothing else.  This is that
+write, and it is the same upsert ``memory set --meta`` goes through: versioned,
+indexed, link-parsed, broadcast, and readable in a text editor.
+
+**Custody is the one axis this refuses.**  ``custody``, ``owner`` and the
+lease's companion keys move under rules a field write does not know — a live
+claim is not stealable, an expired one is, and expiry is derived from a clock
+rather than written down.  A plain field write setting ``owner`` would forge a
+claim that passed none of that, so the reserved keys are refused by name and
+pointed at the endpoint that does own them.
+
+**Only a memory has fields.**  Episodes, agents and any other projected row are
+read out of state that lives elsewhere, so there is no frontmatter to write and
+the refusal says so rather than inventing a file.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.services.filesystem import get_room_dir, read_memory_file, unmanaged_meta
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+#: Frontmatter a lease owns.  Frozen in ``contracts/board-vocabulary.json``
+#: under ``custody`` (``field`` + ``companion_fields``) plus the holder itself;
+#: ``tests/test_fields.py`` asserts this set against that file.
+RESERVED = frozenset(
+    {"custody", "owner", "claimed_at", "ttl_minutes", "custody_note", "custody_note_by"}
+)
+
+RESERVED_REASON = (
+    "custody moves through the lease endpoints (/leases/claim, /release, /resolve), "
+    "not a field write — a claim has rules a field write cannot check"
+)
+
+
+class FieldError(Exception):
+    """A field write the room refuses, with the reason a reader needs."""
+
+    def __init__(self, reason: str, *, status: int = 400, **detail: Any) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.status = status
+        self.detail = detail
+
+
+def reserved_in(names: Iterable[str]) -> list[str]:
+    """Which of ``names`` a lease owns, in a stable order for the message."""
+    return sorted(set(names) & RESERVED)
+
+
+async def upsert_patch(
+    room: str,
+    key: str,
+    meta: dict,
+    content: str,
+    patch: dict,
+    handle: str,
+    *,
+    notify: bool = True,
+) -> dict:
+    """Merge ``patch`` into a memory's frontmatter and return the fresh half.
+
+    The single writer behind both a board field write and a custody lease, so
+    the two cannot drift in how a frontmatter change reaches the store.  A
+    ``None`` value clears its key, which is how a lease hands a row back.
+    """
+    from app.routes.memory import _reconstruct_value, upsert_memories
+    from app.schemas import MemoryBatchCreate, MemoryCreate
+
+    payload = MemoryBatchCreate(
+        items=[
+            MemoryCreate(
+                key=key,
+                value=_reconstruct_value(meta, content),
+                content_text=content or None,
+                # Frontmatter changed, prose did not: re-running the embedder
+                # over unchanged text would burn a model call per verb. The
+                # stored vector is carried forward instead.
+                embed=False,
+                created_by=handle,
+                meta=patch,
+            )
+        ]
+    )
+    written = await upsert_memories(room, payload, notify=notify)
+    return {**unmanaged_meta(meta), **patch, "version": written[0].version}
+
+
+def _load(room: str, key: str) -> tuple[dict, str]:
+    found = read_memory_file(get_room_dir(room), key)
+    if found is None:
+        raise FieldError(f"no memory '{key}' in this room", status=404, key=key)
+    return found
+
+
+def read(room: str, key: str) -> dict:
+    """A row's writable fields as they stand, without changing anything."""
+    meta, _ = _load(room, key)
+    return {"key": key, "fields": unmanaged_meta(meta), "version": meta.get("version")}
+
+
+async def write(room: str, key: str, patch: dict, handle: str) -> dict:
+    """Put ``patch`` on the row's frontmatter, refusing what a lease owns."""
+    if not patch:
+        raise FieldError("no fields to write", status=422, key=key)
+    clashes = reserved_in(patch)
+    if clashes:
+        raise FieldError(RESERVED_REASON, status=422, key=key, reserved=clashes)
+    meta, content = _load(room, key)
+    fresh = await upsert_patch(room, key, meta, content, patch, handle)
+    return {
+        "key": key,
+        "fields": {k: v for k, v in fresh.items() if k != "version"},
+        "version": fresh.get("version"),
+    }

--- a/fastapi-backend/app/services/leases.py
+++ b/fastapi-backend/app/services/leases.py
@@ -42,7 +42,6 @@ from app.services.filesystem import (
     get_room_dir,
     list_memory_files,
     read_memory_file,
-    unmanaged_meta,
 )
 
 FIELD = "custody"
@@ -170,27 +169,15 @@ def _describe(key: str, meta: dict, now: datetime) -> dict:
 async def _write(
     room: str, key: str, meta: dict, content: str, patch: dict, handle: str, *, notify: bool = True
 ) -> dict:
-    """Put a custody change on the row, through the canonical memory upsert."""
-    from app.routes.memory import _reconstruct_value, upsert_memories
-    from app.schemas import MemoryBatchCreate, MemoryCreate
+    """Put a custody change on the row, through the canonical memory upsert.
 
-    payload = MemoryBatchCreate(
-        items=[
-            MemoryCreate(
-                key=key,
-                value=_reconstruct_value(meta, content),
-                content_text=content or None,
-                # A lease changes who holds the row, not what it says: re-running
-                # the embedder over unchanged prose would burn a model call per
-                # heartbeat. The stored vector is carried forward instead.
-                embed=False,
-                created_by=handle,
-                meta=patch,
-            )
-        ]
-    )
-    written = await upsert_memories(room, payload, notify=notify)
-    fresh_meta = {**unmanaged_meta(meta), **patch, "version": written[0].version}
+    The upsert itself is :func:`app.services.fields.upsert_patch`, shared with
+    the board's field writes so a lease and a status change cannot drift in how
+    they reach the store.
+    """
+    from app.services.fields import upsert_patch
+
+    fresh_meta = await upsert_patch(room, key, meta, content, patch, handle, notify=notify)
     return _describe(key, fresh_meta, datetime.now(UTC))
 
 

--- a/fastapi-backend/tests/test_fields.py
+++ b/fastapi-backend/tests/test_fields.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Field writes: a board verb that reaches the room instead of the browser.
+
+The property behind all of it: a row is a title plus its frontmatter, so
+changing a row means writing frontmatter — and the write has to be the same one
+every other memory change goes through, or the board becomes a second store.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+
+from app.services import fields, leases
+from app.services.filesystem import get_room_dir, read_memory_file
+
+CONTRACT = json.loads(
+    (Path(__file__).resolve().parents[2] / "contracts" / "board-vocabulary.json").read_text()
+)["custody"]
+
+
+async def make_room(client: AsyncClient, name: str) -> None:
+    await client.post("/api/rooms", json={"name": name})
+
+
+async def make_memory(client: AsyncClient, room: str, key: str, **meta) -> None:
+    await client.post(
+        f"/api/rooms/{room}/memory",
+        json={
+            "items": [
+                {
+                    "key": key,
+                    "value": "Ship the aligner rewrite",
+                    "created_by": "julia",
+                    "embed": False,
+                    "meta": meta or None,
+                }
+            ]
+        },
+    )
+
+
+def frontmatter(room: str, key: str) -> dict:
+    found = read_memory_file(get_room_dir(room), key)
+    assert found is not None
+    return found[0]
+
+
+class TestContract:
+    """The reserved set is a derivation of the custody contract, not a copy."""
+
+    def test_reserved_is_the_custody_field_its_companions_and_the_holder(self):
+        assert {
+            CONTRACT["field"],
+            "owner",
+            *CONTRACT["companion_fields"],
+        } == fields.RESERVED
+
+
+@pytest.mark.asyncio
+class TestWrite:
+    async def test_a_field_write_lands_in_frontmatter(self, client: AsyncClient):
+        await make_room(client, "fw")
+        await make_memory(client, "fw", "decisions/ttl")
+
+        resp = await client.post(
+            "/api/rooms/fw/fields",
+            json={"key": "decisions/ttl", "handle": "julia", "fields": {"status": "in_review"}},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["fields"]["status"] == "in_review"
+        assert frontmatter("fw", "decisions/ttl")["status"] == "in_review"
+
+    async def test_it_writes_any_namespace_not_just_leasable_ones(self, client: AsyncClient):
+        # Custody is restricted to work/; a status change is not. A decision
+        # that cannot be moved is the overlay problem with extra steps.
+        await make_room(client, "fw2")
+        await make_memory(client, "fw2", "decisions/ttl")
+
+        resp = await client.post(
+            "/api/rooms/fw2/fields",
+            json={"key": "decisions/ttl", "handle": "julia", "fields": {"priority": "urgent"}},
+        )
+
+        assert resp.status_code == 200
+        assert not leases.leasable("decisions/ttl")
+        assert frontmatter("fw2", "decisions/ttl")["priority"] == "urgent"
+
+    async def test_a_null_clears_a_key(self, client: AsyncClient):
+        await make_room(client, "fw3")
+        await make_memory(client, "fw3", "work/spike", blocked_by="#502")
+
+        await client.post(
+            "/api/rooms/fw3/fields",
+            json={"key": "work/spike", "handle": "julia", "fields": {"blocked_by": None}},
+        )
+
+        assert frontmatter("fw3", "work/spike").get("blocked_by") is None
+
+    async def test_it_preserves_frontmatter_it_was_not_asked_to_change(self, client: AsyncClient):
+        await make_room(client, "fw4")
+        await make_memory(client, "fw4", "work/spike", priority="high", assignee="@dana")
+
+        await client.post(
+            "/api/rooms/fw4/fields",
+            json={"key": "work/spike", "handle": "julia", "fields": {"status": "in_review"}},
+        )
+
+        meta = frontmatter("fw4", "work/spike")
+        assert meta["priority"] == "high"
+        assert meta["assignee"] == "@dana"
+        assert meta["status"] == "in_review"
+
+    async def test_it_versions_like_any_other_memory_write(self, client: AsyncClient):
+        await make_room(client, "fw5")
+        await make_memory(client, "fw5", "work/spike")
+        before = frontmatter("fw5", "work/spike")["version"]
+
+        await client.post(
+            "/api/rooms/fw5/fields",
+            json={"key": "work/spike", "handle": "julia", "fields": {"status": "in_review"}},
+        )
+
+        assert frontmatter("fw5", "work/spike")["version"] == before + 1
+
+    async def test_it_leaves_the_prose_alone(self, client: AsyncClient):
+        await make_room(client, "fw6")
+        await make_memory(client, "fw6", "work/spike")
+
+        await client.post(
+            "/api/rooms/fw6/fields",
+            json={"key": "work/spike", "handle": "julia", "fields": {"status": "in_review"}},
+        )
+
+        found = read_memory_file(get_room_dir("fw6"), "work/spike")
+        assert found is not None
+        assert "Ship the aligner rewrite" in found[1]
+
+
+@pytest.mark.asyncio
+class TestRefusals:
+    @pytest.mark.parametrize("reserved", sorted(fields.RESERVED))
+    async def test_custody_keys_are_refused_by_name(self, client: AsyncClient, reserved: str):
+        await make_room(client, "fr")
+        await make_memory(client, "fr", "work/spike")
+
+        resp = await client.post(
+            "/api/rooms/fr/fields",
+            json={"key": "work/spike", "handle": "mallory", "fields": {reserved: "held"}},
+        )
+
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert reserved in detail["reserved"]
+        assert "leases" in detail["message"]
+
+    async def test_a_refused_write_changes_nothing(self, client: AsyncClient):
+        # The point of the refusal is that a forged claim never lands, so a
+        # partly-applied batch would defeat it.
+        await make_room(client, "fr2")
+        await make_memory(client, "fr2", "work/spike")
+        before = frontmatter("fr2", "work/spike")
+
+        await client.post(
+            "/api/rooms/fr2/fields",
+            json={
+                "key": "work/spike",
+                "handle": "mallory",
+                "fields": {"status": "resolved", "owner": "@mallory"},
+            },
+        )
+
+        after = frontmatter("fr2", "work/spike")
+        assert after.get("status") == before.get("status")
+        assert after.get("owner") == before.get("owner")
+        assert after["version"] == before["version"]
+
+    async def test_a_missing_row_is_a_404_not_a_new_file(self, client: AsyncClient):
+        await make_room(client, "fr3")
+
+        resp = await client.post(
+            "/api/rooms/fr3/fields",
+            json={"key": "work/never-existed", "handle": "julia", "fields": {"status": "open"}},
+        )
+
+        assert resp.status_code == 404
+        assert read_memory_file(get_room_dir("fr3"), "work/never-existed") is None
+
+    async def test_an_empty_write_is_refused_rather_than_bumping_a_version(
+        self, client: AsyncClient
+    ):
+        await make_room(client, "fr4")
+        await make_memory(client, "fr4", "work/spike")
+        before = frontmatter("fr4", "work/spike")["version"]
+
+        resp = await client.post(
+            "/api/rooms/fr4/fields",
+            json={"key": "work/spike", "handle": "julia", "fields": {}},
+        )
+
+        assert resp.status_code == 422
+        assert frontmatter("fr4", "work/spike")["version"] == before
+
+    async def test_an_unknown_room_is_a_404(self, client: AsyncClient):
+        resp = await client.post(
+            "/api/rooms/no-such-room/fields",
+            json={"key": "work/spike", "handle": "julia", "fields": {"status": "open"}},
+        )
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestRead:
+    async def test_it_returns_the_unmanaged_half_only(self, client: AsyncClient):
+        await make_room(client, "fread")
+        await make_memory(client, "fread", "work/spike", priority="high")
+
+        resp = await client.get("/api/rooms/fread/fields/work/spike")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["fields"]["priority"] == "high"
+        # The store's own keys are not the row's fields.
+        assert "created_by" not in body["fields"]
+        assert "version" not in body["fields"]
+
+
+@pytest.mark.asyncio
+class TestSharedWriterWithLeases:
+    async def test_a_lease_still_moves_custody_through_the_shared_upsert(self, client: AsyncClient):
+        # leases._write delegates to fields.upsert_patch; this is the guard that
+        # the delegation did not change what a claim writes.
+        await make_room(client, "fs")
+        await make_memory(client, "fs", "work/spike")
+
+        resp = await client.post(
+            "/api/rooms/fs/leases/claim",
+            json={"key": "work/spike", "handle": "dana", "ttl_minutes": 30},
+        )
+
+        assert resp.status_code == 200
+        meta = frontmatter("fs", "work/spike")
+        assert meta["custody"] == "held"
+        assert meta["owner"] == "@dana"
+        assert meta["claimed_at"]
+
+    async def test_a_field_write_does_not_disturb_a_live_lease(self, client: AsyncClient):
+        await make_room(client, "fs2")
+        await make_memory(client, "fs2", "work/spike")
+        await client.post(
+            "/api/rooms/fs2/leases/claim",
+            json={"key": "work/spike", "handle": "dana", "ttl_minutes": 30},
+        )
+
+        await client.post(
+            "/api/rooms/fs2/fields",
+            json={"key": "work/spike", "handle": "julia", "fields": {"priority": "urgent"}},
+        )
+
+        meta = frontmatter("fs2", "work/spike")
+        assert meta["custody"] == "held"
+        assert meta["owner"] == "@dana"
+        assert meta["priority"] == "urgent"

--- a/mycelium-cli/src/mycelium/board/fields.py
+++ b/mycelium-cli/src/mycelium/board/fields.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Where a board verb's write may land.
+
+A verb that is not custody writes frontmatter, and only a memory has any.  The
+rest of the board is projected out of state living elsewhere — a checklist
+line, an episode record, a presence lease — so there is nothing to write onto,
+and saying that beats accepting a change that goes nowhere.
+
+Frozen in ``contracts/board-vocabulary.json`` under ``fields``; the GUI carries
+its own copy and ``tests/test_board_fields.py`` asserts this one against that
+file, so neither can drift alone.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mycelium.board.custody import COMPANION_FIELDS, FIELD
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from mycelium.board.model import LiveItem
+
+#: The only row kind with frontmatter behind it.
+WRITABLE_SOURCE_KINDS = ["memory"]
+
+#: Why a row refuses a field write, in its own terms.
+REFUSALS = {
+    "plan": "a plan task is a checklist line; there is no frontmatter on it to write",
+    "episode": "an episode is a recorded negotiation, not a row the room can edit",
+    "agent": "presence is what the runtime reports, not a field you set",
+    "capture": "this row is not in the room yet; capture it first",
+    "github": "this value belongs to the tool it came from; change it there",
+}
+
+#: Custody's own keys, derived from the lease model rather than restated.  A
+#: lease owns who holds a row and until when, under rules a field write cannot
+#: check — a live claim is not stealable, and expiry is read off a clock.
+RESERVED_FIELDS = [FIELD, "owner", *COMPANION_FIELDS]
+
+
+def memory_key_of(item: LiveItem) -> str | None:
+    """The memory key behind a row, or ``None`` when the row is not a memory."""
+    if item.source.kind not in WRITABLE_SOURCE_KINDS:
+        return None
+    return item.id.split(":", 1)[1] if ":" in item.id else item.id
+
+
+def refusal_for(item: LiveItem) -> str | None:
+    """Why this row cannot take a field write, or ``None`` when it can."""
+    kind = item.source.kind
+    if kind in WRITABLE_SOURCE_KINDS:
+        return None
+    return REFUSALS.get(kind, "this row has no frontmatter to write")
+
+
+def reserved_in(names: Iterable[str]) -> list[str]:
+    """Which of ``names`` a lease owns, so a caller can refuse before writing."""
+    return sorted(set(names) & set(RESERVED_FIELDS))

--- a/mycelium-cli/src/mycelium/commands/board.py
+++ b/mycelium-cli/src/mycelium/commands/board.py
@@ -10,10 +10,11 @@ through whichever lens you ask for.  The default lens is "needs you", because a
 board worth having is one you can ignore until it says your name.
 
 The verbs (claim / resolve / block / promote / dismiss) are the same words the
-GUI uses and the same words an agent drives over the ledger.  In this proof of
-concept only the ones with a real write behind them act: ``resolve`` on a row
-that came from a plan task toggles the task.  Everything else prints what it
-would write rather than pretending.
+GUI uses and the same words an agent drives over the ledger, and each one
+writes.  Custody goes through a lease, because who holds a row moves under
+rules a plain write cannot check; everything else is frontmatter on the row's
+memory.  A row projected from somewhere other than a memory has nothing to
+write onto and says so.
 """
 
 from __future__ import annotations
@@ -33,6 +34,7 @@ from rich.table import Table
 from rich.text import Text
 
 from mycelium.board import LiveItem, attach_upstream, custody, infer_schema, project_items
+from mycelium.board import fields as board_fields
 from mycelium.board.activity import (
     DAILY_GOAL,
     by_day,
@@ -483,7 +485,7 @@ def board(
 
 @doc_ref(
     usage="mycelium board resolve <id>",
-    desc="Resolve a board row. Plan tasks and work/ leases write through; other rows report what they would write.",
+    desc="Resolve a board row: a plan task toggles, a work/ lease resolves, any other memory row takes status=resolved.",
     group="board",
 )
 @app.command(name="resolve")
@@ -506,7 +508,9 @@ def board_resolve(
     if item is not None and custody.refusal_for(item) is None:
         _lease(cfg, name, "resolve", key=_lease_key(item), handle=cfg.get_current_identity())
         return
-    _would_write("resolve", row_id, {"custody": "resolved"})
+    # Not leasable, but still a row with frontmatter: `status` is a stage, and a
+    # stage is a field write. Custody stays out of it — that is the lease's.
+    _write_fields(cfg, name, row_id, {"status": "resolved"})
 
 
 @doc_ref(
@@ -588,7 +592,9 @@ def board_block(
             "[yellow]·[/yellow] block needs --on: a row is blocked because it names a blocker."
         )
         raise typer.Exit(1)
-    _would_write("block", row_id, {"blocked_by": on})
+    cfg = MyceliumConfig.load()
+    name = _resolve_room(cfg, room)
+    _write_fields(cfg, name, row_id, {custody.BLOCKED_FIELD: on})
 
 
 def _lease_key(item: LiveItem) -> str:
@@ -648,14 +654,42 @@ def _lease(cfg: MyceliumConfig, room: str, action: str, **body: Any) -> None:
         console.print(f"[green]✓[/green] {action}d [bold]{data.get('key')}[/bold]")
 
 
-def _would_write(verb: str, row_id: str, patch: dict) -> None:
-    """Say what a verb implies where no write exists behind it yet."""
+def _write_fields(cfg: MyceliumConfig, room: str, row_id: str, patch: dict) -> None:
+    """Put a verb's frontmatter on the row, and say what landed.
+
+    The same upsert a ``memory set --meta`` goes through, so a verb typed here
+    and an agent writing frontmatter leave one kind of trace. A row with no
+    frontmatter behind it, or a key a lease owns, is refused in its own terms
+    rather than written somewhere it would not be read back.
+    """
+    item = _row(room, row_id)
+    if item is None:
+        console.print(f"[dim]No row '{row_id}' on this board.[/dim]")
+        raise typer.Exit(1)
+    refusal = board_fields.refusal_for(item)
+    if refusal:
+        console.print(f"[yellow]·[/yellow] {row_id} can't take a field write — {refusal}")
+        raise typer.Exit(1)
+    reserved = board_fields.reserved_in(patch)
+    if reserved:
+        console.print(
+            f"[yellow]·[/yellow] {', '.join(reserved)} moves through a lease, not a field "
+            "write — use claim / release / resolve."
+        )
+        raise typer.Exit(1)
+    key = board_fields.memory_key_of(item)
+    body = {"key": key, "handle": cfg.get_current_identity(), "fields": patch}
+    try:
+        with hub_client(cfg, timeout=30) as client:
+            resp = client.post(f"/api/rooms/{room}/fields", json=body)
+    except httpx.HTTPError as e:
+        console.print(f"[red]✗[/red] hub unreachable: {e}")
+        raise typer.Exit(1) from e
+    if resp.status_code >= 400:
+        console.print(f"[red]✗[/red] write failed: {resp.text}")
+        raise typer.Exit(1)
     rendered = " ".join(f"{k}={v}" for k, v in patch.items())
-    console.print(
-        f"[yellow]·[/yellow] {verb} [bold]{row_id}[/bold] → {rendered}\n"
-        "[dim]  Not written. Custody verbs (claim / release / resolve) write through on "
-        "work/ rows; the rest report what they would write.[/dim]"
-    )
+    console.print(f"[green]✓[/green] wrote [bold]{key}[/bold] → {rendered}")
 
 
 # ── the log ──────────────────────────────────────────────────────────────────

--- a/mycelium-cli/src/mycelium/docs/concepts/board.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/board.md
@@ -28,12 +28,6 @@ Review 1
          @agent-z   feat/custody-seam   CI green   #504       12m
 ```
 
-> **Experimental.** The board reads and writes real room state. A triage verb
-> puts frontmatter on the row's memory, through the same upsert a `memory set`
-> goes through — so a card you move is a versioned, indexed change the room can
-> read back, not a change to your own view. Rows projected from somewhere other
-> than a memory say so instead of taking the write.
-
 ## Nothing to fill in
 
 You never add anything to the board. It's assembled from what the room already
@@ -167,11 +161,20 @@ One keystroke each in the interface, one word each on the command line, and the
 same words agents use. Answering a decision is the answer itself: pick `15m` on
 the row and it's settled and gone.
 
+Every one of them writes. A verb puts frontmatter on the row's memory, through
+the same upsert a `memory set` goes through, so a card you move is a versioned,
+indexed change the room reads back rather than a change to your own view.
+Custody is the exception, and only because it needs to be: who holds a row moves
+through a lease, under rules a plain write can't check. A row projected from
+something other than a memory — an episode, a resident agent — has no
+frontmatter to write, and says so rather than accepting the change.
+
 `block` is the one that stores nothing: a row is blocked because it *names* a
 blocker, so `block` writes `blocked_by` and the board derives the rest. Captured
 concerns expire if nobody claims them, so the board stays a picture of now
-instead of turning into a backlog. Anything that should outlive the work gets
-`promote`d into a GitHub issue and leaves, with a link left behind.
+instead of turning into a backlog. `promote` marks a row as belonging somewhere
+more durable and resolves it; filing the GitHub issue itself is still yours to
+do, and the verb doesn't invent a link it didn't create.
 
 ## Waiting on a lease, not on the room
 

--- a/mycelium-cli/src/mycelium/docs/concepts/board.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/board.md
@@ -28,9 +28,11 @@ Review 1
          @agent-z   feat/custody-seam   CI green   #504       12m
 ```
 
-> **Experimental.** The board reads real room state today. The triage verbs act
-> on your own view: `resolve` writes through to a plan task, and the rest change
-> what you see without yet writing back to the room.
+> **Experimental.** The board reads and writes real room state. A triage verb
+> puts frontmatter on the row's memory, through the same upsert a `memory set`
+> goes through — so a card you move is a versioned, indexed change the room can
+> read back, not a change to your own view. Rows projected from somewhere other
+> than a memory say so instead of taking the write.
 
 ## Nothing to fill in
 

--- a/mycelium-cli/src/mycelium/docs/reference/architecture.md
+++ b/mycelium-cli/src/mycelium/docs/reference/architecture.md
@@ -218,12 +218,11 @@ work already lives in**, so that a [board](#board) row pointing at a pull reques
 can report whether it's approved, blocked or failing instead of someone copying
 that state into Mycelium.
 
-> **Experimental.** This works end to end: give the hub a token, write a pull
-> request into a plan task, and the board row for that task carries the pull
-> request's state, in both the app and `mycelium board`. Nothing refreshes on a
-> schedule: a read reports what is known, starts a fetch for what is not, and
-> the surfaces show that plainly rather than pretending. Check the module before
-> writing a provider.
+This works end to end: give the hub a token, write a pull request into a row,
+and that row carries the pull request's state, in both the app and `mycelium
+board`. Nothing refreshes on a schedule: a read reports what is known, starts a
+fetch for what is not, and the surfaces show that plainly rather than
+pretending. Check the module before writing a provider.
 
 | Provider | Recognises | Reports |
 |----------|------------|---------|

--- a/mycelium-cli/tests/test_board_fields.py
+++ b/mycelium-cli/tests/test_board_fields.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Field writes: the board's verbs, and where each one is allowed to land.
+
+The property under test is that a verb never reports a change the room was not
+told about. A CLI that printed what it *would* write was honest about it; a CLI
+that printed a write it did not make would not be.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mycelium.board import fields as board_fields
+from mycelium.board.custody import COMPANION_FIELDS, FIELD
+from mycelium.board.model import ItemSource, LiveItem
+
+VOCAB = json.loads(
+    (Path(__file__).resolve().parents[2] / "contracts" / "board-vocabulary.json").read_text()
+)
+CONTRACT = VOCAB["fields"]
+
+
+def row(kind: str, label: str = "work/auth-spike", **fields) -> LiveItem:
+    return LiveItem(
+        id=f"{kind}:{label}",
+        title=label,
+        source=ItemSource(kind, label),
+        fields=fields,
+    )
+
+
+class TestContract:
+    """The GUI carries its own copy of every constant here."""
+
+    def test_refusals_match_the_contract_word_for_word(self):
+        assert CONTRACT["refusals"] == board_fields.REFUSALS
+
+    def test_writable_kinds_match_the_contract(self):
+        assert CONTRACT["writable_source_kinds"] == board_fields.WRITABLE_SOURCE_KINDS
+
+    def test_reserved_is_derived_from_custody_not_restated(self):
+        # The contract deliberately carries no second copy: a lease owns these,
+        # so they are read out of the custody block.
+        assert [FIELD, "owner", *COMPANION_FIELDS] == board_fields.RESERVED_FIELDS
+        assert [
+            VOCAB["custody"]["field"],
+            "owner",
+            *VOCAB["custody"]["companion_fields"],
+        ] == board_fields.RESERVED_FIELDS
+
+
+class TestWhereAWriteMayLand:
+    def test_a_memory_row_takes_a_write(self):
+        item = row("memory")
+        assert board_fields.refusal_for(item) is None
+        assert board_fields.memory_key_of(item) == "work/auth-spike"
+
+    def test_it_writes_outside_the_leasable_namespaces(self):
+        # Custody is restricted to work/; a status change is not. A decision
+        # nobody can move is the overlay problem with extra steps.
+        item = row("memory", "decisions/ttl")
+        assert board_fields.refusal_for(item) is None
+        assert board_fields.memory_key_of(item) == "decisions/ttl"
+
+    @pytest.mark.parametrize("kind", ["plan", "episode", "agent", "capture", "github"])
+    def test_every_other_kind_is_refused_in_its_own_terms(self, kind: str):
+        item = row(kind, "x")
+        assert board_fields.refusal_for(item) == board_fields.REFUSALS[kind]
+        assert board_fields.memory_key_of(item) is None
+
+    def test_an_unknown_kind_is_refused_rather_than_written_somewhere(self):
+        # A new source kind added without a refusal must not fall through.
+        assert board_fields.refusal_for(row("wormhole", "x")) is not None
+        assert board_fields.memory_key_of(row("wormhole", "x")) is None
+
+
+class TestWhatALeaseOwns:
+    @pytest.mark.parametrize("name", board_fields.RESERVED_FIELDS)
+    def test_each_reserved_key_is_reported(self, name: str):
+        assert board_fields.reserved_in([name]) == [name]
+
+    def test_an_ordinary_field_passes(self):
+        assert board_fields.reserved_in(["status", "priority", "blocked_by", "assignee"]) == []
+
+    def test_every_clash_is_named_not_just_the_first(self):
+        assert board_fields.reserved_in(["status", "owner", FIELD]) == sorted([FIELD, "owner"])

--- a/mycelium-frontend/src/components/board/room-board.tsx
+++ b/mycelium-frontend/src/components/board/room-board.tsx
@@ -243,10 +243,6 @@ export function RoomBoard({ roomName }: Props) {
 
   const runVerb = useCallback(
     (item: LiveItem, verb: Verb) => {
-      // No `issueNumber`: a promote has no GitHub write behind it, and a
-      // synthetic `#712` was survivable as an overlay but would now be a
-      // fabricated back-link written into the room, which the upstream
-      // provider would then resolve against a real, unrelated issue.
       const fields = applyVerb(item, verb, { actor, now: new Date().toISOString() });
       setSelectedId(item.id);
       play(verb);

--- a/mycelium-frontend/src/components/board/room-board.tsx
+++ b/mycelium-frontend/src/components/board/room-board.tsx
@@ -29,8 +29,9 @@ import {
   useRoomRoster,
   useRoomStatus,
 } from "@/lib/room-data";
-import { writeLease } from "@/lib/api";
-import { custodyRefusal } from "@/lib/board/custody";
+import { writeFields, writeLease } from "@/lib/api";
+import { custodyRefusal, reservedIn } from "@/lib/board/custody";
+import { fieldWriteRefusal, memoryKeyOf } from "@/lib/board/fields";
 import { applyVerb, LENSES, type Lens, type LiveItem, type Verb } from "@/lib/board/item";
 import { projectItems } from "@/lib/board/projection";
 import { attachUpstream } from "@/lib/board/upstream";
@@ -197,18 +198,56 @@ export function RoomBoard({ roomName }: Props) {
     [view.mode, groups, flat],
   );
 
-  const patch = useCallback((id: string, fields: Record<string, unknown>) => {
+  // What the surface shows the instant you act, before the room has answered.
+  const echoLocal = useCallback((id: string, fields: Record<string, unknown>) => {
     setOverlay(prev => ({ ...prev, [id]: { ...(prev[id] ?? {}), ...fields } }));
   }, []);
 
+  /**
+   * A verb's write: the overlay is the optimistic echo, the room is the record.
+   *
+   * A row whose fields live somewhere other than frontmatter says why instead
+   * of accepting a change that would exist in this tab and nowhere else, which
+   * is what the board did for every verb but custody.
+   */
+  const patch = useCallback(
+    (item: LiveItem, fields: Record<string, unknown>) => {
+      echoLocal(item.id, fields);
+      const refusal = fieldWriteRefusal(item);
+      if (refusal) {
+        setEcho(`${item.id} — ${refusal}`);
+        return;
+      }
+      const key = memoryKeyOf(item);
+      if (!key) return;
+      // `updated` is the board's name for the store's own `updated_at`, so
+      // sending it would write a second, competing timestamp.
+      const rest = Object.fromEntries(Object.entries(fields).filter(([k]) => k !== "updated"));
+      const reserved = reservedIn(Object.keys(rest));
+      if (reserved.length) {
+        setEcho(`${item.id} — ${reserved.join(", ")} moves through a lease, not a field write`);
+        return;
+      }
+      // Clearing a field is `null` on the wire: `undefined` would be dropped by
+      // JSON.stringify and the key would silently survive.
+      const writable = Object.fromEntries(
+        Object.entries(rest).map(([k, v]) => [k, v === undefined ? null : v]),
+      );
+      if (!Object.keys(writable).length) return;
+      void writeFields(roomName, { key, handle: actor, fields: writable })
+        .then(() => revalidate())
+        .catch((e: unknown) => setEcho(`write ${item.id} failed — ${String(e)}`));
+    },
+    [actor, echoLocal, revalidate, roomName],
+  );
+
   const runVerb = useCallback(
     (item: LiveItem, verb: Verb) => {
-      const fields = applyVerb(item, verb, {
-        actor,
-        now: new Date().toISOString(),
-        issueNumber: 700 + (Object.keys(overlay).length % 90),
-      });
-      patch(item.id, fields);
+      // No `issueNumber`: a promote has no GitHub write behind it, and a
+      // synthetic `#712` was survivable as an overlay but would now be a
+      // fabricated back-link written into the room, which the upstream
+      // provider would then resolve against a real, unrelated issue.
+      const fields = applyVerb(item, verb, { actor, now: new Date().toISOString() });
       setSelectedId(item.id);
       play(verb);
       // The echo is the point: a human gesture and an agent's call are the same
@@ -220,11 +259,14 @@ export function RoomBoard({ roomName }: Props) {
           .join(" ")}`,
       );
 
-      // Custody is the half of the board with a real write behind it. A claim
-      // from here is the same versioned frontmatter a claim from the CLI is, so
-      // the overlay above is only the optimistic echo of it — and a row that
-      // can't hold a lease says why instead of silently doing nothing.
-      if (verb !== "claim" && verb !== "release" && verb !== "resolve") return;
+      // Custody moves under its own rules — a live claim is not stealable, and
+      // expiry is read off a clock — so it keeps its own endpoint. Every other
+      // verb is a frontmatter write and goes through `patch`.
+      if (verb !== "claim" && verb !== "release" && verb !== "resolve") {
+        patch(item, fields);
+        return;
+      }
+      echoLocal(item.id, fields);
       const refusal = custodyRefusal(item);
       if (refusal) {
         if (verb !== "resolve") setEcho(`${verb} ${item.id} — ${refusal}`);
@@ -237,13 +279,13 @@ export function RoomBoard({ roomName }: Props) {
         })
         .catch((e: unknown) => setEcho(`${verb} ${item.id} failed — ${String(e)}`));
     },
-    [actor, overlay, patch, play, revalidate, roomName],
+    [actor, echoLocal, patch, play, revalidate, roomName],
   );
 
   const answer = useCallback(
     (item: LiveItem, choice: string) => {
-      patch(item.id, { status: "resolved", decision: choice, updated: new Date().toISOString() });
-      setEcho(`answer ${item.id} → decision=${choice} status=resolved · commit:converged over L9`);
+      patch(item, { status: "resolved", decision: choice, updated: new Date().toISOString() });
+      setEcho(`answer ${item.id} → decision=${choice} status=resolved`);
       play("answer");
     },
     [patch, play],
@@ -386,7 +428,7 @@ export function RoomBoard({ roomName }: Props) {
               // The "no value" column is not a value: dropping a card there
               // means clear the field, not write the column's own key into it.
               const cleared = value === UNGROUPED;
-              patch(item.id, {
+              patch(item, {
                 [field]: cleared ? undefined : value,
                 updated: new Date().toISOString(),
               });
@@ -413,7 +455,7 @@ export function RoomBoard({ roomName }: Props) {
                 selectedId={selectedId}
                 onSelect={setSelectedId}
                 onEdit={(item, field, value) => {
-                  patch(item.id, { [field]: value, updated: new Date().toISOString() });
+                  patch(item, { [field]: value, updated: new Date().toISOString() });
                   setEcho(`edit ${item.id} → ${field}=${String(value)} · written to frontmatter`);
                 }}
                 sort={view.sort}

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -230,6 +230,31 @@ export async function writeLease(
   });
 }
 
+export interface FieldState {
+  key: string;
+  fields: Record<string, unknown>;
+  version: number | null;
+}
+
+/**
+ * Put fields on a row — the write behind every board verb that is not custody.
+ *
+ * The same upsert a `memory set --meta` goes through, so a status changed by
+ * dragging a card is the same versioned, indexed, broadcast change an agent
+ * writing frontmatter makes. A board that moved a card in the browser and
+ * nowhere else was a surface asserting something the room had never been told.
+ */
+export async function writeFields(
+  roomName: string,
+  body: { key: string; handle: string; fields: Record<string, unknown> },
+): Promise<FieldState> {
+  return apiFetch<FieldState>(`/api/rooms/${roomName}/fields`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
 /** `fetchMemories`'s page size — exported so a caller showing a raw count
  *  (the dashboard's room cards) can tell "exactly this many" apart from
  *  "at least this many" instead of reporting the cap as a true total. */

--- a/mycelium-frontend/src/lib/board/board.test.ts
+++ b/mycelium-frontend/src/lib/board/board.test.ts
@@ -267,9 +267,10 @@ describe("applyVerb", () => {
     expect(patch.status).toBeUndefined();
   });
 
-  it("promote stamps the back-link and drops the row off the live board", () => {
-    const patch = applyVerb(item("a", { status: "open" }), "promote", { actor: "julia", now: "t", issueNumber: 704 });
-    expect(patch).toMatchObject({ status: "resolved", promoted: true, issue: "#704" });
+  it("promote drops the row off the live board without inventing a back-link", () => {
+    const patch = applyVerb(item("a", { status: "open" }), "promote", { actor: "julia", now: "t" });
+    expect(patch).toMatchObject({ status: "resolved", promoted: true });
+    expect(patch.issue).toBeUndefined();
   });
 });
 

--- a/mycelium-frontend/src/lib/board/custody.ts
+++ b/mycelium-frontend/src/lib/board/custody.ts
@@ -86,6 +86,22 @@ export const CUSTODY_REFUSALS: Record<string, string> = {
   memory: "leases live on work/ memories; this row is in another namespace",
 };
 
+/**
+ * Custody's own keys, which a plain field write must not touch.
+ *
+ * Derived from the model above rather than restated: a lease owns who holds a
+ * row and for how long, under rules a field write cannot check — a live claim
+ * is not stealable, and expiry is read off a clock rather than written down.
+ * The backend refuses these too; this is so the surface can say why without
+ * making the round trip.
+ */
+export const RESERVED_FIELDS = [CUSTODY_FIELD, "owner", ...CUSTODY_COMPANION_FIELDS];
+
+/** Which of `names` a lease owns, so a caller can refuse before writing. */
+export function reservedIn(names: string[]): string[] {
+  return names.filter(n => RESERVED_FIELDS.includes(n)).sort();
+}
+
 /** A row is blocked because it names a blocker. Nothing stores the word. */
 export const BLOCKED_FIELD = "blocked_by";
 

--- a/mycelium-frontend/src/lib/board/fields.test.ts
+++ b/mycelium-frontend/src/lib/board/fields.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Field writes: the board's verbs, and where each one is allowed to land.
+ *
+ * The property under test is that the board never accepts a change it cannot
+ * put in the room. A status set in the browser and nowhere else is a surface
+ * asserting something the room was never told, which is the failure that made
+ * every verb but custody an overlay in the first place.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  FIELD_REFUSALS,
+  WRITABLE_SOURCE_KINDS,
+  fieldWriteRefusal,
+  memoryKeyOf,
+} from "@/lib/board/fields";
+import {
+  CUSTODY_COMPANION_FIELDS,
+  CUSTODY_FIELD,
+  RESERVED_FIELDS,
+  reservedIn,
+} from "@/lib/board/custody";
+import { applyVerb, type LiveItem, type SourceKind } from "@/lib/board/item";
+
+const VOCAB = JSON.parse(
+  readFileSync(join(process.cwd(), "..", "contracts", "board-vocabulary.json"), "utf8"),
+);
+const CONTRACT = VOCAB.fields;
+
+const row = (kind: SourceKind, label: string, fields: Record<string, unknown> = {}): LiveItem => ({
+  id: `${kind}:${label}`,
+  title: label,
+  source: { kind, label },
+  fields,
+});
+
+describe("the fields contract", () => {
+  it("refuses the kinds the CLI refuses, in the same words", () => {
+    expect(FIELD_REFUSALS).toEqual(CONTRACT.refusals);
+  });
+
+  it("agrees on which rows have frontmatter behind them", () => {
+    expect(WRITABLE_SOURCE_KINDS).toEqual(CONTRACT.writable_source_kinds);
+  });
+
+  it("derives the reserved set from custody rather than restating it", () => {
+    // The contract deliberately carries no second copy of these: a lease owns
+    // them, so they are read out of the custody block.
+    expect(RESERVED_FIELDS).toEqual([CUSTODY_FIELD, "owner", ...CUSTODY_COMPANION_FIELDS]);
+    expect(RESERVED_FIELDS).toEqual([
+      VOCAB.custody.field,
+      "owner",
+      ...VOCAB.custody.companion_fields,
+    ]);
+  });
+});
+
+describe("where a field write may land", () => {
+  it("accepts a memory row", () => {
+    expect(fieldWriteRefusal(row("memory", "work/auth-spike"))).toBeNull();
+    expect(memoryKeyOf(row("memory", "work/auth-spike"))).toBe("work/auth-spike");
+  });
+
+  it.each(["plan", "episode", "agent", "capture", "github"] as SourceKind[])(
+    "refuses a %s row, and says why",
+    kind => {
+      const refusal = fieldWriteRefusal(row(kind, "x"));
+      expect(refusal).toBe(FIELD_REFUSALS[kind]);
+      expect(refusal).toBeTruthy();
+      expect(memoryKeyOf(row(kind, "x"))).toBeNull();
+    },
+  );
+
+  it("refuses an unknown kind rather than writing it somewhere", () => {
+    // A new SourceKind added without a refusal must not fall through to a write.
+    expect(fieldWriteRefusal(row("wormhole" as SourceKind, "x"))).toBeTruthy();
+  });
+});
+
+describe("what a lease owns", () => {
+  it.each(RESERVED_FIELDS)("reports %s as a lease's to move", name => {
+    expect(reservedIn([name])).toEqual([name]);
+  });
+
+  it("lets an ordinary field through", () => {
+    expect(reservedIn(["status", "priority", "blocked_by", "assignee"])).toEqual([]);
+  });
+
+  it("names every clash, not just the first", () => {
+    expect(reservedIn(["status", "owner", "custody"])).toEqual(["custody", "owner"]);
+  });
+});
+
+describe("the verbs that are field writes", () => {
+  const item = row("memory", "work/auth-spike");
+  const ctx = { actor: "julia", now: "2026-08-23T12:00:00Z" };
+
+  it.each(["block", "unblock", "dismiss", "promote"] as const)(
+    "%s writes nothing a lease owns",
+    verb => {
+      const patch = applyVerb(item, verb, ctx);
+      expect(reservedIn(Object.keys(patch))).toEqual([]);
+    },
+  );
+
+  it("does not invent a GitHub back-link when promoting", () => {
+    // A synthetic issue number was survivable as an overlay. Written to the
+    // room it is a fabricated reference the upstream provider would resolve
+    // against a real, unrelated issue.
+    const patch = applyVerb(item, "promote", ctx);
+    expect(patch.promoted).toBe(true);
+    expect(patch.issue).toBeUndefined();
+  });
+
+  it("clears a blocker with null rather than by dropping the key", () => {
+    // `undefined` would be dropped by JSON.stringify and the field would
+    // silently survive the write.
+    expect(applyVerb(item, "unblock", ctx).blocked_by).toBeNull();
+  });
+});

--- a/mycelium-frontend/src/lib/board/fields.ts
+++ b/mycelium-frontend/src/lib/board/fields.ts
@@ -14,6 +14,39 @@
 
 import type { LiveItem } from "./item";
 
+/**
+ * Why a row refuses a field write, in its own terms.
+ *
+ * A verb that is not custody writes frontmatter, and only a memory has any. The
+ * rest of the board is projected out of state that lives elsewhere — a
+ * checklist line, an episode record, a presence lease — so there is nothing to
+ * write onto, and saying that beats accepting a write that goes nowhere.
+ *
+ * Frozen in `contracts/board-vocabulary.json` under `fields`; the CLI carries
+ * its own copy and a test on each side asserts against that file.
+ */
+export const FIELD_REFUSALS: Record<string, string> = {
+  plan: "a plan task is a checklist line; there is no frontmatter on it to write",
+  episode: "an episode is a recorded negotiation, not a row the room can edit",
+  agent: "presence is what the runtime reports, not a field you set",
+  capture: "this row is not in the room yet; capture it first",
+  github: "this value belongs to the tool it came from; change it there",
+};
+
+/** The only row kind with frontmatter behind it. */
+export const WRITABLE_SOURCE_KINDS = ["memory"];
+
+/** The memory key behind a row, or null when the row is not a memory. */
+export function memoryKeyOf(item: LiveItem): string | null {
+  return item.source.kind === "memory" ? item.id.replace(/^memory:/, "") : null;
+}
+
+/** Why this row cannot take a field write, or null when it can. */
+export function fieldWriteRefusal(item: LiveItem): string | null {
+  if (WRITABLE_SOURCE_KINDS.includes(item.source.kind)) return null;
+  return FIELD_REFUSALS[item.source.kind] ?? "this row has no frontmatter to write";
+}
+
 export function str(item: LiveItem, name: string): string | null {
   const v = item.fields[name];
   return typeof v === "string" && v.trim() ? v.trim() : null;

--- a/mycelium-frontend/src/lib/board/item.ts
+++ b/mycelium-frontend/src/lib/board/item.ts
@@ -166,8 +166,6 @@ export interface VerbContext {
   /** Who the gesture acts as — `claim` with no target claims for you. */
   actor: string;
   now: string;
-  /** Issue number a `promote` would file as, in a PoC with no GitHub write. */
-  issueNumber?: number;
   /** Why a `release` is handing the row back, recorded against the releaser. */
   note?: string;
   /** Minutes a `claim` holds for before it drains. */
@@ -178,8 +176,10 @@ export interface VerbContext {
 
 /**
  * A verb returns the field patch it implies. `promote` is the one that leaves
- * the board: it stamps the back-link and resolves, because the record now lives
- * in GitHub and the live slice shouldn't hold a second copy of it.
+ * the board: it marks the row as belonging somewhere more durable and resolves,
+ * so the live slice stops carrying it. It does not stamp a back-link — nothing
+ * here files the issue, and a reference the verb invented would be one the
+ * status providers then resolve against a real, unrelated one.
  */
 export function applyVerb(
   item: LiveItem,
@@ -211,7 +211,6 @@ export function applyVerb(
     case "promote":
       patch.status = "resolved";
       patch.promoted = true;
-      if (ctx.issueNumber) patch.issue = `#${ctx.issueNumber}`;
       break;
     case "dismiss":
       patch.status = "dismissed";

--- a/openapi.json
+++ b/openapi.json
@@ -1418,6 +1418,107 @@
         }
       }
     },
+    "/api/rooms/{room_name}/fields": {
+      "post": {
+        "tags": [
+          "fields"
+        ],
+        "summary": "Write Fields",
+        "description": "Put fields on a row, through the canonical memory upsert.",
+        "operationId": "write_fields_api_rooms__room_name__fields_post",
+        "parameters": [
+          {
+            "name": "room_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Room Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WriteBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/rooms/{room_name}/fields/{key}": {
+      "get": {
+        "tags": [
+          "fields"
+        ],
+        "summary": "Read Fields",
+        "description": "A row's writable fields, without changing anything.",
+        "operationId": "read_fields_api_rooms__room_name__fields__key__get",
+        "parameters": [
+          {
+            "name": "room_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Room Name"
+            }
+          },
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/rooms/{room_name}/episodes": {
       "get": {
         "tags": [
@@ -6758,6 +6859,33 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "WriteBody": {
+        "properties": {
+          "key": {
+            "type": "string",
+            "title": "Key",
+            "description": "Memory key of the row being written"
+          },
+          "handle": {
+            "type": "string",
+            "title": "Handle",
+            "description": "Who is writing \u2014 recorded as the memory's author"
+          },
+          "fields": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Fields",
+            "description": "Frontmatter to merge onto the row. A null value clears its key. Custody keys are refused: those move through /leases."
+          }
+        },
+        "type": "object",
+        "required": [
+          "key",
+          "handle",
+          "fields"
+        ],
+        "title": "WriteBody"
       }
     }
   }


### PR DESCRIPTION
## Summary

Only `claim` / `release` / `resolve` had a write behind them, and only on `work/` rows. Every other verb — `block`, `dismiss`, `promote`, a kanban drag, a table cell edit — set a React overlay that evaporated on reload. Meanwhile the table's inline editor already echoed **"· written to frontmatter"** while writing nothing, and the CLI's `_would_write` printed a patch it never sent.

A surface asserting a change the room was never told is the failure the board's own custody model exists to prevent — it is the same shape as a claim held as a fact rather than a lease.

The board's thesis is that **a row is a title plus its frontmatter**, so a verb is a frontmatter write. This makes that true.

It is the first of the three moves in #825, and the one the other two are blocked on: `plan/` cannot stop being a store until the board can write a row.

## Changes

**Backend**

- `app/services/fields.py` — writes a frontmatter patch through the canonical memory upsert, so a card moved in a browser is the same versioned, indexed, link-parsed, broadcast change a `memory set --meta` makes. `null` clears a key.
- `app/routes/fields.py` — `POST /rooms/{room}/fields`, `GET /rooms/{room}/fields/{key}`. A sibling router rather than routes under `/memory`, for the reason `leases` and `links` already sit beside it: the memory router ends in a `{key:path}` catch-all.
- `leases._write` now delegates its upsert to `fields.upsert_patch`, so a lease and a status change cannot drift in how they reach the store. One writer, two callers.

**Custody is refused rather than shared.** A lease owns `custody` / `owner` / `claimed_at` / `ttl_minutes` / `custody_note` / `custody_note_by` under rules a field write cannot check — a live claim is not stealable, an expired one is, and expiry is derived from a clock rather than written down. A plain write setting `owner` would forge a claim that passed none of that, so those keys are refused by name and pointed at `/leases`. A refused write is refused whole: no partial application.

**Only a memory has frontmatter.** `plan`, `episode`, `agent`, `capture` and `github` rows refuse in their own terms instead of accepting a write that goes nowhere.

**Frontend**

- `writeFields` in `lib/api.ts`; `fieldWriteRefusal` / `memoryKeyOf` in `lib/board/fields.ts`; `RESERVED_FIELDS` / `reservedIn` in `lib/board/custody.ts` (it sits above `fields.ts`, which the module header keeps below both `item` and `custody`).
- `room-board.tsx` — the overlay becomes the optimistic echo and `patch` does the write. Custody verbs keep the lease path; everything else goes through the field write, including the kanban drag, the table edit and the cockpit's answer buttons. `updated` is stripped (it is the board's name for the store's own `updated_at`, so sending it would write a second competing timestamp) and `undefined` becomes `null` (`JSON.stringify` drops the former, so a cleared field would silently survive).

**`promote` no longer invents a GitHub back-link.** It was writing `700 + (overlay.length % 90)` as an `issue:` field. Survivable as an overlay; written to the room it is a fabricated reference the upstream provider would then resolve against a real, unrelated issue.

**CLI**

- `_would_write` becomes `_write_fields`. `board block --on` writes, and `board resolve` on a memory row that cannot hold a lease writes `status: resolved` instead of describing it.
- `mycelium/board/fields.py` mirrors the GUI's refusals and reserved set.

**Contract**

`contracts/board-vocabulary.json` grows a `fields` block for the refusals and the writable source kinds. It deliberately carries **no copy of the reserved keys** — those are derived from `custody` (its field, its companion fields, and the holder), and all three implementations assert that derivation rather than a fourth list that could drift.

**Docs** — the Board concept page's "Experimental" note said the verbs act on your own view; it now says what they do. The `board.py` module docstring said the same. Docs site regenerated.

## Testing

Mutation-checked, not just green: removing the reserved-key guard reddens 7 tests, and making a missing row auto-create instead of 404 reddens the one that names it.

```
backend    930 passed, 13 skipped   (20 new)
CLI        698 passed,  2 skipped   (19 new)
frontend   704 passed              (24 new)
ruff check / ruff format --check / ty check      clean
tsc --noEmit / eslint                            clean (5 warnings, all pre-existing)
scripts/check_docs_links.py     47 documents, every link resolves
scripts/check_workflows.py      pinned, permissions declared, budgets aligned
```

`openapi.json` refreshed — the frontend's `api-contract` test caught the missing refresh before I did, which is that derivation gate doing its job.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)

## What is still rough

- **No memory prose editing.** This writes fields, not text. A `plan/{slug}.md` narrative is still readable and not editable in the GUI, which is the gap #823 named honestly and which move 3 of #825 makes more urgent, not less.
- **Not verified in the running app.** Every layer is unit-covered on all three sides and the API is exercised end to end in the backend tests, but a real drag in a real browser against a live hub has not been done.
- **`promote` still resolves the row without filing anything.** Dropping the fabricated issue number makes it honest, not complete: there is no GitHub write behind that verb yet.
- **Field writes broadcast.** Unlike a lease renewal, which is deliberately quiet, every verb is news. That is probably right for a status change and probably wrong for a rapid sequence of table edits.

## Related Issues

First of the three moves in #825. Does not close it — plan tasks becoming `work/` memories, and the deletion of `plan/`, follow.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TiKo4bgUAxxURBvvdxAUV3

---
_Generated by [Claude Code](https://claude.ai/code/session_01TiKo4bgUAxxURBvvdxAUV3)_