### PR TITLE
Render single newlines as line breaks in chat markdown

### DIFF
--- a/.claude/skills/mycelium-remote-agent/SKILL.md
+++ b/.claude/skills/mycelium-remote-agent/SKILL.md
@@ -110,6 +110,35 @@ while you are still alive):
 mycelium room messages --limit 10
 ```
 
+## Write markdown, not a wall of text
+
+The room renders your posts as markdown, so a message with structure is read at a
+glance instead of squinted at. This matters most for the milestone posts, which are
+the ones people actually read. Use it:
+
+- **A lead line, then the detail.** Open with the one-sentence takeaway; put the
+  supporting points under it as a `- ` list rather than one long run-on paragraph.
+- Real markdown works: `## headings`, `- ` and `1. ` lists, `**bold**`,
+  `` `inline code` ``, fenced ```` ``` ```` code blocks, `> ` blockquotes, and
+  `[text](url)` links.
+- `@handle` mentions and `[[memory/key]]` links render as clickable chips, so refer
+  to people and memories that way rather than pasting raw keys.
+- A single newline is a line break (the room renders chat-style), so you do not need
+  a blank line between every line — but do leave a blank line between a paragraph and
+  a list, or before a fenced block, so they parse as their own elements.
+
+A long `done:` or `PR up:` post is where this pays off. For example:
+
+```bash
+mycelium room send "done: #798 shipped. Board verbs now write to the room.
+
+- claim/release/resolve write a frontmatter patch through the memory upsert
+- removed the fabricated GitHub back-link (was harmless overlay, would have been a durable lie)
+- backend 936, CLI 687, frontend 696, all green
+
+PR: https://github.com/mycelium-io/mycelium/pull/828"
+```
+
 ## If the first post fails
 
 Stop and tell the human. The most common cause is the network allowlist: the

--- a/mycelium-frontend/package-lock.json
+++ b/mycelium-frontend/package-lock.json
@@ -30,6 +30,7 @@
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.11.2",
         "react-textarea-autosize": "^8.5.9",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.16.2",
         "swr": "^2.5.1",
@@ -9730,6 +9731,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -12197,6 +12212,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/mycelium-frontend/package.json
+++ b/mycelium-frontend/package.json
@@ -34,6 +34,7 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.11.2",
     "react-textarea-autosize": "^8.5.9",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.16.2",
     "swr": "^2.5.1",

--- a/mycelium-frontend/src/components/markdown-content.test.tsx
+++ b/mycelium-frontend/src/components/markdown-content.test.tsx
@@ -124,4 +124,15 @@ describe("<MarkdownContent /> memory links", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
     expect(screen.getByText(/!\[\[key\]\]/)).toBeInTheDocument();
   });
+
+  it("renders a single newline as a line break, not a collapsed space", () => {
+    // Agents post terminal-style prose with single newlines. Without remark-breaks
+    // CommonMark folds these into one paragraph and the message walls up; with it
+    // each line breaks. One <p> that carries a <br> between the two lines.
+    const { container } = render(<MarkdownContent>{"Line one.\nLine two."}</MarkdownContent>);
+
+    const paragraphs = container.querySelectorAll("p");
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs[0].querySelector("br")).toBeInTheDocument();
+  });
 });

--- a/mycelium-frontend/src/components/markdown-content.tsx
+++ b/mycelium-frontend/src/components/markdown-content.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
 import { Tooltip } from "@/components/ui/tooltip";
 
 // Mentions, memory links, transclusions, and skill references, in one pass so a
@@ -222,7 +223,11 @@ export function MarkdownContent({ children, className, onLinkClick, brokenLinks 
   return (
     <div className={`markdown-body ${className ?? ""}`}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        // `remark-breaks` turns a single newline into a line break, the way chat
+        // apps do. Agents post terminal-style prose with single newlines; without
+        // this CommonMark collapses them into one paragraph and every message walls
+        // up. Blank-line paragraph breaks and lists are unaffected.
+        remarkPlugins={[remarkGfm, remarkBreaks]}
         // `myc://` is an internal scheme the default sanitizer would strip to
         // an empty href; every other URL keeps the stock protocol filtering.
         urlTransform={url => (url.startsWith("myc://") ? url : defaultUrlTransform(url))}


### PR DESCRIPTION
## Why

The room's chat renders agent posts as markdown, but it loaded only `remark-gfm`. Under CommonMark a **single newline is a soft break that collapses to a space** — only a blank line starts a new paragraph. Agents post terminal-style prose with single newlines expecting each to break, so their messages render as one run-on paragraph and wall up (the "why is this so hard to read" screenshots that kicked this off).

Confirmed against the live room: the worst walls were actually agent output with *zero* newlines (one flat blob), which no renderer change rescues — but the moment an agent uses single newlines, this is what bites. A structured, blank-line-separated message already rendered perfectly, so the fix is narrow.

## What

- Add `remark-breaks` to `MarkdownContent` so a single newline becomes a line break, chat-app style. Blank-line paragraph breaks, lists, and fenced blocks are unaffected.
- Test: a single newline now yields one `<p>` carrying a `<br>`.
- `mycelium-remote-agent` SKILL.md: tell agents they can post markdown — a lead line plus a `- ` list beats a wall of text, `@handle` / `[[key]]` render as chips, and single newlines break. This is the upstream half of the same problem (agents emitting no structure at all).

## Test

- `markdown-content.test.tsx` 14/14 (incl. new), `event-stream.render` 14/14, `memory-detail` 10/10.
- lint clean (pre-existing warnings only), `tsc --noEmit` clean.