### PR TITLE
Bind a work row to its thread, so a board row is a unit of work (#836)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    # Integration branches are in the filter so a change lands checked rather
+    # than only at the point the whole branch merges to main. Same tier, same
+    # jobs — a PR into `epic/x` is a PR, and finding a break in the branch that
+    # collected six of them is the most expensive place to find it.
+    branches: [main, "epic/**"]
 
 # Read-only by default; the timing job asks for `actions: read` on top of this.
 permissions:

--- a/contracts/board-vocabulary.json
+++ b/contracts/board-vocabulary.json
@@ -55,6 +55,31 @@
     "work",
     "failed"
   ],
+  "unit": {
+    "_comment": "A unit of work is a board row and a thread: one row per unit, with its coordination folded into it. The binding is `binding_field` on the row's memory \u2014 store-owned, minted by the backend, carried across writes, so it is absent from the meta bag a caller can write and a field write cannot move a row onto someone else's thread. The thread's own state lands under `thread_fields` because a unit's status and custody are the unit's: a negotiation that converges or aborts inside a row must not resolve the row or take it off its holder, which is what `unit_fields` names \u2014 the container-outlives-the-negotiation rule, as a list both sides assert a fold against. An episode no row is bound to is an ORPHAN: it keeps its own row rather than being hidden or deleted, which is why the board still projects episodes.",
+    "binding_field": "episode",
+    "thread_fields": [
+      "episode",
+      "thread",
+      "thread_state",
+      "participants",
+      "rounds"
+    ],
+    "thread_states": [
+      "open",
+      "converged",
+      "resolved",
+      "rejected",
+      "committed"
+    ],
+    "unit_fields": [
+      "status",
+      "custody",
+      "owner",
+      "kind",
+      "priority"
+    ]
+  },
   "log": {
     "_comment": "The daily log's calendar conventions. A day is a calendar date in the reader's timezone; weeks start Monday; the heat scale steps at these upper bounds.",
     "week_starts_on": "monday",

--- a/docs/index.html
+++ b/docs/index.html
@@ -650,7 +650,12 @@ Review 1
          @agent-z   feat/custody-seam   CI green   #504       12m</code></pre>
       <h2 id="board-nothing-to-fill-in">Nothing to fill in</h2>
       <p>You never add anything to the board. It&#x27;s assembled from what the room already has: the work compiled out of its agreements, the negotiations running in it, the memories under <code>decisions/</code>, <code>status/</code>, <code>work/</code> and <code>failed/</code>, and which agents are actually resident right now. Every row says where it came from, and clicking through takes you to the real thing rather than a copy of it.</p>
-      <p>That means there&#x27;s no second place to keep up to date. Resolve a task and its row resolves. End a negotiation and its decision row closes. Nothing to groom, and nothing that can quietly disagree with the room it describes.</p>
+      <p>That means there&#x27;s no second place to keep up to date. Resolve a task and its row resolves. Nothing to groom, and nothing that can quietly disagree with the room it describes.</p>
+      <h2 id="board-a-row-is-a-unit-of-work-and-a-unit-of-work-is-a-thread">A row is a unit of work, and a unit of work is a thread</h2>
+      <p>A <code>work/</code> row carries the episode URN of the thread its coordination happens in. The row and the thread are one object, so the board draws one row per unit — the negotiation that produced a task shows up <em>on</em> that task (<code>thread</code>, <code>thread_state</code>, who was at the table, how many rounds) rather than beside it as a second row.</p>
+      <p>The URN is the store&#x27;s: it is minted when the unit is created, it survives every later write, and no <code>memory set --meta</code> or board verb can set or move it. A unit is therefore bound to one thread for its whole life — a second negotiation about the same work opens its own episode, and the row stays pointed at the conversation that produced it.</p>
+      <p><strong>The unit outlives what happens inside it.</strong> A thread&#x27;s state never writes the row&#x27;s own axes. Converging inside a unit does not resolve the unit, aborting a negotiation does not take the row off whoever is holding it, and a unit can be created, claimed, worked and resolved with no negotiation ever opened. That is the whole point of the separation: a negotiation is one optional thing that can happen inside a piece of work, not the reason the work exists.</p>
+      <p>A negotiation nobody compiled into work has no unit to fold into, so it keeps a row of its own — a recorded negotiation is still something the room did.</p>
       <h2 id="board-three-lenses">Three lenses</h2>
       <div class="table-wrap">
         <table>
@@ -801,7 +806,7 @@ Review 1
       <p>A resident loop renews the claims its handle holds, so <code>mycelium await --loop</code> is all an agent needs to keep its work. Stop looping and the claims drain, with nobody writing that down.</p>
       <h2 id="board-related">Related</h2>
       <ul>
-        <li><a href="#episodes">episodes</a>: a negotiation, which appears as a decision row.</li>
+        <li><a href="#episodes">episodes</a>: the thread inside a unit — folded onto its row, or a row of its own when no work came out of it.</li>
         <li><a href="#memory">memory</a>: where a row&#x27;s fields actually live.</li>
       </ul>
       <p class="edit-page"><a href="https://github.com/mycelium-io/mycelium/blob/main/mycelium-cli/src/mycelium/docs/concepts/board.md" target="_blank" rel="noopener"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>Edit this page on GitHub</a></p>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -740,8 +740,32 @@ resident right now. Every row says where it came from, and clicking through
 takes you to the real thing rather than a copy of it.
 
 That means there's no second place to keep up to date. Resolve a task and
-its row resolves. End a negotiation and its decision row closes. Nothing to
-groom, and nothing that can quietly disagree with the room it describes.
+its row resolves. Nothing to groom, and nothing that can quietly disagree with
+the room it describes.
+
+## A row is a unit of work, and a unit of work is a thread
+
+A `work/` row carries the episode URN of the thread its coordination happens in.
+The row and the thread are one object, so the board draws one row per unit — the
+negotiation that produced a task shows up *on* that task (`thread`,
+`thread_state`, who was at the table, how many rounds) rather than beside it as a
+second row.
+
+The URN is the store's: it is minted when the unit is created, it survives every
+later write, and no `memory set --meta` or board verb can set or move it. A unit
+is therefore bound to one thread for its whole life — a second negotiation about
+the same work opens its own episode, and the row stays pointed at the
+conversation that produced it.
+
+**The unit outlives what happens inside it.** A thread's state never writes the
+row's own axes. Converging inside a unit does not resolve the unit, aborting a
+negotiation does not take the row off whoever is holding it, and a unit can be
+created, claimed, worked and resolved with no negotiation ever opened. That is
+the whole point of the separation: a negotiation is one optional thing that can
+happen inside a piece of work, not the reason the work exists.
+
+A negotiation nobody compiled into work has no unit to fold into, so it keeps a
+row of its own — a recorded negotiation is still something the room did.
 
 ## Three lenses
 
@@ -1030,7 +1054,8 @@ nobody writing that down.
 
 ## Related
 
-- [episodes](#episodes): a negotiation, which appears as a decision row.
+- [episodes](#episodes): the thread inside a unit — folded onto its row, or a
+  row of its own when no work came out of it.
 - [memory](#memory): where a row's fields actually live.
 
 

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -252,6 +252,13 @@ window.MYCELIUM_SEARCH_INDEX = [
     "p": "Guide"
   },
   {
+    "u": "index.html#board-a-row-is-a-unit-of-work-and-a-unit-of-work-is-a-thread",
+    "t": "A row is a unit of work, and a unit of work is a thread",
+    "s": "Concepts › Board",
+    "x": "A work/ row carries the episode URN of the thread its coordination happens in. The row and the thread are one object, so the board draws one row per unit — the negotiation that produced a task shows up on that task (thread, thread_state, who was at the table, how many rounds) rather than beside it as a second row. The URN is the store's: it is minted when the unit is created, it survives every later write, and no mem",
+    "p": "Guide"
+  },
+  {
     "u": "index.html#board-three-lenses",
     "t": "Three lenses",
     "s": "Concepts › Board",
@@ -346,7 +353,7 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "index.html#board-related",
     "t": "Related",
     "s": "Concepts › Board",
-    "x": "episodes: a negotiation, which appears as a decision row. memory: where a row's fields actually live.",
+    "x": "episodes: the thread inside a unit — folded onto its row, or a row of its own when no work came out of it. memory: where a row's fields actually live.",
     "p": "Guide"
   },
   {

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -87,6 +87,23 @@ async def lifespan(app: FastAPI):
             logger.warning("auth: %s", warning)
     else:
         logger.info("HTTP-API JWT gate disabled — requests are unauthenticated")
+    # A work/ row written before the unit-of-work binding carries no thread, so
+    # it reads as a task that was never coordinated anywhere. Minting one is a
+    # store annotation rather than an edit: the row keeps its version, its stamps
+    # and its place on a time-ordered board. Runs before the index scan, so the
+    # rows it rewrites are indexed once rather than caught on the next restart.
+    from app.services.filesystem import list_room_names
+    from app.services.units import backfill_room
+
+    bound_units = 0
+    for _room in list_room_names():
+        try:
+            bound_units += backfill_room(_room)
+        except Exception:
+            logger.exception("unit backfill failed for room %s", _room)
+    if bound_units:
+        logger.info("bound %d pre-existing work row(s) to a thread on startup", bound_units)
+
     # Incremental scan of filesystem → JSONL search index
     from app.services.reindex import start_watcher, startup_scan, stop_watcher
 
@@ -169,8 +186,6 @@ async def lifespan(app: FastAPI):
     # existing room channel-less (a zombie) with no recovery path until it was
     # deleted + recreated. Runs after the aligner/plan-sync hooks are wired so
     # each restarted persister picks them up.
-    from app.services.filesystem import list_room_names
-
     reprovisioned = 0
     restored_custody = 0
     for _room in list_room_names():

--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -43,7 +43,9 @@ from app.schemas import (
 from app.services import actor, links, local_state, memory_sync, search_index
 from app.services.embedding import embed_text
 from app.services.filesystem import (
+    EPISODE_META,
     MANAGED_META,
+    SYSTEM_META,
     delete_memory_file,
     get_room_dir,
     list_memory_files,
@@ -51,6 +53,7 @@ from app.services.filesystem import (
     read_memory_file,
     recover_timestamps,
     room_exists,
+    system_meta,
     unmanaged_meta,
     value_to_content,
     write_memory_file,
@@ -106,6 +109,7 @@ def _memory_read_from_file(room_name: str, key: str, meta: dict, content: str) -
         version=meta.get("version", 1),
         tags=meta.get("tags"),
         meta=unmanaged_meta(meta) or None,
+        episode=meta.get(EPISODE_META),
         expandable=links.is_expandable(meta),
         created_at=created_at,
         updated_at=updated_at,
@@ -212,7 +216,11 @@ async def create_memories(room_name: str, payload: MemoryBatchCreate, request: R
 
 
 async def upsert_memories(
-    room_name: str, payload: MemoryBatchCreate, *, notify: bool = True
+    room_name: str,
+    payload: MemoryBatchCreate,
+    *,
+    notify: bool = True,
+    system: dict[str, Any] | None = None,
 ) -> list[MemoryRead]:
     """The write itself, with ``created_by`` already resolved to its true author.
 
@@ -224,8 +232,20 @@ async def upsert_memories(
     re-dating a lease it already holds.  The file, the index and the link graph
     are all updated exactly as usual; what is skipped is telling the room, which
     a loop running every few seconds must not do.
+
+    ``system`` sets the store-owned frontmatter in :data:`SYSTEM_META` — today
+    just the ``episode`` a unit of work is bound to.  An in-process parameter has
+    no wire form, so nothing over HTTP can point a row at a thread it was never
+    part of; the same key stays ignored in ``MemoryCreate.meta``.
+
+    It is **write-once**: a value already on the row wins, so a unit stays bound
+    to the thread its history is in for the row's whole life.
     """
     _require_room(room_name)
+    if system and not set(system) <= SYSTEM_META:
+        raise ValueError(
+            f"system meta outside {sorted(SYSTEM_META)}: {sorted(set(system) - SYSTEM_META)}"
+        )
     room_dir = get_room_dir(room_name)
 
     from app.services.metrics import record_memory_write
@@ -277,6 +297,14 @@ async def upsert_memories(
         if item.meta:
             extra_meta.update({k: v for k, v in item.meta.items() if k not in MANAGED_META})
 
+        # The store's own minted keys, which nothing here recomputes. ``system``
+        # supplies one; what the row already carries wins, so the binding is
+        # write-once: a field write cannot silently unbind a row from its thread,
+        # and a later writer cannot move it onto a different one.
+        if system:
+            extra_meta.update(system)
+        extra_meta.update(system_meta(existing_meta))
+
         # Persist structured values into frontmatter so non-text keys survive
         # the round-trip (the markdown body only carries the ``text``/rendering).
         structured = set(value.keys()) != {"text"}
@@ -320,6 +348,7 @@ async def upsert_memories(
                 "version": new_version,
                 "tags": item.tags,
                 "meta": unmanaged_meta(extra_meta) or None,
+                "episode": extra_meta.get(EPISODE_META),
                 "expandable": links.is_expandable(extra_meta),
                 "created_at": created_at.isoformat(),
                 "updated_at": now.isoformat(),
@@ -340,6 +369,7 @@ async def upsert_memories(
                 version=new_version,
                 tags=item.tags,
                 meta=unmanaged_meta(extra_meta) or None,
+                episode=extra_meta.get(EPISODE_META),
                 expandable=links.is_expandable(extra_meta),
                 created_at=created_at,
                 updated_at=now,
@@ -444,6 +474,7 @@ async def search_memories(room_name: str, payload: MemorySearchRequest):
             version=rec.get("version", 1),
             tags=rec.get("tags"),
             meta=rec.get("meta") or None,
+            episode=rec.get(EPISODE_META),
             expandable=bool(rec.get("expandable")),
             created_at=created_at,
             updated_at=updated_at,

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -402,6 +402,15 @@ class MemoryRead(BaseModel):
             "what ``MemoryCreate.meta`` wrote, read back."
         ),
     )
+    episode: str | None = Field(
+        None,
+        description=(
+            "The episode URN this row's coordination happens in — what makes a unit "
+            "of work a thread. Store-owned: minted by the backend, so it is absent "
+            "from ``meta`` and cannot be set by a write. Null on a memory that is "
+            "not a unit of work, and on one no thread has been opened for."
+        ),
+    )
     expandable: bool = Field(
         False,
         description=(

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -57,7 +57,7 @@ from app.services.room_channels import BACKEND_AGENT
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from app.services.l9_episode import EpisodeState
+    from app.services.l9_episode import NegotiationState
     from app.services.l9_models import L9
     from app.services.persister import RoomPersister, TranscriptRecord
     from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
@@ -468,7 +468,7 @@ class AlignerEngine:
         self,
         managed: ManagedRoomChannel,
         persister: RoomPersister,
-        ep: EpisodeState,
+        ep: NegotiationState,
         sender: str,
         episode: str,
         topic: str,
@@ -645,7 +645,7 @@ class AlignerEngine:
             managed.persister.ingest_local(env, content)
 
     def _fold_reading(
-        self, ep: EpisodeState, handle: str, reading: dict[str, Any], proposing: bool
+        self, ep: NegotiationState, handle: str, reading: dict[str, Any], proposing: bool
     ) -> None:
         """Fold one interpreted SAO move into the episode so metrics stay live.
 
@@ -706,7 +706,7 @@ class AlignerEngine:
             *(_norm(h) for h in _NON_PARTICIPANTS),
         }
 
-    def _verdict(self, ep: EpisodeState) -> tuple[bool, dict[str, Any] | None]:
+    def _verdict(self, ep: NegotiationState) -> tuple[bool, dict[str, Any] | None]:
         """(converged, metrics). Converged ⇔ metrics exist and MPC ≥ threshold."""
         metrics = l9_episode.compute_metrics(ep)
         converged = metrics is not None and metrics["mpc"] >= self._threshold
@@ -717,7 +717,7 @@ class AlignerEngine:
     async def _emit_verdict(
         self,
         managed: ManagedRoomChannel,
-        ep: EpisodeState,
+        ep: NegotiationState,
         assignments: dict[str, Any],
         converged: bool,
         metrics: dict[str, Any] | None,

--- a/fastapi-backend/app/services/briefing.py
+++ b/fastapi-backend/app/services/briefing.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from app.services.filesystem import read_room_meta
 from app.services.leases import state_of
-from app.services.task_sync import ASSIGNEE_FIELD, WORK_NAMESPACE
+from app.services.units import ASSIGNEE_FIELD, WORK_NAMESPACE
 
 #: How many open rows a briefing names before it stops. A briefing long enough
 #: to skim past is one an agent reads none of.

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -40,12 +40,16 @@ _MISSING = object()
 # Last-resort stamp for a memory with no recoverable time (see recover_timestamps).
 _EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
 
+# The frontmatter key binding a unit of work to its thread: the episode URN of
+# the coordination that happens inside the row. Minted by the backend, never by a
+# caller — a row that could be pointed at someone else's thread by a field write
+# would be a board row claiming a conversation it was never part of.
+EPISODE_META = "episode"
+
 # Frontmatter the store owns. Everything else in a memory's frontmatter is user
 # data: it survives a rewrite, a caller can set it via ``MemoryCreate.meta``, and
 # it is returned as ``MemoryRead.meta``.
 MANAGED_META = frozenset(
-    # `episode` binds a work row to its unit-of-work thread. System-owned, so it is
-    # filtered out of user meta and a field write cannot overwrite it.
     {
         "key",
         "created_by",
@@ -55,14 +59,29 @@ MANAGED_META = frozenset(
         "updated_at",
         "tags",
         "value",
-        "episode",
+        EPISODE_META,
     }
 )
+
+# The managed keys the write path does not recompute: minted once and carried
+# forward verbatim on every later write. Managed, so no caller sets one through
+# ``MemoryCreate.meta``; carried forward, so a write that doesn't supply one
+# keeps what the row has instead of dropping it.
+SYSTEM_META = frozenset({EPISODE_META})
 
 
 def unmanaged_meta(meta: dict[str, Any]) -> dict[str, Any]:
     """The user-owned half of a memory's frontmatter — everything outside MANAGED_META."""
     return {k: v for k, v in meta.items() if k not in MANAGED_META}
+
+
+def system_meta(meta: dict[str, Any]) -> dict[str, Any]:
+    """The system-minted half of a memory's frontmatter, for carrying forward.
+
+    Empty values are dropped rather than carried: a row whose ``episode`` was
+    hand-blanked in the file reads as unbound, not as bound to "".
+    """
+    return {k: v for k, v in meta.items() if k in SYSTEM_META and v not in (None, "")}
 
 
 def get_data_dir() -> Path:

--- a/fastapi-backend/app/services/indexer.py
+++ b/fastapi-backend/app/services/indexer.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from app.services import links, search_index
 from app.services.embedding import embed_text
 from app.services.filesystem import (
+    EPISODE_META,
     get_data_dir,
     list_memory_files,
     parse_memory,
@@ -62,6 +63,7 @@ def _build_record(room_name: str, key: str, content: str, meta: dict) -> dict:
         "version": meta.get("version", 1),
         "tags": meta.get("tags"),
         "meta": unmanaged_meta(meta) or None,
+        "episode": meta.get(EPISODE_META),
         "expandable": links.is_expandable(meta),
         "created_at": _iso(meta.get("created_at"), now),
         "updated_at": _iso(meta.get("updated_at"), now),

--- a/fastapi-backend/app/services/l9_episode.py
+++ b/fastapi-backend/app/services/l9_episode.py
@@ -2,10 +2,18 @@
 # Copyright 2026 Mycelium Contributors
 
 """
-L9 episode tracking for CFN negotiations.
+L9 episode tracking.
 
-One :class:`EpisodeState` accompanies each ``_CfnRoundState`` in
-``coordination.py``. It does three things:
+:class:`EpisodeState` is what any episode is — a tagged thread over the room's
+channel, with its participants, its topic and the envelopes it has carried.
+:class:`NegotiationState` adds what a *negotiation* inside one accumulates: the
+opening asks, the offer grid, and the belief-move scoreboard. The split is the
+unit-of-work model's: a unit of work is a thread, and a negotiation is one
+optional thing that happens inside it, so a thread opened for a board row does
+not carry an SAO scoreboard it will never fill in.
+
+A :class:`NegotiationState` accompanies each mediated session. It does three
+things:
 
 1. Builds the L9 envelopes that ride inside coordination message content
    (ticks are ``exchange``, the consensus is ``commit:converged`` /
@@ -71,7 +79,14 @@ def _clean_str_list(value: Any) -> list[str]:
 
 @dataclass
 class EpisodeState:
-    """L9 episode accumulator for one coordination session."""
+    """What every episode is: a tagged thread over the room's own channel.
+
+    A unit of work is one of these; so is a negotiation inside a unit. Everything
+    here is what a thread has whatever happens in it — who it is scoped to, what
+    it is about, and the envelopes it has carried. The accumulators a *negotiation*
+    needs are :class:`NegotiationState`'s, so opening a thread for a board row
+    does not drag an SAO scoreboard along with it.
+    """
 
     episode: str  # URN
     topic: str  # concept URN
@@ -86,6 +101,20 @@ class EpisodeState:
     # back to the system actor (an episode opened outside an engine context).
     engine_handle: str = ""
     intent_id: str = ""
+    # Ordered record of every envelope in the episode (dicts, wire shape).
+    messages: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class NegotiationState(EpisodeState):
+    """The extra bookkeeping a *negotiation* inside an episode accumulates.
+
+    Split from :class:`EpisodeState` because a negotiation is one optional thing
+    that can happen inside a unit of work rather than the reason the unit exists.
+    Opening positions, an SAO offer grid and the belief-move scoreboard mean
+    nothing to a thread nobody is negotiating in.
+    """
+
     # Each participant's opening prose, captured before mediation runs — the
     # structured snapshot the episode record renders as "Opening Positions" so a
     # negotiation can be audited against what the room believed going in.
@@ -102,8 +131,6 @@ class EpisodeState:
     # The negotiable issues' ordered option grids (issue -> options), so
     # satisfaction can be scored as ordinal distance on the grid actually negotiated.
     issue_options: dict[str, list[str]] = field(default_factory=dict)
-    # Ordered record of every envelope in the episode (dicts, wire shape).
-    messages: list[dict[str, Any]] = field(default_factory=list)
     # handle -> l9 message id of the last tick sent to that agent.
     last_tick_ids: dict[str, str] = field(default_factory=dict)
     # handle -> l9 message id of that agent's last recorded reply.
@@ -131,8 +158,8 @@ def open_episode(
     joined_intents: str,
     engine_handle: str = "",
     opening_positions: dict[str, str] | None = None,
-) -> EpisodeState:
-    """Open the episode: mint URNs and record the ``intent`` envelope.
+) -> NegotiationState:
+    """Open a negotiation episode: mint URNs and record the ``intent`` envelope.
 
     ``engine_handle`` is the registered engine mediating the episode; it signs
     the intent/tick/consensus envelopes so the wire carries the engine's real
@@ -142,7 +169,7 @@ def open_episode(
     captured before mediation runs; it is rendered into the episode record's
     "Opening Positions" section for audit.
     """
-    ep = EpisodeState(
+    ep = NegotiationState(
         episode=l9.episode_urn(parent_room, short_id),
         topic=l9.topic_urn(parent_room),
         parent_room=parent_room,
@@ -171,7 +198,7 @@ def open_episode(
 
 
 def record_tick(
-    ep: EpisodeState, *, handle: str, round_n: int | None, payload: dict[str, Any]
+    ep: NegotiationState, *, handle: str, round_n: int | None, payload: dict[str, Any]
 ) -> dict[str, Any]:
     """Record the tick sent to ``handle`` and return its envelope dict.
 
@@ -201,7 +228,7 @@ def record_tick(
 
 
 def record_term_check(
-    ep: EpisodeState,
+    ep: NegotiationState,
     *,
     mismatches: list[dict[str, Any]],
     clarifications: dict[str, str],
@@ -218,7 +245,7 @@ def record_term_check(
 
 
 def record_reply(
-    ep: EpisodeState,
+    ep: NegotiationState,
     *,
     handle: str,
     reply: dict[str, Any],
@@ -328,7 +355,7 @@ def record_reply(
             ep.deferred.pop(handle, None)
 
 
-def compute_metrics(ep: EpisodeState) -> dict[str, Any] | None:
+def compute_metrics(ep: NegotiationState) -> dict[str, Any] | None:
     """SIEP agreement-quality metrics over the agents that reported confidence.
     Returns None when participation is too thin to mean anything (fewer than two
     reporters, or more than one silent agent)."""
@@ -403,7 +430,7 @@ def estimate_satisfaction(
 
 
 def build_consensus_envelope(
-    ep: EpisodeState,
+    ep: NegotiationState,
     *,
     broken: bool,
     assignments: dict[str, Any],
@@ -442,8 +469,6 @@ def write_episode_record(
     """Persist the episode to ``log/episodes/{short_id}.md`` in the parent
     room's memory. Best-effort: never raises into the consensus path."""
     try:
-        from app.services.filesystem import get_room_dir, write_memory_file
-
         lines = [
             f"# Episode {ep.episode}",
             "",
@@ -465,6 +490,12 @@ def write_episode_record(
             )
         if tasks:
             lines.append("- work: " + ", ".join(f"`{key}`" for key in tasks))
+        # The header and the envelope chain are any thread's; the sections below
+        # exist only where a negotiation actually ran.
+        if not isinstance(ep, NegotiationState):
+            _append_messages(lines, ep)
+            _write_record(ep, lines)
+            return
         if ep.opening_positions:
             lines += [
                 "",
@@ -503,28 +534,38 @@ def write_episode_record(
                         if handle in ep.clarifications
                     ),
                 ]
-        lines += [
-            "",
-            "## Messages",
-            "",
-            "The full causally-linked L9 message record (one JSON envelope per line):",
-            "",
-            "```jsonl",
-            *(json.dumps(m, sort_keys=True) for m in ep.messages),
-            "```",
-            "",
-        ]
-        base = get_room_dir(ep.parent_room)
-        base.mkdir(parents=True, exist_ok=True)
-        write_memory_file(
-            base,
-            f"log/episodes/{ep.short_id}",
-            "\n".join(lines),
-            created_by=l9.SYSTEM_ACTOR_ID,
-            updated_by=l9.SYSTEM_ACTOR_ID,
-        )
+        _append_messages(lines, ep)
+        _write_record(ep, lines)
     except Exception:
         logger.exception("episode record write failed for %s", ep.episode)
+
+
+def _append_messages(lines: list[str], ep: EpisodeState) -> None:
+    lines += [
+        "",
+        "## Messages",
+        "",
+        "The full causally-linked L9 message record (one JSON envelope per line):",
+        "",
+        "```jsonl",
+        *(json.dumps(m, sort_keys=True) for m in ep.messages),
+        "```",
+        "",
+    ]
+
+
+def _write_record(ep: EpisodeState, lines: list[str]) -> None:
+    from app.services.filesystem import get_room_dir, write_memory_file
+
+    base = get_room_dir(ep.parent_room)
+    base.mkdir(parents=True, exist_ok=True)
+    write_memory_file(
+        base,
+        f"log/episodes/{ep.short_id}",
+        "\n".join(lines),
+        created_by=l9.SYSTEM_ACTOR_ID,
+        updated_by=l9.SYSTEM_ACTOR_ID,
+    )
 
 
 # One canonical converged-rule memory per room (each room is one topic). Reading

--- a/fastapi-backend/app/services/l9_slim.py
+++ b/fastapi-backend/app/services/l9_slim.py
@@ -20,9 +20,11 @@ This module owns three things the *app* must, not SLIM:
    any dependents it unblocks) in causal order.
 
 3. **Episode ↔ channel lifecycle.** The channel is durable for the room's life;
-   an *episode* is one negotiation inside it. :class:`EpisodeLifecycle` enforces
-   L9's stable-membership rule: a membership change mid-episode **aborts** the
-   episode (emitted as ``commit:rejected``), without tearing down the channel.
+   an *episode* is one tagged thread inside it — a unit of work, or a negotiation
+   within a unit. :class:`EpisodeLifecycle` enforces L9's stable-membership rule
+   where it means something: a membership change aborts an active *negotiation*
+   (emitted as ``commit:rejected``), without tearing down the channel or the unit
+   the negotiation was happening inside.
 
 :class:`L9SlimChannel` composes 1-2 over a single SLIM group session: one call
 to :meth:`send` publishes an envelope; :meth:`receive` pulls one broadcast and
@@ -168,32 +170,56 @@ class CausalOrderBuffer:
 
 @dataclass
 class EpisodeLifecycle:
-    """Tracks one negotiation (episode) within a durable room channel.
+    """Tracks one episode within a durable room channel.
 
-    An episode freezes the membership it opened with. A membership change while
-    the episode is active violates L9's stable-membership rule and **aborts** the
-    episode — the channel itself is untouched. A new episode can
-    be opened afterward with the changed membership.
+    **Freezing membership is a negotiation's policy, not an episode's.** L9's
+    stable-membership rule exists because an offer/counter exchange scored across
+    a changing set of participants means nothing — so a membership change while a
+    *negotiation* is running **aborts** it (the channel itself is untouched, and a
+    new episode can open afterward with the changed membership).
+
+    A unit of work is an episode too, and nothing about it wants that rule: it is
+    a container that outlives what happens inside it, so someone joining the room
+    must not end the thread a board row's history lives in. Such an episode opens
+    with ``negotiation=False``, and :attr:`frozen` — not :attr:`active` — is what
+    callers gate the freeze on.
     """
 
     episode: str | None = None
     members: frozenset[str] = field(default_factory=frozenset)
     active: bool = False
+    negotiation: bool = True
 
-    def open(self, episode: str, members: set[str] | frozenset[str]) -> None:
-        """Begin an episode over the given frozen membership."""
+    @property
+    def frozen(self) -> bool:
+        """Whether membership is frozen right now: an active *negotiation*.
+
+        The gate for anything a membership change would break — aborting, and
+        deferring an invite until the episode closes.
+        """
+        return self.active and self.negotiation
+
+    def open(
+        self, episode: str, members: set[str] | frozenset[str], *, negotiation: bool = True
+    ) -> None:
+        """Begin an episode over the given membership.
+
+        ``negotiation=False`` opens a container (a unit of work's thread) that a
+        later join or leave leaves running.
+        """
         self.episode = episode
         self.members = frozenset(members)
         self.active = True
+        self.negotiation = negotiation
 
     def on_membership_change(self, members: set[str] | frozenset[str]) -> bool:
-        """Record a membership change; return True if it aborts an active episode.
+        """Record a membership change; return True if it aborts a negotiation.
 
-        When no episode is active the new membership is simply adopted as the
-        baseline (so the *next* episode opens clean).
+        When nothing is frozen the new membership is simply adopted as the
+        baseline (so the *next* negotiation opens clean).
         """
         new_members = frozenset(members)
-        if self.active and new_members != self.members:
+        if self.frozen and new_members != self.members:
             self.active = False
             return True
         self.members = new_members
@@ -203,6 +229,7 @@ class EpisodeLifecycle:
         """Close the episode normally (converged/rejected reached)."""
         self.active = False
         self.episode = None
+        self.negotiation = True
 
 
 def build_episode_abort_envelope(

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -8,7 +8,8 @@ Creating/opening a room **provisions a SLIM group channel**, and the always-on
 backend is its **moderator** — it creates the group session and invites members
 as they join. This registry holds one long-lived moderator session per room,
 tracks membership (SLIM's built-in presence), and enforces the episode↔channel
-lifecycle (a mid-episode membership change aborts the episode; the channel is
+lifecycle (a membership change mid-*negotiation* aborts that negotiation; the
+channel, and any unit of work the negotiation was happening inside, are
 untouched).
 
 Everything here is **best-effort**. When no node is reachable (or no wheel is
@@ -806,10 +807,12 @@ class RoomChannelManager:
             if handle in present or handle == BACKEND_AGENT:
                 continue
             if _is_own_registered_agent(room, handle):
-                if managed.lifecycle.active:
-                    # Inviting a new member mid-episode would abort it (L9's
+                if managed.lifecycle.frozen:
+                    # Inviting a new member mid-negotiation would abort it (L9's
                     # stable-membership rule), so queue like a consent accept —
                     # flush_queued_invites applies it once the episode closes.
+                    # Gated on ``frozen``, not ``active``: a unit of work's thread
+                    # is an episode too, and it must not hold invites hostage.
                     queued = self._invites.request(
                         room, handle, requested_by=sender, trigger_text=text
                     )
@@ -861,7 +864,7 @@ class RoomChannelManager:
         managed = self._channels.get(invite.room)
         if managed is None:
             return self._invites.mark(invite_id, DECLINED)
-        if managed.lifecycle.active:
+        if managed.lifecycle.frozen:
             logger.info(
                 "invite for @%s in %s queued until episode %s closes",
                 invite.agent,
@@ -936,21 +939,24 @@ class RoomChannelManager:
         await self._enforce_membership_change(managed)
         return True
 
-    def open_episode(self, room: str, episode: str) -> bool:
-        """Open a negotiation episode over the room's current membership.
+    def open_episode(self, room: str, episode: str, *, negotiation: bool = True) -> bool:
+        """Open an episode over the room's current membership.
 
-        Freezes membership: a subsequent join/leave aborts it.
+        A negotiation freezes that membership: a subsequent join/leave aborts it.
+        ``negotiation=False`` opens a container — a unit of work's thread — which
+        a join or leave leaves running, because the unit outlives what happens
+        inside it.
         """
         managed = self._channels.get(room)
         if managed is None:
             return False
-        managed.lifecycle.open(episode, managed.members)
+        managed.lifecycle.open(episode, managed.members, negotiation=negotiation)
         return True
 
     async def close_episode(self, room: str) -> bool:
         """Close the room's active episode normally and flush queued invites.
 
-        The membership-freeze that an episode holds is released here, so invites
+        The membership-freeze a negotiation holds is released here, so invites
         an ``@``-mention deferred mid-episode are now safe to apply.
         """
         managed = self._channels.get(room)
@@ -961,7 +967,7 @@ class RoomChannelManager:
         return True
 
     async def _enforce_membership_change(self, managed: ManagedRoomChannel) -> None:
-        """Abort the active episode if membership changed under it."""
+        """Abort the active negotiation if membership changed under it."""
         if not managed.lifecycle.on_membership_change(managed.members):
             return
         episode = managed.lifecycle.episode

--- a/fastapi-backend/app/services/task_sync.py
+++ b/fastapi-backend/app/services/task_sync.py
@@ -31,11 +31,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from typing import TYPE_CHECKING, Any
 
 from app.services import l9, task_compiler
-from app.services.filesystem import get_room_dir, list_memory_files, read_memory_file
+from app.services.filesystem import EPISODE_META, get_room_dir, list_memory_files, read_memory_file
+from app.services.units import ASSIGNEE_FIELD, TASK_KIND, WORK_NAMESPACE, slugify
 
 if TYPE_CHECKING:
     from app.services.l9_models import L9
@@ -44,36 +44,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#: Compiled work lands here, which is the namespace a lease can be taken on.
-WORK_NAMESPACE = "work"
 
-#: What a board row calls a unit of agreed work. Written explicitly because the
-#: projection's default for this namespace is "concern" — a task is an action.
-TASK_KIND = "action"
+def _episode_from(envelope: L9) -> str | None:
+    """The episode the verdict was reached in, off the envelope's own header.
 
-#: Who a task is *meant for*, which is not who holds it.
-#:
-#: Deliberately not ``owner``: that is the lease's, and a lease is something an
-#: actor takes under rules this stage cannot satisfy — it has no claim window,
-#: no renewal, and nobody on the other end who has agreed to hold anything. An
-#: assignment written as custody would be a claim on behalf of an agent that
-#: never made one, and it would drain to "expired" the moment its TTL passed.
-ASSIGNEE_FIELD = "assignee"
-
-_SLUG_STRIP = re.compile(r"[^a-z0-9]+")
-
-#: Longest slug taken from a task's title, before any de-duplicating suffix.
-SLUG_MAX = 48
-
-
-def slugify(title: str) -> str:
-    """A stable, readable key fragment for a task title.
-
-    Deterministic, so re-compiling an unchanged task lands on the row it
-    already has rather than opening a second one beside it.
+    A compiled row is born inside a negotiation, so the negotiation is the
+    thread it starts life in — the row does not need one minted for it.
     """
-    slug = _SLUG_STRIP.sub("-", title.casefold()).strip("-")[:SLUG_MAX].strip("-")
-    return slug or "task"
+    message = envelope.header.message
+    return message.episode if message is not None else None
 
 
 def _assignments_from(envelope: L9) -> dict[str, str]:
@@ -154,8 +133,9 @@ class TaskSyncEngine:
     async def compile_and_write(self, room: str, envelope: L9) -> list[str]:
         """Compile the verdict into ``work/`` rows and return the keys written."""
         assignments = _assignments_from(envelope)
+        episode = _episode_from(envelope)
         tasks = await self._compile(room, assignments)
-        written = [await self._write_task(room, t) for t in tasks]
+        written = [await self._write_task(room, t, episode) for t in tasks]
         logger.info("compiled %d task row(s) for room %s", len(written), room)
         return written
 
@@ -180,13 +160,16 @@ class TaskSyncEngine:
             )
             return task_compiler.fallback_tasks(assignments)
 
-    async def _write_task(self, room: str, task: CompiledTask) -> str:
-        """Put one task in the room as a ``work/`` row.
+    async def _write_task(self, room: str, task: CompiledTask, episode: str | None) -> str:
+        """Put one task in the room as a ``work/`` row, bound to its episode.
 
         An unchanged task re-compiles to the same key, so this is an upsert onto
         the row it already has. Its ``status`` is deliberately left alone on a
         rewrite: a re-negotiation that restates a task nobody has touched must
-        not re-open one somebody already moved.
+        not re-open one somebody already moved. Its ``episode`` is likewise the
+        row's own — a later verdict must not move the row off the conversation
+        that produced it. The binding is write-once in the store, so passing this
+        verdict's episode is only ever an offer.
         """
         from app.routes.memory import upsert_memories
         from app.schemas import MemoryBatchCreate, MemoryCreate
@@ -211,5 +194,6 @@ class TaskSyncEngine:
                     )
                 ]
             ),
+            system={EPISODE_META: episode} if episode else None,
         )
         return key

--- a/fastapi-backend/app/services/units.py
+++ b/fastapi-backend/app/services/units.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""A unit of work, and the thread it is worked in.
+
+A ``work/`` row is the unit: one board row, one thing to do, with its own
+custody and status.  This module binds that row to an **episode URN** — a tag
+over the room's existing channel, not a new one — so the same row is also the
+thread the coordination about it happens in.  Nothing new is stored to make that
+true: the URN is one frontmatter key on the memory the row already is.
+
+Two properties everything downstream reads off this module:
+
+**The container outlives what happens inside it.**  A unit's episode is minted
+when the unit is created, not when someone argues about it.  A negotiation
+inside a unit is its own, later episode with its own lifecycle
+(:class:`~app.services.l9_slim.EpisodeLifecycle`), and closing or aborting one
+touches neither the row's custody nor its status.  A unit can be created,
+claimed, worked and resolved with no negotiation ever opened.
+
+**Binding happens once.**  The URN is minted on the write that creates the unit
+and carried forward by every later write
+(:data:`~app.services.filesystem.SYSTEM_META`), so a row's thread is stable for
+the row's life.  Re-negotiating inside a unit opens a *new* negotiation episode;
+it does not re-mint the unit's own.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from app.services import l9
+from app.services.filesystem import (
+    EPISODE_META,
+    get_room_dir,
+    list_memory_files,
+    read_memory_file,
+    serialize_memory,
+    system_meta,
+)
+
+if TYPE_CHECKING:
+    from app.schemas import MemoryRead
+
+logger = logging.getLogger(__name__)
+
+#: The namespace a unit of work lives in — the one the board leases against.
+WORK_NAMESPACE = "work"
+
+#: What a board row calls a unit of work.  Written explicitly because the
+#: projection's default for this namespace is "concern" — a unit is an action.
+TASK_KIND = "action"
+
+#: Who a unit is *meant for*, which is not who holds it.
+#:
+#: Deliberately not ``owner``: that is the lease's, and a lease is something an
+#: actor takes under rules a compiler or a creation call cannot satisfy — no
+#: claim window, no renewal, and nobody on the other end who has agreed to hold
+#: anything.  An assignment written as custody would be a claim on behalf of an
+#: agent that never made one, and it would drain to "expired" the moment its TTL
+#: passed.
+ASSIGNEE_FIELD = "assignee"
+
+#: Longest slug taken from a unit's title, before any de-duplicating suffix.
+SLUG_MAX = 48
+
+_SLUG_STRIP = re.compile(r"[^a-z0-9]+")
+
+#: Frontmatter :func:`serialize_memory` writes from its own arguments; passing
+#: it through ``extra_meta`` as well would write each of those keys twice.
+_REWRITTEN_META = frozenset({"key", "created_by", "updated_by", "version", "tags"})
+
+
+def slugify(title: str) -> str:
+    """A stable, readable key fragment for a unit's title.
+
+    Deterministic, so re-compiling an unchanged task lands on the row it already
+    has rather than opening a second one beside it.
+    """
+    slug = _SLUG_STRIP.sub("-", title.casefold()).strip("-")[:SLUG_MAX].strip("-")
+    return slug or "task"
+
+
+def mint_episode_id() -> str:
+    """A fresh episode id: the short half of a URN, and what a reader types."""
+    return uuid.uuid4().hex[:8]
+
+
+def mint_episode_urn(room: str) -> str:
+    """A fresh episode URN over ``room``'s own channel."""
+    return l9.episode_urn(room, mint_episode_id())
+
+
+def short_id_of(episode: str) -> str:
+    """The trailing short id of an episode URN."""
+    return episode.rsplit(":", 1)[-1]
+
+
+def episode_of(room: str, key: str) -> str | None:
+    """The episode URN bound to a row, or ``None`` when it has no thread."""
+    found = read_memory_file(get_room_dir(room), key)
+    if found is None:
+        return None
+    return system_meta(found[0]).get(EPISODE_META)
+
+
+def bound_episodes(room: str) -> set[str]:
+    """Every episode URN some row in the room already carries.
+
+    What tells a unit's thread from an *orphaned* episode — one no row is bound
+    to, which stays a row of its own rather than being hidden or deleted.
+    """
+    urns: set[str] = set()
+    for _key, meta, _content in list_memory_files(get_room_dir(room)):
+        urn = system_meta(meta).get(EPISODE_META)
+        if isinstance(urn, str) and urn:
+            urns.add(urn)
+    return urns
+
+
+async def bind_episode(room: str, key: str, *, episode: str | None = None) -> str:
+    """Bind ``key`` to a thread, minting one unless it already has one.
+
+    Idempotent: a row that is already bound keeps the URN it has, so a
+    coordination step that binds on its way in is safe however often it is
+    retried, and a second negotiation never moves a unit's thread.
+    """
+    existing = episode_of(room, key)
+    if existing:
+        return existing
+    found = read_memory_file(get_room_dir(room), key)
+    if found is None:
+        raise KeyError(key)
+    meta, content = found
+    urn = episode or mint_episode_urn(room)
+
+    from app.routes.memory import _reconstruct_value, upsert_memories
+    from app.schemas import MemoryBatchCreate, MemoryCreate
+
+    await upsert_memories(
+        room,
+        MemoryBatchCreate(
+            items=[
+                MemoryCreate(
+                    key=key,
+                    value=_reconstruct_value(meta, content),
+                    content_text=content or None,
+                    # The prose is untouched, so the stored vector is carried
+                    # forward rather than paying for an identical re-embed.
+                    embed=False,
+                    created_by=meta.get("updated_by")
+                    or meta.get("created_by")
+                    or l9.SYSTEM_ACTOR_ID,
+                )
+            ]
+        ),
+        system={EPISODE_META: urn},
+    )
+    return urn
+
+
+async def create_unit(
+    room: str,
+    title: str,
+    *,
+    created_by: str,
+    key: str | None = None,
+    meta: dict[str, Any] | None = None,
+) -> MemoryRead:
+    """Create a unit of work board-first, with its thread already minted.
+
+    The row comes first and any coordination inside it is optional, so putting
+    something on the board takes no negotiation to converge first.
+    """
+    from app.routes.memory import upsert_memories
+    from app.schemas import MemoryBatchCreate, MemoryCreate
+
+    row_key = key or f"{WORK_NAMESPACE}/{slugify(title)}"
+    fields: dict[str, Any] = {"kind": TASK_KIND, "status": "open", **(meta or {})}
+    written = await upsert_memories(
+        room,
+        MemoryBatchCreate(
+            items=[MemoryCreate(key=row_key, value=title, created_by=created_by, meta=fields)]
+        ),
+        system={EPISODE_META: mint_episode_urn(room)},
+    )
+    return written[0]
+
+
+def backfill_room(room: str) -> int:
+    """Mint a thread for every ``work/`` row that carries none, in place.
+
+    Written straight to the file: minting a URN records where a row's thread
+    *is*, so it must not bump the version, re-date ``updated_at`` or broadcast a
+    write, which is what the upsert would do — announcing a change nobody made
+    and shuffling every stale row to the top of a time-ordered board.  Returns
+    how many rows were bound.
+    """
+    base = get_room_dir(room)
+    bound = 0
+    for key, meta, content in list_memory_files(base, prefix=f"{WORK_NAMESPACE}/"):
+        if system_meta(meta).get(EPISODE_META):
+            continue
+        # Everything serialize_memory does not write from its own arguments,
+        # timestamps included, so the URN is the only thing that changes.
+        extra = {k: v for k, v in meta.items() if k not in _REWRITTEN_META}
+        extra[EPISODE_META] = mint_episode_urn(room)
+        (base / f"{key}.md").write_text(
+            serialize_memory(
+                content,
+                key=meta.get("key", key),
+                created_by=meta.get("created_by", l9.SYSTEM_ACTOR_ID),
+                updated_by=meta.get("updated_by"),
+                version=meta.get("version", 1),
+                tags=meta.get("tags"),
+                extra_meta=extra,
+            ),
+            encoding="utf-8",
+        )
+        bound += 1
+    if bound:
+        logger.info("bound %d pre-existing work row(s) in %s to a thread", bound, room)
+    return bound

--- a/fastapi-backend/tests/test_l9_episode.py
+++ b/fastapi-backend/tests/test_l9_episode.py
@@ -10,7 +10,7 @@ import pytest
 from app.services import l9_episode
 
 
-def _open() -> l9_episode.EpisodeState:
+def _open() -> l9_episode.NegotiationState:
     return l9_episode.open_episode(
         parent_room="sprint",
         short_id="abc123",

--- a/fastapi-backend/tests/test_l9_slim.py
+++ b/fastapi-backend/tests/test_l9_slim.py
@@ -182,6 +182,34 @@ def test_membership_change_with_no_active_episode_adopts_baseline():
     assert lc.on_membership_change({"agent-a"}) is False
 
 
+def test_a_unit_s_thread_outlives_a_membership_change():
+    """A unit of work is an episode too, and freezing membership is not its rule.
+
+    L9's stable-membership rule exists because an offer/counter exchange scored
+    across a changing set of participants means nothing. A container has no such
+    problem — so someone joining the room must not end the thread a board row's
+    history lives in.
+    """
+    lc = l9_slim.EpisodeLifecycle()
+    lc.open("urn:ioc:mycelium:episode:r:unit", {"agent-a"}, negotiation=False)
+    assert lc.active is True
+    assert lc.frozen is False
+    assert lc.on_membership_change({"agent-a", "agent-b"}) is False
+    assert lc.active is True
+    assert lc.episode == "urn:ioc:mycelium:episode:r:unit"
+
+
+def test_a_negotiation_is_what_freezes_membership():
+    lc = l9_slim.EpisodeLifecycle()
+    lc.open("urn:ioc:mycelium:episode:r:s", {"agent-a"})
+    assert lc.frozen is True
+    lc.close()
+    assert lc.frozen is False
+    # Closing restores the default, so the next open is a negotiation unless it
+    # says otherwise — a container must be asked for, never inherited.
+    assert lc.negotiation is True
+
+
 def test_episode_abort_envelope_is_rejected_commit():
     env = l9_slim.build_episode_abort_envelope(
         "urn:ioc:mycelium:episode:r:s",

--- a/fastapi-backend/tests/test_task_sync.py
+++ b/fastapi-backend/tests/test_task_sync.py
@@ -17,8 +17,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.services import l9, task_sync
-from app.services.filesystem import get_room_dir, read_memory_file
+from app.services import l9, task_sync, units
+from app.services.filesystem import EPISODE_META, get_room_dir, read_memory_file
 from app.services.l9_models import L9, Kind
 from app.services.task_compiler import CompiledTask
 from tests.fakes import FakeManager
@@ -61,16 +61,16 @@ async def _run(room: str, tasks: list[CompiledTask] | Exception, assignments: di
 
 class TestSlugify:
     def test_is_readable_and_stable(self):
-        assert task_sync.slugify("Ship the auth rewrite") == "ship-the-auth-rewrite"
+        assert units.slugify("Ship the auth rewrite") == "ship-the-auth-rewrite"
 
     def test_collapses_punctuation(self):
-        assert task_sync.slugify("Ship auth (v2) — now!") == "ship-auth-v2-now"
+        assert units.slugify("Ship auth (v2) — now!") == "ship-auth-v2-now"
 
     def test_never_returns_an_empty_key(self):
-        assert task_sync.slugify("!!!") == "task"
+        assert units.slugify("!!!") == "task"
 
     def test_is_bounded(self):
-        assert len(task_sync.slugify("x" * 200)) <= task_sync.SLUG_MAX
+        assert len(units.slugify("x" * 200)) <= units.SLUG_MAX
 
 
 @pytest.mark.asyncio
@@ -89,7 +89,7 @@ class TestConvergedToRows:
     async def test_a_row_carries_what_makes_it_a_row(self):
         await _run("r2", [CompiledTask(title="ship auth", assignee="a")], {"a": "auth"})
         meta, body = _row("r2", "work/ship-auth")
-        assert meta["kind"] == task_sync.TASK_KIND
+        assert meta["kind"] == units.TASK_KIND
         assert meta["status"] == "open"
         assert "ship auth" in body
 
@@ -99,14 +99,14 @@ class TestConvergedToRows:
         # nobody made, and it would drain to "expired" on its own.
         await _run("r3", [CompiledTask(title="ship auth", assignee="a")], {"a": "auth"})
         meta, _ = _row("r3", "work/ship-auth")
-        assert meta[task_sync.ASSIGNEE_FIELD] == "@a"
+        assert meta[units.ASSIGNEE_FIELD] == "@a"
         assert "owner" not in meta
         assert "custody" not in meta
 
     async def test_an_untagged_task_names_nobody(self):
         await _run("r4", [CompiledTask(title="ship auth", assignee=None)], {"a": "auth"})
         meta, _ = _row("r4", "work/ship-auth")
-        assert task_sync.ASSIGNEE_FIELD not in meta
+        assert units.ASSIGNEE_FIELD not in meta
 
     async def test_a_recompiled_task_lands_on_the_row_it_already_has(self):
         task = [CompiledTask(title="ship auth", assignee="a")]
@@ -115,6 +115,40 @@ class TestConvergedToRows:
         assert keys == ["work/ship-auth"]
         meta, _ = _row("r5", "work/ship-auth")
         assert meta["version"] == 2  # an upsert, not a second row
+
+    async def test_a_row_is_bound_to_the_episode_it_was_agreed_in(self):
+        # The keystone: a compiled row is born inside a negotiation, so that
+        # negotiation is the thread the row starts life in. Read off the
+        # envelope's own header rather than minted, so work → episode → messages
+        # round-trips back to the conversation that produced it.
+        await _run("r6", [CompiledTask(title="ship auth", assignee="a")], {"a": "auth"})
+        meta, _ = _row("r6", "work/ship-auth")
+        assert meta[EPISODE_META] == l9.episode_urn("r", "live")
+
+    async def test_a_re_negotiation_does_not_move_a_row_off_its_thread(self):
+        # A row's thread is where its history is. A later verdict that restates
+        # the task must leave the binding alone, or the row loses the argument
+        # that produced it.
+        task = [CompiledTask(title="ship auth", assignee="a")]
+        await _run("r7", task, {"a": "auth"})
+        first = _row("r7", "work/ship-auth")[0][EPISODE_META]
+        mgr = FakeManager()
+        engine = task_sync.TaskSyncEngine(mgr)  # type: ignore[arg-type]
+        later = l9.build_envelope(
+            kind=Kind.commit,
+            subkind="converged",
+            episode=l9.episode_urn("r", "second"),
+            recipients=["a"],
+            topic=l9.topic_urn("r"),
+            payload_type="consensus",
+            payload_data={"assignments": {"a": "auth"}},
+        )
+        with (
+            patch.object(task_sync.task_compiler, "compile_tasks", AsyncMock(return_value=task)),
+            patch("app.routes.memory.embed_text", return_value=[0.0]),
+        ):
+            await engine.compile_and_write("r7", later)
+        assert _row("r7", "work/ship-auth")[0][EPISODE_META] == first
 
     async def test_a_rewrite_does_not_reopen_work_somebody_moved(self):
         # A re-negotiation that restates an untouched task must not undo a

--- a/fastapi-backend/tests/test_units.py
+++ b/fastapi-backend/tests/test_units.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""A unit of work is a board row and a thread — the binding, and what it survives.
+
+``work/`` rows carry the episode URN their coordination happens in. These tests
+hold the three properties the rest of the model rests on: the binding survives
+every later write, it is the store's alone to set, and a unit can be created and
+worked with no episode ever opened.
+"""
+
+import pytest
+
+from app.routes.memory import upsert_memories
+from app.schemas import MemoryBatchCreate, MemoryCreate
+from app.services import fields, units
+from app.services.filesystem import EPISODE_META, get_room_dir, read_memory_file
+
+
+@pytest.fixture(autouse=True)
+def _no_embedding(monkeypatch):
+    """Rows are written without a model; the vector is not what is under test."""
+    monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+
+
+def _room(name: str) -> str:
+    """A room is a folder; making it is all a write needs."""
+    get_room_dir(name)
+    return name
+
+
+def _meta(room: str, key: str) -> dict:
+    found = read_memory_file(get_room_dir(room), key)
+    assert found is not None, f"expected a row at {key}"
+    return found[0]
+
+
+async def _write(room: str, key: str, value: str, **meta) -> None:
+    await upsert_memories(
+        room,
+        MemoryBatchCreate(
+            items=[MemoryCreate(key=key, value=value, created_by="tester", meta=meta or None)]
+        ),
+    )
+
+
+class TestMinting:
+    def test_a_urn_is_scoped_to_its_room(self):
+        assert units.mint_episode_urn("atlas").startswith("urn:ioc:mycelium:episode:atlas:")
+
+    def test_every_mint_is_a_distinct_thread(self):
+        assert units.mint_episode_urn("atlas") != units.mint_episode_urn("atlas")
+
+    def test_the_short_id_is_the_tail_a_reader_types(self):
+        urn = units.mint_episode_urn("atlas")
+        assert units.short_id_of(urn) == urn.rsplit(":", 1)[-1]
+
+
+@pytest.mark.asyncio
+class TestBoardFirstCreation:
+    async def test_a_unit_is_born_with_a_thread(self):
+        room = _room("u-create")
+        written = await units.create_unit(room, "Ship passkey login", created_by="julia")
+        assert written.key == "work/ship-passkey-login"
+        assert written.episode
+        assert _meta(room, written.key)[EPISODE_META] == written.episode
+
+    async def test_a_unit_is_open_work_nobody_negotiated_for(self):
+        # The inversion: today a work/ row exists only because a negotiation
+        # converged into one. A unit needs no episode to have *happened*.
+        room = _room("u-create-2")
+        written = await units.create_unit(room, "Ship passkey login", created_by="julia")
+        meta = _meta(room, written.key)
+        assert meta["status"] == "open"
+        assert meta["kind"] == units.TASK_KIND
+        assert "owner" not in meta and "custody" not in meta
+
+    async def test_two_units_are_two_rows(self):
+        room = _room("u-create-3")
+        one = await units.create_unit(room, "Ship passkey login", created_by="julia")
+        two = await units.create_unit(room, "Rotate the signing keys", created_by="julia")
+        assert one.key != two.key
+        assert one.episode != two.episode
+
+
+@pytest.mark.asyncio
+class TestTheBindingSurvives:
+    async def test_a_later_write_keeps_the_thread(self):
+        room = _room("u-survive")
+        written = await units.create_unit(room, "Ship passkey login", created_by="julia")
+        await _write(room, written.key, "Ship passkey login, revised", priority="high")
+        meta = _meta(room, written.key)
+        assert meta[EPISODE_META] == written.episode
+        assert meta["priority"] == "high"
+
+    async def test_a_field_write_keeps_the_thread(self):
+        # The board's own verb path. Without the carry-forward this is where a
+        # binding evaporated: the first claim on a row unbound it from its thread.
+        room = _room("u-survive-2")
+        written = await units.create_unit(room, "Ship passkey login", created_by="julia")
+        await fields.write(room, written.key, {"status": "in_review"}, "julia")
+        meta = _meta(room, written.key)
+        assert meta[EPISODE_META] == written.episode
+        assert meta["status"] == "in_review"
+
+    async def test_the_thread_is_the_store_s_to_set_not_a_caller_s(self):
+        room = _room("u-survive-3")
+        written = await units.create_unit(room, "Ship passkey login", created_by="julia")
+        await _write(room, written.key, "Ship passkey login", episode="urn:someone:else")
+        assert _meta(room, written.key)[EPISODE_META] == written.episode
+
+    async def test_the_thread_is_not_in_the_meta_bag(self):
+        # It is store-owned, so it reads back as its own field rather than as
+        # something ``MemoryCreate.meta`` could have written.
+        room = _room("u-survive-4")
+        written = await units.create_unit(room, "Ship passkey login", created_by="julia")
+        assert EPISODE_META not in (written.meta or {})
+        assert written.episode
+
+    async def test_a_write_outside_the_system_keys_is_refused(self):
+        room = _room("u-survive-5")
+        with pytest.raises(ValueError, match="system meta"):
+            await upsert_memories(
+                room,
+                MemoryBatchCreate(
+                    items=[MemoryCreate(key="work/x", value="x", created_by="julia")]
+                ),
+                system={"owner": "@julia"},
+            )
+
+
+@pytest.mark.asyncio
+class TestBinding:
+    async def test_binding_mints_for_a_row_that_has_none(self):
+        room = _room("u-bind")
+        await _write(room, "work/legacy", "An older row")
+        urn = await units.bind_episode(room, "work/legacy")
+        assert _meta(room, "work/legacy")[EPISODE_META] == urn
+
+    async def test_the_binding_is_write_once_even_from_the_system_seam(self):
+        # The store, not the caller, is what makes the binding stick: a second
+        # writer offering a different thread gets the row's own back.
+        room = _room("u-bind-5")
+        written = await units.create_unit(room, "Ship passkey login", created_by="julia")
+        await upsert_memories(
+            room,
+            MemoryBatchCreate(
+                items=[
+                    MemoryCreate(key=written.key, value="Ship passkey login", created_by="other")
+                ]
+            ),
+            system={EPISODE_META: "urn:ioc:mycelium:episode:elsewhere:zzz"},
+        )
+        assert _meta(room, written.key)[EPISODE_META] == written.episode
+
+    async def test_binding_twice_does_not_move_the_thread(self):
+        # Re-negotiating inside a unit opens a NEW negotiation episode; it must
+        # not re-point the row at it, or the row loses its own history.
+        room = _room("u-bind-2")
+        await _write(room, "work/legacy", "An older row")
+        first = await units.bind_episode(room, "work/legacy")
+        again = await units.bind_episode(room, "work/legacy", episode="urn:a:different:one")
+        assert again == first
+
+    async def test_binding_an_absent_row_says_so(self):
+        room = _room("u-bind-3")
+        with pytest.raises(KeyError):
+            await units.bind_episode(room, "work/nothing-here")
+
+    async def test_bound_episodes_is_what_tells_an_orphan_from_a_unit(self):
+        room = _room("u-bind-4")
+        written = await units.create_unit(room, "Ship passkey login", created_by="julia")
+        assert units.bound_episodes(room) == {written.episode}
+
+
+@pytest.mark.asyncio
+class TestMigration:
+    async def test_a_row_written_before_the_binding_gets_a_thread(self):
+        room = _room("u-migrate")
+        await _write(room, "work/legacy", "An older row")
+        assert units.backfill_room(room) == 1
+        assert _meta(room, "work/legacy")[EPISODE_META]
+
+    async def test_minting_is_not_an_edit_anybody_made(self):
+        # Going through the upsert would bump the version, re-date updated_at and
+        # broadcast a write nobody made — shuffling every stale row to the top of
+        # a time-ordered board on the first restart after the upgrade.
+        room = _room("u-migrate-2")
+        await _write(room, "work/legacy", "An older row", status="in_review")
+        before = _meta(room, "work/legacy")
+        units.backfill_room(room)
+        after = _meta(room, "work/legacy")
+        assert after["version"] == before["version"]
+        assert after["updated_at"] == before["updated_at"]
+        assert after["created_at"] == before["created_at"]
+        assert after["status"] == "in_review"
+
+    async def test_a_second_pass_binds_nothing(self):
+        room = _room("u-migrate-3")
+        await _write(room, "work/legacy", "An older row")
+        units.backfill_room(room)
+        bound = _meta(room, "work/legacy")[EPISODE_META]
+        assert units.backfill_room(room) == 0
+        assert _meta(room, "work/legacy")[EPISODE_META] == bound
+
+    async def test_only_units_are_bound(self):
+        # A decision is not a unit of work; nothing is coordinated *inside* it.
+        room = _room("u-migrate-4")
+        await _write(room, "decisions/db", "PostgreSQL")
+        assert units.backfill_room(room) == 0
+        assert EPISODE_META not in _meta(room, "decisions/db")

--- a/mycelium-cli/src/mycelium/board/model.py
+++ b/mycelium-cli/src/mycelium/board/model.py
@@ -41,6 +41,23 @@ LENS_OF_STATUS = {
 
 LIVE_NAMESPACES = ["decisions", "status", "work", "failed"]
 
+#: The store-owned frontmatter key binding a row to its thread. Minted by the
+#: backend and carried across writes, so a row's thread is stable for its life.
+EPISODE_FIELD = "episode"
+
+#: What a row says about the thread inside it. Deliberately its own names: a
+#: unit's ``status`` and ``custody`` are the unit's, so a negotiation that
+#: converges inside a row must not resolve the row or take it off its holder.
+THREAD_FIELDS = ["episode", "thread", "thread_state", "participants", "rounds"]
+
+#: How the thread inside a unit reads. ``open`` while it is still running;
+#: the rest are the commit subkinds a negotiation closes on.
+THREAD_STATES = ["open", "converged", "resolved", "rejected", "committed"]
+
+#: The row's own axes, which folding a thread onto it must never write. This is
+#: the container-outlives-the-negotiation rule as a list.
+UNIT_FIELDS = ["status", "custody", "owner", "kind", "priority"]
+
 
 @dataclass(frozen=True)
 class ItemSource:

--- a/mycelium-cli/src/mycelium/board/projection.py
+++ b/mycelium-cli/src/mycelium/board/projection.py
@@ -6,6 +6,16 @@
 Nothing here is a new store: episodes, memories and presence are
 read where they live and flattened into one row shape.  The board is a lens on
 the room, so a row can't be stale relative to the thing it describes.
+
+**One row per unit of work.**  A row and the thread its coordination happens in
+are the same object, bound by the ``episode`` key the store puts on the row's
+memory, so a unit and its episode fold into one row rather than sitting beside
+each other as two.  The thread's state lands under
+:data:`~mycelium.board.model.THREAD_FIELDS` and never on the row's own axes:
+closing a negotiation inside a unit must not resolve the unit or take it off
+whoever is holding it.  An episode no row is bound to is an **orphan** — it keeps
+a row of its own, because a recorded negotiation nobody compiled into work is
+still something the room did.
 """
 
 from __future__ import annotations
@@ -14,7 +24,7 @@ from datetime import datetime
 from typing import Any
 
 from mycelium.board import custody
-from mycelium.board.model import LIVE_NAMESPACES, ItemSource, LiveItem
+from mycelium.board.model import EPISODE_FIELD, LIVE_NAMESPACES, ItemSource, LiveItem
 
 
 def _pretty_topic(topic: str) -> str:
@@ -36,6 +46,8 @@ def _episode_item(episode: dict) -> LiveItem:
         ),
         source=ItemSource("episode", f"episode {episode.get('short_id')}"),
         fields={
+            EPISODE_FIELD: episode.get("episode"),
+            "thread": episode.get("short_id"),
             # A rejected negotiation is not a stage called "blocked" — nothing is
             # blocking it, it failed and wants a human. It reads open, and the
             # kind carries what happened.
@@ -105,6 +117,12 @@ def _memory_item(memory: dict) -> LiveItem:
     meta = memory.get("meta")
     if isinstance(meta, dict):
         fields.update(meta)
+    # The binding is store-owned, so it arrives as its own field rather than in
+    # the meta bag a caller can write.
+    episode = memory.get(EPISODE_FIELD)
+    if isinstance(episode, str) and episode:
+        fields[EPISODE_FIELD] = episode
+        fields["thread"] = episode.rsplit(":", 1)[-1]
     return LiveItem(
         id=f"memory:{key}", title=title or key, source=ItemSource("memory", key), fields=fields
     )
@@ -142,6 +160,20 @@ def _agent_item(agent: dict, presence: dict, now: str) -> LiveItem:
     )
 
 
+def _thread_fields(episode: dict) -> dict[str, Any]:
+    """What a unit's row says about the thread inside it.
+
+    Never the row's own axes (:data:`~mycelium.board.model.UNIT_FIELDS`) — a
+    converged negotiation is a fact about the conversation, not a claim that the
+    work is done or that anyone is holding it.
+    """
+    return {
+        "thread_state": episode.get("subkind") or episode.get("outcome") or "open",
+        "participants": episode.get("participants") or [],
+        "rounds": episode.get("message_count"),
+    }
+
+
 def project_items(
     *,
     episodes: list[dict],
@@ -153,12 +185,24 @@ def project_items(
     stamp = now.isoformat()
     items: list[LiveItem] = []
 
-    for episode in episodes:
-        items.append(_episode_item(episode))
-    for memory in memories:
-        namespace = memory.get("key", "").split("/")[0]
-        if namespace in LIVE_NAMESPACES:
-            items.append(_memory_item(memory))
+    rows = [
+        _memory_item(memory)
+        for memory in memories
+        if memory.get("key", "").split("/")[0] in LIVE_NAMESPACES
+    ]
+    # A unit folds in its thread; what nothing folded is an orphan episode, which
+    # keeps its own row rather than being hidden.
+    by_urn = {str(e.get("episode")): e for e in episodes if e.get("episode")}
+    folded: set[str] = set()
+    for row in rows:
+        episode = by_urn.get(str(row.fields.get(EPISODE_FIELD)))
+        if episode is None:
+            continue
+        folded.add(str(episode.get("episode")))
+        row.fields.update(_thread_fields(episode))
+
+    items += [_episode_item(e) for e in episodes if str(e.get("episode")) not in folded]
+    items += rows
 
     # A resident agent is a peer, so it holds a row like anyone else.  A merely
     # registered one doesn't: a board of things that need steering shouldn't

--- a/mycelium-cli/src/mycelium/docs/concepts/board.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/board.md
@@ -37,8 +37,32 @@ resident right now. Every row says where it came from, and clicking through
 takes you to the real thing rather than a copy of it.
 
 That means there's no second place to keep up to date. Resolve a task and
-its row resolves. End a negotiation and its decision row closes. Nothing to
-groom, and nothing that can quietly disagree with the room it describes.
+its row resolves. Nothing to groom, and nothing that can quietly disagree with
+the room it describes.
+
+## A row is a unit of work, and a unit of work is a thread
+
+A `work/` row carries the episode URN of the thread its coordination happens in.
+The row and the thread are one object, so the board draws one row per unit — the
+negotiation that produced a task shows up *on* that task (`thread`,
+`thread_state`, who was at the table, how many rounds) rather than beside it as a
+second row.
+
+The URN is the store's: it is minted when the unit is created, it survives every
+later write, and no `memory set --meta` or board verb can set or move it. A unit
+is therefore bound to one thread for its whole life — a second negotiation about
+the same work opens its own episode, and the row stays pointed at the
+conversation that produced it.
+
+**The unit outlives what happens inside it.** A thread's state never writes the
+row's own axes. Converging inside a unit does not resolve the unit, aborting a
+negotiation does not take the row off whoever is holding it, and a unit can be
+created, claimed, worked and resolved with no negotiation ever opened. That is
+the whole point of the separation: a negotiation is one optional thing that can
+happen inside a piece of work, not the reason the work exists.
+
+A negotiation nobody compiled into work has no unit to fold into, so it keeps a
+row of its own — a recorded negotiation is still something the room did.
 
 ## Three lenses
 
@@ -327,5 +351,6 @@ nobody writing that down.
 
 ## Related
 
-- [episodes](#episodes): a negotiation, which appears as a decision row.
+- [episodes](#episodes): the thread inside a unit — folded onto its row, or a
+  row of its own when no work came out of it.
 - [memory](#memory): where a row's fields actually live.

--- a/mycelium-cli/tests/test_board.py
+++ b/mycelium-cli/tests/test_board.py
@@ -48,6 +48,19 @@ class TestVocabularyContract:
     def test_live_namespaces_match_the_contract(self):
         assert CONTRACT["live_namespaces"] == model.LIVE_NAMESPACES
 
+    def test_folds_a_thread_under_exactly_the_contracted_field_names(self):
+        unit_contract = CONTRACT["unit"]
+        assert unit_contract["binding_field"] == model.EPISODE_FIELD
+        assert unit_contract["thread_fields"] == model.THREAD_FIELDS
+        assert unit_contract["thread_states"] == model.THREAD_STATES
+        assert unit_contract["unit_fields"] == model.UNIT_FIELDS
+
+    def test_a_thread_never_writes_one_of_the_unit_s_own_axes(self):
+        # The container-outlives-the-negotiation rule, asserted as a
+        # disjointness rather than promised in a comment.
+        unit_contract = CONTRACT["unit"]
+        assert not set(unit_contract["thread_fields"]) & set(unit_contract["unit_fields"])
+
     def test_infers_the_type_the_contract_names_for_every_case(self):
         """The same table the GUI suite runs. These two classifiers drifted once,
         so neither may answer differently about the same frontmatter again."""
@@ -216,6 +229,93 @@ class TestProjection:
         row = next(r for r in self.project(episodes=episodes) if r.id.startswith("episode:"))
         assert row.kind == "decision"
         assert row.title.startswith("atlas migration: negotiating")
+
+
+URN = "urn:ioc:mycelium:episode:atlas:e4f1a2"
+
+EPISODE = {
+    "short_id": "e4f1a2",
+    "episode": URN,
+    "topic": "urn:concept:mycelium:atlas",
+    "outcome": "converged",
+    "subkind": "converged",
+    "participants": ["growth", "risk"],
+    "message_count": 7,
+    "updated_at": "2026-08-22T10:00:00Z",
+}
+
+
+def unit(**extra) -> dict:
+    return {
+        "key": "work/cutover",
+        "value": "run the cutover",
+        "updated_at": "2026-08-22T10:00:00Z",
+        "updated_by": "aligner",
+        "episode": URN,
+        "meta": {"kind": "action", "status": "open", **extra},
+    }
+
+
+class TestUnitOfWork:
+    """A unit of work is one row, and it is a thread.
+
+    The GUI runs the same six cases over its own projection; neither surface may
+    start drawing a unit and its thread as two rows without the other.
+    """
+
+    def project(self, episodes: list[dict], memories: list[dict]) -> list[LiveItem]:
+        return project_items(episodes=episodes, memories=memories, agents=[], members=[], now=NOW)
+
+    def test_folds_a_bound_episode_into_the_row_instead_of_a_second_one(self):
+        rows = self.project([EPISODE], [unit()])
+        assert [r.id for r in rows] == ["memory:work/cutover"]
+        assert rows[0].fields["episode"] == URN
+        assert rows[0].fields["thread"] == "e4f1a2"
+        assert rows[0].fields["thread_state"] == "converged"
+        assert rows[0].fields["participants"] == ["growth", "risk"]
+        assert rows[0].fields["rounds"] == 7
+
+    def test_a_closing_thread_leaves_the_unit_s_own_axes_alone(self):
+        # The container outlives the negotiation. A converged episode is a fact
+        # about the conversation, not a claim that the work is done or that
+        # anyone is holding it.
+        held = {
+            "custody": "held",
+            "owner": "@growth",
+            "claimed_at": "2026-08-22T11:55:00Z",
+            "ttl_minutes": 30,
+        }
+        row = self.project([EPISODE], [unit(**held)])[0]
+        assert row.status == "open"
+        assert row.owner == "growth"
+        assert custody.custody_of(row, NOW) == "held"
+
+    def test_an_orphaned_episode_keeps_a_row_of_its_own(self):
+        # A recorded negotiation nobody compiled into work is still something
+        # the room did, so it is surfaced rather than hidden or deleted.
+        rows = self.project([EPISODE], [])
+        assert [r.id for r in rows] == ["episode:e4f1a2"]
+        assert rows[0].fields["episode"] == URN
+
+    def test_every_row_compiled_out_of_one_negotiation_carries_it(self):
+        second = {**unit(), "key": "work/soak"}
+        rows = self.project([EPISODE], [unit(), second])
+        assert [r.id for r in rows] == ["memory:work/cutover", "memory:work/soak"]
+        assert all(r.fields["thread_state"] == "converged" for r in rows)
+
+    def test_a_unit_no_thread_has_run_in_says_nothing_it_does_not_know(self):
+        # The inversion: a unit is created board-first and worked with no episode
+        # ever opened. It carries its binding and claims no thread state.
+        row = self.project([], [unit()])[0]
+        assert row.fields["episode"] == URN
+        assert row.fields["thread"] == "e4f1a2"
+        assert "thread_state" not in row.fields
+        assert "rounds" not in row.fields
+
+    def test_a_row_with_no_binding_is_left_alone(self):
+        row = self.project([], [{**unit(), "episode": None}])[0]
+        assert "episode" not in row.fields
+        assert "thread" not in row.fields
 
 
 class TestSchema:

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -177,6 +177,12 @@ export interface Memory {
   expandable?: boolean;
   /** Frontmatter the store doesn't own — whatever the writer put there. */
   meta?: Record<string, unknown> | null;
+  /**
+   * The episode URN this row's coordination happens in — what makes a unit of
+   * work a thread. Store-owned: minted by the backend, so it is absent from
+   * `meta` and cannot be set by a write.
+   */
+  episode?: string | null;
 }
 
 /** Shape sent to POST /api/rooms/{room}/memory to create or upsert a memory. */

--- a/mycelium-frontend/src/lib/board/board.test.ts
+++ b/mycelium-frontend/src/lib/board/board.test.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { inferSchema, groupableFields } from "@/lib/board/schema";
-import { projectItems } from "@/lib/board/projection";
+import { projectItems, EPISODE_FIELD, THREAD_FIELDS, THREAD_STATES, UNIT_FIELDS } from "@/lib/board/projection";
 import { applyView, filterItems, lensCounts, groupItems, UNGROUPED, DEFAULT_VIEW } from "@/lib/board/view";
 import { CUSTODY_STATES, DEFAULT_TTL_MINUTES, custodyOf } from "@/lib/board/custody";
 import {
@@ -157,6 +157,101 @@ describe("projectItems", () => {
       overlay: { "memory:work/flip-reads-behind-a-flag": { status: "dismissed" } },
     });
     expect(items[0].fields.status).toBe("dismissed");
+  });
+});
+
+describe("a unit of work is one row, and it is a thread", () => {
+  const NOW = "2026-08-22T10:00:00Z";
+  const URN = "urn:ioc:mycelium:episode:atlas:e4f1a2";
+
+  const episode = {
+    short_id: "e4f1a2",
+    episode: URN,
+    topic: "urn:concept:mycelium:atlas",
+    outcome: "converged",
+    subkind: "converged",
+    participants: ["growth", "risk"],
+    metrics: null,
+    assignments: { cutover: "phased" },
+    tasks: ["work/cutover"],
+    message_count: 7,
+    updated_at: NOW,
+    updated_by: "aligner",
+  } as unknown as Parameters<typeof projectItems>[0]["episodes"][number];
+
+  const unit = (extra: Record<string, unknown> = {}) => ({
+    key: "work/cutover",
+    value: "run the cutover",
+    meta: { kind: "action", status: "open", ...extra },
+    version: 1,
+    created_by: "aligner",
+    updated_by: "aligner",
+    updated_at: NOW,
+    episode: URN,
+  }) as unknown as Parameters<typeof projectItems>[0]["memories"][number];
+
+  const project = (episodes: unknown[], memories: unknown[]) =>
+    projectItems({
+      room: "atlas",
+      episodes: episodes as Parameters<typeof projectItems>[0]["episodes"],
+      memories: memories as Parameters<typeof projectItems>[0]["memories"],
+      agents: [],
+      presence: new Map(),
+      now: NOW,
+    });
+
+  it("folds a bound episode into the row instead of drawing a second one", () => {
+    const items = project([episode], [unit()]);
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe("memory:work/cutover");
+    expect(items[0].fields).toMatchObject({
+      episode: URN,
+      thread: "e4f1a2",
+      thread_state: "converged",
+      participants: ["growth", "risk"],
+      rounds: 7,
+    });
+  });
+
+  it("leaves a unit's own axes alone when the thread inside it closes", () => {
+    // The container outlives the negotiation. A converged episode is a fact
+    // about the conversation, not a claim that the work is done or that anyone
+    // is holding it — the row keeps its status, its custody and its holder.
+    const held = { custody: "held", owner: "@growth", claimed_at: NOW, ttl_minutes: 30 };
+    const [row] = project([episode], [unit(held)]);
+    expect(row.fields).toMatchObject({ status: "open", custody: "held", owner: "@growth" });
+    expect(custodyOf(row, Date.parse(NOW))).toBe("held");
+  });
+
+  it("keeps an orphaned episode as a row of its own", () => {
+    // A recorded negotiation nobody compiled into work is still something the
+    // room did, so it is surfaced rather than hidden or deleted.
+    const items = project([episode], []);
+    expect(items.map(i => i.id)).toEqual(["episode:e4f1a2"]);
+    expect(items[0].fields).toMatchObject({ episode: URN, thread: "e4f1a2" });
+  });
+
+  it("gives every row an episode compiled out of the same negotiation", () => {
+    const second = { ...unit(), key: "work/soak" };
+    const items = project([episode], [unit(), second]);
+    expect(items.map(i => i.id)).toEqual(["memory:work/cutover", "memory:work/soak"]);
+    for (const row of items) expect(row.fields.thread_state).toBe("converged");
+  });
+
+  it("draws a unit no thread has run in yet, with no thread state to show", () => {
+    // The inversion: a unit is created board-first and worked with no episode
+    // ever opened. It carries its binding and says nothing it doesn't know.
+    const [row] = project([], [unit()]);
+    expect(row.fields).toMatchObject({ episode: URN, thread: "e4f1a2", status: "open" });
+    expect(row.fields.thread_state).toBeUndefined();
+    expect(row.fields.rounds).toBeUndefined();
+  });
+
+  it("leaves a row with no binding entirely alone", () => {
+    const unbound = { ...unit(), episode: null };
+    const [row] = project([], [unbound]);
+    expect(row.fields.episode).toBeUndefined();
+    expect(row.fields.thread).toBeUndefined();
   });
 });
 
@@ -398,6 +493,23 @@ describe("shared vocabulary contract", () => {
     });
     const written = new Set(out.flatMap(r => Object.keys(r.fields)));
     expect([...written].sort()).toEqual([upstream.field, ...upstream.companion_fields].sort());
+  });
+
+  it("folds a thread onto a row under exactly the contracted field names", () => {
+    const unit = (contract as unknown as {
+      unit: { binding_field: string; thread_fields: string[]; unit_fields: string[]; thread_states: string[] };
+    }).unit;
+    expect(EPISODE_FIELD).toBe(unit.binding_field);
+    expect(THREAD_FIELDS).toEqual(unit.thread_fields);
+    expect(THREAD_STATES).toEqual(unit.thread_states);
+    expect(UNIT_FIELDS).toEqual(unit.unit_fields);
+  });
+
+  it("never lets a thread write one of the unit's own axes", () => {
+    // The container-outlives-the-negotiation rule, asserted as a disjointness
+    // rather than as a promise in a comment.
+    const unit = (contract as unknown as { unit: { thread_fields: string[]; unit_fields: string[] } }).unit;
+    expect(unit.thread_fields.filter(f => unit.unit_fields.includes(f))).toEqual([]);
   });
 
   it("keeps the log's calendar conventions the CLI also asserts", () => {

--- a/mycelium-frontend/src/lib/board/projection.ts
+++ b/mycelium-frontend/src/lib/board/projection.ts
@@ -8,6 +8,15 @@
  * read where they live and flattened into one row shape. The board is a lens on
  * the room, so a row can't be stale relative to the thing it describes, and
  * deleting the board would lose nothing.
+ *
+ * **One row per unit of work.** A row and the thread its coordination happens in
+ * are the same object, bound by the `episode` key the store puts on the row's
+ * memory, so a unit and its episode fold into one row rather than sitting beside
+ * each other as two. The thread's state lands under `THREAD_FIELDS` and never on
+ * the row's own axes: closing a negotiation inside a unit must not resolve the
+ * unit or take it off whoever is holding it. An episode no row is bound to is an
+ * **orphan** — it keeps a row of its own, because a recorded negotiation nobody
+ * compiled into work is still something the room did.
  */
 
 import type { AgentSummary, EpisodeSummary, Memory } from "@/lib/api";
@@ -18,6 +27,31 @@ import { memoryHref } from "@/lib/memory-routes";
 
 /** Namespaces whose memories read as coordination state rather than prose. */
 const LIVE_NAMESPACES = ["decisions", "status", "work", "failed"];
+
+/**
+ * The store-owned frontmatter key binding a row to its thread. Minted by the
+ * backend and carried across writes, so a row's thread is stable for its life.
+ */
+export const EPISODE_FIELD = "episode";
+
+/**
+ * What a row says about the thread inside it. Deliberately its own names: a
+ * unit's `status` and `custody` are the unit's, so a negotiation that converges
+ * inside a row must not resolve the row or take it off its holder.
+ */
+export const THREAD_FIELDS = ["episode", "thread", "thread_state", "participants", "rounds"];
+
+/**
+ * How the thread inside a unit reads. `open` while it is still running; the rest
+ * are the commit subkinds a negotiation closes on.
+ */
+export const THREAD_STATES = ["open", "converged", "resolved", "rejected", "committed"];
+
+/**
+ * The row's own axes, which folding a thread onto it must never write. This is
+ * the container-outlives-the-negotiation rule as a list.
+ */
+export const UNIT_FIELDS = ["status", "custody", "owner", "kind", "priority"];
 
 /** Episode topics arrive as URNs; the board shows the part a person wrote. */
 function prettyTopic(topic: string): string {
@@ -41,6 +75,8 @@ function episodeItem(ep: EpisodeSummary, room: string): LiveItem {
       href: `/room/${encodeURIComponent(room)}?focus=episode:${encodeURIComponent(ep.short_id)}`,
     },
     fields: {
+      [EPISODE_FIELD]: ep.episode,
+      thread: ep.short_id,
       // A rejected negotiation is not a stage called "blocked" — nothing is
       // blocking it, it failed and wants a human. It reads open, and the kind
       // carries what happened.
@@ -114,7 +150,27 @@ function memoryItem(memory: Memory, room: string): LiveItem {
       ...(LEASABLE_NAMESPACES.includes(namespace) ? { [CUSTODY_FIELD]: "unclaimed" } : {}),
       ...custom,
       ...meta,
+      // The binding is store-owned, so it arrives as its own field rather than
+      // in the meta bag a caller can write.
+      ...(memory.episode
+        ? { [EPISODE_FIELD]: memory.episode, thread: memory.episode.split(":").pop() }
+        : {}),
     },
+  };
+}
+
+/**
+ * What a unit's row says about the thread inside it.
+ *
+ * Never the row's own axes (`UNIT_FIELDS`) — a converged negotiation is a fact
+ * about the conversation, not a claim that the work is done or that anyone is
+ * holding it.
+ */
+function threadFields(ep: EpisodeSummary): Record<string, unknown> {
+  return {
+    thread_state: ep.subkind ?? ep.outcome ?? "open",
+    participants: ep.participants,
+    rounds: ep.message_count,
   };
 }
 
@@ -170,11 +226,23 @@ export interface ProjectionInput {
 export function projectItems(input: ProjectionInput): LiveItem[] {
   const items: LiveItem[] = [];
 
-  for (const ep of input.episodes) items.push(episodeItem(ep, input.room));
-  for (const memory of input.memories) {
-    if (!LIVE_NAMESPACES.includes(memory.key.split("/")[0] ?? "")) continue;
-    items.push(memoryItem(memory, input.room));
+  const rows = input.memories
+    .filter(memory => LIVE_NAMESPACES.includes(memory.key.split("/")[0] ?? ""))
+    .map(memory => memoryItem(memory, input.room));
+  // A unit folds in its thread; what nothing folded is an orphan episode, which
+  // keeps its own row rather than being hidden.
+  const byUrn = new Map(input.episodes.map(ep => [ep.episode, ep]));
+  const folded = new Set<string>();
+  for (const row of rows) {
+    const ep = byUrn.get(row.fields[EPISODE_FIELD] as string);
+    if (!ep) continue;
+    folded.add(ep.episode);
+    Object.assign(row.fields, threadFields(ep));
   }
+  for (const ep of input.episodes) {
+    if (!folded.has(ep.episode)) items.push(episodeItem(ep, input.room));
+  }
+  items.push(...rows);
   // Nor does an agent whose lease has drained — a session that went quiet an
   // hour ago is not residency, and a row saying it is would be the board's most
   // expensive lie.

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -70,6 +70,11 @@ export interface MockMemory {
   room_name?: string;
   tags?: string[];
   expandable?: boolean;
+  /** The episode URN binding this row to the thread its coordination happens in
+   *  (`MemoryRead.episode`). Store-owned rather than part of `meta`, so a write
+   *  carries it forward rather than replacing it — the board folds the bound
+   *  episode into this row instead of drawing a second one beside it. */
+  episode?: string | null;
 }
 
 export interface MockMessage {
@@ -297,6 +302,10 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "aligner",
     version: 1,
     updated_at: iso(40),
+    // Both rows were compiled out of the atlas negotiation, so both are bound to
+    // it: the board draws two units carrying their thread, not two units plus a
+    // separate episode row for the conversation that produced them.
+    episode: ATLAS_EPISODE,
   },
   {
     key: "work/retire-the-legacy-store",
@@ -307,6 +316,7 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "aligner",
     version: 1,
     updated_at: iso(40),
+    episode: ATLAS_EPISODE,
   },
   {
     key: "decisions/token-ttl",

--- a/openapi.json
+++ b/openapi.json
@@ -5049,6 +5049,18 @@
             "title": "Meta",
             "description": "The memory's unmanaged frontmatter \u2014 every key the store doesn't own (so not key, authorship, version, timestamps, tags or value). This is what ``MemoryCreate.meta`` wrote, read back."
           },
+          "episode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Episode",
+            "description": "The episode URN this row's coordination happens in \u2014 what makes a unit of work a thread. Store-owned: minted by the backend, so it is absent from ``meta`` and cannot be set by a write. Null on a memory that is not a unit of work, and on one no thread has been opened for."
+          },
           "expandable": {
             "type": "boolean",
             "title": "Expandable",


### PR DESCRIPTION
## Summary

Leg 1 of #835 — the keystone the other three legs read from. A `work/` row now carries the episode URN its coordination happens in, and the board draws **one row per unit** with that thread folded onto it. A task and the negotiation that produced it stop being two rows.

Two design calls worth arguing with, because everything downstream depends on them:

**The binding is store-owned and write-once.** `episode` was already in `MANAGED_META` (b1d9d04), which filtered it out of user meta — but `unmanaged_meta` is also what builds the carry-forward, so the key was dropped on every rewrite. The first `board claim` on a row would have silently unbound it from its thread. The write path now carries the system-minted keys forward, and **what the row already has wins over any supplied value**: a claim, a status change, or a second verdict about the same work all leave the row pointed at the conversation that made it. Write-once is enforced in the store rather than remembered by each caller, so `task_sync` passing this verdict's episode is only ever an offer. Setting one is an in-process `system=` parameter with no wire form, not a body field, so nothing over HTTP can point a row at a thread it was never part of.

**The container outlives what happens inside it.** `EpisodeState` splits into the thread every episode is and the `NegotiationState` an SAO run accumulates, and membership-freeze becomes a *negotiation's* policy rather than an episode's — `EpisodeLifecycle` gates aborts and deferred invites on `frozen`, not `active`. Without that split, opening a thread for a board row would freeze the room's membership and hold every `@`-mention invite hostage for the life of the row. Folding a thread onto a row never writes the row's own axes, so converging inside a unit does not resolve it and aborting does not take it off its holder. A unit can be created board-first, claimed, worked and resolved with no episode ever opened.

The unit vocabulary (`WORK_NAMESPACE`, `TASK_KIND`, `ASSIGNEE_FIELD`, `slugify`) moves out of `task_sync` into `services/units.py`. In a unit-of-work-first model the unit's own words should not live in the converged→rows consumer; `task_sync` and `briefing` import them now. #828's call that a task carries `assignee`, never `owner`, is preserved verbatim — an assignment is not a claim, and neither is a thread.

## Changes

- **`filesystem.py`** — `EPISODE_META` + `SYSTEM_META`: the managed keys the write path does not recompute, with `system_meta()` for the carry-forward.
- **`routes/memory.py`** — `upsert_memories(..., system=)`, an in-process seam restricted to `SYSTEM_META` and write-once; `MemoryRead.episode` on every read path (file, upsert, search index).
- **`services/units.py`** (new) — minting, `bind_episode` (idempotent), `create_unit` (board-first), `bound_episodes` (what tells a unit's thread from an orphan), and the in-place backfill.
- **`task_sync.py`** — a compiled row is bound to the episode it was agreed in, read off the `commit:converged` envelope's own `header.message.episode` rather than minted.
- **`l9_episode.py`** — `EpisodeState` (thread) / `NegotiationState` (SAO accumulators); the episode record renders the negotiation sections only where a negotiation ran.
- **`l9_slim.py` / `room_channels.py`** — `EpisodeLifecycle.negotiation` + `frozen`; `open_episode(..., negotiation=False)` opens a container a join or leave leaves running.
- **Both projections** (`board/projection.py`, `board/projection.ts`) — one unit-of-work row; `thread`, `thread_state`, `participants`, `rounds` fold on, the row's own axes never do. An orphaned episode keeps its own row (a recorded negotiation is still something the room did).
- **`contracts/board-vocabulary.json`** — a `unit` section, asserted from both suites, including that `thread_fields` and `unit_fields` are disjoint.
- **Migration** — backfill runs at startup *before* the index scan, writing straight to the file: minting a URN records where a thread is, so it keeps the row's version and stamps rather than shuffling every stale row to the top of a time-ordered board.
- Docs: a new board.md section; `openapi.json` refreshed; mock fixtures bind the atlas tasks to the atlas episode, so the mock app exercises the fold.

## Testing

Backend 949 · CLI 695 · frontend 704 · docs 46/46. Lint, format and typecheck clean on all three.

New coverage: `tests/test_units.py` (20) for minting, board-first creation, the four ways the binding survives a write, write-once from both the meta bag and the system seam, and the migration's version/stamp preservation; `test_task_sync.py` for the envelope-read binding and a re-negotiation not moving a row off its thread; `test_l9_slim.py` for the container surviving a membership change; six mirrored fold cases in each board suite.

Also walked the acceptance criteria against the real store rather than only in unit tests — create a unit with no negotiation, claim it, move its status, watch an aborted negotiation fold on, and confirm the row still reads `status: in_review`, `custody: held`, `owner: @julia` with `thread_state: rejected`, while a legacy row migrated at `version: 1` with its original `updated_at`.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)

## Related Issues

Closes #836. Part of #835 — #837 (transport) and #838 (CLI resolution) read the binding this lands; #839 reads the unified row.

Targets `epic/unit-of-work-first`, not `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FJu8vMnTPJysC87k8gVFQw)_