### PR TITLE
Carry a message into a thread, and wake on one — UoW Leg 2 transport (#837)

### DIFF
--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -167,6 +167,14 @@ async def send_message(room_name: str, payload: MessageCreate, request: Request)
     if not published:
         bus.publish(room_channel(channel), notify_payload)
 
+    # Exactly one ping per threaded write, whatever the message type and whether
+    # or not the channel is up. Raised here rather than inside ``publish_human``
+    # because that only sees broadcasts over a live channel: an ``event`` into a
+    # thread, or any write while the channel is down, would move a unit in
+    # silence, and the ping is the only thing that surfaces a thread into the room.
+    await room_channels.manager.raise_ping(
+        base_room, episode=msg.episode, sender=msg.sender_handle, message_id=msg.message_id
+    )
     return MessageRead.model_validate(msg)
 
 
@@ -358,8 +366,18 @@ async def amend_message(
                 "amends": amends,
                 "created_at": msg.created_at.isoformat(),
                 "room_name": channel,
+                "episode": msg.episode,
             },
         )
+
+    # Exactly one ping per threaded write, whatever the message type and whether
+    # or not the channel is up. Raised here rather than inside ``publish_human``
+    # because that only sees broadcasts over a live channel: an ``event`` into a
+    # thread, or any write while the channel is down, would move a unit in
+    # silence, and the ping is the only thing that surfaces a thread into the room.
+    await room_channels.manager.raise_ping(
+        base_room, episode=msg.episode, sender=sender_handle, message_id=msg.message_id
+    )
 
     # Answer with the folded message — the row the room now reads — rather than
     # the amendment, so a client refreshes to exactly what it was handed.

--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -27,7 +27,7 @@ from app.schemas import (
     MessageRead,
     MessageType,
 )
-from app.services import actor, l9, local_state, persister, principals, room_channels
+from app.services import actor, l9, local_state, persister, principals, room_channels, units
 from app.services.filesystem import room_exists
 
 logger = logging.getLogger(__name__)
@@ -55,6 +55,19 @@ def _resolve_channel(name: str) -> tuple[str, local_state.CoordSessionShim | Non
     raise HTTPException(status_code=404, detail="Room or session not found")
 
 
+def _room_episode(
+    room: str, coord: local_state.CoordSessionShim | None, episode: str | None
+) -> str | None:
+    """The episode a stored row carries: the named thread, or the room's own.
+
+    A coordination session is not a room and has no channel, so it stays
+    episode-less; everywhere else "no thread" is the ``live`` URN spelled out.
+    """
+    if coord is not None:
+        return episode
+    return episode or l9.live_episode_urn(room)
+
+
 @router.post("", response_model=MessageRead, status_code=201)
 async def send_message(room_name: str, payload: MessageCreate, request: Request):
     """Send a message to a room; publish it to the room's live stream."""
@@ -75,6 +88,19 @@ async def send_message(room_name: str, payload: MessageCreate, request: Request)
     if reason:
         raise HTTPException(status_code=403, detail=reason)
 
+    # A thread write has to name a thread the room has, and stay out of a
+    # negotiation it is not part of. Refused before anything is stored, so a
+    # rejected write leaves nothing behind.
+    if payload.episode and not l9.is_live_episode(base_room, payload.episode):
+        if coord is not None:
+            raise HTTPException(
+                status_code=409,
+                detail="A coordination session has no threads to post into",
+            )
+        refusal = units.thread_write_refusal(base_room, sender_handle, payload.episode)
+        if refusal is not None:
+            raise HTTPException(status_code=refusal.status, detail=refusal.detail)
+
     msg = local_state.StoredMessage(
         room_name=None if coord else channel,
         coordination_session_id=coord.id if coord else None,
@@ -82,6 +108,11 @@ async def send_message(room_name: str, payload: MessageCreate, request: Request)
         recipient_handle=payload.recipient_handle,
         message_type=payload.message_type,
         content=payload.content,
+        # Always the URN, never a bare ``None`` for "the room": the transcript
+        # projection stamps ``live`` on the same message, and a row that agrees
+        # with its own transcript copy is what makes ``?episode=<live>`` mean
+        # "the room without its threads" — the read a legible main channel needs.
+        episode=_room_episode(base_room, coord, payload.episode),
     )
     if payload.metadata is not None:
         meta = payload.metadata.model_dump(exclude_none=True)
@@ -106,6 +137,8 @@ async def send_message(room_name: str, payload: MessageCreate, request: Request)
     if coord is not None:
         notify_payload["coordination_session_id"] = str(coord.id)
     notify_payload["room_name"] = channel
+    if msg.episode:
+        notify_payload["episode"] = msg.episode
 
     # Human-in-the-room: backend publishes onto the channel as proxy for live SLIM
     # rooms, parsing ``@`` recipients and raising consent for absent mentions. The
@@ -118,7 +151,7 @@ async def send_message(room_name: str, payload: MessageCreate, request: Request)
         and room_channels.manager.is_live(channel)
     ):
         result = await room_channels.manager.publish_human(
-            channel, sender=msg.sender_handle, text=msg.content
+            channel, sender=msg.sender_handle, text=msg.content, episode=payload.episode
         )
         published = result is not None
         if result is not None:
@@ -272,6 +305,16 @@ async def amend_message(
             detail=f"Message type {target.message_type!r} is not chat — nothing to amend",
         )
 
+    # An amendment lands in the thread of the message it revises — never in the
+    # room. Publishing it to ``live`` would echo a thread's prose onto the main
+    # channel, which is the one thing a thread exists to prevent, and the
+    # ``?episode=`` read of that thread would not show the revision it folded in.
+    # It is a write into that thread, so it passes the same guard as any other:
+    # a roster that froze after the original message must still hold.
+    refusal = units.thread_write_refusal(base_room, sender_handle, target.episode)
+    if refusal is not None:
+        raise HTTPException(status_code=refusal.status, detail=refusal.detail)
+
     # The envelope id when the target rode the channel; its row id otherwise (a
     # message posted while the channel was down never got one). Either way the
     # amendment names something the read path can resolve.
@@ -285,6 +328,7 @@ async def amend_message(
         message_type=target.message_type,
         content=payload.content,
         amends=amends,
+        episode=_room_episode(base_room, coord, target.episode),
     )
 
     published = False
@@ -295,6 +339,7 @@ async def amend_message(
             text=payload.content,
             subkind=l9.AMEND_SUBKIND,
             parents=[amends],
+            episode=target.episode,
         )
         published = result is not None
         if result is not None:

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -18,6 +18,14 @@ delivery queue. The agent participates with two plain, stateless HTTP calls:
   (role ``agent``) recorded into the transcript, which the aligner's poll scores
   as a position.
 
+Both take an optional **thread** — the episode URN of a unit of work, or of a
+negotiation inside one. A thread is a tag over the room's own channel, so this is
+one field on each call rather than a second transport: ``await?episode=`` narrows
+what wakes the handle (against that thread's own persisted cursor, so watching a
+unit consumes nothing from the room inbox behind it), and ``reply``'s ``episode``
+names where the answer lands. Writing into a thread raises a **ping** in the room
+— that a unit moved, never what was said in it.
+
 No client SLIM connection, no backgrounding, no compound shell — just two simple
 commands, which is all a headless/allowlisted agent can safely issue.
 """
@@ -26,15 +34,16 @@ from __future__ import annotations
 
 import asyncio
 import re
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
-from app.services import actor, l9, principals, room_channels
+from app.services import actor, l9, principals, room_channels, units
 from app.services.filesystem import room_exists
 from app.services.l9_models import Kind
 from app.services.l9_slim import serialize_content, serialize_envelope
+from app.services.persister import record_episode
 
 router = APIRouter(prefix="/rooms/{room_name}", tags=["participate"])
 
@@ -54,6 +63,12 @@ _MAX_WAIT_S = 3600.0
 # ``[[mycelium: confidence=0.85 stance=accept]]``; those fields are lifted onto the
 # L9 payload so the aligner can score convergence, and stripped from the prose.
 _MARKER_RE = re.compile(r"\[\[\s*mycelium\s*:(.*?)\]\]", re.IGNORECASE | re.DOTALL)
+# Payloads that are never an addressed turn however they are actor-labelled:
+# presence/keepalive are liveness, and a ``ping`` is the signal that a *thread*
+# moved — a nudge to look, not a turn to take. Excluded structurally here so a
+# resident loop consumes one silently rather than reasoning about it.
+_UNADDRESSED_PAYLOADS = frozenset({"presence", "keepalive", l9.PING_PAYLOAD_TYPE})
+
 _STANCE_TO_ACTION = {
     "accept": "accept",
     "agree": "accept",
@@ -100,7 +115,7 @@ def _addressed_to(content: dict[str, Any], handle: str) -> bool:
     header = env.get("header") or {}
     if header.get("kind") != "exchange":
         return False
-    if ((env.get("payload") or {}).get("type")) in ("presence", "keepalive"):
+    if ((env.get("payload") or {}).get("type")) in _UNADDRESSED_PAYLOADS:
         return False
     actors = (header.get("participants") or {}).get("actors") or []
     sender = actors[0].get("id") if actors and isinstance(actors[0], dict) else None
@@ -116,6 +131,19 @@ def _addressed_to(content: dict[str, Any], handle: str) -> bool:
         return False
     nxt = text[idx + len(needle)] if idx + len(needle) < len(text) else ""
     return not (nxt.isalnum() or nxt in "_-")
+
+
+def _refuse_thread_write(refusal: units.ThreadRefusal | None) -> None:
+    """Answer a refused thread write, or return and let the write proceed.
+
+    A room write is unchanged; a *thread* write has to name a thread the room
+    has and stay out of a negotiation it is not part of — the rule and its
+    reasoning live in :func:`app.services.units.episode_write_rejection`. This is
+    the seam that keeps a handle from side-channelling a position into someone
+    else's negotiation by naming its URN.
+    """
+    if refusal is not None:
+        raise HTTPException(status_code=refusal.status, detail=refusal.detail)
 
 
 def _describe(room: str, handle: str, record: Any) -> dict[str, Any]:
@@ -135,8 +163,34 @@ def _describe(room: str, handle: str, record: Any) -> dict[str, Any]:
 
 
 @router.get("/await")
-async def await_message(room_name: str, request: Request, handle: str, timeout: int = 0):
-    """Long-poll for the next message addressed to ``handle`` (server-held member)."""
+async def await_message(
+    room_name: str,
+    request: Request,
+    handle: str,
+    timeout: int = 0,
+    # Annotated rather than a ``Query(...)`` default: the default is then a real
+    # ``None``, so calling this as a plain function (as the unit tests do) scopes
+    # to the room instead of to a truthy ``Query`` object.
+    episode: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Wake only on this thread (an episode URN). Omit to wake on anything "
+                "addressed to the handle anywhere in the room."
+            )
+        ),
+    ] = None,
+):
+    """Long-poll for the next message addressed to ``handle`` (server-held member).
+
+    ``episode`` narrows the wake to one thread — a unit of work being coordinated
+    in, or a negotiation inside one. It narrows *only* the wake: the handle's
+    presence lease stays room-scoped (a member of a thread is a member of the
+    room), and so does its room-wide delivery position, so scoping to a unit
+    never eats mentions made to it elsewhere. The thread's own position is
+    persisted the same way, so a restart mid-thread resumes rather than
+    re-serving.
+    """
     if not room_exists(room_name):
         raise HTTPException(status_code=404, detail="Room not found")
     # Draining a queue consumes it: the cursor advances, so a served turn is not
@@ -154,22 +208,41 @@ async def await_message(room_name: str, request: Request, handle: str, timeout: 
     # holds an @-addressed turn for an untracked recipient) and preserved across a
     # backend restart. So a message sitting in the transcript before this handle's
     # first ``await`` is delivered, not skipped.
+    #
+    # A thread-scoped call reads and commits a *different* cursor over the same
+    # transcript — the thread's — so watching one unit consumes nothing from the
+    # handle's room inbox, and vice versa.
+    scoped = episode if episode and not l9.is_live_episode(room_name, episode) else None
+
+    def _position() -> int:
+        return (
+            persister.episode_position(handle, scoped) if scoped else persister.log.position(handle)
+        )
+
+    def _commit(pos: int) -> None:
+        if scoped:
+            persister.advance_episode_cursor(handle, scoped, pos)
+        else:
+            persister.advance_cursor(handle, pos)
+
     loop = asyncio.get_event_loop()
     deadline = loop.time() + (timeout if timeout > 0 else _MAX_WAIT_S)
     while True:
         records = persister.log.records
-        i = persister.log.position(handle)
+        i = _position()
         while i < len(records):
             record = records[i]
             i += 1
+            if scoped and record_episode(record) != scoped:
+                continue
             if _addressed_to(record.content, handle):
-                persister.advance_cursor(handle, i)
+                _commit(i)
                 _last_tick[key] = record.content
                 room_channels.manager.refresh_lease(room_name, handle)
                 return _describe(room_name, handle, record)
         # Nothing addressed in the scanned range: consume it (advance past the
         # observer/broadcast turns this handle doesn't await) and keep polling.
-        persister.advance_cursor(handle, len(records))
+        _commit(len(records))
         if loop.time() >= deadline:
             return {"room": room_name, "handle": handle, "message": None}
         room_channels.manager.refresh_lease(room_name, handle)
@@ -179,6 +252,13 @@ async def await_message(room_name: str, request: Request, handle: str, timeout: 
 class ReplyBody(BaseModel):
     handle: str = Field(..., description="The handle publishing the reply")
     text: str = Field(..., description="The reply / position prose (may carry a position marker)")
+    episode: str | None = Field(
+        None,
+        description=(
+            "Thread to reply into (an episode URN). Overrides the episode inherited "
+            "from the tick that woke the handle; omit to answer where you were asked."
+        ),
+    )
 
 
 @router.post("/reply")
@@ -211,16 +291,26 @@ async def post_reply(room_name: str, body: ReplyBody, request: Request):
     tick_sender = (
         woke_actors[0].get("id") if woke_actors and isinstance(woke_actors[0], dict) else None
     )
-    episode = woke_msg.get("episode") or l9.episode_urn(room_name, "live")
+    # An explicit target wins over the inherited one: a reply answers where it was
+    # asked by default, which is what keeps a resident loop threaded without the
+    # agent tracking URNs — but a caller that names a thread means that thread.
+    episode = body.episode or woke_msg.get("episode") or l9.live_episode_urn(room_name)
+    _refuse_thread_write(units.thread_write_refusal(room_name, handle, episode))
     topic = ((woke_header.get("context") or {}).get("topic")) or l9.topic_urn(room_name)
-    parents = [woke_msg["id"]] if woke_msg.get("id") else []
+    # Parent onto the tick only when the reply lands where the tick did. A reply
+    # redirected into another thread is not an answer to that tick, and a causal
+    # edge reaching across threads would put one thread's message in another's
+    # chain — read back as a conversation that never happened.
+    answers_the_tick = woke_msg.get("episode", l9.live_episode_urn(room_name)) == episode
+    parents = [woke_msg["id"]] if answers_the_tick and woke_msg.get("id") else []
+    recipients = [tick_sender] if answers_the_tick and tick_sender else [l9.SYSTEM_ACTOR_ID]
 
     envelope = l9.build_envelope(
         kind=Kind.exchange,
         episode=episode,
         sender=handle,
         sender_role="agent",
-        recipients=[tick_sender] if tick_sender else [l9.SYSTEM_ACTOR_ID],
+        recipients=recipients,
         topic=topic,
         payload_type="reply",
         payload_data=payload_data or {"action": "reply"},
@@ -248,6 +338,12 @@ async def post_reply(room_name: str, body: ReplyBody, request: Request):
             await managed.channel.send(envelope, extra={"content": clean})
         except Exception:
             pass
+    await room_channels.manager.raise_ping(
+        room_name,
+        episode=episode,
+        sender=handle,
+        message_id=envelope.header.message.id if envelope.header.message else None,
+    )
     return {
         "room": room_name,
         "handle": handle,

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -291,17 +291,21 @@ async def post_reply(room_name: str, body: ReplyBody, request: Request):
     tick_sender = (
         woke_actors[0].get("id") if woke_actors and isinstance(woke_actors[0], dict) else None
     )
+    # Where the tick was asked, and where this reply lands. Read once: two
+    # accessors of the same field drift, and the answer decides both the target
+    # and whether the causal edge below survives.
+    tick_episode = woke_msg.get("episode") or l9.live_episode_urn(room_name)
     # An explicit target wins over the inherited one: a reply answers where it was
     # asked by default, which is what keeps a resident loop threaded without the
     # agent tracking URNs — but a caller that names a thread means that thread.
-    episode = body.episode or woke_msg.get("episode") or l9.live_episode_urn(room_name)
+    episode = body.episode or tick_episode
     _refuse_thread_write(units.thread_write_refusal(room_name, handle, episode))
     topic = ((woke_header.get("context") or {}).get("topic")) or l9.topic_urn(room_name)
     # Parent onto the tick only when the reply lands where the tick did. A reply
     # redirected into another thread is not an answer to that tick, and a causal
     # edge reaching across threads would put one thread's message in another's
     # chain — read back as a conversation that never happened.
-    answers_the_tick = woke_msg.get("episode", l9.live_episode_urn(room_name)) == episode
+    answers_the_tick = tick_episode == episode
     parents = [woke_msg["id"]] if answers_the_tick and woke_msg.get("id") else []
     recipients = [tick_sender] if answers_the_tick and tick_sender else [l9.SYSTEM_ACTOR_ID]
 

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -169,6 +169,13 @@ class MessageCreate(BaseModel):
     metadata: EventMetadata | None = Field(
         None, description='Structured event metadata; required when message_type="event"'
     )
+    episode: str | None = Field(
+        None,
+        description=(
+            "Thread to post into (an episode URN — a unit of work's, or a negotiation "
+            "inside one). Omit to post to the room itself."
+        ),
+    )
 
     @model_validator(mode="after")
     def _metadata_matches_type(self) -> "MessageCreate":

--- a/fastapi-backend/app/services/l9.py
+++ b/fastapi-backend/app/services/l9.py
@@ -76,6 +76,19 @@ VALID_SUBKINDS: dict[Kind, frozenset[str]] = {
 }
 
 
+#: The session id of a room's own channel — the episode everything said *to the
+#: room* rides under, as opposed to a thread inside it. A unit of work's thread
+#: and a negotiation are episodes too; ``live`` is the one that is the room.
+LIVE_SESSION = "live"
+
+#: The payload type of a **ping**: the compact signal raised into ``live`` saying
+#: a thread moved, carrying no echo of what was said. It sits beside
+#: ``presence``/``keepalive`` as a control payload — deliberately not chat, and
+#: deliberately not an addressed turn, so it surfaces activity without waking
+#: anyone (:func:`app.routes.participate._addressed_to`).
+PING_PAYLOAD_TYPE = "ping"
+
+
 class L9ValidationError(ValueError):
     """An envelope violates the L9 structure or the CFN subkind table."""
 
@@ -83,6 +96,19 @@ class L9ValidationError(ValueError):
 def episode_urn(parent_room: str, session_id: str) -> str:
     """Mint the episode URN scoping all messages of one coordination session."""
     return f"urn:ioc:mycelium:episode:{parent_room}:{session_id}"
+
+
+def live_episode_urn(parent_room: str) -> str:
+    """The URN of the room's own channel — where a message with no thread lands."""
+    return episode_urn(parent_room, LIVE_SESSION)
+
+
+def is_live_episode(parent_room: str, episode: str | None) -> bool:
+    """Whether ``episode`` is the room itself rather than a thread inside it.
+
+    ``None`` is the room: a caller that names no thread is talking to the room.
+    """
+    return episode is None or episode == live_episode_urn(parent_room)
 
 
 def topic_urn(parent_room: str) -> str:

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -293,6 +293,54 @@ class DeliveryLog:
         self._cursors[handle] = len(self._records)
 
 
+class EpisodeCursors:
+    """Per-``(handle, episode)`` delivery positions over the same transcript.
+
+    A room has one ordered transcript; a thread is a *tag* on records inside it,
+    not a second log. So a thread cursor is an index into that same list — the
+    count of leading records this handle has already been served **for that
+    thread** — and reading a thread costs no second store.
+
+    Deliberately *not* the room-wide cursor of :class:`DeliveryLog`. Scoping an
+    ``await`` to a thread must not consume the handle's room inbox: an agent that
+    watches one unit still has every mention made to it in the room waiting when
+    it looks. The two positions move independently, and both persist.
+
+    A handle with no position on a thread starts at its **room-wide** one, so the
+    fork happens where it is standing: the ``@``-mention that pulled it into the
+    thread anchored that cursor (:meth:`DeliveryLog.record`) and is therefore
+    still ahead of it, while everything it had already consumed stays consumed.
+    """
+
+    def __init__(self, cursors: dict[str, dict[str, int]] | None = None) -> None:
+        self._by_episode: dict[str, dict[str, int]] = {
+            str(episode): {str(h): int(pos) for h, pos in positions.items()}
+            for episode, positions in (cursors or {}).items()
+        }
+
+    @property
+    def snapshot(self) -> dict[str, dict[str, int]]:
+        """A copy for persistence, keyed episode -> handle -> position."""
+        return {episode: dict(positions) for episode, positions in self._by_episode.items()}
+
+    def position(self, handle: str, episode: str, *, default: int) -> int:
+        """``handle``'s position on ``episode``, clamped to ``default`` on a first read."""
+        return self._by_episode.get(episode, {}).get(handle, default)
+
+    def advance(self, handle: str, episode: str, pos: int, *, limit: int) -> None:
+        """Move the position forward to ``pos`` (clamped to ``limit``, never backward)."""
+        clamped = max(0, min(int(pos), limit))
+        positions = self._by_episode.setdefault(episode, {})
+        if clamped > positions.get(handle, -1):
+            positions[handle] = clamped
+
+
+def record_episode(record: TranscriptRecord) -> str | None:
+    """The episode URN a transcript record rode under, if it carries one."""
+    episode = record.content.get("l9", {}).get("header", {}).get("message", {}).get("episode")
+    return episode if isinstance(episode, str) and episode else None
+
+
 def record_from(
     envelope: L9, content: dict[str, Any], *, now: str | None = None
 ) -> TranscriptRecord:
@@ -685,6 +733,43 @@ def write_cursors(room: str, cursors: dict[str, int]) -> None:
         logger.exception("delivery-cursor write failed for room %s", room)
 
 
+# Thread cursors persist in their own file rather than namespaced into the
+# room-wide one: ``load_cursors`` feeds ``DeliveryLog``, which reads every key it
+# is handed as a handle, and a composite key there would show up as a phantom
+# member in ``knows``/``undelivered``.
+def _episode_cursors_path(room: str) -> Path:
+    from app.services.filesystem import get_room_dir
+
+    return get_room_dir(room) / "log" / ".thread-cursors.json"
+
+
+def load_episode_cursors(room: str) -> dict[str, dict[str, int]]:
+    """Read a room's persisted per-thread delivery positions (empty when none)."""
+    path = _episode_cursors_path(room)
+    try:
+        if path.exists():
+            data = json.loads(path.read_text())
+            if isinstance(data, dict):
+                return {
+                    str(episode): {str(h): int(pos) for h, pos in positions.items()}
+                    for episode, positions in data.items()
+                    if isinstance(positions, dict)
+                }
+    except (OSError, ValueError, TypeError):
+        logger.warning("could not load thread cursors for room %s; starting empty", room)
+    return {}
+
+
+def write_episode_cursors(room: str, cursors: dict[str, dict[str, int]]) -> None:
+    """Persist a room's per-thread delivery positions (best-effort)."""
+    try:
+        path = _episode_cursors_path(room)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(cursors))
+    except Exception:
+        logger.exception("thread-cursor write failed for room %s", room)
+
+
 # ── The receive loop ─────────────────────────────────────────────────────────
 
 SummonHook = Callable[[str, "L9", list[str], str], None]
@@ -795,6 +880,10 @@ class RoomPersister:
         # delivery position — so a member that was offline at shutdown is still
         # recognised as a reconnect and re-served exactly its missed tail.
         self.log = DeliveryLog(load_transcript(room), cursors=load_cursors(room))
+        # The same resume, for a thread-scoped ``await``: a per-(handle, thread)
+        # position over the transcript above, so waking on one unit never
+        # re-serves what it already served across a restart.
+        self.episode_cursors = EpisodeCursors(load_episode_cursors(room))
         # handle -> most recent inbound MessageContext, for targeted re-serve.
         self._contexts: dict[str, slim_bindings.MessageContext] = {}
         # Message ids ingested this process lifetime, so a message the backend
@@ -824,6 +913,19 @@ class RoomPersister:
     def _persist_cursors(self) -> None:
         """Snapshot the delivery cursors to disk (best-effort, per mutation)."""
         write_cursors(self.room, self.log.cursors)
+
+    def _persist_episode_cursors(self) -> None:
+        """Snapshot the per-thread delivery positions to disk (best-effort)."""
+        write_episode_cursors(self.room, self.episode_cursors.snapshot)
+
+    def episode_position(self, handle: str, episode: str) -> int:
+        """``handle``'s delivery position on ``episode``, forked off its room one."""
+        return self.episode_cursors.position(handle, episode, default=self.log.position(handle))
+
+    def advance_episode_cursor(self, handle: str, episode: str, pos: int) -> None:
+        """Advance ``handle``'s durable position on ``episode`` and persist it."""
+        self.episode_cursors.advance(handle, episode, pos, limit=len(self.log.records))
+        self._persist_episode_cursors()
 
     def advance_cursor(self, handle: str, pos: int) -> None:
         """Advance ``handle``'s durable delivery cursor to ``pos`` and persist it.

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -743,6 +743,7 @@ class RoomChannelManager:
         text: str,
         subkind: str | None = None,
         parents: list[str] | None = None,
+        episode: str | None = None,
     ) -> HumanPublishResult | None:
         """Publish a human's message onto the room channel as their proxy.
 
@@ -755,6 +756,12 @@ class RoomChannelManager:
         ``subkind``/``parents`` carry an ``amend`` revising an earlier message —
         the same publish in every other respect, since a revision is a message
         the room hears like any other (mentions and the consent gate included).
+
+        ``episode`` names the **thread** the message lands in; without one it
+        lands in the room itself. A thread is a tag over this same channel, so a
+        threaded message is broadcast and recorded exactly like any other — what
+        changes is that it does not clutter the room, and that a
+        :meth:`raise_ping` is raised into ``live`` in its place.
 
         The published message is ingested locally via the persister so the
         transcript and UI bus see it exactly once, independent of whether SLIM
@@ -771,7 +778,7 @@ class RoomChannelManager:
         envelope = l9.build_envelope(
             kind=Kind.exchange,
             subkind=subkind,
-            episode=l9.episode_urn(room, "live"),
+            episode=episode or l9.live_episode_urn(room),
             parents=parents,
             sender=sender,
             sender_role="human",
@@ -790,6 +797,7 @@ class RoomChannelManager:
             # ``local_state`` row (its id/ledger), stamped with this envelope's id so
             # a cold read dedups the two.
             managed.persister.ingest_local(envelope, content, list_write=False)
+        await self.raise_ping(room, episode=episode, sender=sender, message_id=message_id)
 
         # Consent gate: an @-mention of an agent not on the channel invites
         # it — but the user's OWN registered agents in this room are pre-authorized
@@ -828,6 +836,59 @@ class RoomChannelManager:
         return HumanPublishResult(
             mentioned=mentioned, recipients=recipients, invites=invites, message_id=message_id
         )
+
+    async def raise_ping(
+        self,
+        room: str,
+        *,
+        episode: str | None,
+        sender: str,
+        message_id: str | None,
+    ) -> str | None:
+        """Raise a thread's activity into ``live`` as a **ping**, and nothing more.
+
+        The room stays legible because a thread absorbs its own noise: what
+        surfaces is that a unit moved, not what was said in it. So the ping
+        carries no text — only the thread it is about, who wrote, and the id of
+        the message, which is enough for a reader to open the thread and no use
+        to anyone trying to read it without.
+
+        Two properties it must hold, both structural rather than a convention a
+        later caller has to remember:
+
+        *It wakes nobody.* The ping is addressed to no one and rides a ``ping``
+        payload, which :func:`app.routes.participate._addressed_to` excludes the
+        same way it excludes presence — so a resident agent's ``await`` consumes
+        it silently instead of spending a turn on it.
+
+        *It does not go out on the wire.* This is the aligner's
+        record-locally-don't-broadcast seam: ``ingest_local`` alone, so the ping
+        lands in the transcript and on the SSE bus for the GUI without being
+        published to the group. Nothing on the channel has to filter it out.
+
+        Returns the ping's message id, or ``None`` when there was nothing to
+        announce (a message in the room itself, or no live channel).
+        """
+        if episode is None or l9.is_live_episode(room, episode):
+            return None
+        managed = self._channels.get(room)
+        if managed is None or managed.persister is None:
+            return None
+        ping = l9.build_envelope(
+            kind=Kind.exchange,
+            episode=l9.live_episode_urn(room),
+            sender=l9.SYSTEM_ACTOR_ID,
+            sender_role=l9.SYSTEM_ACTOR_ROLE,
+            topic=l9.topic_urn(room),
+            payload_type=l9.PING_PAYLOAD_TYPE,
+            payload_data={
+                "episode": episode,
+                "sender": sender,
+                **({"message": message_id} if message_id else {}),
+            },
+        )
+        managed.persister.ingest_local(ping, serialize_content(ping), list_write=False)
+        return ping.header.message.id if ping.header.message else None
 
     # -- consent-gated invites --
 

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -47,7 +47,14 @@ from app.services.l9_slim import (
     build_episode_abort_envelope,
     serialize_content,
 )
-from app.services.persister import ConvergedHook, RoomPersister, SummonHook, parse_mentions
+from app.services.persister import (
+    ConvergedHook,
+    RoomPersister,
+    SummonHook,
+    l9_bus_frame,
+    parse_mentions,
+    record_from,
+)
 from app.services.slim_client import (
     SlimClient,
     SlimIdentity,
@@ -760,8 +767,10 @@ class RoomChannelManager:
         ``episode`` names the **thread** the message lands in; without one it
         lands in the room itself. A thread is a tag over this same channel, so a
         threaded message is broadcast and recorded exactly like any other — what
-        changes is that it does not clutter the room, and that a
-        :meth:`raise_ping` is raised into ``live`` in its place.
+        changes is only that it does not clutter the room. The :meth:`raise_ping`
+        that surfaces it there is the *caller's*: this publish is one of several
+        ways a message reaches a thread, and a ping raised from inside it would
+        be silently skipped by every other one.
 
         The published message is ingested locally via the persister so the
         transcript and UI bus see it exactly once, independent of whether SLIM
@@ -797,7 +806,6 @@ class RoomChannelManager:
             # ``local_state`` row (its id/ledger), stamped with this envelope's id so
             # a cold read dedups the two.
             managed.persister.ingest_local(envelope, content, list_write=False)
-        await self.raise_ping(room, episode=episode, sender=sender, message_id=message_id)
 
         # Consent gate: an @-mention of an agent not on the channel invites
         # it — but the user's OWN registered agents in this room are pre-authorized
@@ -866,13 +874,10 @@ class RoomChannelManager:
         lands in the transcript and on the SSE bus for the GUI without being
         published to the group. Nothing on the channel has to filter it out.
 
-        Returns the ping's message id, or ``None`` when there was nothing to
-        announce (a message in the room itself, or no live channel).
+        Returns the ping's message id, or ``None`` when there is nothing to
+        announce — a message in the room itself, which *is* the room.
         """
         if episode is None or l9.is_live_episode(room, episode):
-            return None
-        managed = self._channels.get(room)
-        if managed is None or managed.persister is None:
             return None
         ping = l9.build_envelope(
             kind=Kind.exchange,
@@ -887,7 +892,19 @@ class RoomChannelManager:
                 **({"message": message_id} if message_id else {}),
             },
         )
-        managed.persister.ingest_local(ping, serialize_content(ping), list_write=False)
+        content = serialize_content(ping)
+        managed = self._channels.get(room)
+        if managed is not None and managed.persister is not None:
+            managed.persister.ingest_local(ping, content, list_write=False)
+        else:
+            # No channel means no transcript to raise into — and the message this
+            # announces reached only the bus for the same reason. So the ping
+            # matches its reach rather than vanishing: the exact frame the
+            # persister would have pushed, built by the same projection, so a
+            # client decodes it identically either way.
+            from app.bus import bus, room_channel
+
+            bus.publish(room_channel(room), l9_bus_frame(room, record_from(ping, content)))
         return ping.header.message.id if ping.header.message else None
 
     # -- consent-gated invites --

--- a/fastapi-backend/app/services/units.py
+++ b/fastapi-backend/app/services/units.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 import logging
 import re
 import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from app.services import l9
@@ -72,6 +74,11 @@ _SLUG_STRIP = re.compile(r"[^a-z0-9]+")
 #: Frontmatter :func:`serialize_memory` writes from its own arguments; passing
 #: it through ``extra_meta`` as well would write each of those keys twice.
 _REWRITTEN_META = frozenset({"key", "created_by", "updated_by", "version", "tags"})
+
+
+def _norm(handle: str) -> str:
+    """A handle as it compares: the roster and the caller may spell it differently."""
+    return handle.strip().lstrip("@").casefold()
 
 
 def slugify(title: str) -> str:
@@ -119,6 +126,106 @@ def bound_episodes(room: str) -> set[str]:
         if isinstance(urn, str) and urn:
             urns.add(urn)
     return urns
+
+
+@dataclass(frozen=True)
+class ThreadRefusal:
+    """Why a write into a named thread was refused, and how to answer it."""
+
+    status: int
+    detail: str
+
+
+def known_episode(room: str, episode: str, *, transcript: Iterable[str] = ()) -> bool:
+    """Whether ``episode`` is a thread this room actually has.
+
+    Checked cheapest-first, because it runs on the write path: the URNs already
+    on the room's in-memory transcript settle every thread that has ever been
+    spoken in (a negotiation's, and an orphaned episode's, as well as a unit's),
+    and only a *first* write into a thread that is still silent falls through to
+    the store scan — once per thread, not once per message. ``transcript`` is
+    read newest-first and short-circuits, so recognising an active thread costs
+    a handful of records rather than the whole history.
+    """
+    if episode in transcript:
+        return True
+    return episode in bound_episodes(room)
+
+
+def episode_write_rejection(
+    room: str,
+    handle: str,
+    episode: str | None,
+    *,
+    frozen_episode: str | None = None,
+    frozen_members: Iterable[str] = (),
+    transcript: Iterable[str] = (),
+) -> ThreadRefusal | None:
+    """Why ``handle`` may not write into ``episode``, or ``None`` if it may.
+
+    Two refusals, and the difference between them is the whole model:
+
+    A thread the room does not have is refused (404) — naming a URN must not be
+    how one comes into being, or the transcript grows threads nobody opened.
+
+    A thread that is a **frozen negotiation** is refused to anyone outside the
+    roster it froze on (403). That is L9's stable-membership rule: an
+    offer/counter exchange scored across a set of participants means nothing if
+    an outsider can drop a position into it.
+
+    A **container** — a unit of work's thread — refuses neither, and that is
+    deliberate rather than unfinished. Freezing membership is a negotiation's
+    policy, not an episode's (:class:`~app.services.l9_slim.EpisodeLifecycle`):
+    a unit outlives what happens inside it, so an agent that claims a row after
+    the thread opened must be able to speak in it.  The honest boundary: a unit's
+    thread is scoped to the room, not narrower.  Everyone who may write in the
+    room may write in its threads — threads separate *attention*, not access, and
+    the room's own guards (membership, principal, delegation) are what a write
+    still has to pass.
+    """
+    if episode is None or l9.is_live_episode(room, episode):
+        return None
+    if not known_episode(room, episode, transcript=transcript):
+        return ThreadRefusal(404, f"No thread {short_id_of(episode)!r} in room {room!r}")
+    if episode == frozen_episode and _norm(handle) not in {_norm(m) for m in frozen_members}:
+        return ThreadRefusal(
+            403,
+            f"@{handle} is not a member of the negotiation in thread {short_id_of(episode)!r}",
+        )
+    return None
+
+
+def thread_write_refusal(room: str, handle: str, episode: str | None) -> ThreadRefusal | None:
+    """:func:`episode_write_rejection`, read against the room's live channel state.
+
+    The one call both write routes make, so ``/messages`` and ``/reply`` cannot
+    grow separate ideas of who may speak in a thread. A room with no live channel
+    has no negotiation to be outside of and no transcript to recognise a thread
+    by, so the rule falls back to what the store knows.
+    """
+    if episode is None or l9.is_live_episode(room, episode):
+        return None
+
+    from app.services.room_channels import manager
+
+    managed = manager.get(room)
+    lifecycle = managed.lifecycle if managed is not None else None
+    persister = managed.persister if managed is not None else None
+    spoken: Iterable[str] = ()
+    if persister is not None:
+        from app.services.persister import record_episode
+
+        # Newest-first and lazy: a thread being written into was almost certainly
+        # spoken in recently, so the membership test stops within a few records.
+        spoken = (urn for r in reversed(persister.log.records) if (urn := record_episode(r)))
+    return episode_write_rejection(
+        room,
+        handle,
+        episode,
+        frozen_episode=(lifecycle.episode if lifecycle is not None and lifecycle.frozen else None),
+        frozen_members=lifecycle.members if lifecycle is not None else (),
+        transcript=spoken,
+    )
 
 
 async def bind_episode(room: str, key: str, *, episode: str | None = None) -> str:

--- a/fastapi-backend/tests/test_handle_binding.py
+++ b/fastapi-backend/tests/test_handle_binding.py
@@ -255,6 +255,11 @@ async def test_reply_as_an_owned_agent_is_allowed(client: AsyncClient, as_princi
             # PSK default: no custodial session, so the reply falls back to a moderator send.
             return False
 
+        async def raise_ping(self, room: str, **_kw: Any) -> None:
+            # A reply to the room itself pings nothing; the fake only has to answer
+            # the call the reply route makes every time.
+            return None
+
     monkeypatch.setattr(room_channels, "manager", _Manager())
 
     await _make_room(client)
@@ -303,6 +308,11 @@ async def test_reply_stamps_the_token_handle_on_the_l9_actor(
         async def send_as_custodian(self, room: str, handle: str, data: bytes) -> bool:
             # PSK default: no custodial session, so the reply falls back to a moderator send.
             return False
+
+        async def raise_ping(self, room: str, **_kw: Any) -> None:
+            # A reply to the room itself pings nothing; the fake only has to answer
+            # the call the reply route makes every time.
+            return None
 
     monkeypatch.setattr(room_channels, "manager", _Manager())
 

--- a/fastapi-backend/tests/test_participate_await.py
+++ b/fastapi-backend/tests/test_participate_await.py
@@ -43,13 +43,21 @@ def _addressed_record(message_id: str, *, to: str, sender: str = "avery"):
 
 class _FakePersister:
     """Just enough of RoomPersister for the await loop: a durable log + the
-    consume-side cursor advance (no disk write needed in the unit test)."""
+    consume-side cursor advance, room-wide and per-thread (no disk write needed
+    in the unit test)."""
 
     def __init__(self, log: persister.DeliveryLog) -> None:
         self.log = log
+        self.episode_cursors = persister.EpisodeCursors()
 
     def advance_cursor(self, handle: str, pos: int) -> None:
         self.log.advance(handle, pos)
+
+    def episode_position(self, handle: str, episode: str) -> int:
+        return self.episode_cursors.position(handle, episode, default=self.log.position(handle))
+
+    def advance_episode_cursor(self, handle: str, episode: str, pos: int) -> None:
+        self.episode_cursors.advance(handle, episode, pos, limit=len(self.log.records))
 
 
 class _Managed:

--- a/fastapi-backend/tests/test_thread_transport.py
+++ b/fastapi-backend/tests/test_thread_transport.py
@@ -15,13 +15,14 @@ from __future__ import annotations
 
 import json
 from typing import Any
+from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from starlette.requests import Request
 
 from app.routes import participate
-from app.services import l9, persister, units
+from app.services import l9, persister, room_channels, units
 from app.services.filesystem import get_room_dir
 from app.services.l9_models import Kind
 from app.services.l9_slim import serialize_content
@@ -31,6 +32,13 @@ THREAD = l9.episode_urn(ROOM, "t3")
 OTHER_THREAD = l9.episode_urn(ROOM, "t9")
 
 _REQUEST = Request({"type": "http", "method": "GET", "path": "/await", "headers": []})
+
+
+async def _unit_thread(room: str, title: str) -> str:
+    """Create a unit and hand back the thread it was minted with."""
+    unit = await units.create_unit(room, title, created_by="avery")
+    assert unit.episode, "a unit is created with its thread already minted"
+    return unit.episode
 
 
 def _record(message_id: str, *, to: str, episode: str, sender: str = "avery"):
@@ -248,6 +256,10 @@ class _RecordingPersister:
 
     def __init__(self) -> None:
         self.ingested: list[tuple[Any, dict, bool]] = []
+        # The write guard reads the transcript to recognise a thread already
+        # spoken in; empty here, so every test resolves its thread off the row
+        # it is bound to — the first-write path, which is the one that matters.
+        self.log = persister.DeliveryLog()
 
     def ingest_local(self, envelope, content, *, list_write=False):
         self.ingested.append((envelope, content, list_write))
@@ -281,81 +293,277 @@ def _live_room(members: set[str] | None = None):
 
 
 class TestPing:
-    """A thread write surfaces in the room as a signal, never as its content."""
+    """A thread write surfaces in the room as a signal, never as its content.
 
-    @pytest.mark.asyncio
-    async def test_a_thread_write_leaves_exactly_one_ping_in_live(self):
-        """The whole point of the epic's PING: the human's channel shows that a
-        unit moved, once, instead of the argument inside it."""
+    Driven through the write route rather than ``publish_human``, because the
+    property is "every write into a thread raises one ping" and the publish
+    helper only ever sees one of the ways a write gets there.
+    """
+
+    @pytest.fixture
+    async def room(self, client, monkeypatch):
+        assert (await client.post("/api/rooms", json={"name": ROOM})).status_code in (200, 201)
+        monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+        return ROOM
+
+    @pytest.fixture
+    def live(self):
+        """A live channel for ROOM whose sends and local ingests are observable."""
         manager, managed = _live_room()
-        await manager.publish_human(
-            ROOM, sender="api", text="the token goes in memory", episode=THREAD
+        with mock.patch.object(room_channels, "manager", manager):
+            yield managed
+
+    @staticmethod
+    async def _post(client, *, episode, text="the token goes in memory", kind="broadcast"):
+        return await client.post(
+            f"/api/rooms/{ROOM}/messages",
+            json={
+                "message_type": kind,
+                "sender_handle": "api",
+                "content": text,
+                "episode": episode,
+            },
         )
 
-        assert len(managed.persister.pings) == 1
-        ping, _content = managed.persister.pings[0]
+    @pytest.mark.asyncio
+    async def test_a_thread_write_leaves_exactly_one_ping_in_live(self, client, room, live):
+        """The whole point of the epic's PING: the human's channel shows that a
+        unit moved, once, instead of the argument inside it."""
+        thread = await _unit_thread(room, "pick a token store")
+        assert (await self._post(client, episode=thread)).status_code == 201
+
+        assert len(live.persister.pings) == 1
+        ping, _content = live.persister.pings[0]
         assert ping.header.message.episode == l9.live_episode_urn(ROOM)
-        assert ping.payload.data["episode"] == THREAD
+        assert ping.payload.data["episode"] == thread
 
     @pytest.mark.asyncio
-    async def test_the_ping_carries_no_echo_of_what_was_said(self):
-        manager, managed = _live_room()
-        secret = "the token goes in memory"
-        await manager.publish_human(ROOM, sender="api", text=secret, episode=THREAD)
+    async def test_the_ping_carries_no_echo_of_what_was_said(self, client, room, live):
+        thread = await _unit_thread(room, "pick a token store")
+        secret = "the token goes in the keychain"
+        await self._post(client, episode=thread, text=secret)
 
-        _ping, content = managed.persister.pings[0]
+        _ping, content = live.persister.pings[0]
         assert "content" not in content
         assert secret not in json.dumps(content)
 
     @pytest.mark.asyncio
-    async def test_the_ping_names_the_thread_and_the_writer(self):
-        manager, managed = _live_room()
-        await manager.publish_human(ROOM, sender="api", text="hi", episode=THREAD)
+    async def test_the_ping_names_the_thread_and_the_writer(self, client, room, live):
+        thread = await _unit_thread(room, "pick a token store")
+        await self._post(client, episode=thread)
 
-        ping, _content = managed.persister.pings[0]
-        assert ping.payload.data["episode"] == THREAD
+        ping, _content = live.persister.pings[0]
+        assert ping.payload.data["episode"] == thread
         assert ping.payload.data["sender"] == "api"
         assert ping.payload.data["message"]  # enough to open the thread on
 
     @pytest.mark.asyncio
-    async def test_the_ping_never_goes_out_on_the_wire(self):
+    async def test_the_ping_never_goes_out_on_the_wire(self, client, room, live):
         """Record locally, don't broadcast — the aligner's seam. The channel
         already carried the real message; the ping is for the transcript and GUI."""
-        manager, managed = _live_room()
-        await manager.publish_human(ROOM, sender="api", text="hi", episode=THREAD)
+        thread = await _unit_thread(room, "pick a token store")
+        await self._post(client, episode=thread)
 
-        sent = [call.args[0] for call in managed.channel.send.call_args_list]
+        sent = [call.args[0] for call in live.channel.send.call_args_list]
         assert [e for e in sent if e.payload.type == l9.PING_PAYLOAD_TYPE] == []
         assert len(sent) == 1  # the thread message itself, and only that
+        assert sent[0].header.message.episode == thread  # a tag, not a second channel
 
     @pytest.mark.asyncio
-    async def test_the_ping_wakes_nobody(self):
+    async def test_the_ping_wakes_nobody(self, client, room, live):
         """A nudge to look, not a turn to take: a resident ``await`` consumes it
         silently rather than spending a reasoning turn on it."""
-        manager, managed = _live_room()
-        await manager.publish_human(ROOM, sender="api", text="@sec thoughts?", episode=THREAD)
+        thread = await _unit_thread(room, "pick a token store")
+        await self._post(client, episode=thread, text="@sec thoughts?")
 
-        _ping, content = managed.persister.pings[0]
+        _ping, content = live.persister.pings[0]
         assert not participate._addressed_to(content, "sec")
         assert not participate._addressed_to(content, "api")
 
     @pytest.mark.asyncio
-    async def test_a_message_to_the_room_pings_nothing(self):
-        manager, managed = _live_room()
-        await manager.publish_human(ROOM, sender="api", text="hi")
-        await manager.publish_human(
-            ROOM, sender="api", text="hi", episode=l9.live_episode_urn(ROOM)
-        )
-        assert managed.persister.pings == []
+    async def test_a_message_to_the_room_pings_nothing(self, client, room, live):
+        assert (await self._post(client, episode=None)).status_code == 201
+        assert (await self._post(client, episode=l9.live_episode_urn(ROOM))).status_code == 201
+        assert live.persister.pings == []
 
     @pytest.mark.asyncio
-    async def test_a_thread_message_still_rides_the_channel_normally(self):
-        """A thread is a tag over the room's own channel, not a second one."""
-        manager, managed = _live_room()
-        await manager.publish_human(ROOM, sender="api", text="hi", episode=THREAD)
+    async def test_a_write_that_is_not_a_broadcast_still_pings(self, client, room, live):
+        """Only a broadcast reaches ``publish_human``. A thread that can be moved
+        by an ``announce`` without the room hearing of it is a thread the board
+        would show as idle while work happened in it."""
+        thread = await _unit_thread(room, "pick a token store")
+        assert (await self._post(client, episode=thread, kind="announce")).status_code == 201
 
-        sent = [call.args[0] for call in managed.channel.send.call_args_list]
-        assert sent[0].header.message.episode == THREAD
+        assert len(live.persister.pings) == 1
+        assert live.persister.pings[0][0].payload.data["episode"] == thread
+
+    @pytest.mark.asyncio
+    async def test_an_amendment_in_a_thread_pings_too(self, client, room, live):
+        thread = await _unit_thread(room, "pick a token store")
+        posted = await self._post(client, episode=thread, text="in memory")
+        live.persister.ingested.clear()
+
+        await client.post(
+            f"/api/rooms/{ROOM}/messages/{posted.json()['id']}/amend",
+            json={"sender_handle": "api", "content": "in the keychain"},
+        )
+        assert len(live.persister.pings) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_thread_write_with_no_channel_still_reaches_the_bus(self, monkeypatch):
+        """A room whose channel is down has no transcript to raise into — so the
+        ping matches the reach of the message it announces (bus only) instead of
+        vanishing, in the frame a client already decodes."""
+        from app.bus import bus, room_channel
+        from app.services.room_channels import RoomChannelManager
+
+        published: list[tuple[str, dict]] = []
+        monkeypatch.setattr(bus, "publish", lambda ch, frame: published.append((ch, frame)))
+
+        manager = RoomChannelManager(endpoint="http://127.0.0.1:46357", default_workspace="m")
+        mid = await manager.raise_ping(ROOM, episode=THREAD, sender="api", message_id="m1")
+
+        assert mid is not None
+        assert len(published) == 1
+        channel, frame = published[0]
+        assert channel == room_channel(ROOM)
+        assert frame["message_type"] == "l9_exchange"
+        assert frame["episode"] == l9.live_episode_urn(ROOM)
+        assert THREAD in frame["content"]
+
+
+class TestReplyTargeting:
+    """Where an agent's reply lands, and what it is an answer *to*.
+
+    The route's subtlest path: a resident loop replies where it was asked
+    without ever naming a URN, and a caller that does name one gets that thread
+    — including the causal edge, which must not follow it across.
+    """
+
+    @pytest.fixture
+    async def replying(self, client, monkeypatch):
+        """A registered agent, a live channel, and a tick already served to it."""
+        assert (await client.post("/api/rooms", json={"name": ROOM})).status_code in (200, 201)
+        monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+        monkeypatch.setattr(participate.principals, "post_rejection_reason", lambda *a, **k: None)
+
+        manager, managed = _live_room()
+
+        async def _provision(_room, **_kw):
+            return managed
+
+        monkeypatch.setattr(manager, "provision", _provision)
+        monkeypatch.setattr(manager, "send_as_custodian", AsyncMock(return_value=False))
+        monkeypatch.setattr(participate.room_channels, "manager", manager)
+        monkeypatch.setattr(room_channels, "manager", manager)
+        participate._last_tick.clear()
+        return managed
+
+    @staticmethod
+    def _woke(episode: str, *, sender: str = "aligner", message_id: str = "tick-1") -> None:
+        """Stand the caller where an ``await`` on ``episode`` would have left it."""
+        env = l9.build_envelope(
+            kind=Kind.exchange,
+            episode=episode,
+            sender=sender,
+            recipients=["api"],
+            topic=l9.topic_urn(ROOM),
+            message_id=message_id,
+            payload_type="message",
+        )
+        participate._last_tick[(ROOM, "api")] = serialize_content(
+            env, extra={"content": "@api where should the token live?"}
+        )
+
+    @staticmethod
+    def _replied(managed) -> Any:
+        """The reply envelope the route recorded.
+
+        Selected by payload type: the moderator also ingests the ping, and a
+        ``create_unit`` in the test's own setup broadcasts a ``knowledge`` write.
+        """
+        replies = [
+            env for env, _c, _lw in managed.persister.ingested if env.payload.type == "reply"
+        ]
+        assert len(replies) == 1, "the route records exactly one reply"
+        return replies[0]
+
+    async def _reply(self, client, **body) -> Any:
+        return await client.post(
+            f"/api/rooms/{ROOM}/reply", json={"handle": "api", "text": "in memory", **body}
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_reply_answers_where_it_was_asked(self, client, replying):
+        """The inherit: a resident loop stays threaded without tracking URNs."""
+        thread = await _unit_thread(ROOM, "pick a token store")
+        self._woke(thread)
+
+        assert (await self._reply(client)).status_code == 200
+        env = self._replied(replying)
+        assert env.header.message.episode == thread
+        assert env.header.message.parents == ["tick-1"]
+        assert [a.id for a in env.header.participants.actors] == ["api", "aligner"]
+
+    @pytest.mark.asyncio
+    async def test_a_named_thread_beats_the_one_inherited(self, client, replying):
+        thread = await _unit_thread(ROOM, "pick a token store")
+        other = await _unit_thread(ROOM, "rotate the signing key")
+        self._woke(thread)
+
+        assert (await self._reply(client, episode=other)).status_code == 200
+        assert self._replied(replying).header.message.episode == other
+
+    @pytest.mark.asyncio
+    async def test_a_redirected_reply_drops_the_causal_edge(self, client, replying):
+        """A reply carried into another thread is not an answer to the tick that
+        woke it. Keeping the parent would splice one thread's message into
+        another's chain, which reads back as a conversation nobody had — and
+        would leave the tick's sender addressed in a thread they never spoke in."""
+        thread = await _unit_thread(ROOM, "pick a token store")
+        other = await _unit_thread(ROOM, "rotate the signing key")
+        self._woke(thread)
+
+        await self._reply(client, episode=other)
+        env = self._replied(replying)
+        assert env.header.message.parents == []
+        assert [a.id for a in env.header.participants.actors] == ["api", l9.SYSTEM_ACTOR_ID]
+
+    @pytest.mark.asyncio
+    async def test_naming_the_same_thread_keeps_the_edge(self, client, replying):
+        """Redirecting is what drops the parent, not the act of naming a thread."""
+        thread = await _unit_thread(ROOM, "pick a token store")
+        self._woke(thread)
+
+        await self._reply(client, episode=thread)
+        assert self._replied(replying).header.message.parents == ["tick-1"]
+
+    @pytest.mark.asyncio
+    async def test_a_reply_into_a_thread_pings_the_room(self, client, replying):
+        thread = await _unit_thread(ROOM, "pick a token store")
+        self._woke(thread)
+
+        await self._reply(client)
+        assert len(replying.persister.pings) == 1
+        assert replying.persister.pings[0][0].payload.data["episode"] == thread
+
+    @pytest.mark.asyncio
+    async def test_a_reply_to_the_room_pings_nothing(self, client, replying):
+        self._woke(l9.live_episode_urn(ROOM))
+
+        await self._reply(client)
+        assert self._replied(replying).header.message.episode == l9.live_episode_urn(ROOM)
+        assert replying.persister.pings == []
+
+    @pytest.mark.asyncio
+    async def test_a_reply_into_an_invented_thread_is_refused(self, client, replying):
+        self._woke(l9.live_episode_urn(ROOM))
+
+        resp = await self._reply(client, episode=THREAD)
+        assert resp.status_code == 404
+        # Refused before anything was recorded — no reply, and no ping either.
+        assert [e for e, _c, _lw in replying.persister.ingested if e.payload.type == "reply"] == []
+        assert replying.persister.pings == []
 
 
 class TestWriteRoutes:
@@ -401,9 +609,7 @@ class TestWriteRoutes:
         self, client, room, monkeypatch
     ):
         monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
-        unit = await units.create_unit(room, "ship passkey login", created_by="avery")
-        thread = unit.episode
-        assert thread, "a unit is created with its thread already minted"
+        thread = await _unit_thread(room, "ship passkey login")
 
         resp = await client.post(
             f"/api/rooms/{room}/messages",
@@ -422,8 +628,7 @@ class TestWriteRoutes:
         """Write-then-read round-trips on the same URN, which is what makes a board
         row openable as a conversation."""
         monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
-        unit = await units.create_unit(room, "rotate the signing key", created_by="avery")
-        thread = unit.episode
+        thread = await _unit_thread(room, "rotate the signing key")
 
         await client.post(
             f"/api/rooms/{room}/messages",
@@ -456,8 +661,7 @@ class TestWriteRoutes:
         the one thing a thread exists to prevent — and the thread's own read has
         to show the revision it folded in."""
         monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
-        unit = await units.create_unit(room, "pick a token store", created_by="avery")
-        thread = unit.episode
+        thread = await _unit_thread(room, "pick a token store")
 
         posted = await client.post(
             f"/api/rooms/{room}/messages",

--- a/fastapi-backend/tests/test_thread_transport.py
+++ b/fastapi-backend/tests/test_thread_transport.py
@@ -1,0 +1,485 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Writing into a thread, waking on one, and the ping that surfaces it (#837).
+
+A unit of work's thread is a tag over the room's own channel, so the transport
+that reaches it is the room's transport with one field on it. These tests hold
+the three things that field has to be worth: a write can be *targeted* at a
+thread and is refused when it may not be, a wake can be *scoped* to one without
+eating the room inbox behind it, and a thread write leaves the room itself
+carrying a ping — a signal that a unit moved, never an echo of what was said.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.requests import Request
+
+from app.routes import participate
+from app.services import l9, persister, units
+from app.services.filesystem import get_room_dir
+from app.services.l9_models import Kind
+from app.services.l9_slim import serialize_content
+
+ROOM = "threaded"
+THREAD = l9.episode_urn(ROOM, "t3")
+OTHER_THREAD = l9.episode_urn(ROOM, "t9")
+
+_REQUEST = Request({"type": "http", "method": "GET", "path": "/await", "headers": []})
+
+
+def _record(message_id: str, *, to: str, episode: str, sender: str = "avery"):
+    """A human exchange @-addressed to ``to``, riding ``episode``."""
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=episode,
+        sender=sender,
+        sender_role="human",
+        recipients=[to],
+        topic=l9.topic_urn(ROOM),
+        message_id=message_id,
+        payload_type="message",
+    )
+    return persister.record_from(env, serialize_content(env, extra={"content": f"@{to} hello"}))
+
+
+class _FakePersister:
+    """The delivery half of RoomPersister: a log, and both cursors over it."""
+
+    def __init__(self, log: persister.DeliveryLog) -> None:
+        self.log = log
+        self.episode_cursors = persister.EpisodeCursors()
+
+    def advance_cursor(self, handle: str, pos: int) -> None:
+        self.log.advance(handle, pos)
+
+    def episode_position(self, handle: str, episode: str) -> int:
+        return self.episode_cursors.position(handle, episode, default=self.log.position(handle))
+
+    def advance_episode_cursor(self, handle: str, episode: str, pos: int) -> None:
+        self.episode_cursors.advance(handle, episode, pos, limit=len(self.log.records))
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    """Point the await route at a transcript the test controls."""
+
+    def _wire(log: persister.DeliveryLog) -> _FakePersister:
+        fake = _FakePersister(log)
+        managed = type("_Managed", (), {"persister": fake})()
+
+        async def _provision(_room):
+            return managed
+
+        monkeypatch.setattr(participate, "room_exists", lambda _r: True)
+        monkeypatch.setattr(participate.actor, "authorize_handle", lambda *a, **k: None)
+        monkeypatch.setattr(participate.room_channels.manager, "provision", _provision)
+        monkeypatch.setattr(
+            participate.room_channels.manager, "refresh_lease", lambda *a, **k: None
+        )
+        monkeypatch.setattr(participate, "_POLL_INTERVAL_S", 0.01)
+        return fake
+
+    return _wire
+
+
+class TestScopedAwait:
+    """``await --episode`` wakes on one thread, and only on that thread."""
+
+    @pytest.mark.asyncio
+    async def test_it_wakes_on_its_own_thread(self, wired):
+        log = persister.DeliveryLog()
+        log.record(_record("m1", to="api", episode=THREAD), delivered_to=set(), recipients=["api"])
+
+        wired(log)
+        result = await participate.await_message(
+            ROOM, _REQUEST, handle="api", timeout=0, episode=THREAD
+        )
+        assert result["message_id"] == "m1"
+        assert result["episode"] == THREAD
+
+    @pytest.mark.asyncio
+    async def test_a_turn_in_another_thread_is_not_its_turn(self, wired):
+        """Scoping to a unit is the whole point: the room's noise stays out."""
+        log = persister.DeliveryLog()
+        log.record(
+            _record("m1", to="api", episode=OTHER_THREAD), delivered_to=set(), recipients=["api"]
+        )
+        log.record(
+            _record("m2", to="api", episode=l9.live_episode_urn(ROOM)),
+            delivered_to=set(),
+            recipients=["api"],
+        )
+
+        wired(log)
+        result = await participate.await_message(
+            ROOM, _REQUEST, handle="api", timeout=1, episode=THREAD
+        )
+        assert result["message"] is None
+
+    @pytest.mark.asyncio
+    async def test_watching_a_thread_leaves_the_room_inbox_alone(self, wired):
+        """The two cursors are independent — draining one must not drain the other.
+
+        An agent that spends a turn on a unit still has its room mentions waiting
+        when it looks; the reverse of the bug a single shared cursor would cause.
+        """
+        log = persister.DeliveryLog()
+        log.record(
+            _record("room-1", to="api", episode=l9.live_episode_urn(ROOM)),
+            delivered_to=set(),
+            recipients=["api"],
+        )
+        log.record(_record("t-1", to="api", episode=THREAD), delivered_to=set(), recipients=["api"])
+
+        wired(log)
+        threaded = await participate.await_message(
+            ROOM, _REQUEST, handle="api", timeout=0, episode=THREAD
+        )
+        assert threaded["message_id"] == "t-1"
+
+        room_wide = await participate.await_message(ROOM, _REQUEST, handle="api", timeout=0)
+        assert room_wide["message_id"] == "room-1"
+
+    @pytest.mark.asyncio
+    async def test_a_served_thread_turn_is_not_served_twice(self, wired):
+        log = persister.DeliveryLog()
+        log.record(_record("t-1", to="api", episode=THREAD), delivered_to=set(), recipients=["api"])
+
+        wired(log)
+        first = await participate.await_message(
+            ROOM, _REQUEST, handle="api", timeout=0, episode=THREAD
+        )
+        assert first["message_id"] == "t-1"
+
+        again = await participate.await_message(
+            ROOM, _REQUEST, handle="api", timeout=1, episode=THREAD
+        )
+        assert again["message"] is None
+
+    @pytest.mark.asyncio
+    async def test_the_thread_position_survives_a_restart(self, wired, tmp_path, monkeypatch):
+        """The cursor is persisted, so a restart resumes rather than re-serving."""
+        monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+        persister.write_episode_cursors(ROOM, {THREAD: {"api": 1}})
+        assert persister.load_episode_cursors(ROOM) == {THREAD: {"api": 1}}
+
+        log = persister.DeliveryLog()
+        log.record(_record("t-1", to="api", episode=THREAD), delivered_to=set(), recipients=["api"])
+        fake = _FakePersister(log)
+        fake.episode_cursors = persister.EpisodeCursors(persister.load_episode_cursors(ROOM))
+        assert fake.episode_position("api", THREAD) == 1  # already served, before the restart
+
+
+class TestThreadWriteAuthorization:
+    """Naming a thread is not how one comes into being, and a frozen roster holds."""
+
+    def test_the_room_itself_is_always_writable(self):
+        assert units.episode_write_rejection(ROOM, "api", None) is None
+        assert units.episode_write_rejection(ROOM, "api", l9.live_episode_urn(ROOM)) is None
+
+    def test_an_invented_thread_is_refused(self):
+        refusal = units.episode_write_rejection(ROOM, "api", THREAD)
+        assert refusal is not None
+        assert refusal.status == 404
+
+    def test_a_thread_the_room_has_spoken_in_is_writable(self):
+        assert units.episode_write_rejection(ROOM, "api", THREAD, transcript={THREAD}) is None
+
+    def test_a_bound_row_makes_its_thread_writable(self, tmp_path, monkeypatch):
+        """A unit's thread is writable from the moment the row carries it — before
+        anything has been said in it, which is exactly when the first write lands."""
+        monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+        get_room_dir(ROOM)
+        monkeypatch.setattr(units, "bound_episodes", lambda _room: {THREAD})
+        assert units.episode_write_rejection(ROOM, "api", THREAD) is None
+
+    def test_an_outsider_cannot_drop_a_position_into_a_negotiation(self):
+        """L9's stable-membership rule, enforced on the write side: a score across
+        a frozen roster means nothing if anyone can post into it."""
+        refusal = units.episode_write_rejection(
+            ROOM,
+            "mallory",
+            THREAD,
+            frozen_episode=THREAD,
+            frozen_members={"api", "sec"},
+            transcript={THREAD},
+        )
+        assert refusal is not None
+        assert refusal.status == 403
+        assert "mallory" in refusal.detail
+
+    def test_a_member_of_the_negotiation_may_write(self):
+        assert (
+            units.episode_write_rejection(
+                ROOM,
+                "@API",
+                THREAD,
+                frozen_episode=THREAD,
+                frozen_members={"api"},
+                transcript={THREAD},
+            )
+            is None
+        )
+
+    def test_a_container_takes_a_newcomer(self):
+        """A unit outlives what happens inside it, so an agent that claims the row
+        after the thread opened can speak in it. The freeze is the negotiation's."""
+        assert (
+            units.episode_write_rejection(
+                ROOM,
+                "newcomer",
+                THREAD,
+                frozen_episode=OTHER_THREAD,
+                frozen_members={"api"},
+                transcript={THREAD, OTHER_THREAD},
+            )
+            is None
+        )
+
+
+class _RecordingPersister:
+    """Records what the moderator ingests locally, and nothing else."""
+
+    def __init__(self) -> None:
+        self.ingested: list[tuple[Any, dict, bool]] = []
+
+    def ingest_local(self, envelope, content, *, list_write=False):
+        self.ingested.append((envelope, content, list_write))
+
+    @property
+    def pings(self) -> list[tuple[Any, dict]]:
+        return [
+            (env, content)
+            for env, content, _ in self.ingested
+            if env.payload.type == l9.PING_PAYLOAD_TYPE
+        ]
+
+
+def _live_room(members: set[str] | None = None):
+    """A manager holding one live room whose sends and ingests are observable."""
+    from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
+
+    manager = RoomChannelManager(endpoint="http://127.0.0.1:46357", default_workspace="mycelium")
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    managed = ManagedRoomChannel(
+        room=ROOM,
+        workspace="mycelium",
+        client=MagicMock(),
+        channel=channel,
+        members=set(members or set()),
+    )
+    managed.persister = _RecordingPersister()  # type: ignore[assignment]
+    manager._channels[ROOM] = managed
+    return manager, managed
+
+
+class TestPing:
+    """A thread write surfaces in the room as a signal, never as its content."""
+
+    @pytest.mark.asyncio
+    async def test_a_thread_write_leaves_exactly_one_ping_in_live(self):
+        """The whole point of the epic's PING: the human's channel shows that a
+        unit moved, once, instead of the argument inside it."""
+        manager, managed = _live_room()
+        await manager.publish_human(
+            ROOM, sender="api", text="the token goes in memory", episode=THREAD
+        )
+
+        assert len(managed.persister.pings) == 1
+        ping, _content = managed.persister.pings[0]
+        assert ping.header.message.episode == l9.live_episode_urn(ROOM)
+        assert ping.payload.data["episode"] == THREAD
+
+    @pytest.mark.asyncio
+    async def test_the_ping_carries_no_echo_of_what_was_said(self):
+        manager, managed = _live_room()
+        secret = "the token goes in memory"
+        await manager.publish_human(ROOM, sender="api", text=secret, episode=THREAD)
+
+        _ping, content = managed.persister.pings[0]
+        assert "content" not in content
+        assert secret not in json.dumps(content)
+
+    @pytest.mark.asyncio
+    async def test_the_ping_names_the_thread_and_the_writer(self):
+        manager, managed = _live_room()
+        await manager.publish_human(ROOM, sender="api", text="hi", episode=THREAD)
+
+        ping, _content = managed.persister.pings[0]
+        assert ping.payload.data["episode"] == THREAD
+        assert ping.payload.data["sender"] == "api"
+        assert ping.payload.data["message"]  # enough to open the thread on
+
+    @pytest.mark.asyncio
+    async def test_the_ping_never_goes_out_on_the_wire(self):
+        """Record locally, don't broadcast — the aligner's seam. The channel
+        already carried the real message; the ping is for the transcript and GUI."""
+        manager, managed = _live_room()
+        await manager.publish_human(ROOM, sender="api", text="hi", episode=THREAD)
+
+        sent = [call.args[0] for call in managed.channel.send.call_args_list]
+        assert [e for e in sent if e.payload.type == l9.PING_PAYLOAD_TYPE] == []
+        assert len(sent) == 1  # the thread message itself, and only that
+
+    @pytest.mark.asyncio
+    async def test_the_ping_wakes_nobody(self):
+        """A nudge to look, not a turn to take: a resident ``await`` consumes it
+        silently rather than spending a reasoning turn on it."""
+        manager, managed = _live_room()
+        await manager.publish_human(ROOM, sender="api", text="@sec thoughts?", episode=THREAD)
+
+        _ping, content = managed.persister.pings[0]
+        assert not participate._addressed_to(content, "sec")
+        assert not participate._addressed_to(content, "api")
+
+    @pytest.mark.asyncio
+    async def test_a_message_to_the_room_pings_nothing(self):
+        manager, managed = _live_room()
+        await manager.publish_human(ROOM, sender="api", text="hi")
+        await manager.publish_human(
+            ROOM, sender="api", text="hi", episode=l9.live_episode_urn(ROOM)
+        )
+        assert managed.persister.pings == []
+
+    @pytest.mark.asyncio
+    async def test_a_thread_message_still_rides_the_channel_normally(self):
+        """A thread is a tag over the room's own channel, not a second one."""
+        manager, managed = _live_room()
+        await manager.publish_human(ROOM, sender="api", text="hi", episode=THREAD)
+
+        sent = [call.args[0] for call in managed.channel.send.call_args_list]
+        assert sent[0].header.message.episode == THREAD
+
+
+class TestWriteRoutes:
+    """The two write surfaces take a thread target, and refuse the same way."""
+
+    @pytest.fixture
+    async def room(self, client):
+        assert (await client.post("/api/rooms", json={"name": ROOM})).status_code in (200, 201)
+        return ROOM
+
+    @pytest.mark.asyncio
+    async def test_posting_into_an_invented_thread_is_refused(self, client, room):
+        """A URN is not a way to open a thread — otherwise the transcript grows
+        threads nobody created, each one unreachable from any board row."""
+        resp = await client.post(
+            f"/api/rooms/{room}/messages",
+            json={
+                "message_type": "broadcast",
+                "sender_handle": "api",
+                "content": "hi",
+                "episode": THREAD,
+            },
+        )
+        assert resp.status_code == 404
+        assert "t3" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_a_refused_post_stores_nothing(self, client, room):
+        await client.post(
+            f"/api/rooms/{room}/messages",
+            json={
+                "message_type": "broadcast",
+                "sender_handle": "api",
+                "content": "hi",
+                "episode": THREAD,
+            },
+        )
+        listed = await client.get(f"/api/rooms/{room}/messages")
+        assert listed.json()["messages"] == []
+
+    @pytest.mark.asyncio
+    async def test_posting_into_a_units_thread_lands_on_that_thread(
+        self, client, room, monkeypatch
+    ):
+        monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+        unit = await units.create_unit(room, "ship passkey login", created_by="avery")
+        thread = unit.episode
+        assert thread, "a unit is created with its thread already minted"
+
+        resp = await client.post(
+            f"/api/rooms/{room}/messages",
+            json={
+                "message_type": "broadcast",
+                "sender_handle": "api",
+                "content": "starting on this",
+                "episode": thread,
+            },
+        )
+        assert resp.status_code == 201
+        assert resp.json()["episode"] == thread
+
+    @pytest.mark.asyncio
+    async def test_a_thread_read_filter_answers_the_thread_write(self, client, room, monkeypatch):
+        """Write-then-read round-trips on the same URN, which is what makes a board
+        row openable as a conversation."""
+        monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+        unit = await units.create_unit(room, "rotate the signing key", created_by="avery")
+        thread = unit.episode
+
+        await client.post(
+            f"/api/rooms/{room}/messages",
+            json={
+                "message_type": "broadcast",
+                "sender_handle": "api",
+                "content": "in the thread",
+                "episode": thread,
+            },
+        )
+        await client.post(
+            f"/api/rooms/{room}/messages",
+            json={"message_type": "broadcast", "sender_handle": "api", "content": "in the room"},
+        )
+
+        in_thread = await client.get(f"/api/rooms/{room}/messages", params={"episode": thread})
+        assert [m["content"] for m in in_thread.json()["messages"]] == ["in the thread"]
+
+        # And the inverse, which is what a legible main channel is read with: the
+        # room without its threads. A row posted with no thread carries the
+        # ``live`` URN rather than a bare null, so this filter is answerable.
+        in_room = await client.get(
+            f"/api/rooms/{room}/messages", params={"episode": l9.live_episode_urn(room)}
+        )
+        assert [m["content"] for m in in_room.json()["messages"]] == ["in the room"]
+
+    @pytest.mark.asyncio
+    async def test_an_amendment_stays_in_the_thread_it_revises(self, client, room, monkeypatch):
+        """Revising a thread message must not republish its prose to the room —
+        the one thing a thread exists to prevent — and the thread's own read has
+        to show the revision it folded in."""
+        monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+        unit = await units.create_unit(room, "pick a token store", created_by="avery")
+        thread = unit.episode
+
+        posted = await client.post(
+            f"/api/rooms/{room}/messages",
+            json={
+                "message_type": "broadcast",
+                "sender_handle": "api",
+                "content": "in memory",
+                "episode": thread,
+            },
+        )
+        amended = await client.post(
+            f"/api/rooms/{room}/messages/{posted.json()['id']}/amend",
+            json={"sender_handle": "api", "content": "in the keychain"},
+        )
+        assert amended.status_code == 201
+        assert amended.json()["episode"] == thread
+
+        in_thread = await client.get(f"/api/rooms/{room}/messages", params={"episode": thread})
+        assert [m["content"] for m in in_thread.json()["messages"]] == ["in the keychain"]
+
+        in_room = await client.get(
+            f"/api/rooms/{room}/messages", params={"episode": l9.live_episode_urn(room)}
+        )
+        assert in_room.json()["messages"] == []
+        assert "keychain" not in json.dumps(in_room.json())

--- a/openapi.json
+++ b/openapi.json
@@ -1681,7 +1681,7 @@
           "participate"
         ],
         "summary": "Await Message",
-        "description": "Long-poll for the next message addressed to ``handle`` (server-held member).",
+        "description": "Long-poll for the next message addressed to ``handle`` (server-held member).\n\n``episode`` narrows the wake to one thread \u2014 a unit of work being coordinated\nin, or a negotiation inside one. It narrows *only* the wake: the handle's\npresence lease stays room-scoped (a member of a thread is a member of the\nroom), and so does its room-wide delivery position, so scoping to a unit\nnever eats mentions made to it elsewhere. The thread's own position is\npersisted the same way, so a restart mid-thread resumes rather than\nre-serving.",
         "operationId": "await_message_api_rooms__room_name__await_get",
         "parameters": [
           {
@@ -1711,6 +1711,24 @@
               "default": 0,
               "title": "Timeout"
             }
+          },
+          {
+            "name": "episode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Wake only on this thread (an episode URN). Omit to wake on anything addressed to the handle anywhere in the room.",
+              "title": "Episode"
+            },
+            "description": "Wake only on this thread (an episode URN). Omit to wake on anything addressed to the handle anywhere in the room."
           }
         ],
         "responses": {
@@ -5256,6 +5274,18 @@
               }
             ],
             "description": "Structured event metadata; required when message_type=\"event\""
+          },
+          "episode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Episode",
+            "description": "Thread to post into (an episode URN \u2014 a unit of work's, or a negotiation inside one). Omit to post to the room itself."
           }
         },
         "type": "object",
@@ -5615,6 +5645,18 @@
             "type": "string",
             "title": "Text",
             "description": "The reply / position prose (may carry a position marker)"
+          },
+          "episode": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Episode",
+            "description": "Thread to reply into (an episode URN). Overrides the episode inherited from the tick that woke the handle; omit to answer where you were asked."
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary

Leg 1 (#836) made a `work/` row carry the episode URN its coordination happens in — a board row **is** a thread. Nothing could reach that thread yet: every write hardcoded the room's own `live` episode (`room_channels.py` minted it inline), and every wake read one room-wide cursor.

This is the transport. It lands as **one field on the calls that already exist**, not a second way to talk to a room — a thread is a tag over the room's own channel, so a threaded message is broadcast, recorded, ordered and re-served exactly like any other. What changes is where it lands, what wakes on it, and what the room sees instead of it.

Targets `epic/unit-of-work-first`.

## Changes

**Write side.** `MessageCreate.episode` and `ReplyBody.episode` name a thread; `publish_human` takes one instead of minting `live`. On `/reply` an explicit target beats the episode inherited from the tick that woke the caller — the inherit is what keeps a resident loop threaded without the agent tracking URNs, and the override is what lets a caller mean a specific thread. A reply redirected elsewhere no longer parents onto that tick: a causal edge across threads would read back as a conversation that never happened.

**Read side.** `await?episode=` narrows what wakes a handle, against a **separate persisted cursor** for that thread. Sharing the room-wide one would mean watching a unit silently drains the mentions waiting for you in the room, so `.thread-cursors.json` sits beside the delivery cursors: a position per `(handle, thread)` over the same transcript (a thread is a tag, not a second log), forked off the room position on first read so the `@`-mention that pulled you into the thread is still ahead of you. Restart-safe like its room-wide sibling.

**PING.** A write into a thread raises exactly one compact signal into `live`: which thread, who wrote, the message id, and no prose. Three properties, all structural rather than a convention the next caller has to remember:

- *It never goes on the wire* — the aligner's record-locally-don't-broadcast seam, so it reaches the transcript and the SSE bus without being published to the group. Nothing on the channel has to filter it out, which is also why the CLI's SLIM engine loop needs no change.
- *It wakes nobody* — addressed to no one, and riding a `ping` payload that `_addressed_to` excludes alongside `presence`/`keepalive`, so a resident `await` consumes it instead of spending a reasoning turn on it.
- *Every threaded write raises one* — whatever the message type, and whether or not the channel is up. Raised from the write routes' common store path rather than from inside `publish_human`, which only ever sees a broadcast over a live channel.

**Membership auth on non-`live` writes**, in one function both write routes call (`units.thread_write_refusal`), so `/messages` and `/reply` cannot grow separate ideas of who may speak in a thread. Two refusals:

- **404** — a thread the room does not have. Naming a URN must not be how one comes into being, or the transcript grows threads nobody opened and no board row can reach.
- **403** — a frozen negotiation you are not in the roster of. That is L9's stable-membership rule, which is meaningless if an outsider can drop a position into a scored exchange.

## Two design calls worth arguing with

**A unit's thread refuses neither, and that is deliberate rather than unfinished.** #836 made freezing membership a *negotiation's* policy, not an episode's (`EpisodeLifecycle.frozen`, not `.active`) — a unit outlives what happens inside it. A container that refused non-roster writes would contradict that directly: an agent that claims a row after its thread opened could never speak in it. So the honest boundary is that **a unit's thread is scoped to the room, not narrower** — everyone who may write in the room may write in its threads. Threads separate *attention*, not access; the room's own guards (membership, principal, delegation) are still what a write has to pass. The refusals above are the ones that carry real weight.

**Read filtering of the room feed is left alone.** The aligner deliberately records its ticks into the transcript so humans can follow a negotiation (`aligner.py`'s `ingest_local` — "without this the negotiation is invisible in the room"). Defaulting `GET /messages` to the live episode would break that and would pre-empt #839, which explicitly owns rendering thread activity as a coalesced `SystemNotice`. The ping and the `?episode=` filter are what that leg builds on.

## Bugs found on the way, fixed here

- **An amendment was published to `live` whatever it revised.** Editing a message in a thread would have echoed its prose onto the main channel — the one thing a thread exists to prevent — and the thread's own `?episode=` read would not have shown the revision it folded in. An amendment now lands in its target's thread and passes the same write guard (a roster that froze after the original message still holds). Its bus payload was dropping `episode` too, so an amendment reached the GUI untagged.
- **Filtering the read to the live episode answered nothing.** A room message stored over HTTP carried a null episode while its transcript copy carried the `live` URN, so `?episode=` with the live URN — "the room without its threads", the read a legible main channel needs — matched no rows. Both stores now agree, and both directions of the filter are asserted.
- **A thread could move in silence** (second commit, from review). The ping fired only inside `publish_human`'s broadcast-over-a-live-channel branch, so an `announce`/`event` into a thread, or any threaded write while the channel was down, stored into the thread and raised nothing. A room with no channel has no transcript to raise into — and the message it would announce reached only the bus for the same reason — so the ping now matches that reach rather than vanishing, pushed as the exact frame the persister would have built (`l9_bus_frame`), not a parallel shape.

## Testing

`tests/test_thread_transport.py` (33 tests) holds the acceptance criteria:

- **Scoped await** — wakes on its own thread and not another's, the two cursors drain independently, a served thread turn is not served twice, the position survives a restart.
- **Write refusals** — invented thread, frozen negotiation from outside the roster, and the container that deliberately takes a newcomer.
- **PING** — one per write, no echo (the posted text is asserted absent from the whole frame), never sent on the channel, addressed to nobody, raised for a non-broadcast write and for an amendment, and reaching the bus when there is no channel.
- **`/reply` targeting** — inherits the thread it was asked in and parents onto that tick; a named thread beats the inherited one; a redirected reply drops both the causal edge and the tick sender's address; naming the *same* thread keeps the edge; a threaded reply pings and a room reply does not; an invented thread is refused before anything is recorded.

The two properties added in the second commit were mutation-checked rather than assumed: reverting `answers_the_tick` to always-true fails the redirect test, and removing the ping from the send path fails five.

- [x] Unit tests pass — backend 982, CLI 695, frontend 704
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `uv run ty check .`
- [x] `openapi.json` refreshed (matches the live app); OpenAPI client regenerates clean
- [x] Docs regenerate with no drift (46/46)

Not extended: `contracts/slim-l9-wire.json`. That contract exists because the thin CLI carries its own copy of the SLIM+L9 primitives — a ping never crosses the wire, so there is no second implementation for it to drift from, and an entry with nothing to assert against is the stale-exemption failure mode that file is meant to avoid.

**Note for #838/#839:** `await?episode=`, `ReplyBody.episode`, `MessageCreate.episode` and `?episode=` on the read are the four seams the CLI verbs and the thread pane resolve a row onto — `units.episode_of(room, key)` turns a board row into the URN they all take, and `units.thread_write_refusal(room, handle, episode)` is the single answer to "may this handle write here". The presence lease is still room-scoped (a member of a thread is a member of the room); only the wake narrows.

## Related Issues

Part of #835. Closes #837. Builds on #836 (merged into the epic branch).