### PR TITLE
Hear that a task moved, not what was said in it — UoW Leg 4 frontend

### DIFF
--- a/contracts/slim-l9-wire.json
+++ b/contracts/slim-l9-wire.json
@@ -13,7 +13,8 @@
     "the same PR and both suites will re-lock to the new value.",
     "",
     "Tests: fastapi-backend/tests/test_slim_l9_wire.py,",
-    "mycelium-cli/tests/test_slim_l9_wire.py"
+    "mycelium-cli/tests/test_slim_l9_wire.py,",
+    "mycelium-frontend/src/lib/threads.contract.test.ts (the ping + urn sections only)"
   ],
 
   "master_secret": "mycelium-dev-shared-secret-v1-do-not-use-in-prod",
@@ -46,7 +47,7 @@
   },
 
   "ping": {
-    "_comment": "The payload type a thread's activity surfaces into the room as. The backend PRODUCES it (room_channels.raise_ping, off app.services.l9.PING_PAYLOAD_TYPE) on every write into a thread; the CLI READS it (mycelium.slim.l9.ping_of) to draw the one activity line `room watch` shows when a task moves. A ping deliberately carries no prose \u2014 only which thread moved, who wrote it and the message id \u2014 so payload_fields is the whole of it, and a reader expecting text would draw an empty line instead of the argument the thread exists to absorb. It is also what the backend's participate._addressed_to excludes, so a resident agent consumes a ping silently rather than spending a turn on it: rename the type on one side only and every agent in the room wakes on every thread write.",
+    "_comment": "The payload type a thread's activity surfaces into the room as. The backend PRODUCES it (room_channels.raise_ping, off app.services.l9.PING_PAYLOAD_TYPE) on every write into a thread; the CLI READS it (mycelium.slim.l9.ping_of) to draw the one activity line `room watch` shows when a task moves. A ping deliberately carries no prose \u2014 only which thread moved, who wrote it and the message id \u2014 so payload_fields is the whole of it, and a reader expecting text would draw an empty line instead of the argument the thread exists to absorb. It is also what the backend's participate._addressed_to excludes, so a resident agent consumes a ping silently rather than spending a turn on it: rename the type on one side only and every agent in the room wakes on every thread write. The GUI is the third reader (mycelium-frontend/src/lib/threads.ts, ping_of + PING_PAYLOAD_TYPE): it draws the coalesced 'activity in <task>' notice the room sees in place of the thread's prose, so a drift here empties the channel of any sign its threads moved.",
     "payload_type": "ping",
     "payload_fields": ["episode", "sender", "message"]
   },
@@ -60,7 +61,7 @@
   },
 
   "urn": {
-    "_comment": "Room-scoped episode/topic URN forms. Backend: l9.episode_urn(room, session) / l9.topic_urn(room). CLI connector: _room_episode(room) / _room_topic(room) with the 'live' session literal.",
+    "_comment": "Room-scoped episode/topic URN forms. Backend: l9.episode_urn(room, session) / l9.topic_urn(room). CLI connector: _room_episode(room) / _room_topic(room) with the 'live' session literal. Frontend: mycelium-frontend/src/lib/threads.ts liveEpisodeUrn(room), which is how the channel tells the room's own messages from a thread's.",
     "room": "acme",
     "session": "live",
     "expected_episode": "urn:ioc:mycelium:episode:acme:live",

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -7,14 +7,16 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDefaultLayout } from "react-resizable-panels";
 import { type EpisodeSummary } from "@/lib/api";
-import { useRoom, useRoomRevalidate } from "@/lib/room-data";
+import { useRoom, useRoomRevalidate, useRoomThreads } from "@/lib/room-data";
 import { parseFocus, type FocusTarget } from "@/lib/search";
 import { memoryHref } from "@/lib/memory-routes";
 import { AppShell } from "@/components/app-shell";
 import { EventStream, type View, type NegotiationPhase } from "@/components/event-stream";
 import { RoomChatBox } from "@/components/room-chat-box";
+import { ThreadView } from "@/components/thread-view";
 import { RoomInspector, type Tab } from "@/components/room-inspector";
 import { RoomTour } from "@/components/room-tour";
+import { cn } from "@/lib/utils";
 import { GlobalStatusItems, StatusButton } from "@/components/status-items";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCommands, useKeyAction, useKeyScope } from "@/components/keymap-provider";
@@ -72,6 +74,9 @@ function RoomWorkspace() {
   const [inviteEngine, setInviteEngine] = useState(false);
   const [focusMemory, setFocusMemory] = useState<{ key: string; nonce: number } | null>(null);
   const [focusEpisode, setFocusEpisode] = useState<{ shortId: string; nonce: number } | null>(null);
+  // The open thread, as a URN. A transient pane and nothing more: no rail holds
+  // it, no route names it, and closing it leaves the room exactly as it was.
+  const [threadEpisode, setThreadEpisode] = useState<string | null>(null);
 
   const handleTourExit = useCallback(() => {
     setTourActive(false);
@@ -105,6 +110,20 @@ function RoomWorkspace() {
   }, []);
 
   const handleEngineInviteShown = useCallback(() => setInviteEngine(false), []);
+
+  // A board row's thread chip, or a ping in the channel. Both name the same
+  // thing — the episode — because a row and its thread are one object.
+  const openThread = useCallback((episode: string) => setThreadEpisode(episode), []);
+  const closeThread = useCallback(() => setThreadEpisode(null), []);
+
+  // The task a thread belongs to, when the room knows of one. A coordination
+  // phase opens its own episode and records no back-link, so the pane names the
+  // thread instead of guessing at a row.
+  const threads = useRoomThreads(roomName);
+  const threadTarget = useMemo(
+    () => (threadEpisode ? { episode: threadEpisode, title: threads.get(threadEpisode)?.title ?? null } : null),
+    [threadEpisode, threads],
+  );
 
   // Arriving from search: `?focus=<type>:<id>` names one item in this room.
   // Reveal the surface it lives on, then hand the id to the panel that owns the
@@ -270,23 +289,44 @@ function RoomWorkspace() {
           onLayoutChanged={inspectorOpen ? onLayoutChanged : undefined}
         >
           <ResizablePanel id={PANEL_MAIN} minSize={MAIN_PANEL.min} className="flex min-w-0">
-            <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
-              <div className="flex-1 overflow-hidden">
-                <EventStream
-                  roomName={roomName}
-                  onMemoryChanged={handleMemoryChanged}
-                  onConnectionChange={setConnected}
-                  onNegotiationPhaseChange={setNegPhase}
-                  onOpenMemory={openMemory}
-                  onOpenEpisode={openEpisode}
-                  view={editorView}
-                  onViewChange={setEditorView}
-                  suppressInvites={tourActive}
-                  focusMessageId={focus?.type === "message" ? focus.id : null}
-                  onFocusConsumed={clearFocus}
-                />
+            <main className="flex min-w-0 flex-1 overflow-hidden">
+              {/* The room's own surface stays mounted behind an open thread, so
+                  closing the pane returns to the feed where it was left. Only a
+                  screen too narrow for both hands the width over. */}
+              <div
+                className={cn(
+                  "min-w-0 flex-1 flex-col overflow-hidden",
+                  threadTarget ? "hidden lg:flex" : "flex",
+                )}
+              >
+                <div className="flex-1 overflow-hidden">
+                  <EventStream
+                    roomName={roomName}
+                    onMemoryChanged={handleMemoryChanged}
+                    onConnectionChange={setConnected}
+                    onNegotiationPhaseChange={setNegPhase}
+                    onOpenMemory={openMemory}
+                    onOpenEpisode={openEpisode}
+                    onOpenThread={openThread}
+                    view={editorView}
+                    onViewChange={setEditorView}
+                    suppressInvites={tourActive}
+                    focusMessageId={focus?.type === "message" ? focus.id : null}
+                    onFocusConsumed={clearFocus}
+                  />
+                </div>
+                <RoomChatBox roomName={roomName} className={editorView !== "channel" ? "hidden" : undefined} />
               </div>
-              <RoomChatBox roomName={roomName} className={editorView !== "channel" ? "hidden" : undefined} />
+              {threadTarget && (
+                <div className="flex min-w-0 flex-1 border-l border-border lg:max-w-[26rem] xl:max-w-[34rem]">
+                  <ThreadView
+                    roomName={roomName}
+                    target={threadTarget}
+                    onClose={closeThread}
+                    onOpenMemory={openMemory}
+                  />
+                </div>
+              )}
             </main>
           </ResizablePanel>
           {inspectorOpen && (

--- a/mycelium-frontend/src/components/board/board-bits.tsx
+++ b/mycelium-frontend/src/components/board/board-bits.tsx
@@ -12,17 +12,21 @@ import {
   Eye,
   GitBranch,
   GitPullRequest,
+  MessageSquare,
   Radio,
   TriangleAlert,
   UserRound,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { custodyNote, custodyOf, remainingMinutes } from "@/lib/board/custody";
+import { EPISODE_FIELD } from "@/lib/board/projection";
+import { threadShortId } from "@/lib/threads";
 import {
   arr,
   bool,
   formatAge,
   kindOf,
+  num,
   priorityOf,
   statusOf,
   str,
@@ -394,6 +398,53 @@ export function LiveDot({ item }: { item: LiveItem }) {
       <span className="size-1.5 animate-pulse rounded-full bg-accent" />
       live
     </span>
+  );
+}
+
+/**
+ * The way into a row's conversation.
+ *
+ * A row and the thread its coordination happens in are the same object, so the
+ * thread is not a second thing to find — it is the row, opened. The chip draws
+ * only where a row is actually bound to one: a task created before threading,
+ * or one nobody has said anything about, has no thread to open and says so by
+ * not offering.
+ *
+ * What it opens is a transient pane, not a rail, which is why this is a chip on
+ * the row rather than a permanent column of its own.
+ */
+export function ThreadChip({ item, onOpen }: { item: LiveItem; onOpen?: (episode: string) => void }) {
+  const episode = str(item, EPISODE_FIELD);
+  const shortId = threadShortId(episode);
+  if (!episode || !shortId) return null;
+  const state = str(item, "thread_state");
+  const rounds = num(item, "rounds");
+  // A count only where the thread has one, and never zero: "0 messages" reads
+  // as a claim about a conversation nobody has had.
+  const label = rounds && rounds > 0 ? `${shortId} · ${rounds}` : shortId;
+  const title = state && state !== "open" ? `thread ${shortId} · ${state}` : `thread ${shortId}`;
+  if (!onOpen) {
+    return (
+      <span className="inline-flex items-center gap-1 font-mono text-micro text-muted-foreground" title={title}>
+        <MessageSquare className="size-3" strokeWidth={1.8} />
+        {label}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={e => {
+        e.stopPropagation();
+        onOpen(episode);
+      }}
+      title={`${title}  (t)`}
+      aria-label={`Open thread ${shortId}`}
+      className="inline-flex items-center gap-1 rounded px-1 font-mono text-micro text-accent transition-colors hover:bg-accent-soft hover:underline"
+    >
+      <MessageSquare className="size-3" strokeWidth={1.8} />
+      {label}
+    </button>
   );
 }
 

--- a/mycelium-frontend/src/components/board/board-cockpit.tsx
+++ b/mycelium-frontend/src/components/board/board-cockpit.tsx
@@ -24,6 +24,7 @@ import {
   CustodyChip,
   PriorityMeter,
   SourceTag,
+  ThreadChip,
   TtlBar,
   UpstreamChip,
   WorkLinks,
@@ -36,6 +37,8 @@ interface Props {
   onSelect: (id: string) => void;
   onVerb: (item: LiveItem, verb: Verb) => void;
   onAnswer: (item: LiveItem, choice: string) => void;
+  /** Open a row's thread. Absent, the thread chip reads as a label. */
+  onOpenThread?: (episode: string) => void;
 }
 
 /**
@@ -43,7 +46,7 @@ interface Props {
  * every row carries its own verbs — triage is one gesture from wherever the eye
  * already is, never a detour through a detail page.
  */
-export function BoardCockpit({ groups, now, selectedId, onSelect, onVerb, onAnswer }: Props) {
+export function BoardCockpit({ groups, now, selectedId, onSelect, onVerb, onAnswer, onOpenThread }: Props) {
   return (
     <div className="flex flex-col gap-6 px-5 py-4">
       {groups.map(group => (
@@ -65,6 +68,7 @@ export function BoardCockpit({ groups, now, selectedId, onSelect, onVerb, onAnsw
                 onSelect={() => onSelect(item.id)}
                 onVerb={verb => onVerb(item, verb)}
                 onAnswer={choice => onAnswer(item, choice)}
+                onOpenThread={onOpenThread}
               />
             ))}
           </div>
@@ -81,6 +85,7 @@ function CockpitRow({
   onSelect,
   onVerb,
   onAnswer,
+  onOpenThread,
 }: {
   item: LiveItem;
   now: number;
@@ -88,6 +93,7 @@ function CockpitRow({
   onSelect: () => void;
   onVerb: (verb: Verb) => void;
   onAnswer: (choice: string) => void;
+  onOpenThread?: (episode: string) => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   // Keyboard navigation moves the selection, so the selection has to bring the
@@ -138,6 +144,7 @@ function CockpitRow({
           <SourceTag item={item} />
           <span className="text-faint">·</span>
           <CustodyChip item={item} now={now} />
+          <ThreadChip item={item} onOpen={onOpenThread} />
           <WorkLinks item={item} />
           <UpstreamChip item={item} />
           <BlocksNote item={item} />

--- a/mycelium-frontend/src/components/board/board-kanban.tsx
+++ b/mycelium-frontend/src/components/board/board-kanban.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { lensOf, type LiveItem } from "@/lib/board/item";
 import type { ItemGroup } from "@/lib/board/view";
 import { humanize } from "@/lib/board/schema";
-import { AgeTag, KindGlyph, CustodyChip, PriorityMeter, SourceTag, TtlBar, UpstreamChip, WorkLinks } from "./board-bits";
+import { AgeTag, KindGlyph, CustodyChip, PriorityMeter, SourceTag, ThreadChip, TtlBar, UpstreamChip, WorkLinks } from "./board-bits";
 
 interface Props {
   groups: ItemGroup[];
@@ -18,6 +18,8 @@ interface Props {
   onSelect: (id: string) => void;
   /** Dropping a card writes the column's value into the grouped field. */
   onMove: (item: LiveItem, field: string, value: string) => void;
+  /** Open a row's thread. Absent, the thread chip reads as a label. */
+  onOpenThread?: (episode: string) => void;
 }
 
 /**
@@ -25,7 +27,7 @@ interface Props {
  * a status board that happens to exist — it's what the table looks like when you
  * pivot it, and dropping a card is just a write to that one field.
  */
-export function BoardKanban({ groups, groupBy, now, selectedId, onSelect, onMove }: Props) {
+export function BoardKanban({ groups, groupBy, now, selectedId, onSelect, onMove, onOpenThread }: Props) {
   const [dragging, setDragging] = useState<LiveItem | null>(null);
   const [over, setOver] = useState<string | null>(null);
 
@@ -84,6 +86,7 @@ export function BoardKanban({ groups, groupBy, now, selectedId, onSelect, onMove
                   </div>
                   <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1">
                     <CustodyChip item={item} now={now} />
+                    <ThreadChip item={item} onOpen={onOpenThread} />
                     <WorkLinks item={item} />
           <UpstreamChip item={item} />
                   </div>

--- a/mycelium-frontend/src/components/board/board-thread.test.tsx
+++ b/mycelium-frontend/src/components/board/board-thread.test.tsx
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// A board row and the thread its coordination happens in are the same object,
+// so opening the thread is the row opened — not a second surface to find.
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { render } from "@testing-library/react";
+import { renderWithSWR } from "@/test/swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchMemories = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  logFetchError: () => () => undefined,
+  fetchRoom: vi.fn().mockResolvedValue({ name: "atlas", title: "Atlas" }),
+  fetchEpisodes: vi.fn().mockResolvedValue([]),
+  fetchMemories: (...args: unknown[]) => fetchMemories(...args),
+  fetchRoomAgents: vi.fn().mockResolvedValue([]),
+  fetchRoomMembers: vi.fn().mockResolvedValue([]),
+  fetchMessages: vi.fn().mockResolvedValue({ messages: [] }),
+  fetchRoomStatus: vi.fn().mockResolvedValue({ room: "atlas", field: "upstream", providers: [], refs: [], rows: {}, refreshing: false }),
+  writeFields: vi.fn(),
+  writeLease: vi.fn(),
+}));
+
+vi.mock("@/components/current-user", () => ({
+  useCurrentUser: () => ({ principal: "julia" }),
+}));
+
+vi.mock("@/components/notifications-provider", () => ({
+  useNotifications: () => ({ settings: { soundEnabled: false, soundVolume: 0 } }),
+}));
+
+import { ThreadChip } from "@/components/board/board-bits";
+import { RoomBoard } from "@/components/board/room-board";
+import type { LiveItem } from "@/lib/board/item";
+
+const THREAD = "urn:ioc:mycelium:episode:atlas:t3aa11bb";
+
+const row = (fields: Record<string, unknown>): LiveItem => ({
+  id: "memory:work/flip",
+  title: "flip reads behind a flag",
+  source: { kind: "memory", label: "work/flip" },
+  fields,
+});
+
+describe("<ThreadChip />", () => {
+  it("opens the row's thread by URN", async () => {
+    const onOpen = vi.fn();
+    render(<ThreadChip item={row({ episode: THREAD, thread: "t3aa11bb" })} onOpen={onOpen} />);
+    await userEvent.click(screen.getByRole("button", { name: "Open thread t3aa11bb" }));
+    expect(onOpen).toHaveBeenCalledWith(THREAD);
+  });
+
+  it("offers nothing on a row no thread has run in", () => {
+    // A task created board-first and worked with no episode ever opened is the
+    // normal case, not a broken row — so it says so by not offering.
+    const { container } = render(<ThreadChip item={row({ status: "open" })} onOpen={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("does not draw the room's own channel as a thread", () => {
+    const live = "urn:ioc:mycelium:episode:atlas:live";
+    const { container } = render(<ThreadChip item={row({ episode: live })} onOpen={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("counts the thread only where it has said something", async () => {
+    const onOpen = vi.fn();
+    const { rerender } = render(<ThreadChip item={row({ episode: THREAD, rounds: 6 })} onOpen={onOpen} />);
+    expect(screen.getByRole("button", { name: "Open thread t3aa11bb" })).toHaveTextContent("t3aa11bb · 6");
+    // "0 messages" would read as a claim about a conversation nobody has had.
+    rerender(<ThreadChip item={row({ episode: THREAD, rounds: 0 })} onOpen={onOpen} />);
+    expect(screen.getByRole("button", { name: "Open thread t3aa11bb" })).toHaveTextContent("t3aa11bb");
+    expect(screen.getByRole("button", { name: "Open thread t3aa11bb" })).not.toHaveTextContent("· 0");
+  });
+
+  it("reads as a plain label where nothing is listening", () => {
+    render(<ThreadChip item={row({ episode: THREAD })} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByText("t3aa11bb")).toBeInTheDocument();
+  });
+});
+
+const bound = {
+  key: "work/flip-reads-behind-a-flag",
+  value: { title: "flip reads behind a flag", status: "open" },
+  version: 1,
+  created_by: "aligner",
+  updated_at: "2026-08-04T10:00:00+00:00",
+  episode: THREAD,
+};
+
+/** A task created board-first and worked with no thread ever opened in it. */
+const unbound = { ...bound, key: "work/cache-sweep", value: { title: "cache sweep", status: "open" }, episode: null };
+
+describe("<RoomBoard /> thread affordance", () => {
+  beforeEach(() => {
+    fetchMemories.mockReset().mockResolvedValue([bound]);
+    vi.stubGlobal("EventSource", class { close() {} addEventListener() {} });
+  });
+
+  it("says why a row has no thread rather than opening some other conversation", async () => {
+    // A row nothing has been said about is the ordinary case, not a broken one,
+    // so the board refuses in the terms `board messages` refuses in — it does
+    // not fall back to the room, which would show a different conversation than
+    // the one asked for.
+    fetchMemories.mockResolvedValue([unbound]);
+    const onOpenThread = vi.fn();
+    renderWithSWR(<RoomBoard roomName="atlas" onOpenThread={onOpenThread} />);
+    await screen.findByText("cache sweep");
+
+    await userEvent.keyboard("j");
+    await userEvent.keyboard("t");
+    expect(onOpenThread).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText(/a thread belongs to a task; this row is in another namespace/),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the selected row's thread on `t`", async () => {
+    const onOpenThread = vi.fn();
+    renderWithSWR(<RoomBoard roomName="atlas" onOpenThread={onOpenThread} />);
+    const chip = await screen.findByRole("button", { name: "Open thread t3aa11bb" });
+
+    // Select the row the way the keyboard does, then reach its thread from the
+    // caret — the board is keyboard-first and the thread is one of its verbs.
+    await userEvent.keyboard("j");
+    await userEvent.keyboard("t");
+    await waitFor(() => expect(onOpenThread).toHaveBeenCalledWith(THREAD));
+
+    // And by pointer, from the row itself.
+    onOpenThread.mockClear();
+    await userEvent.click(chip);
+    expect(onOpenThread).toHaveBeenCalledWith(THREAD);
+  });
+});

--- a/mycelium-frontend/src/components/board/board-timeline.tsx
+++ b/mycelium-frontend/src/components/board/board-timeline.tsx
@@ -5,7 +5,7 @@
 
 import { cn } from "@/lib/utils";
 import { ageMinutes, lensOf, type LiveItem } from "@/lib/board/item";
-import { AgeTag, KindGlyph, CustodyChip, SourceTag, UpstreamChip, WorkLinks, kindColor } from "./board-bits";
+import { AgeTag, KindGlyph, CustodyChip, SourceTag, ThreadChip, UpstreamChip, WorkLinks, kindColor } from "./board-bits";
 
 interface Props {
   items: LiveItem[];
@@ -69,6 +69,7 @@ export function BoardTimeline({ items, now, selectedId, onSelect }: Props) {
                   <span className="mt-0.5 flex flex-wrap items-center gap-x-2.5 gap-y-1">
                     <SourceTag item={item} />
                     <CustodyChip item={item} now={now} />
+                    <ThreadChip item={item} />
                     <WorkLinks item={item} />
           <UpstreamChip item={item} />
                   </span>

--- a/mycelium-frontend/src/components/board/room-board.tsx
+++ b/mycelium-frontend/src/components/board/room-board.tsx
@@ -29,9 +29,9 @@ import {
 } from "@/lib/room-data";
 import { writeFields, writeLease } from "@/lib/api";
 import { custodyRefusal, reservedIn } from "@/lib/board/custody";
-import { fieldWriteRefusal, memoryKeyOf } from "@/lib/board/fields";
-import { applyVerb, LENSES, type Lens, type LiveItem, type Verb } from "@/lib/board/item";
-import { projectItems } from "@/lib/board/projection";
+import { fieldWriteRefusal, memoryKeyOf, threadRefusal } from "@/lib/board/fields";
+import { applyVerb, LENSES, str, type Lens, type LiveItem, type Verb } from "@/lib/board/item";
+import { EPISODE_FIELD, projectItems } from "@/lib/board/projection";
 import { attachUpstream } from "@/lib/board/upstream";
 import { localZone, projectActivity } from "@/lib/board/activity";
 import { captureToItem, type ParsedCapture } from "@/lib/board/capture";
@@ -63,6 +63,13 @@ const TZ_KEY = "mycelium.board.tz";
 
 interface Props {
   roomName: string;
+  /**
+   * Open a row's thread. A row and the thread its coordination happens in are
+   * the same object, so this is the row opened rather than a second surface —
+   * and it stays a callback because the pane it opens belongs to the room's
+   * workspace, not to the board.
+   */
+  onOpenThread?: (episode: string) => void;
 }
 
 /**
@@ -73,7 +80,7 @@ interface Props {
  * rows already carry; and the cockpit, kanban and table are three configs over
  * one pipeline rather than three screens.
  */
-export function RoomBoard({ roomName }: Props) {
+export function RoomBoard({ roomName, onOpenThread }: Props) {
   const { room } = useRoom(roomName);
   const { episodes } = useRoomEpisodes(roomName);
   const { memories } = useRoomMemories(roomName);
@@ -325,6 +332,20 @@ export function RoomBoard({ roomName }: Props) {
         return;
       }
       if (key === "escape") return setSelectedId(null);
+      if (key === "t") {
+        if (!selected) return;
+        e.preventDefault();
+        const episode = str(selected, EPISODE_FIELD);
+        // A row with nothing to open says why, in the same terms `board
+        // messages` refuses in — never by opening some other conversation.
+        const refusal = threadRefusal(selected, episode);
+        if (refusal) {
+          setEcho(`${selected.id} has no thread — ${refusal}`);
+          return;
+        }
+        onOpenThread?.(episode as string);
+        return;
+      }
       if (key === "v") {
         const index = MODES.findIndex(m => m.id === view.mode);
         return setMode(MODES[(index + 1) % MODES.length].id);
@@ -349,7 +370,7 @@ export function RoomBoard({ roomName }: Props) {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [ordered, selectedId, pick, runVerb, view.mode, setMode]);
+  }, [ordered, selectedId, pick, runVerb, view.mode, setMode, onOpenThread]);
 
   const applySaved = (slug: string) => {
     const saved = SAVED_VIEWS.find(s => s.slug === slug);
@@ -409,6 +430,7 @@ export function RoomBoard({ roomName }: Props) {
             now={now}
             selectedId={selectedId}
             onSelect={setSelectedId}
+            onOpenThread={onOpenThread}
             onMove={(item, field, value) => {
               // The "no value" column is not a value: dropping a card there
               // means clear the field, not write the column's own key into it.
@@ -431,6 +453,7 @@ export function RoomBoard({ roomName }: Props) {
                 onSelect={setSelectedId}
                 onVerb={runVerb}
                 onAnswer={answer}
+                onOpenThread={onOpenThread}
               />
             ) : view.mode === "table" ? (
               <BoardTable
@@ -633,6 +656,7 @@ function BoardFooter({
         <Key k="p" /> promote
         <Key k="x" /> dismiss
         <Key k="n" /> capture
+        <Key k="t" /> thread
       </span>
       <span className="ml-auto flex items-center gap-2 font-mono text-micro">
         {echo && <span className="truncate text-accent" title={echo}>{echo}</span>}

--- a/mycelium-frontend/src/components/event-stream.consent.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.consent.test.tsx
@@ -10,6 +10,8 @@ import { resetStreamHub } from "@/lib/stream-hub";
 
 vi.mock("@/lib/api", () => ({
   fetchMessages: vi.fn().mockResolvedValue({ messages: [] }),
+  fetchL9History: vi.fn().mockResolvedValue([]),
+  fetchMemories: vi.fn().mockResolvedValue([]),
   fetchRoomAgents: vi.fn().mockResolvedValue([]),
   fetchPendingInvites: vi.fn().mockResolvedValue([]),
   respondToInvite: vi.fn().mockResolvedValue({ id: "i1", status: "accepted" }),

--- a/mycelium-frontend/src/components/event-stream.render.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.render.test.tsx
@@ -11,6 +11,8 @@ import { resetStreamHub } from "@/lib/stream-hub";
 
 vi.mock("@/lib/api", () => ({
   fetchMessages: vi.fn().mockResolvedValue({ messages: [] }),
+  fetchL9History: vi.fn().mockResolvedValue([]),
+  fetchMemories: vi.fn().mockResolvedValue([]),
   fetchRoomAgents: vi.fn().mockResolvedValue([]),
   fetchPendingInvites: vi.fn().mockResolvedValue([]),
   respondToInvite: vi.fn(),

--- a/mycelium-frontend/src/components/event-stream.thread.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.thread.test.tsx
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// What the room hears while its threads are busy.
+//
+// The whole claim of the unit-of-work model is that a task absorbs its own
+// argument and the channel stays readable — so these cases are about what does
+// *not* appear as much as what does.
+
+import { act } from "react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithSWR } from "@/test/swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeEventSource } from "@/test/fake-event-source";
+import { resetStreamHub } from "@/lib/stream-hub";
+import { fetchL9History, fetchMessages, fetchMemories } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  fetchMessages: vi.fn().mockResolvedValue({ messages: [] }),
+  fetchL9History: vi.fn().mockResolvedValue([]),
+  fetchMemories: vi.fn().mockResolvedValue([]),
+  fetchRoomAgents: vi.fn().mockResolvedValue([]),
+  fetchPendingInvites: vi.fn().mockResolvedValue([]),
+  respondToInvite: vi.fn(),
+  logFetchError: () => () => undefined,
+}));
+
+import { EventStream } from "@/components/event-stream";
+
+const ROOM = "atlas";
+const LIVE = "urn:ioc:mycelium:episode:atlas:live";
+const THREAD = "urn:ioc:mycelium:episode:atlas:t3aa11bb";
+const CREATED = "2026-08-04T10:00:00.000000+00:00";
+
+/** A message as the live stream carries it: prose inside an L9 exchange. */
+function said(text: string, episode: string | null, sender = "growth") {
+  return {
+    id: `m-${text.length}-${sender}`,
+    message_type: "l9_exchange",
+    sender_handle: sender,
+    created_at: CREATED,
+    episode,
+    content: JSON.stringify({
+      content: text,
+      l9: {
+        header: { kind: "exchange", message: { id: "m", parents: [], episode } },
+      },
+      payload: { type: "message", data: {} },
+    }),
+  };
+}
+
+/** The ping the backend raises into `live` when a thread moves. */
+function ping(sender: string, message: string, episode = THREAD) {
+  return {
+    id: `ping-${message}`,
+    message_type: "l9_exchange",
+    sender_handle: "system",
+    created_at: CREATED,
+    episode: LIVE,
+    content: JSON.stringify({
+      l9: {
+        header: { kind: "exchange", message: { id: `ping-${message}`, parents: [], episode: LIVE } },
+        payload: { type: "ping", data: { episode, sender, message } },
+      },
+    }),
+  };
+}
+
+describe("<EventStream /> and the threads inside the room", () => {
+  beforeEach(() => {
+    resetStreamHub();
+    FakeEventSource.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    vi.mocked(fetchMessages).mockResolvedValue({ messages: [] });
+    vi.mocked(fetchL9History).mockResolvedValue([]);
+    vi.mocked(fetchMemories).mockResolvedValue([]);
+  });
+
+  it("keeps a thread's prose out of the channel and shows the ping instead", async () => {
+    renderWithSWR(<EventStream roomName={ROOM} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(said("hold the flip until the lag alarm is green", THREAD));
+      es.emit(ping("risk", "m-1"));
+    });
+
+    // The argument is not lost, it is placed: `board messages` and the thread
+    // pane read it. What the room gets is that the task moved.
+    expect(screen.queryByText(/hold the flip/)).not.toBeInTheDocument();
+    expect(await screen.findByText("Activity")).toBeInTheDocument();
+    expect(screen.getByText("· 1 new")).toBeInTheDocument();
+  });
+
+  it("still shows what was said in the room itself", async () => {
+    renderWithSWR(<EventStream roomName={ROOM} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(said("dual-write is live in staging", LIVE));
+      es.emit(said("and the backfill finished", null));
+    });
+
+    // The live URN is the room, and so is no episode at all — a message written
+    // before threading must not read as a thread nobody can open.
+    expect(await screen.findByText("dual-write is live in staging")).toBeInTheDocument();
+    expect(screen.getByText("and the backfill finished")).toBeInTheDocument();
+  });
+
+  it("collapses a burst from one thread into a single line with its count", async () => {
+    renderWithSWR(<EventStream roomName={ROOM} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(ping("risk", "m-1"));
+      es.emit(ping("growth", "m-2"));
+      es.emit(ping("risk", "m-3"));
+    });
+
+    expect(await screen.findByText("· 3 new")).toBeInTheDocument();
+    expect(screen.getAllByText("Activity")).toHaveLength(1);
+    expect(screen.getByText("· @risk, @growth")).toBeInTheDocument();
+  });
+
+  it("opens the thread a ping names, by URN and not by short id", async () => {
+    const onOpenThread = vi.fn();
+    renderWithSWR(<EventStream roomName={ROOM} onOpenThread={onOpenThread} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(ping("risk", "m-1"));
+    });
+
+    await userEvent.click(await screen.findByRole("button", { name: "Open thread t3aa11bb" }));
+    expect(onOpenThread).toHaveBeenCalledWith(THREAD);
+  });
+
+  it("names the task a thread belongs to when the room knows of one", async () => {
+    vi.mocked(fetchMemories).mockResolvedValue([
+      {
+        key: "work/flip-reads-behind-a-flag",
+        value: { title: "flip reads behind a flag" },
+        version: 1,
+        created_by: "aligner",
+        updated_at: CREATED,
+        episode: THREAD,
+      },
+    ]);
+    renderWithSWR(<EventStream roomName={ROOM} onOpenThread={vi.fn()} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(ping("risk", "m-1"));
+    });
+
+    expect(await screen.findByText("flip reads behind a flag")).toBeInTheDocument();
+  });
+
+  it("will not name a thread several rows share", async () => {
+    // A converged negotiation binds every task it compiled to the episode it
+    // converged in, so there is no one row to name — picking one would be the
+    // board asserting something nobody wrote.
+    const bound = (key: string, title: string) => ({
+      key,
+      value: { title },
+      version: 1,
+      created_by: "aligner",
+      updated_at: CREATED,
+      episode: THREAD,
+    });
+    vi.mocked(fetchMemories).mockResolvedValue([
+      bound("work/flip-reads-behind-a-flag", "flip reads behind a flag"),
+      bound("work/retire-the-legacy-store", "retire the legacy store"),
+    ]);
+    renderWithSWR(<EventStream roomName={ROOM} onOpenThread={vi.fn()} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(ping("risk", "m-1"));
+    });
+
+    expect(await screen.findByText("t3aa11bb")).toBeInTheDocument();
+    expect(screen.queryByText("retire the legacy store")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the thread's short id when no row is bound to it", async () => {
+    // A coordination phase opens its own episode and records no back-link to the
+    // task that summoned it, so this is the honest read, not a gap to paper over.
+    renderWithSWR(<EventStream roomName={ROOM} onOpenThread={vi.fn()} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(ping("aligner", "m-1"));
+    });
+
+    expect(await screen.findByText("t3aa11bb")).toBeInTheDocument();
+  });
+
+  it("recovers the pings on a cold read, where the message list has none", async () => {
+    // A ping is a control frame, so the conversational read drops it; only the
+    // transcript's L9 replay keeps it. Without merging both, a reload would show
+    // a quiet room that had been busy all morning.
+    vi.mocked(fetchMessages).mockResolvedValue({ messages: [said("morning", LIVE, "operator")] });
+    vi.mocked(fetchL9History).mockResolvedValue([ping("risk", "m-1")]);
+
+    renderWithSWR(<EventStream roomName={ROOM} />);
+    await act(async () => {});
+
+    expect(await screen.findByText("morning")).toBeInTheDocument();
+    expect(screen.getByText("Activity")).toBeInTheDocument();
+  });
+
+  it("takes only the pings from the L9 replay, so nothing lands twice", async () => {
+    // Every other frame in that replay already reaches the feed as a message.
+    const knowledge = {
+      id: "k-1",
+      message_type: "l9_knowledge",
+      sender_handle: "system",
+      created_at: CREATED,
+      episode: LIVE,
+      content: JSON.stringify({
+        content: "memory updated → work/flip",
+        l9: { payload: { type: "extraction", data: { key: "work/flip" } } },
+      }),
+    };
+    vi.mocked(fetchMessages).mockResolvedValue({ messages: [knowledge] });
+    vi.mocked(fetchL9History).mockResolvedValue([knowledge]);
+
+    renderWithSWR(<EventStream roomName={ROOM} />);
+    await act(async () => {});
+
+    expect(await screen.findAllByText("memory updated → work/flip")).toHaveLength(1);
+  });
+});

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -5,13 +5,15 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  fetchL9History,
   fetchMessages,
   fetchPendingInvites,
   respondToInvite,
   logFetchError,
   type PendingInvite,
 } from "@/lib/api";
-import { useRoomAgents } from "@/lib/room-data";
+import { useRoomAgents, useRoomThreads } from "@/lib/room-data";
+import { PING_TYPE, coalescePings, isLiveEpisode, pingOf, threadShortId } from "@/lib/threads";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomBoard } from "@/components/board/room-board";
@@ -28,7 +30,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Monogram } from "@/components/ui/monogram";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import { ArrowDown, Bot, MessagesSquare } from "lucide-react";
+import { ArrowDown, Bot, MessageSquare, MessagesSquare } from "lucide-react";
 
 interface Event {
   /** Render key only — synthesized, so a message republished by a status
@@ -43,6 +45,8 @@ interface Event {
   sender: string;
   recipient: string | null;
   time: string;
+  /** The full stamp, for ordering two reads into one feed. */
+  at: string;
   // The L9 episode URN this event belongs to, when it rode one. Negotiation
   // turns share their mediator's episode; casual chat carries the room default
   // or none. Lets the feed group/fold one negotiation's turns together.
@@ -52,6 +56,13 @@ interface Event {
   amends: string | null;
   /** True once an amendment has revised this message's text. */
   edited: boolean;
+  /** The thread a **ping** is about — never the episode the ping itself rode,
+   *  which is the room. Null on everything that is not a ping. */
+  thread: string | null;
+  /** How many pings this row stands for, once a burst has been coalesced. */
+  pings: number;
+  /** Who wrote in the thread during that burst, in the order they first did. */
+  pingSenders: string[];
   raw: Record<string, unknown>;
 }
 
@@ -74,12 +85,19 @@ export const L9_RAISE_UP_TYPES = [
 // negotiation lifecycle ("alice joined session X", "CONSENSUS in session X
 // → 4 work rows", "TIMEOUT in session X, no agreement") instead of
 // burying it all under the EVENTS tab.
-const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES]);
+const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES, PING_TYPE]);
 
 // Lifecycle events that render as slim system notices (not chat rows). Used to
 // decide message grouping: a chat message only groups under the sender above it
 // when no system notice interrupts the run.
-const SYSTEM_TYPES = new Set(L9_RAISE_UP_TYPES);
+/**
+ * A ping is a system notice too, but deliberately not on the shared raise-up
+ * list: that list names message types both surfaces promote out of the L9
+ * inspector, and a ping is an `l9_exchange` already on the chat path that is
+ * *renamed* here — the same branch the CLI takes inside `chat_line`. Adding it
+ * to the contract would claim a drift that isn't one.
+ */
+const SYSTEM_TYPES = new Set([...L9_RAISE_UP_TYPES, PING_TYPE]);
 
 /** Skeleton loader for chat rows. */
 function ChannelSkeleton() {
@@ -131,7 +149,7 @@ function SystemNotice({
   );
 }
 
-function parseEvent(msg: Record<string, unknown>): Event {
+function parseEvent(msg: Record<string, unknown>, room: string): Event {
   let mtype = (msg.message_type as string) || (msg.type as string) || "unknown";
   const sender = (msg.sender_handle as string) || (msg.updated_by as string) || "?";
   const recipient = (msg.recipient_handle as string) || null;
@@ -140,6 +158,8 @@ function parseEvent(msg: Record<string, unknown>): Event {
 
   let content = "";
   let raw: Record<string, unknown> = {};
+  let thread: string | null = null;
+  let pingSender: string | null = null;
 
   try {
     if (typeof msg.content === "string") {
@@ -209,7 +229,18 @@ function parseEvent(msg: Record<string, unknown>): Event {
       content = `${key} v${version} by ${by}`;
       break;
     }
-    case "l9_exchange":
+    case "l9_exchange": {
+      // A ping rides the exchange kind like everything else, so it has to be
+      // recognised before the prose unwrap below — which would otherwise turn
+      // it into an empty chat row from `system`, the one shape a thread exists
+      // to keep out of the room.
+      const ping = pingOf(raw);
+      if (ping) {
+        thread = ping.episode;
+        pingSender = ping.sender;
+        mtype = PING_TYPE;
+        break;
+      }
       // The live SSE stream wraps human/agent messages as an L9 exchange
       // envelope, while the REST snapshot (loaded on mount/refresh) delivers the
       // same message as a plain "broadcast". Unwrap the prose and normalise to
@@ -218,6 +249,7 @@ function parseEvent(msg: Record<string, unknown>): Event {
       content = (raw.content as string) || "";
       mtype = recipient ? "direct" : "broadcast";
       break;
+    }
     case "l9_commit": {
       // Unwrap the L9 commit envelope into the coordination_consensus shape
       // so NegotiationView can render it.
@@ -288,11 +320,27 @@ function parseEvent(msg: Record<string, unknown>): Event {
     sender,
     recipient,
     time,
+    at: created,
     episode,
     amends,
     edited: typeof msg.edited_at === "string",
+    thread,
+    pings: thread ? 1 : 0,
+    pingSenders: pingSender ? [pingSender] : [],
     raw,
   };
+}
+
+/**
+ * Whether this event's prose belongs to a thread rather than to the room.
+ *
+ * Only prose: a thread absorbs the argument, not the outcome. A consensus or a
+ * join is the room's business however deep inside a task it happened, which is
+ * why the raise-up notices are not asked this question — the same split the CLI
+ * makes by consulting its own `in_a_thread` from the chat branch alone.
+ */
+function inAThread(event: Event, room: string): boolean {
+  return CHAT_TYPES.has(event.type) && !isLiveEpisode(room, event.episode);
 }
 
 /** A reader a couple of lines off the bottom still counts as reading the tail,
@@ -333,6 +381,9 @@ interface Props {
   /** Open an episode by short id — wired to the episode tags on coordination
    *  notices, so the episode a notice names is one click from its record. */
   onOpenEpisode?: (shortId: string) => void;
+  /** Open a thread by its episode URN — from a ping in the channel, or from the
+   *  board row the thread belongs to. */
+  onOpenThread?: (episode: string) => void;
   /** Optional controlled tab (e.g. driven by the onboarding tour). */
   view?: View;
   onViewChange?: (view: View) => void;
@@ -344,7 +395,7 @@ interface Props {
   onFocusConsumed?: () => void;
 }
 
-export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onNegotiationPhaseChange, onOpenMemory, onOpenEpisode, view: viewProp, onViewChange, suppressInvites = false, focusMessageId = null, onFocusConsumed }: Props) {
+export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onNegotiationPhaseChange, onOpenMemory, onOpenEpisode, onOpenThread, view: viewProp, onViewChange, suppressInvites = false, focusMessageId = null, onFocusConsumed }: Props) {
   const [events, setEvents] = useState<Event[]>([]);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const connected = useRoomConnected(roomName);
@@ -364,22 +415,46 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   // read, so this costs no request of its own; owner is resolved at render time
   // so it always reflects the current manifest, never a stale stamp.
   const { agents } = useRoomAgents(roomName);
+  // Which task each thread belongs to, so a ping can name the row rather than
+  // six characters of URN. Off the room's shared memory read, so it costs
+  // nothing; a thread no row is bound to simply has no name to give.
+  const threads = useRoomThreads(roomName);
   const agentHandles = useMemo(() => new Set(agents.map((a) => a.handle)), [agents]);
   const agentOwners = useMemo(
     () => new Map(agents.filter((a) => a.owner).map((a) => [a.handle, a.owner as string])),
     [agents],
   );
 
-  // Load initial messages
+  // Two reads, one feed.
+  //
+  // The room's messages are what was *said*; a ping is a control frame and the
+  // conversational read leaves it out by construction — which would mean the
+  // channel's account of a busy thread survived only as long as the tab that
+  // watched it land. The transcript's L9 replay is where a ping does survive, so
+  // the pings are lifted out of it and merged back in by time. Everything else
+  // in that replay already reaches the feed as a message, so only pings are
+  // taken; reading both is what makes a reload say what the room said.
   useEffect(() => {
-    fetchMessages(roomName).then(data => {
-      const msgs = (data.messages || []).reverse();
-      setEvents(msgs.map(parseEvent));
-      setHistoryLoaded(true);
-    }).catch((err) => {
-      logFetchError("fetchMessages")(err);
-      setHistoryLoaded(true);
-    });
+    let live = true;
+    Promise.all([fetchMessages(roomName), fetchL9History(roomName)])
+      .then(([data, frames]) => {
+        if (!live) return;
+        const said = (data.messages || []).map((m) => parseEvent(m, roomName));
+        const pings = frames
+          .map((frame) => parseEvent(frame, roomName))
+          .filter((e) => e.type === PING_TYPE);
+        setEvents(
+          [...said, ...pings].sort((a, b) => (Date.parse(a.at) || 0) - (Date.parse(b.at) || 0)),
+        );
+        setHistoryLoaded(true);
+      })
+      .catch((err) => {
+        logFetchError("fetchMessages")(err);
+        if (live) setHistoryLoaded(true);
+      });
+    return () => {
+      live = false;
+    };
   }, [roomName]);
 
   // Load any consent prompts already open (an @-invite raised before this
@@ -408,7 +483,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
       } catch {}
       return;
     }
-    const event = parseEvent(msg);
+    const event = parseEvent(msg, roomName);
     setEvents(prev => (event.amends ? foldAmendment(prev, event) : [...prev, event]));
     if (event.type === "memory_changed") onMemoryChanged?.();
     // A consensus compiles the negotiation into work rows, so nudge the
@@ -422,9 +497,18 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
     }
   });
 
+  // What the room actually says. A thread's prose is dropped — it is not lost,
+  // it is placed, and the pane the ping opens is where it reads — and a burst of
+  // pings from one thread collapses to a single line, so the surface that exists
+  // to stay legible cannot be flooded by the mechanism meant to protect it.
   const visible = useMemo(
-    () => events.filter(e => CHANNEL_VIEW_TYPES.has(e.type)),
-    [events],
+    () =>
+      coalescePings(
+        events.filter(e => CHANNEL_VIEW_TYPES.has(e.type) && !inAThread(e, roomName)),
+        e => e.pings,
+        (latest, pings, pingSenders) => ({ ...latest, pings, pingSenders }),
+      ),
+    [events, roomName],
   );
 
   // Arriving from search: mark the named message and scroll it into sight once
@@ -492,10 +576,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
     highlightRow.current?.scrollIntoView({ block: "center" });
   }, [highlight, historyLoaded, visible]);
 
-  const channelCount = useMemo(
-    () => events.filter(e => CHANNEL_VIEW_TYPES.has(e.type)).length,
-    [events],
-  );
+  const channelCount = visible.length;
 
   // Negotiation phase, derived from the coordination stream. Drives the live
   // tab dot and (via the callback) the onboarding tour's convergence sync.
@@ -564,7 +645,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
       </div>
       {view === "board" ? (
         <div className="flex-1 min-h-0">
-          <RoomBoard roomName={roomName} />
+          <RoomBoard roomName={roomName} onOpenThread={onOpenThread} />
         </div>
       ) : view === "network" ? (
         // Unified Network pane: SLIM channel diagnostics as a rail on top, the
@@ -603,6 +684,33 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
               // Coordination + plan lifecycle events render as slim, centered
               // system notices — quiet dividers woven into the conversation,
               // not loud rows. Chat messages group under one sender header.
+              if (ev.type === PING_TYPE && ev.thread) {
+                const thread = ev.thread;
+                const shortId = threadShortId(thread) ?? "thread";
+                const owner = threads.get(thread);
+                const who = ev.pingSenders;
+                return (
+                  <SystemNotice key={ev.id} time={ev.time} dot="var(--accent)" label="Activity">
+                    <span>in</span>
+                    <button
+                      type="button"
+                      onClick={() => onOpenThread?.(thread)}
+                      disabled={!onOpenThread}
+                      title={thread}
+                      aria-label={`Open thread ${shortId}`}
+                      className="inline-flex max-w-[18rem] items-center gap-1 truncate rounded px-1 text-accent transition-colors enabled:hover:bg-accent-soft enabled:hover:underline disabled:cursor-default"
+                    >
+                      <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
+                      <span className="truncate">{owner?.title ?? shortId}</span>
+                    </button>
+                    <span>· {ev.pings} new</span>
+                    {who.length > 0 && (
+                      <span className="truncate">· {who.map(h => `@${h}`).join(", ")}</span>
+                    )}
+                    {onOpenThread && <span className="text-faint">· click to open</span>}
+                  </SystemNotice>
+                );
+              }
               if (ev.type === "l9_knowledge") {
                 const key = ev.raw.key as string | undefined;
                 const updatedBy = ev.raw.updated_by as string | undefined;

--- a/mycelium-frontend/src/components/room-chat-box.test.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.test.tsx
@@ -125,3 +125,37 @@ describe("<RoomChatBox /> composer triggers", () => {
     });
   });
 });
+
+describe("<RoomChatBox /> targeting", () => {
+  beforeEach(() => {
+    sendRoomMessage.mockClear();
+  });
+
+  it("writes to the room when no thread is named", async () => {
+    renderWithSWR(<RoomChatBox roomName="demo" />);
+    const box = await textarea();
+    await userEvent.type(box, "morning{Enter}");
+    await waitFor(() => expect(sendRoomMessage).toHaveBeenCalled());
+    expect(sendRoomMessage.mock.calls[0][1]).toMatchObject({ content: "morning", episode: null });
+  });
+
+  it("writes into the thread it was pointed at", async () => {
+    const episode = "urn:ioc:mycelium:episode:demo:t3aa11bb";
+    renderWithSWR(<RoomChatBox roomName="demo" episode={episode} threadLabel="flip reads" />);
+    // Where it lands is the one thing the composer must not be coy about: the
+    // same box writes both places, and the difference is whether an argument
+    // stays inside a task or becomes the room's.
+    const box = await screen.findByPlaceholderText(/Reply in flip reads/);
+    await userEvent.type(box, "gating on the lag alarm{Enter}");
+    await waitFor(() => expect(sendRoomMessage).toHaveBeenCalled());
+    expect(sendRoomMessage.mock.calls[0][1]).toMatchObject({
+      content: "gating on the lag alarm",
+      episode,
+    });
+  });
+
+  it("still says it is a thread when nothing named it", async () => {
+    renderWithSWR(<RoomChatBox roomName="demo" episode="urn:ioc:mycelium:episode:demo:t9" />);
+    expect(await screen.findByPlaceholderText(/Reply in this thread/)).toBeInTheDocument();
+  });
+});

--- a/mycelium-frontend/src/components/room-chat-box.tsx
+++ b/mycelium-frontend/src/components/room-chat-box.tsx
@@ -17,6 +17,14 @@ interface Props {
   /** Fired after a successful POST so the parent can refresh the event stream. */
   onSent?: () => void;
   className?: string;
+  /**
+   * The thread this composer writes into. Without one it writes to the room —
+   * the same composer either way, since a thread is a tag over the room's own
+   * channel and not a second place to type.
+   */
+  episode?: string | null;
+  /** What to call that thread in the placeholder, e.g. a task's title. */
+  threadLabel?: string | null;
 }
 
 // Three sigils, three vocabularies, one composer (#618, #619):
@@ -72,7 +80,7 @@ function memoryKey(m: Memory): string {
   return m.key;
 }
 
-export function RoomChatBox({ roomName, onSent, className }: Props) {
+export function RoomChatBox({ roomName, onSent, className, episode = null, threadLabel = null }: Props) {
   const [content, setContent] = useState("");
   // A human message is sent as the acting-as principal — the single source of
   // "who am I" (the ActingAsPicker), not a per-composer handle. Anonymous falls
@@ -192,7 +200,7 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
     setSending(true);
     setError(null);
     try {
-      await sendRoomMessage(roomName, { sender_handle: handle, content: body });
+      await sendRoomMessage(roomName, { sender_handle: handle, content: body, episode });
       setContent("");
       setTrigger(null);
       onSent?.();
@@ -204,7 +212,13 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
       // render, so refocus after that commit lands to keep the user typing.
       requestAnimationFrame(() => inputRef.current?.focus());
     }
-  }, [content, onSent, roomName, principal, sending]);
+  }, [content, episode, onSent, roomName, principal, sending]);
+
+  // Where this lands is the one thing the composer must never be coy about: the
+  // same box writes to the room and into a thread, and the difference is whether
+  // an argument stays inside a task or becomes everyone's.
+  const target = episode ? `Reply in ${threadLabel || "this thread"}…` : "Message the room…";
+  const placeholder = `${target}  @ mention · [[ memory · / skill`;
 
   // The button carries no chrome at rest — the composer's own border is the
   // affordance and Enter is the primary path. It only colors up, and only
@@ -281,7 +295,7 @@ export function RoomChatBox({ roomName, onSent, className }: Props) {
             value={content}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
-            placeholder="Message the room…  @ mention · [[ memory · / skill"
+            placeholder={placeholder}
             minRows={1}
             maxRows={10}
             className="w-full resize-none bg-transparent px-4 pt-3 pb-1.5 text-body text-text leading-relaxed focus:outline-none placeholder:text-muted-foreground"

--- a/mycelium-frontend/src/components/thread-view.test.tsx
+++ b/mycelium-frontend/src/components/thread-view.test.tsx
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithSWR } from "@/test/swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { FakeEventSource } from "@/test/fake-event-source";
+import { resetStreamHub } from "@/lib/stream-hub";
+
+const fetchMessages = vi.fn();
+const sendRoomMessage = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/lib/api", () => ({
+  logFetchError: () => () => undefined,
+  fetchMessages: (...args: unknown[]) => fetchMessages(...args),
+  sendRoomMessage: (...args: unknown[]) => sendRoomMessage(...args),
+  fetchRoomAgents: vi.fn().mockResolvedValue([]),
+  fetchRoomMembers: vi.fn().mockResolvedValue([]),
+  fetchMemories: vi.fn().mockResolvedValue([]),
+  fetchSkills: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/components/current-user", () => ({
+  useCurrentUser: () => ({ principal: "julia" }),
+}));
+
+vi.mock("@/components/keymap-provider", () => ({
+  useKeyAction: () => undefined,
+}));
+
+import { ThreadView } from "@/components/thread-view";
+
+const THREAD = "urn:ioc:mycelium:episode:atlas:t3aa11bb";
+
+/** The backend answers newest-first; a conversation reads the other way. */
+const NEWEST_FIRST = {
+  messages: [
+    { id: "m2", sender_handle: "growth", content: "agreed, gating on the lag alarm", created_at: "2026-08-04T10:01:00+00:00" },
+    { id: "m1", sender_handle: "risk", content: "hold the flip until lag is under a second", created_at: "2026-08-04T10:00:00+00:00" },
+  ],
+};
+
+describe("<ThreadView />", () => {
+  beforeEach(() => {
+    fetchMessages.mockReset().mockResolvedValue(NEWEST_FIRST);
+    sendRoomMessage.mockClear();
+    resetStreamHub();
+    FakeEventSource.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+
+  it("reads only its own episode, and says so on the wire", async () => {
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={vi.fn()} />,
+    );
+    await screen.findByText(/hold the flip/);
+    // The narrowing is the server's, not a filter over the room's feed: a pane
+    // that fetched everything and hid most of it would page in the room's noise
+    // to show one task's conversation.
+    expect(fetchMessages).toHaveBeenCalledWith("atlas", expect.any(Number), { episode: THREAD });
+  });
+
+  it("reads the conversation oldest-first", async () => {
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={vi.fn()} />,
+    );
+    const said = await screen.findAllByText(/lag/);
+    expect(said[0]).toHaveTextContent("hold the flip until lag is under a second");
+  });
+
+  it("names the task it belongs to, and falls back to the thread when nothing does", async () => {
+    const { unmount } = renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD, title: "flip reads behind a flag" }} onClose={vi.fn()} />,
+    );
+    expect(await screen.findByText("flip reads behind a flag")).toBeInTheDocument();
+    unmount();
+
+    renderWithSWR(<ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={vi.fn()} />);
+    expect(await screen.findByText("Thread t3aa11bb")).toBeInTheDocument();
+  });
+
+  it("posts into its own episode, not into the room", async () => {
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD, title: "flip reads" }} onClose={vi.fn()} />,
+    );
+    const box = await screen.findByPlaceholderText(/Reply in flip reads/);
+    await userEvent.type(box, "flag is wired{Enter}");
+    await waitFor(() => expect(sendRoomMessage).toHaveBeenCalled());
+    expect(sendRoomMessage.mock.calls[0][1]).toMatchObject({ episode: THREAD });
+  });
+
+  it("closes on Esc and on the close button, because it is a pane and not a rail", async () => {
+    const onClose = vi.fn();
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={onClose} />,
+    );
+    await userEvent.click(await screen.findByRole("button", { name: "Close thread" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not close on Esc typed into the composer", async () => {
+    // Esc there dismisses the completion popover; stealing it would close the
+    // pane out from under someone mid-sentence.
+    const onClose = vi.fn();
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={onClose} />,
+    );
+    const box = await screen.findByPlaceholderText(/Reply in/);
+    await userEvent.click(box);
+    await userEvent.keyboard("{Escape}");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("shows what was said, not the frames a thread also carries", async () => {
+    // A join, a mediator tick and the commit it converged on are the thread's
+    // lifecycle, not things anybody said — the row's own state is where that
+    // reads, and echoing them here would be a conversation full of blanks.
+    fetchMessages.mockResolvedValue({
+      messages: [
+        { id: "c1", sender_handle: "aligner", message_type: "coordination_consensus", content: JSON.stringify({ assignments: { window: "48h" } }), created_at: "2026-08-04T10:02:00+00:00" },
+        { id: "m1", sender_handle: "risk", content: "hold the flip until lag is under a second", created_at: "2026-08-04T10:00:00+00:00" },
+      ],
+    });
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={vi.fn()} />,
+    );
+    expect(await screen.findByText(/hold the flip/)).toBeInTheDocument();
+    expect(screen.queryByText("aligner")).not.toBeInTheDocument();
+  });
+
+  it("says a quiet thread is quiet rather than looking broken", async () => {
+    fetchMessages.mockResolvedValue({ messages: [] });
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={vi.fn()} />,
+    );
+    expect(await screen.findByText("Nothing said here yet")).toBeInTheDocument();
+  });
+
+  it("re-reads when a write lands in its own thread, and not when one lands elsewhere", async () => {
+    // The pane is a read of one episode, so a live write is a reason to re-read
+    // rather than something to append by hand — and a busy room next door is not
+    // a reason at all.
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={vi.fn()} />,
+    );
+    await screen.findByText(/hold the flip/);
+    const reads = fetchMessages.mock.calls.length;
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit({ message_type: "broadcast", sender_handle: "ops", content: "unrelated", episode: "urn:ioc:mycelium:episode:atlas:live" });
+    });
+    expect(fetchMessages.mock.calls.length).toBe(reads);
+
+    await act(async () => {
+      es.emit({ message_type: "broadcast", sender_handle: "risk", content: "one more thing", episode: THREAD });
+    });
+    await waitFor(() => expect(fetchMessages.mock.calls.length).toBe(reads + 1));
+  });
+
+  it("re-reads on the ping that announces a write into it", async () => {
+    // The ping rides in `live` and names this thread in its payload, so the two
+    // ways a write reaches the stream both land the pane on the same re-read.
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={vi.fn()} />,
+    );
+    await screen.findByText(/hold the flip/);
+    const reads = fetchMessages.mock.calls.length;
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit({
+        message_type: "l9_exchange",
+        sender_handle: "system",
+        episode: "urn:ioc:mycelium:episode:atlas:live",
+        content: JSON.stringify({
+          l9: { payload: { type: "ping", data: { episode: THREAD, sender: "risk", message: "m3" } } },
+        }),
+      });
+    });
+    await waitFor(() => expect(fetchMessages.mock.calls.length).toBe(reads + 1));
+  });
+});

--- a/mycelium-frontend/src/components/thread-view.tsx
+++ b/mycelium-frontend/src/components/thread-view.tsx
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import { MessageSquare, X } from "lucide-react";
+import type { RoomMessage } from "@/lib/api";
+import { useRoomAgents, useThreadMessages } from "@/lib/room-data";
+import { useRoomStream } from "@/lib/stream-hub";
+import { pingOf, threadShortId } from "@/lib/threads";
+import { MarkdownContent } from "@/components/markdown-content";
+import { RoomChatBox } from "@/components/room-chat-box";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Monogram } from "@/components/ui/monogram";
+import { Kbd } from "@/components/ui/kbd";
+import { Tooltip } from "@/components/ui/tooltip";
+
+/** What a thread is a thread *of*, as far as anything can tell. */
+export interface ThreadTarget {
+  /** The episode URN the conversation is tagged with. */
+  episode: string;
+  /**
+   * The task this thread belongs to, when the room knows. A coordination phase
+   * opens its own episode and records no back-link to the task that summoned
+   * it, so this is absent for one — the pane says which thread rather than
+   * inventing which task.
+   */
+  title?: string | null;
+}
+
+interface Props {
+  roomName: string;
+  target: ThreadTarget;
+  onClose: () => void;
+  /** A `[[wikilink]]` in a thread message opens the memory, same as in chat. */
+  onOpenMemory?: (key: string) => void;
+}
+
+/** The prose a thread message carries, or "" when it carries none. */
+function textOf(message: RoomMessage): string {
+  const content = message.content;
+  if (typeof content !== "string") return "";
+  if (!content.startsWith("{")) return content;
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return typeof parsed.content === "string"
+      ? parsed.content
+      : typeof parsed.text === "string"
+        ? parsed.text
+        : "";
+  } catch {
+    return content;
+  }
+}
+
+/**
+ * One task's conversation, on its own.
+ *
+ * A **transient pane**, not a rail: it is here because you opened a row and
+ * gone when you close it, and the room keeps no chrome for it in between —
+ * the same restraint that keeps skills out of a rail of their own. There is
+ * deliberately no "all threads" view either: a thread is reached through the
+ * task it belongs to, which is the only place it means anything.
+ *
+ * The read is its own SWR entry (`useThreadMessages`), so opening this never
+ * replaces the room's feed with a filtered slice of itself, and the composer at
+ * the foot is the room's composer pointed at this episode — one way to write,
+ * aimed differently.
+ */
+export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
+  const { messages, loading, refresh } = useThreadMessages(roomName, target.episode);
+  const { agents } = useRoomAgents(roomName);
+  const agentHandles = new Set(agents.map(a => a.handle));
+  const shortId = threadShortId(target.episode) ?? "thread";
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // A write into this thread reaches the room's one multiplexed stream twice —
+  // as the message itself (tagged with this episode) and as the ping that
+  // announces it (tagged `live`, naming this episode in its payload). Either is
+  // reason to re-read; nothing else here is, so a busy room does not refetch a
+  // quiet thread. The refresh is a revalidation, not an append: the pane stays
+  // a read of one episode rather than a second feed assembled by hand.
+  useRoomStream(roomName, frame => {
+    const message = frame as Record<string, unknown>;
+    if (message.episode === target.episode) {
+      refresh();
+      return;
+    }
+    let content = message.content;
+    if (typeof content === "string") {
+      try {
+        content = JSON.parse(content);
+      } catch {
+        return;
+      }
+    }
+    if (pingOf(content as Record<string, unknown>)?.episode === target.episode) refresh();
+  });
+
+  // Esc closes: the pane is transient, so leaving it must be as cheap as
+  // opening it was.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const el = e.target as HTMLElement | null;
+      if (el && /^(INPUT|TEXTAREA|SELECT)$/.test(el.tagName)) return;
+      onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  // The backend answers newest-first; a conversation reads the other way.
+  //
+  // A thread carries its lifecycle as well as its argument — joins, mediator
+  // ticks, the commit it converged on — and those are frames, not things
+  // anybody said. Selecting on whether a message has prose keeps the pane a
+  // conversation without it having to know which types aren't one; what the
+  // lifecycle amounts to is the row's own state, which the board already draws.
+  const ordered = [...messages]
+    .reverse()
+    .map(message => ({ message, text: textOf(message) }))
+    .filter(({ text }) => text.trim().length > 0);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [ordered.length]);
+
+  return (
+    <section
+      aria-label={`Thread ${shortId}`}
+      data-thread={target.episode}
+      className="flex min-h-0 flex-1 flex-col bg-bg"
+    >
+      <header className="flex h-[48px] shrink-0 items-center gap-2 border-b border-border bg-paper px-4">
+        <MessageSquare className="size-3.5 shrink-0 text-accent" strokeWidth={1.9} />
+        <span className="min-w-0 truncate text-label font-semibold text-text">
+          {target.title || `Thread ${shortId}`}
+        </span>
+        {/* The short id only where a task's name is what the header says —
+            otherwise the header is already the id, and this would repeat it. */}
+        {target.title && (
+          <Tooltip content={target.episode}>
+            <span className="shrink-0 rounded bg-hairline px-1.5 py-px font-mono text-micro text-muted-foreground">
+              {shortId}
+            </span>
+          </Tooltip>
+        )}
+        <span className="ml-auto flex items-center gap-2">
+          <Kbd size="xs" tone="muted">Esc</Kbd>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close thread"
+            className="grid size-6 place-items-center rounded text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+          >
+            <X className="size-3.5" strokeWidth={1.9} />
+          </button>
+        </span>
+      </header>
+
+      <ScrollArea className="min-h-0 flex-1" viewportRef={scrollRef}>
+        {loading && ordered.length === 0 ? (
+          <div className="flex flex-col gap-4 px-5 py-4">
+            <Skeleton className="h-3 w-2/5" />
+            <Skeleton className="h-3 w-3/5" />
+          </div>
+        ) : ordered.length === 0 ? (
+          <EmptyState
+            className="h-full"
+            icon={MessageSquare}
+            title="Nothing said here yet"
+            description="Reply below, or @-mention an agent — it lands in this task, not in the room."
+          />
+        ) : (
+          <div className="py-3">
+            {ordered.map(({ message, text }, i) => {
+              const sender = message.sender_handle ?? message.updated_by ?? "?";
+              const previous = ordered[i - 1]?.message;
+              const grouped = previous && (previous.sender_handle ?? previous.updated_by) === sender;
+              const isAgent = agentHandles.has(sender);
+              return (
+                <div
+                  key={message.id ?? `${sender}-${i}`}
+                  className={`flex gap-3 px-5 ${grouped ? "py-0.5" : "mt-3 pt-1 first:mt-0"}`}
+                >
+                  <div className="w-7 flex-shrink-0">
+                    {!grouped && (
+                      <Monogram
+                        handle={sender}
+                        color={isAgent ? undefined : "var(--avatar-neutral)"}
+                        className="size-7 text-micro"
+                      />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    {!grouped && (
+                      <span className="text-label font-semibold text-text">{sender}</span>
+                    )}
+                    <MarkdownContent
+                      className="contrast text-body leading-relaxed"
+                      onLinkClick={onOpenMemory}
+                    >
+                      {text}
+                    </MarkdownContent>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </ScrollArea>
+
+      <RoomChatBox
+        roomName={roomName}
+        episode={target.episode}
+        threadLabel={target.title || shortId}
+        onSent={refresh}
+      />
+    </section>
+  );
+}

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -525,15 +525,30 @@ export interface MessagesResponse {
 const isMessagesResponse = (d: unknown): d is MessagesResponse =>
   !!d && typeof d === "object" && Array.isArray((d as { messages?: unknown }).messages);
 
-export async function fetchMessages(roomName: string, limit?: number): Promise<MessagesResponse> {
-  const url = limit
-    ? `/api/rooms/${roomName}/messages?limit=${limit}`
-    : `/api/rooms/${roomName}/messages`;
-  return apiFetch<MessagesResponse>(url, {
-    cache: "no-store",
-    fallback: { messages: [] },
-    guard: isMessagesResponse,
-  });
+/** Narrow a read to one conversation. Without it the room answers with all of
+ *  them — its own and every thread inside it. */
+export interface MessageQuery {
+  /** An episode URN: a task's thread, or the room's own `live` URN. */
+  episode?: string | null;
+}
+
+export async function fetchMessages(
+  roomName: string,
+  limit?: number,
+  query: MessageQuery = {},
+): Promise<MessagesResponse> {
+  const params = new URLSearchParams();
+  if (limit) params.set("limit", String(limit));
+  if (query.episode) params.set("episode", query.episode);
+  const qs = params.toString();
+  return apiFetch<MessagesResponse>(
+    `/api/rooms/${roomName}/messages${qs ? `?${qs}` : ""}`,
+    {
+      cache: "no-store",
+      fallback: { messages: [] },
+      guard: isMessagesResponse,
+    },
+  );
 }
 
 /** The room's L9 wire history (transcript replay), for backfilling the live
@@ -552,7 +567,13 @@ export async function fetchL9History(
 
 export async function sendRoomMessage(
   roomName: string,
-  data: { sender_handle: string; content: string; message_type?: string },
+  data: {
+    sender_handle: string;
+    content: string;
+    message_type?: string;
+    /** The thread this lands in. Omitted, it lands in the room itself. */
+    episode?: string | null;
+  },
 ): Promise<RoomMessage> {
   return apiFetch<RoomMessage>(`/api/rooms/${roomName}/messages`, {
     method: "POST",

--- a/mycelium-frontend/src/lib/board/board.test.ts
+++ b/mycelium-frontend/src/lib/board/board.test.ts
@@ -17,6 +17,7 @@ import {
   VERBS,
   type LiveItem,
 } from "@/lib/board/item";
+import { THREAD_REFUSALS, threadRefusal } from "@/lib/board/fields";
 import { parseCapture } from "@/lib/board/capture";
 import { DAILY_GOAL, heatLevel, weekdayIndex } from "@/lib/board/activity";
 import { attachUpstream, UPSTREAM_STATES, upstreamAge, type RoomStatus } from "@/lib/board/upstream";
@@ -510,6 +511,19 @@ describe("shared vocabulary contract", () => {
     // rather than as a promise in a comment.
     const task = (contract as unknown as { task: { thread_fields: string[]; task_fields: string[] } }).task;
     expect(task.thread_fields.filter(f => task.task_fields.includes(f))).toEqual([]);
+  });
+
+  it("refuses to open a thread in the terms the CLI refuses in", () => {
+    const task = (contract as unknown as { task: { refusals: Record<string, string> } }).task;
+    expect(THREAD_REFUSALS).toEqual(task.refusals);
+    // A row that has one is not refused, whatever produced it — including an
+    // orphan episode row, which *is* a thread.
+    const episode: LiveItem = { id: "episode:e4f1a2", title: "e4f1a2", source: { kind: "episode", label: "e" }, fields: {} };
+    expect(threadRefusal(episode, "urn:ioc:mycelium:episode:atlas:e4f1a2")).toBeNull();
+    // And one that hasn't is refused by what produced it, never generically.
+    const agent: LiveItem = { id: "agent:risk", title: "risk", source: { kind: "agent", label: "a" }, fields: {} };
+    expect(threadRefusal(agent, null)).toBe(task.refusals.agent);
+    expect(threadRefusal(item("work/x", {}), null)).toBe(task.refusals.memory);
   });
 
   it("keeps the log's calendar conventions the CLI also asserts", () => {

--- a/mycelium-frontend/src/lib/board/board.test.ts
+++ b/mycelium-frontend/src/lib/board/board.test.ts
@@ -88,6 +88,20 @@ describe("inferSchema", () => {
     expect(groupableFields(schema).map(f => f.name)).toEqual(["status"]);
   });
 
+  it("reads a thread's state as a column but never as an axis to pivot on", () => {
+    // Folding a thread onto a row is so it can be read. Grouping is not reading:
+    // it makes the field what the board is organised by, and pivoting tasks by
+    // how the negotiation inside them went is the container-outlives-the-
+    // negotiation rule inverted where it shows most.
+    const schema = inferSchema([
+      item("a", { status: "open", thread_state: "converged", rounds: 6 }),
+      item("b", { status: "open", thread_state: "converged", rounds: 2 }),
+      item("c", { status: "in_review", thread_state: "rejected", rounds: 4 }),
+    ]);
+    expect(schema.find(f => f.name === "thread_state")?.type).toBe("select");
+    expect(groupableFields(schema).map(f => f.name)).toEqual(["status"]);
+  });
+
   it("offers custody as a column, so a board can group by who holds what", () => {
     const schema = inferSchema([item("a", { custody: "held" })]);
     const custody = schema.find(f => f.name === "custody");
@@ -504,6 +518,25 @@ describe("shared vocabulary contract", () => {
     expect(THREAD_FIELDS).toEqual(task.thread_fields);
     expect(THREAD_STATES).toEqual(task.thread_states);
     expect(TASK_FIELDS).toEqual(task.task_fields);
+  });
+
+  it("keeps every thread field off the pivot axes, not just the one that reaches them today", () => {
+    // What makes a thread field ineligible is whose field it is, not its type.
+    // Only `thread_state` classifies as a select off real rows, so inferring the
+    // schema would leave the other four excluded by type and prove nothing about
+    // them — the fields are handed in already type-eligible, which is the state a
+    // room could put any of them in tomorrow.
+    const task = (contract as unknown as { task: { thread_fields: string[] } }).task;
+    const bounded = (name: string) => ({
+      name,
+      label: name,
+      type: "select" as const,
+      options: [{ value: "a", count: 2 }, { value: "b", count: 1 }],
+      filled: 3,
+      total: 3,
+    });
+    const schema = [...task.thread_fields.map(bounded), bounded("status")];
+    expect(groupableFields(schema).map(f => f.name)).toEqual(["status"]);
   });
 
   it("never lets a thread write one of the task's own axes", () => {

--- a/mycelium-frontend/src/lib/board/fields.ts
+++ b/mycelium-frontend/src/lib/board/fields.ts
@@ -35,6 +35,35 @@ export const FIELD_REFUSALS: Record<string, string> = {
 /** The only row kind with frontmatter behind it. */
 export const WRITABLE_SOURCE_KINDS = ["memory"];
 
+/**
+ * Why a projected row has no thread to open, keyed by what produced it.
+ *
+ * The surface refuses in these terms rather than opening the room instead: a
+ * pane that quietly showed a different conversation than the one asked for is
+ * worse than one that did not open. Keyed by source kind, so an episode row is
+ * absent — an episode *is* a thread, and its row always carries one.
+ *
+ * Frozen in `contracts/board-vocabulary.json` under `task.refusals`; the CLI
+ * carries its own copy (`mycelium/board/model.py THREAD_REFUSALS`) and a test on
+ * each side asserts against that file.
+ */
+export const THREAD_REFUSALS: Record<string, string> = {
+  agent: "presence is a lease the runtime renews, not a conversation to join",
+  memory: "a thread belongs to a task; this row is in another namespace",
+};
+
+/**
+ * Why this row's thread cannot be opened, or null when it can.
+ *
+ * A `work/` row with no binding is the common case and reads as the memory
+ * refusal's sibling: nothing has been said about it yet, so there is no thread
+ * rather than no place for one.
+ */
+export function threadRefusal(item: LiveItem, episode: string | null): string | null {
+  if (episode) return null;
+  return THREAD_REFUSALS[item.source.kind] ?? THREAD_REFUSALS.memory;
+}
+
 /** The memory key behind a row, or null when the row is not a memory. */
 export function memoryKeyOf(item: LiveItem): string | null {
   return item.source.kind === "memory" ? item.id.replace(/^memory:/, "") : null;

--- a/mycelium-frontend/src/lib/board/schema.ts
+++ b/mycelium-frontend/src/lib/board/schema.ts
@@ -11,6 +11,7 @@
  */
 
 import { CUSTODY_STATES } from "./custody";
+import { THREAD_FIELDS } from "./projection";
 import { STATUS_ORDER, type LiveItem } from "./item";
 import { UPSTREAM_STATES } from "./upstream";
 
@@ -185,10 +186,24 @@ export function inferSchema(items: LiveItem[]): FieldSchema[] {
   });
 }
 
-/** Fields a board can group into columns: a bounded vocabulary, ≥2 values. */
+/**
+ * Fields a board can group into columns: a bounded vocabulary, ≥2 values, and
+ * never one of the thread's.
+ *
+ * The thread fields are folded onto a row so they can be *read* — a column, a
+ * chip — and grouping is not reading: it makes the field the axis the board is
+ * organised by. Pivoting tasks by `thread_state` would sort them by how the
+ * negotiation inside them went, which is the container-outlives-the-negotiation
+ * rule inverted on the one surface where it is most visible. So the exclusion
+ * is the whole of `THREAD_FIELDS` rather than the one field that reaches here
+ * today: what makes them ineligible is whose fields they are, not their type.
+ */
 export function groupableFields(schema: FieldSchema[]): FieldSchema[] {
   return schema.filter(
-    f => (f.type === "select" || f.type === "handle" || f.type === "checkbox") && f.options.length >= 2,
+    f =>
+      !THREAD_FIELDS.includes(f.name) &&
+      (f.type === "select" || f.type === "handle" || f.type === "checkbox") &&
+      f.options.length >= 2,
   );
 }
 

--- a/mycelium-frontend/src/lib/room-data.test.tsx
+++ b/mycelium-frontend/src/lib/room-data.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/lib/api", () => ({
 
 import { fetchMessages, fetchRoomAgents, fetchRoomMembers } from "@/lib/api";
 import { CurrentUserProvider } from "@/components/current-user";
-import { useRoomRevalidate, useRoomRoster } from "@/lib/room-data";
+import { useRoomMessages, useRoomRevalidate, useRoomRoster, useThreadMessages } from "@/lib/room-data";
 
 const agent = (handle: string, extra: Record<string, unknown> = {}) => ({
   handle,
@@ -144,5 +144,74 @@ describe("useRoomRoster", () => {
 
     await waitFor(() => expect(fetchRoomAgents).toHaveBeenCalledTimes(2));
     expect(vi.mocked(fetchRoomAgents).mock.calls.map(([room]) => room)).toEqual(["demo", "other"]);
+  });
+});
+
+/** Two readers of the same room's messages: the channel, and one thread's pane. */
+function Feeds({ room, episode }: { room: string; episode: string }) {
+  const { messages } = useRoomMessages(room, 200);
+  const thread = useThreadMessages(room, episode, 200);
+  return (
+    <>
+      <ul data-testid="room">{messages.map((m, i) => <li key={i}>{String(m.content)}</li>)}</ul>
+      <ul data-testid="thread">{thread.messages.map((m, i) => <li key={i}>{String(m.content)}</li>)}</ul>
+    </>
+  );
+}
+
+describe("useThreadMessages", () => {
+  const EPISODE = "urn:ioc:mycelium:episode:demo:t3aa11bb";
+
+  beforeEach(() => {
+    vi.mocked(fetchMessages).mockReset();
+    vi.mocked(fetchMessages).mockImplementation(async (_room, _limit, query) =>
+      query?.episode
+        ? { messages: [{ content: "inside the task" }] }
+        : { messages: [{ content: "in the room" }] },
+    );
+  });
+
+  it("keeps its own cache entry, so a thread never overwrites the room's feed", async () => {
+    // A shared key would have the pane's filtered slice served to the channel —
+    // the room emptied by the mechanism that exists to keep it readable.
+    renderWithSWR(<Feeds room="demo" episode={EPISODE} />);
+    await waitFor(() => expect(screen.getByTestId("thread")).toHaveTextContent("inside the task"));
+    expect(screen.getByTestId("room")).toHaveTextContent("in the room");
+    expect(screen.getByTestId("room")).not.toHaveTextContent("inside the task");
+  });
+
+  it("narrows on the server rather than filtering the room's page", async () => {
+    renderWithSWR(<Feeds room="demo" episode={EPISODE} />);
+    await waitFor(() => expect(fetchMessages).toHaveBeenCalledTimes(2));
+    expect(vi.mocked(fetchMessages).mock.calls.map(([, , query]) => query?.episode)).toEqual([
+      undefined,
+      EPISODE,
+    ]);
+  });
+
+  it("is reached by the room's revalidation, so an SSE thread write refreshes both", async () => {
+    renderWithSWR(
+      <>
+        <Feeds room="demo" episode={EPISODE} />
+        <Revalidator room="demo" />
+      </>,
+    );
+    await waitFor(() => expect(fetchMessages).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      screen.getByRole("button", { name: "refresh" }).click();
+    });
+
+    await waitFor(() => expect(fetchMessages).toHaveBeenCalledTimes(4));
+  });
+
+  it("fetches nothing while no thread is open", async () => {
+    function Closed() {
+      const { messages } = useThreadMessages("demo", null);
+      return <span data-testid="closed">{messages.length}</span>;
+    }
+    renderWithSWR(<Closed />);
+    await waitFor(() => expect(screen.getByTestId("closed")).toHaveTextContent("0"));
+    expect(fetchMessages).not.toHaveBeenCalled();
   });
 });

--- a/mycelium-frontend/src/lib/room-data.ts
+++ b/mycelium-frontend/src/lib/room-data.ts
@@ -79,6 +79,33 @@ const POSTER_LIMIT = 200;
  *  scans a short window past any protocol ticks on top of it. */
 const LATEST_LIMIT = 20;
 
+/** A thread is one task's conversation, so its whole history is a short read. */
+const THREAD_LIMIT = 200;
+
+/** What a thread belongs to, for anything that has to name it. */
+export interface ThreadOwner {
+  /** Every row bound to this thread, in the order the room lists them. */
+  keys: string[];
+  /**
+   * What to call it — the row's own title, but **only** where exactly one row
+   * is bound. A negotiation compiles several tasks and binds all of them to the
+   * episode it converged in, so naming one of those would be picking a row at
+   * random and asserting it. Null means the thread is named by its short id,
+   * which is what is actually true of it.
+   */
+  title: string | null;
+}
+
+/** A row's own title where its frontmatter carries one, else its key. */
+function memoryTitle(memory: Memory): string {
+  const value = memory.value;
+  const title =
+    value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>).title
+      : null;
+  return typeof title === "string" && title.trim() ? title.trim() : memory.key;
+}
+
 // Stable empties: a fresh `[]` per render would break every downstream memo.
 const NO_STATUS: RoomStatus = {
   room: "",
@@ -220,6 +247,64 @@ export function useRoomMessages(room: string, limit = 200, opts: RoomQueryOption
     void mutate();
   }, [mutate]);
   return { messages: data?.messages ?? NO_MESSAGES, loading: isLoading, refresh };
+}
+
+/**
+ * One thread's messages, and nothing else.
+ *
+ * Its own cache entry — `["room", <name>, "messages", "thread", <urn>]` — so a
+ * thread pane never overwrites the room's own feed with a filtered slice of it,
+ * which is what a shared key would do the moment both are open. Still under the
+ * `["room", <name>]` prefix, so `useRoomRevalidate` reaches it: an SSE write
+ * into a thread refreshes the thread and the room together.
+ *
+ * A null episode parks the hook, so a closed pane fetches nothing.
+ */
+export function useThreadMessages(
+  room: string,
+  episode: string | null,
+  limit = THREAD_LIMIT,
+  opts: RoomQueryOptions = {},
+) {
+  const { data, isLoading, mutate } = useSWR(
+    room && episode ? (["room", room, "messages", "thread", episode, limit] as const) : null,
+    () => fetchMessages(room, limit, { episode }),
+    { refreshInterval: opts.refreshInterval ?? POLL.messages },
+  );
+  const refresh = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+  return { messages: data?.messages ?? NO_MESSAGES, loading: isLoading, refresh };
+}
+
+/**
+ * Every thread the room's rows are bound to, keyed by URN.
+ *
+ * The binding is the task's (`Memory.episode`), so this is that same edge read
+ * the other way round — what a bare URN in a ping is a thread *of*. Derived off
+ * the shared memories cache, so naming a thread costs no request.
+ *
+ * Two ways a thread ends up without a name here, both honest rather than
+ * missing: an episode no row mentions (a coordination phase opens its own and
+ * records no back-link to the task that summoned it), and an episode several
+ * rows share (a converged negotiation binds every task it compiled to itself).
+ */
+export function useRoomThreads(room: string): Map<string, ThreadOwner> {
+  const { memories } = useRoomMemories(room);
+  return useMemo(() => {
+    const index = new Map<string, ThreadOwner>();
+    for (const memory of memories) {
+      if (!memory.episode) continue;
+      const known = index.get(memory.episode);
+      if (known) {
+        known.keys.push(memory.key);
+        known.title = null;
+      } else {
+        index.set(memory.episode, { keys: [memory.key], title: memoryTitle(memory) });
+      }
+    }
+    return index;
+  }, [memories]);
 }
 
 /** The last readable line in a room, for an inbox-style row. Its own SWR key,

--- a/mycelium-frontend/src/lib/threads.contract.test.ts
+++ b/mycelium-frontend/src/lib/threads.contract.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// Contract drift guard for the thread/ping wire constants (frontend side).
+//
+// The backend produces a ping (`room_channels.raise_ping`), the CLI reads one
+// (`mycelium.slim.l9.ping_of`), and this is the third reader. All three carry
+// their own copy — the frontend's Docker build context is mycelium-frontend/
+// only, so it cannot import the repo root at runtime — and each asserts its copy
+// against contracts/slim-l9-wire.json here. Rename the payload type on one side
+// alone and the room silently stops hearing that its threads have moved.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { LIVE_SESSION, PING_PAYLOAD_FIELDS, PING_PAYLOAD_TYPE, liveEpisodeUrn } from "@/lib/threads";
+
+const CONTRACT_PATH = path.resolve(__dirname, "../../../contracts/slim-l9-wire.json");
+
+function contract(): {
+  ping: { payload_type: string; payload_fields: string[] };
+  urn: { room: string; session: string; expected_episode: string };
+} {
+  return JSON.parse(readFileSync(CONTRACT_PATH, "utf-8"));
+}
+
+describe("thread wire constants contract", () => {
+  it("mints the room's live-episode URN the way the backend and CLI do", () => {
+    const { urn } = contract();
+    expect(LIVE_SESSION).toBe(urn.session);
+    expect(liveEpisodeUrn(urn.room)).toBe(urn.expected_episode);
+  });
+
+  it("reads the contracted ping payload type and fields", () => {
+    const { ping } = contract();
+    expect(PING_PAYLOAD_TYPE).toBe(ping.payload_type);
+    expect([...PING_PAYLOAD_FIELDS]).toEqual(ping.payload_fields);
+  });
+});

--- a/mycelium-frontend/src/lib/threads.test.ts
+++ b/mycelium-frontend/src/lib/threads.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import {
+  PING_TYPE,
+  coalescePings,
+  isLiveEpisode,
+  liveEpisodeUrn,
+  pingOf,
+  threadShortId,
+  type Pingable,
+} from "@/lib/threads";
+
+const ROOM = "atlas";
+const THREAD = "urn:ioc:mycelium:episode:atlas:t3aa11bb";
+
+function pingFrame(episode: string, sender?: string, message?: string) {
+  return {
+    l9: {
+      header: { kind: "exchange", message: { episode: liveEpisodeUrn(ROOM) } },
+      payload: { type: "ping", data: { episode, ...(sender ? { sender } : {}), ...(message ? { message } : {}) } },
+    },
+  };
+}
+
+describe("the room, and the threads inside it", () => {
+  it("reads a message with no episode as the room's own", () => {
+    // Rows written before threading carry none. Reading those as a thread would
+    // empty the channel of its own history.
+    expect(isLiveEpisode(ROOM, null)).toBe(true);
+    expect(isLiveEpisode(ROOM, undefined)).toBe(true);
+  });
+
+  it("reads the live URN as the room, and anything else as a thread", () => {
+    expect(isLiveEpisode(ROOM, liveEpisodeUrn(ROOM))).toBe(true);
+    expect(isLiveEpisode(ROOM, THREAD)).toBe(false);
+  });
+
+  it("does not mistake another room's live URN for this room's", () => {
+    expect(isLiveEpisode(ROOM, liveEpisodeUrn("pricing"))).toBe(false);
+  });
+
+  it("names a thread by the tail of its URN, and the room by nothing", () => {
+    expect(threadShortId(THREAD)).toBe("t3aa11bb");
+    expect(threadShortId(liveEpisodeUrn(ROOM))).toBeNull();
+    expect(threadShortId(null)).toBeNull();
+  });
+});
+
+describe("reading a ping", () => {
+  it("takes the thread from the payload, never from the frame's own episode", () => {
+    // A ping rides in `live` — that is what makes it reach the room — so the
+    // two answer different questions and confusing them would point every ping
+    // at the room it was raised in.
+    const ping = pingOf(pingFrame(THREAD, "risk", "m7"));
+    expect(ping).toEqual({ episode: THREAD, sender: "risk", message: "m7" });
+  });
+
+  it("is not a ping when the payload is a message", () => {
+    const frame = { content: "hello", l9: { payload: { type: "message", data: {} } } };
+    expect(pingOf(frame)).toBeNull();
+  });
+
+  it("refuses a ping that names no thread rather than inventing one", () => {
+    expect(pingOf({ l9: { payload: { type: "ping", data: {} } } })).toBeNull();
+  });
+
+  it("survives a frame with no envelope at all", () => {
+    expect(pingOf({})).toBeNull();
+    expect(pingOf(null)).toBeNull();
+  });
+});
+
+describe("coalescing a burst of pings", () => {
+  const ping = (thread: string, sender: string): Pingable & { id: string; count: number } => ({
+    id: `${thread}-${sender}`,
+    type: PING_TYPE,
+    thread,
+    pingSenders: [sender],
+    count: 1,
+  });
+  const said = (id: string): Pingable & { id: string; count: number } => ({
+    id,
+    type: "broadcast",
+    thread: null,
+    pingSenders: [],
+    count: 0,
+  });
+  const fold = <T extends Pingable & { count: number }>(rows: T[]) =>
+    coalescePings(rows, r => r.count, (latest, count) => ({ ...latest, count }));
+
+  it("turns a busy thread into one line carrying the count", () => {
+    const rows = fold([ping(THREAD, "risk"), ping(THREAD, "growth"), ping(THREAD, "risk")]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].count).toBe(3);
+  });
+
+  it("keeps two active threads apart", () => {
+    const other = "urn:ioc:mycelium:episode:atlas:t9";
+    const rows = fold([ping(THREAD, "risk"), ping(other, "growth"), ping(THREAD, "risk")]);
+    expect(rows.map(r => r.thread)).toEqual([THREAD, other]);
+    expect(rows[0].count).toBe(2);
+    expect(rows[1].count).toBe(1);
+  });
+
+  it("stops at the first thing said in the room", () => {
+    // A ping after someone speaks is new activity, not more of the same, and
+    // folding it backwards would move a line that has already been read.
+    const rows = fold([ping(THREAD, "risk"), said("a1"), ping(THREAD, "risk")]);
+    expect(rows.map(r => r.id)).toEqual([`${THREAD}-risk`, "a1", `${THREAD}-risk`]);
+  });
+
+  it("leaves a feed with no pings in it exactly as it found it", () => {
+    const rows = [said("a1"), said("a2")];
+    expect(fold(rows)).toEqual(rows);
+  });
+
+  it("collects who wrote, in the order they first did", () => {
+    const senders = coalescePings(
+      [ping(THREAD, "risk"), ping(THREAD, "growth"), ping(THREAD, "risk")],
+      r => r.count,
+      (latest, count, who) => ({ ...latest, count, who }),
+    ) as (Pingable & { who?: string[] })[];
+    expect(senders[0].who).toEqual(["risk", "growth"]);
+  });
+});

--- a/mycelium-frontend/src/lib/threads.ts
+++ b/mycelium-frontend/src/lib/threads.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * Threads, and how the room hears about them.
+ *
+ * A task's coordination happens in a **thread** — an episode URN tagged over
+ * the room's own channel, not a channel of its own. The room itself is an
+ * episode too (the `live` URN), which is what makes "the room without its
+ * threads" a question this module can answer rather than a special case.
+ *
+ * What surfaces in the room when a thread moves is a **ping**: which thread,
+ * who wrote, and the message's id. Deliberately no prose — a thread exists so
+ * an argument inside a task does not become the room's problem, and echoing it
+ * here would undo that. The backend produces the ping
+ * (`room_channels.raise_ping`) and the CLI reads it (`slim.l9.ping_of`); this
+ * is the third reader, so the constants below are frozen in
+ * `contracts/slim-l9-wire.json` and asserted by `threads.contract.test.ts`.
+ */
+
+/** The session literal naming a room's own channel among its episodes. */
+export const LIVE_SESSION = "live";
+
+/** The payload type a thread's activity surfaces into the room as. */
+export const PING_PAYLOAD_TYPE = "ping";
+
+/** The whole of a ping. A reader expecting prose here would draw an empty line. */
+export const PING_PAYLOAD_FIELDS = ["episode", "sender", "message"] as const;
+
+/**
+ * The normalized type a ping wears once parsed.
+ *
+ * A ping arrives as an `l9_exchange` like any other message, so it would
+ * otherwise render as a chat row from `system` with nothing in it. Naming it
+ * here is what lets the feed render it as the notice it is.
+ */
+export const PING_TYPE = "thread_ping";
+
+/** The URN of a room's own channel — where a message with no thread lands. */
+export function liveEpisodeUrn(room: string): string {
+  return `urn:ioc:mycelium:episode:${room}:${LIVE_SESSION}`;
+}
+
+/**
+ * Whether this episode is the room itself rather than a thread inside it.
+ *
+ * A missing episode is the room: rows written before threading carry none, and
+ * reading them as a thread would empty the channel of its own history.
+ */
+export function isLiveEpisode(room: string, episode: string | null | undefined): boolean {
+  return !episode || episode === liveEpisodeUrn(room);
+}
+
+/** The short id a thread is named by — the tail of its URN. */
+export function threadShortId(episode: string | null | undefined): string | null {
+  if (!episode) return null;
+  const tail = episode.split(":").pop();
+  return tail && tail !== LIVE_SESSION ? tail : null;
+}
+
+/** What a ping says: the thread that moved, who wrote, and what they wrote. */
+export interface Ping {
+  episode: string;
+  sender: string | null;
+  message: string | null;
+}
+
+/**
+ * The ping a wire frame carries, or null when it isn't one.
+ *
+ * Reads the L9 envelope's own payload rather than the frame's `episode` field:
+ * a ping rides in `live` (that is the point of it) and names the thread it is
+ * about in its payload, so the two answer different questions.
+ */
+export function pingOf(raw: Record<string, unknown> | null | undefined): Ping | null {
+  const envelope = (raw?.l9 ?? null) as Record<string, unknown> | null;
+  const payload = (envelope?.payload ?? null) as Record<string, unknown> | null;
+  if (!payload || payload.type !== PING_PAYLOAD_TYPE) return null;
+  const data = (payload.data ?? {}) as Record<string, unknown>;
+  const episode = data.episode;
+  if (typeof episode !== "string" || !episode) return null;
+  return {
+    episode,
+    sender: typeof data.sender === "string" ? data.sender : null,
+    message: typeof data.message === "string" ? data.message : null,
+  };
+}
+
+/** The minimum a feed row has to expose to be coalesced. */
+export interface Pingable {
+  type: string;
+  /** The thread this row is about, on a ping; null on everything else. */
+  thread: string | null;
+  /** Who wrote in the thread. A row's own sender is the system that raised the
+   *  ping, which is nobody, so the writers are read from the payload instead. */
+  pingSenders: string[];
+}
+
+/**
+ * Collapse a burst of pings into one line per thread.
+ *
+ * A thread that is genuinely busy would otherwise write a line per message into
+ * the channel it exists to keep quiet — the noise back, one indirection later.
+ * So a **run** of consecutive pings (nothing else said in between) becomes at
+ * most one row per thread, counting what landed and keeping the newest ping's
+ * identity so opening it still reaches the latest.
+ *
+ * Coalescing stops at the first non-ping row: a ping after someone speaks is
+ * new activity, not more of the same, and folding it backwards would move a
+ * line that has already been read.
+ */
+export function coalescePings<T extends Pingable>(
+  rows: T[],
+  count: (row: T) => number,
+  merge: (latest: T, total: number, senders: string[]) => T,
+): T[] {
+  const out: T[] = [];
+  let run: T[] = [];
+
+  const flush = () => {
+    if (!run.length) return;
+    const byThread = new Map<string, T[]>();
+    for (const row of run) {
+      const thread = row.thread as string;
+      const group = byThread.get(thread);
+      if (group) group.push(row);
+      else byThread.set(thread, [row]);
+    }
+    for (const group of byThread.values()) {
+      const latest = group[group.length - 1];
+      const total = group.reduce((sum, row) => sum + count(row), 0);
+      // Who has been in the thread since the last thing said in the room. In
+      // first-seen order, so the list reads as the conversation happened.
+      const senders = [...new Set(group.flatMap(row => row.pingSenders))];
+      out.push(total > count(latest) || senders.length > 1 ? merge(latest, total, senders) : latest);
+    }
+    run = [];
+  };
+
+  for (const row of rows) {
+    if (row.type === PING_TYPE && row.thread) run.push(row);
+    else {
+      flush();
+      out.push(row);
+    }
+  }
+  flush();
+  return out;
+}

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -156,6 +156,10 @@ const a2aManifest = (description: string, card: string, skills: string[]): strin
 // ── atlas-migration: the rich, converged room ─────────────────────────────────
 
 const ATLAS_EPISODE = "urn:ioc:mycelium:episode:atlas-migration:e4f1a2";
+// The room's own channel. A message with no thread lands here, and a ping about
+// a thread is raised here — which is why the ping's own episode is this one and
+// the thread it names is in its payload.
+const ATLAS_LIVE = "urn:ioc:mycelium:episode:atlas-migration:live";
 
 // The negotiation the aligner brokered: growth (big-bang, fast) vs risk
 // (phased, safe), converging over four rounds of Stacked Alternating Offers.
@@ -266,6 +270,39 @@ const atlasL9Frames: Record<string, unknown>[] = atlasL9Chain.map((env, i) => ({
   created_at: iso(44 - i),
   content: env,
 }));
+
+/**
+ * A thread's activity as the room hears it: a **ping**, and only a ping.
+ *
+ * The shape the backend raises (`room_channels.raise_ping`) — an exchange
+ * envelope in `live` naming the thread that moved, who wrote and which message,
+ * carrying no prose, so there is nothing here to echo even by accident.
+ *
+ * It belongs to the L9 wire feed and *not* to the message list, which is where
+ * the backend puts it too: a ping is a control frame, so the conversational
+ * read drops it and the transcript replay is where it survives a reload. A mock
+ * that served it from both would hide the merge the channel actually does.
+ */
+function atlasPing(message: string, sender: string, minutesAgo: number): Record<string, unknown> {
+  return {
+    id: `ping-${message}`,
+    sender_handle: "system",
+    message_type: "l9_exchange",
+    created_at: iso(minutesAgo),
+    room_name: "atlas-migration",
+    episode: ATLAS_LIVE,
+    content: {
+      l9: {
+        header: {
+          kind: "exchange",
+          message: { id: `ping-${message}`, parents: [], episode: ATLAS_LIVE },
+          participants: { actors: [{ id: "system", role: "coordinator" }] },
+        },
+        payload: { type: "ping", data: { episode: ATLAS_EPISODE, sender, message } },
+      },
+    },
+  };
+}
 
 const atlasEpisodeSummary: EpisodeSummary = {
   short_id: "e4f1a2",
@@ -553,6 +590,12 @@ const atlas: RoomFixture = {
     ...atlasNegotiation,
     { id: "a6", sender_handle: "aligner", message_type: "coordination_consensus", content: JSON.stringify({ assignments: { cutover: "phased", window: "48h" }, episode: ATLAS_EPISODE, metrics: { gar: 0.79 } }), created_at: iso(41), episode: ATLAS_EPISODE },
     { id: "a7", sender_handle: "growth", message_type: "broadcast", content: "Dual-write is live in staging. ✅", created_at: iso(30) },
+    // Two agents working the flag row talk inside its thread. The channel does
+    // not carry this — that is the whole point — so the room hears the pings
+    // below instead, and the prose reads in the thread pane.
+    { id: "t1", sender_handle: "growth", message_type: "broadcast", content: "Flag is wired: reads flip on `atlas.reads.v2`, default off.", created_at: iso(22), episode: ATLAS_EPISODE },
+    { id: "t2", sender_handle: "risk", message_type: "broadcast", content: "Hold the flip until replica lag has been under a second for an hour.", created_at: iso(21), episode: ATLAS_EPISODE },
+    { id: "t3", sender_handle: "growth", message_type: "broadcast", content: "Agreed — gating the flip on the lag alarm.", created_at: iso(20), episode: ATLAS_EPISODE },
   ],
   episodes: [atlasEpisodeSummary],
   episodeDetails: { e4f1a2: { ...atlasEpisodeSummary, messages: atlasL9Chain } },
@@ -564,7 +607,7 @@ const atlas: RoomFixture = {
     { handle: "growth", kind: "slim", last_seen: null },
     { handle: "risk", kind: "lease", last_seen: iso(1) },
   ],
-  l9: atlasL9Frames,
+  l9: [...atlasL9Frames, atlasPing("t2", "risk", 21), atlasPing("t3", "growth", 20)],
   // Three work rows name pull requests; the hub resolved them. The first row
   // mentions two, one green and one failing, so it shows the failing one and says
   // there was another. The shapes are GitHub's own wording.

--- a/mycelium-frontend/src/mocks/handlers.ts
+++ b/mycelium-frontend/src/mocks/handlers.ts
@@ -345,9 +345,14 @@ export async function handleMock(req: Request): Promise<Response | null> {
       if (method === "GET") {
         // The backend serves newest-first; the UI reverses to oldest-first.
         const limit = Number(searchParams.get("limit") ?? "0");
-        const ordered = [...fx.messages].reverse();
+        // `?episode=` narrows to one conversation — a thread, or the room's own
+        // `live` URN. Exact-match, as the backend filters, so the mock can't let
+        // a thread pane pass while the real read returns everything.
+        const episode = searchParams.get("episode");
+        const scoped = episode ? fx.messages.filter((m) => m.episode === episode) : fx.messages;
+        const ordered = [...scoped].reverse();
         const messages = limit > 0 ? ordered.slice(0, limit) : ordered;
-        return json({ messages, total: fx.messages.length });
+        return json({ messages, total: scoped.length });
       }
       if (method === "POST") {
         const body = await readJson(req);
@@ -356,6 +361,7 @@ export async function handleMock(req: Request): Promise<Response | null> {
           sender_handle: String(body.sender_handle ?? "operator"),
           message_type: String(body.message_type ?? "broadcast"),
           content: String(body.content ?? ""),
+          episode: body.episode ?? null,
           created_at: new Date(0).toISOString(),
         });
       }


### PR DESCRIPTION
## Summary

The GUI half of #835. A thread absorbs the argument inside a task, so the room's channel stops carrying it: prose tagged with an episode other than the room's own is dropped from the feed, and what surfaces instead is the **ping** the backend raises — one coalesced line per busy thread, naming the task, counting what landed, one click from reading it.

The thread itself is a **transient pane**. It opens from the row it belongs to (a chip on the row, or `t` on the selected one) and from the ping that announced it, reads its own episode on its own SWR key, and closes on `Esc` leaving no chrome behind. No rail, no room-wide "all threads" view — the same restraint that keeps skills out of a rail of their own. The composer at its foot is the room's composer pointed at that episode, and says so ("Reply in flip reads behind a flag…").

Built on Legs 1–3, and reading the four seams @be-transport-837 left: `?episode=` on the read, `MessageCreate.episode` on the write, the `l9_exchange` ping frame, and `units.episode_of` as the row→URN binding (read here off `Memory.episode`, the same edge the other way round).

### Three calls worth arguing with

**A ping is live-only in the message list, so the channel reads twice.** `stored_message_from_record` projects a record into the cold read only when it carries prose or is a raise-up *kind*; a ping is neither, so `GET /messages` drops it — which would mean the room's account of a busy morning survived exactly as long as the tab that watched it land. The alternative was widening that backend branch, but `mycelium room messages` prints raw content and would then print ping envelopes. So the channel merges `GET /messages` with the pings from `GET /messages/l9` (the transcript replay, which does keep them) and orders by time. Purely frontend, no CLI regression, and it makes a reload say what the room said.

**Only prose is filtered by episode.** A consensus or a join is the room's business however deep inside a task it happened — the epic's own "raises only the consensus" — which is the same split the CLI makes by consulting `in_a_thread` from its chat branch alone. Related: a message with no episode at all reads as the room's, not as a thread. Filtering the channel with `?episode=<live>` on the wire would have hidden every row written before threading (the backend's filter is exact-match, and legacy `local_state` rows carry `null`), so the channel filters client-side and the *thread pane* is what uses `?episode=`.

**A thread is named by the task bound to it, but only where exactly one is.** `task_sync._write_task` binds every task a negotiation compiled to the episode it converged in, so the URN→row index is genuinely many-to-one; naming one of those would be picking a row at random and asserting it. Those threads read as their short id. Same honesty covers a coordination phase, which opens its own episode and records no back-link to the task that summoned it (the pending Leg 1 follow-up) — nothing here depends on that link existing.

## Changes

- **`lib/threads.ts` (new)** — `liveEpisodeUrn` / `isLiveEpisode` / `threadShortId`, `pingOf` (reads the thread from the payload, never from the frame's own episode — a ping rides in `live`, that is the point of it), and `coalescePings`, which collapses a *run* of consecutive pings into one row per thread and stops at the first thing said in the room.
- **`event-stream.tsx`** — parses a ping into its own normalized type before the prose unwrap (it would otherwise render as an empty chat row from `system`); drops thread prose from the channel; renders the coalesced `SystemNotice` ("Activity in *flip reads behind a flag* · 3 new · @risk, @growth · click to open"); merges the two reads on mount.
- **`thread-view.tsx` (new)** — the pane. Own SWR entry, prose only (a thread carries its lifecycle too, and those are frames, not things anybody said), re-reads on an SSE write into it *or* on the ping announcing one, and nothing else.
- **`room-data.ts`** — `useThreadMessages` keyed `["room", name, "messages", "thread", urn, limit]` (under the `["room", name]` prefix, so `useRoomRevalidate` reaches it), and `useRoomThreads`, the URN→task index derived off the shared memories cache.
- **Board** — `ThreadChip` on the cockpit/kanban rows and as a label on the timeline (whose row is itself a button); `t` opens the selected row's thread and refuses in the terms `board messages` refuses in; `onOpenThread` threaded through to the room workspace, which owns the pane.
- **`room-chat-box.tsx`** — optional `episode` + `threadLabel`, threaded into `sendRoomMessage`; the placeholder says where the message lands.
- **`api.ts`** — `fetchMessages(room, limit?, { episode })`, `sendRoomMessage(..., { episode })`.
- **Mocks** — `?episode=` honoured on the read (exact-match, as the backend filters), pings served from the L9 feed and *not* the message list (a mock that served both would hide the merge), and the atlas room grows a thread with three messages and two pings.
- **Contracts** — `slim-l9-wire.json` gains the frontend as a third asserter of the ping payload and the live-URN form (`threads.contract.test.ts`); the GUI's thread refusals are asserted against `board-vocabulary.json`'s `task.refusals` rather than restated.

Leg 1 had already unified `projection.ts` into one task-row with orphan episodes keeping their own; the audit of the `LiveItem` consumers found no regression from the folded thread fields (they land as table columns and are not offered as kanban groupings), so that bullet is coverage and affordances rather than a rewrite.

## Testing

- Frontend: **751 tests pass** (was 702), `tsc --noEmit` clean, `eslint` clean (6 pre-existing warnings, 0 errors).
- Backend `991 passed, 13 skipped`; CLI `723 passed, 2 skipped` — both re-run because the contract file changed.
- New coverage: `threads.test.ts` (13) and `threads.contract.test.ts` (2); `event-stream.thread.test.tsx` (9) — thread prose is out and the ping is in, the coalescing, the two-read merge and that it takes only pings from the replay, the naming fallbacks; `thread-view.test.tsx` (10) — the wire narrowing, prose-only, targeting, live re-read vs. a busy room next door, Esc-but-not-from-the-composer; `board-thread.test.tsx` (7); plus the SWR-collision and revalidation cases in `room-data.test.tsx` and the refusal contract case in `board.test.ts`.
- Driven in the mock app (`shot app /room/atlas-migration --mock`) at phone/tablet/laptop/wide: the channel shows the ping and not the thread's prose; a row's chip opens the pane beside the board on wide, over it on narrow.

Not applicable here (frontend-only diff): the Python gates in the template.

## Related Issues

Closes #839. Part of #835.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXtr2zCyU5jTvfYRZKZ6L1)_