### PR TITLE
Wrap unbroken text in the memory hovercard

### DIFF
--- a/mycelium-frontend/src/components/memory-preview-card.tsx
+++ b/mycelium-frontend/src/components/memory-preview-card.tsx
@@ -77,7 +77,7 @@ export function MemoryPreviewCard({ memory, anchor }: Props) {
         width: PREVIEW_CARD_WIDTH,
         visibility: top === null ? "hidden" : "visible",
       }}
-      className="pointer-events-none z-50 animate-in fade-in-0 zoom-in-95 rounded-xl border border-border bg-elevated shadow-lg duration-100"
+      className="pointer-events-none z-50 animate-in fade-in-0 zoom-in-95 overflow-hidden rounded-xl border border-border bg-elevated shadow-lg duration-100"
     >
       <div className="flex items-start gap-1.5 border-b border-border px-3 py-2">
         <FileText className="mt-px size-3.5 flex-shrink-0 text-faint" />
@@ -99,7 +99,7 @@ export function MemoryPreviewCard({ memory, anchor }: Props) {
             {preview.lines.map((line, i) => (
               <p
                 key={i}
-                className={`text-label leading-snug ${line ? "text-muted-foreground" : "h-1"}`}
+                className={`break-words text-label leading-snug ${line ? "text-muted-foreground" : "h-1"}`}
               >
                 {line}
               </p>


### PR DESCRIPTION
## Summary

A memory whose body has no break opportunities — a single keymashed word — overflowed the rail hovercard. The card is a fixed 320px, but its excerpt lines had no word-breaking, so one long token ran straight out of the card and across the memories list underneath it, drawing over the rows the reader is trying to click.

Break inside the word (`break-words`), and clip the card (`overflow-hidden`) so nothing a child renders can reach the list the card is previewing.

### Before / after

Hovering `context/keymash`, a memory whose whole body is one 280-character keymash. Before, the line runs out of the card and over `keymash.md` in the rail; after, it wraps inside the card and the list is untouched. (Screenshots are in the first comment — GitHub only renders inline images uploaded through the web drag-drop.)

## Changes

- `memory-preview-card.tsx`: excerpt lines wrap inside a word when they have to; the card clips its own overflow.

## Testing

Reproduced and verified with shotkit against the mock frontend, using a temporary keymash fixture (reverted — no fixture change is in this diff):

- long unbroken body overflows before the change, wraps after
- a body past the 520-character excerpt budget still clips to ~11 lines and shows "Click to read the rest…", so wrapping can't grow the card without bound
- ordinary prose previews (`decisions/cutover`) render exactly as before

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`) — not applicable, frontend-only CSS change
- [ ] Linting passes (`uv run ruff check .`) — not applicable
- [ ] Format check passes (`uv run ruff format --check .`) — not applicable

## Related Issues

<!-- none -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaMSqaC59iy5PBSiMpVvcR


---
_Generated by [Claude Code](https://claude.ai/code/session_01XaMSqaC59iy5PBSiMpVvcR)_