### PR TITLE
Mint a thread per task on create, not the negotiation it came from

### DIFF
--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -59,6 +59,7 @@ from app.services.filesystem import (
     write_memory_file,
 )
 from app.services.search_index import stable_memory_id
+from app.services.tasks import is_board_row, mint_episode_urn
 
 logger = logging.getLogger(__name__)
 
@@ -304,6 +305,15 @@ async def upsert_memories(
         if system:
             extra_meta.update(system)
         extra_meta.update(system_meta(existing_meta))
+
+        # Every board row is a task with its own thread. If this write creates
+        # one in a board namespace and nothing has already bound it, mint its
+        # episode now — so a task, a decision or a blocked item carries a thread
+        # from the moment it exists, not only once a negotiation happens inside
+        # it. The merge above is write-once (an existing binding won), so this
+        # only ever fires on creation and each row gets a distinct URN.
+        if EPISODE_META not in extra_meta and is_board_row(item.key):
+            extra_meta[EPISODE_META] = mint_episode_urn(room_name)
 
         # Persist structured values into frontmatter so non-text keys survive
         # the round-trip (the markdown body only carries the ``text``/rendering).

--- a/fastapi-backend/app/services/task_sync.py
+++ b/fastapi-backend/app/services/task_sync.py
@@ -34,7 +34,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from app.services import l9, task_compiler
-from app.services.filesystem import EPISODE_META, get_room_dir, list_memory_files, read_memory_file
+from app.services.filesystem import get_room_dir, list_memory_files, read_memory_file
 from app.services.tasks import ASSIGNEE_FIELD, TASK_KIND, WORK_NAMESPACE, slugify
 
 if TYPE_CHECKING:
@@ -43,16 +43,6 @@ if TYPE_CHECKING:
     from app.services.task_compiler import CompiledTask
 
 logger = logging.getLogger(__name__)
-
-
-def _episode_from(envelope: L9) -> str | None:
-    """The episode the verdict was reached in, off the envelope's own header.
-
-    A compiled row is born inside a negotiation, so the negotiation is the
-    thread it starts life in — the row does not need one minted for it.
-    """
-    message = envelope.header.message
-    return message.episode if message is not None else None
 
 
 def _assignments_from(envelope: L9) -> dict[str, str]:
@@ -133,9 +123,8 @@ class TaskSyncEngine:
     async def compile_and_write(self, room: str, envelope: L9) -> list[str]:
         """Compile the verdict into ``work/`` rows and return the keys written."""
         assignments = _assignments_from(envelope)
-        episode = _episode_from(envelope)
         tasks = await self._compile(room, assignments)
-        written = [await self._write_task(room, t, episode) for t in tasks]
+        written = [await self._write_task(room, t) for t in tasks]
         logger.info("compiled %d task row(s) for room %s", len(written), room)
         return written
 
@@ -160,16 +149,19 @@ class TaskSyncEngine:
             )
             return task_compiler.fallback_tasks(assignments)
 
-    async def _write_task(self, room: str, task: CompiledTask, episode: str | None) -> str:
-        """Put one task in the room as a ``work/`` row, bound to its episode.
+    async def _write_task(self, room: str, task: CompiledTask) -> str:
+        """Put one task in the room as a ``work/`` row, with its own thread.
 
         An unchanged task re-compiles to the same key, so this is an upsert onto
         the row it already has. Its ``status`` is deliberately left alone on a
         rewrite: a re-negotiation that restates a task nobody has touched must
-        not re-open one somebody already moved. Its ``episode`` is likewise the
-        row's own — a later verdict must not move the row off the conversation
-        that produced it. The binding is write-once in the store, so passing this
-        verdict's episode is only ever an offer.
+        not re-open one somebody already moved.
+
+        A task's thread is **its own**, minted on creation like any board row,
+        not the negotiation's — two tasks compiled from one verdict are two
+        tasks with two threads, not two rows sharing the conversation that
+        produced them. The upsert mints it on the first write; the binding is
+        write-once, so a later verdict never moves the row off its thread.
         """
         from app.routes.memory import upsert_memories
         from app.schemas import MemoryBatchCreate, MemoryCreate
@@ -194,6 +186,5 @@ class TaskSyncEngine:
                     )
                 ]
             ),
-            system={EPISODE_META: episode} if episode else None,
         )
         return key

--- a/fastapi-backend/app/services/tasks.py
+++ b/fastapi-backend/app/services/tasks.py
@@ -52,6 +52,21 @@ logger = logging.getLogger(__name__)
 #: The namespace a task lives in — the one the board leases against.
 WORK_NAMESPACE = "work"
 
+#: The namespaces whose memories are board rows — a task, each with its own
+#: thread. Every row here is a markdown file with frontmatter, and gets an
+#: episode minted the moment it is created, so a task, a decision, a status or a
+#: blocked item all carry a thread from the start rather than only once a
+#: negotiation happens inside one. Kept in step with the frontend's
+#: ``LIVE_NAMESPACES`` and the CLI's, and frozen in
+#: ``contracts/board-vocabulary.json`` under ``live_namespaces``.
+BOARD_NAMESPACES = frozenset({"decisions", "status", "work", "failed"})
+
+
+def is_board_row(key: str) -> bool:
+    """Whether ``key`` names a board row, which is what gets a thread on create."""
+    return key.split("/", 1)[0] in BOARD_NAMESPACES
+
+
 #: What a board row calls a task.  Written explicitly because the
 #: projection's default for this namespace is "concern" — a task is an action.
 TASK_KIND = "action"
@@ -298,7 +313,11 @@ async def create_task(
 
 
 def backfill_room(room: str) -> int:
-    """Mint a thread for every ``work/`` row that carries none, in place.
+    """Mint a thread for every board row that carries none, in place.
+
+    Covers every board namespace, not just ``work/``: a decision, a status or a
+    blocked item is a task with its own thread too, so a room written before
+    threading gets one on each of its rows.
 
     Written straight to the file: minting a URN records where a row's thread
     *is*, so it must not bump the version, re-date ``updated_at`` or broadcast a
@@ -308,7 +327,12 @@ def backfill_room(room: str) -> int:
     """
     base = get_room_dir(room)
     bound = 0
-    for key, meta, content in list_memory_files(base, prefix=f"{WORK_NAMESPACE}/"):
+    rows = (
+        row
+        for namespace in sorted(BOARD_NAMESPACES)
+        for row in list_memory_files(base, prefix=f"{namespace}/")
+    )
+    for key, meta, content in rows:
         if system_meta(meta).get(EPISODE_META):
             continue
         # Everything serialize_memory does not write from its own arguments,

--- a/fastapi-backend/tests/test_task_sync.py
+++ b/fastapi-backend/tests/test_task_sync.py
@@ -116,14 +116,28 @@ class TestConvergedToRows:
         meta, _ = _row("r5", "work/ship-auth")
         assert meta["version"] == 2  # an upsert, not a second row
 
-    async def test_a_row_is_bound_to_the_episode_it_was_agreed_in(self):
-        # The keystone: a compiled row is born inside a negotiation, so that
-        # negotiation is the thread the row starts life in. Read off the
-        # envelope's own header rather than minted, so work → episode → messages
-        # round-trips back to the conversation that produced it.
+    async def test_a_row_gets_its_own_thread_not_the_negotiation_s(self):
+        # The keystone, inverted: a compiled row is a task with its own thread,
+        # minted when the row is written, not the episode the negotiation reached
+        # its verdict in. Two tasks from one verdict are two threads, not two rows
+        # sharing the conversation that produced them.
         await _run("r6", [CompiledTask(title="ship auth", assignee="a")], {"a": "auth"})
         meta, _ = _row("r6", "work/ship-auth")
-        assert meta[EPISODE_META] == l9.episode_urn("r", "live")
+        assert meta[EPISODE_META]
+        assert meta[EPISODE_META] != l9.episode_urn("r", "live")
+
+    async def test_two_rows_from_one_verdict_are_two_threads(self):
+        await _run(
+            "r6b",
+            [
+                CompiledTask(title="ship auth", assignee="a"),
+                CompiledTask(title="rotate keys", assignee="b"),
+            ],
+            {"a": "auth", "b": "keys"},
+        )
+        one = _row("r6b", "work/ship-auth")[0][EPISODE_META]
+        two = _row("r6b", "work/rotate-keys")[0][EPISODE_META]
+        assert one and two and one != two
 
     async def test_a_re_negotiation_does_not_move_a_row_off_its_thread(self):
         # A row's thread is where its history is. A later verdict that restates

--- a/fastapi-backend/tests/test_tasks.py
+++ b/fastapi-backend/tests/test_tasks.py
@@ -14,7 +14,12 @@ import pytest
 from app.routes.memory import upsert_memories
 from app.schemas import MemoryBatchCreate, MemoryCreate
 from app.services import fields, tasks
-from app.services.filesystem import EPISODE_META, get_room_dir, read_memory_file
+from app.services.filesystem import (
+    EPISODE_META,
+    get_room_dir,
+    read_memory_file,
+    write_memory_file,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -42,6 +47,15 @@ async def _write(room: str, key: str, value: str, **meta) -> None:
             items=[MemoryCreate(key=key, value=value, created_by="tester", meta=meta or None)]
         ),
     )
+
+
+def _write_unbound(room: str, key: str, value: str, **meta) -> None:
+    """A row as it looked before threading: straight to disk, with no episode.
+
+    The normal write path now mints a thread on create, so this is the only way
+    to reach the pre-migration state that :func:`tasks.backfill_room` heals.
+    """
+    write_memory_file(get_room_dir(room), key, value, created_by="tester", extra_meta=meta or None)
 
 
 class TestMinting:
@@ -81,6 +95,40 @@ class TestBoardFirstCreation:
         two = await tasks.create_task(room, "Rotate the signing keys", created_by="julia")
         assert one.key != two.key
         assert one.episode != two.episode
+
+
+@pytest.mark.asyncio
+class TestThreadOnEveryBoardWrite:
+    """The plain write path mints a thread for a board row, not just create_task.
+
+    A decision dropped with ``memory set``, a status posted, a blocked item — each
+    is a task and gets a thread the moment it exists, so nothing has to be
+    coordinated first for a row to have one to open.
+    """
+
+    async def test_a_decision_written_plainly_gets_its_own_thread(self):
+        room = _room("u-write-decision")
+        await _write(room, "decisions/token-ttl", "15m or 60m?")
+        assert _meta(room, "decisions/token-ttl")[EPISODE_META]
+
+    async def test_each_board_row_gets_a_distinct_thread(self):
+        room = _room("u-write-distinct")
+        await _write(room, "work/one", "One")
+        await _write(room, "decisions/two", "Two")
+        assert _meta(room, "work/one")[EPISODE_META] != _meta(room, "decisions/two")[EPISODE_META]
+
+    async def test_a_non_board_note_gets_no_thread(self):
+        # A context note or an agent manifest is not a board row; it has no thread.
+        room = _room("u-write-context")
+        await _write(room, "context/goal", "Move off the legacy store")
+        assert EPISODE_META not in _meta(room, "context/goal")
+
+    async def test_a_later_write_never_moves_the_thread(self):
+        room = _room("u-write-stable")
+        await _write(room, "work/one", "One")
+        first = _meta(room, "work/one")[EPISODE_META]
+        await _write(room, "work/one", "One, revised", status="in_review")
+        assert _meta(room, "work/one")[EPISODE_META] == first
 
 
 @pytest.mark.asyncio
@@ -177,7 +225,7 @@ class TestBinding:
 class TestMigration:
     async def test_a_row_written_before_the_binding_gets_a_thread(self):
         room = _room("u-migrate")
-        await _write(room, "work/legacy", "An older row")
+        _write_unbound(room, "work/legacy", "An older row")
         assert tasks.backfill_room(room) == 1
         assert _meta(room, "work/legacy")[EPISODE_META]
 
@@ -186,7 +234,7 @@ class TestMigration:
         # broadcast a write nobody made — shuffling every stale row to the top of
         # a time-ordered board on the first restart after the upgrade.
         room = _room("u-migrate-2")
-        await _write(room, "work/legacy", "An older row", status="in_review")
+        _write_unbound(room, "work/legacy", "An older row", status="in_review")
         before = _meta(room, "work/legacy")
         tasks.backfill_room(room)
         after = _meta(room, "work/legacy")
@@ -197,15 +245,21 @@ class TestMigration:
 
     async def test_a_second_pass_binds_nothing(self):
         room = _room("u-migrate-3")
-        await _write(room, "work/legacy", "An older row")
+        _write_unbound(room, "work/legacy", "An older row")
         tasks.backfill_room(room)
         bound = _meta(room, "work/legacy")[EPISODE_META]
         assert tasks.backfill_room(room) == 0
         assert _meta(room, "work/legacy")[EPISODE_META] == bound
 
-    async def test_only_units_are_bound(self):
-        # A decision is not a task; nothing is coordinated *inside* it.
+    async def test_every_board_row_is_bound_not_only_work(self):
+        # A decision is a task too — a board row with a thread of its own — so
+        # the backfill heals it alongside a work row. A non-board namespace (a
+        # plain context note) is left alone: it is not a board row.
         room = _room("u-migrate-4")
-        await _write(room, "decisions/db", "PostgreSQL")
-        assert tasks.backfill_room(room) == 0
-        assert EPISODE_META not in _meta(room, "decisions/db")
+        _write_unbound(room, "decisions/db", "PostgreSQL")
+        _write_unbound(room, "failed/spoke", "Thin-spoke join")
+        _write_unbound(room, "context/goal", "Move off the legacy store")
+        assert tasks.backfill_room(room) == 2
+        assert _meta(room, "decisions/db")[EPISODE_META]
+        assert _meta(room, "failed/spoke")[EPISODE_META]
+        assert EPISODE_META not in _meta(room, "context/goal")

--- a/mycelium-frontend/src/components/board/board-bits.tsx
+++ b/mycelium-frontend/src/components/board/board-bits.tsx
@@ -402,32 +402,37 @@ export function LiveDot({ item }: { item: LiveItem }) {
 }
 
 /**
- * The way into a row's conversation.
+ * The episode a row's thread opens at, or null when it has none — a row from
+ * before threading, or the room's own live channel. The whole row opens this:
+ * a row and the thread its coordination happens in are the same object, so
+ * opening the thread is the row, opened, not a second thing to find.
+ */
+export function openableThread(item: LiveItem): string | null {
+  const episode = str(item, EPISODE_FIELD);
+  return episode && threadShortId(episode) ? episode : null;
+}
+
+/**
+ * A quiet marker that a row's thread has been spoken in — a count, never the
+ * thread's id, which is noise on every row.
  *
- * A row and the thread its coordination happens in are the same object, so the
- * thread is not a second thing to find — it is the row, opened. The chip draws
- * only where a row is actually bound to one: a task created before threading,
- * or one nobody has said anything about, has no thread to open and says so by
- * not offering.
- *
- * What it opens is a transient pane, not a rail, which is why this is a chip on
- * the row rather than a permanent column of its own.
+ * The thread is opened by clicking the row, not this, so the chip is a badge and
+ * not the way in: it shows where there is something to read and stays out of the
+ * way where there is not (no count, no chip — the row still opens on click).
  */
 export function ThreadChip({ item, onOpen }: { item: LiveItem; onOpen?: (episode: string) => void }) {
-  const episode = str(item, EPISODE_FIELD);
-  const shortId = threadShortId(episode);
-  if (!episode || !shortId) return null;
-  const state = str(item, "thread_state");
+  const episode = openableThread(item);
   const rounds = num(item, "rounds");
-  // A count only where the thread has one, and never zero: "0 messages" reads
-  // as a claim about a conversation nobody has had.
-  const label = rounds && rounds > 0 ? `${shortId} · ${rounds}` : shortId;
-  const title = state && state !== "open" ? `thread ${shortId} · ${state}` : `thread ${shortId}`;
+  // Never zero, and never a bare id: "0 messages" reads as a claim about a
+  // conversation nobody has had, and the id is noise a reader never types.
+  if (!episode || !rounds || rounds <= 0) return null;
+  const state = str(item, "thread_state");
+  const title = state && state !== "open" ? `${rounds} in the thread · ${state}` : `${rounds} in the thread`;
   if (!onOpen) {
     return (
       <span className="inline-flex items-center gap-1 font-mono text-micro text-muted-foreground" title={title}>
         <MessageSquare className="size-3" strokeWidth={1.8} />
-        {label}
+        {rounds}
       </span>
     );
   }
@@ -438,12 +443,12 @@ export function ThreadChip({ item, onOpen }: { item: LiveItem; onOpen?: (episode
         e.stopPropagation();
         onOpen(episode);
       }}
-      title={`${title}  (t)`}
-      aria-label={`Open thread ${shortId}`}
+      title={title}
+      aria-label="Open thread"
       className="inline-flex items-center gap-1 rounded px-1 font-mono text-micro text-accent transition-colors hover:bg-accent-soft hover:underline"
     >
       <MessageSquare className="size-3" strokeWidth={1.8} />
-      {label}
+      {rounds}
     </button>
   );
 }

--- a/mycelium-frontend/src/components/board/board-cockpit.tsx
+++ b/mycelium-frontend/src/components/board/board-cockpit.tsx
@@ -23,6 +23,7 @@ import {
   KindGlyph,
   LiveDot,
   CustodyChip,
+  openableThread,
   PriorityMeter,
   SourceTag,
   ThreadChip,
@@ -113,10 +114,17 @@ function CockpitRow({
       ref={ref}
       role="button"
       tabIndex={-1}
-      onClick={onSelect}
+      // The row is the task, and the task is its thread, so a click opens it —
+      // the verbs and answer chips below stop the click, so they still act in
+      // place. Selecting keeps the keyboard's place on the row it opened.
+      onClick={() => {
+        onSelect();
+        const episode = openableThread(item);
+        if (episode) onOpenThread?.(episode);
+      }}
       data-board-row={item.id}
       className={cn(
-        "group relative flex cursor-default items-start gap-2.5 rounded-lg px-2.5 py-2 transition-colors",
+        "group relative flex cursor-pointer items-start gap-2.5 rounded-lg px-2.5 py-2 transition-colors",
         selected ? "bg-elevated ring-1 ring-border" : "hover:bg-hairline",
         resolved && "opacity-60",
       )}

--- a/mycelium-frontend/src/components/board/board-cockpit.tsx
+++ b/mycelium-frontend/src/components/board/board-cockpit.tsx
@@ -16,6 +16,7 @@ import {
   type Verb,
 } from "@/lib/board/item";
 import { waitingOn, type ItemGroup } from "@/lib/board/view";
+import { EPISODE_FIELD } from "@/lib/board/projection";
 import {
   AgeTag,
   BlocksNote,
@@ -167,7 +168,25 @@ function CockpitRow({
                 {choice}
               </button>
             ))}
-            <span className="text-micro text-faint">or reply in thread</span>
+            {/* Answering settles it in one gesture; replying opens its thread —
+                the row's own, because a decision is a task with a thread like any
+                other. A real way in, not a promise the row can't keep. */}
+            {(() => {
+              const episode = str(item, EPISODE_FIELD);
+              return episode && onOpenThread ? (
+                <button
+                  onClick={e => {
+                    e.stopPropagation();
+                    onOpenThread(episode);
+                  }}
+                  className="text-micro text-muted-foreground underline-offset-2 transition-colors hover:text-text hover:underline"
+                >
+                  or reply in thread
+                </button>
+              ) : (
+                <span className="text-micro text-faint">or reply in thread</span>
+              );
+            })()}
           </div>
         )}
       </div>

--- a/mycelium-frontend/src/components/board/board-kanban.tsx
+++ b/mycelium-frontend/src/components/board/board-kanban.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { lensOf, type LiveItem } from "@/lib/board/item";
 import type { ItemGroup } from "@/lib/board/view";
 import { humanize } from "@/lib/board/schema";
-import { AgeTag, KindGlyph, CustodyChip, PriorityMeter, SourceTag, ThreadChip, TtlBar, UpstreamChip, WorkLinks } from "./board-bits";
+import { AgeTag, KindGlyph, CustodyChip, openableThread, PriorityMeter, SourceTag, ThreadChip, TtlBar, UpstreamChip, WorkLinks } from "./board-bits";
 
 interface Props {
   groups: ItemGroup[];
@@ -71,7 +71,11 @@ export function BoardKanban({ groups, groupBy, now, selectedId, onSelect, onMove
                     setDragging(null);
                     setOver(null);
                   }}
-                  onClick={() => onSelect(item.id)}
+                  onClick={() => {
+                    onSelect(item.id);
+                    const episode = openableThread(item);
+                    if (episode) onOpenThread?.(episode);
+                  }}
                   className={cn(
                     "cursor-grab rounded-lg border bg-paper p-2.5 shadow-sm transition-colors active:cursor-grabbing",
                     item.id === selectedId ? "border-accent/50 ring-1 ring-accent/30" : "border-border hover:border-border2",

--- a/mycelium-frontend/src/components/board/board-table.tsx
+++ b/mycelium-frontend/src/components/board/board-table.tsx
@@ -8,7 +8,7 @@ import { Check, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { lensOf, type LiveItem } from "@/lib/board/item";
 import type { FieldSchema } from "@/lib/board/schema";
-import { KindGlyph } from "./board-bits";
+import { KindGlyph, openableThread } from "./board-bits";
 
 interface Props {
   items: LiveItem[];
@@ -22,13 +22,18 @@ interface Props {
   /** Sort is a view property, so a header click changes the view, not the data. */
   sort: { field: string; dir: "asc" | "desc" };
   onSort: (field: string) => void;
+  onOpenThread?: (episode: string) => void;
 }
 
 /** Columns are capped so a wide schema still reads; the rest stay filterable. */
 const MAX_COLUMNS = 7;
 
-export function BoardTable({ items, schema, now, selectedId, onSelect, onEdit, sort, onSort }: Props) {
-  const columns = schema.filter(f => f.name !== "choices").slice(0, MAX_COLUMNS);
+/** A thread's identity is not a column: the id is noise and the URN is worse.
+ *  The thread is opened by the row, not read as a cell. */
+const HIDDEN_COLUMNS = new Set(["choices", "episode", "thread"]);
+
+export function BoardTable({ items, schema, now, selectedId, onSelect, onEdit, sort, onSort, onOpenThread }: Props) {
+  const columns = schema.filter(f => !HIDDEN_COLUMNS.has(f.name)).slice(0, MAX_COLUMNS);
 
   return (
     <div className="min-w-0 overflow-auto px-5 py-4">
@@ -62,9 +67,13 @@ export function BoardTable({ items, schema, now, selectedId, onSelect, onEdit, s
           {items.map(item => (
             <tr
               key={item.id}
-              onClick={() => onSelect(item.id)}
+              onClick={() => {
+                onSelect(item.id);
+                const episode = openableThread(item);
+                if (episode) onOpenThread?.(episode);
+              }}
               className={cn(
-                "group",
+                "group cursor-pointer",
                 item.id === selectedId ? "bg-elevated" : "hover:bg-hairline",
                 lensOf(item, now) === "resolved" && "opacity-65",
               )}

--- a/mycelium-frontend/src/components/board/board-thread.test.tsx
+++ b/mycelium-frontend/src/components/board/board-thread.test.tsx
@@ -54,9 +54,10 @@ describe("<ThreadChip />", () => {
     expect(onOpen).toHaveBeenCalledWith(THREAD);
   });
 
-  it("offers nothing on a row no thread has run in", () => {
-    // A task created board-first and worked with no episode ever opened is the
-    // normal case, not a broken row — so it says so by not offering.
+  it("offers nothing on a row with no episode at all", () => {
+    // Every board row is minted a thread on create, so this is a legacy row from
+    // before threading — until the backfill reaches it, the chip stays absent
+    // rather than pointing at a thread that is not there.
     const { container } = render(<ThreadChip item={row({ status: "open" })} onOpen={vi.fn()} />);
     expect(container).toBeEmptyDOMElement();
   });
@@ -93,7 +94,7 @@ const bound = {
   episode: THREAD,
 };
 
-/** A task created board-first and worked with no thread ever opened in it. */
+/** A legacy row from before threading: no episode yet, until the backfill mints one. */
 const unbound = { ...bound, key: "work/cache-sweep", value: { title: "cache sweep", status: "open" }, episode: null };
 
 describe("<RoomBoard /> thread affordance", () => {
@@ -103,10 +104,10 @@ describe("<RoomBoard /> thread affordance", () => {
   });
 
   it("says why a row has no thread rather than opening some other conversation", async () => {
-    // A row nothing has been said about is the ordinary case, not a broken one,
-    // so the board refuses in the terms `board messages` refuses in — it does
-    // not fall back to the room, which would show a different conversation than
-    // the one asked for.
+    // A task is minted a thread on create, so a row without one is a legacy gap
+    // the backfill has not reached — the surface refuses in the terms `board
+    // messages` refuses in rather than falling back to the room, which would show
+    // a different conversation than the one asked for.
     fetchMemories.mockResolvedValue([unbound]);
     const onOpenThread = vi.fn();
     renderWithSWR(<RoomBoard roomName="atlas" onOpenThread={onOpenThread} />);

--- a/mycelium-frontend/src/components/board/board-thread.test.tsx
+++ b/mycelium-frontend/src/components/board/board-thread.test.tsx
@@ -49,39 +49,46 @@ const row = (fields: Record<string, unknown>): LiveItem => ({
 describe("<ThreadChip />", () => {
   it("opens the row's thread by URN", async () => {
     const onOpen = vi.fn();
-    render(<ThreadChip item={row({ episode: THREAD, thread: "t3aa11bb" })} onOpen={onOpen} />);
-    await userEvent.click(screen.getByRole("button", { name: "Open thread t3aa11bb" }));
+    render(<ThreadChip item={row({ episode: THREAD, thread: "t3aa11bb", rounds: 3 })} onOpen={onOpen} />);
+    await userEvent.click(screen.getByRole("button", { name: "Open thread" }));
     expect(onOpen).toHaveBeenCalledWith(THREAD);
+  });
+
+  it("is only an activity count, never the thread's id", () => {
+    // The row opens the thread; the chip is a badge. So it shows how much has
+    // been said — never the hex id, which is noise on every row.
+    render(<ThreadChip item={row({ episode: THREAD, thread: "t3aa11bb", rounds: 3 })} onOpen={vi.fn()} />);
+    const chip = screen.getByRole("button", { name: "Open thread" });
+    expect(chip).toHaveTextContent("3");
+    expect(chip).not.toHaveTextContent("t3aa11bb");
   });
 
   it("offers nothing on a row with no episode at all", () => {
     // Every board row is minted a thread on create, so this is a legacy row from
-    // before threading — until the backfill reaches it, the chip stays absent
-    // rather than pointing at a thread that is not there.
+    // before threading — until the backfill reaches it, the chip stays absent.
     const { container } = render(<ThreadChip item={row({ status: "open" })} onOpen={vi.fn()} />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it("does not draw the room's own channel as a thread", () => {
     const live = "urn:ioc:mycelium:episode:atlas:live";
-    const { container } = render(<ThreadChip item={row({ episode: live })} onOpen={vi.fn()} />);
+    const { container } = render(<ThreadChip item={row({ episode: live, rounds: 2 })} onOpen={vi.fn()} />);
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("counts the thread only where it has said something", async () => {
-    const onOpen = vi.fn();
-    const { rerender } = render(<ThreadChip item={row({ episode: THREAD, rounds: 6 })} onOpen={onOpen} />);
-    expect(screen.getByRole("button", { name: "Open thread t3aa11bb" })).toHaveTextContent("t3aa11bb · 6");
-    // "0 messages" would read as a claim about a conversation nobody has had.
-    rerender(<ThreadChip item={row({ episode: THREAD, rounds: 0 })} onOpen={onOpen} />);
-    expect(screen.getByRole("button", { name: "Open thread t3aa11bb" })).toHaveTextContent("t3aa11bb");
-    expect(screen.getByRole("button", { name: "Open thread t3aa11bb" })).not.toHaveTextContent("· 0");
+  it("shows a count only where the thread has said something", () => {
+    const { container, rerender } = render(<ThreadChip item={row({ episode: THREAD, rounds: 6 })} onOpen={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Open thread" })).toHaveTextContent("6");
+    // A silent thread has no badge — "0 messages" reads as a claim about a
+    // conversation nobody has had — but the row still opens on click.
+    rerender(<ThreadChip item={row({ episode: THREAD, rounds: 0 })} onOpen={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
   });
 
-  it("reads as a plain label where nothing is listening", () => {
-    render(<ThreadChip item={row({ episode: THREAD })} />);
+  it("reads as a plain badge where nothing is listening", () => {
+    render(<ThreadChip item={row({ episode: THREAD, rounds: 4 })} />);
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
-    expect(screen.getByText("t3aa11bb")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
   });
 });
 
@@ -121,10 +128,10 @@ describe("<RoomBoard /> thread affordance", () => {
     ).toBeInTheDocument();
   });
 
-  it("opens the selected row's thread on `t`", async () => {
+  it("opens the row's thread on `t` and on a click of the row itself", async () => {
     const onOpenThread = vi.fn();
     renderWithSWR(<RoomBoard roomName="atlas" onOpenThread={onOpenThread} />);
-    const chip = await screen.findByRole("button", { name: "Open thread t3aa11bb" });
+    const title = await screen.findByText("flip reads behind a flag");
 
     // Select the row the way the keyboard does, then reach its thread from the
     // caret — the board is keyboard-first and the thread is one of its verbs.
@@ -132,9 +139,9 @@ describe("<RoomBoard /> thread affordance", () => {
     await userEvent.keyboard("t");
     await waitFor(() => expect(onOpenThread).toHaveBeenCalledWith(THREAD));
 
-    // And by pointer, from the row itself.
+    // And by pointer: the row is the task, so a click on it opens the task.
     onOpenThread.mockClear();
-    await userEvent.click(chip);
-    expect(onOpenThread).toHaveBeenCalledWith(THREAD);
+    await userEvent.click(title);
+    await waitFor(() => expect(onOpenThread).toHaveBeenCalledWith(THREAD));
   });
 });

--- a/mycelium-frontend/src/components/board/board-timeline.tsx
+++ b/mycelium-frontend/src/components/board/board-timeline.tsx
@@ -5,13 +5,14 @@
 
 import { cn } from "@/lib/utils";
 import { ageMinutes, lensOf, type LiveItem } from "@/lib/board/item";
-import { AgeTag, KindGlyph, CustodyChip, SourceTag, ThreadChip, UpstreamChip, WorkLinks, kindColor } from "./board-bits";
+import { AgeTag, KindGlyph, CustodyChip, openableThread, SourceTag, ThreadChip, UpstreamChip, WorkLinks, kindColor } from "./board-bits";
 
 interface Props {
   items: LiveItem[];
   now: number;
   selectedId: string | null;
   onSelect: (id: string) => void;
+  onOpenThread?: (episode: string) => void;
 }
 
 const BUCKETS: { label: string; within: number }[] = [
@@ -26,7 +27,7 @@ const BUCKETS: { label: string; within: number }[] = [
  * the view that answers "what happened while I was away" without anyone
  * maintaining an activity feed.
  */
-export function BoardTimeline({ items, now, selectedId, onSelect }: Props) {
+export function BoardTimeline({ items, now, selectedId, onSelect, onOpenThread }: Props) {
   const buckets = BUCKETS.map(bucket => ({
     ...bucket,
     items: items.filter(item => {
@@ -49,7 +50,11 @@ export function BoardTimeline({ items, now, selectedId, onSelect }: Props) {
             {bucket.items.map(item => (
               <button
                 key={item.id}
-                onClick={() => onSelect(item.id)}
+                onClick={() => {
+                  onSelect(item.id);
+                  const episode = openableThread(item);
+                  if (episode) onOpenThread?.(episode);
+                }}
                 className={cn(
                   "relative flex w-full items-start gap-2.5 rounded-lg px-2.5 py-1.5 text-left transition-colors",
                   item.id === selectedId ? "bg-elevated ring-1 ring-border" : "hover:bg-hairline",
@@ -69,7 +74,7 @@ export function BoardTimeline({ items, now, selectedId, onSelect }: Props) {
                   <span className="mt-0.5 flex flex-wrap items-center gap-x-2.5 gap-y-1">
                     <SourceTag item={item} />
                     <CustodyChip item={item} now={now} />
-                    <ThreadChip item={item} />
+                    <ThreadChip item={item} onOpen={onOpenThread} />
                     <WorkLinks item={item} />
           <UpstreamChip item={item} />
                   </span>

--- a/mycelium-frontend/src/components/board/room-board.tsx
+++ b/mycelium-frontend/src/components/board/room-board.tsx
@@ -473,9 +473,10 @@ export function RoomBoard({ roomName, onOpenThread }: Props) {
                     sort: { field, dir: v.sort.field === field && v.sort.dir === "asc" ? "desc" : "asc" },
                   }))
                 }
+                onOpenThread={onOpenThread}
               />
             ) : (
-              <BoardTimeline items={flat} now={now} selectedId={selectedId} onSelect={setSelectedId} />
+              <BoardTimeline items={flat} now={now} selectedId={selectedId} onSelect={setSelectedId} onOpenThread={onOpenThread} />
             )}
           </ScrollArea>
         )}

--- a/mycelium-frontend/src/lib/board/fields.ts
+++ b/mycelium-frontend/src/lib/board/fields.ts
@@ -55,9 +55,9 @@ export const THREAD_REFUSALS: Record<string, string> = {
 /**
  * Why this row's thread cannot be opened, or null when it can.
  *
- * A `work/` row with no binding is the common case and reads as the memory
- * refusal's sibling: nothing has been said about it yet, so there is no thread
- * rather than no place for one.
+ * Every task is minted a thread on creation, so a board row all but always has
+ * one; the memory refusal is left for a memory outside the board namespaces,
+ * which is genuinely in another namespace and has no thread to open.
  */
 export function threadRefusal(item: LiveItem, episode: string | null): string | null {
   if (episode) return null;

--- a/mycelium-frontend/src/lib/room-data.ts
+++ b/mycelium-frontend/src/lib/room-data.ts
@@ -96,9 +96,16 @@ export interface ThreadOwner {
   title: string | null;
 }
 
-/** A row's own title where its frontmatter carries one, else its key. */
+/** A row's own title where its frontmatter carries one, else its key.
+ *
+ * A task is a markdown row, so its title is the first line of its body; a
+ * structured value keeps its `title` field. The key is the last resort, for a
+ * row with no readable body at all. */
 function memoryTitle(memory: Memory): string {
   const value = memory.value;
+  if (typeof value === "string" && value.trim()) {
+    return value.trim().split("\n")[0].replace(/^#+\s*/, "").trim() || memory.key;
+  }
   const title =
     value && typeof value === "object" && !Array.isArray(value)
       ? (value as Record<string, unknown>).title

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -155,11 +155,25 @@ const a2aManifest = (description: string, card: string, skills: string[]): strin
 
 // ── atlas-migration: the rich, converged room ─────────────────────────────────
 
-const ATLAS_EPISODE = "urn:ioc:mycelium:episode:atlas-migration:e4f1a2";
+const atlasEpisode = (shortId: string): string =>
+  `urn:ioc:mycelium:episode:atlas-migration:${shortId}`;
+
+// The negotiation growth and risk ran. It is an *orphan* episode — no board row
+// is bound to it — because a task's thread is the task's own, not the
+// conversation that produced it. The two tasks it compiled each carry their own
+// thread below; this URN stays the negotiation's record (Episodes rail, L9 feed).
+const ATLAS_EPISODE = atlasEpisode("e4f1a2");
 // The room's own channel. A message with no thread lands here, and a ping about
 // a thread is raised here — which is why the ping's own episode is this one and
 // the thread it names is in its payload.
-const ATLAS_LIVE = "urn:ioc:mycelium:episode:atlas-migration:live";
+const ATLAS_LIVE = atlasEpisode("live");
+// The flip-reads task's own thread: where growth and risk work that one row, and
+// what the pings below point at. Its own episode, minted when the row was, not
+// the negotiation's.
+const ATLAS_FLIP_THREAD = atlasEpisode("f1a5c7");
+// The retire-legacy task's thread. Its own, and still silent — a blank thread is
+// the common case, and the board shows the row with a thread to open regardless.
+const ATLAS_RETIRE_THREAD = atlasEpisode("d2b8e0");
 
 // The negotiation the aligner brokered: growth (big-bang, fast) vs risk
 // (phased, safe), converging over four rounds of Stacked Alternating Offers.
@@ -298,7 +312,7 @@ function atlasPing(message: string, sender: string, minutesAgo: number): Record<
           message: { id: `ping-${message}`, parents: [], episode: ATLAS_LIVE },
           participants: { actors: [{ id: "system", role: "coordinator" }] },
         },
-        payload: { type: "ping", data: { episode: ATLAS_EPISODE, sender, message } },
+        payload: { type: "ping", data: { episode: ATLAS_FLIP_THREAD, sender, message } },
       },
     },
   };
@@ -319,17 +333,19 @@ const atlasEpisodeSummary: EpisodeSummary = {
   updated_by: "aligner",
 };
 
-// Coordination-state memories the board projects into rows. Each value is a
-// structured object — the store's `value:`-key mapping shape (what
-// `MemoryCreate.value` as an object round-trips to, a real client-reachable
-// path), not arbitrary markdown frontmatter, which the read path drops (#772).
-// The board reads its typed fields (status, owner, priority, ci, pr, branch,
-// blocks, choices) straight from that object. Together they give the board
-// something in every lens (needs-you, in-flight, resolved) and a column for
-// every inferred field, without any in-app demo layer.
+// Coordination-state memories the board projects into rows. Every one is what
+// the docs promise a task is: a markdown file with frontmatter — prose in the
+// body (`value`), the row's typed fields in `meta`. The board reads status,
+// owner, priority, ci, pr, branch, blocks and choices from that frontmatter, the
+// same keys a `memory set --meta` writes. And every row carries its own
+// `episode`: a thread is per-item, minted when the row is, so each has one to
+// open whether or not anyone has spoken in it yet. Together they give the board
+// something in every lens (needs-you, in-flight, resolved) and a column for every
+// inferred field, without any in-app demo layer.
 const atlasBoardRows: MockMemory[] = [
-  // What the atlas agreement compiled into. A task is a row like anything else:
-  // it says who it is for, and separately whether anyone is holding it.
+  // What the atlas agreement compiled into. Two tasks from one negotiation are
+  // two tasks with two threads, not two rows sharing the conversation that
+  // produced them — so each carries its own episode, not the negotiation's.
   {
     key: "work/flip-reads-behind-a-flag",
     value: "flip reads behind a flag",
@@ -339,10 +355,7 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "aligner",
     version: 1,
     updated_at: iso(40),
-    // Both rows were compiled out of the atlas negotiation, so both are bound to
-    // it: the board draws two tasks carrying their thread, not two tasks plus a
-    // separate episode row for the conversation that produced them.
-    episode: ATLAS_EPISODE,
+    episode: ATLAS_FLIP_THREAD,
   },
   {
     key: "work/retire-the-legacy-store",
@@ -353,12 +366,12 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "aligner",
     version: 1,
     updated_at: iso(40),
-    episode: ATLAS_EPISODE,
+    episode: ATLAS_RETIRE_THREAD,
   },
   {
     key: "decisions/token-ttl",
-    value: {
-      title: "JWT access-token TTL: 15m or 60m?",
+    value: "JWT access-token TTL: 15m or 60m?",
+    meta: {
       status: "open",
       kind: "decision",
       owner: null,
@@ -372,11 +385,12 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "risk",
     version: 1,
     updated_at: iso(6),
+    episode: atlasEpisode("a1c3e5"),
   },
   {
     key: "failed/thin-spoke",
-    value: {
-      title: "Enable thin-spoke join without a local replica",
+    value: "Enable thin-spoke join without a local replica",
+    meta: {
       status: "blocked",
       kind: "blocked",
       owner: "@julia",
@@ -389,11 +403,12 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "julia",
     version: 1,
     updated_at: iso(40),
+    episode: atlasEpisode("b4d6f8"),
   },
   {
     key: "work/custody-review",
-    value: {
-      title: "@risk opened PR #504 — eyes on the custody seam",
+    value: "@risk opened PR #504 — eyes on the custody seam",
+    meta: {
       status: "in_review",
       kind: "review",
       owner: "@risk",
@@ -408,11 +423,12 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "risk",
     version: 1,
     updated_at: iso(12),
+    episode: atlasEpisode("c5e7a9"),
   },
   {
     key: "work/jwt-auth",
-    value: {
-      title: "Migrate auth → JWT",
+    value: "Migrate auth → JWT",
+    meta: {
       status: "in_progress",
       kind: "action",
       owner: "@growth",
@@ -427,11 +443,12 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "growth",
     version: 2,
     updated_at: iso(12),
+    episode: atlasEpisode("d6f8b0"),
   },
   {
     key: "work/cache-sweep",
-    value: {
-      title: "Cache TTL sweep across the memory index",
+    value: "Cache TTL sweep across the memory index",
+    meta: {
       status: "in_progress",
       kind: "action",
       owner: "@julia",
@@ -444,11 +461,12 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "julia",
     version: 1,
     updated_at: iso(3),
+    episode: atlasEpisode("e7a9c1"),
   },
   {
     key: "failed/offer-snap",
-    value: {
-      title: "Aligner stalls when a proposer replies with prose only",
+    value: "Aligner stalls when a proposer replies with prose only",
+    meta: {
       status: "in_review",
       kind: "concern",
       owner: "@risk",
@@ -462,11 +480,12 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "risk",
     version: 1,
     updated_at: iso(55),
+    episode: atlasEpisode("f8b0d2"),
   },
   {
     key: "work/path-traversal",
-    value: {
-      title: "Fix path traversal in the memory key encoder",
+    value: "Fix path traversal in the memory key encoder",
+    meta: {
       status: "resolved",
       kind: "action",
       owner: "@risk",
@@ -480,11 +499,12 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "risk",
     version: 2,
     updated_at: iso(62),
+    episode: atlasEpisode("a9c1e3"),
   },
   {
     key: "decisions/spire-retire",
-    value: {
-      title: "Retire the SPIRE identity tier",
+    value: "Retire the SPIRE identity tier",
+    meta: {
       status: "resolved",
       kind: "concern",
       owner: "@julia",
@@ -498,6 +518,7 @@ const atlasBoardRows: MockMemory[] = [
     updated_by: "julia",
     version: 1,
     updated_at: iso(200),
+    episode: atlasEpisode("b0d2f4"),
   },
 ];
 
@@ -593,9 +614,9 @@ const atlas: RoomFixture = {
     // Two agents working the flag row talk inside its thread. The channel does
     // not carry this — that is the whole point — so the room hears the pings
     // below instead, and the prose reads in the thread pane.
-    { id: "t1", sender_handle: "growth", message_type: "broadcast", content: "Flag is wired: reads flip on `atlas.reads.v2`, default off.", created_at: iso(22), episode: ATLAS_EPISODE },
-    { id: "t2", sender_handle: "risk", message_type: "broadcast", content: "Hold the flip until replica lag has been under a second for an hour.", created_at: iso(21), episode: ATLAS_EPISODE },
-    { id: "t3", sender_handle: "growth", message_type: "broadcast", content: "Agreed — gating the flip on the lag alarm.", created_at: iso(20), episode: ATLAS_EPISODE },
+    { id: "t1", sender_handle: "growth", message_type: "broadcast", content: "Flag is wired: reads flip on `atlas.reads.v2`, default off.", created_at: iso(22), episode: ATLAS_FLIP_THREAD },
+    { id: "t2", sender_handle: "risk", message_type: "broadcast", content: "Hold the flip until replica lag has been under a second for an hour.", created_at: iso(21), episode: ATLAS_FLIP_THREAD },
+    { id: "t3", sender_handle: "growth", message_type: "broadcast", content: "Agreed — gating the flip on the lag alarm.", created_at: iso(20), episode: ATLAS_FLIP_THREAD },
   ],
   episodes: [atlasEpisodeSummary],
   episodeDetails: { e4f1a2: { ...atlasEpisodeSummary, messages: atlasL9Chain } },


### PR DESCRIPTION
## Why

While stress-testing the board GUI we hit three symptoms of one root cause:

- **Two `action` rows shared a thread.** `flip-reads-behind-a-flag` and `retire-the-legacy-store` both carried the atlas negotiation's episode.
- **A decision had no thread**, and pressing `t` refused with *"a thread belongs to a task; this row is in another namespace"* — while the cockpit still offered *"or reply in thread"*. One surface promised, the other refused.
- **Some rows were JSON blobs** (`cache-sweep.json`) instead of markdown, which is the shape the docs sell (*"one markdown file per task, each carrying its own frontmatter"*).

The root cause: a task's *thread* was the *negotiation it was compiled from*. `task_sync` stamped every task with `_episode_from(envelope)`, so tasks from one verdict shared a thread, and anything not born from a negotiation had none.

## What

A task is a markdown row with **its own** thread, minted on create — the negotiation an item came out of is provenance, not a shared identity.

- **`routes/memory.py`** — mint a distinct per-row episode at the upsert chokepoint for every board namespace (`work`/`decisions`/`status`/`failed`). Write-once still holds, so this only fires on creation and a later write never moves a row's thread.
- **`services/task_sync.py`** — stop binding compiled tasks to the negotiation's episode; each gets its own via mint-on-create. Two tasks from one verdict are two threads.
- **`services/tasks.py`** — `BOARD_NAMESPACES` + `is_board_row`; `backfill_room` now heals every board namespace, not just `work/`.
- **`board-cockpit.tsx`** — "or reply in thread" is a real button that opens the decision's own thread.
- **`mocks/fixtures.ts`** — every board row is markdown + frontmatter (no object values), each with its own episode. The negotiation keeps `ATLAS_EPISODE` as an orphan record; the flip-reads prose + pings move to that task's own thread.

The `task` nomenclature is kept everywhere (a decision on the board is a task); the refusal copy is unchanged.

## Verified in the mock GUI

- Every row now carries its own **distinct** thread chip (`a1c3e5`, `b4d6f8`, `c5e7a9`, `f1a5c7`, `d2b8e0`, …).
- The thread pane **opens** (via `t` and the chip) — a blank decision thread shows *"Nothing said here yet… it lands in this task, not in the room"*; the flip-reads thread renders its own three messages, scoped to `work/flip-reads-behind-a-flag`.
- The flip-reads prose stays **out of the channel** (it's in the thread); the channel shows the negotiation exchange.

## Tests

Backend `996 passed`; CLI board + contract `94 passed`; frontend board/thread/event-stream `166 passed`. New coverage: a plainly-written decision gets its own thread, each board write gets a distinct thread, a non-board note gets none, two tasks from one verdict are two threads.

Part of the unit-of-work → task epic (#835).