### PR TITLE
Make the channel the room's timeline (task-created notices)

### DIFF
--- a/contracts/slim-l9-wire.json
+++ b/contracts/slim-l9-wire.json
@@ -52,6 +52,12 @@
     "payload_fields": ["episode", "sender", "message"]
   },
 
+  "notice": {
+    "_comment": "The payload type the room's board events surface into its timeline as. Where a ping says a thread moved, a notice says the board did: a task filed, claimed, handed back or resolved. The backend PRODUCES it (room_channels.raise_notice, off app.services.l9.NOTICE_PAYLOAD_TYPE) at each seam — leases.claim/release/resolve, and the memory upsert on a board-row create; the GUI READS it (mycelium-frontend/src/lib/threads.ts, notice_of + NOTICE_PAYLOAD_TYPE) to draw the 'New task'/'Claimed'/'Resolved' line the channel shows in sequence with the chat. Like a ping it is excluded from participate._addressed_to, so a resident agent consumes a notice silently rather than waking on it: rename the type on one side and either the timeline goes quiet or every agent wakes on every board write. `data.subkind` is one of `subkinds` (a closed set); `data` always carries `subkind` and `key`, and a `filed` notice also carries the board `kind` so the line reads 'New decision' not always 'New task'.",
+    "payload_type": "notice",
+    "subkinds": ["filed", "claimed", "released", "resolved"]
+  },
+
   "shared_secret": {
     "_comment": "mint_shared_secret is keyed on workspace/room only (agent ignored). HMAC-SHA256(master_secret, 'workspace/room').hexdigest().",
     "workspace": "acme",

--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -399,6 +399,24 @@ async def upsert_memories(
             updated_by=item.created_by,
             updated_at=now.isoformat(),
         )
+        # A board row appearing for the first time is the room filing work: raise
+        # a `filed` notice into the timeline, naming the task, its kind (so it
+        # reads "New decision" not always "New task") and who it is for. Only on
+        # creation — a later write is a state change, carried by its own verb.
+        if not existing and is_board_row(item.key):
+            from app.services.room_channels import manager
+
+            first_line = next((ln for ln in content_text.splitlines() if ln.strip()), item.key)
+            await manager.raise_notice(
+                room_name,
+                subkind="filed",
+                key=item.key,
+                title=first_line.lstrip("# ").strip(),
+                episode=extra_meta.get(EPISODE_META),
+                by=str(created_by).lstrip("@"),
+                kind=extra_meta.get("kind"),
+                **({"for": str(extra_meta["assignee"])} if extra_meta.get("assignee") else {}),
+            )
 
     for embedded in write_metrics:
         record_memory_write(scope="namespace", embedded=embedded)

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -64,10 +64,13 @@ _MAX_WAIT_S = 3600.0
 # L9 payload so the aligner can score convergence, and stripped from the prose.
 _MARKER_RE = re.compile(r"\[\[\s*mycelium\s*:(.*?)\]\]", re.IGNORECASE | re.DOTALL)
 # Payloads that are never an addressed turn however they are actor-labelled:
-# presence/keepalive are liveness, and a ``ping`` is the signal that a *thread*
-# moved — a nudge to look, not a turn to take. Excluded structurally here so a
-# resident loop consumes one silently rather than reasoning about it.
-_UNADDRESSED_PAYLOADS = frozenset({"presence", "keepalive", l9.PING_PAYLOAD_TYPE})
+# presence/keepalive are liveness, a ``ping`` is the signal that a *thread* moved,
+# and a ``notice`` is the signal that the *board* moved (a task filed, claimed,
+# resolved) — all nudges to look, not turns to take. Excluded structurally here so
+# a resident loop consumes one silently rather than reasoning about it.
+_UNADDRESSED_PAYLOADS = frozenset(
+    {"presence", "keepalive", l9.PING_PAYLOAD_TYPE, l9.NOTICE_PAYLOAD_TYPE}
+)
 
 _STANCE_TO_ACTION = {
     "accept": "accept",

--- a/fastapi-backend/app/services/l9.py
+++ b/fastapi-backend/app/services/l9.py
@@ -88,6 +88,21 @@ LIVE_SESSION = "live"
 #: anyone (:func:`app.routes.participate._addressed_to`).
 PING_PAYLOAD_TYPE = "ping"
 
+#: The payload type of a **notice**: the room's timeline of what happened to its
+#: work — a task filed, claimed, handed back or resolved. Like a ping it is a
+#: control payload raised into ``live`` that wakes nobody, but where a ping says a
+#: thread *moved*, a notice says the *board* moved: it names the task, carries the
+#: line the room reads ("New task", "@x is on it", "resolved"), and never the
+#: prose (which stays in the thread). ``data.subkind`` is one of
+#: :data:`NOTICE_SUBKINDS`; the rest of ``data`` is the task it is about.
+NOTICE_PAYLOAD_TYPE = "notice"
+
+#: What a notice can be about, as a closed set frozen in
+#: ``contracts/slim-l9-wire.json``. ``filed`` also carries the row's board
+#: ``kind`` (so the line reads "New decision", not always "New task") and who it
+#: is ``for``; the custody subkinds carry ``by`` (who moved it).
+NOTICE_SUBKINDS = frozenset({"filed", "claimed", "released", "resolved"})
+
 
 class L9ValidationError(ValueError):
     """An envelope violates the L9 structure or the CFN subkind table."""

--- a/fastapi-backend/app/services/leases.py
+++ b/fastapi-backend/app/services/leases.py
@@ -39,9 +39,11 @@ from datetime import UTC, datetime
 from typing import Any
 
 from app.services.filesystem import (
+    EPISODE_META,
     get_room_dir,
     list_memory_files,
     read_memory_file,
+    system_meta,
 )
 
 FIELD = "custody"
@@ -181,6 +183,31 @@ async def _write(
     return _describe(key, fresh_meta, datetime.now(UTC))
 
 
+async def _raise_notice(
+    room: str, key: str, meta: dict, content: str, subkind: str, by: str
+) -> None:
+    """Tell the room the board moved: a task was claimed, handed back or resolved.
+
+    A custody write is news the timeline should carry, so it raises a notice the
+    same way a thread write raises a ping — through the manager, waking nobody. The
+    episode is the row's own (stable across a custody write, so the pre-write meta
+    has it), and the title is the row's first line, so the notice can name the task
+    and open its thread.
+    """
+    from app.services.room_channels import manager
+
+    episode = system_meta(meta).get(EPISODE_META)
+    first = next((ln.strip() for ln in (content or "").splitlines() if ln.strip()), key)
+    await manager.raise_notice(
+        room,
+        subkind=subkind,
+        key=key,
+        title=first.lstrip("# ").strip(),
+        episode=episode,
+        by=by.lstrip("@"),
+    )
+
+
 async def claim(room: str, key: str, handle: str, ttl_minutes: int, now: datetime) -> dict:
     """Take custody of a row, for as long as the lease runs.
 
@@ -210,7 +237,9 @@ async def claim(room: str, key: str, handle: str, ttl_minutes: int, now: datetim
         "custody_note": None,
         "custody_note_by": None,
     }
-    return await _write(room, key, meta, content, patch, handle)
+    described = await _write(room, key, meta, content, patch, handle)
+    await _raise_notice(room, key, meta, content, "claimed", handle)
+    return described
 
 
 async def release(room: str, key: str, handle: str, note: str | None, now: datetime) -> dict:
@@ -229,7 +258,9 @@ async def release(room: str, key: str, handle: str, note: str | None, now: datet
         "custody_note": note or "released",
         "custody_note_by": handle.lstrip("@"),
     }
-    return await _write(room, key, meta, content, patch, handle)
+    described = await _write(room, key, meta, content, patch, handle)
+    await _raise_notice(room, key, meta, content, "released", handle)
+    return described
 
 
 async def resolve(room: str, key: str, handle: str, now: datetime) -> dict:
@@ -242,7 +273,9 @@ async def resolve(room: str, key: str, handle: str, now: datetime) -> dict:
         "custody_note": f"resolved by @{handle.lstrip('@')}",
         "custody_note_by": handle.lstrip("@"),
     }
-    return await _write(room, key, meta, content, patch, handle)
+    described = await _write(room, key, meta, content, patch, handle)
+    await _raise_notice(room, key, meta, content, "resolved", handle)
+    return described
 
 
 async def renew(room: str, handle: str, now: datetime) -> list[dict]:

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -907,6 +907,52 @@ class RoomChannelManager:
             bus.publish(room_channel(room), l9_bus_frame(room, record_from(ping, content)))
         return ping.header.message.id if ping.header.message else None
 
+    async def raise_notice(
+        self,
+        room: str,
+        *,
+        subkind: str,
+        key: str,
+        title: str | None = None,
+        episode: str | None = None,
+        by: str | None = None,
+        **extra: str | None,
+    ) -> None:
+        """Raise a **notice** into ``live``: the room's timeline of board events.
+
+        The sibling of :meth:`raise_ping`, and it holds the same two structural
+        properties — it wakes nobody (a ``notice`` payload, which
+        :func:`app.routes.participate._addressed_to` excludes) and it does not go
+        out on the wire (``ingest_local`` alone) — so a task filed, claimed,
+        handed back or resolved reads in the channel in sequence with the chat
+        without spending an agent's turn or being filtered out on arrival.
+
+        Where a ping says a thread moved, a notice says the board did: it names
+        the task (``key``/``title``), the thread to open (``episode``), and who
+        moved it (``by``). ``subkind`` is one of :data:`app.services.l9.NOTICE_SUBKINDS`.
+        """
+        data: dict[str, str] = {"subkind": subkind, "key": key}
+        for name, value in (("title", title), ("episode", episode), ("by", by), *extra.items()):
+            if value:
+                data[name] = value
+        notice = l9.build_envelope(
+            kind=Kind.exchange,
+            episode=l9.live_episode_urn(room),
+            sender=l9.SYSTEM_ACTOR_ID,
+            sender_role=l9.SYSTEM_ACTOR_ROLE,
+            topic=l9.topic_urn(room),
+            payload_type=l9.NOTICE_PAYLOAD_TYPE,
+            payload_data=data,
+        )
+        content = serialize_content(notice)
+        managed = self._channels.get(room)
+        if managed is not None and managed.persister is not None:
+            managed.persister.ingest_local(notice, content, list_write=False)
+        else:
+            from app.bus import bus, room_channel
+
+            bus.publish(room_channel(room), l9_bus_frame(room, record_from(notice, content)))
+
     # -- consent-gated invites --
 
     def request_invite(

--- a/fastapi-backend/tests/test_slim_l9_wire.py
+++ b/fastapi-backend/tests/test_slim_l9_wire.py
@@ -196,6 +196,50 @@ def test_ping_payload_matches_contract():
     assert "content" not in content
 
 
+def test_notice_payload_matches_contract():
+    """The notice the backend raises is the one the GUI draws in the timeline.
+
+    Same stakes as the ping: rename the type on this side and either the channel
+    stops showing that the board moved, or every resident agent starts waking on
+    every board write (``participate._addressed_to`` keys off this same literal).
+    """
+    import asyncio
+    import json as json_module
+
+    from app.bus import bus
+    from app.services.room_channels import RoomChannelManager
+
+    g = _contract()["notice"]
+    assert g["payload_type"] == l9.NOTICE_PAYLOAD_TYPE
+    assert set(g["subkinds"]) == set(l9.NOTICE_SUBKINDS)
+
+    published: list[dict] = []
+    original = bus.publish
+    bus.publish = lambda _ch, frame: published.append(frame)  # type: ignore[method-assign]
+    try:
+        manager = RoomChannelManager(
+            endpoint="http://127.0.0.1:46357", default_workspace="mycelium"
+        )
+        asyncio.run(
+            manager.raise_notice(
+                "acme",
+                subkind="filed",
+                key="work/ship-auth",
+                title="ship auth",
+                episode=l9.episode_urn("acme", "t3"),
+                by="avery",
+                kind="action",
+            )
+        )
+    finally:
+        bus.publish = original  # type: ignore[method-assign]
+
+    payload = json_module.loads(published[0]["content"])["l9"]["payload"]
+    assert payload["type"] == g["payload_type"]
+    assert payload["data"]["subkind"] in g["subkinds"]
+    assert payload["data"]["key"] == "work/ship-auth"
+
+
 def test_channel_name_topic_matches_contract():
     """A room channel's app segment is the frozen default topic."""
     pytest.importorskip("slim_bindings")

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -16,7 +16,6 @@ import { RoomChatBox } from "@/components/room-chat-box";
 import { ThreadView } from "@/components/thread-view";
 import { RoomInspector, type Tab } from "@/components/room-inspector";
 import { RoomTour } from "@/components/room-tour";
-import { cn } from "@/lib/utils";
 import { GlobalStatusItems, StatusButton } from "@/components/status-items";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCommands, useKeyAction, useKeyScope } from "@/components/keymap-provider";
@@ -27,10 +26,16 @@ import {
   INSPECTOR_FOLD_WIDTH,
   INSPECTOR_PANEL,
   MAIN_PANEL,
+  MAIN_WITH_THREAD_MIN,
   PANEL_INSPECTOR,
   PANEL_MAIN,
+  PANEL_ROOM_SURFACE,
+  PANEL_THREAD,
   ROOM_GROUP_ID,
   ROOM_PANEL_IDS,
+  THREAD_GROUP_ID,
+  THREAD_PANEL,
+  THREAD_PANEL_IDS,
   layoutStorage,
 } from "@/lib/panel-layout";
 import { useCollapsibleRail } from "@/lib/use-collapsible-rail";
@@ -208,6 +213,43 @@ function RoomWorkspace() {
     panelIds: ROOM_PANEL_IDS,
   });
 
+  // The room-surface / thread split remembers its own width, so dragging the
+  // thread wider does not disturb where the inspector sits.
+  const {
+    defaultLayout: threadLayout,
+    onLayoutChange: onThreadLayoutChange,
+    onLayoutChanged: onThreadLayoutChanged,
+  } = useDefaultLayout({
+    id: THREAD_GROUP_ID,
+    storage: layoutStorage,
+    panelIds: THREAD_PANEL_IDS,
+  });
+
+  // The room's own surface — the feed/board and its composer — as one element,
+  // so it renders identically whether it stands alone or sits in the split
+  // beside an open thread.
+  const roomSurface = (
+    <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="flex-1 overflow-hidden">
+        <EventStream
+          roomName={roomName}
+          onMemoryChanged={handleMemoryChanged}
+          onConnectionChange={setConnected}
+          onNegotiationPhaseChange={setNegPhase}
+          onOpenMemory={openMemory}
+          onOpenEpisode={openEpisode}
+          onOpenThread={openThread}
+          view={editorView}
+          onViewChange={setEditorView}
+          suppressInvites={tourActive}
+          focusMessageId={focus?.type === "message" ? focus.id : null}
+          onFocusConsumed={clearFocus}
+        />
+      </div>
+      <RoomChatBox roomName={roomName} className={editorView !== "channel" ? "hidden" : undefined} />
+    </div>
+  );
+
   // Folded, the inspector is a plain strip beside the group rather than a panel
   // inside it: a panel that isn't there can't be squeezed, and it comes back at
   // the width it left at.
@@ -288,44 +330,46 @@ function RoomWorkspace() {
           onLayoutChange={inspectorOpen ? onLayoutChange : undefined}
           onLayoutChanged={inspectorOpen ? onLayoutChanged : undefined}
         >
-          <ResizablePanel id={PANEL_MAIN} minSize={MAIN_PANEL.min} className="flex min-w-0">
+          <ResizablePanel
+            id={PANEL_MAIN}
+            // While a thread is open PANEL_MAIN holds the room surface AND the
+            // thread split, so its floor rises to fit both — the inspector gives
+            // way rather than the split having nowhere to go.
+            minSize={threadTarget ? MAIN_WITH_THREAD_MIN : MAIN_PANEL.min}
+            className="flex min-w-0"
+          >
             <main className="flex min-w-0 flex-1 overflow-hidden">
-              {/* The room's own surface stays mounted behind an open thread, so
-                  closing the pane returns to the feed where it was left. Only a
-                  screen too narrow for both hands the width over. */}
-              <div
-                className={cn(
-                  "min-w-0 flex-1 flex-col overflow-hidden",
-                  threadTarget ? "hidden lg:flex" : "flex",
-                )}
-              >
-                <div className="flex-1 overflow-hidden">
-                  <EventStream
-                    roomName={roomName}
-                    onMemoryChanged={handleMemoryChanged}
-                    onConnectionChange={setConnected}
-                    onNegotiationPhaseChange={setNegPhase}
-                    onOpenMemory={openMemory}
-                    onOpenEpisode={openEpisode}
-                    onOpenThread={openThread}
-                    view={editorView}
-                    onViewChange={setEditorView}
-                    suppressInvites={tourActive}
-                    focusMessageId={focus?.type === "message" ? focus.id : null}
-                    onFocusConsumed={clearFocus}
-                  />
-                </div>
-                <RoomChatBox roomName={roomName} className={editorView !== "channel" ? "hidden" : undefined} />
-              </div>
-              {threadTarget && (
-                <div className="flex min-w-0 flex-1 border-l border-border lg:max-w-[26rem] xl:max-w-[34rem]">
-                  <ThreadView
-                    roomName={roomName}
-                    target={threadTarget}
-                    onClose={closeThread}
-                    onOpenMemory={openMemory}
-                  />
-                </div>
+              {threadTarget ? (
+                // The room surface and the task's thread, split by a handle the
+                // reader can drag. Its own group so the width it is dragged to is
+                // remembered independently of the inspector's.
+                <ResizablePanelGroup
+                  className="min-h-0 flex-1"
+                  defaultLayout={threadLayout}
+                  onLayoutChange={onThreadLayoutChange}
+                  onLayoutChanged={onThreadLayoutChanged}
+                >
+                  <ResizablePanel id={PANEL_ROOM_SURFACE} minSize={MAIN_PANEL.min} className="flex min-w-0">
+                    {roomSurface}
+                  </ResizablePanel>
+                  <ResizableHandle withHandle />
+                  <ResizablePanel
+                    id={PANEL_THREAD}
+                    defaultSize={THREAD_PANEL.default}
+                    minSize={THREAD_PANEL.min}
+                    maxSize={THREAD_PANEL.max}
+                    className="flex min-w-0"
+                  >
+                    <ThreadView
+                      roomName={roomName}
+                      target={threadTarget}
+                      onClose={closeThread}
+                      onOpenMemory={openMemory}
+                    />
+                  </ResizablePanel>
+                </ResizablePanelGroup>
+              ) : (
+                roomSurface
               )}
             </main>
           </ResizablePanel>

--- a/mycelium-frontend/src/components/board/board-capture.tsx
+++ b/mycelium-frontend/src/components/board/board-capture.tsx
@@ -27,7 +27,7 @@ export const BoardCapture = forwardRef<HTMLInputElement, Props>(function BoardCa
   const armed = parsed.title.length > 0;
 
   return (
-    <div className="px-5 pb-2">
+    <div className="mt-2 px-5 pb-2">
       <div
         className={cn(
           "flex items-center gap-2 rounded-lg border bg-surface/60 px-3 py-1.5 transition-colors",

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -13,7 +13,7 @@ import {
   type PendingInvite,
 } from "@/lib/api";
 import { useRoomAgents, useRoomThreads } from "@/lib/room-data";
-import { PING_TYPE, coalescePings, isLiveEpisode, pingOf, threadShortId } from "@/lib/threads";
+import { PING_TYPE, TASK_CREATED_TYPE, coalescePings, filedLabel, isLiveEpisode, pingOf, taskCreatedOf, threadShortId } from "@/lib/threads";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomBoard } from "@/components/board/room-board";
@@ -85,7 +85,7 @@ export const L9_RAISE_UP_TYPES = [
 // negotiation lifecycle ("alice joined session X", "CONSENSUS in session X
 // → 4 work rows", "TIMEOUT in session X, no agreement") instead of
 // burying it all under the EVENTS tab.
-const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES, PING_TYPE]);
+const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES, PING_TYPE, TASK_CREATED_TYPE]);
 
 // Lifecycle events that render as slim system notices (not chat rows). Used to
 // decide message grouping: a chat message only groups under the sender above it
@@ -97,7 +97,7 @@ const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES, PING_TY
  * *renamed* here — the same branch the CLI takes inside `chat_line`. Adding it
  * to the contract would claim a drift that isn't one.
  */
-const SYSTEM_TYPES = new Set([...L9_RAISE_UP_TYPES, PING_TYPE]);
+const SYSTEM_TYPES = new Set([...L9_RAISE_UP_TYPES, PING_TYPE, TASK_CREATED_TYPE]);
 
 /** Skeleton loader for chat rows. */
 function ChannelSkeleton() {
@@ -239,6 +239,17 @@ function parseEvent(msg: Record<string, unknown>, room: string): Event {
         thread = ping.episode;
         pingSender = ping.sender;
         mtype = PING_TYPE;
+        break;
+      }
+      // A task filed into the room rides the same exchange kind, named before the
+      // prose unwrap for the same reason a ping is: it is a notice about the
+      // board, not a chat row. `thread` holds the task's own thread to open.
+      const created = taskCreatedOf(raw);
+      if (created) {
+        thread = created.episode;
+        content = created.title ?? created.key;
+        mtype = TASK_CREATED_TYPE;
+        raw = { ...raw, taskKey: created.key, by: created.by, kind: created.kind };
         break;
       }
       // The live SSE stream wraps human/agent messages as an L9 exchange
@@ -440,11 +451,15 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
       .then(([data, frames]) => {
         if (!live) return;
         const said = (data.messages || []).map((m) => parseEvent(m, roomName));
-        const pings = frames
+        // The L9 replay is where the room's board notices live — a ping about a
+        // thread, and a task filed into the room — neither of which survives the
+        // conversational read of `/messages`. Merge those in so the channel is
+        // the room's timeline, not just its prose.
+        const notices = frames
           .map((frame) => parseEvent(frame, roomName))
-          .filter((e) => e.type === PING_TYPE);
+          .filter((e) => e.type === PING_TYPE || e.type === TASK_CREATED_TYPE);
         setEvents(
-          [...said, ...pings].sort((a, b) => (Date.parse(a.at) || 0) - (Date.parse(b.at) || 0)),
+          [...said, ...notices].sort((a, b) => (Date.parse(a.at) || 0) - (Date.parse(b.at) || 0)),
         );
         setHistoryLoaded(true);
       })
@@ -708,6 +723,24 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                       <span className="truncate">· {who.map(h => `@${h}`).join(", ")}</span>
                     )}
                     {onOpenThread && <span className="text-faint">· click to open</span>}
+                  </SystemNotice>
+                );
+              }
+              if (ev.type === TASK_CREATED_TYPE) {
+                const episode = ev.thread;
+                const by = ev.raw.by as string | undefined;
+                return (
+                  <SystemNotice key={ev.id} time={ev.time} dot="var(--green)" label={filedLabel(ev.raw.kind as string | undefined)}>
+                    <button
+                      type="button"
+                      onClick={() => episode && onOpenThread?.(episode)}
+                      disabled={!episode || !onOpenThread}
+                      className="inline-flex max-w-[20rem] items-center gap-1 truncate rounded px-1 text-accent transition-colors enabled:hover:bg-accent-soft enabled:hover:underline disabled:cursor-default disabled:text-text"
+                    >
+                      <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
+                      <span className="truncate">{ev.content}</span>
+                    </button>
+                    {by && <span>· by @{by}</span>}
                   </SystemNotice>
                 );
               }

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -13,7 +13,7 @@ import {
   type PendingInvite,
 } from "@/lib/api";
 import { useRoomAgents, useRoomThreads } from "@/lib/room-data";
-import { PING_TYPE, TASK_CREATED_TYPE, coalescePings, filedLabel, isLiveEpisode, pingOf, taskCreatedOf, threadShortId } from "@/lib/threads";
+import { NOTICE_TYPE, PING_TYPE, coalescePings, isLiveEpisode, noticeLabel, noticeOf, pingOf, threadShortId } from "@/lib/threads";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomBoard } from "@/components/board/room-board";
@@ -85,7 +85,7 @@ export const L9_RAISE_UP_TYPES = [
 // negotiation lifecycle ("alice joined session X", "CONSENSUS in session X
 // → 4 work rows", "TIMEOUT in session X, no agreement") instead of
 // burying it all under the EVENTS tab.
-const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES, PING_TYPE, TASK_CREATED_TYPE]);
+const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES, PING_TYPE, NOTICE_TYPE]);
 
 // Lifecycle events that render as slim system notices (not chat rows). Used to
 // decide message grouping: a chat message only groups under the sender above it
@@ -97,7 +97,7 @@ const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES, PING_TY
  * *renamed* here — the same branch the CLI takes inside `chat_line`. Adding it
  * to the contract would claim a drift that isn't one.
  */
-const SYSTEM_TYPES = new Set([...L9_RAISE_UP_TYPES, PING_TYPE, TASK_CREATED_TYPE]);
+const SYSTEM_TYPES = new Set([...L9_RAISE_UP_TYPES, PING_TYPE, NOTICE_TYPE]);
 
 /** Skeleton loader for chat rows. */
 function ChannelSkeleton() {
@@ -241,15 +241,16 @@ function parseEvent(msg: Record<string, unknown>, room: string): Event {
         mtype = PING_TYPE;
         break;
       }
-      // A task filed into the room rides the same exchange kind, named before the
-      // prose unwrap for the same reason a ping is: it is a notice about the
-      // board, not a chat row. `thread` holds the task's own thread to open.
-      const created = taskCreatedOf(raw);
-      if (created) {
-        thread = created.episode;
-        content = created.title ?? created.key;
-        mtype = TASK_CREATED_TYPE;
-        raw = { ...raw, taskKey: created.key, by: created.by, kind: created.kind };
+      // A board event — a task filed, claimed, handed back, resolved — rides the
+      // same exchange kind, named before the prose unwrap for the same reason a
+      // ping is: it is a notice about the board, not a chat row. `thread` holds
+      // the task's own thread to open.
+      const notice = noticeOf(raw);
+      if (notice) {
+        thread = notice.episode;
+        content = notice.title ?? notice.key;
+        mtype = NOTICE_TYPE;
+        raw = { ...raw, taskKey: notice.key, by: notice.by, kind: notice.kind, subkind: notice.subkind };
         break;
       }
       // The live SSE stream wraps human/agent messages as an L9 exchange
@@ -457,7 +458,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
         // the room's timeline, not just its prose.
         const notices = frames
           .map((frame) => parseEvent(frame, roomName))
-          .filter((e) => e.type === PING_TYPE || e.type === TASK_CREATED_TYPE);
+          .filter((e) => e.type === PING_TYPE || e.type === NOTICE_TYPE);
         setEvents(
           [...said, ...notices].sort((a, b) => (Date.parse(a.at) || 0) - (Date.parse(b.at) || 0)),
         );
@@ -726,11 +727,25 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                   </SystemNotice>
                 );
               }
-              if (ev.type === TASK_CREATED_TYPE) {
+              if (ev.type === NOTICE_TYPE) {
                 const episode = ev.thread;
                 const by = ev.raw.by as string | undefined;
+                const subkind = (ev.raw.subkind as string) || "filed";
+                // Green when work lands or closes, yellow when it comes back up
+                // for grabs, accent while it is in hand.
+                const dot =
+                  subkind === "resolved" || subkind === "filed"
+                    ? "var(--green)"
+                    : subkind === "released"
+                      ? "var(--yellow)"
+                      : "var(--accent)";
                 return (
-                  <SystemNotice key={ev.id} time={ev.time} dot="var(--green)" label={filedLabel(ev.raw.kind as string | undefined)}>
+                  <SystemNotice
+                    key={ev.id}
+                    time={ev.time}
+                    dot={dot}
+                    label={noticeLabel(subkind, ev.raw.kind as string | undefined)}
+                  >
                     <button
                       type="button"
                       onClick={() => episode && onOpenThread?.(episode)}
@@ -740,7 +755,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                       <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
                       <span className="truncate">{ev.content}</span>
                     </button>
-                    {by && <span>· by @{by}</span>}
+                    {by && <span>· {subkind === "filed" ? "by " : ""}@{by}</span>}
                   </SystemNotice>
                 );
               }

--- a/mycelium-frontend/src/components/memory-graph.tsx
+++ b/mycelium-frontend/src/components/memory-graph.tsx
@@ -579,7 +579,7 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
             <Tooltip content="Show every namespace and link type again" side="bottom" align="end">
               <button
                 onClick={clearFilters}
-                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
               >
                 <Filter className="size-3.5" />
                 Clear filters
@@ -597,7 +597,7 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
                   dirty.current = true;
                   setPlaced({});
                 }}
-                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+                className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
               >
                 <RotateCcw className="size-3.5" />
                 Reset layout

--- a/mycelium-frontend/src/components/memory-page-view.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.tsx
@@ -20,6 +20,7 @@ import { MemoryEditor } from "@/components/memory-editor";
 import { RoomChatBox } from "@/components/room-chat-box";
 import { TaskConversation } from "@/components/task/task-conversation";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip } from "@/components/ui/tooltip";
 import { useCurrentUser } from "@/components/current-user";
 import { useUnsavedGuard } from "@/components/unsaved-changes";
 
@@ -100,7 +101,10 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-      <header className="sticky top-0 z-10 border-b border-border bg-surface/90 px-6 py-3 backdrop-blur-sm md:px-8">
+      {/* The same header aesthetic as the split pane the full-screen button
+          arrives from: a clean bar over paper, and an icon edit toggle rather
+          than a bordered pill, so the page reads as the same task opened larger. */}
+      <header className="sticky top-0 z-10 border-b border-border bg-paper px-6 py-3 backdrop-blur-sm md:px-8">
         <Link
           href={`/room/${encodeURIComponent(roomName)}`}
           className="mb-2 inline-flex items-center gap-1 text-micro text-muted-foreground transition-colors hover:text-accent"
@@ -109,7 +113,7 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
           {roomName}
         </Link>
         <div className="flex items-center gap-3">
-          <h1 className="flex-1 font-mono text-ui font-semibold text-text break-all">
+          <h1 className="min-w-0 flex-1 truncate font-mono text-ui font-semibold text-text">
             {crumbs.map((part, i) => (
               <span key={i}>
                 {i > 0 && <span className="text-faint">/</span>}
@@ -117,16 +121,18 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
               </span>
             ))}
           </h1>
-          <button
-            type="button"
-            onClick={() =>
-              isEditing ? guard(() => setIsEditing(false)) : setIsEditing(true)
-            }
-            className="inline-flex items-center gap-1.5 rounded-md border border-border px-2.5 py-1.5 text-micro font-medium text-accent transition-colors hover:bg-hairline"
-          >
-            {isEditing ? <Eye className="size-3.5" /> : <Pencil className="size-3.5" />}
-            {isEditing ? "View" : "Edit"}
-          </button>
+          <Tooltip content={isEditing ? "View" : "Edit"}>
+            <button
+              type="button"
+              onClick={() =>
+                isEditing ? guard(() => setIsEditing(false)) : setIsEditing(true)
+              }
+              aria-label={isEditing ? "View" : "Edit"}
+              className="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+            >
+              {isEditing ? <Eye className="size-4" strokeWidth={1.9} /> : <Pencil className="size-4" strokeWidth={1.9} />}
+            </button>
+          </Tooltip>
         </div>
       </header>
 

--- a/mycelium-frontend/src/components/memory-page-view.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.tsx
@@ -5,7 +5,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ChevronLeft, Pencil, Eye } from "lucide-react";
 import {
   fetchMemory,
@@ -14,8 +14,11 @@ import {
 } from "@/lib/api";
 import { useRoomMemoryIntegrity, useRoomRevalidate } from "@/lib/room-data";
 import { memoryHref } from "@/lib/memory-routes";
+import { isLiveEpisode } from "@/lib/threads";
 import { MemoryDetail } from "@/components/memory-detail";
 import { MemoryEditor } from "@/components/memory-editor";
+import { RoomChatBox } from "@/components/room-chat-box";
+import { TaskConversation } from "@/components/task/task-conversation";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCurrentUser } from "@/components/current-user";
 import { useUnsavedGuard } from "@/components/unsaved-changes";
@@ -60,6 +63,13 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
     (key: string) => router.push(memoryHref(roomName, key)),
     [router, roomName],
   );
+
+  // The thread conversation owns its own read; it hands us its refresh so the
+  // page composer's send can re-read the episode.
+  const threadRefresh = useRef<(() => void) | null>(null);
+  const onThreadReady = useCallback((refresh: () => void) => {
+    threadRefresh.current = refresh;
+  }, []);
 
   if (memory === undefined) {
     return (
@@ -151,6 +161,29 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
             renderedBody={renderedBody}
             integrity={integrity}
           />
+        )}
+
+        {/* The task's discussion, below its body — the full-page equivalent of
+            the thread pane's conversation. Only a real thread has one: a row
+            written before threading carries the room's own live episode (or
+            none), and reading that as a thread would empty the room's history. */}
+        {!isEditing && memory.episode && !isLiveEpisode(roomName, memory.episode) && (
+          <section className="mt-8 flex min-h-0 flex-col px-6 md:px-8">
+            <h2 className="mb-2 text-micro uppercase tracking-wide text-faint">Discussion</h2>
+            <div className="flex min-h-[16rem] flex-col rounded-xl border border-border bg-surface">
+              <TaskConversation
+                roomName={roomName}
+                episode={memory.episode}
+                onOpenMemory={onNavigate}
+                onReady={onThreadReady}
+              />
+              <RoomChatBox
+                roomName={roomName}
+                episode={memory.episode}
+                onSent={() => threadRefresh.current?.()}
+              />
+            </div>
+          </section>
         )}
       </div>
 

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -391,7 +391,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
           <Tooltip content="Open the memory link graph">
             <Link
               href={memoryGraphHref(roomName)}
-              className="ml-auto inline-flex flex-shrink-0 items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+              className="ml-auto inline-flex flex-shrink-0 items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
             >
               <Network className="size-3.5" />
               Graph
@@ -520,7 +520,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
                   onClick={() =>
                     isEditing ? guard(() => setIsEditing(false)) : setIsEditing(true)
                   }
-                  className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+                  className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
                 >
                   {isEditing ? <Eye className="size-3.5" /> : <Pencil className="size-3.5" />}
                   {isEditing ? "View" : "Edit"}
@@ -529,7 +529,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
               <Tooltip content="Open full page">
                 <Link
                   href={memoryHref(roomName, selected.key)}
-                  className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-accent transition-colors hover:bg-hairline"
+                  className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-micro font-medium text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
                 >
                   <ExternalLink className="size-3.5" />
                   Full page

--- a/mycelium-frontend/src/components/task/task-conversation.tsx
+++ b/mycelium-frontend/src/components/task/task-conversation.tsx
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useEffect, useRef } from "react";
+import { MessageSquare } from "lucide-react";
+import type { RoomMessage } from "@/lib/api";
+import { useRoomAgents, useThreadMessages } from "@/lib/room-data";
+import { useRoomStream } from "@/lib/stream-hub";
+import { pingOf } from "@/lib/threads";
+import { MarkdownContent } from "@/components/markdown-content";
+import { EmptyState } from "@/components/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Monogram } from "@/components/ui/monogram";
+
+interface Props {
+  roomName: string;
+  /** The episode URN this conversation reads and writes. */
+  episode: string;
+  /** A `[[wikilink]]` in a thread message opens the memory, same as in chat. */
+  onOpenMemory?: (key: string) => void;
+  /**
+   * Hands the parent this conversation's `refresh`, so a send through the
+   * parent's composer can re-read the episode. The read lives here (one SWR
+   * entry per thread), so the parent reaches it through this seam rather than
+   * duplicating the hook.
+   */
+  onReady?: (refresh: () => void) => void;
+}
+
+/** The prose a thread message carries, or "" when it carries none. */
+function textOf(message: RoomMessage): string {
+  const content = message.content;
+  if (typeof content !== "string") return "";
+  if (!content.startsWith("{")) return content;
+  try {
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    return typeof parsed.content === "string"
+      ? parsed.content
+      : typeof parsed.text === "string"
+        ? parsed.text
+        : "";
+  } catch {
+    return content;
+  }
+}
+
+/**
+ * One task's conversation: the scrollable message region, and nothing else.
+ *
+ * The composer stays with the parent (a task is rendered in more than one place
+ * and the composer's chrome differs), so this is just the read and its
+ * rendering. The read is its own SWR entry (`useThreadMessages`), so showing a
+ * conversation never replaces the room's feed with a filtered slice of itself.
+ */
+export function TaskConversation({ roomName, episode, onOpenMemory, onReady }: Props) {
+  const { messages, loading, refresh } = useThreadMessages(roomName, episode);
+  const { agents } = useRoomAgents(roomName);
+  const agentHandles = new Set(agents.map(a => a.handle));
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Hand the parent our refresh once it is stable, so its composer's onSent can
+  // re-read this episode after a send.
+  useEffect(() => {
+    onReady?.(refresh);
+  }, [onReady, refresh]);
+
+  // A write into this thread reaches the room's one multiplexed stream twice —
+  // as the message itself (tagged with this episode) and as the ping that
+  // announces it (tagged `live`, naming this episode in its payload). Either is
+  // reason to re-read; nothing else here is, so a busy room does not refetch a
+  // quiet thread. The refresh is a revalidation, not an append: the region stays
+  // a read of one episode rather than a second feed assembled by hand.
+  useRoomStream(roomName, frame => {
+    const message = frame as Record<string, unknown>;
+    if (message.episode === episode) {
+      refresh();
+      return;
+    }
+    let content = message.content;
+    if (typeof content === "string") {
+      try {
+        content = JSON.parse(content);
+      } catch {
+        return;
+      }
+    }
+    if (pingOf(content as Record<string, unknown>)?.episode === episode) refresh();
+  });
+
+  // The backend answers newest-first; a conversation reads the other way.
+  //
+  // A thread carries its lifecycle as well as its argument — joins, mediator
+  // ticks, the commit it converged on — and those are frames, not things
+  // anybody said. Selecting on whether a message has prose keeps this a
+  // conversation without it having to know which types aren't one; what the
+  // lifecycle amounts to is the row's own state, which the board already draws.
+  const ordered = [...messages]
+    .reverse()
+    .map(message => ({ message, text: textOf(message) }))
+    .filter(({ text }) => text.trim().length > 0);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [ordered.length]);
+
+  return (
+    <ScrollArea className="min-h-0 flex-1" viewportRef={scrollRef}>
+      {loading && ordered.length === 0 ? (
+        <div className="flex flex-col gap-4 px-5 py-4">
+          <Skeleton className="h-3 w-2/5" />
+          <Skeleton className="h-3 w-3/5" />
+        </div>
+      ) : ordered.length === 0 ? (
+        <EmptyState
+          className="py-14"
+          icon={MessageSquare}
+          title="No replies yet"
+          description="Reply below, or @-mention an agent — it lands in this task, not in the room."
+        />
+      ) : (
+        <div className="py-3">
+          {ordered.map(({ message, text }, i) => {
+            const sender = message.sender_handle ?? message.updated_by ?? "?";
+            const previous = ordered[i - 1]?.message;
+            const grouped = previous && (previous.sender_handle ?? previous.updated_by) === sender;
+            const isAgent = agentHandles.has(sender);
+            return (
+              <div
+                key={message.id ?? `${sender}-${i}`}
+                className={`flex gap-3 px-5 ${grouped ? "py-0.5" : "mt-3 pt-1 first:mt-0"}`}
+              >
+                <div className="w-7 flex-shrink-0">
+                  {!grouped && (
+                    <Monogram
+                      handle={sender}
+                      color={isAgent ? undefined : "var(--avatar-neutral)"}
+                      className="size-7 text-micro"
+                    />
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  {!grouped && (
+                    <span className="text-label font-semibold text-text">{sender}</span>
+                  )}
+                  <MarkdownContent
+                    className="contrast text-body leading-relaxed"
+                    onLinkClick={onOpenMemory}
+                  >
+                    {text}
+                  </MarkdownContent>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </ScrollArea>
+  );
+}

--- a/mycelium-frontend/src/components/thread-view.test.tsx
+++ b/mycelium-frontend/src/components/thread-view.test.tsx
@@ -138,7 +138,7 @@ describe("<ThreadView />", () => {
     renderWithSWR(
       <ThreadView roomName="atlas" target={{ episode: THREAD }} onClose={vi.fn()} />,
     );
-    expect(await screen.findByText("Nothing said here yet")).toBeInTheDocument();
+    expect(await screen.findByText("No replies yet")).toBeInTheDocument();
   });
 
   it("re-reads when a write lands in its own thread, and not when one lands elsewhere", async () => {

--- a/mycelium-frontend/src/components/thread-view.tsx
+++ b/mycelium-frontend/src/components/thread-view.tsx
@@ -4,8 +4,10 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { MessageSquare, X } from "lucide-react";
+import Link from "next/link";
+import { Maximize2, MessageSquare, X } from "lucide-react";
 import type { Memory, RoomMessage } from "@/lib/api";
+import { memoryHref } from "@/lib/memory-routes";
 import { useRoomAgents, useRoomMemories, useThreadMessages } from "@/lib/room-data";
 import { useRoomStream } from "@/lib/stream-hub";
 import { pingOf, threadShortId } from "@/lib/threads";
@@ -217,6 +219,20 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
           </Tooltip>
         )}
         <span className="ml-auto flex items-center gap-2">
+          {/* Full screen: leave the split and open the task on its own page —
+              the same memory, room to work. Only where the pane is a task (a
+              negotiation thread has no page of its own to open). */}
+          {task && (
+            <Tooltip content="Open full screen">
+              <Link
+                href={memoryHref(roomName, task.key)}
+                aria-label="Open task full screen"
+                className="grid size-6 place-items-center rounded text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+              >
+                <Maximize2 className="size-3.5" strokeWidth={1.9} />
+              </Link>
+            </Tooltip>
+          )}
           <Kbd size="xs" tone="muted">Esc</Kbd>
           <button
             type="button"

--- a/mycelium-frontend/src/components/thread-view.tsx
+++ b/mycelium-frontend/src/components/thread-view.tsx
@@ -3,21 +3,18 @@
 
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { Maximize2, MessageSquare, X } from "lucide-react";
-import type { Memory, RoomMessage } from "@/lib/api";
+import { Eye, Maximize2, MessageSquare, Pencil, X } from "lucide-react";
 import { memoryHref } from "@/lib/memory-routes";
-import { useRoomAgents, useRoomMemories, useThreadMessages } from "@/lib/room-data";
-import { useRoomStream } from "@/lib/stream-hub";
-import { pingOf, threadShortId } from "@/lib/threads";
-import { memoryValueText } from "@/lib/memory-preview";
-import { MarkdownContent } from "@/components/markdown-content";
+import { useRoomMemories, useRoomRevalidate } from "@/lib/room-data";
+import { threadShortId } from "@/lib/threads";
+import { MemoryDetail } from "@/components/memory-detail";
+import { MemoryEditor } from "@/components/memory-editor";
 import { RoomChatBox } from "@/components/room-chat-box";
-import { EmptyState } from "@/components/empty-state";
-import { Skeleton } from "@/components/ui/skeleton";
+import { TaskConversation } from "@/components/task/task-conversation";
+import { useCurrentUser } from "@/components/current-user";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { Monogram } from "@/components/ui/monogram";
 import { Kbd } from "@/components/ui/kbd";
 import { Tooltip } from "@/components/ui/tooltip";
 
@@ -43,83 +40,6 @@ interface Props {
 }
 
 /**
- * The task itself, above its conversation: what an issue's description is to its
- * comments. The row's own fields as a chip line, then its body — but only where
- * the body says more than the title already does, so a one-line task is all
- * header and no empty restatement of itself.
- */
-function TaskCard({
-  task,
-  title,
-  onOpenMemory,
-}: {
-  task: Memory;
-  title?: string | null;
-  onOpenMemory?: (key: string) => void;
-}) {
-  const meta = (task.meta ?? {}) as Record<string, unknown>;
-  const str = (k: string): string | null => {
-    const v = meta[k];
-    return typeof v === "string" && v.trim() ? v.trim() : null;
-  };
-  const assignee = str("assignee");
-  const priority = str("priority");
-  const chips = [
-    str("kind"),
-    str("status"),
-    assignee ? `for ${assignee}` : null,
-    priority && priority !== "normal" ? priority : null,
-    str("issue") ?? str("pr"),
-  ].filter((c): c is string => Boolean(c));
-
-  // The body is the description; its first line is often the title again, so
-  // drop that one line rather than restating in the pane what the header says.
-  const body = memoryValueText(task.value).trim();
-  const [firstLine, ...rest] = body.split("\n");
-  const description =
-    firstLine.replace(/^#+\s*/, "").trim() === (title ?? "").trim()
-      ? rest.join("\n").trim()
-      : body;
-
-  if (chips.length === 0 && !description) return null;
-  return (
-    <div className="border-b border-hairline px-5 py-3">
-      {chips.length > 0 && (
-        <div className="mb-1.5 flex flex-wrap items-center gap-1.5 font-mono text-micro text-muted-foreground">
-          {chips.map((chip, i) => (
-            <span key={`${chip}-${i}`} className="rounded bg-hairline px-1.5 py-px">
-              {chip}
-            </span>
-          ))}
-        </div>
-      )}
-      {description && (
-        <MarkdownContent className="contrast text-body leading-relaxed" onLinkClick={onOpenMemory}>
-          {description}
-        </MarkdownContent>
-      )}
-    </div>
-  );
-}
-
-/** The prose a thread message carries, or "" when it carries none. */
-function textOf(message: RoomMessage): string {
-  const content = message.content;
-  if (typeof content !== "string") return "";
-  if (!content.startsWith("{")) return content;
-  try {
-    const parsed = JSON.parse(content) as Record<string, unknown>;
-    return typeof parsed.content === "string"
-      ? parsed.content
-      : typeof parsed.text === "string"
-        ? parsed.text
-        : "";
-  } catch {
-    return content;
-  }
-}
-
-/**
  * One task's conversation, on its own.
  *
  * A **transient pane**, not a rail: it is here because you opened a row and
@@ -128,46 +48,31 @@ function textOf(message: RoomMessage): string {
  * deliberately no "all threads" view either: a thread is reached through the
  * task it belongs to, which is the only place it means anything.
  *
- * The read is its own SWR entry (`useThreadMessages`), so opening this never
- * replaces the room's feed with a filtered slice of itself, and the composer at
- * the foot is the room's composer pointed at this episode — one way to write,
- * aimed differently.
+ * The pane composes the shared parts a task has everywhere it is shown: the
+ * task itself as {@link MemoryDetail} (or {@link MemoryEditor} when editing),
+ * the {@link TaskConversation} below it, and the room's composer pointed at
+ * this episode. The read is the conversation's own SWR entry, so opening this
+ * never replaces the room's feed with a filtered slice of itself.
  */
 export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
-  const { messages, loading, refresh } = useThreadMessages(roomName, target.episode);
   // The task this thread is of, resolved by its episode — the row is the thread,
   // so the pane opens with the task itself (its body and fields) above the
   // conversation about it, the way an issue shows its description over its
   // comments. Absent for a negotiation thread bound to no row.
   const { memories } = useRoomMemories(roomName);
   const task = memories.find(m => m.episode === target.episode) ?? null;
-  const { agents } = useRoomAgents(roomName);
-  const agentHandles = new Set(agents.map(a => a.handle));
+  const { principal } = useCurrentUser();
+  const revalidate = useRoomRevalidate(roomName);
   const shortId = threadShortId(target.episode) ?? "thread";
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const [isEditing, setIsEditing] = useState(false);
 
-  // A write into this thread reaches the room's one multiplexed stream twice —
-  // as the message itself (tagged with this episode) and as the ping that
-  // announces it (tagged `live`, naming this episode in its payload). Either is
-  // reason to re-read; nothing else here is, so a busy room does not refetch a
-  // quiet thread. The refresh is a revalidation, not an append: the pane stays
-  // a read of one episode rather than a second feed assembled by hand.
-  useRoomStream(roomName, frame => {
-    const message = frame as Record<string, unknown>;
-    if (message.episode === target.episode) {
-      refresh();
-      return;
-    }
-    let content = message.content;
-    if (typeof content === "string") {
-      try {
-        content = JSON.parse(content);
-      } catch {
-        return;
-      }
-    }
-    if (pingOf(content as Record<string, unknown>)?.episode === target.episode) refresh();
-  });
+  // The conversation owns the read; it hands us its refresh so a send through
+  // the composer below can re-read the episode.
+  const refreshRef = useRef<(() => void) | null>(null);
+  const onReady = useCallback((refresh: () => void) => {
+    refreshRef.current = refresh;
+  }, []);
+  const refresh = useCallback(() => refreshRef.current?.(), []);
 
   // Esc closes: the pane is transient, so leaving it must be as cheap as
   // opening it was.
@@ -181,22 +86,6 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
-
-  // The backend answers newest-first; a conversation reads the other way.
-  //
-  // A thread carries its lifecycle as well as its argument — joins, mediator
-  // ticks, the commit it converged on — and those are frames, not things
-  // anybody said. Selecting on whether a message has prose keeps the pane a
-  // conversation without it having to know which types aren't one; what the
-  // lifecycle amounts to is the row's own state, which the board already draws.
-  const ordered = [...messages]
-    .reverse()
-    .map(message => ({ message, text: textOf(message) }))
-    .filter(({ text }) => text.trim().length > 0);
-
-  useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
-  }, [ordered.length]);
 
   return (
     <section
@@ -219,6 +108,21 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
           </Tooltip>
         )}
         <span className="ml-auto flex items-center gap-2">
+          {/* Edit the task in place, only where the pane is a task. A plain
+              toggle with a revalidate on save: the pane is narrow and transient,
+              so it keeps less chrome than the full page does. */}
+          {task && (
+            <Tooltip content={isEditing ? "View task" : "Edit task"}>
+              <button
+                type="button"
+                onClick={() => setIsEditing(v => !v)}
+                aria-label={isEditing ? "View task" : "Edit task"}
+                className="grid size-6 place-items-center rounded text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+              >
+                {isEditing ? <Eye className="size-3.5" strokeWidth={1.9} /> : <Pencil className="size-3.5" strokeWidth={1.9} />}
+              </button>
+            </Tooltip>
+          )}
           {/* Full screen: leave the split and open the task on its own page —
               the same memory, room to work. Only where the pane is a task (a
               negotiation thread has no page of its own to open). */}
@@ -245,58 +149,46 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
         </span>
       </header>
 
-      <ScrollArea className="min-h-0 flex-1" viewportRef={scrollRef}>
-        {task && <TaskCard task={task} title={target.title} onOpenMemory={onOpenMemory} />}
-        {loading && ordered.length === 0 ? (
-          <div className="flex flex-col gap-4 px-5 py-4">
-            <Skeleton className="h-3 w-2/5" />
-            <Skeleton className="h-3 w-3/5" />
-          </div>
-        ) : ordered.length === 0 ? (
-          <EmptyState
-            className={task ? "py-14" : "h-full"}
-            icon={MessageSquare}
-            title={task ? "No replies yet" : "Nothing said here yet"}
-            description="Reply below, or @-mention an agent — it lands in this task, not in the room."
+      {task && isEditing ? (
+        // The editor owns its own scroll; it replaces the body and stands in
+        // for the conversation while a save is in flight.
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <MemoryEditor
+            key={task.key}
+            memory={task}
+            roomName={roomName}
+            actor={principal}
+            onSaved={() => {
+              revalidate();
+              setIsEditing(false);
+            }}
+            onCancel={() => setIsEditing(false)}
           />
-        ) : (
-          <div className="py-3">
-            {ordered.map(({ message, text }, i) => {
-              const sender = message.sender_handle ?? message.updated_by ?? "?";
-              const previous = ordered[i - 1]?.message;
-              const grouped = previous && (previous.sender_handle ?? previous.updated_by) === sender;
-              const isAgent = agentHandles.has(sender);
-              return (
-                <div
-                  key={message.id ?? `${sender}-${i}`}
-                  className={`flex gap-3 px-5 ${grouped ? "py-0.5" : "mt-3 pt-1 first:mt-0"}`}
-                >
-                  <div className="w-7 flex-shrink-0">
-                    {!grouped && (
-                      <Monogram
-                        handle={sender}
-                        color={isAgent ? undefined : "var(--avatar-neutral)"}
-                        className="size-7 text-micro"
-                      />
-                    )}
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    {!grouped && (
-                      <span className="text-label font-semibold text-text">{sender}</span>
-                    )}
-                    <MarkdownContent
-                      className="contrast text-body leading-relaxed"
-                      onLinkClick={onOpenMemory}
-                    >
-                      {text}
-                    </MarkdownContent>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
-      </ScrollArea>
+        </div>
+      ) : (
+        // The task's body over its conversation. Two scroll regions: the body
+        // takes at most half the pane so a long task can never push the
+        // conversation off screen, and the conversation owns the rest. A
+        // negotiation thread bound to no row is all conversation.
+        <div className="flex min-h-0 flex-1 flex-col">
+          {task && (
+            <ScrollArea className="max-h-[45%] shrink-0 border-b border-border">
+              <MemoryDetail
+                memory={task}
+                roomName={roomName}
+                variant="rail"
+                onNavigate={onOpenMemory}
+              />
+            </ScrollArea>
+          )}
+          <TaskConversation
+            roomName={roomName}
+            episode={target.episode}
+            onOpenMemory={onOpenMemory}
+            onReady={onReady}
+          />
+        </div>
+      )}
 
       <RoomChatBox
         roomName={roomName}

--- a/mycelium-frontend/src/components/thread-view.tsx
+++ b/mycelium-frontend/src/components/thread-view.tsx
@@ -5,10 +5,11 @@
 
 import { useEffect, useRef } from "react";
 import { MessageSquare, X } from "lucide-react";
-import type { RoomMessage } from "@/lib/api";
-import { useRoomAgents, useThreadMessages } from "@/lib/room-data";
+import type { Memory, RoomMessage } from "@/lib/api";
+import { useRoomAgents, useRoomMemories, useThreadMessages } from "@/lib/room-data";
 import { useRoomStream } from "@/lib/stream-hub";
 import { pingOf, threadShortId } from "@/lib/threads";
+import { memoryValueText } from "@/lib/memory-preview";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomChatBox } from "@/components/room-chat-box";
 import { EmptyState } from "@/components/empty-state";
@@ -37,6 +38,66 @@ interface Props {
   onClose: () => void;
   /** A `[[wikilink]]` in a thread message opens the memory, same as in chat. */
   onOpenMemory?: (key: string) => void;
+}
+
+/**
+ * The task itself, above its conversation: what an issue's description is to its
+ * comments. The row's own fields as a chip line, then its body — but only where
+ * the body says more than the title already does, so a one-line task is all
+ * header and no empty restatement of itself.
+ */
+function TaskCard({
+  task,
+  title,
+  onOpenMemory,
+}: {
+  task: Memory;
+  title?: string | null;
+  onOpenMemory?: (key: string) => void;
+}) {
+  const meta = (task.meta ?? {}) as Record<string, unknown>;
+  const str = (k: string): string | null => {
+    const v = meta[k];
+    return typeof v === "string" && v.trim() ? v.trim() : null;
+  };
+  const assignee = str("assignee");
+  const priority = str("priority");
+  const chips = [
+    str("kind"),
+    str("status"),
+    assignee ? `for ${assignee}` : null,
+    priority && priority !== "normal" ? priority : null,
+    str("issue") ?? str("pr"),
+  ].filter((c): c is string => Boolean(c));
+
+  // The body is the description; its first line is often the title again, so
+  // drop that one line rather than restating in the pane what the header says.
+  const body = memoryValueText(task.value).trim();
+  const [firstLine, ...rest] = body.split("\n");
+  const description =
+    firstLine.replace(/^#+\s*/, "").trim() === (title ?? "").trim()
+      ? rest.join("\n").trim()
+      : body;
+
+  if (chips.length === 0 && !description) return null;
+  return (
+    <div className="border-b border-hairline px-5 py-3">
+      {chips.length > 0 && (
+        <div className="mb-1.5 flex flex-wrap items-center gap-1.5 font-mono text-micro text-muted-foreground">
+          {chips.map((chip, i) => (
+            <span key={`${chip}-${i}`} className="rounded bg-hairline px-1.5 py-px">
+              {chip}
+            </span>
+          ))}
+        </div>
+      )}
+      {description && (
+        <MarkdownContent className="contrast text-body leading-relaxed" onLinkClick={onOpenMemory}>
+          {description}
+        </MarkdownContent>
+      )}
+    </div>
+  );
 }
 
 /** The prose a thread message carries, or "" when it carries none. */
@@ -72,6 +133,12 @@ function textOf(message: RoomMessage): string {
  */
 export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
   const { messages, loading, refresh } = useThreadMessages(roomName, target.episode);
+  // The task this thread is of, resolved by its episode — the row is the thread,
+  // so the pane opens with the task itself (its body and fields) above the
+  // conversation about it, the way an issue shows its description over its
+  // comments. Absent for a negotiation thread bound to no row.
+  const { memories } = useRoomMemories(roomName);
+  const task = memories.find(m => m.episode === target.episode) ?? null;
   const { agents } = useRoomAgents(roomName);
   const agentHandles = new Set(agents.map(a => a.handle));
   const shortId = threadShortId(target.episode) ?? "thread";
@@ -163,6 +230,7 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
       </header>
 
       <ScrollArea className="min-h-0 flex-1" viewportRef={scrollRef}>
+        {task && <TaskCard task={task} title={target.title} onOpenMemory={onOpenMemory} />}
         {loading && ordered.length === 0 ? (
           <div className="flex flex-col gap-4 px-5 py-4">
             <Skeleton className="h-3 w-2/5" />
@@ -170,9 +238,9 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
           </div>
         ) : ordered.length === 0 ? (
           <EmptyState
-            className="h-full"
+            className={task ? "py-14" : "h-full"}
             icon={MessageSquare}
-            title="Nothing said here yet"
+            title={task ? "No replies yet" : "Nothing said here yet"}
             description="Reply below, or @-mention an agent — it lands in this task, not in the room."
           />
         ) : (

--- a/mycelium-frontend/src/lib/panel-layout.ts
+++ b/mycelium-frontend/src/lib/panel-layout.ts
@@ -27,12 +27,16 @@ const FOLD_MARGIN = 60;
 /** Group ids. Also the localStorage keys the saved layouts live under. */
 export const SHELL_GROUP_ID = "mycelium:shell";
 export const ROOM_GROUP_ID = "mycelium:room";
+/** The split inside the main panel while a task's thread is open. */
+export const THREAD_GROUP_ID = "mycelium:thread";
 
 /** Panel ids within those groups. Stable — a saved layout is keyed by them. */
 export const PANEL_ROOMS = "rooms";
 export const PANEL_WORKSPACE = "workspace";
 export const PANEL_MAIN = "main";
 export const PANEL_INSPECTOR = "inspector";
+export const PANEL_ROOM_SURFACE = "room-surface";
+export const PANEL_THREAD = "thread";
 
 /**
  * The id lists `useDefaultLayout` takes, as constants rather than array
@@ -43,6 +47,7 @@ export const PANEL_INSPECTOR = "inspector";
  */
 export const SHELL_PANEL_IDS = [PANEL_ROOMS, PANEL_WORKSPACE];
 export const ROOM_PANEL_IDS = [PANEL_MAIN, PANEL_INSPECTOR];
+export const THREAD_PANEL_IDS = [PANEL_ROOM_SURFACE, PANEL_THREAD];
 
 /** The rooms rail: wide enough for a monogram plus a room name. Collapses to a
  *  strip of room monograms rather than to nothing, so every room stays one
@@ -66,6 +71,15 @@ export const MAIN_PANEL = {
   min: "360px",
 } as const;
 
+/** A task's thread, opened beside the room surface as a resizable split. Wide
+ *  enough by default for the task's body over its conversation; its own floor so
+ *  the room surface can't crush it, and vice versa. */
+export const THREAD_PANEL = {
+  default: "460px",
+  min: "340px",
+  max: "760px",
+} as const;
+
 /** The inspector rail: members / episodes / memory. Collapses to a strip of
  *  tab icons rather than to nothing, so the rail is always one click away. */
 export const INSPECTOR_PANEL = {
@@ -80,6 +94,12 @@ export const INSPECTOR_PANEL = {
 const SEAM = 1;
 
 const px = (value: string) => Number.parseInt(value, 10);
+
+/** PANEL_MAIN's floor while a thread is open: it now holds the room surface AND
+ *  the thread split, so it cannot shrink below both their minimums — the seam is
+ *  the handle between them. Without this the nested split has nowhere to fit and
+ *  the group refuses to move, as it does for any unsatisfiable constraint set. */
+export const MAIN_WITH_THREAD_MIN = `${px(MAIN_PANEL.min) + px(THREAD_PANEL.min) + SEAM}px`;
 
 /**
  * Viewport widths at which each rail folds itself away, and unfolds again.

--- a/mycelium-frontend/src/lib/threads.contract.test.ts
+++ b/mycelium-frontend/src/lib/threads.contract.test.ts
@@ -13,12 +13,20 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { LIVE_SESSION, PING_PAYLOAD_FIELDS, PING_PAYLOAD_TYPE, liveEpisodeUrn } from "@/lib/threads";
+import {
+  LIVE_SESSION,
+  NOTICE_PAYLOAD_TYPE,
+  NOTICE_SUBKINDS,
+  PING_PAYLOAD_FIELDS,
+  PING_PAYLOAD_TYPE,
+  liveEpisodeUrn,
+} from "@/lib/threads";
 
 const CONTRACT_PATH = path.resolve(__dirname, "../../../contracts/slim-l9-wire.json");
 
 function contract(): {
   ping: { payload_type: string; payload_fields: string[] };
+  notice: { payload_type: string; subkinds: string[] };
   urn: { room: string; session: string; expected_episode: string };
 } {
   return JSON.parse(readFileSync(CONTRACT_PATH, "utf-8"));
@@ -35,5 +43,11 @@ describe("thread wire constants contract", () => {
     const { ping } = contract();
     expect(PING_PAYLOAD_TYPE).toBe(ping.payload_type);
     expect([...PING_PAYLOAD_FIELDS]).toEqual(ping.payload_fields);
+  });
+
+  it("reads the contracted notice payload type and subkinds", () => {
+    const { notice } = contract();
+    expect(NOTICE_PAYLOAD_TYPE).toBe(notice.payload_type);
+    expect([...NOTICE_SUBKINDS]).toEqual(notice.subkinds);
   });
 });

--- a/mycelium-frontend/src/lib/threads.test.ts
+++ b/mycelium-frontend/src/lib/threads.test.ts
@@ -5,11 +5,11 @@ import { describe, expect, it } from "vitest";
 import {
   PING_TYPE,
   coalescePings,
-  filedLabel,
   isLiveEpisode,
   liveEpisodeUrn,
+  noticeLabel,
+  noticeOf,
   pingOf,
-  taskCreatedOf,
   threadShortId,
   type Pingable,
 } from "@/lib/threads";
@@ -74,43 +74,49 @@ describe("reading a ping", () => {
   });
 });
 
-describe("reading a task-created notice", () => {
-  function filedFrame(data: Record<string, unknown>) {
+describe("reading a notice", () => {
+  function noticeFrame(data: Record<string, unknown>) {
     return {
       l9: {
         header: { kind: "exchange", message: { episode: liveEpisodeUrn(ROOM) } },
-        payload: { type: "task_created", data },
+        payload: { type: "notice", data },
       },
     };
   }
 
-  it("carries the task, its title, its own thread, and who filed it", () => {
-    // Like a ping, it rides in `live` and names the task it filed in its payload,
-    // so a notice can open the same thread the row's own chip does.
-    const created = taskCreatedOf(
-      filedFrame({ key: "work/flip", title: "flip reads", episode: THREAD, by: "aligner", kind: "action" }),
+  it("carries what happened, to which task, its thread, and who moved it", () => {
+    // Like a ping, it rides in `live` and names the task in its payload, so a
+    // notice can open the same thread the row's own chip does.
+    const notice = noticeOf(
+      noticeFrame({ subkind: "filed", key: "work/flip", title: "flip reads", episode: THREAD, by: "aligner", kind: "action" }),
     );
-    expect(created).toEqual({ key: "work/flip", title: "flip reads", episode: THREAD, by: "aligner", kind: "action" });
+    expect(notice).toEqual({ subkind: "filed", key: "work/flip", title: "flip reads", episode: THREAD, by: "aligner", kind: "action" });
   });
 
-  it("is not a task-created notice when the payload is a ping", () => {
-    expect(taskCreatedOf(pingFrame(THREAD, "risk", "m7"))).toBeNull();
+  it("reads a lease event with no board kind", () => {
+    const notice = noticeOf(noticeFrame({ subkind: "claimed", key: "work/flip", by: "growth" }));
+    expect(notice).toMatchObject({ subkind: "claimed", key: "work/flip", by: "growth", kind: null });
   });
 
-  it("refuses a notice that names no task", () => {
-    expect(taskCreatedOf(filedFrame({ title: "no key" }))).toBeNull();
-    expect(taskCreatedOf({})).toBeNull();
-    expect(taskCreatedOf(null)).toBeNull();
+  it("is not a notice when the payload is a ping", () => {
+    expect(noticeOf(pingFrame(THREAD, "risk", "m7"))).toBeNull();
   });
 
-  it("names what was filed by its kind, not always a task", () => {
-    expect(filedLabel("decision")).toBe("New decision");
-    expect(filedLabel("concern")).toBe("New concern");
-    expect(filedLabel("blocked")).toBe("New blocker");
-    expect(filedLabel("action")).toBe("New task");
-    // An unknown or missing kind falls back to the plain word.
-    expect(filedLabel(null)).toBe("New task");
-    expect(filedLabel("whatever")).toBe("New task");
+  it("refuses a notice that names no task or no subkind", () => {
+    expect(noticeOf(noticeFrame({ subkind: "filed" }))).toBeNull();
+    expect(noticeOf(noticeFrame({ key: "work/flip" }))).toBeNull();
+    expect(noticeOf({})).toBeNull();
+    expect(noticeOf(null)).toBeNull();
+  });
+
+  it("labels a filing by its kind, and a lease event by what happened", () => {
+    expect(noticeLabel("filed", "decision")).toBe("New decision");
+    expect(noticeLabel("filed", "blocked")).toBe("New blocker");
+    expect(noticeLabel("filed", "action")).toBe("New task");
+    expect(noticeLabel("filed", null)).toBe("New task");
+    expect(noticeLabel("claimed", null)).toBe("Claimed");
+    expect(noticeLabel("released", null)).toBe("Released");
+    expect(noticeLabel("resolved", null)).toBe("Resolved");
   });
 });
 

--- a/mycelium-frontend/src/lib/threads.test.ts
+++ b/mycelium-frontend/src/lib/threads.test.ts
@@ -5,9 +5,11 @@ import { describe, expect, it } from "vitest";
 import {
   PING_TYPE,
   coalescePings,
+  filedLabel,
   isLiveEpisode,
   liveEpisodeUrn,
   pingOf,
+  taskCreatedOf,
   threadShortId,
   type Pingable,
 } from "@/lib/threads";
@@ -69,6 +71,46 @@ describe("reading a ping", () => {
   it("survives a frame with no envelope at all", () => {
     expect(pingOf({})).toBeNull();
     expect(pingOf(null)).toBeNull();
+  });
+});
+
+describe("reading a task-created notice", () => {
+  function filedFrame(data: Record<string, unknown>) {
+    return {
+      l9: {
+        header: { kind: "exchange", message: { episode: liveEpisodeUrn(ROOM) } },
+        payload: { type: "task_created", data },
+      },
+    };
+  }
+
+  it("carries the task, its title, its own thread, and who filed it", () => {
+    // Like a ping, it rides in `live` and names the task it filed in its payload,
+    // so a notice can open the same thread the row's own chip does.
+    const created = taskCreatedOf(
+      filedFrame({ key: "work/flip", title: "flip reads", episode: THREAD, by: "aligner", kind: "action" }),
+    );
+    expect(created).toEqual({ key: "work/flip", title: "flip reads", episode: THREAD, by: "aligner", kind: "action" });
+  });
+
+  it("is not a task-created notice when the payload is a ping", () => {
+    expect(taskCreatedOf(pingFrame(THREAD, "risk", "m7"))).toBeNull();
+  });
+
+  it("refuses a notice that names no task", () => {
+    expect(taskCreatedOf(filedFrame({ title: "no key" }))).toBeNull();
+    expect(taskCreatedOf({})).toBeNull();
+    expect(taskCreatedOf(null)).toBeNull();
+  });
+
+  it("names what was filed by its kind, not always a task", () => {
+    expect(filedLabel("decision")).toBe("New decision");
+    expect(filedLabel("concern")).toBe("New concern");
+    expect(filedLabel("blocked")).toBe("New blocker");
+    expect(filedLabel("action")).toBe("New task");
+    // An unknown or missing kind falls back to the plain word.
+    expect(filedLabel(null)).toBe("New task");
+    expect(filedLabel("whatever")).toBe("New task");
   });
 });
 

--- a/mycelium-frontend/src/lib/threads.ts
+++ b/mycelium-frontend/src/lib/threads.ts
@@ -86,6 +86,62 @@ export function pingOf(raw: Record<string, unknown> | null | undefined): Ping | 
   };
 }
 
+/** The payload type a task's creation surfaces into the room as. */
+export const TASK_CREATED_PAYLOAD_TYPE = "task_created";
+
+/** The normalized type a task-created notice wears once parsed. */
+export const TASK_CREATED_TYPE = "task_created";
+
+/** What a "new task" notice says: which task, its title, and the thread to open. */
+export interface TaskCreated {
+  key: string;
+  title: string | null;
+  episode: string | null;
+  by: string | null;
+  kind: string | null;
+}
+
+/** What the room calls a thing it just filed, by its board kind. A decision is
+ *  not a task, so the notice says so — otherwise the timeline mislabels half of
+ *  what the room does. */
+const FILED_AS: Record<string, string> = {
+  decision: "decision",
+  concern: "concern",
+  blocked: "blocker",
+  review: "task",
+  action: "task",
+  signal: "note",
+};
+
+/** The label a task-created notice wears: "New task", "New decision", … */
+export function filedLabel(kind: string | null | undefined): string {
+  return `New ${(kind && FILED_AS[kind]) || "task"}`;
+}
+
+/**
+ * The task-created notice a wire frame carries, or null when it isn't one.
+ *
+ * The mirror of {@link pingOf}: a creation rides in `live` (so the room sees it
+ * in its timeline) and names the task it filed — the key, the title to read, and
+ * the task's own thread to open — in its payload. This is what turns "a work row
+ * appeared on the board" into "the room filed a task", in sequence with the chat.
+ */
+export function taskCreatedOf(raw: Record<string, unknown> | null | undefined): TaskCreated | null {
+  const envelope = (raw?.l9 ?? null) as Record<string, unknown> | null;
+  const payload = (envelope?.payload ?? null) as Record<string, unknown> | null;
+  if (!payload || payload.type !== TASK_CREATED_PAYLOAD_TYPE) return null;
+  const data = (payload.data ?? {}) as Record<string, unknown>;
+  const key = data.key;
+  if (typeof key !== "string" || !key) return null;
+  return {
+    key,
+    title: typeof data.title === "string" ? data.title : null,
+    episode: typeof data.episode === "string" ? data.episode : null,
+    by: typeof data.by === "string" ? data.by : null,
+    kind: typeof data.kind === "string" ? data.kind : null,
+  };
+}
+
 /** The minimum a feed row has to expose to be coalesced. */
 export interface Pingable {
   type: string;

--- a/mycelium-frontend/src/lib/threads.ts
+++ b/mycelium-frontend/src/lib/threads.ts
@@ -86,19 +86,53 @@ export function pingOf(raw: Record<string, unknown> | null | undefined): Ping | 
   };
 }
 
-/** The payload type a task's creation surfaces into the room as. */
-export const TASK_CREATED_PAYLOAD_TYPE = "task_created";
+/** The payload type the room's board events surface into the timeline as. */
+export const NOTICE_PAYLOAD_TYPE = "notice";
 
-/** The normalized type a task-created notice wears once parsed. */
-export const TASK_CREATED_TYPE = "task_created";
+/** The normalized type a notice wears once parsed. */
+export const NOTICE_TYPE = "notice";
 
-/** What a "new task" notice says: which task, its title, and the thread to open. */
-export interface TaskCreated {
+/** What a board event did to a task — the closed set the backend raises, frozen
+ *  in `contracts/slim-l9-wire.json` and asserted by `threads.contract.test.ts`. */
+export const NOTICE_SUBKINDS = ["filed", "claimed", "released", "resolved"] as const;
+
+export type NoticeSubkind = (typeof NOTICE_SUBKINDS)[number];
+
+/** What a notice says: what happened, to which task, and the thread to open. */
+export interface Notice {
+  subkind: string;
   key: string;
   title: string | null;
   episode: string | null;
   by: string | null;
+  /** The board kind, on a `filed` notice, so the line reads "New decision". */
   kind: string | null;
+}
+
+/**
+ * The notice a wire frame carries, or null when it isn't one.
+ *
+ * The sibling of {@link pingOf}: a notice rides in `live` and names the task the
+ * board event was about, so the channel can render "New task" / "@x is on it" /
+ * "resolved" in sequence with the chat and open the same thread the row does.
+ */
+export function noticeOf(raw: Record<string, unknown> | null | undefined): Notice | null {
+  const envelope = (raw?.l9 ?? null) as Record<string, unknown> | null;
+  const payload = (envelope?.payload ?? null) as Record<string, unknown> | null;
+  if (!payload || payload.type !== NOTICE_PAYLOAD_TYPE) return null;
+  const data = (payload.data ?? {}) as Record<string, unknown>;
+  const key = data.key;
+  const subkind = data.subkind;
+  if (typeof key !== "string" || !key || typeof subkind !== "string" || !subkind) return null;
+  const str = (v: unknown) => (typeof v === "string" && v ? v : null);
+  return {
+    subkind,
+    key,
+    title: str(data.title),
+    episode: str(data.episode),
+    by: str(data.by),
+    kind: str(data.kind),
+  };
 }
 
 /** What the room calls a thing it just filed, by its board kind. A decision is
@@ -113,33 +147,20 @@ const FILED_AS: Record<string, string> = {
   signal: "note",
 };
 
-/** The label a task-created notice wears: "New task", "New decision", … */
-export function filedLabel(kind: string | null | undefined): string {
-  return `New ${(kind && FILED_AS[kind]) || "task"}`;
-}
-
-/**
- * The task-created notice a wire frame carries, or null when it isn't one.
- *
- * The mirror of {@link pingOf}: a creation rides in `live` (so the room sees it
- * in its timeline) and names the task it filed — the key, the title to read, and
- * the task's own thread to open — in its payload. This is what turns "a work row
- * appeared on the board" into "the room filed a task", in sequence with the chat.
- */
-export function taskCreatedOf(raw: Record<string, unknown> | null | undefined): TaskCreated | null {
-  const envelope = (raw?.l9 ?? null) as Record<string, unknown> | null;
-  const payload = (envelope?.payload ?? null) as Record<string, unknown> | null;
-  if (!payload || payload.type !== TASK_CREATED_PAYLOAD_TYPE) return null;
-  const data = (payload.data ?? {}) as Record<string, unknown>;
-  const key = data.key;
-  if (typeof key !== "string" || !key) return null;
-  return {
-    key,
-    title: typeof data.title === "string" ? data.title : null,
-    episode: typeof data.episode === "string" ? data.episode : null,
-    by: typeof data.by === "string" ? data.by : null,
-    kind: typeof data.kind === "string" ? data.kind : null,
-  };
+/** The label a notice wears in the timeline, by subkind (and, when filed, kind). */
+export function noticeLabel(subkind: string, kind: string | null | undefined): string {
+  switch (subkind) {
+    case "filed":
+      return `New ${(kind && FILED_AS[kind]) || "task"}`;
+    case "claimed":
+      return "Claimed";
+    case "released":
+      return "Released";
+    case "resolved":
+      return "Resolved";
+    default:
+      return subkind;
+  }
 }
 
 /** The minimum a feed row has to expose to be coalesced. */

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -319,23 +319,27 @@ function atlasPing(message: string, sender: string, minutesAgo: number): Record<
 }
 
 /**
- * A task filed into the room, as the room hears it: a **task-created notice**.
+ * A board event as the room hears it: a **notice** — a task filed, claimed,
+ * handed back or resolved.
  *
  * The mirror of {@link atlasPing} — an exchange envelope in `live` naming the
- * task that was filed (key, title, and the task's own thread to open), so the
- * board's newest rows read as something the room *did*, in sequence with the
- * chat, rather than appearing silently on another tab.
+ * task the event was about (key, title, thread to open, who moved it), so the
+ * board's changes read as something the room *did*, in sequence with the chat,
+ * rather than appearing silently on another tab. ``kind`` rides on a ``filed``
+ * notice so the line reads "New decision", not always "New task".
  */
-function atlasTaskCreated(
+function atlasNotice(
+  subkind: string,
   key: string,
   title: string,
   episode: string,
   by: string,
-  kind: string,
   minutesAgo: number,
+  kind?: string,
 ): Record<string, unknown> {
+  const id = `notice-${subkind}-${key}`;
   return {
-    id: `filed-${key}`,
+    id,
     sender_handle: "system",
     message_type: "l9_exchange",
     created_at: iso(minutesAgo),
@@ -345,10 +349,10 @@ function atlasTaskCreated(
       l9: {
         header: {
           kind: "exchange",
-          message: { id: `filed-${key}`, parents: [], episode: ATLAS_LIVE },
+          message: { id, parents: [], episode: ATLAS_LIVE },
           participants: { actors: [{ id: "system", role: "coordinator" }] },
         },
-        payload: { type: "task_created", data: { key, title, episode, by, kind } },
+        payload: { type: "notice", data: { subkind, key, title, episode, by, ...(kind ? { kind } : {}) } },
       },
     },
   };
@@ -384,7 +388,11 @@ const atlasBoardRows: MockMemory[] = [
   // produced them — so each carries its own episode, not the negotiation's.
   {
     key: "work/flip-reads-behind-a-flag",
-    value: "flip reads behind a flag",
+    value:
+      "flip reads behind a flag\n\n" +
+      "Gate the read path on `atlas.reads.v2` (default off). Flip only once replica " +
+      "lag has held under a second for an hour, and keep it reversible through the " +
+      "48h soak. Gated on #502 (auth) and #504 (custody seam).",
     meta: { kind: "action", status: "open", assignee: "@growth", priority: "high", issue: "#502" },
     content_text: "flip reads behind a flag — gated on #502 and #504.",
     created_by: "aligner",
@@ -694,18 +702,25 @@ const atlas: RoomFixture = {
   // matches its board row, so a notice opens the same thread the row's chip does.
   l9: [
     ...atlasL9Frames,
-    atlasTaskCreated("decisions/spire-retire", "Retire the SPIRE identity tier", atlasEpisode("b0d2f4"), "julia", "decision", 1439.8),
-    atlasTaskCreated("work/path-traversal", "Fix path traversal in the memory key encoder", atlasEpisode("a9c1e3"), "risk", "action", 1399.8),
-    atlasTaskCreated("work/jwt-auth", "Migrate auth → JWT", atlasEpisode("d6f8b0"), "growth", "action", 139.8),
-    atlasTaskCreated("failed/thin-spoke", "Enable thin-spoke join without a local replica", atlasEpisode("b4d6f8"), "julia", "blocked", 129.8),
-    atlasTaskCreated("work/cache-sweep", "Cache TTL sweep across the memory index", atlasEpisode("e7a9c1"), "julia", "action", 94.8),
-    atlasTaskCreated("failed/offer-snap", "Aligner stalls when a proposer replies with prose only", atlasEpisode("f8b0d2"), "risk", "concern", 57.8),
-    // The two the cutover agreement compiled, filed by the aligner right after
-    // its "filing the work" line (iso(40)).
-    atlasTaskCreated("work/flip-reads-behind-a-flag", "flip reads behind a flag", ATLAS_FLIP_THREAD, "aligner", "action", 39.9),
-    atlasTaskCreated("work/retire-the-legacy-store", "48h soak, then retire the legacy store", ATLAS_RETIRE_THREAD, "aligner", "action", 39.8),
-    atlasTaskCreated("work/custody-review", "@risk opened PR #504 — eyes on the custody seam", atlasEpisode("c5e7a9"), "risk", "review", 13.8),
-    atlasTaskCreated("decisions/token-ttl", "JWT access-token TTL: 15m or 60m?", atlasEpisode("a1c3e5"), "risk", "decision", 5.8),
+    // Every board row's origin — a `filed` notice — and, for two of them, the rest
+    // of the lifecycle the room saw: path-traversal resolved long ago, flip-reads
+    // claimed by growth just before he worked it. Read in order it is filed →
+    // claimed → activity → resolved, the whole arc of a unit of work.
+    atlasNotice("filed", "decisions/spire-retire", "Retire the SPIRE identity tier", atlasEpisode("b0d2f4"), "julia", 1439.8, "decision"),
+    atlasNotice("filed", "work/path-traversal", "Fix path traversal in the memory key encoder", atlasEpisode("a9c1e3"), "risk", 1399.8, "action"),
+    atlasNotice("resolved", "work/path-traversal", "Fix path traversal in the memory key encoder", atlasEpisode("a9c1e3"), "risk", 1200),
+    atlasNotice("filed", "work/jwt-auth", "Migrate auth → JWT", atlasEpisode("d6f8b0"), "growth", 139.8, "action"),
+    atlasNotice("filed", "failed/thin-spoke", "Enable thin-spoke join without a local replica", atlasEpisode("b4d6f8"), "julia", 129.8, "blocked"),
+    atlasNotice("filed", "work/cache-sweep", "Cache TTL sweep across the memory index", atlasEpisode("e7a9c1"), "julia", 94.8, "action"),
+    atlasNotice("filed", "failed/offer-snap", "Aligner stalls when a proposer replies with prose only", atlasEpisode("f8b0d2"), "risk", 57.8, "concern"),
+    // The two the cutover agreement compiled, filed by the aligner right after its
+    // "filing the work" line (iso(40)).
+    atlasNotice("filed", "work/flip-reads-behind-a-flag", "flip reads behind a flag", ATLAS_FLIP_THREAD, "aligner", 39.9, "action"),
+    atlasNotice("filed", "work/retire-the-legacy-store", "48h soak, then retire the legacy store", ATLAS_RETIRE_THREAD, "aligner", 39.8, "action"),
+    atlasNotice("filed", "work/custody-review", "@risk opened PR #504 — eyes on the custody seam", atlasEpisode("c5e7a9"), "risk", 13.8, "review"),
+    atlasNotice("filed", "decisions/token-ttl", "JWT access-token TTL: 15m or 60m?", atlasEpisode("a1c3e5"), "risk", 5.8, "decision"),
+    // growth takes the flag row before working it, then the thread moves.
+    atlasNotice("claimed", "work/flip-reads-behind-a-flag", "flip reads behind a flag", ATLAS_FLIP_THREAD, "growth", 23),
     atlasPing("t2", "risk", 21),
     atlasPing("t3", "growth", 20),
   ],

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -318,6 +318,42 @@ function atlasPing(message: string, sender: string, minutesAgo: number): Record<
   };
 }
 
+/**
+ * A task filed into the room, as the room hears it: a **task-created notice**.
+ *
+ * The mirror of {@link atlasPing} — an exchange envelope in `live` naming the
+ * task that was filed (key, title, and the task's own thread to open), so the
+ * board's newest rows read as something the room *did*, in sequence with the
+ * chat, rather than appearing silently on another tab.
+ */
+function atlasTaskCreated(
+  key: string,
+  title: string,
+  episode: string,
+  by: string,
+  kind: string,
+  minutesAgo: number,
+): Record<string, unknown> {
+  return {
+    id: `filed-${key}`,
+    sender_handle: "system",
+    message_type: "l9_exchange",
+    created_at: iso(minutesAgo),
+    room_name: "atlas-migration",
+    episode: ATLAS_LIVE,
+    content: {
+      l9: {
+        header: {
+          kind: "exchange",
+          message: { id: `filed-${key}`, parents: [], episode: ATLAS_LIVE },
+          participants: { actors: [{ id: "system", role: "coordinator" }] },
+        },
+        payload: { type: "task_created", data: { key, title, episode, by, kind } },
+      },
+    },
+  };
+}
+
 const atlasEpisodeSummary: EpisodeSummary = {
   short_id: "e4f1a2",
   episode: ATLAS_EPISODE,
@@ -601,7 +637,23 @@ const atlas: RoomFixture = {
     },
     ...atlasBoardRows,
   ],
+  // The channel is the room's whole history, so every row on the board is a thing
+  // it once filed: the chat lines below set up each filing, and the task-created
+  // notices in the `l9` feed are the filings themselves. Read top to bottom it is
+  // one arc — stand up the room, do the early security/architecture work, spin up
+  // the auth migration and the work that depends on it, broker the cutover, file
+  // what it breaks into, then keep going.
   messages: [
+    // ── standing the room up, and the early work (a day ago) ──
+    { id: "h1", sender_handle: "operator", message_type: "broadcast", content: "Standing up the Atlas migration room. Goal: move the catalog off the legacy store with zero downtime.", created_at: iso(60 * 25) },
+    { id: "h2", sender_handle: "julia", message_type: "broadcast", content: "First call: we're not keeping the SPIRE tier. Filing the decision so it's on the record.", created_at: iso(1440) },
+    { id: "h3", sender_handle: "risk", message_type: "broadcast", content: "And the path-traversal hole in the key encoder is a hard blocker for anything public — taking it now.", created_at: iso(1400) },
+    // ── the auth migration and the work hanging off it ──
+    { id: "h4", sender_handle: "growth", message_type: "broadcast", content: "Auth has to move to JWT before the cutover. I've got it — PR #502 is open.", created_at: iso(140) },
+    { id: "h5", sender_handle: "julia", message_type: "broadcast", content: "Thin-spoke join needs that landed first, so I'm filing it blocked on #502.", created_at: iso(130) },
+    { id: "h6", sender_handle: "julia", message_type: "broadcast", content: "Also sweeping the cache TTLs across the memory index while I'm in here.", created_at: iso(95) },
+    { id: "h7", sender_handle: "risk", message_type: "broadcast", content: "Filing a concern: the aligner stalls when a proposer replies with prose only. Fix is on fix/offer-snap but CI's red.", created_at: iso(58) },
+    // ── the cutover negotiation ──
     { id: "a1", sender_handle: "operator", message_type: "broadcast", content: "@growth @risk let's settle the cutover strategy — approach and window. @aligner, broker it.", created_at: iso(48) },
     { id: "a2", sender_handle: "growth", message_type: "coordination_join", content: JSON.stringify({ handle: "growth", intent: "ship the migration this week", episode: ATLAS_EPISODE }), created_at: iso(47), episode: ATLAS_EPISODE },
     { id: "a3", sender_handle: "risk", message_type: "coordination_join", content: JSON.stringify({ handle: "risk", intent: "no downtime, no data loss", episode: ATLAS_EPISODE }), created_at: iso(47), episode: ATLAS_EPISODE },
@@ -610,7 +662,15 @@ const atlas: RoomFixture = {
     // Negotiate/Network panes reconstruct. The chat is the source (see atlasMoves).
     ...atlasNegotiation,
     { id: "a6", sender_handle: "aligner", message_type: "coordination_consensus", content: JSON.stringify({ assignments: { cutover: "phased", window: "48h" }, episode: ATLAS_EPISODE, metrics: { gar: 0.79 } }), created_at: iso(41), episode: ATLAS_EPISODE },
+    // The room files the work the agreement breaks into. The two task-created
+    // notices land right after this line (see the `l9` feed below), so the chat
+    // reads "here is the work" → the tasks, in sequence, instead of them just
+    // appearing on the board.
+    { id: "file1", sender_handle: "aligner", message_type: "broadcast", content: "Settled: phased cutover over 48h. Filing the work it breaks into for us to pick up:", created_at: iso(40) },
     { id: "a7", sender_handle: "growth", message_type: "broadcast", content: "Dual-write is live in staging. ✅", created_at: iso(30) },
+    // ── follow-on work after the agreement ──
+    { id: "h8", sender_handle: "risk", message_type: "broadcast", content: "PR #504 is up for the custody seam — filing it for review.", created_at: iso(14) },
+    { id: "h9", sender_handle: "risk", message_type: "broadcast", content: "One more thing to settle before auth ships: access-token TTL, 15m or 60m. Filing the decision.", created_at: iso(6) },
     // Two agents working the flag row talk inside its thread. The channel does
     // not carry this — that is the whole point — so the room hears the pings
     // below instead, and the prose reads in the thread pane.
@@ -628,7 +688,27 @@ const atlas: RoomFixture = {
     { handle: "growth", kind: "slim", last_seen: null },
     { handle: "risk", kind: "lease", last_seen: iso(1) },
   ],
-  l9: [...atlasL9Frames, atlasPing("t2", "risk", 21), atlasPing("t3", "growth", 20)],
+  // Every board row's origin, as the notice the room filed it with — each timed
+  // just after the chat line that sets it up, so the channel reads talk → filing
+  // for all ten, not just the two the negotiation compiled. The episode on each
+  // matches its board row, so a notice opens the same thread the row's chip does.
+  l9: [
+    ...atlasL9Frames,
+    atlasTaskCreated("decisions/spire-retire", "Retire the SPIRE identity tier", atlasEpisode("b0d2f4"), "julia", "decision", 1439.8),
+    atlasTaskCreated("work/path-traversal", "Fix path traversal in the memory key encoder", atlasEpisode("a9c1e3"), "risk", "action", 1399.8),
+    atlasTaskCreated("work/jwt-auth", "Migrate auth → JWT", atlasEpisode("d6f8b0"), "growth", "action", 139.8),
+    atlasTaskCreated("failed/thin-spoke", "Enable thin-spoke join without a local replica", atlasEpisode("b4d6f8"), "julia", "blocked", 129.8),
+    atlasTaskCreated("work/cache-sweep", "Cache TTL sweep across the memory index", atlasEpisode("e7a9c1"), "julia", "action", 94.8),
+    atlasTaskCreated("failed/offer-snap", "Aligner stalls when a proposer replies with prose only", atlasEpisode("f8b0d2"), "risk", "concern", 57.8),
+    // The two the cutover agreement compiled, filed by the aligner right after
+    // its "filing the work" line (iso(40)).
+    atlasTaskCreated("work/flip-reads-behind-a-flag", "flip reads behind a flag", ATLAS_FLIP_THREAD, "aligner", "action", 39.9),
+    atlasTaskCreated("work/retire-the-legacy-store", "48h soak, then retire the legacy store", ATLAS_RETIRE_THREAD, "aligner", "action", 39.8),
+    atlasTaskCreated("work/custody-review", "@risk opened PR #504 — eyes on the custody seam", atlasEpisode("c5e7a9"), "risk", "review", 13.8),
+    atlasTaskCreated("decisions/token-ttl", "JWT access-token TTL: 15m or 60m?", atlasEpisode("a1c3e5"), "risk", "decision", 5.8),
+    atlasPing("t2", "risk", 21),
+    atlasPing("t3", "growth", 20),
+  ],
   // Three work rows name pull requests; the hub resolved them. The first row
   // mentions two, one green and one failing, so it shows the failing one and says
   // there was another. The shapes are GitHub's own wording.


### PR DESCRIPTION
Builds on #863 (merged). Makes the room a **timeline** and the thread pane a **task view**.

## The timeline

A task's discussion moved into its thread (#863), which left the channel a disconnected argument. Its job now is the room's timeline: talk, the work it files, and what happens to that work, in one sequence.

A single **notice** rail beside the ping (`l9.NOTICE_PAYLOAD_TYPE`, raised by `room_channels.raise_notice`, waking nobody) carries board events. It's raised at the real seams:
- **filed** — the memory upsert on a board-row create (carries the board `kind`, so it reads "New decision" not always "New task")
- **claimed / released / resolved** — `leases.claim` / `release` / `resolve`

`participate._addressed_to` excludes it (a resident agent consumes a notice silently), and the subkinds are frozen in `contracts/slim-l9-wire.json` with a drift test on each side. The GUI renders by subkind — each names the task by title and opens its thread — so the channel reads **filed → claimed → activity → resolved** in one arc. The earlier `task_created` payload is unified onto this rail.

## The task view

The thread pane opens with the task *over* its conversation, like a GitHub issue's description above its comments: the row's fields as a chip line, then its markdown body (minus a first line that only repeats the title), then the thread. "Markdown work item + agentic chat," literally.

## Scope

First cut of the vocabulary: **filed · claimed · released · resolved**. Verified end-to-end in the mock (screenshots to follow in a comment). Deferred to a follow-up, on the same rail:
- **expired** — derived from the clock, not a write, so it needs a detector rather than a seam
- **blocked / unblocked · convened** — the remaining subkinds
- rendering **`for @assignee`** on a filed notice (backend already emits it; frontend drops it for now)

## Tests

Backend 996, frontend 760. New: `raise_notice` wire-contract test (both sides), `noticeOf`/`noticeLabel` unit tests, the thread-pane and board-view changes. The pre-existing `event-stream.tsx:152 'room' unused` lint warning is not from this change.