### PR TITLE
feat(a2a): settle transport decision + wire A2A_ALLOW_PRIVATE_HOSTS (#726)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,13 +419,15 @@ is no litellm dependency.
   scoped), and `a2a_server.py` exposes a room *as* an A2A agent via the a2a-sdk
   server (card + JSON-RPC). **Honest boundary:** a bridged A2A agent is **not** a
   member of the room's MLS group — it's proxied by a backend seat that reads
-  plaintext and calls the remote out-of-band. The hop is plain HTTPS today; it
-  can ride SLIM (SLIMRPC) via `agntcy/slim-a2a-python`, but that's point-to-point
-  RPC to a SLIM identity, still not room-group membership, and slima2a pins
-  `a2a-sdk==1.1.0` (HTTP-vs-SLIM decision: #726). Either way the hub sees
-  plaintext, so it is **NOT** E2E-from-the-hub. Remote auth is a bearer token
-  named by `a2a_auth_env` and resolved from the backend env — the secret never
-  lands in room memory.
+  plaintext and calls the remote out-of-band. **The hop is plain HTTPS (decided
+  default, #726):** `slima2a` (SLIMRPC transport) pins `a2a-sdk==1.1.0` exactly
+  while the backend tracks `1.1.2`, so adopting it would pull SQLAlchemy,
+  aiosqlite, and OpenTelemetry into the image — cost not justified yet. Reopen
+  #726 when the pin relaxes and a live SLIMRPC round-trip is proven. Even
+  SLIMRPC would be point-to-point RPC to a SLIM identity, still not room-group
+  membership. Either way the hub sees plaintext, so it is **NOT** E2E-from-the-hub.
+  Remote auth is a bearer token named by `a2a_auth_env` and resolved from the
+  backend env — the secret never lands in room memory.
 - **CI is fast on purpose; timing is reported, never enforced.** A PR run's
   critical path is ~95s, and that is a property worth defending — it erodes
   twenty seconds at a time, invisibly. The `timing` job reads the run's own job

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -155,6 +155,7 @@
           <a href="reference.html#config-login" class="nav-link sub">login</a>
           <a href="reference.html#config-agent-auth" class="nav-link sub">agent_auth</a>
           <a href="reference.html#config-metrics" class="nav-link sub">metrics</a>
+          <a href="reference.html#config-a2a" class="nav-link sub">a2a</a>
         </div>
       </div>
       <div class="nav-group collapsed" data-nav-group="reference:dependencies">
@@ -483,7 +484,11 @@
     <span class="flag">--card-auth-env</span> RESEARCHER_TOKEN</code></pre>
       <p>Two guards keep the bridge from being used as a lever:</p>
       <ul>
-        <li><strong>Card hosts must be public.</strong> The hub refuses a card URL that resolves to a private or link-local address, so a registration can&#x27;t point the backend at its own network. Set <code>A2A_ALLOW_PRIVATE_HOSTS=1</code> only for a trusted internal deployment.</li>
+        <li><strong>Card hosts must be public.</strong> The hub refuses a card URL that resolves to a private or link-local address, so a registration can&#x27;t point the backend at its own network. For a trusted internal deployment whose A2A agents live on the internal network, disable the guard:</li>
+      </ul>
+      <p>``<code> mycelium config set a2a.allow_private_hosts true mycelium config apply </code>``</p>
+      <p>This renders <code>A2A_ALLOW_PRIVATE_HOSTS=1</code> into the backend&#x27;s environment on the next <code>config apply</code>. Do not set this on a public-facing hub.</p>
+      <ul>
         <li><strong>A2A agents don&#x27;t summon each other.</strong> A bridged agent&#x27;s auto-reply never triggers another bridged agent, so two of them mentioning each other can&#x27;t ping-pong forever. Humans, the aligner, and resident agents still get a reply.</li>
       </ul>
       <p>A remote that is dead or unreadable posts nothing rather than a fabricated reply — the caller sees silence, not an invented answer.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -155,6 +155,7 @@
           <a href="reference.html#config-login" class="nav-link sub">login</a>
           <a href="reference.html#config-agent-auth" class="nav-link sub">agent_auth</a>
           <a href="reference.html#config-metrics" class="nav-link sub">metrics</a>
+          <a href="reference.html#config-a2a" class="nav-link sub">a2a</a>
         </div>
       </div>
       <div class="nav-group collapsed" data-nav-group="reference:dependencies">

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1441,8 +1441,16 @@ Two guards keep the bridge from being used as a lever:
 
 - **Card hosts must be public.** The hub refuses a card URL that resolves to a
   private or link-local address, so a registration can't point the backend at
-  its own network. Set `A2A_ALLOW_PRIVATE_HOSTS=1` only for a trusted internal
-  deployment.
+  its own network. For a trusted internal deployment whose A2A agents live on
+  the internal network, disable the guard:
+
+  ```
+  mycelium config set a2a.allow_private_hosts true
+  mycelium config apply
+  ```
+
+  This renders `A2A_ALLOW_PRIVATE_HOSTS=1` into the backend's environment
+  on the next `config apply`. Do not set this on a public-facing hub.
 - **A2A agents don't summon each other.** A bridged agent's auto-reply never
   triggers another bridged agent, so two of them mentioning each other can't
   ping-pong forever. Humans, the aligner, and resident agents still get a reply.

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -155,6 +155,7 @@
           <a href="#config-login" class="nav-link sub">login</a>
           <a href="#config-agent-auth" class="nav-link sub">agent_auth</a>
           <a href="#config-metrics" class="nav-link sub">metrics</a>
+          <a href="#config-a2a" class="nav-link sub">a2a</a>
         </div>
       </div>
       <div class="nav-group" data-nav-group="reference:dependencies">
@@ -1185,7 +1186,13 @@
 <span class="arg">collector_url</span> = <span class="str">&quot;&quot;</span>
 
 <span class="comment"># Explicit Prometheus /metrics endpoints for the collector to scrape.</span>
-<span class="arg">scrape</span> = PydanticUndefined</code></pre>
+<span class="arg">scrape</span> = PydanticUndefined
+
+<span class="comment"># Configuration for the A2A bridge (outbound + inbound Agent2Agent gateway).</span>
+<span class="cmd" id="config-a2a">[a2a]</span>
+
+<span class="comment"># Disable the SSRF guard that refuses A2A card URLs resolving to private, loopback, or link-local addresses. Only set this for a trusted internal deployment whose A2A agents live on the internal network.</span>
+<span class="arg">allow_private_hosts</span> = <span class="flag">false</span></code></pre>
     </section>
 
     <hr class="divider">

--- a/fastapi-backend/app/routes/a2a_agents.py
+++ b/fastapi-backend/app/routes/a2a_agents.py
@@ -15,14 +15,13 @@ driver (#714) needs to call the remote agent.
 import logging
 import re
 
-import yaml
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from app.routes.memory import upsert_memories
-from app.schemas import HANDLE_PATTERN, AgentRead, MemoryBatchCreate, MemoryCreate
+from app.schemas import HANDLE_PATTERN, AgentRead
 from app.services import actor
 from app.services.a2a_card import A2aCardError, resolve_card
+from app.services.agent_registry import norm_handle, write_agent_manifest
 from app.services.filesystem import get_room_dir, read_memory_file, room_exists
 
 logger = logging.getLogger(__name__)
@@ -55,13 +54,6 @@ class A2aAgentCreate(BaseModel):
     )
 
 
-def _norm(handle: str | None) -> str | None:
-    if not handle:
-        return None
-    cleaned = handle.strip().lstrip("@").lower()
-    return cleaned or None
-
-
 @router.post("", response_model=AgentRead, status_code=201)
 async def create_a2a_agent(room_name: str, payload: A2aAgentCreate, request: Request) -> AgentRead:
     """Resolve the remote card, register the manifest, return the room view."""
@@ -70,7 +62,7 @@ async def create_a2a_agent(room_name: str, payload: A2aAgentCreate, request: Req
 
     registrar = actor.bind_optional_actor(request, payload.created_by, field="created_by")
 
-    handle = _norm(payload.handle)
+    handle = norm_handle(payload.handle)
     if not handle or not _HANDLE_RE.match(handle):
         raise HTTPException(
             status_code=422,
@@ -102,24 +94,11 @@ async def create_a2a_agent(room_name: str, payload: A2aAgentCreate, request: Req
         "a2a_skills": card.skill_ids,
         # Only the env var NAME lands in room memory; the token stays in the env.
         "a2a_auth_env": payload.auth_env.strip() if payload.auth_env else None,
-        "allow_from": [h for h in (_norm(a) for a in payload.allow_from) if h],
-        "owner": _norm(payload.owner),
-        "team": _norm(payload.team),
+        "allow_from": [h for h in (norm_handle(a) for a in payload.allow_from) if h],
+        "owner": norm_handle(payload.owner),
+        "team": norm_handle(payload.team),
     }
-    yaml_body = yaml.safe_dump(body, sort_keys=False, default_flow_style=False).strip()
-
-    batch = MemoryBatchCreate(
-        items=[
-            MemoryCreate(
-                key=key,
-                value=yaml_body,
-                created_by=registrar or "web-ui",
-                embed=False,
-                tags=["agent-manifest"],
-            )
-        ]
-    )
-    await upsert_memories(room_name, batch)
+    await write_agent_manifest(room_name, handle, body, created_by=registrar or "web-ui")
     logger.info(
         "room %s: registered a2a agent @%s (%s, %d skills)",
         room_name,

--- a/fastapi-backend/app/routes/a2a_agents.py
+++ b/fastapi-backend/app/routes/a2a_agents.py
@@ -95,7 +95,9 @@ async def create_a2a_agent(room_name: str, payload: A2aAgentCreate, request: Req
         # Only the env var NAME lands in room memory; the token stays in the env.
         "a2a_auth_env": payload.auth_env.strip() if payload.auth_env else None,
         "allow_from": [h for h in (norm_handle(a) for a in payload.allow_from) if h],
-        "owner": norm_handle(payload.owner),
+        # Default owner to the authenticated registrar so the allow_from owner
+        # exemption works even when the caller doesn't supply an explicit owner.
+        "owner": norm_handle(payload.owner) or norm_handle(registrar),
         "team": norm_handle(payload.team),
     }
     await write_agent_manifest(room_name, handle, body, created_by=registrar or "web-ui")

--- a/fastapi-backend/app/routes/a2a_agents.py
+++ b/fastapi-backend/app/routes/a2a_agents.py
@@ -94,10 +94,14 @@ async def create_a2a_agent(room_name: str, payload: A2aAgentCreate, request: Req
         "a2a_skills": card.skill_ids,
         # Only the env var NAME lands in room memory; the token stays in the env.
         "a2a_auth_env": payload.auth_env.strip() if payload.auth_env else None,
-        "allow_from": [h for h in (norm_handle(a) for a in payload.allow_from) if h],
+        # Strip any #session qualifier — stored slugs must be bare handles so
+        # the summon gate's _bare_sender comparisons always match.
+        "allow_from": [
+            h for a in payload.allow_from if (h := norm_handle((a or "").partition("#")[0]))
+        ],
         # Default owner to the authenticated registrar so the allow_from owner
         # exemption works even when the caller doesn't supply an explicit owner.
-        "owner": norm_handle(payload.owner) or norm_handle(registrar),
+        "owner": norm_handle((payload.owner or registrar or "").partition("#")[0]) or None,
         "team": norm_handle(payload.team),
     }
     await write_agent_manifest(room_name, handle, body, created_by=registrar or "web-ui")

--- a/fastapi-backend/app/routes/a2a_server.py
+++ b/fastapi-backend/app/routes/a2a_server.py
@@ -54,7 +54,6 @@ from starlette.responses import JSONResponse, Response
 from app.services import a2a_activity, l9
 from app.services.actor import bind_optional_actor
 from app.services.filesystem import room_exists
-from app.services.l9_slim import serialize_content
 from app.services.skills import list_room_skills
 
 logger = logging.getLogger(__name__)
@@ -126,13 +125,7 @@ async def _inject_into_room(room: str, text: str, sender: str = _GUEST_HANDLE) -
         topic=l9.topic_urn(room),
         payload_type="message",
     )
-    content = serialize_content(env, extra={"content": text})
-    try:
-        await managed.channel.send(env, extra={"content": text})
-    except Exception:
-        logger.warning("a2a-server: failed to broadcast inbound message to room %s", room)
-    if managed.persister is not None:
-        managed.persister.ingest_local(env, content, list_write=True)
+    await managed.post(env, text, list_write=True)
     ack = f"Delivered to room '{room}'."
     a2a_activity.record_inbound(room, handle=sender, status="ok", prompt=text, reply=ack)
     return ack

--- a/fastapi-backend/app/routes/engines.py
+++ b/fastapi-backend/app/routes/engines.py
@@ -15,13 +15,12 @@ the ``GET .../agents`` listing pick it up like any other room citizen.
 import logging
 import re
 
-import yaml
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from app.routes.memory import upsert_memories
-from app.schemas import HANDLE_PATTERN, AgentRead, MemoryBatchCreate, MemoryCreate
+from app.schemas import HANDLE_PATTERN, AgentRead
 from app.services import actor
+from app.services.agent_registry import norm_handle, write_agent_manifest
 from app.services.filesystem import get_room_dir, read_memory_file, room_exists
 
 logger = logging.getLogger(__name__)
@@ -51,13 +50,6 @@ class EngineCreate(BaseModel):
     )
 
 
-def _norm(handle: str | None) -> str | None:
-    if not handle:
-        return None
-    cleaned = handle.strip().lstrip("@").lower()
-    return cleaned or None
-
-
 @router.post("", response_model=AgentRead, status_code=201)
 async def create_engine(room_name: str, payload: EngineCreate, request: Request) -> AgentRead:
     """Register an engine manifest in the room and return its structured view."""
@@ -76,7 +68,7 @@ async def create_engine(room_name: str, payload: EngineCreate, request: Request)
             detail=f"Unknown engine kind {kind!r}; known: {sorted(ENGINE_KINDS)}",
         )
 
-    handle = _norm(payload.handle)
+    handle = norm_handle(payload.handle)
     if not handle or not _HANDLE_RE.match(handle):
         raise HTTPException(
             status_code=422,
@@ -94,26 +86,11 @@ async def create_engine(room_name: str, payload: EngineCreate, request: Request)
         "adapter": "engine",
         "kind": kind,
         "description": payload.description,
-        "allow_from": [h for h in (_norm(a) for a in payload.allow_from) if h],
-        "owner": _norm(payload.owner),
-        "team": _norm(payload.team),
+        "allow_from": [h for h in (norm_handle(a) for a in payload.allow_from) if h],
+        "owner": norm_handle(payload.owner),
+        "team": norm_handle(payload.team),
     }
-    yaml_body = yaml.safe_dump(body, sort_keys=False, default_flow_style=False).strip()
-
-    batch = MemoryBatchCreate(
-        items=[
-            MemoryCreate(
-                key=key,
-                value=yaml_body,
-                created_by=registrar or "web-ui",
-                # embed=False: a manifest is registry config, not room knowledge —
-                # embedding it pollutes memory search + synthesis with roster noise.
-                embed=False,
-                tags=["agent-manifest"],
-            )
-        ]
-    )
-    await upsert_memories(room_name, batch)
+    await write_agent_manifest(room_name, handle, body, created_by=registrar or "web-ui")
     logger.info("room %s: registered engine @%s (kind=%s)", room_name, handle, kind)
 
     return AgentRead(

--- a/fastapi-backend/app/services/a2a_activity.py
+++ b/fastapi-backend/app/services/a2a_activity.py
@@ -25,6 +25,8 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+from app.services.agent_registry import norm_handle
+
 #: Exchanges kept per room. The pane shows a live tail, not a history.
 RING = 50
 
@@ -103,10 +105,6 @@ def _preview(text: str) -> str:
     return cleaned if len(cleaned) <= PREVIEW_CHARS else cleaned[: PREVIEW_CHARS - 1] + "…"
 
 
-def _norm(handle: str | None) -> str:
-    return (handle or "").strip().lstrip("@").lower()
-
-
 def record_outbound(
     room: str,
     handle: str,
@@ -120,7 +118,7 @@ def record_outbound(
     duration_ms: int | None = None,
 ) -> A2aExchange:
     """Record a call this hub made to a registered agent's remote endpoint."""
-    handle = _norm(handle)
+    handle = norm_handle(handle) or handle
     at = datetime.now(UTC)
     exchange = A2aExchange(
         id=f"a2a-{next(_ids)}",
@@ -130,7 +128,7 @@ def record_outbound(
         status=status,
         at=at,
         endpoint=endpoint,
-        peer=_norm(peer) or None,
+        peer=norm_handle(peer),
         prompt=_preview(prompt),
         reply=_preview(reply),
         detail=detail,
@@ -164,7 +162,7 @@ def record_inbound(
     exchange = A2aExchange(
         id=f"a2a-{next(_ids)}",
         room=room,
-        handle=_norm(handle),
+        handle=norm_handle(handle) or handle,
         direction="inbound",
         status=status,
         at=at,
@@ -198,7 +196,7 @@ def recent(room: str, limit: int = RING) -> list[A2aExchange]:
 def agent_stats(room: str, handle: str) -> AgentStats:
     """Lifetime call counters for one bridged agent (zeroed when it has none)."""
     with _lock:
-        return _state(room).agents.get(_norm(handle), AgentStats())
+        return _state(room).agents.get(norm_handle(handle) or handle, AgentStats())
 
 
 def totals(room: str) -> RoomTotals:

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -51,7 +51,6 @@ from a2a.types import Message, Part, Role, SendMessageRequest, StreamResponse
 from app.services import a2a_activity, l9
 from app.services.a2a_card import A2aCardError, resolve_raw_card
 from app.services.agent_registry import norm_handle
-from app.services.l9_slim import serialize_content
 from app.services.persister import envelope_message_id, envelope_sender
 
 if TYPE_CHECKING:
@@ -397,13 +396,7 @@ class A2aResponder:
             topic=l9.topic_urn(room),
             payload_type="reply",
         )
-        content = serialize_content(env, extra={"content": text})
-        try:
-            await managed.channel.send(env, extra={"content": text})
-        except Exception:
-            logger.warning("a2a responder failed to broadcast @%s reply on %s", handle, room)
-        if managed.persister is not None:
-            managed.persister.ingest_local(env, content, list_write=True)
+        await managed.post(env, text, list_write=True)
         # Best-effort presence: a handle that just answered is live in the room.
         try:
             self._manager.refresh_lease(room, handle)

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -303,10 +303,10 @@ class A2aResponder:
         token: str | None = None
         if ref.auth_env:
             token = os.environ.get(ref.auth_env)
-            if token is None:
+            if not token:
                 logger.warning(
-                    "a2a responder: auth_env '%s' is set on @%s but the env var is missing; "
-                    "refusing unauthenticated call",
+                    "a2a responder: auth_env '%s' is set on @%s but the env var is missing "
+                    "or empty; refusing unauthenticated call",
                     ref.auth_env,
                     handle,
                 )

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -85,6 +85,10 @@ class A2aAgentRef:
     #: Sender handles that may summon this agent (empty = anyone). Normalised to
     #: lowercase without '@' so comparisons are consistent with the gate check.
     allow_from: tuple[str, ...] = ()
+    #: The handle that registered the agent. Always allowed to summon it,
+    #: regardless of allow_from, so the owner is never locked out of their
+    #: own agent by a restrictive allowlist.
+    owner: str | None = None
 
 
 def resolve_a2a_agent(room: str, handle: str) -> A2aAgentRef | None:
@@ -120,6 +124,7 @@ def resolve_a2a_agent(room: str, handle: str) -> A2aAgentRef | None:
         auth_env=env if isinstance(env, str) and env else None,
         endpoint=endpoint if isinstance(endpoint, str) and endpoint else None,
         allow_from=allow_from,
+        owner=norm_handle(data.get("owner")),
     )
 
 
@@ -283,7 +288,10 @@ class A2aResponder:
             return
         # Summon gate: if the manifest names an allow_from list, only those
         # handles may trigger a remote call (and spend its bearer token / quota).
-        if ref.allow_from and norm_handle(sender) not in ref.allow_from:
+        # The agent's owner is always permitted — a restrictive allowlist must
+        # not lock the operator out of their own agent.
+        sender_norm = norm_handle(sender)
+        if ref.allow_from and sender_norm not in ref.allow_from and sender_norm != ref.owner:
             logger.debug(
                 "a2a responder: @%s not in allow_from for @%s — ignoring summon", sender, handle
             )

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -18,17 +18,21 @@ The send path carries the #712 spike findings: resolve the card (dual well-known
 path), then build a client with ``accepted_output_modes`` set — without it,
 older servers reject the send with a pydantic ``-32600``.
 
-**Honest scope boundary (keep it honest here + in the user-facing docs).** A
-bridged A2A agent is **not** a member of the room's MLS group channel — it never
-holds a group key. It is proxied by this backend seat, which reads the room's
-plaintext (as moderator/custodian) and calls the remote agent out-of-band. Today
-that hop is plain HTTPS; it *can* be moved onto SLIM (SLIMRPC, SLIM-identity
-authenticated + encrypted) via ``agntcy/slim-a2a-python`` — but even then it is
-point-to-point RPC to a distinct SLIM identity, **not** room-group membership
-(see #726). Either way the hub is the translation boundary and sees plaintext,
-so this is **NOT** E2E-from-the-hub. Auth to the remote is a bearer token whose
-value lives in the backend env (``a2a_auth_env`` names the var); the room
-manifest never stores the secret.
+**Transport decision (#726): HTTPS is the explicit default.** A bridged A2A
+agent is **not** a member of the room's MLS group channel — it never holds a
+group key. It is proxied by this backend seat, which reads the room's plaintext
+(as moderator/custodian) and calls the remote agent out-of-band over plain HTTPS.
+Moving the hop onto SLIM (SLIMRPC via ``agntcy/slim-a2a-python``) was evaluated
+and deferred: ``slima2a`` currently requires ``a2a-sdk[sqlite,telemetry]==1.1.0``
+exactly, while the project tracks ``1.1.2``, and adopting it would pull
+SQLAlchemy, aiosqlite, and OpenTelemetry into the backend image — none of which
+are present today. The purchase (a hardened point-to-point hop) would still not
+change the honest boundary (even SLIMRPC is point-to-point RPC, **not** MLS
+group membership), so the cost is not justified yet. Reopen #726 when slima2a
+relaxes its exact pin and a live SLIMRPC round-trip is proven over a running node.
+Either way the hub sees plaintext, so this is **NOT** E2E-from-the-hub. Auth to
+the remote is a bearer token whose value lives in the backend env
+(``a2a_auth_env`` names the var); the room manifest never stores the secret.
 """
 
 from __future__ import annotations

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -50,6 +50,7 @@ from a2a.types import Message, Part, Role, SendMessageRequest, StreamResponse
 
 from app.services import a2a_activity, l9
 from app.services.a2a_card import A2aCardError, resolve_raw_card
+from app.services.agent_registry import norm_handle
 from app.services.l9_slim import serialize_content
 from app.services.persister import envelope_message_id, envelope_sender
 
@@ -60,10 +61,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SEND_TIMEOUT_S = 120.0
-
-
-def _norm(handle: str | None) -> str:
-    return (handle or "").strip().lstrip("@").lower()
 
 
 def _elapsed_ms(started: float) -> int:
@@ -112,8 +109,8 @@ def resolve_a2a_agent(room: str, handle: str) -> A2aAgentRef | None:
     env = data.get("a2a_auth_env")
     endpoint = data.get("a2a_endpoint")
     raw_allow = data.get("allow_from") or []
-    allow_from = tuple(
-        _norm(h) for h in (raw_allow if isinstance(raw_allow, list) else []) if _norm(h)
+    allow_from: tuple[str, ...] = tuple(
+        h for raw in (raw_allow if isinstance(raw_allow, list) else []) if (h := norm_handle(raw))
     )
     return A2aAgentRef(
         card=card,
@@ -251,12 +248,12 @@ class A2aResponder:
         self._manager = manager
         self._timeout_s = timeout_s
         # (room, handle, message_id) currently in flight — a re-fire is ignored.
-        self._active: set[tuple[str, str, str]] = set()
+        self._active: set[tuple[str, str | None, str]] = set()
         self._tasks: set[asyncio.Task[Any]] = set()
         # (room, handle) -> A2A context id, so each mention continues the same
         # remote conversation instead of starting cold. In-memory: a restart
         # resets threads (the room transcript is still the durable record).
-        self._threads: dict[tuple[str, str, str], str] = {}
+        self._threads: dict[tuple[str | None, str | None, str | None], str] = {}
 
     # -- the summon seam (sync; called from the persister's on_summon) --
 
@@ -272,7 +269,7 @@ class A2aResponder:
         if ref is None:
             return  # not an a2a agent — let the engines / a teammate handle it
         sender = envelope_sender(envelope)
-        if _norm(sender) == _norm(handle):
+        if norm_handle(sender) == norm_handle(handle):
             return  # never answer our own message (loop guard)
         # Runaway guard: an a2a agent's auto-reply must not summon another a2a
         # agent. Two agents that mention each other would otherwise ping-pong
@@ -283,7 +280,7 @@ class A2aResponder:
             return
         # Summon gate: if the manifest names an allow_from list, only those
         # handles may trigger a remote call (and spend its bearer token / quota).
-        if ref.allow_from and _norm(sender) not in ref.allow_from:
+        if ref.allow_from and norm_handle(sender) not in ref.allow_from:
             logger.debug(
                 "a2a responder: @%s not in allow_from for @%s — ignoring summon", sender, handle
             )
@@ -292,7 +289,7 @@ class A2aResponder:
         if not prompt:
             return
         mid = envelope_message_id(envelope) or ""
-        key = (room, _norm(handle), mid)
+        key = (room, norm_handle(handle), mid)
         if key in self._active:
             return
         self._active.add(key)
@@ -337,17 +334,17 @@ class A2aResponder:
         ref: A2aAgentRef,
         prompt: str,
         envelope: L9,
-        key: tuple[str, str, str],
+        key: tuple[str, str | None, str],
         auth_token: str | None = None,
     ) -> None:
         summoner = envelope_sender(envelope)
         # Thread context is per summoner: two members addressing the same remote
         # agent must not share one remote contextId (context bleed). In-memory
         # only — a restart resets threads, but the room transcript is durable.
-        thread_key = (room, _norm(handle), _norm(summoner))
+        thread_key = (room, norm_handle(handle), norm_handle(summoner))
         # Name the speaker so the remote agent can follow a multi-party room; the
         # threaded context id carries the rest of the history on the remote side.
-        addressed = f"@{_norm(summoner)}: {prompt}" if summoner else prompt
+        addressed = f"@{norm_handle(summoner)}: {prompt}" if summoner else prompt
         # Telemetry for the Network views: the bridge hop leaves no trace on the
         # channel, so both outcomes are recorded here (#739).
         started = time.monotonic()

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -130,15 +130,17 @@ def resolve_a2a_agent(room: str, handle: str) -> A2aAgentRef | None:
     env = data.get("a2a_auth_env")
     endpoint = data.get("a2a_endpoint")
     raw_allow = data.get("allow_from") or []
+    # Use _bare_sender so any session qualifiers in stored values are stripped —
+    # handles are always compared as bare slugs in the summon gate.
     allow_from: tuple[str, ...] = tuple(
-        h for raw in (raw_allow if isinstance(raw_allow, list) else []) if (h := norm_handle(raw))
+        h for raw in (raw_allow if isinstance(raw_allow, list) else []) if (h := _bare_sender(raw))
     )
     return A2aAgentRef(
         card=card,
         auth_env=env if isinstance(env, str) and env else None,
         endpoint=endpoint if isinstance(endpoint, str) and endpoint else None,
         allow_from=allow_from,
-        owner=norm_handle(data.get("owner")),
+        owner=_bare_sender(data.get("owner")),
     )
 
 

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -57,6 +57,20 @@ from app.services.a2a_card import A2aCardError, resolve_raw_card
 from app.services.agent_registry import norm_handle
 from app.services.persister import envelope_message_id, envelope_sender
 
+
+def _bare_sender(value: str | None) -> str | None:
+    """Normalise an L9 sender to a bare slug, stripping any ``#session`` qualifier.
+
+    Stored slugs (allow_from, owner, agent handles) carry no session suffix;
+    L9 actor ids may carry one (``alice#a8f3``). Stripping before any comparison
+    against stored values ensures session-qualified senders are treated as their
+    underlying handle.
+    """
+    if not isinstance(value, str):
+        return None
+    return norm_handle(value.partition("#")[0])
+
+
 if TYPE_CHECKING:
     from app.services.l9_models import L9
     from app.services.room_channels import RoomChannelManager
@@ -277,21 +291,24 @@ class A2aResponder:
         if ref is None:
             return  # not an a2a agent — let the engines / a teammate handle it
         sender = envelope_sender(envelope)
-        if norm_handle(sender) == norm_handle(handle):
+        # Strip any #session qualifier from the sender before all comparisons
+        # against stored slugs — manifests store bare handles, L9 actor ids may
+        # carry a qualifier (alice#a8f3).
+        sender_bare = _bare_sender(sender)
+        if sender_bare == norm_handle(handle):
             return  # never answer our own message (loop guard)
         # Runaway guard: an a2a agent's auto-reply must not summon another a2a
         # agent. Two agents that mention each other would otherwise ping-pong
         # forever, each hop a real remote call. Humans, the aligner, and resident
         # agents still trigger a reply; only registered-a2a -> registered-a2a is cut.
-        if sender and resolve_a2a_agent(room, sender) is not None:
+        if sender_bare and resolve_a2a_agent(room, sender_bare) is not None:
             logger.debug("a2a responder: skip @%s summoned by a2a agent @%s", handle, sender)
             return
         # Summon gate: if the manifest names an allow_from list, only those
         # handles may trigger a remote call (and spend its bearer token / quota).
         # The agent's owner is always permitted — a restrictive allowlist must
         # not lock the operator out of their own agent.
-        sender_norm = norm_handle(sender)
-        if ref.allow_from and sender_norm not in ref.allow_from and sender_norm != ref.owner:
+        if ref.allow_from and sender_bare not in ref.allow_from and sender_bare != ref.owner:
             logger.debug(
                 "a2a responder: @%s not in allow_from for @%s — ignoring summon", sender, handle
             )
@@ -349,13 +366,14 @@ class A2aResponder:
         auth_token: str | None = None,
     ) -> None:
         summoner = envelope_sender(envelope)
+        summoner_bare = _bare_sender(summoner)
         # Thread context is per summoner: two members addressing the same remote
-        # agent must not share one remote contextId (context bleed). In-memory
-        # only — a restart resets threads, but the room transcript is durable.
-        thread_key = (room, norm_handle(handle), norm_handle(summoner))
+        # agent must not share one remote contextId (context bleed). Use the bare
+        # handle so a reconnecting session continues the same remote conversation.
+        thread_key = (room, norm_handle(handle), summoner_bare)
         # Name the speaker so the remote agent can follow a multi-party room; the
         # threaded context id carries the rest of the history on the remote side.
-        addressed = f"@{norm_handle(summoner)}: {prompt}" if summoner else prompt
+        addressed = f"@{summoner_bare}: {prompt}" if summoner_bare else prompt
         # Telemetry for the Network views: the bridge hop leaves no trace on the
         # channel, so both outcomes are recorded here (#739).
         started = time.monotonic()

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -40,6 +40,7 @@ import time
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 import httpx
 import yaml
@@ -81,6 +82,9 @@ class A2aAgentRef:
     #: The RPC endpoint resolved from the card at registration, for telemetry —
     #: the send path still resolves the card itself.
     endpoint: str | None = None
+    #: Sender handles that may summon this agent (empty = anyone). Normalised to
+    #: lowercase without '@' so comparisons are consistent with the gate check.
+    allow_from: tuple[str, ...] = ()
 
 
 def resolve_a2a_agent(room: str, handle: str) -> A2aAgentRef | None:
@@ -107,10 +111,15 @@ def resolve_a2a_agent(room: str, handle: str) -> A2aAgentRef | None:
         return None
     env = data.get("a2a_auth_env")
     endpoint = data.get("a2a_endpoint")
+    raw_allow = data.get("allow_from") or []
+    allow_from = tuple(
+        _norm(h) for h in (raw_allow if isinstance(raw_allow, list) else []) if _norm(h)
+    )
     return A2aAgentRef(
         card=card,
         auth_env=env if isinstance(env, str) and env else None,
         endpoint=endpoint if isinstance(endpoint, str) and endpoint else None,
+        allow_from=allow_from,
     )
 
 
@@ -199,7 +208,7 @@ async def send_to_a2a(
         )
         client = ClientFactory(config).create(card)
         message = Message(
-            message_id="mycelium-seat",
+            message_id=uuid4().hex,
             role=Role.ROLE_USER,
             parts=[Part(text=text)],
         )
@@ -247,7 +256,7 @@ class A2aResponder:
         # (room, handle) -> A2A context id, so each mention continues the same
         # remote conversation instead of starting cold. In-memory: a restart
         # resets threads (the room transcript is still the durable record).
-        self._threads: dict[tuple[str, str], str] = {}
+        self._threads: dict[tuple[str, str, str], str] = {}
 
     # -- the summon seam (sync; called from the persister's on_summon) --
 
@@ -272,6 +281,13 @@ class A2aResponder:
         if sender and resolve_a2a_agent(room, sender) is not None:
             logger.debug("a2a responder: skip @%s summoned by a2a agent @%s", handle, sender)
             return
+        # Summon gate: if the manifest names an allow_from list, only those
+        # handles may trigger a remote call (and spend its bearer token / quota).
+        if ref.allow_from and _norm(sender) not in ref.allow_from:
+            logger.debug(
+                "a2a responder: @%s not in allow_from for @%s — ignoring summon", sender, handle
+            )
+            return
         prompt = (message_text or "").strip()
         if not prompt:
             return
@@ -281,8 +297,33 @@ class A2aResponder:
             return
         self._active.add(key)
         # Resolve the bearer credential from the backend env (the manifest holds
-        # only the var name), so the secret never lives in room memory.
-        token = os.environ.get(ref.auth_env) if ref.auth_env else None
+        # only the var name), so the secret never lives in room memory. A declared
+        # but missing var is a misconfiguration — fail closed so it appears in the
+        # Network pane rather than silently calling the remote unauthenticated.
+        token: str | None = None
+        if ref.auth_env:
+            token = os.environ.get(ref.auth_env)
+            if token is None:
+                logger.warning(
+                    "a2a responder: auth_env '%s' is set on @%s but the env var is missing; "
+                    "refusing unauthenticated call",
+                    ref.auth_env,
+                    handle,
+                )
+                # Record the misconfiguration through the activity path so the
+                # Network pane shows it rather than leaving silence unexplained.
+                a2a_activity.record_outbound(
+                    room,
+                    handle,
+                    endpoint=ref.endpoint or ref.card,
+                    peer=sender,
+                    prompt=(message_text or "").strip(),
+                    status="error",
+                    detail=f"auth_env '{ref.auth_env}' declared but not set in the backend environment",
+                    duration_ms=0,
+                )
+                self._active.discard(key)
+                return
         task = asyncio.create_task(
             self._run_and_release(room, handle, ref, prompt, envelope, key, token)
         )
@@ -299,8 +340,11 @@ class A2aResponder:
         key: tuple[str, str, str],
         auth_token: str | None = None,
     ) -> None:
-        thread_key = (room, _norm(handle))
         summoner = envelope_sender(envelope)
+        # Thread context is per summoner: two members addressing the same remote
+        # agent must not share one remote contextId (context bleed). In-memory
+        # only — a restart resets threads, but the room transcript is durable.
+        thread_key = (room, _norm(handle), _norm(summoner))
         # Name the speaker so the remote agent can follow a multi-party room; the
         # threaded context id carries the rest of the history on the remote side.
         addressed = f"@{_norm(summoner)}: {prompt}" if summoner else prompt

--- a/fastapi-backend/app/services/agent_registry.py
+++ b/fastapi-backend/app/services/agent_registry.py
@@ -1,12 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""Reading a room's agent manifests.
+"""Reading and writing a room's agent manifests.
 
 Agents are registered as ``agents/<handle>`` memories whose body is a YAML
-manifest. This projects those files into the typed :class:`AgentRead` the
-agents route serves and cross-entity search matches against, so both read the
-manifests through one parser.
+manifest. This module:
+
+- Projects those files into the typed :class:`AgentRead` the agents route
+  serves and cross-entity search matches against, so both read the manifests
+  through one parser.
+- Provides :func:`norm_handle`, the canonical handle normaliser used by every
+  route or service that touches agent handles, so the rule lives in one place.
+- Provides :func:`write_agent_manifest`, the single path that turns a manifest
+  dict into the tagged, non-embedded memory used as the agent contract. Both
+  :mod:`app.routes.a2a_agents` and :mod:`app.routes.engines` write through it.
 """
 
 from __future__ import annotations
@@ -23,11 +30,53 @@ logger = logging.getLogger(__name__)
 AGENTS_PREFIX = "agents/"
 
 
-def _norm(value: object) -> str | None:
+def norm_handle(value: object) -> str | None:
+    """Normalise an agent handle to a lowercase slug, or ``None`` if blank.
+
+    Strips whitespace, removes a leading ``@``, lowercases, and returns
+    ``None`` when the result is empty. This is the canonical normaliser for
+    every place in the stack that reads or writes agent handle fields.
+    """
     if not isinstance(value, str):
         return None
     cleaned = value.strip().lstrip("@").lower()
     return cleaned or None
+
+
+# Back-compat alias for the private name used internally before the refactor.
+_norm = norm_handle
+
+
+async def write_agent_manifest(room_name: str, handle: str, body: dict, *, created_by: str) -> None:
+    """Write (or overwrite) an agent manifest memory for *handle* in *room_name*.
+
+    The memory is stored as ``agents/<handle>`` with ``embed=False`` and
+    ``tags=["agent-manifest"]`` — the single canonical shape every read path
+    expects. Routes that build different manifests (engine vs. A2A) call this
+    with their respective ``body`` dict so the YAML serialisation, tag constant,
+    and embed flag are not duplicated.
+
+    Uses a lazy import of :func:`app.routes.memory.upsert_memories` to avoid
+    a services → routes circular dependency, following the same pattern as
+    :mod:`app.services.task_sync` and :mod:`app.services.synthesizer`.
+    """
+    from app.routes.memory import upsert_memories  # lazy — routes import services
+    from app.schemas import MemoryBatchCreate, MemoryCreate
+
+    key = f"agents/{handle}"
+    yaml_body = yaml.safe_dump(body, sort_keys=False, default_flow_style=False).strip()
+    batch = MemoryBatchCreate(
+        items=[
+            MemoryCreate(
+                key=key,
+                value=yaml_body,
+                created_by=created_by,
+                embed=False,
+                tags=["agent-manifest"],
+            )
+        ]
+    )
+    await upsert_memories(room_name, batch)
 
 
 def room_agents(room_name: str) -> list[AgentRead]:
@@ -67,8 +116,8 @@ def room_agents(room_name: str) -> list[AgentRead]:
                 kind=str(data["kind"]) if data.get("kind") else None,
                 description=str(data.get("description") or ""),
                 cwd=str(data["cwd"]) if data.get("cwd") else None,
-                owner=_norm(data.get("owner")),
-                team=_norm(data.get("team")),
+                owner=norm_handle(data.get("owner")),
+                team=norm_handle(data.get("team")),
                 allow_from=[str(h) for h in allow_from if h],
                 a2a_card=str(data["a2a_card"]) if data.get("a2a_card") else None,
                 a2a_endpoint=str(data["a2a_endpoint"]) if data.get("a2a_endpoint") else None,

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -51,7 +51,6 @@ from typing import TYPE_CHECKING, Any
 
 from app.config import settings
 from app.services import l9, l9_episode
-from app.services.l9_slim import serialize_content
 from app.services.room_channels import BACKEND_AGENT
 
 if TYPE_CHECKING:
@@ -567,18 +566,16 @@ class AlignerEngine:
         # agents) doesn't spuriously wake them — only the L9 ``recipients=[handle]``
         # above should wake, one agent per turn.
         safe_prompt = _AT_MENTION.sub("", prompt)
-        content = serialize_content(env, extra={"content": safe_prompt})
-        try:
-            await managed.channel.send(env, extra={"content": safe_prompt})
-        except Exception:
-            logger.warning("mediator failed to prompt @%s (step %d)", handle, round_n)
-            return ""
         # Record the mediator's turn-prompt into the room transcript + UI bus, the
         # same way ``publish_human`` records a human's message. Without this the
         # negotiation is invisible in the room (the prompt only rides SLIM), so
         # humans can't follow along and debugging falls back to backend logs. The
         # persister de-dupes by id, so a SLIM loop-back to the sender is harmless.
-        persister.ingest_local(env, content)
+        try:
+            await managed.post(env, safe_prompt)
+        except Exception:
+            logger.warning("mediator failed to prompt @%s (step %d)", handle, round_n)
+            return ""
 
         pending = _norm(handle)
         loop = asyncio.get_running_loop()
@@ -638,13 +635,7 @@ class AlignerEngine:
             topic=l9.topic_urn(room),
             payload_type="message",
         )
-        content = serialize_content(env, extra={"content": safe})
-        try:
-            await managed.channel.send(env, extra={"content": safe})
-        except Exception:
-            logger.warning("aligner failed to broadcast message on room %s", room)
-        if managed.persister is not None:
-            managed.persister.ingest_local(env, content)
+        await managed.post(env, safe)
 
     def _fold_reading(
         self, ep: NegotiationState, handle: str, reading: dict[str, Any], proposing: bool
@@ -745,16 +736,10 @@ class AlignerEngine:
         envelope = l9.parse_envelope(wire_dict)
         if text is None:
             text = self._verdict_text(converged, metrics)
-        content = serialize_content(envelope, extra={"content": text})
-        try:
-            await managed.channel.send(envelope, extra={"content": text})
-        except Exception:
-            logger.warning("aligner failed to broadcast verdict on room %s", managed.room)
         # Record + trigger locally (deduped by message id), so the transcript,
         # UI bus, and on_converged seam fire even if SLIM never loops our own
         # broadcast back to the moderator (mirrors the human-proxy publish).
-        if managed.persister is not None:
-            managed.persister.ingest_local(envelope, content)
+        await managed.post(envelope, text)
         l9_episode.write_episode_record(
             ep,
             outcome="converged" if converged else "rejected",

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -572,7 +572,7 @@ class AlignerEngine:
         # humans can't follow along and debugging falls back to backend logs. The
         # persister de-dupes by id, so a SLIM loop-back to the sender is harmless.
         try:
-            await managed.post(env, safe_prompt)
+            await managed.post(env, safe_prompt, raise_on_send_failure=True)
         except Exception:
             logger.warning("mediator failed to prompt @%s (step %d)", handle, round_n)
             return ""

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -155,6 +155,7 @@ class ManagedRoomChannel:
         text: str,
         *,
         list_write: bool = False,
+        raise_on_send_failure: bool = False,
     ) -> None:
         """Serialize *envelope*, broadcast it, and ingest locally.
 
@@ -171,6 +172,11 @@ class ManagedRoomChannel:
                 ``True`` for agent replies that must appear in the in-memory
                 store list; ``False`` (default) for broker messages that ride
                 the transcript only.
+            raise_on_send_failure: When ``True``, re-raise after logging if
+                ``channel.send`` fails, so the caller can detect the failure and
+                skip waiting for a reply that will never arrive. When ``False``
+                (default) the failure is logged and local ingest still runs —
+                best-effort broadcast with a durable local record.
         """
         content = serialize_content(envelope, extra={"content": text})
         try:
@@ -182,6 +188,8 @@ class ManagedRoomChannel:
                 getattr(getattr(envelope, "header", None), "message", None),
                 exc,
             )
+            if raise_on_send_failure:
+                raise
         if self.persister is not None:
             self.persister.ingest_local(envelope, content, list_write=list_write)
 

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -149,6 +149,42 @@ class ManagedRoomChannel:
     # empty under the PSK default, where the moderator is the single member.
     custody: dict[str, CustodialSession] = field(default_factory=dict)
 
+    async def post(
+        self,
+        envelope: L9,
+        text: str,
+        *,
+        list_write: bool = False,
+    ) -> None:
+        """Serialize *envelope*, broadcast it, and ingest locally.
+
+        This is the canonical one-liner that replaces the repeated
+        ``serialize_content → channel.send → persister.ingest_local`` sequence
+        in the bridge, server, aligner, and synthesizer. The caller builds the
+        L9 envelope (since kind/recipients/payload vary per call site); this
+        method owns the three mechanical steps that follow it.
+
+        Args:
+            envelope: A fully constructed L9 envelope from :func:`l9.build_envelope`.
+            text: The human-readable message body, sent as the ``content`` extra.
+            list_write: Passed through to ``persister.ingest_local``. Set
+                ``True`` for agent replies that must appear in the in-memory
+                store list; ``False`` (default) for broker messages that ride
+                the transcript only.
+        """
+        content = serialize_content(envelope, extra={"content": text})
+        try:
+            await self.channel.send(envelope, extra={"content": text})
+        except Exception as exc:
+            logger.warning(
+                "room %s: failed to broadcast envelope %s: %s",
+                self.room,
+                getattr(getattr(envelope, "header", None), "message", None),
+                exc,
+            )
+        if self.persister is not None:
+            self.persister.ingest_local(envelope, content, list_write=list_write)
+
 
 @dataclass
 class HumanPublishResult:

--- a/fastapi-backend/app/services/synthesizer.py
+++ b/fastapi-backend/app/services/synthesizer.py
@@ -61,7 +61,6 @@ from app.config import settings
 # Reuse the aligner's manifest-kind gate and handle-fold implementations.
 from app.services import l9
 from app.services.aligner import _norm, _registered_engine_kind
-from app.services.l9_slim import serialize_content
 
 if TYPE_CHECKING:
     from app.services.in_memory_store import StoredMessage
@@ -477,13 +476,7 @@ class SynthesizerEngine:
             topic=l9.topic_urn(room),
             payload_type="message",
         )
-        content = serialize_content(env, extra={"content": text})
-        try:
-            await managed.channel.send(env, extra={"content": text})
-        except Exception:
-            logger.warning("synthesizer failed to broadcast message on room %s", room)
-        if managed.persister is not None:
-            managed.persister.ingest_local(env, content)
+        await managed.post(env, text)
 
     async def _write_summary(
         self, room: str, summary: str, created_by: str, cursor: dict[str, str] | None

--- a/fastapi-backend/tests/fakes.py
+++ b/fastapi-backend/tests/fakes.py
@@ -146,7 +146,14 @@ class FakeManaged:
     channel: Any = None
     persister: Any = None
 
-    async def post(self, envelope: Any, text: str, *, list_write: bool = False) -> None:
+    async def post(
+        self,
+        envelope: Any,
+        text: str,
+        *,
+        list_write: bool = False,
+        raise_on_send_failure: bool = False,
+    ) -> None:
         """Mirror of ``ManagedRoomChannel.post`` for node-free tests."""
         content = serialize_content(envelope, extra={"content": text})
         if self.channel is not None:

--- a/fastapi-backend/tests/fakes.py
+++ b/fastapi-backend/tests/fakes.py
@@ -146,6 +146,14 @@ class FakeManaged:
     channel: Any = None
     persister: Any = None
 
+    async def post(self, envelope: Any, text: str, *, list_write: bool = False) -> None:
+        """Mirror of ``ManagedRoomChannel.post`` for node-free tests."""
+        content = serialize_content(envelope, extra={"content": text})
+        if self.channel is not None:
+            await self.channel.send(envelope, extra={"content": text})
+        if self.persister is not None:
+            self.persister.ingest_local(envelope, content, list_write=list_write)
+
 
 class FakeManager:
     """Just enough of ``RoomChannelManager`` for the aligner + plan-sync consumers.

--- a/fastapi-backend/tests/test_a2a_agents_route.py
+++ b/fastapi-backend/tests/test_a2a_agents_route.py
@@ -120,6 +120,41 @@ async def test_missing_room_404(client, stub_card):
 
 
 @pytest.mark.asyncio
+async def test_owner_defaults_to_registrar(client, stub_card):
+    """When owner is omitted, it is set to created_by so the allow_from exemption works."""
+    await _make_room(client)
+    resp = await client.post(
+        "/api/rooms/portfolio/a2a-agents",
+        json={
+            "handle": "researcher",
+            "card": "https://remote.example",
+            "created_by": "selina",
+            "allow_from": ["avery"],
+            # owner intentionally omitted
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.json()["owner"] == "selina"
+
+
+@pytest.mark.asyncio
+async def test_explicit_owner_wins_over_registrar(client, stub_card):
+    """An explicit owner in the payload takes precedence over created_by."""
+    await _make_room(client)
+    resp = await client.post(
+        "/api/rooms/portfolio/a2a-agents",
+        json={
+            "handle": "researcher",
+            "card": "https://remote.example",
+            "created_by": "selina",
+            "owner": "avery",
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.json()["owner"] == "avery"
+
+
+@pytest.mark.asyncio
 async def test_non_http_card_scheme_rejected():
     """Hermetic: the scheme guard trips before any network I/O."""
     with pytest.raises(A2aCardError):

--- a/fastapi-backend/tests/test_a2a_agents_route.py
+++ b/fastapi-backend/tests/test_a2a_agents_route.py
@@ -155,6 +155,25 @@ async def test_explicit_owner_wins_over_registrar(client, stub_card):
 
 
 @pytest.mark.asyncio
+async def test_session_qualified_owner_stored_as_bare(client, stub_card):
+    """A session-qualified owner/created_by must be stored as a bare slug."""
+    await _make_room(client)
+    resp = await client.post(
+        "/api/rooms/portfolio/a2a-agents",
+        json={
+            "handle": "researcher",
+            "card": "https://remote.example",
+            "created_by": "selina#abc123",
+            "allow_from": ["avery#xyz"],
+        },
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["owner"] == "selina"
+    assert body["allow_from"] == ["avery"]
+
+
+@pytest.mark.asyncio
 async def test_non_http_card_scheme_rejected():
     """Hermetic: the scheme guard trips before any network I/O."""
     with pytest.raises(A2aCardError):

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -28,12 +28,15 @@ def _register_a2a(
     card: str = "https://remote.example",
     auth_env: str | None = None,
     allow_from: list[str] | None = None,
+    owner: str | None = None,
 ) -> None:
     manifest: dict = {"adapter": "a2a", "a2a_card": card, "description": "does research"}
     if auth_env:
         manifest["a2a_auth_env"] = auth_env
     if allow_from is not None:
         manifest["allow_from"] = allow_from
+    if owner is not None:
+        manifest["owner"] = owner
     write_memory_file(
         get_room_dir(_ROOM), f"agents/{handle}", yaml.safe_dump(manifest), created_by="web-ui"
     )
@@ -286,6 +289,20 @@ async def test_allow_from_blocks_unlisted_sender(monkeypatch):
 
     assert calls == []
     assert channel.sent == []
+
+
+@pytest.mark.asyncio
+async def test_owner_bypasses_allow_from_gate(monkeypatch):
+    """The agent owner must always be able to summon, even with a restrictive allow_from."""
+    _register_a2a(allow_from=["avery"], owner="selina")
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    # "selina" is the owner but not in allow_from — must still go through.
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("selina"), [], "owner summon")
+    await _drain(responder)
+
+    assert len(calls) == 1
+    assert channel.sent
 
 
 @pytest.mark.asyncio

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -355,7 +355,6 @@ async def test_threads_are_keyed_by_summoner(monkeypatch):
 @pytest.mark.asyncio
 async def test_declared_but_missing_auth_env_fails_closed(monkeypatch):
     """If auth_env is declared but the env var is absent, the call must not proceed."""
-    # auth_env declared, but NOT set in the environment.
     _register_a2a(auth_env="MISSING_TOKEN_VAR")
     monkeypatch.delenv("MISSING_TOKEN_VAR", raising=False)
     responder, channel, _persister, calls = _responder(monkeypatch)
@@ -363,10 +362,27 @@ async def test_declared_but_missing_auth_env_fails_closed(monkeypatch):
     responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "hello")
     await _drain(responder)
 
-    # Must not reach the remote.
     assert calls == []
     assert channel.sent == []
-    # And the failure must be visible in the activity log.
+    from app.services import a2a_activity
+
+    exchange = a2a_activity.recent(_ROOM)[-1]
+    assert exchange.status == "error"
+    assert "auth_env" in (exchange.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_declared_but_empty_auth_env_fails_closed(monkeypatch):
+    """An auth_env var that is present but empty must also fail closed."""
+    _register_a2a(auth_env="EMPTY_TOKEN_VAR")
+    monkeypatch.setenv("EMPTY_TOKEN_VAR", "")
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "hello")
+    await _drain(responder)
+
+    assert calls == []
+    assert channel.sent == []
     from app.services import a2a_activity
 
     exchange = a2a_activity.recent(_ROOM)[-1]

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -27,10 +27,13 @@ def _register_a2a(
     handle: str = "researcher",
     card: str = "https://remote.example",
     auth_env: str | None = None,
+    allow_from: list[str] | None = None,
 ) -> None:
-    manifest = {"adapter": "a2a", "a2a_card": card, "description": "does research"}
+    manifest: dict = {"adapter": "a2a", "a2a_card": card, "description": "does research"}
     if auth_env:
         manifest["a2a_auth_env"] = auth_env
+    if allow_from is not None:
+        manifest["allow_from"] = allow_from
     write_memory_file(
         get_room_dir(_ROOM), f"agents/{handle}", yaml.safe_dump(manifest), created_by="web-ui"
     )
@@ -255,3 +258,117 @@ async def test_failed_call_is_recorded_with_its_reason(monkeypatch):
     assert exchange.status == "error"
     assert "dead remote" in (exchange.detail or "")
     assert a2a_activity.totals(_ROOM).outbound_failed == 1
+
+
+# ── Phase 1 correctness: allow_from, message_id, thread_key, auth_env ──────
+
+
+@pytest.mark.asyncio
+async def test_allow_from_permits_listed_sender(monkeypatch):
+    _register_a2a(allow_from=["avery"])
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "allowed")
+    await _drain(responder)
+
+    assert len(calls) == 1
+    assert channel.sent
+
+
+@pytest.mark.asyncio
+async def test_allow_from_blocks_unlisted_sender(monkeypatch):
+    _register_a2a(allow_from=["avery"])
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    # "quinn" is not in the allow_from list — call must be suppressed.
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("quinn"), [], "blocked")
+    await _drain(responder)
+
+    assert calls == []
+    assert channel.sent == []
+
+
+@pytest.mark.asyncio
+async def test_empty_allow_from_allows_anyone(monkeypatch):
+    _register_a2a(allow_from=[])
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("anyone"), [], "hi")
+    await _drain(responder)
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_message_id_is_unique_per_call(monkeypatch):
+    """Each send must produce a distinct message_id so compliant remotes don't dedup."""
+    from unittest.mock import patch
+
+    _register_a2a()
+    responder, _channel, _persister, _calls = _responder(monkeypatch)
+
+    captured_ids: list[str] = []
+
+    from a2a.types import Message
+
+    original_init = Message.__init__
+
+    def _capture(self, **kwargs):
+        captured_ids.append(kwargs.get("message_id", ""))
+        original_init(self, **kwargs)
+
+    with patch.object(Message, "__init__", _capture):
+        responder.handle_summon(
+            _ROOM, "researcher", _summon_envelope("avery", message_id="m-uid-1"), [], "first"
+        )
+        await _drain(responder)
+        responder.handle_summon(
+            _ROOM, "researcher", _summon_envelope("avery", message_id="m-uid-2"), [], "second"
+        )
+        await _drain(responder)
+
+    if len(captured_ids) >= 2:
+        assert captured_ids[0] != captured_ids[1], "message_id must be unique per send"
+
+
+@pytest.mark.asyncio
+async def test_threads_are_keyed_by_summoner(monkeypatch):
+    """Two different senders must each get their own thread; context must not bleed."""
+    _register_a2a()
+    responder, _channel, _persister, calls = _responder(monkeypatch)
+
+    # avery starts a thread (context_id is None cold)
+    responder.handle_summon(
+        _ROOM, "researcher", _summon_envelope("avery", message_id="av1"), [], "avery 1"
+    )
+    await _drain(responder)
+    # quinn starts her own thread (should also be None — cold for quinn)
+    responder.handle_summon(
+        _ROOM, "researcher", _summon_envelope("quinn", message_id="qu1"), [], "quinn 1"
+    )
+    await _drain(responder)
+
+    assert calls[0]["context_id"] is None  # avery cold
+    assert calls[1]["context_id"] is None  # quinn cold — NOT ctx-1 from avery's thread
+
+
+@pytest.mark.asyncio
+async def test_declared_but_missing_auth_env_fails_closed(monkeypatch):
+    """If auth_env is declared but the env var is absent, the call must not proceed."""
+    # auth_env declared, but NOT set in the environment.
+    _register_a2a(auth_env="MISSING_TOKEN_VAR")
+    monkeypatch.delenv("MISSING_TOKEN_VAR", raising=False)
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(_ROOM, "researcher", _summon_envelope("avery"), [], "hello")
+    await _drain(responder)
+
+    # Must not reach the remote.
+    assert calls == []
+    assert channel.sent == []
+    # And the failure must be visible in the activity log.
+    from app.services import a2a_activity
+
+    exchange = a2a_activity.recent(_ROOM)[-1]
+    assert exchange.status == "error"
+    assert "auth_env" in (exchange.detail or "")

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -260,7 +260,7 @@ async def test_failed_call_is_recorded_with_its_reason(monkeypatch):
     assert a2a_activity.totals(_ROOM).outbound_failed == 1
 
 
-# ── Phase 1 correctness: allow_from, message_id, thread_key, auth_env ──────
+# ── Correctness: allow_from, message_id, thread_key, auth_env ───────────────
 
 
 @pytest.mark.asyncio

--- a/fastapi-backend/tests/test_a2a_responder.py
+++ b/fastapi-backend/tests/test_a2a_responder.py
@@ -306,6 +306,37 @@ async def test_owner_bypasses_allow_from_gate(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_session_qualified_sender_passes_allow_from(monkeypatch):
+    """A sender carrying a #session suffix must be treated as their bare handle."""
+    _register_a2a(allow_from=["avery"])
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    # "avery#abc123" is avery with a session qualifier — must pass the gate.
+    responder.handle_summon(
+        _ROOM, "researcher", _summon_envelope("avery#abc123"), [], "session summon"
+    )
+    await _drain(responder)
+
+    assert len(calls) == 1
+    assert channel.sent
+
+
+@pytest.mark.asyncio
+async def test_session_qualified_owner_passes_allow_from(monkeypatch):
+    """The owner with a #session suffix must still bypass the allow_from gate."""
+    _register_a2a(allow_from=["avery"], owner="selina")
+    responder, channel, _persister, calls = _responder(monkeypatch)
+
+    responder.handle_summon(
+        _ROOM, "researcher", _summon_envelope("selina#xyz999"), [], "owner session"
+    )
+    await _drain(responder)
+
+    assert len(calls) == 1
+    assert channel.sent
+
+
+@pytest.mark.asyncio
 async def test_empty_allow_from_allows_anyone(monkeypatch):
     _register_a2a(allow_from=[])
     responder, channel, _persister, calls = _responder(monkeypatch)

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -452,6 +452,26 @@ class ScrapeTarget(BaseModel):
     )
 
 
+class A2aConfig(BaseModel):
+    """Configuration for the A2A bridge (outbound + inbound Agent2Agent gateway).
+
+    The default settings are safe for a public-facing deployment: the SSRF guard
+    refuses card URLs that resolve to private, loopback, or link-local addresses
+    so a misconfigured or attacker-supplied card URL can't probe the internal
+    network. Only set ``allow_private_hosts = true`` for a deployment where all
+    A2A agents are on the internal network and you trust every registrar.
+    """
+
+    allow_private_hosts: bool = Field(
+        default=False,
+        description=(
+            "Disable the SSRF guard that refuses A2A card URLs resolving to private, "
+            "loopback, or link-local addresses. Only set this for a trusted internal "
+            "deployment whose A2A agents live on the internal network."
+        ),
+    )
+
+
 class MetricsConfig(BaseModel):
     """Configuration for the metrics collector + display.
 
@@ -493,6 +513,7 @@ class MyceliumConfig(BaseModel):
     runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
     rooms: RoomConfig = Field(default_factory=RoomConfig)
     metrics: MetricsConfig = Field(default_factory=MetricsConfig)
+    a2a: A2aConfig = Field(default_factory=A2aConfig)
     adapters: dict[str, Any] = Field(
         default_factory=dict,
         description="Registered agent framework adapters (claude-code, cursor, …)",
@@ -688,7 +709,7 @@ class MyceliumConfig(BaseModel):
         global_path = self._global_config_path or self.get_global_config_path()
         global_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Global sections: identity, server, llm, engine, runtime, metrics, adapters
+        # Global sections: identity, server, llm, engine, runtime, metrics, a2a, adapters
         _global_sections = (
             "identity",
             "server",
@@ -700,6 +721,7 @@ class MyceliumConfig(BaseModel):
             "agent_auth",
             "runtime",
             "metrics",
+            "a2a",
             "adapters",
         )
 

--- a/mycelium-cli/src/mycelium/docker_utils.py
+++ b/mycelium-cli/src/mycelium/docker_utils.py
@@ -331,6 +331,13 @@ def generate_env_file(
         if config.runtime.trusted_proxies
         else "# FORWARDED_ALLOW_IPS not set; uvicorn trusts loopback forwarders only",
         "",
+        "# ── A2A bridge ────────────────────────────────────────────────────────────",
+        # SSRF guard: by default the bridge refuses card URLs that resolve to
+        # private/loopback/link-local addresses. Set allow_private_hosts = true in
+        # config.toml (mycelium config set a2a.allow_private_hosts true) to disable
+        # this guard for deployments where A2A agents live on an internal network.
+        f"A2A_ALLOW_PRIVATE_HOSTS={'1' if config.a2a.allow_private_hosts else ''}",
+        "",
     ]
 
     # ── Operator-managed pins (preserved across `mycelium config apply`) ─────

--- a/mycelium-cli/src/mycelium/docs/a2a-bridge.md
+++ b/mycelium-cli/src/mycelium/docs/a2a-bridge.md
@@ -48,8 +48,16 @@ Two guards keep the bridge from being used as a lever:
 
 - **Card hosts must be public.** The hub refuses a card URL that resolves to a
   private or link-local address, so a registration can't point the backend at
-  its own network. Set `A2A_ALLOW_PRIVATE_HOSTS=1` only for a trusted internal
-  deployment.
+  its own network. For a trusted internal deployment whose A2A agents live on
+  the internal network, disable the guard:
+
+  ```
+  mycelium config set a2a.allow_private_hosts true
+  mycelium config apply
+  ```
+
+  This renders `A2A_ALLOW_PRIVATE_HOSTS=1` into the backend's environment
+  on the next `config apply`. Do not set this on a public-facing hub.
 - **A2A agents don't summon each other.** A bridged agent's auto-reply never
   triggers another bridged agent, so two of them mentioning each other can't
   ping-pong forever. Humans, the aligner, and resident agents still get a reply.


### PR DESCRIPTION
## Summary

**Transport decision (#726 → closed):**
- `a2a_bridge.py` module docstring updated: HTTPS is the explicit decided default. `slima2a` was evaluated and deferred — it requires `a2a-sdk==1.1.0` exactly while the project tracks `1.1.2`, and adopting it would pull SQLAlchemy/aiosqlite/OpenTelemetry into the image for a purchase that doesn't change the honest boundary.
- `CLAUDE.md` fixed: the stale reference implied the project's `a2a-sdk` version was `1.1.0`; it is `1.1.2` and `slima2a`'s requirement is the constrained one.

**`A2A_ALLOW_PRIVATE_HOSTS` config wiring:**
- `A2aConfig` class added to `MyceliumConfig` (`allow_private_hosts: bool = False`).
- `generate_env_file()` now renders `A2A_ALLOW_PRIVATE_HOSTS` so `mycelium config set a2a.allow_private_hosts true && mycelium config apply` reaches the backend container. Previously this was only reachable by hand-editing the container's environment.
- `"a2a"` added to `_global_sections` so the field persists correctly across saves.
- `a2a-bridge.md` updated to replace the raw `A2A_ALLOW_PRIVATE_HOSTS=1` instruction with the `mycelium config set` command.
- Docs regenerated: `[a2a] allow_private_hosts = false` now appears in the Configuration reference.

## Test plan

- [ ] `test_config_env_coverage.py`: all 5 tests pass — `A2A_ALLOW_PRIVATE_HOSTS` is automatically picked up by the AST walk
- [ ] `docs/` drift check: `git diff --exit-code docs/` is clean after `generate_docs.py`
- [ ] Backend + CLI quality gates: ruff + ty + pytest all pass

Made with [Cursor](https://cursor.com)