### PR TITLE
Fix: lease-only await handle never sees a mention recorded while it holds a lease

### DIFF
--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -460,7 +460,17 @@ class RoomChannelManager:
         managed.persister = RoomPersister(
             room,
             managed.channel,
-            members_provider=lambda: self.members(room),
+            # Real SLIM-connected members only — NOT `self.members(room)`, which
+            # also unions in server-held `await` leases. A lease holder never
+            # receives a push; it polls the transcript past its own cursor. If a
+            # lease-only handle were counted as "delivered", DeliveryLog.record
+            # would jump its cursor straight past a message that mentions it
+            # (see DeliveryLog.record), and its next `await` would silently never
+            # see it. A real SLIM member's cursor still advances live, and a
+            # lease-only handle correctly falls into the "recipients" branch
+            # (tracked at the message's own position on first sight), so its poll
+            # finds the mention as its undelivered tail.
+            members_provider=lambda: set(managed.members),
             on_summon=self._summon_adapter(room),
             on_converged=self._converged_adapter(room),
             on_member_left=lambda handle, _room=room: self._drop_member(_room, handle),

--- a/fastapi-backend/tests/test_room_channels.py
+++ b/fastapi-backend/tests/test_room_channels.py
@@ -146,3 +146,43 @@ async def test_status_reports_per_room_snapshot(
     room = next(r for r in status["rooms"] if r["room"] == "room-a")
     assert room["provisioned"] is True
     assert room["members"] == ["agent-a"]
+
+
+@pytest.mark.asyncio
+async def test_persister_members_provider_excludes_lease_only_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The persister's ``delivered_to`` source must be real SLIM members only.
+
+    A server-held ``await`` lease is polling, not pushed-to: DeliveryLog.record
+    marks anyone in ``delivered_to`` as caught up to the message just recorded,
+    so if a lease-only handle were counted, a mention addressed to it would be
+    marked delivered before its own poll ever read it — silently un-deliverable.
+    ``manager.members(room)`` unions SLIM members with lease holders (correct for
+    the roster/consent-gate uses), so the persister must be wired to the
+    channel's own live SLIM set instead, not that union.
+    """
+    monkeypatch.setattr(settings, "SLIM_ENABLED", True)
+    monkeypatch.setattr(room_channels, "node_reachable", lambda _endpoint: True)
+    monkeypatch.setattr(room_channels, "SlimClient", FakeSlimClient)
+
+    class _FakeRoomPersister:
+        def __init__(self, room, channel, *, members_provider, **_kw):
+            self.members_provider = members_provider
+
+        async def run(self):
+            return None
+
+    monkeypatch.setattr(room_channels, "RoomPersister", _FakeRoomPersister)
+
+    manager = room_channels.RoomChannelManager(endpoint="http://node", default_workspace="ws")
+    managed = await manager.provision("room-a")
+    assert managed is not None
+    managed.members.add("slim-agent")
+    manager.refresh_lease("room-a", "lease-only-agent")
+
+    # The union (roster/consent-gate use) legitimately includes both.
+    assert set(manager.members("room-a")) == {"slim-agent", "lease-only-agent"}
+    # The persister's delivery source must not.
+    fake_persister = cast(_FakeRoomPersister, managed.persister)
+    assert fake_persister.members_provider() == {"slim-agent"}


### PR DESCRIPTION
## Summary

Fixes the root cause behind #880 — an `await`-ing agent could go silent forever after its first poll, and reproducing it live tonight against mycelium.outshift.io confirmed the actual bug is in delivery-cursor bookkeeping, not in the CLI, buffering, or the proxy.

- `manager.members(room)` is a **union** of real SLIM-connected members and anyone holding a live server-held `await` presence lease. That union is correct for the roster and the `@`-mention consent gate — but it was also being wired straight into `DeliveryLog.record(delivered_to=...)` as the persister's "who received this live" source.
- `DeliveryLog.record` advances every `delivered_to` handle's cursor to the message's end — right for a real SLIM push, wrong for a lease holder: a lease is *polled*, never pushed to. So the moment an agent held any live lease (from having called `await` even once), a later `@`-mention of it got marked delivered before its own next poll ever read it — silently undeliverable, forever, for that message.
- Fix: wire the persister to the channel's real SLIM member set (`managed.members`) instead of the lease-inclusive union, leaving that union in place for its other, legitimate uses (roster display, invite/consent gating).

## Repro (before the fix)

Live against a real hub: register an agent, run `mycelium await --handle X --loop` once (so it holds a lease), then `@`-mention it from another session — the loop never wakes, even with an unbounded timeout and even confirmed via a raw concurrent HTTP long-poll (bypassing the CLI entirely).

## Test plan

- [x] New regression test `test_persister_members_provider_excludes_lease_only_handles` (`tests/test_room_channels.py`) — fails against the pre-fix code, passes after
- [x] `uv run pytest tests/ -x -q` — 1005 passed, 6 skipped
- [x] `uv run ruff check .` / `ruff format --check .` / `uv run ty check .` — all clean

Relates to #880 (this is task 1 of the two-task split noted there — the mechanism fix that has to land before per-adapter guidance is worth writing).