### PR TITLE
Align identity.name to the token's handle on login (#882)

### DIFF
--- a/.claude/skills/mycelium-remote-agent/SKILL.md
+++ b/.claude/skills/mycelium-remote-agent/SKILL.md
@@ -11,7 +11,8 @@ room on a remote server. This skill gives you a distinct identity in that room,
 tells you how to work a task of that room's board, and how to report. Run steps 1
 and 2 once at the start of your session, take a task (step 4), report at
 milestones (step 5), and write your findings into the task before you resolve it
-(step 6).
+(step 6). Everything you say goes in your task; you read the room but never post
+to it.
 
 If `MYCELIUM_API_URL` is not set in your environment, this skill does not apply:
 you are not wired to a hub, so do nothing.
@@ -80,7 +81,7 @@ accepted), `--allow-from` lets the shared credential post under your handle, and
 rest of the session (re-export it in each new shell), so every post is attributed
 to `@$HANDLE`.
 
-## 3. Read the room, then say you are starting
+## 3. Read the room. Do not write to it.
 
 Before you touch anything, read the recent activity to get a broad sense of what
 is going on: who else is active, what is in flight, and whether your task overlaps
@@ -91,11 +92,13 @@ another agent, and it is worth doing even when your task looks self-contained.
 mycelium room messages --limit 20
 ```
 
-Then announce that you are starting, in one line:
+**The room is a read for you, not a write.** Do not run `mycelium room send`.
+The room already learns what you are doing without you narrating it: opening,
+claiming, blocking and resolving a row each post a **notice** to the channel, and
+every write into a row's thread surfaces as a **ping**. Announcing your own work
+on top of that is the same news twice, in the one place everybody has to scroll.
 
-```bash
-mycelium room send "starting: <what you are about to do>"
-```
+So say you are starting *in the row* (step 4), not in the channel.
 
 ## 4. Work a task, not a room
 
@@ -107,11 +110,12 @@ the room's main channel.
 mycelium board                                     # what needs someone
 mycelium board new "<what you are here to do>"     # if your task is not on it yet
 mycelium board claim <row-id>                      # take it, as a lease
+mycelium board send <row-id> "starting: <what you are about to do>"
 ```
 
 Every task carries a **thread id** the board shows you (`t3aa11bb`); the verbs
-below take it or the row's key (`work/…`) interchangeably. Then keep the detail
-in the task and the room short:
+below take it or the row's key (`work/…`) interchangeably. **Everything you have
+to say goes through one of these**, from "starting" to the final write-up:
 
 ```bash
 mycelium board send <row-id> "<what you found, what you decided, what you tried>"
@@ -121,10 +125,10 @@ mycelium board resolve <row-id>                    # when it's done
 ```
 
 A write into a thread surfaces in the room as one **ping** — that a task moved,
-never what was said in it. That is why the detail belongs there: the room stays
-a surface a human can scan, and nothing you wrote is lost. Room-wide news still
-goes to the room (step 5); anything attached to a piece of work goes to its
-thread.
+never what was said in it. That is the whole arrangement: the room stays a
+surface a human can scan, the argument stays next to the work it is about, and
+nothing you wrote is lost. It is also why you never post to the room yourself —
+the channel is told, and your row is where the telling has context.
 
 If your whole session is one task, narrow your wake to it rather than the room:
 
@@ -137,33 +141,56 @@ Claiming a row matters even for a short session: a claim is a **lease**, so if
 your container is reclaimed mid-task it drains back to the pool on its own
 rather than leaving a row that looks held forever.
 
-## 5. Report at milestones
+## 5. Report at milestones — in the row
 
-Room-wide, one line each — the things someone scanning the channel needs:
+Every milestone is a write into your task, not into the channel:
 
 ```bash
-mycelium room send "PR up: <url>  <one line>"
-mycelium room send "blocked: <what and why>"      # only if stuck
-mycelium room send "done: <summary + links>"      # at the end
+mycelium board send <row-id> "PR up: <url> — <what it does>"
+mycelium board send <row-id> "blocked: <what and why>"     # only if stuck
 ```
 
-Everything longer than a line — the reasoning, the false starts, the handoff
-notes for whoever picks this up next — goes in the task's thread, where it stays
-attached to the work instead of scrolling past in the room.
+Each of these pings the room by itself, so a human watching the channel sees
+that your task moved and can open it. Nothing is hidden by keeping it in the row;
+the reasoning, the false starts and the handoff notes simply stay attached to the
+work instead of scrolling past in a shared channel.
+
+`block` is worth using over a prose post when you are genuinely stuck, because it
+moves the row rather than only talking about it:
+
+```bash
+mycelium board block <row-id> "<what it is waiting on>"
+```
 
 ## 6. Close the task out before you exit
 
-The room's `done:` line is for whoever is scanning the channel. It is not the
-record. **Write what you actually found into the task before you resolve it** —
-that thread is where the next person looks when they reopen this row six weeks
-from now, and a resolved row with nothing in it teaches them nothing.
+**Write what you actually found into the task before you resolve it.** That row
+is where the next person looks when they reopen this work six weeks from now, and
+a resolved row with nothing in it teaches them nothing.
+
+Two writes, and they are not the same write:
 
 ```bash
-mycelium board send <row-id> "<findings, decisions, what you did NOT do>"
+# 1. the summary, ON the row — what it reads as on the board forever
+mycelium memory set <row-key> --handle "$MYCELIUM_AGENT_AUTH_CLIENT_ID" -f - <<'EOF'
+<title line>
+
+<the outcome in a few paragraphs: what shipped, the calls you made, links>
+EOF
+
+# 2. the working detail, IN its thread
+mycelium board send <row-id> "<findings, alternatives rejected, what is still open>"
+
 mycelium board resolve <row-id>
 ```
 
-What belongs in that final write-up, in markdown (see below):
+The row's **body** is a memory (`work/…`, which is why `memory set` writes it),
+so it is indexed, searchable and linkable — it is the durable answer to "what
+came of this?". The **thread** is the working record underneath it. Put the
+conclusion on the row and the reasoning in the thread; a reader who wants only
+one of the two should not have to read both.
+
+What belongs in the write-up, in markdown (see below):
 
 - **What you changed and where** — the files or seams, not a diff.
 - **Why it is shaped that way** — the decision, and the alternative you rejected.
@@ -174,22 +201,29 @@ What belongs in that final write-up, in markdown (see below):
   should argue with, links to the PR / issue.
 
 Resolve the row once that is written. An unresolved row you have finished reads
-as work still in flight; a resolved row with an empty thread reads as work
-nobody can pick back up.
+as work still in flight; a resolved row with an empty body reads as work nobody
+can pick back up.
+
+> `memory set` is the one verb that will **not** take your delegated agent
+> handle: it asserts `created_by` against the token itself, so
+> `--handle "$MYCELIUM_AGENT_AUTH_CLIENT_ID"` is required and
+> `--handle "$MYCELIUM_AGENT_HANDLE"` gets a 403. `board send` and the other
+> board verbs do accept your own handle — keep using it there, so the thread is
+> attributed to you.
 
 Read replies before you exit (a cloud session cannot be woken later, so check
 while you are still alive):
 
 ```bash
-mycelium room messages --limit 10
-mycelium board messages <row-id>                   # and your own task
+mycelium board messages <row-id>                   # your own task, first
+mycelium room messages --limit 10                  # and the room, as a read
 ```
 
 ## Write markdown, not a wall of text
 
-The room renders your posts as markdown, so a message with structure is read at a
-glance instead of squinted at. This matters most for the milestone posts, which are
-the ones people actually read. Use it:
+A row's body and its thread both render as markdown, so a post with structure is
+read at a glance instead of squinted at. This matters most for the milestone and
+close-out posts, which are the ones people actually read. Use it:
 
 - **A lead line, then the detail.** Open with the one-sentence takeaway; put the
   supporting points under it as a `- ` list rather than one long run-on paragraph.
@@ -198,14 +232,14 @@ the ones people actually read. Use it:
   `[text](url)` links.
 - `@handle` mentions and `[[memory/key]]` links render as clickable chips, so refer
   to people and memories that way rather than pasting raw keys.
-- A single newline is a line break (the room renders chat-style), so you do not need
+- A single newline is a line break (a thread renders chat-style), so you do not need
   a blank line between every line — but do leave a blank line between a paragraph and
   a list, or before a fenced block, so they parse as their own elements.
 
-A long `done:` or `PR up:` post is where this pays off. For example:
+A long close-out or `PR up:` post is where this pays off. For example:
 
 ```bash
-mycelium room send "done: #798 shipped. Board verbs now write to the room.
+mycelium board send t3aa11bb "done: #798 shipped. Board verbs now write to the room.
 
 - claim/release/resolve write a frontmatter patch through the memory upsert
 - removed the fabricated GitHub back-link (was harmless overlay, would have been a durable lie)

--- a/.claude/skills/mycelium-remote-agent/SKILL.md
+++ b/.claude/skills/mycelium-remote-agent/SKILL.md
@@ -9,8 +9,9 @@ user_invocable: true
 You are running in an environment wired to a Mycelium hub: a shared coordination
 room on a remote server. This skill gives you a distinct identity in that room,
 tells you how to work a task of that room's board, and how to report. Run steps 1
-and 2 once at the start of your session, take a task (step 4), and report at
-milestones (step 5).
+and 2 once at the start of your session, take a task (step 4), report at
+milestones (step 5), and write your findings into the task before you resolve it
+(step 6).
 
 If `MYCELIUM_API_URL` is not set in your environment, this skill does not apply:
 you are not wired to a hub, so do nothing.
@@ -149,6 +150,32 @@ mycelium room send "done: <summary + links>"      # at the end
 Everything longer than a line — the reasoning, the false starts, the handoff
 notes for whoever picks this up next — goes in the task's thread, where it stays
 attached to the work instead of scrolling past in the room.
+
+## 6. Close the task out before you exit
+
+The room's `done:` line is for whoever is scanning the channel. It is not the
+record. **Write what you actually found into the task before you resolve it** —
+that thread is where the next person looks when they reopen this row six weeks
+from now, and a resolved row with nothing in it teaches them nothing.
+
+```bash
+mycelium board send <row-id> "<findings, decisions, what you did NOT do>"
+mycelium board resolve <row-id>
+```
+
+What belongs in that final write-up, in markdown (see below):
+
+- **What you changed and where** — the files or seams, not a diff.
+- **Why it is shaped that way** — the decision, and the alternative you rejected.
+- **What you did not do**, and why. The scope you deliberately left is the single
+  most valuable thing you can leave behind, and it is lost the moment your
+  container is reclaimed.
+- **What is still open** — anything you could not verify, anything a reviewer
+  should argue with, links to the PR / issue.
+
+Resolve the row once that is written. An unresolved row you have finished reads
+as work still in flight; a resolved row with an empty thread reads as work
+nobody can pick back up.
 
 Read replies before you exit (a cloud session cannot be woken later, so check
 while you are still alive):

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3218,8 +3218,13 @@ acting as @avery  (avery#a8f3)
 ```
 
 Because a gated hub attributes writes to the token (see *The token is the author*
-below), a self-asserted handle that names someone else is a 403 in waiting;
-`login` and `iam` both say so when they disagree.
+below), a self-asserted handle that names someone else is a 403 in waiting. The
+token wins that disagreement, so `login` settles it for you: on a successful
+sign-in it points `identity.name` at the token's own handle and registers the
+`users/` record — the same thing `mycelium iam <handle>` does, without the second
+command. If that can't land (no readable handle claim, or a handle the store
+rejects), `login` falls back to naming the mismatch and the command that fixes
+it. Setting a handle your token won't back with `iam` still warns.
 
 ### Configuration
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1961,7 +1961,7 @@ role     = &quot;user&quot;</code></pre>
       <p><code>mycelium whoami</code> (and <code>mycelium iam</code> with no arguments) reports the handle from your <strong>token</strong> when you&#x27;re signed in, and the self-asserted <code>identity.name</code> when you&#x27;re not:</p>
       <pre><code>acting as @avery  (avery#a8f3)
   signed in (<span class="url">https://sso.example.com/realms/mycelium,</span> expires in 42 min)</code></pre>
-      <p>Because a gated hub attributes writes to the token (see <em>The token is the author</em> below), a self-asserted handle that names someone else is a 403 in waiting; <code>login</code> and <code>iam</code> both say so when they disagree.</p>
+      <p>Because a gated hub attributes writes to the token (see <em>The token is the author</em> below), a self-asserted handle that names someone else is a 403 in waiting. The token wins that disagreement, so <code>login</code> settles it for you: on a successful sign-in it points <code>identity.name</code> at the token&#x27;s own handle and registers the <code>users/</code> record — the same thing <code>mycelium iam &lt;handle&gt;</code> does, without the second command. If that can&#x27;t land (no readable handle claim, or a handle the store rejects), <code>login</code> falls back to naming the mismatch and the command that fixes it. Setting a handle your token won&#x27;t back with <code>iam</code> still warns.</p>
       <h3 id="auth-configuration">Configuration</h3>
       <div class="table-wrap">
         <table>

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -1930,7 +1930,7 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "reference.html#auth-who-you-are",
     "t": "Who you are",
     "s": "Guides › Authentication",
-    "x": "mycelium whoami (and mycelium iam with no arguments) reports the handle from your token when you're signed in, and the self-asserted identity.name when you're not: acting as @avery (avery#a8f3) signed in (https://sso.example.com/realms/mycelium, expires in 42 min) Because a gated hub attributes writes to the token (see The token is the author below), a self-asserted handle that names someone else is a 403 in waiting;",
+    "x": "mycelium whoami (and mycelium iam with no arguments) reports the handle from your token when you're signed in, and the self-asserted identity.name when you're not: acting as @avery (avery#a8f3) signed in (https://sso.example.com/realms/mycelium, expires in 42 min) Because a gated hub attributes writes to the token (see The token is the author below), a self-asserted handle that names someone else is a 403 in waiting.",
     "p": "Reference"
   },
   {

--- a/mycelium-cli/src/mycelium/commands/login.py
+++ b/mycelium-cli/src/mycelium/commands/login.py
@@ -8,7 +8,9 @@ The browser flow (Authorization Code + PKCE) is the default; ``--device`` is the
 fallback for a shell whose browser can't reach this machine's loopback address:
 SSH, CI, a container. Both end the same way: the session lands in the ``0600``
 token cache (``mycelium.tokens``) and every subsequent backend call carries it,
-because they all build their client through ``mycelium.client``.
+because they all build their client through ``mycelium.client``. A successful
+login also points this machine's ``identity.name`` at the token's own handle,
+since a gated hub refuses a write that claims a different one.
 
 Logging in is opt-in. Nothing here runs unless the user asks for it, and a hub
 with its gate off never needs it.
@@ -83,26 +85,64 @@ def _persist_login_config(
         console.print(f"[dim]Saved login settings to {MyceliumConfig.get_config_path()}[/dim]")
 
 
-def _report(token: StoredToken, config: MyceliumConfig, *, json_output: bool) -> None:
-    handle = token.handle(config.auth.handle_claim) or token.handle() or "(unknown)"
+# What ``_align_identity`` did with the token's handle, for ``_report`` to narrate.
+_SKIPPED = "skipped"  # no readable handle claim; there is nothing to align to
+_ALREADY = "already"  # identity.name already names the token's principal
+_ALIGNED = "aligned"
+_UNREGISTERED = "unregistered"  # identity.name landed, the hub didn't take the record
+_FAILED = "failed"
+
+
+def _align_identity(config: MyceliumConfig, handle: str) -> str:
+    """Point this machine's identity at the token's own handle.
+
+    A token is authoritative over a self-asserted local name, and a gated hub
+    refuses a write that claims a different one — so login does the alignment
+    itself rather than printing a second command for the human to relay back.
+    Same path ``mycelium iam <handle>`` takes: ``identity.name`` plus the
+    ``users/`` record.
+    """
+    asserted = (config.identity.name or "").strip().lstrip("@").lower()
+    if asserted == handle:
+        return _ALREADY
+
+    from mycelium.commands.user import align_identity
+
+    try:
+        _manifest, registered = align_identity(handle, config=config)
+    except Exception:  # noqa: BLE001 — a login that worked must not fail on this
+        return _FAILED
+    return _ALIGNED if registered else _UNREGISTERED
+
+
+def _report(
+    token: StoredToken,
+    config: MyceliumConfig,
+    *,
+    handle: str | None,
+    alignment: str,
+    json_output: bool,
+) -> None:
+    shown = handle or "(unknown)"
     remaining = token.expires_in()
 
     if json_output:
         typer.echo(
             json_module.dumps(
                 {
-                    "handle": handle,
+                    "handle": shown,
                     "issuer": token.issuer,
                     "client_id": token.client_id,
                     "expires_at": token.expires_at,
                     "refreshable": bool(token.refresh_token),
+                    "identity": config.identity.name,
                 },
                 indent=2,
             )
         )
         return
 
-    console.print(f"[green]Signed in as[/green] [cyan]@{handle}[/cyan] [dim]({token.issuer})[/dim]")
+    console.print(f"[green]Signed in as[/green] [cyan]@{shown}[/cyan] [dim]({token.issuer})[/dim]")
     if remaining is not None:
         console.print(f"[dim]Access token valid for {int(remaining // 60)} min[/dim]")
     if not token.refresh_token:
@@ -112,15 +152,23 @@ def _report(token: StoredToken, config: MyceliumConfig, *, json_output: bool) ->
         )
     console.print(f"[dim]Session cached at {token_path()} (mode 0600).[/dim]")
 
-    # A self-asserted identity that names someone else is a 403 waiting to happen, so warn.
-    asserted = (config.identity.name or "").strip().lstrip("@").lower()
-    if asserted and asserted != handle:
+    if alignment in (_ALIGNED, _UNREGISTERED):
+        console.print(f"[dim]This machine now writes as @{shown} (identity.name).[/dim]")
+    if alignment == _UNREGISTERED:
+        console.print(
+            f"[yellow]Not registered on the hub[/yellow] [dim]— couldn't reach "
+            f"{config.server.api_url}. Re-run: mycelium iam {shown}[/dim]"
+        )
+    if alignment == _FAILED:
+        # Couldn't align, so say what a self-asserted identity naming someone
+        # else costs: a gated hub turns it into a 403 at the first write.
+        asserted = (config.identity.name or "").strip().lstrip("@").lower() or "(unset)"
         console.print(
             f"\n[yellow]Heads up:[/yellow] this machine writes as [cyan]@{asserted}[/cyan], "
-            f"but your token says [cyan]@{handle}[/cyan]. A gated hub refuses writes that "
+            f"but your token says [cyan]@{shown}[/cyan]. A gated hub refuses writes that "
             "claim a different handle."
         )
-        console.print(f"[dim]Align them with: mycelium iam {handle}[/dim]")
+        console.print(f"[dim]Align them with: mycelium iam {shown}[/dim]")
 
 
 @doc_ref(
@@ -232,7 +280,10 @@ def login(
         audience=audience,
         scope=scope,
     )
-    _report(token, config, json_output=json_output)
+
+    handle = token.handle(config.auth.handle_claim) or token.handle()
+    alignment = _align_identity(config, handle) if handle else _SKIPPED
+    _report(token, config, handle=handle, alignment=alignment, json_output=json_output)
 
 
 @doc_ref(

--- a/mycelium-cli/src/mycelium/commands/user.py
+++ b/mycelium-cli/src/mycelium/commands/user.py
@@ -141,6 +141,42 @@ def _write_user(user: UserManifest, created_by: str) -> None:
         create_api.sync(client=client, body=body)
 
 
+def align_identity(
+    handle: str,
+    *,
+    config: MyceliumConfig,
+    display_name: str | None = None,
+    teams: list[str] | None = None,
+) -> tuple[UserManifest, bool]:
+    """Make *handle* this machine's identity and ensure its ``users/`` record exists.
+
+    Two halves with different homes: the identity is this machine's config, the
+    user record is the hub's. Registering can fail on its own, and the local half
+    still has to land — otherwise a hub outage leaves you unable to say who you
+    are here. The returned flag says whether the hub took the record.
+
+    Raises ``ValidationError`` when *handle* isn't a valid handle.
+    """
+    manifest = UserManifest(handle=handle, display_name=display_name or "", teams=teams or [])
+
+    registered = True
+    try:
+        # Preserve an existing display name / teams when the caller didn't pass them.
+        existing = load_user(manifest.handle)
+        if existing is not None:
+            if display_name is None:
+                manifest.display_name = existing.display_name
+            if not teams:
+                manifest.teams = existing.teams
+        _write_user(manifest, created_by=manifest.handle)
+    except (httpx.HTTPError, UnexpectedStatus):
+        registered = False
+
+    config.identity.name = manifest.handle
+    config.save()
+    return manifest, registered
+
+
 def _owned_lines(read: UserRead) -> list[tuple[str, str, str]]:
     """The hub's roll-up for a user as ``(handle, adapter, room)`` triples."""
     owns = _unset_to_none(getattr(read, "owns", None)) or []
@@ -442,33 +478,14 @@ def iam(
         return
 
     try:
+        config = MyceliumConfig.load()
         try:
-            manifest = UserManifest(handle=handle, display_name=name or "", teams=team or [])
+            manifest, registered = align_identity(
+                handle, config=config, display_name=name, teams=team
+            )
         except ValidationError as exc:
             typer.secho(f"Invalid handle: {exc}", fg=typer.colors.RED)
             raise typer.Exit(1) from exc
-
-        config = MyceliumConfig.load()
-
-        # Two halves with different homes: the identity is this machine's config,
-        # the user record is the hub's. Registering can fail on its own, and the
-        # local half still has to land — otherwise a hub outage leaves you unable
-        # to say who you are here.
-        registered = True
-        try:
-            # Preserve an existing display name / teams when the caller didn't pass them.
-            existing = load_user(manifest.handle)
-            if existing is not None:
-                if name is None:
-                    manifest.display_name = existing.display_name
-                if not team:
-                    manifest.teams = existing.teams
-            _write_user(manifest, created_by=manifest.handle)
-        except (httpx.HTTPError, UnexpectedStatus):
-            registered = False
-
-        config.identity.name = manifest.handle
-        config.save()
 
         team_line = f" · teams: {', '.join(manifest.teams)}" if manifest.teams else ""
         console.print(

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -133,8 +133,13 @@ acting as @avery  (avery#a8f3)
 ```
 
 Because a gated hub attributes writes to the token (see *The token is the author*
-below), a self-asserted handle that names someone else is a 403 in waiting;
-`login` and `iam` both say so when they disagree.
+below), a self-asserted handle that names someone else is a 403 in waiting. The
+token wins that disagreement, so `login` settles it for you: on a successful
+sign-in it points `identity.name` at the token's own handle and registers the
+`users/` record — the same thing `mycelium iam <handle>` does, without the second
+command. If that can't land (no readable handle claim, or a handle the store
+rejects), `login` falls back to naming the mismatch and the command that fixes
+it. Setting a handle your token won't back with `iam` still warns.
 
 ### Configuration
 

--- a/mycelium-cli/tests/test_login.py
+++ b/mycelium-cli/tests/test_login.py
@@ -12,11 +12,13 @@ Four slices, matching the four things that can quietly go wrong:
   states RFC 8628 defines;
 * **the seam** — every client built by ``mycelium.client`` carries the bearer,
   and carries *nothing* when logged out, which is the off-by-default promise;
-* **the identity** — ``whoami`` / ``iam`` report the token's handle when there
-  is one and are untouched when there isn't.
+* **the identity** — ``login`` points this machine at the token's own handle,
+  ``whoami`` / ``iam`` report it when there is one and are untouched when there
+  isn't.
 
 No issuer and no backend run here: ``httpx`` is stubbed at the module the code
-under test calls into.
+under test calls into, and the hub's user store — which ``login`` now upserts
+through — is stubbed at the generated client.
 """
 
 from __future__ import annotations
@@ -33,6 +35,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 from typer.testing import CliRunner
 
@@ -69,6 +72,42 @@ def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # The "session expired" notice fires once per process; reset the latch so
     # each test observes its own behavior.
     monkeypatch.setattr(client_mod, "_refresh_warned", False)
+
+
+USER_GET_SYNC = "mycelium_backend_client.api.users.get_user_api_users_handle_get.sync"
+USER_CREATE_SYNC = "mycelium_backend_client.api.users.create_user_api_users_post.sync"
+
+
+class _Hub:
+    """The hub's user store, stubbed — ``login`` upserts a record through it now.
+
+    Serves 404 for every read (nobody is registered under this temp home) and
+    records what gets written. Flip ``reachable`` to make the hub disappear.
+    """
+
+    def __init__(self) -> None:
+        self.created: list[str] = []
+        self.reachable = True
+
+    def get(self, **_kwargs: Any) -> None:
+        from mycelium_backend_client.errors import UnexpectedStatus
+
+        if not self.reachable:
+            raise httpx.ConnectError("connection refused")
+        raise UnexpectedStatus(404, b'{"detail":"User not found"}')
+
+    def create(self, **kwargs: Any) -> None:
+        if not self.reachable:
+            raise httpx.ConnectError("connection refused")
+        self.created.append(kwargs["body"].handle)
+
+
+@pytest.fixture(autouse=True)
+def hub(monkeypatch: pytest.MonkeyPatch) -> _Hub:
+    stub = _Hub()
+    monkeypatch.setattr(USER_GET_SYNC, stub.get)
+    monkeypatch.setattr(USER_CREATE_SYNC, stub.create)
+    return stub
 
 
 def _flat(text: str) -> str:
@@ -536,6 +575,124 @@ def test_iam_with_no_handle_reports_rather_than_asserting() -> None:
     assert json.loads(result.stdout)["principal"] == "avery"
     # Reporting is read-only: nothing was written to identity.name.
     assert MyceliumConfig.load().identity.name is None
+
+
+def _login(
+    monkeypatch: pytest.MonkeyPatch,
+    sub: str = "avery",
+    *,
+    json_output: bool = False,
+) -> Any:
+    """Run a successful browser login whose token carries *sub* as its handle."""
+    from mycelium.commands import login as login_cmd
+
+    monkeypatch.setattr(login_cmd, "_browser_available", lambda: True)
+    monkeypatch.setattr(login_cmd, "discover", lambda _issuer: _META)
+    monkeypatch.setattr(
+        login_cmd,
+        "authorization_code_login",
+        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": sub})),
+    )
+    if json_output:
+        # Configured rather than passed: an explicit --issuer prints a
+        # "saved login settings" line that isn't part of the JSON document.
+        config = MyceliumConfig.load()
+        config.login.issuer = _META.issuer
+        config.save()
+        return runner.invoke(app, ["--json", "login"])
+    return runner.invoke(app, ["login", "--issuer", "https://idp.test/realms/mycelium"])
+
+
+def test_login_aligns_this_machines_identity_to_the_token_handle(
+    monkeypatch: pytest.MonkeyPatch, hub: _Hub
+) -> None:
+    """The token is authoritative, so login settles the mismatch itself (#882)."""
+    config = MyceliumConfig.load()
+    config.identity.name = "bob"
+    config.save()
+
+    result = _login(monkeypatch)
+
+    assert result.exit_code == 0
+    assert MyceliumConfig.load().identity.name == "avery"
+    # The other half of ``iam``: the principal exists on the hub, not just here.
+    assert hub.created == ["avery"]
+    assert "now writes as @avery" in _flat(result.stdout)
+    # No second command to relay back by hand.
+    assert "Heads up" not in _flat(result.stdout)
+    assert "mycelium iam avery" not in _flat(result.stdout)
+
+
+def test_login_names_an_unset_identity_rather_than_leaving_it_unknown(
+    monkeypatch: pytest.MonkeyPatch, hub: _Hub
+) -> None:
+    """An unset identity resolves to "unknown", which a gated hub refuses too."""
+    assert MyceliumConfig.load().identity.name is None
+
+    result = _login(monkeypatch)
+
+    assert result.exit_code == 0
+    assert MyceliumConfig.load().identity.name == "avery"
+    assert hub.created == ["avery"]
+
+
+def test_login_leaves_an_already_matching_identity_untouched(
+    monkeypatch: pytest.MonkeyPatch, hub: _Hub
+) -> None:
+    config = MyceliumConfig.load()
+    config.identity.name = "@Avery"
+    config.save()
+
+    result = _login(monkeypatch)
+
+    assert result.exit_code == 0
+    # Nothing disagreed, so login writes nothing — not locally, not on the hub.
+    assert MyceliumConfig.load().identity.name == "@Avery"
+    assert hub.created == []
+    assert "now writes as" not in _flat(result.stdout)
+
+
+def test_login_aligns_locally_even_when_the_hub_is_unreachable(
+    monkeypatch: pytest.MonkeyPatch, hub: _Hub
+) -> None:
+    """The local half is what stops the 403; registration can catch up later."""
+    hub.reachable = False
+
+    result = _login(monkeypatch)
+
+    assert result.exit_code == 0
+    assert MyceliumConfig.load().identity.name == "avery"
+    assert "Not registered on the hub" in _flat(result.stdout)
+    assert "mycelium iam avery" in _flat(result.stdout)
+
+
+def test_login_falls_back_to_the_warning_when_the_handle_cannot_be_aligned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A handle the user store rejects must not turn a good login into a failure."""
+    config = MyceliumConfig.load()
+    config.identity.name = "bob"
+    config.save()
+
+    result = _login(monkeypatch, sub="Avery Quinn")
+
+    assert result.exit_code == 0
+    assert MyceliumConfig.load().identity.name == "bob"
+    assert "this machine writes as @bob" in _flat(result.stdout)
+    assert "mycelium iam" in _flat(result.stdout)
+
+
+def test_login_json_reports_the_identity_it_landed(
+    monkeypatch: pytest.MonkeyPatch, hub: _Hub
+) -> None:
+    """Aligning is behavior, not formatting: --json takes the same path."""
+    result = _login(monkeypatch, json_output=True)
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["handle"] == "avery"
+    assert payload["identity"] == "avery"
+    assert hub.created == ["avery"]
 
 
 def test_iam_flags_a_handle_the_token_will_not_back() -> None:


### PR DESCRIPTION
## Summary

`mycelium login` reported success and then told you to go run `mycelium iam <handle>` yourself, because this machine's self-asserted `identity.name` didn't match the token's own principal. Until that second command ran, every plain write 403'd against a gated hub with "does not match the authenticated principal" — confusing, since login had just said it worked.

A token is authoritative over a self-asserted local name, so login now settles the disagreement itself. The `iam` half — set `identity.name`, upsert the `users/` record — is lifted into `user.align_identity()` and called from login on a successful sign-in. This is the second friction point in onboarding someone onto a shared hub (after #881, issuer auto-discovery); both were information the CLI already had.

Three calls worth arguing with:

- **An unreachable hub does not fall back to the warning.** The issue lists it as a fallback case, but `align_identity` lands the local half regardless — and the local half is the one that stops the 403. Falling back would print "run `mycelium iam <handle>`", which is the same call that just failed. So login aligns locally and says the record still needs registering.
- **An *unset* `identity.name` now gets set too**, not only a mismatched one. Today's warning fires only when the asserted name is truthy, but unset resolves to `"unknown"` through `MyceliumConfig` — a handle a gated hub refuses just the same.
- **`--json` takes the same path** and gained an `identity` key. Aligning is behavior, not formatting.

**Deliberately not done:** `mycelium --json login --issuer <url>` still prints `Saved login settings to …` ahead of the JSON document, so that invocation's output isn't parseable. Real and pre-existing, one line to fix, but it isn't #882 and widening the PR for it isn't mine to decide — the new JSON test configures the issuer rather than passing it. Worth its own issue.

## Also: the remote-agent skill keeps its comms in the task

Second commit, from the same session. The `mycelium-remote-agent` skill had an agent narrating its own work into the room's channel — `starting:`, `PR up:`, `done:` — *on top of* the notices the board already posts when a row is opened, claimed, blocked or resolved, and the ping every thread write emits. Same news twice, in the one surface everybody has to scroll.

- The room becomes a **read**: consult it for what else is in flight, never `room send` to it.
- Every milestone, from "starting" to the close-out, is a write into the row — which pings the channel by itself, so nothing is hidden by keeping it there.
- **Close-out is two writes**, because they answer different questions. The row's *body* (a `work/` memory, so indexed, searchable, linkable) carries the conclusion and is what the board reads as forever; the *thread* underneath carries the reasoning, the alternatives rejected, and what is still open. A reader who wants one shouldn't have to read both.
- Records the asymmetry that bites: `memory set` asserts `created_by` against the token, so writing the row body needs the credential's handle, while `board send` accepts the agent's own delegated handle.

That last point was found the hard way in this session — a live 403 of exactly the class #882 is about.

## Changes

- `commands/user.py`: extract `align_identity(handle, *, config, display_name, teams)` from the body of `iam` — validates the handle, preserves an existing display name / teams, upserts the `users/` record, sets `identity.name`, and returns whether the hub took the record. `iam` is now a caller of it, with unchanged behavior.
- `commands/login.py`: `_align_identity()` runs that same path when the token's handle and `identity.name` disagree. Five outcomes, narrated separately by `_report`: `already` (nothing to do, no write at all), `aligned`, `unregistered` (local half landed, hub didn't take it), `failed` (the old warn-and-suggest), `skipped` (no readable handle claim).
- `docs/guides/auth.md` "Who you are": login settles the mismatch rather than reporting it; regenerated `docs/*.html`, `search-index.js`, `llms-full.txt`.
- `.claude/skills/mycelium-remote-agent/SKILL.md`: room becomes read-only for the agent; milestones and the close-out move into the row; new step 6 with the row-body / thread split.

## Testing

Five new tests in `mycelium-cli/tests/test_login.py`, all mutation-checked rather than assumed — neutering `_align_identity` fails four of them, and removing the already-matching short-circuit fails the fifth:

- aligns a mismatched `identity.name` to the token's handle, writes the `users/` record, and prints no second command to relay back
- names an unset identity rather than leaving it `unknown`
- leaves an already-matching identity untouched — no local write, no hub write
- aligns locally even with the hub unreachable, and says the record still needs registering
- falls back to the warning (exit 0, `identity.name` unchanged) for a handle the user store rejects
- `--json` reports the identity that landed

The module's hub calls are now stubbed at the generated client, so the suite stays hermetic as the docstring claims.

The skill's close-out flow was exercised against the live hub before being written down — the `memory set` row-body write, its `--handle` 403, and the thread/resolve verbs.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 733 passed, 2 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`) — one pre-existing drift in `tests/test_slim_master_secret_config.py`, untouched by this PR
- [x] `uv run ty check .` clean
- [x] `docs/generate_docs.py` regenerated, no drift beyond the guide edit

## Related Issues

Closes #882

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ugScMzxTqxCe51oV52Upr