### PR TITLE
Discover the OIDC issuer from the hub on login (#881)

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3164,7 +3164,6 @@ The gate above is the hub's half. `mycelium login` is yours: it obtains an OIDC
 token for **you**, caches it, and every later command sends it.
 
 ```bash
-mycelium config set login.issuer https://sso.example.com/realms/mycelium
 mycelium config set login.audience mycelium      # match the hub's auth.audience
 mycelium login
 ```
@@ -3172,6 +3171,25 @@ mycelium login
 Your browser opens, you sign in at your identity provider, and the CLI takes it
 from there: `mycelium memory`, `mycelium room`, `await`, `respond` and the rest
 now carry `Authorization: Bearer <token>`.
+
+### The issuer comes from the hub
+
+You do not set `login.issuer` to sign in. A gated hub advertises the issuers it
+trusts in the `auth` block of its `/health`, and `server.api_url` already points
+at it — so with no issuer configured and none passed, `login` asks the hub and
+uses the answer, remembering it once the sign-in it drove has actually worked.
+
+Three cases where it steps back and tells you instead, rather than guessing:
+
+- **The hub is unreachable** — nothing to ask, so you get the original "set
+  `login.issuer`" error.
+- **The hub's gate is off** — it needs no login at all, and says so.
+- **The hub trusts more than one issuer** — which one you sign in against decides
+  who the hub thinks you are, so it lists them and asks you to pick with
+  `--issuer`. The lookup is still done for you; only the choice isn't.
+
+`--issuer` and a configured `login.issuer` both win over discovery, so nothing
+about an existing setup changes and the hub is not consulted at all.
 
 **On a machine with no browser** (SSH, CI, a container) use the device flow.
 The CLI prints a URL and a short code you enter from any other device:
@@ -3230,7 +3248,7 @@ it. Setting a handle your token won't back with `iam` still warns.
 
 | Key | Default | What it does |
 |-----|---------|--------------|
-| `login.issuer` | *(unset)* | OIDC issuer to log in against. Unset means no login is configured. |
+| `login.issuer` | *(unset)* | OIDC issuer to log in against. Unset means `login` asks the hub for one and caches what it gets. |
 | `login.client_id` | `mycelium-cli` | OAuth client id registered for the CLI. |
 | `login.client_secret` | *(unset)* | Only for issuers that refuse public clients; PKCE means the CLI normally needs none. |
 | `login.scopes` | `openid profile email offline_access` | Scopes requested at login. |

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -567,7 +567,7 @@
         <div class="cmd-ref-header">
           <code><span class="bin">mycelium</span> <span class="cmd">login</span> [<span class="flag">--issuer</span> <span class="arg">URL</span>] [<span class="flag">--device</span>] [<span class="flag">--no-browser</span>] [<span class="flag">--client-id</span> <span class="arg">ID</span>]</code>
         </div>
-        <div class="cmd-ref-body">Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code).</div>
+        <div class="cmd-ref-body">Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code); the issuer is discovered from the hub when it isn't configured.</div>
       </div>
 
       <div class="cmd-ref">
@@ -1944,10 +1944,18 @@ role     = &quot;user&quot;</code></pre>
       <p>Each <code>[[auth.issuers]]</code> block takes <code>issuer</code> (the exact <code>iss</code> to trust), <code>jwks_url</code> (optional; omit to resolve it from the issuer&#x27;s OIDC discovery document), <code>audience</code> (optional per-issuer override), and <code>role</code>.</p>
       <h2 id="auth-signing-in-from-the-cli">Signing in from the CLI</h2>
       <p>The gate above is the hub&#x27;s half. <code>mycelium login</code> is yours: it obtains an OIDC token for <strong>you</strong>, caches it, and every later command sends it.</p>
-      <pre><code><span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> login.issuer <span class="url">https://sso.example.com/realms/mycelium</span>
-<span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> login.audience <span class="bin">mycelium</span>      # match the hub&#x27;s auth.audience
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">config</span> <span class="cmd">set</span> login.audience <span class="bin">mycelium</span>      # match the hub&#x27;s auth.audience
 <span class="bin">mycelium</span> <span class="cmd">login</span></code></pre>
       <p>Your browser opens, you sign in at your identity provider, and the CLI takes it from there: <code>mycelium memory</code>, <code>mycelium room</code>, <code>await</code>, <code>respond</code> and the rest now carry <code>Authorization: Bearer &lt;token&gt;</code>.</p>
+      <h3 id="auth-the-issuer-comes-from-the-hub">The issuer comes from the hub</h3>
+      <p>You do not set <code>login.issuer</code> to sign in. A gated hub advertises the issuers it trusts in the <code>auth</code> block of its <code>/health</code>, and <code>server.api_url</code> already points at it — so with no issuer configured and none passed, <code>login</code> asks the hub and uses the answer, remembering it once the sign-in it drove has actually worked.</p>
+      <p>Three cases where it steps back and tells you instead, rather than guessing:</p>
+      <ul>
+        <li><strong>The hub is unreachable</strong> — nothing to ask, so you get the original &quot;set <code>login.issuer</code>&quot; error.</li>
+        <li><strong>The hub&#x27;s gate is off</strong> — it needs no login at all, and says so.</li>
+        <li><strong>The hub trusts more than one issuer</strong> — which one you sign in against decides who the hub thinks you are, so it lists them and asks you to pick with <code>--issuer</code>. The lookup is still done for you; only the choice isn&#x27;t.</li>
+      </ul>
+      <p><code>--issuer</code> and a configured <code>login.issuer</code> both win over discovery, so nothing about an existing setup changes and the hub is not consulted at all.</p>
       <p><strong>On a machine with no browser</strong> (SSH, CI, a container) use the device flow. The CLI prints a URL and a short code you enter from any other device:</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">login</span> <span class="flag">--device</span></code></pre>
       <p>The CLI falls back to this automatically when it finds no browser to open, so <code>mycelium login</code> over SSH does the right thing without the flag.</p>
@@ -1976,7 +1984,7 @@ role     = &quot;user&quot;</code></pre>
             <tr>
               <td><code>login.issuer</code></td>
               <td><em>(unset)</em></td>
-              <td>OIDC issuer to log in against. Unset means no login is configured.</td>
+              <td>OIDC issuer to log in against. Unset means <code>login</code> asks the hub for one and caches what it gets.</td>
             </tr>
             <tr>
               <td><code>login.client_id</code></td>

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -933,7 +933,7 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "reference.html#cli-setup",
     "t": "mycelium login [--issuer URL] [--device] [--no-browser] [--client-id ID]",
     "s": "CLI Reference",
-    "x": "Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code).",
+    "x": "Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code); the issuer is discovered from the hub when it isn't configured.",
     "k": "cmd",
     "p": "Reference"
   },
@@ -1909,7 +1909,14 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "reference.html#auth-signing-in-from-the-cli",
     "t": "Signing in from the CLI",
     "s": "Guides › Authentication",
-    "x": "The gate above is the hub's half. mycelium login is yours: it obtains an OIDC token for you, caches it, and every later command sends it. mycelium config set login.issuer https://sso.example.com/realms/mycelium mycelium config set login.audience mycelium # match the hub's auth.audience mycelium login Your browser opens, you sign in at your identity provider, and the CLI takes it from there: mycelium memory, mycelium ",
+    "x": "The gate above is the hub's half. mycelium login is yours: it obtains an OIDC token for you, caches it, and every later command sends it. mycelium config set login.audience mycelium # match the hub's auth.audience mycelium login Your browser opens, you sign in at your identity provider, and the CLI takes it from there: mycelium memory, mycelium room, await, respond and the rest now carry Authorization: Bearer <token>",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#auth-the-issuer-comes-from-the-hub",
+    "t": "The issuer comes from the hub",
+    "s": "Guides › Authentication",
+    "x": "You do not set login.issuer to sign in. A gated hub advertises the issuers it trusts in the auth block of its /health, and server.api_url already points at it — so with no issuer configured and none passed, login asks the hub and uses the answer, remembering it once the sign-in it drove has actually worked. Three cases where it steps back and tells you instead, rather than guessing: The hub is unreachable — nothing t",
     "p": "Reference"
   },
   {
@@ -1937,7 +1944,7 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "reference.html#auth-configuration",
     "t": "Configuration",
     "s": "Guides › Authentication",
-    "x": "Key Default What it does login.issuer (unset) OIDC issuer to log in against. Unset means no login is configured. login.client_id mycelium-cli OAuth client id registered for the CLI. login.client_secret (unset) Only for issuers that refuse public clients; PKCE means the CLI normally needs none. login.scopes openid profile email offline_access Scopes requested at login. login.audience (unset) Audience to request; shoul",
+    "x": "Key Default What it does login.issuer (unset) OIDC issuer to log in against. Unset means login asks the hub for one and caches what it gets. login.client_id mycelium-cli OAuth client id registered for the CLI. login.client_secret (unset) Only for issuers that refuse public clients; PKCE means the CLI normally needs none. login.scopes openid profile email offline_access Scopes requested at login. login.audience (unset",
     "p": "Reference"
   },
   {

--- a/mycelium-cli/src/mycelium/commands/login.py
+++ b/mycelium-cli/src/mycelium/commands/login.py
@@ -12,6 +12,10 @@ because they all build their client through ``mycelium.client``. A successful
 login also points this machine's ``identity.name`` at the token's own handle,
 since a gated hub refuses a write that claims a different one.
 
+With no issuer configured, login asks the hub for one: a gated hub advertises
+what it trusts at ``/health``, so the URL is the backend's to supply rather than
+the human's to look up.
+
 Logging in is opt-in. Nothing here runs unless the user asks for it, and a hub
 with its gate off never needs it.
 """
@@ -61,6 +65,60 @@ def _announce_device(prompt: DevicePrompt) -> None:
     console.print("[dim]Waiting for you to approve…[/dim]")
 
 
+def _hub_issuers(config: MyceliumConfig) -> tuple[list[str], str | None]:
+    """The OIDC issuers the hub advertises at ``/health``, and why there are none.
+
+    The hub has to be reachable for a session to be worth anything, and it already
+    publishes what it trusts — so a spoke should not need a human to look the
+    issuer up and copy it back in. Returns the issuers and, when the list is
+    empty, a reason to print instead of a bare "no issuer configured".
+    """
+    import httpx
+
+    url = f"{config.server.api_url.rstrip('/')}/health"
+    try:
+        resp = httpx.get(url, timeout=5)
+        resp.raise_for_status()
+        body = resp.json()
+    except (httpx.HTTPError, ValueError):
+        return [], f"couldn't reach {url} to ask it"
+    auth = body.get("auth") or {} if isinstance(body, dict) else {}
+    if not auth.get("enabled"):
+        return [], f"{config.server.api_url} has its gate off, so it needs no login"
+    issuers = [str(i).strip().rstrip("/") for i in auth.get("issuers") or [] if str(i).strip()]
+    if not issuers:
+        return [], f"{config.server.api_url} is gated but advertises no issuer"
+    return issuers, None
+
+
+def _issuer_from_hub(config: MyceliumConfig, *, json_output: bool) -> str | None:
+    """The hub's issuer, when it names exactly one.
+
+    Several trusted issuers is not a default to guess at: which one you sign in
+    against decides who the hub thinks you are, so the choice is named rather
+    than taken. Prints what it found either way — the lookup is the friction, and
+    a listed issuer is one ``--issuer`` away even when it can't be picked here.
+    """
+    issuers, why = _hub_issuers(config)
+    if not issuers:
+        console.print(f"[red]Error:[/red] no OIDC issuer configured, and {why}.")
+        console.print(
+            "[dim]Set one with: mycelium config set login.issuer "
+            "https://sso.example.com/realms/mycelium[/dim]"
+        )
+        console.print("[dim]Or pass it once: mycelium login --issuer <url>[/dim]")
+        return None
+    if len(issuers) > 1:
+        console.print(f"[red]Error:[/red] {config.server.api_url} trusts more than one issuer:")
+        for candidate in issuers:
+            console.print(f"  {candidate}")
+        console.print("[dim]Pick one: mycelium login --issuer <url>[/dim]")
+        return None
+    if not json_output:
+        console.print(f"[dim]Issuer discovered from {config.server.api_url}: {issuers[0]}[/dim]")
+    return issuers[0]
+
+
 def _persist_login_config(
     config: MyceliumConfig,
     *,
@@ -68,8 +126,9 @@ def _persist_login_config(
     client_id: str | None,
     audience: str | None,
     scope: str | None,
+    json_output: bool,
 ) -> None:
-    """Remember explicitly-passed login settings so the next login needs no flags."""
+    """Remember the login settings this run resolved, so the next needs no flags."""
     changed = False
     for field, value in (
         ("issuer", issuer),
@@ -82,7 +141,8 @@ def _persist_login_config(
             changed = True
     if changed:
         config.save()
-        console.print(f"[dim]Saved login settings to {MyceliumConfig.get_config_path()}[/dim]")
+        if not json_output:
+            console.print(f"[dim]Saved login settings to {MyceliumConfig.get_config_path()}[/dim]")
 
 
 # What ``_align_identity`` did with the token's handle, for ``_report`` to narrate.
@@ -173,13 +233,18 @@ def _report(
 
 @doc_ref(
     usage="mycelium login [--issuer URL] [--device] [--no-browser] [--client-id ID]",
-    desc="Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code).",
+    desc=(
+        "Sign in to a gated hub via OIDC (Authorization Code + PKCE, or device code); "
+        "the issuer is discovered from the hub when it isn't configured."
+    ),
     group="setup",
 )
 def login(
     ctx: typer.Context,
     issuer: str | None = typer.Option(
-        None, "--issuer", help="OIDC issuer URL (default: login.issuer from config)."
+        None,
+        "--issuer",
+        help="OIDC issuer URL (default: login.issuer, else discovered from the hub).",
     ),
     client_id: str | None = typer.Option(
         None, "--client-id", help="OAuth client id to log in as (default: login.client_id)."
@@ -202,6 +267,10 @@ def login(
 ) -> None:
     """Obtain an OIDC token for the hub and cache it for subsequent commands.
 
+    With neither ``--issuer`` nor ``login.issuer``, the hub named by
+    ``server.api_url`` is asked for the issuer it trusts, and a single answer is
+    used and remembered.
+
     Examples:
         mycelium login
         mycelium login --issuer https://sso.example.com/realms/mycelium
@@ -211,14 +280,12 @@ def login(
     json_output = ctx.obj.get("json", False) if ctx.obj else False
 
     resolved_issuer = (issuer or config.login.issuer or "").strip().rstrip("/")
+    discovered = None
     if not resolved_issuer:
-        console.print("[red]Error:[/red] no OIDC issuer configured.")
-        console.print(
-            "[dim]Set one with: mycelium config set login.issuer "
-            "https://sso.example.com/realms/mycelium[/dim]"
-        )
-        console.print("[dim]Or pass it once: mycelium login --issuer <url>[/dim]")
-        raise typer.Exit(1)
+        discovered = _issuer_from_hub(config, json_output=json_output)
+        if not discovered:
+            raise typer.Exit(1)
+        resolved_issuer = discovered
 
     resolved_client_id = (client_id or config.login.client_id).strip()
     resolved_scope = (scope or config.login.scopes).strip()
@@ -275,10 +342,13 @@ def login(
 
     _persist_login_config(
         config,
-        issuer=issuer,
+        # A discovered issuer is remembered like a passed one: it cost a round
+        # trip, and it is only written once the login it drove actually worked.
+        issuer=issuer or discovered,
         client_id=client_id,
         audience=audience,
         scope=scope,
+        json_output=json_output,
     )
 
     handle = token.handle(config.auth.handle_claim) or token.handle()

--- a/mycelium-cli/src/mycelium/docs/guides/auth.md
+++ b/mycelium-cli/src/mycelium/docs/guides/auth.md
@@ -79,7 +79,6 @@ The gate above is the hub's half. `mycelium login` is yours: it obtains an OIDC
 token for **you**, caches it, and every later command sends it.
 
 ```bash
-mycelium config set login.issuer https://sso.example.com/realms/mycelium
 mycelium config set login.audience mycelium      # match the hub's auth.audience
 mycelium login
 ```
@@ -87,6 +86,25 @@ mycelium login
 Your browser opens, you sign in at your identity provider, and the CLI takes it
 from there: `mycelium memory`, `mycelium room`, `await`, `respond` and the rest
 now carry `Authorization: Bearer <token>`.
+
+### The issuer comes from the hub
+
+You do not set `login.issuer` to sign in. A gated hub advertises the issuers it
+trusts in the `auth` block of its `/health`, and `server.api_url` already points
+at it — so with no issuer configured and none passed, `login` asks the hub and
+uses the answer, remembering it once the sign-in it drove has actually worked.
+
+Three cases where it steps back and tells you instead, rather than guessing:
+
+- **The hub is unreachable** — nothing to ask, so you get the original "set
+  `login.issuer`" error.
+- **The hub's gate is off** — it needs no login at all, and says so.
+- **The hub trusts more than one issuer** — which one you sign in against decides
+  who the hub thinks you are, so it lists them and asks you to pick with
+  `--issuer`. The lookup is still done for you; only the choice isn't.
+
+`--issuer` and a configured `login.issuer` both win over discovery, so nothing
+about an existing setup changes and the hub is not consulted at all.
 
 **On a machine with no browser** (SSH, CI, a container) use the device flow.
 The CLI prints a URL and a short code you enter from any other device:
@@ -145,7 +163,7 @@ it. Setting a handle your token won't back with `iam` still warns.
 
 | Key | Default | What it does |
 |-----|---------|--------------|
-| `login.issuer` | *(unset)* | OIDC issuer to log in against. Unset means no login is configured. |
+| `login.issuer` | *(unset)* | OIDC issuer to log in against. Unset means `login` asks the hub for one and caches what it gets. |
 | `login.client_id` | `mycelium-cli` | OAuth client id registered for the CLI. |
 | `login.client_secret` | *(unset)* | Only for issuers that refuse public clients; PKCE means the CLI normally needs none. |
 | `login.scopes` | `openid profile email offline_access` | Scopes requested at login. |

--- a/mycelium-cli/tests/test_login.py
+++ b/mycelium-cli/tests/test_login.py
@@ -421,7 +421,36 @@ def test_an_expired_token_with_no_refresh_token_sends_nothing() -> None:
 # ── the commands ─────────────────────────────────────────────────────────────
 
 
-def test_login_without_a_configured_issuer_says_what_to_do() -> None:
+def _health(monkeypatch: pytest.MonkeyPatch, payload: Any, *, boom: bool = False) -> list[str]:
+    """Stub the hub's ``/health`` — where login looks when it has no issuer.
+
+    ``_hub_issuers`` imports httpx inside the call, so the module object is what
+    has to be patched; it is the same one either way.
+    """
+    asked: list[str] = []
+
+    class _Resp:
+        def raise_for_status(self) -> None: ...
+
+        def json(self) -> Any:
+            return payload
+
+    def fake_get(url: str, timeout: float) -> _Resp:  # noqa: ARG001
+        asked.append(url)
+        if boom:
+            raise httpx.ConnectError("connection refused")
+        return _Resp()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    return asked
+
+
+def test_login_without_a_configured_issuer_says_what_to_do(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unreachable hub falls back to the original tell-me-what-to-do error."""
+    _health(monkeypatch, None, boom=True)
+
     result = runner.invoke(app, ["login"])
 
     assert result.exit_code == 1
@@ -566,6 +595,161 @@ def test_whoami_is_unchanged_when_logged_out() -> None:
     assert payload["principal"] == "avery"
 
 
+def _auth(*issuers: str, enabled: bool = True) -> dict[str, Any]:
+    return {"auth": {"enabled": enabled, "issuers": list(issuers)}}
+
+
+def test_login_discovers_the_issuer_from_the_hub(
+    monkeypatch: pytest.MonkeyPatch, hub: _Hub
+) -> None:
+    """The hub advertises what it trusts, so the human never looks it up (#881)."""
+    from mycelium.commands import login as login_cmd
+
+    asked = _health(monkeypatch, _auth(_META.issuer))
+    seen: dict[str, str] = {}
+
+    def fake_discover(url: str) -> ProviderMetadata:
+        seen["issuer"] = url
+        return _META
+
+    monkeypatch.setattr(login_cmd, "_browser_available", lambda: True)
+    monkeypatch.setattr(login_cmd, "discover", fake_discover)
+    monkeypatch.setattr(
+        login_cmd,
+        "authorization_code_login",
+        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": "avery"})),
+    )
+
+    result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 0, result.stdout
+    assert asked == [f"{MyceliumConfig.load().server.api_url.rstrip('/')}/health"]
+    assert seen["issuer"] == _META.issuer
+    assert "Issuer discovered from" in _flat(result.stdout)
+    # Remembered, so the next login costs no round trip.
+    assert MyceliumConfig.load().login.issuer == _META.issuer
+
+
+def test_json_login_stays_parseable_while_discovering_and_saving(
+    monkeypatch: pytest.MonkeyPatch, hub: _Hub
+) -> None:
+    """Discovery both prints and saves, and --json promises one JSON document."""
+    from mycelium.commands import login as login_cmd
+
+    _health(monkeypatch, _auth(_META.issuer))
+    monkeypatch.setattr(login_cmd, "_browser_available", lambda: True)
+    monkeypatch.setattr(login_cmd, "discover", lambda _issuer: _META)
+    monkeypatch.setattr(
+        login_cmd,
+        "authorization_code_login",
+        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": "avery"})),
+    )
+
+    result = runner.invoke(app, ["--json", "login"])
+
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["handle"] == "avery"
+    # Saved anyway — quiet is not the same as skipped.
+    assert MyceliumConfig.load().login.issuer == _META.issuer
+
+
+def test_login_prefers_a_configured_issuer_over_asking_the_hub(
+    monkeypatch: pytest.MonkeyPatch, hub: _Hub
+) -> None:
+    asked = _health(monkeypatch, _auth("https://wrong.test/realms/other"))
+    config = MyceliumConfig.load()
+    config.login.issuer = _META.issuer
+    config.save()
+
+    from mycelium.commands import login as login_cmd
+
+    monkeypatch.setattr(login_cmd, "_browser_available", lambda: True)
+    monkeypatch.setattr(login_cmd, "discover", lambda _issuer: _META)
+    monkeypatch.setattr(
+        login_cmd,
+        "authorization_code_login",
+        lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": "avery"})),
+    )
+
+    result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 0, result.stdout
+    # Configured means configured: the hub is not consulted at all.
+    assert asked == []
+
+
+def test_login_refuses_to_guess_between_several_trusted_issuers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Which issuer you sign in against decides who the hub thinks you are."""
+    _health(monkeypatch, _auth("https://a.test/realms/x", "https://b.test/realms/y"))
+
+    result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 1
+    assert "more than one issuer" in _flat(result.stdout)
+    # Listed, so the lookup is still done for you even when the pick isn't.
+    assert "https://a.test/realms/x" in result.stdout
+    assert "https://b.test/realms/y" in result.stdout
+    assert load_token() is None
+
+
+def test_login_says_an_ungated_hub_needs_no_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    _health(monkeypatch, _auth(enabled=False))
+
+    result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 1
+    assert "gate off" in _flat(result.stdout)
+    assert load_token() is None
+
+
+def test_login_says_when_a_gated_hub_advertises_no_issuer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _health(monkeypatch, _auth())
+
+    result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 1
+    assert "advertises no issuer" in _flat(result.stdout)
+
+
+def test_login_survives_a_health_endpoint_that_is_not_an_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A proxy or a wrong port can answer /health with anything at all."""
+    _health(monkeypatch, ["not", "an", "object"])
+
+    result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 1
+    assert "no OIDC issuer configured" in _flat(result.stdout)
+
+
+def test_a_discovered_issuer_is_not_remembered_when_the_login_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caching a URL that never produced a session would poison the next login."""
+    _health(monkeypatch, _auth(_META.issuer))
+
+    from mycelium.commands import login as login_cmd
+
+    monkeypatch.setattr(login_cmd, "_browser_available", lambda: True)
+    monkeypatch.setattr(login_cmd, "discover", lambda _issuer: _META)
+
+    def boom(*_a: Any, **_k: Any) -> None:
+        raise OidcError("access_denied: user said no")
+
+    monkeypatch.setattr(login_cmd, "authorization_code_login", boom)
+
+    result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 1
+    assert MyceliumConfig.load().login.issuer is None
+    assert load_token() is None
+
+
 def test_iam_with_no_handle_reports_rather_than_asserting() -> None:
     save_token(_token(access_token=_jwt({"sub": "avery", "exp": time.time() + 3600})))
 
@@ -594,8 +778,6 @@ def _login(
         lambda *_a, **_k: oidc.TokenResponse(access_token=_jwt({"sub": sub})),
     )
     if json_output:
-        # Configured rather than passed: an explicit --issuer prints a
-        # "saved login settings" line that isn't part of the JSON document.
         config = MyceliumConfig.load()
         config.login.issuer = _META.issuer
         config.save()


### PR DESCRIPTION
## Summary

`mycelium login` refused to run without `login.issuer` and told the human to go find the URL themselves. But a gated hub already advertises the issuers it trusts in the `auth` block of `/health`, and `server.api_url` has to point at that hub for a session to be worth anything — so the backend had the answer and the person was made to relay it. Same shape as #882, which removed the other half of this onboarding path.

With neither `--issuer` nor `login.issuer`, login now asks the hub, uses a single advertised issuer, and remembers it **only once the sign-in it drove has actually worked** — caching a URL that never produced a session would poison the next attempt.

One call worth arguing with: **several trusted issuers gets listed, not guessed.** The issue sanctions "using the first / only entry, or prompting if there's more than one". I do neither — silently signing you in against whichever issuer the hub happened to list first decides who the hub thinks you are, and a prompt would hang the `--device` flow in CI, which is exactly where this path runs headless. So it prints the candidates and asks for `--issuer`. The lookup — the actual friction the issue is about — is still done for you; only the choice isn't.

It steps back rather than guessing in three cases, each with its own message instead of a bare "no issuer configured":

- **Hub unreachable** → the original set-`login.issuer` error.
- **Hub's gate is off** → says it needs no login at all.
- **Several issuers** → lists them, asks you to pick.

An explicit `--issuer` and a configured `login.issuer` both win and don't consult the hub at all, so no existing setup changes behavior.

**One thing this drags in, and why it isn't scope creep.** Discovery both prints a line and saves to config, which put two non-JSON lines in front of `--json login`'s document *on a path that previously had none* — the same wart I flagged when closing #882. Since my change is what makes it reachable there, both are now quiet under `--json`. The saving still happens; quiet is not the same as skipped, and there's a test pinning that.

**Not done:** the hub also advertises `auth.audience` in the very same payload, and `login.audience` "should match the hub's auth.audience" per the CLI's own help. Auto-filling it when unset is one line on top of the fetch this PR already does, and without it a discovered issuer can still yield a token the hub rejects on `aud`. I left it out because #881 asks for the issuer and this is a separate behavior change — but it is the obvious next step and I'd take it in a follow-up if you want it.

## Changes

- `commands/login.py`:
  - `_hub_issuers()` reads `auth.issuers` off `GET {api_url}/health`, returning the issuers plus a reason when there are none. Tolerates a `/health` that isn't a JSON object (a proxy or a wrong port can answer with anything).
  - `_issuer_from_hub()` turns that into an issuer or a specific refusal.
  - `login()` consults it only when nothing is configured or passed, and threads the discovered value into `_persist_login_config` so it caches after success.
  - `_persist_login_config()` takes `json_output` and stays quiet under it.
- `docs/guides/auth.md`: drops `login.issuer` from the sign-in snippet, adds "The issuer comes from the hub" covering the three step-back cases and the precedence rule; regenerated `docs/*.html`, `search-index.js`, `llms-full.txt`.

## Testing

Seven new tests in `mycelium-cli/tests/test_login.py`, each mutation-checked rather than assumed — neutering discovery fails four, dropping config precedence fails another, caching before the login succeeds fails the "not remembered on failure" test, and removing the `--json` guard fails the parseable-output test:

- discovers the issuer, asks exactly `{api_url}/health`, passes it to the OIDC `discover`, and caches it
- a configured issuer wins and the hub is **not** consulted at all
- refuses to guess between several issuers, and lists them
- says an ungated hub needs no login
- says when a gated hub advertises no issuer
- survives a `/health` that isn't a JSON object
- doesn't remember a discovered issuer when the login itself fails
- `--json login` stays parseable while discovering *and* saving

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 741 passed, 2 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`) — one pre-existing drift in `tests/test_slim_master_secret_config.py`, untouched here and not flagged by CI's pinned ruff
- [x] `uv run ty check .` clean
- [x] `docs/generate_docs.py` regenerated, no drift beyond the guide edit

Verified the payload shape against the live hub rather than assuming it: `auth` returns `{enabled, issuers, localhost_bypass, audience}`.

## Related Issues

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ugScMzxTqxCe51oV52Upr

---
_Generated by [Claude Code](https://claude.ai/code/session_019ugScMzxTqxCe51oV52Upr)_