### PR TITLE
Style markdown headings as document structure, not label chrome (#888)

### DIFF
--- a/mycelium-frontend/src/app/globals.css
+++ b/mycelium-frontend/src/app/globals.css
@@ -276,19 +276,25 @@ body {
 /* Headings are document structure, so they descend in size and hold primary
  * contrast the whole way down. Sized in em rather than the UI scale: that scale
  * tops out at 16px for chrome, and a body renders at whatever size its surface
- * sets, so the ramp has to be relative to it. */
+ * sets, so the ramp has to be relative to it.
+ *
+ * The ramp is deliberately shallow. The same body renders inside a chat message,
+ * where a heading is a line of someone's post rather than a document title — so
+ * weight, spacing and one contrast step do most of the separating, and size only
+ * tips the top of the scale. At the 14px these surfaces set, h1 lands at ~17px:
+ * about the app's largest UI size, not a document title above it. */
 .markdown-body h1, .markdown-body h2, .markdown-body h3,
 .markdown-body h4, .markdown-body h5, .markdown-body h6 {
-  margin: 1.3em 0 0.5em; color: var(--text); font-weight: 700; line-height: 1.3;
+  margin: 1.2em 0 0.45em; color: var(--text); font-weight: 700; line-height: 1.35;
   font-family: 'IBM Plex Sans', sans-serif;
 }
-.markdown-body h1 { font-size: 1.5em; letter-spacing: -0.01em; }
-.markdown-body h2 { font-size: 1.25em; }
-.markdown-body h3 { font-size: 1.1em; }
+.markdown-body h1 { font-size: 1.2em; }
+.markdown-body h2 { font-size: 1.1em; }
+.markdown-body h3 { font-size: 1.05em; }
 .markdown-body h4 { font-size: 1em; }
 /* Past h4 there is no size left to spend; weight and one contrast step carry it. */
 .markdown-body h5 { font-size: 1em; font-weight: 600; color: var(--text2); }
-.markdown-body h6 { font-size: 0.92em; font-weight: 600; color: var(--text2); }
+.markdown-body h6 { font-size: 0.95em; font-weight: 600; color: var(--text2); }
 /* A heading directly under a heading opens no section of its own to separate. */
 .markdown-body :is(h1, h2, h3, h4, h5, h6) + :is(h1, h2, h3, h4, h5, h6) {
   margin-top: 0.6em;

--- a/mycelium-frontend/src/app/globals.css
+++ b/mycelium-frontend/src/app/globals.css
@@ -273,14 +273,26 @@ body {
 .markdown-body ol { list-style: decimal; }
 .markdown-body li { margin: 0.15em 0; line-height: 1.55; color: var(--text2); }
 .markdown-body li::marker { color: var(--muted); }
-.markdown-body h1, .markdown-body h2, .markdown-body h3, .markdown-body h4 {
-  margin: 0.8em 0 0.4em; color: var(--text); font-weight: 700; line-height: 1.25;
+/* Headings are document structure, so they descend in size and hold primary
+ * contrast the whole way down. Sized in em rather than the UI scale: that scale
+ * tops out at 16px for chrome, and a body renders at whatever size its surface
+ * sets, so the ramp has to be relative to it. */
+.markdown-body h1, .markdown-body h2, .markdown-body h3,
+.markdown-body h4, .markdown-body h5, .markdown-body h6 {
+  margin: 1.3em 0 0.5em; color: var(--text); font-weight: 700; line-height: 1.3;
   font-family: 'IBM Plex Sans', sans-serif;
 }
-.markdown-body h1 { font-size: var(--text-ui); }
-.markdown-body h2 { font-size: var(--text-body); text-transform: uppercase; letter-spacing: 0.08em; color: var(--text2); }
-.markdown-body h3 { font-size: var(--text-label); text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); }
-.markdown-body h4 { font-size: var(--text-label); color: var(--text2); }
+.markdown-body h1 { font-size: 1.5em; letter-spacing: -0.01em; }
+.markdown-body h2 { font-size: 1.25em; }
+.markdown-body h3 { font-size: 1.1em; }
+.markdown-body h4 { font-size: 1em; }
+/* Past h4 there is no size left to spend; weight and one contrast step carry it. */
+.markdown-body h5 { font-size: 1em; font-weight: 600; color: var(--text2); }
+.markdown-body h6 { font-size: 0.92em; font-weight: 600; color: var(--text2); }
+/* A heading directly under a heading opens no section of its own to separate. */
+.markdown-body :is(h1, h2, h3, h4, h5, h6) + :is(h1, h2, h3, h4, h5, h6) {
+  margin-top: 0.6em;
+}
 .markdown-body code {
   font-family: 'Geist Mono', 'SF Mono', Menlo, monospace;
   font-size: 0.9em;

--- a/mycelium-frontend/src/components/markdown-content.test.tsx
+++ b/mycelium-frontend/src/components/markdown-content.test.tsx
@@ -136,3 +136,41 @@ describe("<MarkdownContent /> memory links", () => {
     expect(paragraphs[0].querySelector("br")).toBeInTheDocument();
   });
 });
+
+describe("<MarkdownContent /> headings", () => {
+  it("renders every heading level as a heading element", () => {
+    // h5/h6 have no entry in the component map unless one is declared, and
+    // Tailwind's preflight resets headings to body size and weight — so a level
+    // that falls out of the map renders as prose with a heading role and no
+    // visible difference from the paragraph above it.
+    render(
+      <MarkdownContent>
+        {"# One\n\n## Two\n\n### Three\n\n#### Four\n\n##### Five\n\n###### Six"}
+      </MarkdownContent>,
+    );
+
+    for (const [level, text] of [
+      [1, "One"],
+      [2, "Two"],
+      [3, "Three"],
+      [4, "Four"],
+      [5, "Five"],
+      [6, "Six"],
+    ] as const) {
+      expect(screen.getByRole("heading", { level, name: text })).toBeInTheDocument();
+    }
+  });
+
+  it("processes mentions and memory links inside a heading", () => {
+    const onLinkClick = vi.fn();
+    render(
+      <MarkdownContent onLinkClick={onLinkClick}>
+        {"###### @alice on [[work/api]]"}
+      </MarkdownContent>,
+    );
+
+    const heading = screen.getByRole("heading", { level: 6 });
+    expect(heading).toContainElement(screen.getByText("@alice"));
+    expect(heading).toContainElement(screen.getByRole("button", { name: /work\/api/ }));
+  });
+});

--- a/mycelium-frontend/src/components/markdown-content.tsx
+++ b/mycelium-frontend/src/components/markdown-content.tsx
@@ -245,6 +245,8 @@ export function MarkdownContent({ children, className, onLinkClick, brokenLinks 
           h2: ({ children }) => <h2>{processNode(children)}</h2>,
           h3: ({ children }) => <h3>{processNode(children)}</h3>,
           h4: ({ children }) => <h4>{processNode(children)}</h4>,
+          h5: ({ children }) => <h5>{processNode(children)}</h5>,
+          h6: ({ children }) => <h6>{processNode(children)}</h6>,
         }}
       >
         {children}

--- a/mycelium-frontend/src/components/markdown-headings.contract.test.ts
+++ b/mycelium-frontend/src/components/markdown-headings.contract.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// Heading styling lives in globals.css, and jsdom does not apply a stylesheet a
+// component never imports — so a rendering test cannot see it. This reads the
+// rules back out of the source instead and asserts the two properties #888 was
+// about: a markdown heading is not label chrome, and the levels form a ramp.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CSS_PATH = path.resolve(__dirname, "../app/globals.css");
+const LEVELS = [1, 2, 3, 4, 5, 6] as const;
+
+/** Every declaration that reaches `.markdown-body h{level}`, in source order. */
+function declarations(level: number): string[] {
+  const css = readFileSync(CSS_PATH, "utf-8");
+  const selector = new RegExp(`\\.markdown-body h${level}(?![\\d\\w-])`);
+  const rules = css.matchAll(/([^{}]+)\{([^{}]*)\}/g);
+  return [...rules]
+    .filter(([, sel]) => selector.test(sel) && !sel.includes("+"))
+    .flatMap(([, , body]) => body.split(";").map(d => d.trim()))
+    .filter(Boolean);
+}
+
+/** The `font-size` a level resolves to, as a multiple of the body's own size. */
+function fontSize(level: number): number {
+  const declared = declarations(level).filter(d => d.startsWith("font-size:"));
+  const last = declared.at(-1);
+  expect(last, `h${level} declares no font-size`).toBeDefined();
+  const em = /^font-size:\s*([\d.]+)em$/.exec(last!);
+  expect(em, `h${level} sizes in ${last} — the ramp is relative to the body`).not.toBeNull();
+  return Number(em![1]);
+}
+
+describe("markdown heading styling", () => {
+  it("never uppercases a heading", () => {
+    for (const level of LEVELS) {
+      expect(declarations(level).join("; ")).not.toMatch(/text-transform:\s*uppercase/);
+    }
+  });
+
+  it("descends in size, so the levels read as a hierarchy", () => {
+    const sizes = LEVELS.map(fontSize);
+    expect(sizes[0]).toBeGreaterThan(1);
+    for (let i = 1; i < sizes.length; i++) {
+      expect(sizes[i], `h${i + 1} is larger than h${i}`).toBeLessThanOrEqual(sizes[i - 1]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`.markdown-body` uppercased `h2`/`h3` with label tracking and ran a *descending* colour ramp under it (`h2` → `--text2`, `h3` → `--muted`), so a `## Heading` rendered as UI label chrome and each level below faded further out.

The uppercasing was the visible half. The half underneath it is why the section "generally looks bad": **there was no hierarchy to strip back to.** `h1` was 16px, `h2` was 14px — body size — and `h3`/`h4` were 13px, *smaller* than the paragraphs they introduced. Remove the caps and nothing distinguishes a heading from a bold line.

So this does both things the issue asks for: drops the transform and the label tracking, and puts a real size/weight/margin ramp in their place.

| | before | after | at the 14px these surfaces set |
|---|---|---|---|
| h1 | 16px | 1.2em | ~17px |
| h2 | 14px, ALL CAPS, muted | 1.1em | ~15px |
| h3 | 13px, ALL CAPS, muted further | 1.05em | ~15px |
| h4 | 13px, muted | 1em | 14px |
| h5 / h6 | *unstyled — read as body copy* | 1em / 0.95em, weight 600 | 14px / ~13px |

**The ramp is deliberately shallow.** The same body renders inside a chat message, where a heading is a line of someone's post rather than a document title, so `h1` lands about at the app's largest UI size rather than above it. Weight, spacing and one contrast step do most of the separating; size only tips the top of the scale.

## Changes

- **`globals.css` — the heading block.** No `text-transform`, no label `letter-spacing`, primary contrast all the way down to `h4`. `h5`/`h6` join the shared rule and spend weight plus one contrast step, since there is no size left below body. Margins are `1.2em 0 0.45em`, and because they are in `em` they scale with the heading's own size, so a bigger heading opens a bigger gap for free. One adjacency rule: a heading directly under a heading opens no section of its own to separate, so it tightens to `0.6em`.
- **Sized in `em`, not the UI token scale.** Deliberate, and the call most worth arguing with. That scale is five *chrome* roles topping out at 16px with nothing between it and the 25px serif wordmark, so it cannot express a document. A body also renders at whatever size its surface sets, so the ramp has to be relative to that. `.markdown-body code { font-size: 0.9em }` was already the precedent.
- **`markdown-content.tsx` — `h5`/`h6` added to the component map.** They reached neither the CSS block nor the renderer, so Tailwind's preflight left them at body size and weight: a `##### Heading` was literally indistinguishable from the paragraph above it. Being absent from the map also meant `@mentions` and `[[links]]` inside them stayed plain text; now they chip like every other level.

**What I deliberately did not touch.** `th` keeps its uppercase mono — a table header cell is chrome, not a heading in the document outline, and it reads correctly as a column label. Paragraph and list rhythm is unchanged too: the ask names the heading scale, and `p`/`li` spacing is shared with every chat message in the app, so retuning it is a much wider blast radius than this issue justifies.

## Testing

`.markdown-body` lives in `globals.css`, which jsdom never applies — a rendering test cannot see it. `markdown-headings.contract.test.ts` reads the rules back out of the source instead and pins the two properties #888 is about: **no heading level is uppercased**, and **the sizes never rise** from `h1` to `h6`. Both mutation-checked on a scratch copy — reintroducing `text-transform: uppercase` on `h2` fails the first, making `h3` larger than `h2` fails the second with the level named. It pins those properties rather than specific values, so tuning the ramp does not require rewriting the test.

Two renderer tests cover the map: every level `1..6` resolves to a heading element of that level, and a mention plus a wikilink inside an `h6` still render as chips.

- [x] Frontend unit tests pass (`pnpm test` — 60 files, 762 tests; was 59/758)
- [x] Lint + typecheck pass (`pnpm lint` — 0 errors; the 2 warnings are pre-existing in `use-collapsible-rail.ts`)
- [x] Production build passes (`pnpm build`)
- [ ] ~Backend gates~ — no backend code in this PR

### Looked at, not just tested

Captured on both surfaces `MarkdownContent` serves, with a fixture temporarily carrying an `h1`→`h6` document. No image is embedded here: minting a `user-attachments` URL needs GitHub's web drag-drop, which I have no equivalent of, and I would rather describe the shots than link placeholders that 404. Happy to have them dropped in.

- **Memory page, before** — `DECISION` and `ROLLBACK` sit as greyed all-caps labels, visually *below* the paragraphs they head. `Preconditions` is smaller than its own body copy. `Owners` and `Notes` are indistinguishable from paragraphs; nothing marks them as headings at all.
- **Memory page, after** — one clear document: the `h1` title leads, `Decision` and `Rollback` step down at full contrast, `Preconditions` holds at body size on weight alone, and `Owners` / `Notes` read as the minor headings they are. The section gaps open above each heading rather than floating evenly between everything.
- **Room channel, after** — the same markdown posted as one chat message. `# Cutover readiness` reads as a bolded lead line of a post, not a document title dropped into the conversation. This is the tighter of the two constraints, and tuning against the memory page alone is what produced a first ramp that was too large; the current scale is the corrected one.

The capture host has no webfont access, so the shots render in fallback fonts — fine for judging the ramp, which is size, weight and spacing, and not something I would publish as a docs asset.

### Known soft spot

`h4` and `h5` both sit at body size, separated only by weight (700 vs 600) and one contrast step. That is the weakest rung of the ramp. Deliberate — there is no size left below body that does not collide with the paragraphs — but if it wants more daylight, the `h5` colour is the place to spend it rather than the size.

## Related Issues

Closes #888