### PR TITLE
Lift the room's churn out of the conversation and into a rail (#886)

### DIFF
--- a/mycelium-frontend/src/components/activity-rail.tsx
+++ b/mycelium-frontend/src/components/activity-rail.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, MessageSquare } from "lucide-react";
+
+/** One subject's whole run of activity, as the rail shows it. */
+export interface ActivityItem {
+  /** The row's key, or a thread URN where the room knows no row. */
+  subject: string;
+  title: string;
+  /** The thread to open, when there is one. */
+  episode: string | null;
+  /** How many frames the room raised about it. */
+  count: number;
+  /** Who moved it, in the order they first did. */
+  actors: string[];
+  /** The clock of the most recent one. */
+  time: string;
+}
+
+/** How many rows stand open before the rest go behind "more". */
+const SHOWN = 3;
+
+/**
+ * What the room has been doing, held still above the conversation.
+ *
+ * A room under load raises far more state than speech — a task being worked
+ * writes memory, pings its thread and moves on the board, and none of that is
+ * something anybody said. Woven into the feed it is a changelog with the
+ * conversation buried in it; here it is a fixed number of rows that update in
+ * place, so a busy hour costs the same height as a quiet one and the channel
+ * below stays what people wrote.
+ *
+ * Bounded on purpose: the rail is the room's current state, not its history.
+ * Everything it names is one click from its thread, and the transitions worth
+ * narrating — filed, resolved, blocked — still land in the feed in sequence.
+ */
+export function ActivityRail({
+  items,
+  onOpenThread,
+}: {
+  items: ActivityItem[];
+  onOpenThread?: (episode: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  if (!items.length) return null;
+  const shown = open ? items : items.slice(0, SHOWN);
+  const hidden = items.length - shown.length;
+
+  return (
+    <div className="flex-shrink-0 border-b border-border bg-surface-2/40 px-5 py-2">
+      <div className="flex items-center gap-2 text-micro text-muted-foreground">
+        <span className="font-medium">Recently updated</span>
+        <span className="text-faint">
+          {items.length} {items.length === 1 ? "task" : "tasks"}
+        </span>
+        {items.length > SHOWN && (
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            aria-expanded={open}
+            aria-label={open ? "Show fewer" : `Show all ${items.length}`}
+            className="ml-auto inline-flex items-center gap-0.5 rounded px-1 text-faint transition-colors hover:bg-surface-2 hover:text-muted-foreground"
+          >
+            {open ? (
+              <ChevronDown className="size-3" strokeWidth={1.9} />
+            ) : (
+              <ChevronRight className="size-3" strokeWidth={1.9} />
+            )}
+            {open ? "fewer" : `${hidden} more`}
+          </button>
+        )}
+      </div>
+      <ul className="mt-1 flex flex-col">
+        {shown.map((item) => (
+          <li key={item.subject}>
+            <button
+              type="button"
+              onClick={() => item.episode && onOpenThread?.(item.episode)}
+              disabled={!item.episode || !onOpenThread}
+              title={item.subject}
+              className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left text-micro text-muted-foreground transition-colors enabled:hover:bg-surface-2 disabled:cursor-default"
+            >
+              <MessageSquare className="size-3 flex-shrink-0 text-accent" strokeWidth={1.9} />
+              <span className="min-w-0 flex-1 truncate text-text">{item.title}</span>
+              <span className="flex-shrink-0 text-faint">
+                {item.count} {item.count === 1 ? "update" : "updates"}
+              </span>
+              <span className="hidden max-w-[12rem] flex-shrink-0 truncate sm:inline">
+                {item.actors.map((h) => `@${h}`).join(", ")}
+              </span>
+              <span className="tabular flex-shrink-0 text-faint">{item.time.slice(0, 5)}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/event-stream.activity.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.activity.test.tsx
@@ -1,24 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Mycelium Contributors
 
-// What the room's timeline does with its own bookkeeping.
+// What the room's own bookkeeping does to the conversation.
 //
-// A task moving raises three different frames — a board notice, a memory push,
-// a thread ping — and each is worth keeping. Printed one per line they bury the
-// conversation they accompany, so the feed condenses them into one block per
-// task and opens it on demand. These cases are about that block: that it forms,
-// that it names the task rather than its slug, and that nothing folded into it
-// is lost.
+// A task being worked writes memory, pings its thread and moves on the board,
+// and none of that is something anybody said. Taken from a live capture of the
+// hub's own room: ninety minutes, seven agents, 76 system lines and not one
+// sentence of speech. These cases pin the split that makes that legible — the
+// churn goes to the rail, the transitions worth narrating stay in the feed, and
+// the roster's own writes appear in neither.
 
 import { act } from "react";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithSWR } from "@/test/swr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FakeEventSource } from "@/test/fake-event-source";
 import { resetStreamHub } from "@/lib/stream-hub";
 import { fetchL9History, fetchMessages, fetchMemories } from "@/lib/api";
-import { ACTIVITY_WINDOW_MS } from "@/lib/threads";
 
 vi.mock("@/lib/api", () => ({
   fetchMessages: vi.fn().mockResolvedValue({ messages: [] }),
@@ -37,22 +36,23 @@ const LIVE = "urn:ioc:mycelium:episode:atlas:live";
 const THREAD = "urn:ioc:mycelium:episode:atlas:t3aa11bb";
 const TASK = "work/flip-reads-behind-a-flag";
 const TITLE = "flip reads behind a flag";
+const OTHER_TASK = "work/retire-the-legacy-store";
+const OTHER_TITLE = "48h soak, then retire the legacy store";
 const T0 = Date.parse("2026-08-26T10:00:00.000Z");
 const at = (offsetMs = 0) => new Date(T0 + offsetMs).toISOString();
 
-/** The board row the three frames below are all about. */
-const row = {
-  key: TASK,
-  value: { title: TITLE },
+const row = (key: string, title: string, episode: string | null) => ({
+  key,
+  value: { title },
   version: 3,
   created_by: "aligner",
   updated_at: at(),
-  episode: THREAD,
-};
+  ...(episode ? { episode } : {}),
+});
 
-function notice(subkind: string, by: string, offsetMs = 0) {
+function notice(subkind: string, by: string, offsetMs = 0, key = TASK, title = TITLE) {
   return {
-    id: `notice-${subkind}`,
+    id: `notice-${subkind}-${key}`,
     message_type: "l9_exchange",
     sender_handle: "system",
     created_at: at(offsetMs),
@@ -61,23 +61,23 @@ function notice(subkind: string, by: string, offsetMs = 0) {
       l9: {
         payload: {
           type: "notice",
-          data: { subkind, key: TASK, title: TITLE, episode: THREAD, by, kind: "action" },
+          data: { subkind, key, title, episode: THREAD, by, kind: "action" },
         },
       },
     }),
   };
 }
 
-function knowledge(version: number, updatedBy: string, offsetMs = 0) {
+function knowledge(version: number, updatedBy: string, offsetMs = 0, key = TASK) {
   return {
-    id: `knowledge-${version}`,
+    id: `knowledge-${key}-${version}`,
     message_type: "l9_knowledge",
     sender_handle: "system",
     created_at: at(offsetMs),
     episode: LIVE,
     content: JSON.stringify({
-      content: `memory updated → ${TASK}`,
-      l9: { payload: { type: "extraction", data: { key: TASK, updated_by: updatedBy, version } } },
+      content: `memory updated → ${key}`,
+      l9: { payload: { type: "extraction", data: { key, updated_by: updatedBy, version } } },
     }),
   };
 }
@@ -106,6 +106,9 @@ function said(text: string, sender = "operator", offsetMs = 0) {
   };
 }
 
+/** The rail, as a scope to query inside. */
+const rail = () => screen.getByText("Recently updated").closest("div")!.parentElement!;
+
 describe("<EventStream /> and the room's own bookkeeping", () => {
   beforeEach(() => {
     resetStreamHub();
@@ -113,7 +116,10 @@ describe("<EventStream /> and the room's own bookkeeping", () => {
     vi.stubGlobal("EventSource", FakeEventSource);
     vi.mocked(fetchMessages).mockResolvedValue({ messages: [] });
     vi.mocked(fetchL9History).mockResolvedValue([]);
-    vi.mocked(fetchMemories).mockResolvedValue([row]);
+    vi.mocked(fetchMemories).mockResolvedValue([
+      row(TASK, TITLE, THREAD),
+      row(OTHER_TASK, OTHER_TITLE, null),
+    ]);
   });
 
   async function stream(frames: Record<string, unknown>[]) {
@@ -126,76 +132,103 @@ describe("<EventStream /> and the room's own bookkeeping", () => {
     });
   }
 
-  it("folds a notice, a memory push and a ping about one task into a single block", async () => {
-    await stream([
-      notice("filed", "growth"),
-      knowledge(1, "claude-web", 500),
-      ping("growth", "m-1", 900),
-    ]);
-
-    expect(await screen.findByText("· 3 updates")).toBeInTheDocument();
-    // The task's name, once — not its slug three times in three shapes.
-    expect(screen.getByText(TITLE)).toBeInTheDocument();
-    expect(screen.queryByText(TASK)).not.toBeInTheDocument();
-    expect(screen.getByText("· @growth, @claude-web")).toBeInTheDocument();
-  });
-
-  it("keeps folding across what is said in between, and leaves the talk where it was", async () => {
+  it("gathers a task's whole run of churn into one rail entry, not a line each", async () => {
     await stream([
       knowledge(1, "claude-web"),
-      said("what happened to the flag?", "operator", 400),
-      knowledge(2, "claude-web", 800),
-      knowledge(3, "growth", 1200),
+      ping("growth", "m-1", 500),
+      notice("claimed", "growth", 900),
+      knowledge(2, "growth", 1400),
+      ping("risk", "m-2", 1900),
     ]);
 
-    expect(await screen.findByText("· 3 updates")).toBeInTheDocument();
-    expect(screen.getByText("what happened to the flag?")).toBeInTheDocument();
+    const entry = await screen.findByRole("button", { name: new RegExp(TITLE) });
+    expect(within(entry).getByText("5 updates")).toBeInTheDocument();
+    expect(within(entry).getByText("@claude-web, @growth, @risk")).toBeInTheDocument();
   });
 
-  it("opens the block to the events it stands for, so nothing is hidden", async () => {
-    await stream([
-      notice("filed", "growth"),
-      notice("claimed", "growth", 400),
-      knowledge(2, "claude-web", 800),
-    ]);
-
-    await userEvent.click(await screen.findByRole("button", { name: "Show 3 updates" }));
-
-    expect(screen.getByText("New task")).toBeInTheDocument();
-    expect(screen.getByText("Claimed")).toBeInTheDocument();
-    expect(screen.getByText("v2 · @claude-web")).toBeInTheDocument();
-  });
-
-  it("says so again once the window has closed, rather than only counting higher", async () => {
+  it("keeps every one of those out of the conversation", async () => {
     await stream([
       knowledge(1, "claude-web"),
-      knowledge(2, "claude-web", 1000),
-      knowledge(3, "claude-web", ACTIVITY_WINDOW_MS + 1000),
+      ping("growth", "m-1", 500),
+      notice("claimed", "growth", 900),
+      said("so where did we land on the flag?", "operator", 1200),
     ]);
 
-    expect(await screen.findByText("· 2 updates")).toBeInTheDocument();
-    expect(screen.getByText("Knowledge")).toBeInTheDocument();
+    // The one thing anybody said is the one thing in the feed.
+    expect(await screen.findByText("so where did we land on the flag?")).toBeInTheDocument();
+    expect(screen.queryByText("Knowledge")).not.toBeInTheDocument();
+    expect(screen.queryByText("Activity")).not.toBeInTheDocument();
+    expect(screen.queryByText("Claimed")).not.toBeInTheDocument();
   });
 
-  it("keeps two tasks apart", async () => {
-    const other = {
-      id: "notice-other",
-      message_type: "l9_exchange",
-      sender_handle: "system",
-      created_at: at(400),
-      episode: LIVE,
-      content: JSON.stringify({
-        l9: {
-          payload: {
-            type: "notice",
-            data: { subkind: "filed", key: "work/retire-the-legacy-store", title: "48h soak, then retire the legacy store", by: "ops", kind: "action" },
-          },
-        },
-      }),
-    };
-    await stream([notice("filed", "growth"), other, knowledge(2, "claude-web", 800)]);
+  it("still narrates a task arriving and finishing, in sequence with the talk", async () => {
+    await stream([
+      notice("filed", "aligner"),
+      said("taking this one", "growth", 400),
+      notice("resolved", "growth", 800),
+    ]);
 
-    expect(await screen.findByText("· 2 updates")).toBeInTheDocument();
-    expect(screen.getByText("48h soak, then retire the legacy store")).toBeInTheDocument();
+    expect(await screen.findByText("New task")).toBeInTheDocument();
+    expect(screen.getByText("Resolved")).toBeInTheDocument();
+    expect(screen.getByText("taking this one")).toBeInTheDocument();
+  });
+
+  it("folds a run of arrivals by what happened, not by which task", async () => {
+    // Several tasks filed in the same minute is one thing the room did. Naming
+    // the run "New task" would report all of them as one of them.
+    await stream([
+      notice("filed", "aligner", 0, TASK, TITLE),
+      notice("filed", "aligner", 300, OTHER_TASK, OTHER_TITLE),
+    ]);
+
+    expect(await screen.findByText("New tasks")).toBeInTheDocument();
+    expect(screen.queryByText("New task")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Show 2 updates" }));
+    expect(screen.getByRole("button", { name: new RegExp(OTHER_TITLE) })).toBeInTheDocument();
+  });
+
+  it("will not fold an arrival into an outcome", async () => {
+    // Same task, same run of notices — but filed and resolved are two different
+    // pieces of news, and one line would report the second as the first.
+    await stream([notice("filed", "aligner"), notice("resolved", "growth", 400)]);
+
+    expect(await screen.findByText("New task")).toBeInTheDocument();
+    expect(screen.getByText("Resolved")).toBeInTheDocument();
+  });
+
+  it("leaves an agent's own manifest write out of both surfaces", async () => {
+    // Seven agents joining is otherwise seven lines saying somebody arrived,
+    // and the Members rail already says it.
+    await stream([
+      knowledge(1, "claude-web", 0, "agents/task-886"),
+      said("morning", "operator", 400),
+    ]);
+
+    expect(await screen.findByText("morning")).toBeInTheDocument();
+    expect(screen.queryByText("Recently updated")).not.toBeInTheDocument();
+    expect(screen.queryByText(/agents\/task-886/)).not.toBeInTheDocument();
+  });
+
+  it("holds the rail to a fixed height however many tasks are moving", async () => {
+    const keys = ["a", "b", "c", "d", "e"];
+    vi.mocked(fetchMemories).mockResolvedValue(keys.map(k => row(`work/${k}`, `task ${k}`, null)));
+    await stream(keys.map((k, i) => knowledge(1, "claude-web", i * 100, `work/${k}`)));
+
+    expect(await screen.findByText("5 tasks")).toBeInTheDocument();
+    // Three rows stand open and the rest are behind one control, so a busy hour
+    // costs the same height as a quiet one.
+    expect(within(rail()).getAllByRole("button", { name: /^task / })).toHaveLength(3);
+    await userEvent.click(screen.getByRole("button", { name: "Show all 5" }));
+    expect(within(rail()).getAllByRole("button", { name: /^task / })).toHaveLength(5);
+  });
+
+  it("orders the rail by what moved last", async () => {
+    await stream([
+      knowledge(1, "claude-web", 0, TASK),
+      knowledge(1, "claude-web", 500, OTHER_TASK),
+    ]);
+
+    const rows = within(rail()).getAllByRole("button", { name: /flag|legacy store/ });
+    expect(rows[0]).toHaveAccessibleName(new RegExp(OTHER_TITLE));
   });
 });

--- a/mycelium-frontend/src/components/event-stream.activity.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.activity.test.tsx
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+// What the room's timeline does with its own bookkeeping.
+//
+// A task moving raises three different frames — a board notice, a memory push,
+// a thread ping — and each is worth keeping. Printed one per line they bury the
+// conversation they accompany, so the feed condenses them into one block per
+// task and opens it on demand. These cases are about that block: that it forms,
+// that it names the task rather than its slug, and that nothing folded into it
+// is lost.
+
+import { act } from "react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithSWR } from "@/test/swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeEventSource } from "@/test/fake-event-source";
+import { resetStreamHub } from "@/lib/stream-hub";
+import { fetchL9History, fetchMessages, fetchMemories } from "@/lib/api";
+import { ACTIVITY_WINDOW_MS } from "@/lib/threads";
+
+vi.mock("@/lib/api", () => ({
+  fetchMessages: vi.fn().mockResolvedValue({ messages: [] }),
+  fetchL9History: vi.fn().mockResolvedValue([]),
+  fetchMemories: vi.fn().mockResolvedValue([]),
+  fetchRoomAgents: vi.fn().mockResolvedValue([]),
+  fetchPendingInvites: vi.fn().mockResolvedValue([]),
+  respondToInvite: vi.fn(),
+  logFetchError: () => () => undefined,
+}));
+
+import { EventStream } from "@/components/event-stream";
+
+const ROOM = "atlas";
+const LIVE = "urn:ioc:mycelium:episode:atlas:live";
+const THREAD = "urn:ioc:mycelium:episode:atlas:t3aa11bb";
+const TASK = "work/flip-reads-behind-a-flag";
+const TITLE = "flip reads behind a flag";
+const T0 = Date.parse("2026-08-26T10:00:00.000Z");
+const at = (offsetMs = 0) => new Date(T0 + offsetMs).toISOString();
+
+/** The board row the three frames below are all about. */
+const row = {
+  key: TASK,
+  value: { title: TITLE },
+  version: 3,
+  created_by: "aligner",
+  updated_at: at(),
+  episode: THREAD,
+};
+
+function notice(subkind: string, by: string, offsetMs = 0) {
+  return {
+    id: `notice-${subkind}`,
+    message_type: "l9_exchange",
+    sender_handle: "system",
+    created_at: at(offsetMs),
+    episode: LIVE,
+    content: JSON.stringify({
+      l9: {
+        payload: {
+          type: "notice",
+          data: { subkind, key: TASK, title: TITLE, episode: THREAD, by, kind: "action" },
+        },
+      },
+    }),
+  };
+}
+
+function knowledge(version: number, updatedBy: string, offsetMs = 0) {
+  return {
+    id: `knowledge-${version}`,
+    message_type: "l9_knowledge",
+    sender_handle: "system",
+    created_at: at(offsetMs),
+    episode: LIVE,
+    content: JSON.stringify({
+      content: `memory updated → ${TASK}`,
+      l9: { payload: { type: "extraction", data: { key: TASK, updated_by: updatedBy, version } } },
+    }),
+  };
+}
+
+function ping(sender: string, message: string, offsetMs = 0) {
+  return {
+    id: `ping-${message}`,
+    message_type: "l9_exchange",
+    sender_handle: "system",
+    created_at: at(offsetMs),
+    episode: LIVE,
+    content: JSON.stringify({
+      l9: { payload: { type: "ping", data: { episode: THREAD, sender, message } } },
+    }),
+  };
+}
+
+function said(text: string, sender = "operator", offsetMs = 0) {
+  return {
+    id: `said-${text.length}`,
+    message_type: "l9_exchange",
+    sender_handle: sender,
+    created_at: at(offsetMs),
+    episode: LIVE,
+    content: JSON.stringify({ content: text, l9: { payload: { type: "message", data: {} } } }),
+  };
+}
+
+describe("<EventStream /> and the room's own bookkeeping", () => {
+  beforeEach(() => {
+    resetStreamHub();
+    FakeEventSource.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+    vi.mocked(fetchMessages).mockResolvedValue({ messages: [] });
+    vi.mocked(fetchL9History).mockResolvedValue([]);
+    vi.mocked(fetchMemories).mockResolvedValue([row]);
+  });
+
+  async function stream(frames: Record<string, unknown>[]) {
+    renderWithSWR(<EventStream roomName={ROOM} onOpenThread={vi.fn()} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+    await act(async () => {
+      es.open();
+      for (const frame of frames) es.emit(frame);
+    });
+  }
+
+  it("folds a notice, a memory push and a ping about one task into a single block", async () => {
+    await stream([
+      notice("filed", "growth"),
+      knowledge(1, "claude-web", 500),
+      ping("growth", "m-1", 900),
+    ]);
+
+    expect(await screen.findByText("· 3 updates")).toBeInTheDocument();
+    // The task's name, once — not its slug three times in three shapes.
+    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    expect(screen.queryByText(TASK)).not.toBeInTheDocument();
+    expect(screen.getByText("· @growth, @claude-web")).toBeInTheDocument();
+  });
+
+  it("keeps folding across what is said in between, and leaves the talk where it was", async () => {
+    await stream([
+      knowledge(1, "claude-web"),
+      said("what happened to the flag?", "operator", 400),
+      knowledge(2, "claude-web", 800),
+      knowledge(3, "growth", 1200),
+    ]);
+
+    expect(await screen.findByText("· 3 updates")).toBeInTheDocument();
+    expect(screen.getByText("what happened to the flag?")).toBeInTheDocument();
+  });
+
+  it("opens the block to the events it stands for, so nothing is hidden", async () => {
+    await stream([
+      notice("filed", "growth"),
+      notice("claimed", "growth", 400),
+      knowledge(2, "claude-web", 800),
+    ]);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Show 3 updates" }));
+
+    expect(screen.getByText("New task")).toBeInTheDocument();
+    expect(screen.getByText("Claimed")).toBeInTheDocument();
+    expect(screen.getByText("v2 · @claude-web")).toBeInTheDocument();
+  });
+
+  it("says so again once the window has closed, rather than only counting higher", async () => {
+    await stream([
+      knowledge(1, "claude-web"),
+      knowledge(2, "claude-web", 1000),
+      knowledge(3, "claude-web", ACTIVITY_WINDOW_MS + 1000),
+    ]);
+
+    expect(await screen.findByText("· 2 updates")).toBeInTheDocument();
+    expect(screen.getByText("Knowledge")).toBeInTheDocument();
+  });
+
+  it("keeps two tasks apart", async () => {
+    const other = {
+      id: "notice-other",
+      message_type: "l9_exchange",
+      sender_handle: "system",
+      created_at: at(400),
+      episode: LIVE,
+      content: JSON.stringify({
+        l9: {
+          payload: {
+            type: "notice",
+            data: { subkind: "filed", key: "work/retire-the-legacy-store", title: "48h soak, then retire the legacy store", by: "ops", kind: "action" },
+          },
+        },
+      }),
+    };
+    await stream([notice("filed", "growth"), other, knowledge(2, "claude-web", 800)]);
+
+    expect(await screen.findByText("· 2 updates")).toBeInTheDocument();
+    expect(screen.getByText("48h soak, then retire the legacy store")).toBeInTheDocument();
+  });
+});

--- a/mycelium-frontend/src/components/event-stream.render.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.render.test.tsx
@@ -178,8 +178,9 @@ describe("<EventStream /> live message rendering", () => {
       });
     });
 
-    expect(await screen.findByText("plan updated → plan/tasks.md")).toBeInTheDocument();
     expect(screen.getByText("Knowledge")).toBeInTheDocument();
+    // The row named once, not once in the content line and again beside it.
+    expect(await screen.findAllByText("plan/tasks.md")).toHaveLength(1);
     expect(screen.getByText("by @aligner", { exact: false })).toBeInTheDocument();
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();

--- a/mycelium-frontend/src/components/event-stream.render.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.render.test.tsx
@@ -156,7 +156,7 @@ describe("<EventStream /> live message rendering", () => {
     warn.mockRestore();
   });
 
-  it("renders an l9_knowledge streamed over SSE as a knowledge notice, not the unhandled fallback", async () => {
+  it("lifts an l9_knowledge streamed over SSE into the rail, not the unhandled fallback", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     renderWithSWR(<EventStream roomName="sprint" />);
     await act(async () => {});
@@ -178,10 +178,11 @@ describe("<EventStream /> live message rendering", () => {
       });
     });
 
-    expect(screen.getByText("Knowledge")).toBeInTheDocument();
-    // The row named once, not once in the content line and again beside it.
-    expect(await screen.findAllByText("plan/tasks.md")).toHaveLength(1);
-    expect(screen.getByText("by @aligner", { exact: false })).toBeInTheDocument();
+    // A memory push is the room's state, not its speech: it reaches the rail
+    // under the row's own name, once, and never the conversation.
+    expect(await screen.findByText("Recently updated")).toBeInTheDocument();
+    expect(screen.getAllByText("plan/tasks.md")).toHaveLength(1);
+    expect(screen.getByText("@aligner")).toBeInTheDocument();
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });

--- a/mycelium-frontend/src/components/event-stream.thread.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.thread.test.tsx
@@ -92,8 +92,10 @@ describe("<EventStream /> and the threads inside the room", () => {
     // The argument is not lost, it is placed: `board messages` and the thread
     // pane read it. What the room gets is that the task moved.
     expect(screen.queryByText(/hold the flip/)).not.toBeInTheDocument();
-    expect(await screen.findByText("Activity")).toBeInTheDocument();
-    expect(screen.getByText("· @risk")).toBeInTheDocument();
+    // What the room gets is that the task moved — in the rail, which is where
+    // the room's state lives, not woven through what people are saying.
+    expect(await screen.findByText("Recently updated")).toBeInTheDocument();
+    expect(screen.getByText("@risk")).toBeInTheDocument();
   });
 
   it("still shows what was said in the room itself", async () => {
@@ -113,7 +115,7 @@ describe("<EventStream /> and the threads inside the room", () => {
     expect(screen.getByText("and the backfill finished")).toBeInTheDocument();
   });
 
-  it("collapses a burst from one thread into a single line with its count", async () => {
+  it("collapses a burst from one thread into a single rail entry with its count", async () => {
     renderWithSWR(<EventStream roomName={ROOM} />);
     await act(async () => {});
     const es = FakeEventSource.latest();
@@ -125,9 +127,8 @@ describe("<EventStream /> and the threads inside the room", () => {
       es.emit(ping("risk", "m-3"));
     });
 
-    expect(await screen.findByText("· 3 updates")).toBeInTheDocument();
-    expect(screen.getAllByText("Activity")).toHaveLength(1);
-    expect(screen.getByText("· @risk, @growth")).toBeInTheDocument();
+    expect(await screen.findByText("3 updates")).toBeInTheDocument();
+    expect(screen.getByText("@risk, @growth")).toBeInTheDocument();
   });
 
   it("opens the thread a ping names, by URN and not by short id", async () => {
@@ -141,7 +142,7 @@ describe("<EventStream /> and the threads inside the room", () => {
       es.emit(ping("risk", "m-1"));
     });
 
-    await userEvent.click(await screen.findByRole("button", { name: "Open thread t3aa11bb" }));
+    await userEvent.click(await screen.findByRole("button", { name: /t3aa11bb/ }));
     expect(onOpenThread).toHaveBeenCalledWith(THREAD);
   });
 
@@ -223,7 +224,7 @@ describe("<EventStream /> and the threads inside the room", () => {
     await act(async () => {});
 
     expect(await screen.findByText("morning")).toBeInTheDocument();
-    expect(screen.getByText("Activity")).toBeInTheDocument();
+    expect(screen.getByText("Recently updated")).toBeInTheDocument();
   });
 
   it("takes only the pings from the L9 replay, so nothing lands twice", async () => {
@@ -245,9 +246,8 @@ describe("<EventStream /> and the threads inside the room", () => {
     renderWithSWR(<EventStream roomName={ROOM} />);
     await act(async () => {});
 
-    // Once, and as its own line: a second copy would fold in beside the first
-    // and read as two updates to the row rather than as the duplicate it is.
-    expect(await screen.findAllByText("work/flip")).toHaveLength(1);
-    expect(screen.queryByText(/updates$/)).not.toBeInTheDocument();
+    // One update, not two: the L9 replay and the message list both carry this
+    // frame, and a rail that counted it twice would report a duplicate as work.
+    expect(await screen.findByText("1 update")).toBeInTheDocument();
   });
 });

--- a/mycelium-frontend/src/components/event-stream.thread.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.thread.test.tsx
@@ -93,7 +93,7 @@ describe("<EventStream /> and the threads inside the room", () => {
     // pane read it. What the room gets is that the task moved.
     expect(screen.queryByText(/hold the flip/)).not.toBeInTheDocument();
     expect(await screen.findByText("Activity")).toBeInTheDocument();
-    expect(screen.getByText("· 1 new")).toBeInTheDocument();
+    expect(screen.getByText("· @risk")).toBeInTheDocument();
   });
 
   it("still shows what was said in the room itself", async () => {
@@ -125,7 +125,7 @@ describe("<EventStream /> and the threads inside the room", () => {
       es.emit(ping("risk", "m-3"));
     });
 
-    expect(await screen.findByText("· 3 new")).toBeInTheDocument();
+    expect(await screen.findByText("· 3 updates")).toBeInTheDocument();
     expect(screen.getAllByText("Activity")).toHaveLength(1);
     expect(screen.getByText("· @risk, @growth")).toBeInTheDocument();
   });
@@ -245,6 +245,9 @@ describe("<EventStream /> and the threads inside the room", () => {
     renderWithSWR(<EventStream roomName={ROOM} />);
     await act(async () => {});
 
-    expect(await screen.findAllByText("memory updated → work/flip")).toHaveLength(1);
+    // Once, and as its own line: a second copy would fold in beside the first
+    // and read as two updates to the row rather than as the duplicate it is.
+    expect(await screen.findAllByText("work/flip")).toHaveLength(1);
+    expect(screen.queryByText(/updates$/)).not.toBeInTheDocument();
   });
 });

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -3,7 +3,7 @@
 
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import {
   fetchL9History,
   fetchMessages,
@@ -12,8 +12,8 @@ import {
   logFetchError,
   type PendingInvite,
 } from "@/lib/api";
-import { useRoomAgents, useRoomThreads } from "@/lib/room-data";
-import { NOTICE_TYPE, PING_TYPE, coalescePings, isLiveEpisode, noticeLabel, noticeOf, pingOf, threadShortId } from "@/lib/threads";
+import { useRoomAgents, useRoomRowNames, useRoomThreads, type RowNaming, type ThreadOwner } from "@/lib/room-data";
+import { NOTICE_TYPE, PING_TYPE, coalesceActivity, isLiveEpisode, noticeLabel, noticeOf, pingOf, threadShortId } from "@/lib/threads";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomBoard } from "@/components/board/room-board";
@@ -30,7 +30,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Monogram } from "@/components/ui/monogram";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
-import { ArrowDown, Bot, MessageSquare, MessagesSquare } from "lucide-react";
+import { ArrowDown, Bot, ChevronDown, ChevronRight, MessageSquare, MessagesSquare } from "lucide-react";
 
 interface Event {
   /** Render key only — synthesized, so a message republished by a status
@@ -59,9 +59,11 @@ interface Event {
   /** The thread a **ping** is about — never the episode the ping itself rode,
    *  which is the room. Null on everything that is not a ping. */
   thread: string | null;
-  /** How many pings this row stands for, once a burst has been coalesced. */
-  pings: number;
-  /** Who wrote in the thread during that burst, in the order they first did. */
+  /** Every event this row stands for, oldest first, once a burst about one
+   *  subject has been folded into it. Empty on a row that is only itself. */
+  folded: Event[];
+  /** Who wrote in the thread, on a ping. The row's own sender is the system
+   *  that raised it, which is nobody, so the writer is read from the payload. */
   pingSenders: string[];
   raw: Record<string, unknown>;
 }
@@ -125,6 +127,7 @@ function SystemNotice({
   labelColor,
   strong,
   children,
+  trailing,
 }: {
   time: string;
   dot: string;
@@ -132,6 +135,8 @@ function SystemNotice({
   labelColor?: string;
   strong?: boolean;
   children: React.ReactNode;
+  /** Held out of the truncating run, so a control here survives a long title. */
+  trailing?: React.ReactNode;
 }) {
   return (
     <div className="group mt-3 flex items-center gap-2 px-5 py-1 text-micro text-muted-foreground first:mt-0">
@@ -142,6 +147,7 @@ function SystemNotice({
         </span>
       )}
       <span className="flex min-w-0 items-center gap-1.5 truncate">{children}</span>
+      {trailing}
       <span className="ml-auto flex-shrink-0 tabular text-faint opacity-0 transition-opacity group-hover:opacity-100">
         {time.slice(0, 5)}
       </span>
@@ -337,7 +343,7 @@ function parseEvent(msg: Record<string, unknown>, room: string): Event {
     amends,
     edited: typeof msg.edited_at === "string",
     thread,
-    pings: thread ? 1 : 0,
+    folded: [],
     pingSenders: pingSender ? [pingSender] : [],
     raw,
   };
@@ -353,6 +359,98 @@ function parseEvent(msg: Record<string, unknown>, room: string): Event {
  */
 function inAThread(event: Event, room: string): boolean {
   return CHAT_TYPES.has(event.type) && !isLiveEpisode(room, event.episode);
+}
+
+/**
+ * What a row is *about*, so the feed can group by it.
+ *
+ * The room's task key, wherever the room knows one — that is what makes a
+ * thread's ping, the board's notice about that task and the memory write behind
+ * it fold into one block instead of alternating three ways of saying the same
+ * task moved. A thread no single row is bound to is its own subject; naming it
+ * after one of several rows would be picking at random.
+ */
+function subjectOf(event: Event, threads: Map<string, ThreadOwner>): string | null {
+  if (event.type === PING_TYPE && event.thread) {
+    const owner = threads.get(event.thread);
+    return owner && owner.keys.length === 1 ? owner.keys[0] : event.thread;
+  }
+  if (event.type === NOTICE_TYPE) return (event.raw.taskKey as string) || null;
+  if (event.type === "l9_knowledge") return (event.raw.key as string) || null;
+  return null;
+}
+
+/**
+ * What to call a subject, and the thread that opens it.
+ *
+ * Read off the room's own rows, so a task reads in the feed as the name it
+ * carries on the board rather than as its `work/…` slug. A notice carries its
+ * own copy of both, which is what answers for a subject the room's memories do
+ * not have — one filed a moment ago, or one since removed.
+ */
+function nameActivity(
+  subject: string,
+  members: Event[],
+  threads: Map<string, ThreadOwner>,
+  rows: Map<string, RowNaming>,
+): { title: string; episode: string | null } {
+  const noticed = members.find((m) => m.type === NOTICE_TYPE)?.content;
+  if (subject.startsWith("urn:")) {
+    const owner = threads.get(subject);
+    return {
+      title: owner?.title ?? noticed ?? threadShortId(subject) ?? "thread",
+      episode: subject,
+    };
+  }
+  const row = rows.get(subject);
+  return {
+    title: row?.title ?? noticed ?? subject,
+    episode: row?.episode ?? members.find((m) => m.thread)?.thread ?? null,
+  };
+}
+
+/** Who moved a subject, in the order they first did. A ping's own sender is the
+ *  system that raised it, which is nobody, so its writers come off the payload. */
+function actorsOf(members: Event[]): string[] {
+  const who: string[] = [];
+  for (const ev of members) {
+    const from =
+      ev.type === PING_TYPE
+        ? ev.pingSenders
+        : ev.type === NOTICE_TYPE
+          ? [ev.raw.by as string | undefined]
+          : ev.type === "l9_knowledge"
+            ? [ev.raw.updated_by as string | undefined]
+            : [ev.sender];
+    for (const handle of from) if (handle && !who.includes(handle)) who.push(handle);
+  }
+  return who;
+}
+
+/** One folded event, as it reads once a block is opened up. */
+function activityLine(ev: Event): { label: string; detail: string } {
+  if (ev.type === PING_TYPE) {
+    const who = ev.pingSenders.filter(Boolean);
+    return { label: "Activity", detail: who.map((h) => `@${h}`).join(", ") || "a message landed" };
+  }
+  if (ev.type === NOTICE_TYPE) {
+    const by = ev.raw.by as string | undefined;
+    return {
+      label: noticeLabel((ev.raw.subkind as string) || "filed", ev.raw.kind as string | undefined),
+      detail: by ? `@${by}` : "",
+    };
+  }
+  if (ev.type === "l9_knowledge") {
+    const version = ev.raw.version;
+    const by = ev.raw.updated_by as string | undefined;
+    return {
+      label: "Knowledge",
+      detail: [typeof version === "number" ? `v${version}` : "", by ? `@${by}` : ""]
+        .filter(Boolean)
+        .join(" · "),
+    };
+  }
+  return { label: ev.type, detail: ev.sender };
 }
 
 /** A reader a couple of lines off the bottom still counts as reading the tail,
@@ -429,6 +527,9 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   // six characters of URN. Off the room's shared memory read, so it costs
   // nothing; a thread no row is bound to simply has no name to give.
   const threads = useRoomThreads(roomName);
+  // And what each row is called, so a notice, a ping and a memory push about one
+  // task all print its name rather than three shapes of its key.
+  const rowNames = useRoomRowNames(roomName);
   const agentHandles = useMemo(() => new Set(agents.map((a) => a.handle)), [agents]);
   const agentOwners = useMemo(
     () => new Map(agents.filter((a) => a.owner).map((a) => [a.handle, a.owner as string])),
@@ -512,22 +613,35 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   });
 
   // What the room actually says. A thread's prose is dropped — it is not lost,
-  // it is placed, and the pane the ping opens is where it reads — and a burst of
-  // pings from one thread collapses to a single line, so the surface that exists
-  // to stay legible cannot be flooded by the mechanism meant to protect it.
+  // it is placed, and the pane the ping opens is where it reads — and everything
+  // the room raises *about* one task over a window condenses into a single
+  // evolving block, so the surface that exists to stay legible cannot be flooded
+  // by the mechanisms meant to protect it. The block keeps every event it stands
+  // for and opens to them, so this is where activity is tucked, never hidden.
   const visible = useMemo(
     () =>
-      coalescePings(
+      coalesceActivity(
         events.filter(e => CHANNEL_VIEW_TYPES.has(e.type) && !inAThread(e, roomName)),
-        e => e.pings,
-        (latest, pings, pingSenders) => ({ ...latest, pings, pingSenders }),
+        e => subjectOf(e, threads),
+        members => ({ ...members[0], folded: members }),
       ),
-    [events, roomName],
+    [events, roomName, threads],
   );
 
   // Arriving from search: mark the named message and scroll it into sight once
   // history has landed. The mark outlives the request that carried it — a
   // highlight cleared with the URL parameter would be gone before it was read.
+  // Which activity blocks the reader has opened. Keyed by the block's first
+  // event, which is the one row a growing block keeps — so a block does not
+  // close under someone the moment it absorbs another event.
+  const [openBlocks, setOpenBlocks] = useState<Set<string>>(() => new Set());
+  const toggleBlock = (id: string) =>
+    setOpenBlocks((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(id)) next.add(id);
+      return next;
+    });
+
   const [highlight, setHighlight] = useState<string | null>(null);
   const highlightRow = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -698,6 +812,72 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
               // Coordination + plan lifecycle events render as slim, centered
               // system notices — quiet dividers woven into the conversation,
               // not loud rows. Chat messages group under one sender header.
+              // Everything the room raised about one task over a window, as one
+              // evolving line. Tucked away, not hidden: it opens to the events
+              // it stands for, and its subject still opens the thread.
+              if (ev.folded.length > 1) {
+                const subject = subjectOf(ev, threads);
+                const { title, episode } = subject
+                  ? nameActivity(subject, ev.folded, threads, rowNames)
+                  : { title: "activity", episode: null };
+                const who = actorsOf(ev.folded);
+                const open = openBlocks.has(ev.id);
+                return (
+                  <Fragment key={ev.id}>
+                    <SystemNotice
+                      time={ev.time}
+                      dot="var(--accent)"
+                      label="Activity"
+                      trailing={
+                        <button
+                          type="button"
+                          onClick={() => toggleBlock(ev.id)}
+                          aria-expanded={open}
+                          aria-label={`${open ? "Hide" : "Show"} ${ev.folded.length} updates`}
+                          className="inline-flex flex-shrink-0 items-center gap-0.5 rounded px-1 text-faint transition-colors hover:bg-surface-2 hover:text-muted-foreground"
+                        >
+                          {open ? (
+                            <ChevronDown className="size-3" strokeWidth={1.9} />
+                          ) : (
+                            <ChevronRight className="size-3" strokeWidth={1.9} />
+                          )}
+                          {open ? "hide" : "details"}
+                        </button>
+                      }
+                    >
+                      <span>in</span>
+                      <button
+                        type="button"
+                        onClick={() => episode && onOpenThread?.(episode)}
+                        disabled={!episode || !onOpenThread}
+                        title={episode ?? subject ?? undefined}
+                        className="inline-flex max-w-[18rem] items-center gap-1 truncate rounded px-1 text-accent transition-colors enabled:hover:bg-accent-soft enabled:hover:underline disabled:cursor-default disabled:text-text"
+                      >
+                        <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
+                        <span className="truncate">{title}</span>
+                      </button>
+                      <span>· {ev.folded.length} updates</span>
+                      {who.length > 0 && (
+                        <span className="truncate">· {who.map((h) => `@${h}`).join(", ")}</span>
+                      )}
+                    </SystemNotice>
+                    {open && (
+                      <ul className="mb-1 ml-[1.75rem] flex flex-col gap-1 border-l border-border py-1 pl-3 pr-5 text-micro text-muted-foreground">
+                        {ev.folded.map((member) => {
+                          const { label, detail } = activityLine(member);
+                          return (
+                            <li key={member.id} className="flex items-center gap-2">
+                              <span className="tabular flex-shrink-0 text-faint">{member.time.slice(0, 5)}</span>
+                              <span className="flex-shrink-0 font-medium">{label}</span>
+                              {detail && <span className="truncate">{detail}</span>}
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </Fragment>
+                );
+              }
               if (ev.type === PING_TYPE && ev.thread) {
                 const thread = ev.thread;
                 const shortId = threadShortId(thread) ?? "thread";
@@ -717,7 +897,6 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                       <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
                       <span className="truncate">{owner?.title ?? shortId}</span>
                     </button>
-                    <span>· {ev.pings} new</span>
                     {who.length > 0 && (
                       <span className="truncate">· {who.map(h => `@${h}`).join(", ")}</span>
                     )}
@@ -768,11 +947,29 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
               if (ev.type === "l9_knowledge") {
                 const key = ev.raw.key as string | undefined;
                 const updatedBy = ev.raw.updated_by as string | undefined;
+                const version = ev.raw.version;
+                // The key printed once, as the name the room calls it — the
+                // content line already said it, in slug form, and said it again
+                // in the mono span beside it.
+                const named = key ? nameActivity(key, [ev], threads, rowNames) : null;
                 return (
                   <SystemNotice key={ev.id} time={ev.time} dot="var(--yellow)" label="Knowledge">
-                    <span>{ev.content}</span>
-                    {key && <span className="font-mono text-muted-foreground">{key}</span>}
-                    {updatedBy ? <span>by @{updatedBy}</span> : null}
+                    <span>updated</span>
+                    {named ? (
+                      <button
+                        type="button"
+                        onClick={() => named.episode && onOpenThread?.(named.episode)}
+                        disabled={!named.episode || !onOpenThread}
+                        title={key}
+                        className="inline-flex max-w-[18rem] items-center gap-1 truncate rounded px-1 text-accent transition-colors enabled:hover:bg-accent-soft enabled:hover:underline disabled:cursor-default disabled:text-text"
+                      >
+                        <span className="truncate">{named.title}</span>
+                      </button>
+                    ) : (
+                      <span className="truncate">{ev.content}</span>
+                    )}
+                    {typeof version === "number" && <span>· v{version}</span>}
+                    {updatedBy ? <span>· by @{updatedBy}</span> : null}
                   </SystemNotice>
                 );
               }

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -18,6 +18,7 @@ import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
 import { MarkdownContent } from "@/components/markdown-content";
 import { RoomBoard } from "@/components/board/room-board";
 import { ConsentDialog } from "@/components/consent-dialog";
+import { ActivityRail, type ActivityItem } from "@/components/activity-rail";
 import { EpisodeTag } from "@/components/episode-tag";
 import { L9Inspector } from "@/components/l9-inspector";
 import { NegotiationView } from "@/components/negotiation-view";
@@ -142,7 +143,10 @@ function SystemNotice({
     <div className="group mt-3 flex items-center gap-2 px-5 py-1 text-micro text-muted-foreground first:mt-0">
       <span aria-hidden className="inline-block size-1.5 flex-shrink-0 rounded-full" style={{ background: dot }} />
       {label && (
-        <span className={strong ? "font-semibold" : "font-medium"} style={{ color: labelColor ?? "var(--muted-foreground)" }}>
+        <span
+          className={`flex-shrink-0 whitespace-nowrap ${strong ? "font-semibold" : "font-medium"}`}
+          style={{ color: labelColor ?? "var(--muted-foreground)" }}
+        >
           {label}
         </span>
       )}
@@ -362,13 +366,42 @@ function inAThread(event: Event, room: string): boolean {
 }
 
 /**
- * What a row is *about*, so the feed can group by it.
+ * Board events the room narrates, as against the ones it merely records.
+ *
+ * A task appearing, finishing or stalling is something a person would say out
+ * loud, and it reads in sequence with the conversation. A task being picked up
+ * or handed back is bookkeeping about who holds what — true, worth having, and
+ * not worth interrupting anyone for. The first stays in the feed; the second
+ * goes to the rail with the rest of the churn.
+ */
+const NARRATED_SUBKINDS = new Set(["filed", "resolved", "blocked", "unblocked"]);
+
+/**
+ * Whether this row is the room *doing* something rather than saying it.
+ *
+ * A room under load raises far more state than speech: a task being worked
+ * writes memory, pings its thread and moves on the board, and none of it is
+ * something anybody wrote. Woven into the feed, that is a changelog with the
+ * conversation buried in it — so it is lifted out into {@link ActivityRail},
+ * which holds a fixed number of rows however busy the room gets.
+ */
+function isActivity(event: Event): boolean {
+  if (event.type === PING_TYPE) return true;
+  if (event.type === "l9_knowledge") return true;
+  if (event.type === NOTICE_TYPE) {
+    return !NARRATED_SUBKINDS.has((event.raw.subkind as string) || "filed");
+  }
+  return false;
+}
+
+/**
+ * What a row is *about*, so activity can be grouped by it.
  *
  * The room's task key, wherever the room knows one — that is what makes a
  * thread's ping, the board's notice about that task and the memory write behind
- * it fold into one block instead of alternating three ways of saying the same
- * task moved. A thread no single row is bound to is its own subject; naming it
- * after one of several rows would be picking at random.
+ * it fold into one entry instead of three ways of saying the same task moved. A
+ * thread no single row is bound to is its own subject; naming it after one of
+ * several rows would be picking at random.
  */
 function subjectOf(event: Event, threads: Map<string, ThreadOwner>): string | null {
   if (event.type === PING_TYPE && event.thread) {
@@ -376,7 +409,13 @@ function subjectOf(event: Event, threads: Map<string, ThreadOwner>): string | nu
     return owner && owner.keys.length === 1 ? owner.keys[0] : event.thread;
   }
   if (event.type === NOTICE_TYPE) return (event.raw.taskKey as string) || null;
-  if (event.type === "l9_knowledge") return (event.raw.key as string) || null;
+  if (event.type === "l9_knowledge") {
+    const key = (event.raw.key as string) || null;
+    // An agent writing its own manifest is the roster's news, and the Members
+    // rail already carries it. In a room of seven agents it is otherwise seven
+    // lines saying somebody arrived.
+    return key && !key.startsWith("agents/") ? key : null;
+  }
   return null;
 }
 
@@ -612,21 +651,60 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
     }
   });
 
-  // What the room actually says. A thread's prose is dropped — it is not lost,
-  // it is placed, and the pane the ping opens is where it reads — and everything
-  // the room raises *about* one task over a window condenses into a single
-  // evolving block, so the surface that exists to stay legible cannot be flooded
-  // by the mechanisms meant to protect it. The block keeps every event it stands
-  // for and opens to them, so this is where activity is tucked, never hidden.
+  // The room's own timeline, split by what it is: a thread's prose is dropped
+  // (it is not lost, it is placed, and the pane the ping opens is where it
+  // reads), the churn goes up to the rail, and what is left is the conversation
+  // plus the handful of board moves worth narrating — still folded per task, so
+  // a file and a resolve minutes apart read as one line.
+  const inChannel = useMemo(
+    () => events.filter(e => CHANNEL_VIEW_TYPES.has(e.type) && !inAThread(e, roomName)),
+    [events, roomName],
+  );
+
   const visible = useMemo(
     () =>
       coalesceActivity(
-        events.filter(e => CHANNEL_VIEW_TYPES.has(e.type) && !inAThread(e, roomName)),
-        e => subjectOf(e, threads),
+        inChannel.filter(e => !isActivity(e)),
+        // Narrated notices group by *what happened*, not by which task. Five
+        // tasks filed in the same minute is one thing the room did; the same
+        // task filed and resolved twenty minutes apart is two, and folding
+        // those together would report an outcome as if it were an arrival.
+        e => (e.type === NOTICE_TYPE ? `notice:${(e.raw.subkind as string) || "filed"}` : null),
         members => ({ ...members[0], folded: members }),
       ),
-    [events, roomName, threads],
+    [inChannel],
   );
+
+  // What the room has been doing, one entry per task rather than one per frame.
+  // No window here: the rail is the room's current state, so a task that has
+  // been written to all morning is one row that keeps moving up, never a row
+  // per burst. Sorted by what moved last, which is the order a reader wants.
+  const activity = useMemo<ActivityItem[]>(() => {
+    const bySubject = new Map<string, Event[]>();
+    for (const event of inChannel) {
+      if (!isActivity(event)) continue;
+      const subject = subjectOf(event, threads);
+      if (!subject) continue;
+      const group = bySubject.get(subject);
+      if (group) group.push(event);
+      else bySubject.set(subject, [event]);
+    }
+    return [...bySubject.entries()]
+      .map(([subject, members]) => {
+        const latest = members[members.length - 1];
+        const { title, episode } = nameActivity(subject, members, threads, rowNames);
+        return {
+          subject,
+          title,
+          episode,
+          count: members.length,
+          actors: actorsOf(members),
+          time: latest.time,
+          at: Date.parse(latest.at) || 0,
+        };
+      })
+      .sort((a, b) => b.at - a.at);
+  }, [inChannel, threads, rowNames]);
 
   // Arriving from search: mark the named message and scroll it into sight once
   // history has landed. The mark outlives the request that carried it — a
@@ -796,6 +874,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
         </div>
       ) : (
       <div className="relative flex flex-1 min-h-0 flex-col">
+      {historyLoaded && <ActivityRail items={activity} onOpenThread={onOpenThread} />}
       <ScrollArea className="flex-1 min-h-0" viewportRef={scrollRef}>
         {!historyLoaded ? (
           <ChannelSkeleton />
@@ -816,18 +895,29 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
               // evolving line. Tucked away, not hidden: it opens to the events
               // it stands for, and its subject still opens the thread.
               if (ev.folded.length > 1) {
-                const subject = subjectOf(ev, threads);
-                const { title, episode } = subject
-                  ? nameActivity(subject, ev.folded, threads, rowNames)
-                  : { title: "activity", episode: null };
+                const subkind = (ev.raw.subkind as string) || "filed";
+                const label = noticeLabel(subkind, ev.raw.kind as string | undefined);
+                // "New task" over five of them reads as one of them.
+                const heading = subkind === "filed" ? "New tasks" : label;
+                // Two names and a remainder: enough to recognise the run, never
+                // enough to become the line.
+                const NAMED = 2;
+                const named = ev.folded.slice(0, NAMED);
+                const rest = ev.folded.length - named.length;
                 const who = actorsOf(ev.folded);
                 const open = openBlocks.has(ev.id);
                 return (
                   <Fragment key={ev.id}>
                     <SystemNotice
                       time={ev.time}
-                      dot="var(--accent)"
-                      label="Activity"
+                      dot={
+                        subkind === "resolved" || subkind === "filed" || subkind === "unblocked"
+                          ? "var(--green)"
+                          : subkind === "blocked"
+                            ? "var(--red)"
+                            : "var(--accent)"
+                      }
+                      label={heading}
                       trailing={
                         <button
                           type="button"
@@ -845,34 +935,38 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                         </button>
                       }
                     >
-                      <span>in</span>
-                      <button
-                        type="button"
-                        onClick={() => episode && onOpenThread?.(episode)}
-                        disabled={!episode || !onOpenThread}
-                        title={episode ?? subject ?? undefined}
-                        className="inline-flex max-w-[18rem] items-center gap-1 truncate rounded px-1 text-accent transition-colors enabled:hover:bg-accent-soft enabled:hover:underline disabled:cursor-default disabled:text-text"
-                      >
-                        <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
-                        <span className="truncate">{title}</span>
-                      </button>
-                      <span>· {ev.folded.length} updates</span>
+                      <span className="truncate">{named.map((m) => m.content).join(" · ")}</span>
+                      {rest > 0 && <span className="flex-shrink-0 text-faint">+{rest}</span>}
                       {who.length > 0 && (
-                        <span className="truncate">· {who.map((h) => `@${h}`).join(", ")}</span>
+                        <span className="hidden flex-shrink-0 text-faint lg:inline">
+                          · {who.slice(0, 2).map((h) => `@${h}`).join(", ")}
+                          {who.length > 2 && ` +${who.length - 2}`}
+                        </span>
                       )}
                     </SystemNotice>
                     {open && (
                       <ul className="mb-1 ml-[1.75rem] flex flex-col gap-1 border-l border-border py-1 pl-3 pr-5 text-micro text-muted-foreground">
-                        {ev.folded.map((member) => {
-                          const { label, detail } = activityLine(member);
-                          return (
-                            <li key={member.id} className="flex items-center gap-2">
-                              <span className="tabular flex-shrink-0 text-faint">{member.time.slice(0, 5)}</span>
-                              <span className="flex-shrink-0 font-medium">{label}</span>
-                              {detail && <span className="truncate">{detail}</span>}
-                            </li>
-                          );
-                        })}
+                        {ev.folded.map((member) => (
+                          <li key={member.id} className="flex items-center gap-2">
+                            <span className="tabular flex-shrink-0 text-faint">
+                              {member.time.slice(0, 5)}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={() => member.thread && onOpenThread?.(member.thread)}
+                              disabled={!member.thread || !onOpenThread}
+                              className="inline-flex min-w-0 items-center gap-1 truncate rounded px-1 text-accent transition-colors enabled:hover:bg-accent-soft enabled:hover:underline disabled:cursor-default disabled:text-text"
+                            >
+                              <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
+                              <span className="truncate">{member.content}</span>
+                            </button>
+                            {activityLine(member).detail && (
+                              <span className="flex-shrink-0 text-faint">
+                                {activityLine(member).detail}
+                              </span>
+                            )}
+                          </li>
+                        ))}
                       </ul>
                     )}
                   </Fragment>

--- a/mycelium-frontend/src/lib/room-data.ts
+++ b/mycelium-frontend/src/lib/room-data.ts
@@ -314,6 +314,31 @@ export function useRoomThreads(room: string): Map<string, ThreadOwner> {
   }, [memories]);
 }
 
+/** What a row is called, and the thread that opens it. */
+export interface RowNaming {
+  title: string;
+  episode: string | null;
+}
+
+/**
+ * Every row the room holds, keyed by its own key.
+ *
+ * The sibling of {@link useRoomThreads}, read the other way round: a notice and
+ * a memory push both name the *row* they are about, so a feed that wants to
+ * print a task's name rather than its `work/…` slug asks here. Off the same
+ * memories cache, so naming a row costs no request either.
+ */
+export function useRoomRowNames(room: string): Map<string, RowNaming> {
+  const { memories } = useRoomMemories(room);
+  return useMemo(() => {
+    const index = new Map<string, RowNaming>();
+    for (const memory of memories) {
+      index.set(memory.key, { title: memoryTitle(memory), episode: memory.episode ?? null });
+    }
+    return index;
+  }, [memories]);
+}
+
 /** The last readable line in a room, for an inbox-style row. Its own SWR key,
  *  so it never collides with the 200-message page `useRoomPosters` holds. */
 export function useRoomLatest(room: string, opts: RoomQueryOptions = {}) {

--- a/mycelium-frontend/src/lib/threads.test.ts
+++ b/mycelium-frontend/src/lib/threads.test.ts
@@ -3,15 +3,14 @@
 
 import { describe, expect, it } from "vitest";
 import {
-  PING_TYPE,
-  coalescePings,
+  ACTIVITY_WINDOW_MS,
+  coalesceActivity,
   isLiveEpisode,
   liveEpisodeUrn,
   noticeLabel,
   noticeOf,
   pingOf,
   threadShortId,
-  type Pingable,
 } from "@/lib/threads";
 
 const ROOM = "atlas";
@@ -121,56 +120,97 @@ describe("reading a notice", () => {
   });
 });
 
-describe("coalescing a burst of pings", () => {
-  const ping = (thread: string, sender: string): Pingable & { id: string; count: number } => ({
-    id: `${thread}-${sender}`,
-    type: PING_TYPE,
-    thread,
-    pingSenders: [sender],
-    count: 1,
-  });
-  const said = (id: string): Pingable & { id: string; count: number } => ({
+describe("condensing a subject's activity", () => {
+  const TASK = "work/882-login-aligns-identity";
+  const OTHER = "work/886-activity-feed-coalescing";
+  const T0 = Date.parse("2026-08-26T00:00:00Z");
+
+  interface Row {
+    id: string;
+    subject: string | null;
+    at: string;
+    members?: Row[];
+  }
+  const row = (id: string, subject: string | null, offsetMs = 0): Row => ({
     id,
-    type: "broadcast",
-    thread: null,
-    pingSenders: [],
-    count: 0,
+    subject,
+    at: new Date(T0 + offsetMs).toISOString(),
   });
-  const fold = <T extends Pingable & { count: number }>(rows: T[]) =>
-    coalescePings(rows, r => r.count, (latest, count) => ({ ...latest, count }));
+  const said = (id: string, offsetMs = 0): Row => row(id, null, offsetMs);
+  const fold = (rows: Row[], windowMs?: number) =>
+    coalesceActivity(rows, r => r.subject, members => ({ ...members[0], members }), windowMs);
 
-  it("turns a busy thread into one line carrying the count", () => {
-    const rows = fold([ping(THREAD, "risk"), ping(THREAD, "growth"), ping(THREAD, "risk")]);
+  it("turns a burst about one task into a single block", () => {
+    const rows = fold([row("a", TASK), row("b", TASK, 1000), row("c", TASK, 2000)]);
     expect(rows).toHaveLength(1);
-    expect(rows[0].count).toBe(3);
+    expect(rows[0].members?.map(m => m.id)).toEqual(["a", "b", "c"]);
   });
 
-  it("keeps two active threads apart", () => {
-    const other = "urn:ioc:mycelium:episode:atlas:t9";
-    const rows = fold([ping(THREAD, "risk"), ping(other, "growth"), ping(THREAD, "risk")]);
-    expect(rows.map(r => r.thread)).toEqual([THREAD, other]);
-    expect(rows[0].count).toBe(2);
-    expect(rows[1].count).toBe(1);
+  it("folds a ping, a notice and a memory push about the same task into one", () => {
+    // The three ways the room says a task moved. Printed separately they read
+    // as three events; they are one.
+    const rows = fold([row("notice", TASK), row("knowledge", TASK, 500), row("ping", TASK, 900)]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].members).toHaveLength(3);
   });
 
-  it("stops at the first thing said in the room", () => {
-    // A ping after someone speaks is new activity, not more of the same, and
-    // folding it backwards would move a line that has already been read.
-    const rows = fold([ping(THREAD, "risk"), said("a1"), ping(THREAD, "risk")]);
-    expect(rows.map(r => r.id)).toEqual([`${THREAD}-risk`, "a1", `${THREAD}-risk`]);
+  it("keeps two active subjects apart", () => {
+    const rows = fold([row("a", TASK), row("b", OTHER, 100), row("c", TASK, 200)]);
+    expect(rows.map(r => r.subject)).toEqual([TASK, OTHER]);
+    expect(rows[0].members).toHaveLength(2);
+    expect(rows[1].members).toBeUndefined();
   });
 
-  it("leaves a feed with no pings in it exactly as it found it", () => {
-    const rows = [said("a1"), said("a2")];
+  it("keeps folding across what is said in between", () => {
+    // The limitation this replaces: the old ping-only coalesce gave up the
+    // moment anything else was said, so a busy thread and a talkative room
+    // produced exactly the alternating feed the fold exists to prevent.
+    const rows = fold([row("a", TASK), said("m1", 100), row("b", TASK, 200)]);
+    expect(rows.map(r => r.id)).toEqual(["a", "m1"]);
+    expect(rows[0].members?.map(m => m.id)).toEqual(["a", "b"]);
+  });
+
+  it("grows the block where it started rather than moving it down the feed", () => {
+    // Folding forward would move a line the reader has already passed.
+    const rows = fold([row("a", TASK), said("m1", 100), said("m2", 200), row("b", TASK, 300)]);
+    expect(rows.map(r => r.id)).toEqual(["a", "m1", "m2"]);
+  });
+
+  it("opens a new block once the window has closed", () => {
+    // A subject that stays busy keeps saying so — at most one line per window.
+    const rows = fold([
+      row("a", TASK),
+      row("b", TASK, ACTIVITY_WINDOW_MS - 1),
+      row("c", TASK, ACTIVITY_WINDOW_MS + 1),
+    ]);
+    expect(rows.map(r => r.id)).toEqual(["a", "c"]);
+    expect(rows[0].members?.map(m => m.id)).toEqual(["a", "b"]);
+  });
+
+  it("measures the window from the block's first event, not its last", () => {
+    // A sliding gap would let a steadily busy task stay one block for hours,
+    // so genuinely new activity would only ever change a number further up.
+    const rows = fold(
+      [row("a", TASK), row("b", TASK, 60), row("c", TASK, 120), row("d", TASK, 180)],
+      100,
+    );
+    expect(rows.map(r => r.id)).toEqual(["a", "c"]);
+  });
+
+  it("hands the merge every member, oldest first, so nothing is lost", () => {
+    const rows = fold([row("a", TASK), row("b", TASK, 10), row("c", TASK, 20)]);
+    expect(rows[0].members?.map(m => m.at)).toEqual(
+      ["a", "b", "c"].map((_, i) => new Date(T0 + i * 10).toISOString()),
+    );
+  });
+
+  it("passes a subject that moved once through untouched", () => {
+    const only = row("a", TASK);
+    expect(fold([only, said("m1", 10)])[0]).toBe(only);
+  });
+
+  it("leaves a feed with no activity in it exactly as it found it", () => {
+    const rows = [said("m1"), said("m2", 10)];
     expect(fold(rows)).toEqual(rows);
-  });
-
-  it("collects who wrote, in the order they first did", () => {
-    const senders = coalescePings(
-      [ping(THREAD, "risk"), ping(THREAD, "growth"), ping(THREAD, "risk")],
-      r => r.count,
-      (latest, count, who) => ({ ...latest, count, who }),
-    ) as (Pingable & { who?: string[] })[];
-    expect(senders[0].who).toEqual(["risk", "growth"]);
   });
 });

--- a/mycelium-frontend/src/lib/threads.ts
+++ b/mycelium-frontend/src/lib/threads.ts
@@ -182,64 +182,78 @@ export function noticeLabel(subkind: string, kind: string | null | undefined): s
   }
 }
 
-/** The minimum a feed row has to expose to be coalesced. */
-export interface Pingable {
-  type: string;
-  /** The thread this row is about, on a ping; null on everything else. */
-  thread: string | null;
-  /** Who wrote in the thread. A row's own sender is the system that raised the
-   *  ping, which is nobody, so the writers are read from the payload instead. */
-  pingSenders: string[];
+/**
+ * How long one subject's activity keeps condensing into the same block.
+ *
+ * Measured from the block's **first** event, not its last: a sliding gap would
+ * let a task written to every few minutes stay one block for hours, so activity
+ * that is genuinely new would only ever change a number further up the feed.
+ * A bounded span means a busy subject condenses *and* still says so again, at
+ * most one line per window.
+ */
+export const ACTIVITY_WINDOW_MS = 5 * 60 * 1000;
+
+/** The minimum a feed row has to expose to be grouped: when it landed. */
+export interface Activity {
+  at: string;
 }
 
 /**
- * Collapse a burst of pings into one line per thread.
+ * Condense a subject's activity into one evolving block per time window.
  *
- * A thread that is genuinely busy would otherwise write a line per message into
- * the channel it exists to keep quiet — the noise back, one indirection later.
- * So a **run** of consecutive pings (nothing else said in between) becomes at
- * most one row per thread, counting what landed and keeping the newest ping's
- * identity so opening it still reaches the latest.
+ * The room's own timeline is written by everything that moves: a thread pings,
+ * a board event notices, a memory write announces itself. Each is worth having
+ * and none is worth a line — a task compiled, claimed and written to six times
+ * is *one* thing happening, and printed as six near-identical lines it buries
+ * the conversation it is supposed to accompany.
  *
- * Coalescing stops at the first non-ping row: a ping after someone speaks is
- * new activity, not more of the same, and folding it backwards would move a
- * line that has already been read.
+ * So rows naming the same subject fold into one, **across interleaving**: a
+ * person speaking in the middle of a burst no longer splits it in two, which is
+ * the limitation that made the old ping-only coalesce give up the moment
+ * anything else was said. The block sits where its **first** event landed, so
+ * folding never moves a line that has already been read — it only ever grows
+ * one that is already there — and it stops absorbing at {@link ACTIVITY_WINDOW_MS},
+ * so a subject that stays busy keeps saying so.
+ *
+ * Nothing is dropped: `merge` receives every member, oldest first, and the
+ * caller is expected to keep them reachable behind the block it returns. A
+ * subject that moved once is passed through untouched rather than merged into a
+ * group of one.
  */
-export function coalescePings<T extends Pingable>(
+export function coalesceActivity<T extends Activity>(
   rows: T[],
-  count: (row: T) => number,
-  merge: (latest: T, total: number, senders: string[]) => T,
+  subjectOf: (row: T) => string | null,
+  merge: (members: T[]) => T,
+  windowMs: number = ACTIVITY_WINDOW_MS,
 ): T[] {
   const out: T[] = [];
-  let run: T[] = [];
-
-  const flush = () => {
-    if (!run.length) return;
-    const byThread = new Map<string, T[]>();
-    for (const row of run) {
-      const thread = row.thread as string;
-      const group = byThread.get(thread);
-      if (group) group.push(row);
-      else byThread.set(thread, [row]);
-    }
-    for (const group of byThread.values()) {
-      const latest = group[group.length - 1];
-      const total = group.reduce((sum, row) => sum + count(row), 0);
-      // Who has been in the thread since the last thing said in the room. In
-      // first-seen order, so the list reads as the conversation happened.
-      const senders = [...new Set(group.flatMap(row => row.pingSenders))];
-      out.push(total > count(latest) || senders.length > 1 ? merge(latest, total, senders) : latest);
-    }
-    run = [];
-  };
+  /** Every block opened over this feed, by the slot it holds in `out`. */
+  const blocks: { slot: number; members: T[] }[] = [];
+  /** The block currently absorbing each subject — the newest one opened for it. */
+  const open = new Map<string, { slot: number; members: T[]; from: number }>();
 
   for (const row of rows) {
-    if (row.type === PING_TYPE && row.thread) run.push(row);
-    else {
-      flush();
+    const subject = subjectOf(row);
+    if (!subject) {
       out.push(row);
+      continue;
     }
+    const at = Date.parse(row.at) || 0;
+    const block = open.get(subject);
+    if (block && at - block.from <= windowMs) {
+      block.members.push(row);
+      continue;
+    }
+    const fresh = { slot: out.length, members: [row], from: at };
+    open.set(subject, fresh);
+    blocks.push(fresh);
+    // Held until the feed is read out: a block is only a block once something
+    // else joins it, and until then this row is its own line.
+    out.push(row);
   }
-  flush();
+
+  for (const block of blocks) {
+    if (block.members.length > 1) out[block.slot] = merge(block.members);
+  }
   return out;
 }

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -942,9 +942,331 @@ const scratch: RoomFixture = {
   invites: [],
 };
 
+// ── mycelium-general: the room as it actually reads under load ────────────────
+//
+// Lifted from a live capture of the hub's own room: seven agents each working a
+// task, and in ninety minutes the channel carried 76 system lines and not one
+// sentence anyone said. That is the shape the activity design has to survive, so
+// it is the shape the mock serves.
+
+const GENERAL_LIVE = "urn:ioc:mycelium:episode:mycelium-general:live";
+function generalEpisode(short: string): string {
+  return `urn:ioc:mycelium:episode:mycelium-general:${short}`;
+}
+
+const generalMemories: MockMemory[] = [
+  {
+    key: "work/860-retire-the-negotiate-pane-channel-board-netw",
+    value: "860: retire the Negotiate pane — Channel · Board · Network",
+    meta: { kind: "action", status: "open", assignee: "@fix-860" },
+    created_by: "fix-860",
+    version: 3,
+    updated_at: iso(63),
+    episode: generalEpisode("t860"),
+  },
+  {
+    key: "work/872-every-memory-can-be-discussed-widen-thread-m",
+    value: "872: every memory can be discussed",
+    meta: { kind: "action", status: "open", assignee: "@task-872" },
+    created_by: "task-872",
+    version: 3,
+    updated_at: iso(62),
+    episode: generalEpisode("t872"),
+  },
+  {
+    key: "work/881-mycelium-login-auto-discovers-the-oidc-issue",
+    value: "881: mycelium login auto-discovers the OIDC issuer from the hub",
+    meta: { kind: "action", status: "open", assignee: "@fix-881" },
+    created_by: "fix-881",
+    version: 3,
+    updated_at: iso(68),
+    episode: generalEpisode("t881"),
+  },
+  {
+    key: "work/886-activity-feed-needs-real-coalescing-group-kn",
+    value: "886: activity feed needs real coalescing — group Knowledge/pings/notices",
+    meta: { kind: "action", status: "open", assignee: "@task-886" },
+    created_by: "task-886",
+    version: 3,
+    updated_at: iso(67),
+    episode: generalEpisode("t886"),
+  },
+  {
+    key: "work/887-task-view-has-a-double-scroll-one-scroll-col",
+    value: "887: task view has a double-scroll — one scroll, collapsible markdown over the chat",
+    meta: { kind: "action", status: "open", assignee: "@task-887" },
+    created_by: "task-887",
+    version: 3,
+    updated_at: iso(60),
+    episode: generalEpisode("t887"),
+  },
+  {
+    key: "work/888-markdown-headings-are-uppercased-and-the-bod",
+    value: "888: markdown headings are uppercased and the body styling looks poor",
+    meta: { kind: "action", status: "open", assignee: "@task-888" },
+    created_by: "task-888",
+    version: 3,
+    updated_at: iso(6),
+    episode: generalEpisode("t888"),
+  },
+  {
+    key: "work/889-channel-ping-notice-rendering-slug-instead-o",
+    value: "889: channel ping/notice rendering — slug instead of title, ragged type",
+    meta: { kind: "action", status: "open", assignee: "@task-889" },
+    created_by: "task-889",
+    version: 3,
+    updated_at: iso(63),
+    episode: generalEpisode("t889"),
+  },
+  {
+    key: "agents/fix-860",
+    value: agentManifest("Working 860."),
+    created_by: "claude-web",
+    version: 1,
+    updated_at: iso(75),
+  },
+  {
+    key: "agents/task-872",
+    value: agentManifest("Working 872."),
+    created_by: "claude-web",
+    version: 1,
+    updated_at: iso(79),
+  },
+  {
+    key: "agents/task-886",
+    value: agentManifest("Working 886."),
+    created_by: "claude-web",
+    version: 1,
+    updated_at: iso(86),
+  },
+  {
+    key: "agents/task-887",
+    value: agentManifest("Working 887."),
+    created_by: "claude-web",
+    version: 1,
+    updated_at: iso(81),
+  },
+  {
+    key: "agents/task-888",
+    value: agentManifest("Working 888."),
+    created_by: "claude-web",
+    version: 1,
+    updated_at: iso(80),
+  },
+  {
+    key: "agents/task-889",
+    value: agentManifest("Working 889."),
+    created_by: "claude-web",
+    version: 1,
+    updated_at: iso(80),
+  },
+];
+
+const generalL9: Record<string, unknown>[] = [
+  generalNotice("filed", "work/886-activity-feed-needs-real-coalescing-group-kn", "886: activity feed needs real coalescing — group Knowledge/pings/notices", "task-886", 86),
+  generalNotice("claimed", "work/886-activity-feed-needs-real-coalescing-group-kn", "886: activity feed needs real coalescing — group Knowledge/pings/notices", "task-886", 86),
+  generalPing("work/886-activity-feed-needs-real-coalescing-group-kn", "task-886", "m5-0", 86),
+  generalNotice("filed", "work/887-task-view-has-a-double-scroll-one-scroll-col", "887: task view has a double-scroll — one scroll, collapsible markdown over the chat", "task-887", 81),
+  generalNotice("claimed", "work/887-task-view-has-a-double-scroll-one-scroll-col", "887: task view has a double-scroll — one scroll, collapsible markdown over the chat", "task-887", 80),
+  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "task-887", "m11-0", 80),
+  generalNotice("filed", "work/888-markdown-headings-are-uppercased-and-the-bod", "888: markdown headings are uppercased and the body styling looks poor", "task-888", 79),
+  generalNotice("claimed", "work/888-markdown-headings-are-uppercased-and-the-bod", "888: markdown headings are uppercased and the body styling looks poor", "task-888", 78),
+  generalPing("work/888-markdown-headings-are-uppercased-and-the-bod", "task-888", "m19-0", 78),
+  generalNotice("filed", "work/872-every-memory-can-be-discussed-widen-thread-m", "872: every memory can be discussed — widen thread-minting beyond the board namespaces", "task-872", 78),
+  generalNotice("claimed", "work/872-every-memory-can-be-discussed-widen-thread-m", "872: every memory can be discussed — widen thread-minting beyond the board namespaces", "task-872", 78),
+  generalPing("work/872-every-memory-can-be-discussed-widen-thread-m", "task-872", "m24-0", 78),
+  generalNotice("filed", "work/889-channel-ping-notice-rendering-slug-instead-o", "889: channel ping/notice rendering — slug instead of title, ragged type", "task-889", 77),
+  generalNotice("claimed", "work/889-channel-ping-notice-rendering-slug-instead-o", "889: channel ping/notice rendering — slug instead of title, ragged type", "task-889", 77),
+  generalPing("work/889-channel-ping-notice-rendering-slug-instead-o", "task-889", "m29-0", 77),
+  generalNotice("filed", "work/860-retire-the-negotiate-pane-channel-board-netw", "860: retire the Negotiate pane — Channel · Board · Network", "fix-860", 74),
+  generalNotice("claimed", "work/860-retire-the-negotiate-pane-channel-board-netw", "860: retire the Negotiate pane — Channel · Board · Network", "fix-860", 74),
+  generalPing("work/860-retire-the-negotiate-pane-channel-board-netw", "fix-860", "m35-0", 73),
+  generalPing("work/888-markdown-headings-are-uppercased-and-the-bod", "task-888", "m36-0", 70),
+  generalPing("work/886-activity-feed-needs-real-coalescing-group-kn", "task-886", "m37-0", 70),
+  generalPing("work/886-activity-feed-needs-real-coalescing-group-kn", "task-886", "m40-0", 69),
+  generalPing("work/881-mycelium-login-auto-discovers-the-oidc-issue", "fix-881", "m42-0", 68),
+  generalNotice("resolved", "work/881-mycelium-login-auto-discovers-the-oidc-issue", "881: mycelium login auto-discovers the OIDC issuer from the hub", "fix-881", 68),
+  generalPing("work/888-markdown-headings-are-uppercased-and-the-bod", "task-888", "m46-0", 68),
+  generalPing("work/886-activity-feed-needs-real-coalescing-group-kn", "task-886", "m47-0", 68),
+  generalNotice("resolved", "work/888-markdown-headings-are-uppercased-and-the-bod", "888: markdown headings are uppercased and the body styling looks poor", "task-888", 68),
+  generalNotice("claimed", "work/888-markdown-headings-are-uppercased-and-the-bod", "888: markdown headings are uppercased and the body styling looks poor", "task-888", 67),
+  generalPing("work/888-markdown-headings-are-uppercased-and-the-bod", "task-888", "m53-0", 67),
+  generalPing("work/889-channel-ping-notice-rendering-slug-instead-o", "task-889", "m54-0", 65),
+  generalPing("work/860-retire-the-negotiate-pane-channel-board-netw", "fix-860", "m55-0", 65),
+  generalPing("work/860-retire-the-negotiate-pane-channel-board-netw", "fix-860", "m58-0", 65),
+  generalPing("work/889-channel-ping-notice-rendering-slug-instead-o", "task-889", "m59-0", 63),
+  generalPing("work/889-channel-ping-notice-rendering-slug-instead-o", "task-889", "m59-1", 63),
+  generalPing("work/872-every-memory-can-be-discussed-widen-thread-m", "task-872", "m60-0", 63),
+  generalNotice("resolved", "work/889-channel-ping-notice-rendering-slug-instead-o", "889: channel ping/notice rendering — slug instead of title, ragged type", "task-889", 63),
+  generalPing("work/860-retire-the-negotiate-pane-channel-board-netw", "fix-860", "m63-0", 63),
+  generalNotice("resolved", "work/860-retire-the-negotiate-pane-channel-board-netw", "860: retire the Negotiate pane — Channel · Board · Network", "fix-860", 63),
+  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "task-887", "m67-0", 62),
+  generalPing("work/872-every-memory-can-be-discussed-widen-thread-m", "task-872", "m69-0", 62),
+  generalNotice("resolved", "work/872-every-memory-can-be-discussed-widen-thread-m", "872: every memory can be discussed", "task-872", 62),
+  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "juliarvalenti@gmail.com", "m73-0", 60),
+  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "juliarvalenti@gmail.com", "m73-1", 60),
+  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "juliarvalenti@gmail.com", "m73-2", 60),
+  generalNotice("claimed", "work/888-markdown-headings-are-uppercased-and-the-bod", "888: markdown headings are uppercased and the body styling looks poor", "task-888", 6),
+];
+
+const generalKnowledgePushes: MockMessage[] = [
+  generalKnowledge("agents/task-886", "claude-web", 86),
+  generalKnowledge("work/886-activity-feed-needs-real-coalescing-group-kn", "task-886", 86),
+  generalKnowledge("work/886-activity-feed-needs-real-coalescing-group-kn", "task-886", 86),
+  generalKnowledge("agents/task-887", "claude-web", 81),
+  generalKnowledge("work/887-task-view-has-a-double-scroll-one-scroll-col", "task-887", 81),
+  generalKnowledge("work/887-task-view-has-a-double-scroll-one-scroll-col", "task-887", 80),
+  generalKnowledge("agents/task-888", "claude-web", 80),
+  generalKnowledge("agents/task-889", "claude-web", 80),
+  generalKnowledge("work/888-markdown-headings-are-uppercased-and-the-bod", "task-888", 79),
+  generalKnowledge("agents/task-872", "claude-web", 79),
+  generalKnowledge("work/888-markdown-headings-are-uppercased-and-the-bod", "task-888", 78),
+  generalKnowledge("work/872-every-memory-can-be-discussed-widen-thread-m", "task-872", 78),
+  generalKnowledge("work/872-every-memory-can-be-discussed-widen-thread-m", "task-872", 78),
+  generalKnowledge("work/889-channel-ping-notice-rendering-slug-instead-o", "task-889", 77),
+  generalKnowledge("work/889-channel-ping-notice-rendering-slug-instead-o", "task-889", 77),
+  generalKnowledge("agents/fix-860", "claude-web", 75),
+  generalKnowledge("work/860-retire-the-negotiate-pane-channel-board-netw", "fix-860", 74),
+  generalKnowledge("work/860-retire-the-negotiate-pane-channel-board-netw", "fix-860", 74),
+  generalKnowledge("work/886-activity-feed-needs-real-coalescing-group-kn", "claude-web", 69),
+  generalKnowledge("work/888-markdown-headings-are-uppercased-and-the-bod", "claude-web", 69),
+  generalKnowledge("work/881-mycelium-login-auto-discovers-the-oidc-issue", "claude-web", 69),
+  generalKnowledge("work/881-mycelium-login-auto-discovers-the-oidc-issue", "fix-881", 68),
+  generalKnowledge("work/888-markdown-headings-are-uppercased-and-the-bod", "claude-web", 68),
+  generalKnowledge("work/888-markdown-headings-are-uppercased-and-the-bod", "task-888", 68),
+  generalKnowledge("work/886-activity-feed-needs-real-coalescing-group-kn", "claude-web", 67),
+  generalKnowledge("work/888-markdown-headings-are-uppercased-and-the-bod", "task-888", 67),
+  generalKnowledge("work/860-retire-the-negotiate-pane-channel-board-netw", "claude-web", 65),
+  generalKnowledge("work/889-channel-ping-notice-rendering-slug-instead-o", "claude-web", 65),
+  generalKnowledge("work/889-channel-ping-notice-rendering-slug-instead-o", "task-889", 63),
+  generalKnowledge("work/860-retire-the-negotiate-pane-channel-board-netw", "fix-860", 63),
+  generalKnowledge("work/889-channel-ping-notice-rendering-slug-instead-o", "claude-web", 63),
+  generalKnowledge("work/872-every-memory-can-be-discussed-widen-thread-m", "claude-web", 62),
+  generalKnowledge("work/872-every-memory-can-be-discussed-widen-thread-m", "task-872", 62),
+  generalKnowledge("work/887-task-view-has-a-double-scroll-one-scroll-col", "claude-web", 61),
+  generalKnowledge("work/888-markdown-headings-are-uppercased-and-the-bod", "task-888", 6),
+];
+
+/** A ping in mycelium-general's `live`, naming the thread that moved. */
+function generalPing(key: string, sender: string, message: string, minutesAgo: number): Record<string, unknown> {
+  const episode = generalEpisode(`t${key.replace(/^work\/(\d+)-.*$/, "$1")}`);
+  return {
+    id: `gp-${message}`,
+    sender_handle: "system",
+    message_type: "l9_exchange",
+    created_at: iso(minutesAgo),
+    room_name: "mycelium-general",
+    episode: GENERAL_LIVE,
+    content: {
+      l9: {
+        header: { kind: "exchange", message: { id: `gp-${message}`, parents: [], episode: GENERAL_LIVE } },
+        payload: { type: "ping", data: { episode, sender, message } },
+      },
+    },
+  };
+}
+
+/** A board event in mycelium-general's `live`. */
+function generalNotice(
+  subkind: string,
+  key: string,
+  title: string,
+  by: string,
+  minutesAgo: number,
+): Record<string, unknown> {
+  const id = `gn-${subkind}-${key}-${minutesAgo}`;
+  return {
+    id,
+    sender_handle: "system",
+    message_type: "l9_exchange",
+    created_at: iso(minutesAgo),
+    room_name: "mycelium-general",
+    episode: GENERAL_LIVE,
+    content: {
+      l9: {
+        header: { kind: "exchange", message: { id, parents: [], episode: GENERAL_LIVE } },
+        payload: {
+          type: "notice",
+          data: {
+            subkind,
+            key,
+            title,
+            episode: generalEpisode(`t${key.replace(/^work\/(\d+)-.*$/, "$1")}`),
+            by,
+            ...(subkind === "filed" ? { kind: "action" } : {}),
+          },
+        },
+      },
+    },
+  };
+}
+
+/** A memory push, as the persister announces one into the room. */
+function generalKnowledge(key: string, updatedBy: string, minutesAgo: number): MockMessage {
+  return {
+    id: `gk-${key}-${minutesAgo}`,
+    sender_handle: "system",
+    message_type: "l9_knowledge",
+    created_at: iso(minutesAgo),
+    episode: GENERAL_LIVE,
+    content: JSON.stringify({
+      content: `memory updated → ${key}`,
+      l9: { payload: { type: "extraction", data: { key, updated_by: updatedBy, version: 3 } } },
+    }),
+  };
+}
+
+/** The little that was actually said out loud while all of that went past. */
+const generalSaid: MockMessage[] = [
+  {
+    id: "gs-1",
+    sender_handle: "juliarvalenti@gmail.com",
+    message_type: "broadcast",
+    created_at: iso(70),
+    episode: GENERAL_LIVE,
+    content: "Is mycelium login now becoming an interactive terminal flow when it wasn't before?",
+  },
+  {
+    id: "gs-2",
+    sender_handle: "juliarvalenti@gmail.com",
+    message_type: "broadcast",
+    created_at: iso(30),
+    episode: GENERAL_LIVE,
+    content: "Which of these is actually blocked on me? I can't tell from here.",
+  },
+  {
+    id: "gs-3",
+    sender_handle: "juliarvalenti@gmail.com",
+    message_type: "broadcast",
+    created_at: iso(8),
+    episode: GENERAL_LIVE,
+    content: "Let's get 886 in first — the rest of this is unreadable until it lands.",
+  },
+];
+
+const general: RoomFixture = {
+  room: {
+    id: 4,
+    name: "mycelium-general",
+    created_at: iso(60 * 96),
+    is_public: true,
+    is_persistent: true,
+    mas_id: "mas_9f3c02de",
+  },
+  memories: generalMemories,
+  messages: [...generalKnowledgePushes, ...generalSaid].sort(
+    (a, b) => Date.parse(a.created_at) - Date.parse(b.created_at),
+  ),
+  episodes: [],
+  episodeDetails: {},
+  invites: [],
+  l9: generalL9,
+};
+
 export const ROOM_FIXTURES: Record<string, RoomFixture> = {
   "atlas-migration": atlas,
   "pricing-model": pricing,
+  "mycelium-general": general,
   scratch,
 };
 


### PR DESCRIPTION
## Summary

Grouping the activity **in place** was not enough, and the honest way to show that is against real data. This PR carries a live capture of the hub's own `mycelium-general` — ninety minutes, seven agents each working a task — into the mock fixtures, because that is the shape the design has to survive:

| | feed lines |
|---|---|
| today (`coalescePings`, consecutive pings only) | **76** |
| grouping per task, in place (this PR's first commit) | **20** |
| this PR | **7** |

In that whole ninety minutes the channel carried **not one sentence anyone said**. Per-task grouping took 76 to 20 — still a changelog with the conversation buried in it, and the same task recurring down the feed each time a window closed.

So the split is by what a line *is*, not how many of them there are.

## Changes

- **`src/components/activity-rail.tsx` (new)** — a pinned rail above the feed holding what the room has been *doing*: memory pushes, thread pings, claims and releases. One entry per task rather than one per frame, newest first, three rows and one control for the rest. **No time window here** — the rail is the room's current state, so a task written to all morning is one entry that keeps moving up, never an entry per burst. Bounded, so a busy hour costs the same height as a quiet one.
- **`src/components/event-stream.tsx`** — `isActivity` splits the timeline; `NARRATED_SUBKINDS` keeps `filed` / `resolved` / `blocked` / `unblocked` in the feed and sends `claimed` / `released` to the rail. `subjectOf` maps a ping (via its thread's bound row), a notice and a memory push onto one task key; `nameActivity` resolves that key to the row's **title**; `actorsOf` collects who moved it.
- **Narrated notices fold by transition, not by task.** Several tasks filed in one minute is one thing the room did ("New tasks · 886: … · 887: … +2"), while a task filed and later resolved is two pieces of news and must not read as one.
- **`src/lib/threads.ts`** — `coalescePings` → `coalesceActivity(rows, subjectOf, merge, windowMs)`: groups over a key and a window, folding across interleaving, handing `merge` every member oldest-first.
- **`src/lib/room-data.ts`** — `useRoomRowNames`, the sibling of `useRoomThreads` read the other way round (key → title + thread), off the same memories cache.
- **An agent's own manifest write reaches neither surface.** Seven agents joining was seven lines saying somebody arrived; the Members rail already says it.
- **Double-key render fixed** — a memory push printed its key twice and never as the row's title.
- **`src/mocks/fixtures.ts`** — the capture itself as a `mycelium-general` mock room: 7 work rows, 6 agent manifests, 44 L9 frames, 35 memory pushes, and the three things a human actually managed to say.

## Calls worth arguing with

- **The rail is unbounded in time but bounded in height; the feed is the reverse.** State does not scroll, news does. That is the whole split, and if it is wrong the rest follows from it.
- **`claimed` is bookkeeping, `filed` is news.** An agent picking work up is not worth interrupting a conversation for; a task appearing or finishing is. Debatable, one line to move.
- **Three rows before "more"** is a guess, tuned on this capture.

## Testing

- Frontend **771 passed / 60 files**, `tsc --noEmit` clean, `eslint` 0 errors (2 pre-existing warnings in untouched files), `next build` green.
- `event-stream.activity.test.tsx` rewritten for the new contract: churn gathers into one rail entry; none of it reaches the conversation; arrivals and outcomes still narrate in sequence; a run of arrivals folds by transition; an arrival never folds into an outcome; `agents/*` reaches neither surface; the rail holds a fixed height at five tasks; the rail orders by what moved last.
- The duplicate-ingest guard in `event-stream.thread.test.tsx` now asserts the rail reads **1 update**, since a rail that counted the L9 replay and the message list separately would report a duplicate as work.
- Verified in the running app against the captured room at phone / tablet / laptop / wide.

## Related Issues

Closes #886