### PR TITLE
Name a task the same way everywhere the channel mentions it (#889)

### DIFF
--- a/mycelium-frontend/src/app/globals.css
+++ b/mycelium-frontend/src/app/globals.css
@@ -226,6 +226,16 @@ body {
   letter-spacing: 0.18em;
   text-transform: uppercase;
 }
+/* An identifier set inline in sans copy — an episode's short id, a metric, a
+ * file name. Geist Mono runs optically larger than IBM Plex Sans at the same
+ * nominal size, so a bare `font-mono` inside a line of copy reads as a size
+ * change rather than a change of register; stepping it down is what makes the
+ * line one size. Relative, so it holds at every step of the scale. */
+.mono-inline {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+}
+
 .square-dot {
   display: inline-block;
   width: 8px;

--- a/mycelium-frontend/src/components/episode-tag.tsx
+++ b/mycelium-frontend/src/components/episode-tag.tsx
@@ -23,7 +23,7 @@ interface Props {
  * clickable-reference look across chat, whichever kind of record it points at.
  */
 export function EpisodeTag({ urn, shortId, onOpen }: Props) {
-  const base = "rounded font-mono transition-colors";
+  const base = "rounded mono-inline transition-colors";
   if (!onOpen) {
     return (
       <Tooltip content={urn}>

--- a/mycelium-frontend/src/components/event-stream.render.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.render.test.tsx
@@ -178,7 +178,9 @@ describe("<EventStream /> live message rendering", () => {
       });
     });
 
-    expect(await screen.findByText("plan updated → plan/tasks.md")).toBeInTheDocument();
+    // No row in this room carries that key, so the chip reads as the key —
+    // the honest read, and the only case in which a slug reaches the channel.
+    expect(await screen.findByText("plan/tasks.md")).toBeInTheDocument();
     expect(screen.getByText("Knowledge")).toBeInTheDocument();
     expect(screen.getByText("by @aligner", { exact: false })).toBeInTheDocument();
     expect(warn).not.toHaveBeenCalled();

--- a/mycelium-frontend/src/components/event-stream.thread.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.thread.test.tsx
@@ -168,6 +168,70 @@ describe("<EventStream /> and the threads inside the room", () => {
     expect(await screen.findByText("flip reads behind a flag")).toBeInTheDocument();
   });
 
+  it("names a prose row by its first line, in the shape the store hands it over", async () => {
+    // The store keeps prose in the markdown body and rebuilds `value` from it,
+    // so a task row arrives as `{text: …}` rather than as a bare string. Reading
+    // only the string is what put a `work/…` slug in the channel where the
+    // board, one line above, was showing the row's name.
+    vi.mocked(fetchMemories).mockResolvedValue([
+      {
+        key: "work/flip-reads-behind-a-flag",
+        value: { text: "flip reads behind a flag\n\nGate the read path on the flag." },
+        content_text: "flip reads behind a flag\n\nGate the read path on the flag.",
+        version: 1,
+        created_by: "aligner",
+        updated_at: CREATED,
+        episode: THREAD,
+      },
+    ]);
+    renderWithSWR(<EventStream roomName={ROOM} onOpenThread={vi.fn()} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit(ping("risk", "m-1"));
+    });
+
+    expect(await screen.findByText("flip reads behind a flag")).toBeInTheDocument();
+    expect(screen.queryByText("work/flip-reads-behind-a-flag")).not.toBeInTheDocument();
+  });
+
+  it("names the memory a knowledge push wrote, not the key it is filed under", async () => {
+    vi.mocked(fetchMemories).mockResolvedValue([
+      {
+        key: "context/synthesis",
+        value: { text: "where the room got to on the cutover" },
+        version: 3,
+        created_by: "synthesizer",
+        updated_at: CREATED,
+        episode: null,
+      },
+    ]);
+    renderWithSWR(<EventStream roomName={ROOM} />);
+    await act(async () => {});
+    const es = FakeEventSource.latest();
+
+    await act(async () => {
+      es.open();
+      es.emit({
+        id: "k-1",
+        message_type: "l9_knowledge",
+        sender_handle: "system",
+        created_at: CREATED,
+        episode: LIVE,
+        content: JSON.stringify({
+          l9: {
+            payload: { type: "distillation", data: { key: "context/synthesis", updated_by: "synthesizer" } },
+          },
+        }),
+      });
+    });
+
+    expect(await screen.findByText("where the room got to on the cutover")).toBeInTheDocument();
+    expect(screen.queryByText("context/synthesis")).not.toBeInTheDocument();
+  });
+
   it("will not name a thread several rows share", async () => {
     // A converged negotiation binds every task it compiled to the episode it
     // converged in, so there is no one row to name — picking one would be the
@@ -245,6 +309,6 @@ describe("<EventStream /> and the threads inside the room", () => {
     renderWithSWR(<EventStream roomName={ROOM} />);
     await act(async () => {});
 
-    expect(await screen.findAllByText("memory updated → work/flip")).toHaveLength(1);
+    expect(await screen.findAllByText("work/flip")).toHaveLength(1);
   });
 });

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -12,7 +12,7 @@ import {
   logFetchError,
   type PendingInvite,
 } from "@/lib/api";
-import { useRoomAgents, useRoomThreads } from "@/lib/room-data";
+import { useRoomAgents, useRoomThreads, useRoomTitles } from "@/lib/room-data";
 import { NOTICE_TYPE, PING_TYPE, coalescePings, isLiveEpisode, noticeLabel, noticeOf, pingOf, threadShortId } from "@/lib/threads";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
 import { MarkdownContent } from "@/components/markdown-content";
@@ -114,6 +114,50 @@ function ChannelSkeleton() {
         </div>
       ))}
     </div>
+  );
+}
+
+/**
+ * What a system notice points at, drawn one way.
+ *
+ * A ping, a board notice and a knowledge push all name the same kind of thing —
+ * a task, by the name a human gave it — so they draw the same chip rather than
+ * three near-identical buttons that drift apart. The row it sits in is the
+ * caller's; what it points at, and how wide that is allowed to get, is here.
+ */
+function NoticeChip({
+  label,
+  what,
+  title,
+  onOpen,
+}: {
+  label: string;
+  /** What the chip points at, for the label a screen reader reads. */
+  what: string;
+  /** The underlying key or URN, for the reader who wants to check. */
+  title?: string;
+  onOpen?: () => void;
+}) {
+  const base = "inline-flex max-w-[20rem] items-center gap-1 truncate rounded px-1";
+  if (!onOpen) {
+    return (
+      <span className={`${base} text-text`} title={title}>
+        <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
+        <span className="truncate">{label}</span>
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      title={title}
+      aria-label={`Open ${what} ${label}`}
+      className={`${base} text-accent transition-colors hover:bg-accent-soft hover:underline`}
+    >
+      <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
+      <span className="truncate">{label}</span>
+    </button>
   );
 }
 
@@ -429,6 +473,9 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
   // six characters of URN. Off the room's shared memory read, so it costs
   // nothing; a thread no row is bound to simply has no name to give.
   const threads = useRoomThreads(roomName);
+  // And what each memory is called, for the events that name a key rather than
+  // a thread. Same cache again, so the third reader is still one request.
+  const titles = useRoomTitles(roomName);
   const agentHandles = useMemo(() => new Set(agents.map((a) => a.handle)), [agents]);
   const agentOwners = useMemo(
     () => new Map(agents.filter((a) => a.owner).map((a) => [a.handle, a.owner as string])),
@@ -706,22 +753,16 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                 return (
                   <SystemNotice key={ev.id} time={ev.time} dot="var(--accent)" label="Activity">
                     <span>in</span>
-                    <button
-                      type="button"
-                      onClick={() => onOpenThread?.(thread)}
-                      disabled={!onOpenThread}
+                    <NoticeChip
+                      label={owner?.title ?? shortId}
+                      what="thread"
                       title={thread}
-                      aria-label={`Open thread ${shortId}`}
-                      className="inline-flex max-w-[18rem] items-center gap-1 truncate rounded px-1 text-accent transition-colors enabled:hover:bg-accent-soft enabled:hover:underline disabled:cursor-default"
-                    >
-                      <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
-                      <span className="truncate">{owner?.title ?? shortId}</span>
-                    </button>
+                      onOpen={onOpenThread && (() => onOpenThread(thread))}
+                    />
                     <span>· {ev.pings} new</span>
                     {who.length > 0 && (
                       <span className="truncate">· {who.map(h => `@${h}`).join(", ")}</span>
                     )}
-                    {onOpenThread && <span className="text-faint">· click to open</span>}
                   </SystemNotice>
                 );
               }
@@ -746,15 +787,12 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                     dot={dot}
                     label={noticeLabel(subkind, ev.raw.kind as string | undefined)}
                   >
-                    <button
-                      type="button"
-                      onClick={() => episode && onOpenThread?.(episode)}
-                      disabled={!episode || !onOpenThread}
-                      className="inline-flex max-w-[20rem] items-center gap-1 truncate rounded px-1 text-accent transition-colors enabled:hover:bg-accent-soft enabled:hover:underline disabled:cursor-default disabled:text-text"
-                    >
-                      <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
-                      <span className="truncate">{ev.content}</span>
-                    </button>
+                    <NoticeChip
+                      label={ev.content}
+                      what="task"
+                      title={ev.raw.taskKey as string | undefined}
+                      onOpen={episode && onOpenThread ? () => onOpenThread(episode) : undefined}
+                    />
                     {/* A filed task reads by who it is for; a lease event by who
                         moved it. Fall back to the filer when a task is for no one. */}
                     {subkind === "filed" && ev.raw.for ? (
@@ -770,9 +808,20 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                 const updatedBy = ev.raw.updated_by as string | undefined;
                 return (
                   <SystemNotice key={ev.id} time={ev.time} dot="var(--yellow)" label="Knowledge">
-                    <span>{ev.content}</span>
-                    {key && <span className="font-mono text-muted-foreground">{key}</span>}
-                    {updatedBy ? <span>by @{updatedBy}</span> : null}
+                    {/* A knowledge push names a memory, so it reads by the same
+                        name the board and the ping give it — never the key it
+                        happens to be filed under. */}
+                    {key ? (
+                      <NoticeChip
+                        label={titles.get(key) ?? key}
+                        what="memory"
+                        title={key}
+                        onOpen={onOpenMemory && (() => onOpenMemory(key))}
+                      />
+                    ) : (
+                      <span className="truncate">{ev.content}</span>
+                    )}
+                    {updatedBy ? <span>· by @{updatedBy}</span> : null}
                   </SystemNotice>
                 );
               }
@@ -802,7 +851,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                     {shortId ? (
                       <EpisodeTag urn={episodeUrn} shortId={shortId} onOpen={onOpenThread && episodeUrn ? () => onOpenThread(episodeUrn) : undefined} />
                     ) : (
-                      <span className="font-mono">episode</span>
+                      <span className="mono-inline">episode</span>
                     )}
                     {broken ? (
                       <span>· no agreement</span>
@@ -812,7 +861,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                         {gar !== undefined ? (
                           <Tooltip content="Genuine agreement ratio: how many agents actually moved toward the outcome">
                             <span
-                              className="font-mono"
+                              className="mono-inline"
                               aria-description="Genuine agreement ratio: how many agents actually moved toward the outcome"
                             >
                               · GAR {gar.toFixed(2)}
@@ -820,7 +869,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onN
                           </Tooltip>
                         ) : null}
                         {planFile ? (
-                          <span>→ <span className="font-mono text-accent">{planFile}</span></span>
+                          <span>→ <span className="mono-inline text-accent">{planFile}</span></span>
                         ) : null}
                       </>
                     )}

--- a/mycelium-frontend/src/lib/board/projection.ts
+++ b/mycelium-frontend/src/lib/board/projection.ts
@@ -24,6 +24,7 @@ import type { PresenceMember } from "@/lib/api";
 import { ASSIGNMENT_FIELD, DEFAULT_TTL_MINUTES, ASSIGNABLE_NAMESPACES, assignmentOf } from "./assignment";
 import type { LiveItem } from "./item";
 import { memoryHref } from "@/lib/memory-routes";
+import { memoryTitle } from "@/lib/memory-preview";
 
 /** Namespaces whose memories read as coordination state rather than prose. */
 const LIVE_NAMESPACES = ["decisions", "status", "work", "failed"];
@@ -107,12 +108,7 @@ function memoryItem(memory: Memory, room: string): LiveItem {
   delete custom.text;
   delete custom.content;
 
-  const title =
-    typeof custom.title === "string"
-      ? custom.title
-      : typeof value === "string"
-        ? firstLine(value)
-        : firstLine(memory.content_text ?? memory.key);
+  const title = memoryTitle(memory);
 
   const derivedStatus = namespace === "decisions" ? "resolved" : "open";
 
@@ -124,7 +120,7 @@ function memoryItem(memory: Memory, room: string): LiveItem {
 
   return {
     id: `memory:${memory.key}`,
-    title: title || memory.key,
+    title,
     source: {
       kind: "memory",
       label: memory.key,
@@ -203,11 +199,6 @@ function agentItem(agent: AgentSummary, presence: PresenceMember, now: string): 
       ttl_minutes: DEFAULT_TTL_MINUTES,
     },
   };
-}
-
-function firstLine(text: string): string {
-  const line = text.split("\n").map(l => l.trim()).find(l => l && !l.startsWith("---"));
-  return (line ?? "").replace(/^#+\s*/, "").slice(0, 120);
 }
 
 export interface ProjectionInput {

--- a/mycelium-frontend/src/lib/memory-preview.test.ts
+++ b/mycelium-frontend/src/lib/memory-preview.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   flattenMarkdown,
   memoryPreview,
+  memoryTitle,
   memoryValueText,
   previewCardTop,
 } from "@/lib/memory-preview";
@@ -20,6 +21,46 @@ describe("memoryValueText", () => {
 
   it("serialises a value with no text field", () => {
     expect(memoryValueText({ a: 1 })).toBe('{"a":1}');
+  });
+});
+
+describe("memoryTitle", () => {
+  const row = (over: Record<string, unknown>) =>
+    ({ key: "work/flip-reads-behind-a-flag", value: null, ...over }) as never;
+
+  it("reads the first line of a body the store handed back as `{text}`", () => {
+    // The shape the API actually returns for a markdown memory: prose lives in
+    // the body and `value` is rebuilt from it. A reader that understood only a
+    // bare string printed the key here, which is how a slug reached the channel.
+    expect(memoryTitle(row({ value: { text: "flip reads behind a flag\n\nbody" } }))).toBe(
+      "flip reads behind a flag",
+    );
+  });
+
+  it("reads a bare string value the same way", () => {
+    expect(memoryTitle(row({ value: "flip reads behind a flag\n\nbody" }))).toBe(
+      "flip reads behind a flag",
+    );
+  });
+
+  it("prefers a structured value's own title", () => {
+    expect(memoryTitle(row({ value: { title: "named", text: "first line" } }))).toBe("named");
+  });
+
+  it("strips a heading marker", () => {
+    expect(memoryTitle(row({ value: { text: "# flip reads behind a flag" } }))).toBe(
+      "flip reads behind a flag",
+    );
+  });
+
+  it("falls back to content_text when the value carries no prose", () => {
+    expect(memoryTitle(row({ value: { status: "open" }, content_text: "flip reads" }))).toBe(
+      "flip reads",
+    );
+  });
+
+  it("falls back to the key when there is no readable body at all", () => {
+    expect(memoryTitle(row({ value: {} }))).toBe("work/flip-reads-behind-a-flag");
   });
 });
 

--- a/mycelium-frontend/src/lib/memory-preview.ts
+++ b/mycelium-frontend/src/lib/memory-preview.ts
@@ -14,6 +14,47 @@ export function memoryValueText(value: unknown): string {
   return String(value);
 }
 
+const TITLE_MAX = 120;
+
+/** The mapping a structured value is, or null when the value is prose. */
+function structuredValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** The first line with something on it, stripped of its heading marker. */
+function firstLine(text: string): string {
+  const line = text.split("\n").map(l => l.trim()).find(l => l && !l.startsWith("---"));
+  return (line ?? "").replace(/^#+\s*/, "").slice(0, TITLE_MAX);
+}
+
+/**
+ * What a memory is called.
+ *
+ * One derivation, because a task is a board row *and* a thread and the two must
+ * not disagree about its name: a structured value's own `title`, else the first
+ * readable line of the body, else the key.
+ *
+ * The body is whichever way the store hands it over. Prose lives in the
+ * markdown body and the API value is rebuilt from it, so a prose memory arrives
+ * as `{text: …}` rather than as a bare string — a reader that understands only
+ * the string falls through to the key and prints a slug where the room expects
+ * a name.
+ */
+export function memoryTitle(memory: Pick<Memory, "key" | "value" | "content_text">): string {
+  const structured = structuredValue(memory.value);
+  const explicit = structured?.title;
+  if (typeof explicit === "string" && explicit.trim()) return explicit.trim().slice(0, TITLE_MAX);
+  const body =
+    typeof memory.value === "string"
+      ? memory.value
+      : typeof structured?.text === "string"
+        ? structured.text
+        : memory.content_text ?? "";
+  return firstLine(body) || memory.key;
+}
+
 // The hovercard shows an excerpt, not a rendered document: markdown syntax is
 // flattened to the text it decorates so a cut-off construct can't leave a
 // dangling marker on screen.

--- a/mycelium-frontend/src/lib/room-data.ts
+++ b/mycelium-frontend/src/lib/room-data.ts
@@ -20,6 +20,7 @@
 
 import { useCallback, useMemo } from "react";
 import type { RoomStatus } from "@/lib/board/upstream";
+import { memoryTitle } from "@/lib/memory-preview";
 import useSWR, { useSWRConfig, type SWRConfiguration } from "swr";
 import {
   fetchA2aBridge,
@@ -94,23 +95,6 @@ export interface ThreadOwner {
    * which is what is actually true of it.
    */
   title: string | null;
-}
-
-/** A row's own title where its frontmatter carries one, else its key.
- *
- * A task is a markdown row, so its title is the first line of its body; a
- * structured value keeps its `title` field. The key is the last resort, for a
- * row with no readable body at all. */
-function memoryTitle(memory: Memory): string {
-  const value = memory.value;
-  if (typeof value === "string" && value.trim()) {
-    return value.trim().split("\n")[0].replace(/^#+\s*/, "").trim() || memory.key;
-  }
-  const title =
-    value && typeof value === "object" && !Array.isArray(value)
-      ? (value as Record<string, unknown>).title
-      : null;
-  return typeof title === "string" && title.trim() ? title.trim() : memory.key;
 }
 
 // Stable empties: a fresh `[]` per render would break every downstream memo.
@@ -312,6 +296,22 @@ export function useRoomThreads(room: string): Map<string, ThreadOwner> {
     }
     return index;
   }, [memories]);
+}
+
+/**
+ * What each of a room's memories is called, by key.
+ *
+ * The sibling of {@link useRoomThreads} for the events that name a memory
+ * rather than a thread — a knowledge push carries the key it wrote and nothing
+ * else, and a channel that prints the key prints a slug. Off the same shared
+ * memories cache, so naming one costs no request.
+ */
+export function useRoomTitles(room: string): Map<string, string> {
+  const { memories } = useRoomMemories(room);
+  return useMemo(
+    () => new Map(memories.map(memory => [memory.key, memoryTitle(memory)])),
+    [memories],
+  );
 }
 
 /** The last readable line in a room, for an inbox-style row. Its own SWR key,

--- a/mycelium-frontend/src/mocks/handlers.ts
+++ b/mycelium-frontend/src/mocks/handlers.ts
@@ -85,8 +85,18 @@ function stableUuid(seed: string): string {
  */
 function memoryRead(room: string, memory: MockMemory): Record<string, unknown> {
   const updated = memory.updated_at ?? MOCK_EPOCH;
+  const prose = typeof memory.value === "string";
   return {
     ...memory,
+    // The store keeps prose in the markdown body and rebuilds the API `value`
+    // from it (`routes/memory.py:_reconstruct_value`), so a prose memory reads
+    // back as `{text: …}` and never as the bare string a fixture writes. Doing
+    // that here rather than in the fixtures keeps them readable while every
+    // consumer sees the shape it will actually be handed — the divergence is
+    // what let a reader that understood only the string ship a slug where the
+    // channel expected a title.
+    value: prose ? { text: memory.value } : memory.value,
+    content_text: prose ? (memory.value as string) : memory.content_text,
     id: stableUuid(`${room}/${memory.key}`),
     room_name: memory.room_name ?? room,
     created_at: updated,


### PR DESCRIPTION
## Summary

A thread-activity ping printed a `work/…` slug where the board notice one line above printed the row's name. The channel already looked the title up — what it got back *was* the key.

**The root cause is not where the issue points.** `event-stream.tsx` already rendered `owner?.title ?? shortId`; the title it was handed was the slug. `memoryTitle` (`room-data.ts`) read a title off a **string** `value`, but the store keeps prose in the markdown body and rebuilds the API value from it (`routes/memory.py:_reconstruct_value`), so every prose memory arrives as `{text: …}` and fell straight through to `memory.key`. The board's projection had its own, separate derivation that happened to fall back to `content_text` — which is exactly why one surface read right and the other didn't.

**Why it shipped, and why it would have come back.** The mock served a shape the API never returns: a fixture's prose `value` went out as a bare string, so the bug was invisible in `dev:mock` and in every test that used a fixture-shaped memory. The existing channel tests all used `value: { title: … }` — a structured value — and so never touched the prose path at all.

## Changes

- **One `memoryTitle`**, in `lib/memory-preview.ts`, reading the body whichever way the store hands it over (`{text: …}`, a bare string, or `content_text`). `room-data.ts` and `lib/board/projection.ts` both call it and their two private derivations are gone — a task is a board row *and* a thread, so the two must not disagree about its name.
- **The mock serves the real shape.** `memoryRead` reconstructs `{text: …}` from a prose fixture the way the backend does. Fixtures stay readable as prose; every consumer now sees the shape it will actually be handed.
- **Knowledge notices resolve too.** A `knowledge` envelope carries a key and no prose (`memory_sync.build_knowledge_envelope` has no content field), so that line was *always* the slug — this half of the reporter's screenshot comment was a different miss from the ping's. It now resolves through the same names via `useRoomTitles`, off the same shared memories cache (no extra request), and opens the memory.
- **One treatment for the rows.** A single `NoticeChip` behind the ping, the board notice and the knowledge push, replacing three near-identical buttons at two different max-widths, with a per-row `aria-label` (`Open thread …` / `Open task …` / `Open memory …`).
- **One size.** `.mono-inline` for an identifier set inline in copy (the episode tag, GAR, the plan file). Geist Mono runs optically larger than IBM Plex Sans at the same nominal size, which is what made the feed look ragged — `e4f1a2` and `GAR 0.79` visibly outsized the sans on either side of them. Relative (`0.92em`), so it holds at every step of the scale.
- Dropped the ping row's trailing `· click to open`. Every chip in these rows is clickable and only that one said so.

## Testing

- `pnpm test` — **766 passed**, 59 files.
- `pnpm lint` (`tsc --noEmit && eslint .`) — 0 errors (2 pre-existing warnings in `use-collapsible-rail.ts`, untouched).
- New regression coverage, aimed at the gap that let this ship:
  - `memory-preview.test.ts` — `memoryTitle` over the `{text: …}` shape, a bare string, a structured `title`, a heading marker, the `content_text` fallback, and the key as last resort.
  - `event-stream.thread.test.tsx` — a ping whose bound row is prose *in the shape the store hands it over* renders the first line and **not** the `work/…` key; a knowledge push renders the memory's name and not its key.
  - Two existing knowledge assertions updated to the new render; one of them now pins the honest case — a key no row in the room carries still reads as the key.
- Visually checked in `dev:mock` before/after via shotkit (`shot app /room/atlas-migration --mock`): titles still resolve under the new value shape on both the channel and the Board pane, and the mono runs now sit at the same optical size as the copy around them.

Backend untouched, so the Python gates in this template don't apply.

## Related Issues

Closes #889

## Notes for the reviewer

- **The one thing worth arguing with** is the mock change. It is the largest blast radius here (every frontend read of a prose memory in mock mode now gets `{text: …}`), and I could have fixed only `memoryTitle` and left the fixtures alone. I did not, because the divergence *is* the bug's cause: without it, `dev:mock` and most of the suite go on asserting against a shape the hub never sends, and the next reader that understands only the string ships the same way. It surfaced no other break — the full suite is green — which is itself the evidence the rest of the tree was already reading `value` defensively.
- **Not done:** the CLI's `_ping_line` (`commands/room.py:535`) prints the thread's short id, not a title. That is not this bug — a terminal tail has no rows loaded to resolve against, and six characters is the terse read a tail wants. Left alone deliberately rather than overlooked.
- `.mono-inline` is applied only to the mono runs inside these notice rows. The `→ recipient` chip in a chat header keeps `font-mono`: it has its own background and reads as a chip, not as copy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XUaSrgbGig4s2BJH4DA3sS)_