### PR TITLE
One scroll for a task, with the markdown body clamped over the chat (#887)

### DIFF
--- a/mycelium-frontend/src/components/memory-detail.tsx
+++ b/mycelium-frontend/src/components/memory-detail.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ArrowUpRight, CornerDownLeft, Share2 } from "lucide-react";
 import { highlightJson } from "@/components/l9-inspector";
 import { MarkdownContent } from "@/components/markdown-content";
+import { Expandable } from "@/components/ui/expandable";
 import { fetchMemoryLinks, type MemoryLink, type MemoryLinksIntegrity } from "@/lib/api";
 import { isJsonRawText, prettyPrintJsonRawText } from "@/lib/json-text";
 import {
@@ -146,6 +147,12 @@ interface Props {
   /** Room integrity report; surfaces this memory's broken-link / graph-role
    *  notes in either variant when supplied. */
   integrity?: MemoryLinksIntegrity | null;
+  /** Clamp a body taller than this many pixels behind an Expand button. Set by
+   *  surfaces that put a conversation under the body, where a long body would
+   *  otherwise push it out of reach. Unset renders the body whole. */
+  collapseBodyAt?: number | null;
+  /** The surface the body sits on, so its fade matches. */
+  bodyFade?: "bg" | "paper" | "surface" | "elevated";
 }
 
 function IntegrityBanner({ notes }: { notes: MemoryIntegrityNotes }) {
@@ -209,6 +216,25 @@ function NeighborChips({
   );
 }
 
+/** The body, clamped where the surface asked for it and untouched where it
+ *  didn't — so a surface that renders the body alone keeps rendering it whole. */
+function MaybeExpandable({
+  collapseAt,
+  fade,
+  children,
+}: {
+  collapseAt: number | null;
+  fade: "bg" | "paper" | "surface" | "elevated";
+  children: React.ReactNode;
+}) {
+  if (!collapseAt) return <>{children}</>;
+  return (
+    <Expandable collapsedHeight={collapseAt} fade={fade} label="the task body">
+      {children}
+    </Expandable>
+  );
+}
+
 /** Read-only review/audit of one memory: metadata, its markdown body, its links. */
 export function MemoryDetail({
   memory,
@@ -217,6 +243,8 @@ export function MemoryDetail({
   variant = "rail",
   renderedBody = null,
   integrity = null,
+  collapseBodyAt = null,
+  bodyFade = "bg",
 }: Props) {
   const pad = variant === "page" ? "px-6 md:px-8" : "px-5";
   const [raw, setRaw] = useState(false);
@@ -354,19 +382,21 @@ export function MemoryDetail({
       </div>
 
       <div className={`${pad} py-4`}>
-        {raw ? (
-          <pre className="overflow-x-auto rounded-lg border border-border bg-surface p-3 font-mono text-micro leading-relaxed text-text whitespace-pre-wrap break-words">
-            {effectiveJsonView ? highlightJson(rawDisplay) : rawDisplay}
-          </pre>
-        ) : (
-          <MarkdownContent
-            className={`contrast leading-relaxed ${variant === "page" ? "text-body max-w-prose" : "text-body"}`}
-            onLinkClick={onNavigate}
-            brokenLinks={broken}
-          >
-            {displayText}
-          </MarkdownContent>
-        )}
+        <MaybeExpandable collapseAt={collapseBodyAt} fade={bodyFade}>
+          {raw ? (
+            <pre className="overflow-x-auto rounded-lg border border-border bg-surface p-3 font-mono text-micro leading-relaxed text-text whitespace-pre-wrap break-words">
+              {effectiveJsonView ? highlightJson(rawDisplay) : rawDisplay}
+            </pre>
+          ) : (
+            <MarkdownContent
+              className={`contrast leading-relaxed ${variant === "page" ? "text-body max-w-prose" : "text-body"}`}
+              onLinkClick={onNavigate}
+              brokenLinks={broken}
+            >
+              {displayText}
+            </MarkdownContent>
+          )}
+        </MaybeExpandable>
       </div>
 
       {variant === "page" && (

--- a/mycelium-frontend/src/components/memory-page-view.test.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.test.tsx
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithSWR } from "@/test/swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/components/memory-detail", () => ({
+  MemoryDetail: (props: { collapseBodyAt?: number | null }) => (
+    <div data-testid="memory-detail" data-collapse-body-at={props.collapseBodyAt ?? ""} />
+  ),
+}));
+
+// The page's Discussion, stubbed: this file is about the page's layout, and the
+// conversation's own reads belong to its own tests.
+vi.mock("@/components/task/task-conversation", () => ({
+  TaskConversation: () => <div data-testid="task-conversation" />,
+}));
+
+vi.mock("@/components/room-chat-box", () => ({
+  RoomChatBox: () => <div data-testid="room-chat-box" />,
+}));
+
+vi.mock("@/components/current-user", () => ({
+  useCurrentUser: () => ({ principal: "alice" }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  logFetchError: () => () => undefined,
+  fetchMemory: vi.fn(),
+  fetchMemoryExpanded: vi.fn(),
+  fetchMemoryIntegrity: vi.fn(),
+}));
+
+import { fetchMemory, fetchMemoryExpanded, fetchMemoryIntegrity } from "@/lib/api";
+import { MemoryPageView } from "@/components/memory-page-view";
+
+const MEMORY = {
+  key: "work/flip-reads",
+  value: { text: "the reads have to flip behind a flag" },
+  content_text: "the reads have to flip behind a flag",
+  version: 1,
+  created_by: "alice",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("<MemoryPageView />", () => {
+  beforeEach(() => {
+    vi.mocked(fetchMemoryExpanded).mockResolvedValue({
+      key: MEMORY.key,
+      rendered: "",
+      expansions: [],
+      found: false,
+    });
+    vi.mocked(fetchMemoryIntegrity).mockResolvedValue({
+      broken: [],
+      orphans: [],
+      roots: [],
+      leaves: [],
+      total_memories: 1,
+      total_links: 0,
+    });
+  });
+
+  it("clamps the body only where a discussion follows it (#887)", async () => {
+    // The page is one scroll from the metadata through the body to the last
+    // reply. A long body is clamped behind an Expand button so it cannot push
+    // the conversation past the fold — but a memory with no thread under it is
+    // all body, and hiding half of it would buy nothing.
+    vi.mocked(fetchMemory).mockResolvedValue(MEMORY);
+    const { unmount } = renderWithSWR(<MemoryPageView roomName="demo" memoryKey={MEMORY.key} />);
+    expect(await screen.findByTestId("memory-detail")).toHaveAttribute("data-collapse-body-at", "");
+    expect(screen.queryByTestId("task-conversation")).not.toBeInTheDocument();
+    unmount();
+
+    vi.mocked(fetchMemory).mockResolvedValue({
+      ...MEMORY,
+      episode: "urn:ioc:mycelium:episode:demo:t9f0",
+    });
+    renderWithSWR(<MemoryPageView roomName="demo" memoryKey={MEMORY.key} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("memory-detail")).not.toHaveAttribute("data-collapse-body-at", ""),
+    );
+    expect(screen.getByTestId("task-conversation")).toBeInTheDocument();
+  });
+
+  it("shows no discussion for a row carrying the room's own live episode", async () => {
+    // Reading that as a thread would empty the room's history into the page.
+    vi.mocked(fetchMemory).mockResolvedValue({
+      ...MEMORY,
+      episode: "urn:ioc:mycelium:episode:demo:live",
+    });
+    renderWithSWR(<MemoryPageView roomName="demo" memoryKey={MEMORY.key} />);
+    expect(await screen.findByTestId("memory-detail")).toHaveAttribute("data-collapse-body-at", "");
+    expect(screen.queryByTestId("task-conversation")).not.toBeInTheDocument();
+  });
+});

--- a/mycelium-frontend/src/components/memory-page-view.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.tsx
@@ -29,6 +29,11 @@ interface Props {
   memoryKey: string;
 }
 
+/** How tall a memory body gets on the full page before it clamps. Generous —
+ *  the page is where you came to read it — but bounded, so a long task does not
+ *  put its discussion a thousand pixels below the fold. */
+const BODY_CLAMP_PX = 720;
+
 /** Full-page wiki view for one memory. */
 export function MemoryPageView({ roomName, memoryKey }: Props) {
   const router = useRouter();
@@ -98,6 +103,7 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
   }
 
   const crumbs = memoryKey.split("/");
+  const hasDiscussion = Boolean(memory.episode) && !isLiveEpisode(roomName, memory.episode ?? "");
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
@@ -166,6 +172,10 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
             variant="page"
             renderedBody={renderedBody}
             integrity={integrity}
+            // Only where a discussion follows the body: on a page that is body
+            // and nothing else, clamping would hide the whole point of opening
+            // it full screen.
+            collapseBodyAt={hasDiscussion ? BODY_CLAMP_PX : null}
           />
         )}
 
@@ -173,10 +183,14 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
             the thread pane's conversation. Only a real thread has one: a row
             written before threading carries the room's own live episode (or
             none), and reading that as a thread would empty the room's history. */}
-        {!isEditing && memory.episode && !isLiveEpisode(roomName, memory.episode) && (
-          <section className="mt-8 flex min-h-0 flex-col px-6 md:px-8">
+        {!isEditing && hasDiscussion && memory.episode && (
+          <section className="mt-8 px-6 md:px-8">
             <h2 className="mb-2 text-micro uppercase tracking-wide text-faint">Discussion</h2>
-            <div className="flex min-h-[16rem] flex-col rounded-xl border border-border bg-surface">
+            {/* The card frames the discussion; it does not scroll it. The page
+                is one scroll from the memory's metadata through its body to the
+                last reply, so the conversation grows the card rather than
+                filling a box of its own. */}
+            <div className="rounded-xl border border-border bg-surface">
               <TaskConversation
                 roomName={roomName}
                 episode={memory.episode}

--- a/mycelium-frontend/src/components/memory-panel.test.tsx
+++ b/mycelium-frontend/src/components/memory-panel.test.tsx
@@ -26,11 +26,16 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("@/components/memory-detail", () => ({
-  MemoryDetail: (props: { integrity?: unknown; renderedBody?: string | null }) => (
+  MemoryDetail: (props: {
+    integrity?: unknown;
+    renderedBody?: string | null;
+    collapseBodyAt?: number | null;
+  }) => (
     <div
       data-testid="memory-detail"
       data-has-integrity={props.integrity ? "yes" : "no"}
       data-rendered-body={props.renderedBody ?? ""}
+      data-collapse-body-at={props.collapseBodyAt ?? ""}
     />
   ),
 }));
@@ -47,6 +52,16 @@ vi.mock("@/components/detail-drawer", () => ({
 
 vi.mock("@/components/current-user", () => ({
   useCurrentUser: () => ({ principal: "alice" }),
+}));
+
+// The drawer's Discussion, stubbed: this file is about what the panel hands its
+// children, and the conversation's own reads belong to its own tests.
+vi.mock("@/components/task/task-conversation", () => ({
+  TaskConversation: () => <div data-testid="task-conversation" />,
+}));
+
+vi.mock("@/components/room-chat-box", () => ({
+  RoomChatBox: () => <div data-testid="room-chat-box" />,
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -170,6 +185,29 @@ describe("<MemoryPanel /> peek navigation", () => {
     await waitFor(() => expect(fetchMemoryExpanded).toHaveBeenCalledWith("demo", offTree.key));
     await waitFor(() => expect(detail).toHaveAttribute("data-has-integrity", "yes"));
     expect(detail).toHaveAttribute("data-rendered-body", "expanded transclusion body");
+  });
+
+  it("clamps the body only where a discussion follows it (#887)", async () => {
+    // The drawer is one scroll from the metadata to the last reply, so a long
+    // body is clamped behind an Expand button rather than boxed off in a
+    // scrollbox of its own. A memory with no thread under it is all body, and
+    // hiding half of it would buy nothing.
+    vi.mocked(fetchMemory).mockResolvedValue(offTree);
+    const { unmount } = renderWithSWR(
+      <MemoryPanel roomName="demo" focusMemory={{ key: offTree.key, nonce: 1 }} />,
+    );
+    expect(await screen.findByTestId("memory-detail")).toHaveAttribute("data-collapse-body-at", "");
+    unmount();
+
+    const threaded = { ...offTree, episode: "urn:ioc:mycelium:episode:demo:t9f0" };
+    vi.mocked(fetchMemory).mockResolvedValue(threaded);
+    renderWithSWR(
+      <MemoryPanel roomName="demo" focusMemory={{ key: threaded.key, nonce: 2 }} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("memory-detail")).not.toHaveAttribute("data-collapse-body-at", ""),
+    );
+    expect(screen.getByTestId("task-conversation")).toBeInTheDocument();
   });
 });
 

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -106,6 +106,9 @@ function fileName(node: TreeNode): string {
 const ROW_H = 22; // px, matches vscode compact density
 const INDENT = 12; // px per depth level
 const PEEK_DELAY = 350; // ms of hover intent before the preview card opens
+/** How tall a memory body gets in the drawer before it clamps behind an Expand
+ *  button — the drawer is narrower than the page, so it clamps sooner. */
+const BODY_CLAMP_PX = 480;
 
 interface TreeRowsProps {
   nodes: TreeNode[];
@@ -382,6 +385,9 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
     if (focusMemory?.key) void openMemoryByKey(focusMemory.key);
   }, [focusMemory, openMemoryByKey]);
 
+  const hasDiscussion =
+    Boolean(selected?.episode) && !isLiveEpisode(roomName, selected?.episode ?? "");
+
   const toggleNs = useCallback((path: string) =>
     setCollapsed(prev => {
       const next = new Set(prev);
@@ -574,16 +580,21 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
                 onNavigate={openMemoryByKey}
                 renderedBody={renderedBody}
                 integrity={integrity}
+                // Only where a discussion follows the body — see the full page.
+                collapseBodyAt={hasDiscussion ? BODY_CLAMP_PX : null}
+                bodyFade="elevated"
               />
               {/* The memory's discussion, below its body — the drawer equivalent
                   of the full page's Discussion and the thread pane's conversation.
                   Only a real thread has one: a memory on the room's own live
                   episode (or none) is not a thread, and reading it as one would
                   empty the room's history. */}
-              {selected.episode && !isLiveEpisode(roomName, selected.episode) && (
-                <section className="mt-6 flex min-h-0 flex-col border-t border-border px-5 py-4">
+              {hasDiscussion && selected.episode && (
+                <section className="mt-6 border-t border-border px-5 py-4">
                   <h2 className="mb-2 text-micro uppercase tracking-wide text-faint">Discussion</h2>
-                  <div className="flex min-h-[16rem] flex-col rounded-xl border border-border bg-surface">
+                  {/* The card frames the discussion; the drawer scrolls it, same
+                      as the full page. */}
+                  <div className="rounded-xl border border-border bg-surface">
                     <TaskConversation
                       roomName={roomName}
                       episode={selected.episode}

--- a/mycelium-frontend/src/components/task/task-conversation.tsx
+++ b/mycelium-frontend/src/components/task/task-conversation.tsx
@@ -12,7 +12,6 @@ import { pingOf } from "@/lib/threads";
 import { MarkdownContent } from "@/components/markdown-content";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Monogram } from "@/components/ui/monogram";
 
 interface Props {
@@ -47,8 +46,25 @@ function textOf(message: RoomMessage): string {
   }
 }
 
+/** How close to the bottom you have to be for a new reply to pull you down. */
+const STICK_PX = 120;
+
+/** The scrollable ancestor an element sits in, if it has one. */
+function scrollParentOf(el: HTMLElement | null): HTMLElement | null {
+  for (let node = el?.parentElement ?? null; node; node = node.parentElement) {
+    const overflow = getComputedStyle(node).overflowY;
+    if (overflow === "auto" || overflow === "scroll") return node;
+  }
+  return null;
+}
+
 /**
- * One task's conversation: the scrollable message region, and nothing else.
+ * One task's conversation: the messages, and nothing else.
+ *
+ * It owns no scroll. The task's body, its metadata and this conversation are
+ * one column in the surface's single scroll region, so a reply flows on below
+ * the task the way a comment follows an issue — rather than sitting in a
+ * fixed-height box with a scrollbar of its own a few pixels inside the pane's.
  *
  * The composer stays with the parent (a task is rendered in more than one place
  * and the composer's chrome differs), so this is just the read and its
@@ -59,7 +75,7 @@ export function TaskConversation({ roomName, episode, onOpenMemory, onReady }: P
   const { messages, loading, refresh } = useThreadMessages(roomName, episode);
   const { agents } = useRoomAgents(roomName);
   const agentHandles = new Set(agents.map(a => a.handle));
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
 
   // Hand the parent our refresh once it is stable, so its composer's onSent can
   // re-read this episode after a send.
@@ -102,12 +118,27 @@ export function TaskConversation({ roomName, episode, onOpenMemory, onReady }: P
     .map(message => ({ message, text: textOf(message) }))
     .filter(({ text }) => text.trim().length > 0);
 
+  // A reply that lands while you are reading the bottom pulls you down with it;
+  // one that lands while you are further up does not, and opening the task lands
+  // on the task rather than on its last comment. With one scroll for the whole
+  // column, sticking unconditionally would scroll the body out of view the
+  // moment anything arrived.
+  const count = ordered.length;
+  const seen = useRef<number | null>(null);
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
-  }, [ordered.length]);
+    const first = seen.current === null;
+    seen.current = count;
+    if (first || count === 0) return;
+    const anchor = endRef.current;
+    const viewport = scrollParentOf(anchor);
+    if (!anchor || !viewport) return;
+    const fromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
+    if (fromBottom > STICK_PX) return;
+    anchor.scrollIntoView({ block: "end" });
+  }, [count]);
 
   return (
-    <ScrollArea className="min-h-0 flex-1" viewportRef={scrollRef}>
+    <div>
       {loading && ordered.length === 0 ? (
         <div className="flex flex-col gap-4 px-5 py-4">
           <Skeleton className="h-3 w-2/5" />
@@ -157,6 +188,7 @@ export function TaskConversation({ roomName, episode, onOpenMemory, onReady }: P
           })}
         </div>
       )}
-    </ScrollArea>
+      <div ref={endRef} />
+    </div>
   );
 }

--- a/mycelium-frontend/src/components/thread-view.test.tsx
+++ b/mycelium-frontend/src/components/thread-view.test.tsx
@@ -11,6 +11,7 @@ import { resetStreamHub } from "@/lib/stream-hub";
 
 const fetchMessages = vi.fn();
 const sendRoomMessage = vi.fn().mockResolvedValue(undefined);
+const fetchMemories = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   logFetchError: () => () => undefined,
@@ -18,7 +19,8 @@ vi.mock("@/lib/api", () => ({
   sendRoomMessage: (...args: unknown[]) => sendRoomMessage(...args),
   fetchRoomAgents: vi.fn().mockResolvedValue([]),
   fetchRoomMembers: vi.fn().mockResolvedValue([]),
-  fetchMemories: vi.fn().mockResolvedValue([]),
+  fetchMemories: (...args: unknown[]) => fetchMemories(...args),
+  fetchMemoryLinks: vi.fn().mockResolvedValue({ outbound: [], backlinks: [] }),
   fetchSkills: vi.fn().mockResolvedValue([]),
 }));
 
@@ -42,9 +44,20 @@ const NEWEST_FIRST = {
   ],
 };
 
+/** The row this thread is of, as the room's memories answer it. */
+const TASK = {
+  key: "work/flip-reads",
+  value: "the reads have to flip behind a flag",
+  content_text: "the reads have to flip behind a flag",
+  version: 1,
+  created_by: "julia",
+  episode: THREAD,
+};
+
 describe("<ThreadView />", () => {
   beforeEach(() => {
     fetchMessages.mockReset().mockResolvedValue(NEWEST_FIRST);
+    fetchMemories.mockReset().mockResolvedValue([]);
     sendRoomMessage.mockClear();
     resetStreamHub();
     FakeEventSource.reset();
@@ -162,6 +175,22 @@ describe("<ThreadView />", () => {
       es.emit({ message_type: "broadcast", sender_handle: "risk", content: "one more thing", episode: THREAD });
     });
     await waitFor(() => expect(fetchMessages.mock.calls.length).toBe(reads + 1));
+  });
+
+  it("is one scroll region — the task's body and its conversation share it", async () => {
+    // Two scroll areas a few pixels apart is the bug (#887): the wheel does
+    // different things depending on where the pointer happens to be. The task
+    // reads as one column, the way an issue body runs into its comments.
+    fetchMemories.mockResolvedValue([TASK]);
+    renderWithSWR(
+      <ThreadView roomName="atlas" target={{ episode: THREAD, title: "flip reads" }} onClose={vi.fn()} />,
+    );
+    await screen.findByText(/hold the flip/);
+
+    const viewports = document.querySelectorAll('[data-slot="scroll-area-viewport"]');
+    expect(viewports).toHaveLength(1);
+    expect(viewports[0]).toHaveTextContent("the reads have to flip behind a flag");
+    expect(viewports[0]).toHaveTextContent("hold the flip until lag is under a second");
   });
 
   it("re-reads on the ping that announces a write into it", async () => {

--- a/mycelium-frontend/src/components/thread-view.tsx
+++ b/mycelium-frontend/src/components/thread-view.tsx
@@ -18,6 +18,11 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Kbd } from "@/components/ui/kbd";
 import { Tooltip } from "@/components/ui/tooltip";
 
+/** How tall a task body gets in the pane before it clamps. The pane is narrow,
+ *  so this is roughly a screenful of prose — enough to read the task, not enough
+ *  to bury the conversation under it. */
+const BODY_CLAMP_PX = 320;
+
 /** What a thread is a thread *of*, as far as anything can tell. */
 export interface ThreadTarget {
   /** The episode URN the conversation is tagged with. */
@@ -166,20 +171,22 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
           />
         </div>
       ) : (
-        // The task's body over its conversation. Two scroll regions: the body
-        // takes at most half the pane so a long task can never push the
-        // conversation off screen, and the conversation owns the rest. A
-        // negotiation thread bound to no row is all conversation.
-        <div className="flex min-h-0 flex-1 flex-col">
+        // The task's body over its conversation, in one scroll. The body is
+        // clamped rather than boxed: a long task fades under an Expand button
+        // instead of taking a scrollbar of its own, so the wheel does one thing
+        // everywhere in the pane. A negotiation thread bound to no row is all
+        // conversation.
+        <ScrollArea className="min-h-0 flex-1">
           {task && (
-            <ScrollArea className="max-h-[45%] shrink-0 border-b border-border">
+            <div className="border-b border-border">
               <MemoryDetail
                 memory={task}
                 roomName={roomName}
                 variant="rail"
                 onNavigate={onOpenMemory}
+                collapseBodyAt={BODY_CLAMP_PX}
               />
-            </ScrollArea>
+            </div>
           )}
           <TaskConversation
             roomName={roomName}
@@ -187,7 +194,7 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
             onOpenMemory={onOpenMemory}
             onReady={onReady}
           />
-        </div>
+        </ScrollArea>
       )}
 
       <RoomChatBox

--- a/mycelium-frontend/src/components/ui/expandable.test.tsx
+++ b/mycelium-frontend/src/components/ui/expandable.test.tsx
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Expandable } from "@/components/ui/expandable";
+
+// jsdom lays nothing out, so `scrollHeight` is 0 for every element. The
+// component's whole decision is a measurement, so the test supplies one.
+let restore: (() => void) | null = null;
+function measuring(px: number) {
+  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, "scrollHeight");
+  Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+    configurable: true,
+    get: () => px,
+  });
+  restore = () => {
+    if (original) Object.defineProperty(HTMLElement.prototype, "scrollHeight", original);
+  };
+}
+
+afterEach(() => {
+  restore?.();
+  restore = null;
+});
+
+describe("<Expandable />", () => {
+  it("leaves short content alone — no clamp, nothing to click", async () => {
+    measuring(120);
+    render(
+      <Expandable collapsedHeight={320} label="the task body">
+        <p>short enough to read</p>
+      </Expandable>,
+    );
+    expect(await screen.findByText("short enough to read")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("clamps long content behind Expand, and lets it back out", async () => {
+    measuring(900);
+    render(
+      <Expandable collapsedHeight={320} label="the task body">
+        <p>a very long task body</p>
+      </Expandable>,
+    );
+
+    const expand = await screen.findByRole("button", { name: "Expand the task body" });
+    const clamped = screen.getByText("a very long task body").parentElement!;
+    expect(clamped).toHaveStyle({ maxHeight: "320px", overflow: "hidden" });
+    expect(expand).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(expand);
+
+    // Expanding releases the clamp rather than opening a scrollbox: the point
+    // is that the surface keeps exactly one scroll.
+    expect(clamped.style.maxHeight).toBe("");
+    expect(clamped.style.overflow).toBe("");
+    expect(
+      screen.getByRole("button", { name: "Collapse the task body" }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/mycelium-frontend/src/components/ui/expandable.tsx
+++ b/mycelium-frontend/src/components/ui/expandable.tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+/** The surface the region sits on, so the fade lands on the right colour. */
+const FADE = {
+  bg: "var(--bg)",
+  paper: "var(--paper)",
+  surface: "var(--surface)",
+  elevated: "var(--elevated)",
+} as const;
+
+/** Below this much overshoot, clamping would hide a line or two and cost a
+ *  click to read them — worse than just showing the whole thing. */
+const SLACK = 48;
+
+interface Props {
+  /** Height, in px, the region clamps to while collapsed. */
+  collapsedHeight: number;
+  /** The surface behind the region. */
+  fade?: keyof typeof FADE;
+  /** Names what expands, for the button's accessible label. */
+  label?: string;
+  children: ReactNode;
+}
+
+/**
+ * A region that clamps itself when it is long, and only then.
+ *
+ * The alternative — a fixed-height inner scrollbox — is what a pane reaches for
+ * first and is worse in the one way that matters: it puts a second scrollbar
+ * inside the first, so the wheel does different things a few pixels apart. This
+ * keeps one scroll for the whole column and makes length a thing you opt into
+ * reading, the way an issue body works.
+ *
+ * Content shorter than {@link Props.collapsedHeight} renders untouched, with no
+ * button and no fade: nothing here appears until there is something to hide.
+ */
+export function Expandable({ collapsedHeight, fade = "bg", label, children }: Props) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [overflows, setOverflows] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  // Measured rather than estimated from the text: the body renders markdown, so
+  // its height is a function of the rendering, not of how many characters came
+  // back. The observer keeps that true as images load and the pane resizes.
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const measure = () => setOverflows(el.scrollHeight > collapsedHeight + SLACK);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [collapsedHeight]);
+
+  const clamped = overflows && !expanded;
+
+  return (
+    <div>
+      <div
+        ref={contentRef}
+        className="relative"
+        style={clamped ? { maxHeight: collapsedHeight, overflow: "hidden" } : undefined}
+      >
+        {children}
+        {clamped && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-20"
+            style={{ background: `linear-gradient(to top, ${FADE[fade]}, transparent)` }}
+          />
+        )}
+      </div>
+      {overflows && (
+        <button
+          type="button"
+          onClick={() => setExpanded(v => !v)}
+          aria-expanded={expanded}
+          aria-label={label ? `${expanded ? "Collapse" : "Expand"} ${label}` : undefined}
+          className="mt-1 inline-flex items-center gap-1 rounded-md border border-border bg-surface px-2.5 py-1 text-micro font-medium text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+        >
+          {expanded ? <ChevronUp className="size-3.5" /> : <ChevronDown className="size-3.5" />}
+          {expanded ? "Collapse" : "Expand"}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The task pane had two vertical scroll regions a few pixels apart: the markdown body in a `max-h-[45%]` scrollbox over a conversation that scrolled independently. The full page and the memory drawer repeated the shape with a `min-h-[16rem]` Discussion card whose `TaskConversation` scrolled inside the page's own scroll. The wheel did different things depending on where the pointer happened to be.

The three surfaces now read as one column in one scroll — metadata, then the body, then the conversation flowing directly below it — with a long body clamped behind an Expand button rather than boxed off, the way an issue body works.

## Changes

- **`ui/expandable.tsx` (new).** Clamps a region only when it *measures* taller than the height its surface asked for, fading it out under an Expand button (which toggles back to Collapse). Shorter content renders untouched, with no button and no fade. Measured with a `ResizeObserver` rather than estimated from the text, since the body is rendered markdown — its height is a function of the rendering, not the character count.
- **`MemoryDetail`** takes `collapseBodyAt` and `bodyFade`. Each surface picks its own height — 320px in the narrow pane, 480 in the drawer, 720 on the full page — and passes it **only where a discussion follows the body**. A page that is body and nothing else stays whole; clamping there would hide the point of opening it.
- **`TaskConversation`** owns no scroll at all now. It keeps stick-to-bottom but conditionally: a new reply pulls you down only if you were already near the bottom, and opening a task lands on the task rather than on its last comment. With one scroll, an unconditional stick would scroll the body out of view the moment anything arrived.
- **`thread-view.tsx`**, **`memory-page-view.tsx`**, **`memory-panel.tsx`**: one scroll region each; the Discussion card now frames the conversation instead of scrolling it, so it grows with its content.

### The call worth arguing with

The clamp is applied **only where a conversation follows the body**, not everywhere. The issue asks for "a single scroll + collapsible markdown" on all three surfaces; a full page of a memory with no thread now gets the single scroll but no clamp, because there is nothing below it that a long body could push out of reach. If you'd rather it clamp unconditionally, it's one expression in `memory-page-view.tsx`.

Three different clamp heights rather than one shared constant, for the same reason: 320px is roughly a screenful in the narrow pane and about a third of one on the page.

### Not done

The composer stays pinned below the pane's scroll region (it was already), and the memory editor keeps its own scroll while editing — neither is a nested read surface.

## Testing

- `npm test` — **764 passed** (61 files), including 6 new:
  - `ui/expandable.test.tsx` — short content renders whole with nothing to click; long content clamps and the button releases the clamp rather than opening a scrollbox. jsdom lays nothing out, so the test supplies the measurement.
  - `thread-view.test.tsx` — the pane is exactly one scroll region, containing both the task's body and its conversation. **Mutation-checked**: restoring the old `ScrollArea` around the body fails it.
  - `memory-panel.test.tsx` / `memory-page-view.test.tsx` (new) — the body is clamped only where a discussion follows it, on the drawer and the page.
- `npm run lint` (`tsc --noEmit && eslint .`) — 0 errors, 2 pre-existing warnings untouched.
- Verified visually with `shot app --mock` against a temporarily-lengthened fixture (reverted, not committed): before/after of the thread pane, the Expand click, and the full page scrolled into its Discussion. The **drawer** was checked by test only — I couldn't drive the mock app into it — but it renders the same components with the same props.
- The Python boxes below are the repo template's; this PR is frontend-only and touches no Python.

- [ ] Unit tests pass (`uv run pytest tests/ -x -q`)
- [ ] Linting passes (`uv run ruff check .`)
- [ ] Format check passes (`uv run ruff format --check .`)

## Related Issues

Closes #887

---
_Generated by [Claude Code](https://claude.ai/code/session_01VetgaV3VUFu3MQuJv29yRR)_