### PR TITLE
Let every memory carry a thread, not only the board namespaces (#872)

### DIFF
--- a/contracts/board-vocabulary.json
+++ b/contracts/board-vocabulary.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Frozen vocabulary for the coordination board. The GUI (mycelium-frontend/src/lib/board/) and the CLI (mycelium-cli/src/mycelium/board/) each carry their own copy of the projection rules — the thin `uv tool` CLI can't import the frontend and vice versa — so the words they must agree on live here, the same way contracts/slim-l9-wire.json freezes the SLIM+L9 constants. A unit test on each side asserts against this file, so neither copy can drift without a red gate.",
-  "version": 2,
+  "version": 3,
   "statuses": [
     "open",
     "in_review",
@@ -86,10 +86,10 @@
       "kind",
       "priority"
     ],
-    "_refusals_comment": "Why a projected row has no thread to speak into, keyed by the source that produced it. A chat verb refuses in these terms rather than falling back to the room: a message that quietly went somewhere other than where it was addressed is worse than one that did not go. Keyed by source kind, so an episode row is absent — an episode IS a thread, and speaking into a recorded negotiation is a write the hub judges (a frozen roster refuses an outsider), not one the surface guesses at.",
+    "_refusals_comment": "Why a row has no thread to speak into, keyed by the source that produced it. A chat verb refuses in these terms rather than falling back to the room: a message that quietly went somewhere other than where it was addressed is worse than one that did not go. Keyed by source kind, so an episode row is absent — an episode IS a thread, and speaking into a recorded negotiation is a write the hub judges (a frozen roster refuses an outsider), not one the surface guesses at. The memory refusal is no longer about namespace: EVERY memory a person authored carries a thread, board namespace or not (#872), so the only unthreaded memory left is one the hub wrote for itself — an agents/ manifest, a log/ record, context/synthesis.",
     "refusals": {
       "agent": "presence is a lease the runtime renews, not a conversation to join",
-      "memory": "a thread belongs to a task; this row is in another namespace"
+      "memory": "the hub writes this memory for itself; a thread belongs to something a person authored"
     }
   },
   "log": {

--- a/docs/index.html
+++ b/docs/index.html
@@ -488,6 +488,7 @@ Review 1
       <p><code>board send</code> and <code>board messages</code> are <code>room send</code> and <code>room messages</code> with a task in front of them. Every command that takes a task accepts the row&#x27;s key, and also the short id of the thread inside it, which <code>board new</code> prints when it creates one.</p>
       <p>What changes is what everyone else sees. The argument stays in the task. The room&#x27;s timeline gets one line saying the task moved, and never the prose. Six agents can argue for an hour inside one task and the channel you are scanning gains one line.</p>
       <p>This is the habit worth forming. Use the room for things that belong to no particular task, a heads-up or an open question, and use a task&#x27;s thread for everything attached to a piece of work.</p>
+      <p>The same verbs reach anything else in the room worth arguing about. Every memory a person writes carries a thread, so <code>board send context/api-shape &quot;…&quot;</code> lands in that note&#x27;s conversation even though the board never shows it as a row. Everything can be discussed; only the four namespaces above are worked. See <a href="#memory">memory</a> for what that covers and what it does not.</p>
       <h3 id="board-the-rooms-timeline">The room&#x27;s timeline</h3>
       <p>The room&#x27;s channel is its timeline: what people and agents said, and what happened to the board, in one sequence. A line lands when a task is <strong>filed</strong>, <strong>claimed</strong>, <strong>handed back</strong>, or <strong>resolved</strong>. Each one names the task and opens its thread, so the room reads as an account of the work rather than a wall of argument:</p>
       <pre><code>New task    Ship passkey login                          @julia
@@ -829,6 +830,12 @@ Resolved    Pick token storage                          @sec</code></pre>
         <div class="callout-bar"></div>
         <div class="callout-body"><strong>Operating the hub.</strong> On the hub itself the files are ordinary files, so an operator can inspect, back up, or bulk-edit them. Edits made outside the CLI bypass the index; run <code>mycelium memory reindex</code> afterwards to resync. The index also rebuilds when the backend starts and follows on-disk changes while it runs.</div>
       </div>
+      <h2 id="memory-every-memory-can-be-discussed">Every memory can be discussed</h2>
+      <p>A memory is not only something to read. Every memory a person writes carries a <strong>thread</strong> of its own — the same threads the <a href="#board">board</a> uses, minted the moment the memory exists — so the argument about a design note lives attached to the note rather than scrolling past in the room:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">send</span> context/api-shape <span class="str">&quot;this predates the v2 routes — still true?&quot;</span>
+<span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">messages</span> context/api-shape</code></pre>
+      <p>The verbs are the board&#x27;s because a thread is a thread; what you put in front of them is a row id, a thread id, or any memory key. The room sees one line saying that memory moved, never the prose.</p>
+      <p>Two limits. <strong>Everything can be discussed; only <code>decisions/</code>, <code>status/</code>, <code>work/</code> and <code>failed/</code> are worked</strong> — a threaded <code>skills/</code> doc never shows up on the board as something to claim. And what the hub writes for itself carries no thread: an <code>agents/</code> manifest is a runtime&#x27;s, a <code>log/</code> record is already the record of a conversation, and <code>context/synthesis</code> is rewritten on the synthesizer&#x27;s schedule rather than yours.</p>
       <h2 id="memory-linking-memories">Linking memories</h2>
       <p>Memories can point at each other, which turns a room&#x27;s flat set of files into an interlinked wiki. Two syntaxes, one meaning:</p>
       <pre><code>We chose Postgres because of [[context/stack]].

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -514,6 +514,12 @@ This is the habit worth forming. Use the room for things that belong to no
 particular task, a heads-up or an open question, and use a task's thread for
 everything attached to a piece of work.
 
+The same verbs reach anything else in the room worth arguing about. Every
+memory a person writes carries a thread, so `board send context/api-shape "…"`
+lands in that note's conversation even though the board never shows it as a row.
+Everything can be discussed; only the four namespaces above are worked. See
+[memory](#memory) for what that covers and what it does not.
+
 ### The room's timeline
 
 The room's channel is its timeline: what people and agents said, and what
@@ -1133,6 +1139,29 @@ curl -s $HUB/api/rooms/atlas/memory/work/api-server | jq .meta
 > bypass the index; run `mycelium memory reindex` afterwards to resync. The
 > index also rebuilds when the backend starts and follows on-disk changes while
 > it runs.
+
+## Every memory can be discussed
+
+A memory is not only something to read. Every memory a person writes carries a
+**thread** of its own — the same threads the [board](#board) uses, minted the
+moment the memory exists — so the argument about a design note lives attached to
+the note rather than scrolling past in the room:
+
+```bash
+mycelium board send context/api-shape "this predates the v2 routes — still true?"
+mycelium board messages context/api-shape
+```
+
+The verbs are the board's because a thread is a thread; what you put in front of
+them is a row id, a thread id, or any memory key. The room sees one line saying
+that memory moved, never the prose.
+
+Two limits. **Everything can be discussed; only `decisions/`, `status/`,
+`work/` and `failed/` are worked** — a threaded `skills/` doc never shows up on
+the board as something to claim. And what the hub writes for itself carries no
+thread: an `agents/` manifest is a runtime's, a `log/` record is already the
+record of a conversation, and `context/synthesis` is rewritten on the
+synthesizer's schedule rather than yours.
 
 ## Linking memories
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -704,14 +704,14 @@
         <div class="cmd-ref-header">
           <code><span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">send</span> <span class="arg">&lt;id&gt;</span> &quot;<span class="arg">&lt;text&gt;</span>&quot;</code>
         </div>
-        <div class="cmd-ref-body">Post into the thread inside a row. The room sees that the task moved, not what was said.</div>
+        <div class="cmd-ref-body">Post into the thread on a row or any memory. The room sees that it moved, not what was said.</div>
       </div>
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
           <code><span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">messages</span> <span class="arg">&lt;id&gt;</span> [<span class="flag">--limit</span> N]</code>
         </div>
-        <div class="cmd-ref-body">Read one row's thread: the conversation about that task, and nothing else from the room.</div>
+        <div class="cmd-ref-body">Read one thread: the conversation about that row or memory, and nothing else from the room.</div>
       </div>
 
       <div class="cmd-ref">

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -350,6 +350,13 @@ window.MYCELIUM_SEARCH_INDEX = [
     "p": "Guide"
   },
   {
+    "u": "index.html#memory-every-memory-can-be-discussed",
+    "t": "Every memory can be discussed",
+    "s": "Concepts › Memory",
+    "x": "A memory is not only something to read. Every memory a person writes carries a thread of its own — the same threads the board uses, minted the moment the memory exists — so the argument about a design note lives attached to the note rather than scrolling past in the room: mycelium board send context/api-shape \"this predates the v2 routes — still true?\" mycelium board messages context/api-shape The verbs are the board",
+    "p": "Guide"
+  },
+  {
     "u": "index.html#memory-linking-memories",
     "t": "Linking memories",
     "s": "Concepts › Memory",
@@ -1099,7 +1106,7 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "reference.html#cli-board",
     "t": "mycelium board send <id> \"<text>\"",
     "s": "CLI Reference",
-    "x": "Post into the thread inside a row. The room sees that the task moved, not what was said.",
+    "x": "Post into the thread on a row or any memory. The room sees that it moved, not what was said.",
     "k": "cmd",
     "p": "Reference"
   },
@@ -1107,7 +1114,7 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "reference.html#cli-board",
     "t": "mycelium board messages <id> [--limit N]",
     "s": "CLI Reference",
-    "x": "Read one row's thread: the conversation about that task, and nothing else from the room.",
+    "x": "Read one thread: the conversation about that row or memory, and nothing else from the room.",
     "k": "cmd",
     "p": "Reference"
   },

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -88,11 +88,12 @@ async def lifespan(app: FastAPI):
             logger.warning("auth: %s", warning)
     else:
         logger.info("HTTP-API JWT gate disabled — requests are unauthenticated")
-    # A work/ row written before the task binding carries no thread, so
-    # it reads as a task that was never coordinated anywhere. Minting one is a
-    # store annotation rather than an edit: the row keeps its version, its stamps
-    # and its place on a time-ordered board. Runs before the index scan, so the
-    # rows it rewrites are indexed once rather than caught on the next restart.
+    # A memory written before the binding carries no thread, so it reads as
+    # something there is nowhere to discuss. Minting one is a store annotation
+    # rather than an edit: the memory keeps its version, its stamps and its place
+    # on a time-ordered board. Runs before the index scan, so what it rewrites is
+    # indexed once rather than caught on the next restart — and walks the same
+    # files that scan is about to read anyway.
     from app.services.filesystem import list_room_names
     from app.services.tasks import backfill_room
 
@@ -103,7 +104,7 @@ async def lifespan(app: FastAPI):
         except Exception:
             logger.exception("task backfill failed for room %s", _room)
     if bound_units:
-        logger.info("bound %d pre-existing work row(s) to a thread on startup", bound_units)
+        logger.info("bound %d pre-existing memories to a thread on startup", bound_units)
 
     # Incremental scan of filesystem → JSONL search index
     from app.services.reindex import start_watcher, startup_scan, stop_watcher

--- a/fastapi-backend/app/routes/memory.py
+++ b/fastapi-backend/app/routes/memory.py
@@ -59,7 +59,7 @@ from app.services.filesystem import (
     write_memory_file,
 )
 from app.services.search_index import stable_memory_id
-from app.services.tasks import is_board_row, mint_episode_urn
+from app.services.tasks import is_board_row, is_threadable, mint_episode_urn
 
 logger = logging.getLogger(__name__)
 
@@ -306,13 +306,15 @@ async def upsert_memories(
             extra_meta.update(system)
         extra_meta.update(system_meta(existing_meta))
 
-        # Every board row is a task with its own thread. If this write creates
-        # one in a board namespace and nothing has already bound it, mint its
-        # episode now — so a task, a decision or a blocked item carries a thread
-        # from the moment it exists, not only once a negotiation happens inside
-        # it. The merge above is write-once (an existing binding won), so this
-        # only ever fires on creation and each row gets a distinct URN.
-        if EPISODE_META not in extra_meta and is_board_row(item.key):
+        # Every memory a person authored can be discussed. If this write creates
+        # one and nothing has already bound it, mint its episode now — so a task,
+        # a decision, a `context/` note or a `skills/` doc carries a thread from
+        # the moment it exists, not only once someone wants to argue about it.
+        # Everything can be *discussed*; only the board namespaces are *worked*,
+        # which is why the gate here is wider than `is_board_row` below. The
+        # merge above is write-once (an existing binding won), so this only ever
+        # fires on creation and each memory gets a distinct URN.
+        if EPISODE_META not in extra_meta and is_threadable(item.key):
             extra_meta[EPISODE_META] = mint_episode_urn(room_name)
 
         # Persist structured values into frontmatter so non-text keys survive
@@ -403,6 +405,9 @@ async def upsert_memories(
         # a `filed` notice into the timeline, naming the task, its kind (so it
         # reads "New decision" not always "New task") and who it is for. Only on
         # creation — a later write is a state change, carried by its own verb.
+        # Board namespaces only, deliberately: a threaded `context/` note is
+        # something to discuss, and announcing it as filed work would put it on a
+        # timeline that reads as the board.
         if not existing and is_board_row(item.key):
             from app.services.room_channels import manager
 

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -412,10 +412,12 @@ class MemoryRead(BaseModel):
     episode: str | None = Field(
         None,
         description=(
-            "The episode URN this row's coordination happens in — what makes a task "
-            "a thread. Store-owned: minted by the backend, so it is absent "
-            "from ``meta`` and cannot be set by a write. Null on a memory that is "
-            "not a task, and on one no thread has been opened for."
+            "The episode URN the conversation about this memory happens in — what "
+            "makes a task a thread, and what makes every other memory "
+            "discussable. Store-owned: minted by the backend on create, so it is "
+            "absent from ``meta`` and cannot be set by a write. Null on what the "
+            "hub writes for itself (an ``agents/`` manifest, a ``log/`` record) "
+            "and on anything written before threading."
         ),
     )
     expandable: bool = Field(

--- a/fastapi-backend/app/services/tasks.py
+++ b/fastapi-backend/app/services/tasks.py
@@ -23,6 +23,13 @@ and carried forward by every later write
 (:data:`~app.services.filesystem.SYSTEM_META`), so a row's thread is stable for
 the row's life.  Re-negotiating inside a task opens a *new* negotiation episode;
 it does not re-mint the task's own.
+
+A task is what this binding was built for, and not the only thing it holds:
+**every memory a person authored carries a thread**, so the conversation about a
+``context/`` design note or a ``skills/`` doc lives attached to it rather than
+scrolling past in the room.  :func:`is_threadable` is that wider gate and
+:func:`is_board_row` is the narrower one — everything can be *discussed*; only
+the board namespaces are *worked*.
 """
 
 from __future__ import annotations
@@ -61,10 +68,44 @@ WORK_NAMESPACE = "work"
 #: ``contracts/board-vocabulary.json`` under ``live_namespaces``.
 BOARD_NAMESPACES = frozenset({"decisions", "status", "work", "failed"})
 
+#: Namespaces the hub writes for itself.  A thread is a place for people to
+#: talk about something someone wrote; these are records the store keeps —
+#: ``agents/`` is a runtime's manifest, ``log/`` is the transcript and the
+#: episode records, and a ``log/episodes/*`` file is already the record *of* a
+#: conversation.  Auto-threading them is noise at best and circular at worst.
+SYSTEM_NAMESPACES = frozenset({"agents", "log"})
+
+#: Individual machine-written keys outside those namespaces.  ``context/`` is a
+#: room's own notes and thoroughly discussable; the synthesizer's briefing is
+#: the one file in it the hub rewrites on its own schedule, so a conversation
+#: attached to it would be attached to a moving target.  Asserted against
+#: :data:`~app.services.synthesizer.SYNTHESIS_KEY` rather than duplicating it by
+#: import, which would make a service the task model depends on.
+SYSTEM_KEYS = frozenset({"context/synthesis"})
+
 
 def is_board_row(key: str) -> bool:
-    """Whether ``key`` names a board row, which is what gets a thread on create."""
+    """Whether ``key`` names a board row — what the board projects and leases."""
     return key.split("/", 1)[0] in BOARD_NAMESPACES
+
+
+def is_threadable(key: str) -> bool:
+    """Whether ``key`` can carry a thread, which is nearly everything.
+
+    Every piece of room knowledge a person authored can be discussed, not only
+    the four namespaces the board works: a ``context/`` design note, a
+    ``procedures/`` runbook, a ``skills/`` doc and a bare user key all get a
+    thread the moment they exist, so the argument about one lives attached to it
+    rather than scrolling past in the room.
+
+    The gate widens; it does not disappear.  What it still refuses is the hub's
+    own writing (:data:`SYSTEM_NAMESPACES`, :data:`SYSTEM_KEYS`) — a denylist
+    rather than an allowlist, so a namespace someone invents next week is
+    discussable without anyone remembering to add it here.
+
+    Costs nothing until someone posts: the binding is one frontmatter key.
+    """
+    return key not in SYSTEM_KEYS and key.split("/", 1)[0] not in SYSTEM_NAMESPACES
 
 
 #: What a board row calls a task.  Written explicitly because the
@@ -83,6 +124,11 @@ ASSIGNEE_FIELD = "assignee"
 
 #: Longest slug taken from a task's title, before any de-duplicating suffix.
 SLUG_MAX = 48
+
+#: How many files one backfill pass reads.  Above :func:`list_memory_files`'s
+#: own default because this walks a whole room rather than one namespace, and a
+#: room whose tail went unread would leave memories silently unthreaded.
+BACKFILL_SCAN_LIMIT = 10_000
 
 _SLUG_STRIP = re.compile(r"[^a-z0-9]+")
 
@@ -313,26 +359,28 @@ async def create_task(
 
 
 def backfill_room(room: str) -> int:
-    """Mint a thread for every board row that carries none, in place.
+    """Mint a thread for every threadable memory that carries none, in place.
 
-    Covers every board namespace, not just ``work/``: a decision, a status or a
-    blocked item is a task with its own thread too, so a room written before
-    threading gets one on each of its rows.
+    Covers everything :func:`is_threadable` allows, not only the board
+    namespaces: a room written before this gets a thread on each of its
+    ``context/`` notes and ``procedures/`` runbooks too, so "every memory can be
+    discussed" is true of the ones that already exist rather than only the ones
+    written next.  A binding is write-once, so this runs to a fixed point.
 
-    Written straight to the file: minting a URN records where a row's thread
+    Written straight to the file: minting a URN records where a memory's thread
     *is*, so it must not bump the version, re-date ``updated_at`` or broadcast a
     write, which is what the upsert would do — announcing a change nobody made
     and shuffling every stale row to the top of a time-ordered board.  Returns
-    how many rows were bound.
+    how many memories were bound.
     """
     base = get_room_dir(room)
     bound = 0
-    rows = (
-        row
-        for namespace in sorted(BOARD_NAMESPACES)
-        for row in list_memory_files(base, prefix=f"{namespace}/")
+    unbound = (
+        found
+        for found in list_memory_files(base, limit=BACKFILL_SCAN_LIMIT)
+        if is_threadable(found[0])
     )
-    for key, meta, content in rows:
+    for key, meta, content in unbound:
         if system_meta(meta).get(EPISODE_META):
             continue
         # Everything serialize_memory does not write from its own arguments,
@@ -353,5 +401,5 @@ def backfill_room(room: str) -> int:
         )
         bound += 1
     if bound:
-        logger.info("bound %d pre-existing work row(s) in %s to a thread", bound, room)
+        logger.info("bound %d pre-existing memories in %s to a thread", bound, room)
     return bound

--- a/fastapi-backend/tests/test_tasks.py
+++ b/fastapi-backend/tests/test_tasks.py
@@ -97,13 +97,55 @@ class TestBoardFirstCreation:
         assert one.episode != two.episode
 
 
-@pytest.mark.asyncio
-class TestThreadOnEveryBoardWrite:
-    """The plain write path mints a thread for a board row, not just create_task.
+class TestThreadable:
+    """What can be discussed: everything a person authored, and nothing else.
 
-    A decision dropped with ``memory set``, a status posted, a blocked item — each
-    is a task and gets a thread the moment it exists, so nothing has to be
-    coordinated first for a row to have one to open.
+    The gate is a denylist, so a namespace nobody has invented yet is
+    discussable without anyone remembering to widen it.
+    """
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "work/passkey-login",
+            "decisions/db",
+            "context/goal",
+            "procedures/deploy",
+            "skills/review",
+            "notebook",
+            "context/synthesis-notes",
+        ],
+    )
+    def test_a_memory_a_person_wrote_can_be_discussed(self, key):
+        assert tasks.is_threadable(key)
+
+    @pytest.mark.parametrize(
+        "key",
+        ["agents/sec", "log/transcript", "log/episodes/a1b2c3d4", "context/synthesis"],
+    )
+    def test_what_the_hub_writes_for_itself_cannot(self, key):
+        assert not tasks.is_threadable(key)
+
+    def test_the_synthesizer_s_own_key_is_the_one_it_is_declared_as(self):
+        # Declared rather than imported, so the task model does not depend on a
+        # service. This is the check that the declaration is still true.
+        from app.services.synthesizer import SYNTHESIS_KEY
+
+        assert SYNTHESIS_KEY in tasks.SYSTEM_KEYS
+
+    def test_a_board_row_is_the_narrower_word_and_stays_narrow(self):
+        # Everything can be discussed; only these four are worked.
+        assert tasks.is_board_row("work/x") and tasks.is_threadable("work/x")
+        assert tasks.is_threadable("context/x") and not tasks.is_board_row("context/x")
+
+
+@pytest.mark.asyncio
+class TestThreadOnEveryWrite:
+    """The plain write path mints a thread for any memory, not just create_task.
+
+    A decision dropped with ``memory set``, a status posted, a ``context/``
+    design note, a ``skills/`` doc — each gets a thread the moment it exists, so
+    nothing has to be coordinated first for there to be somewhere to argue.
     """
 
     async def test_a_decision_written_plainly_gets_its_own_thread(self):
@@ -111,17 +153,32 @@ class TestThreadOnEveryBoardWrite:
         await _write(room, "decisions/token-ttl", "15m or 60m?")
         assert _meta(room, "decisions/token-ttl")[EPISODE_META]
 
-    async def test_each_board_row_gets_a_distinct_thread(self):
+    async def test_each_memory_gets_a_distinct_thread(self):
         room = _room("u-write-distinct")
         await _write(room, "work/one", "One")
         await _write(room, "decisions/two", "Two")
         assert _meta(room, "work/one")[EPISODE_META] != _meta(room, "decisions/two")[EPISODE_META]
 
-    async def test_a_non_board_note_gets_no_thread(self):
-        # A context note or an agent manifest is not a board row; it has no thread.
+    async def test_a_context_note_can_be_discussed_too(self):
+        # #872: the conversation about a design note lives attached to it rather
+        # than scrolling past in the room.
         room = _room("u-write-context")
         await _write(room, "context/goal", "Move off the legacy store")
-        assert EPISODE_META not in _meta(room, "context/goal")
+        assert _meta(room, "context/goal")[EPISODE_META]
+
+    async def test_a_skill_can_be_discussed_too(self):
+        room = _room("u-write-skill")
+        await _write(room, "skills/review", "How we review")
+        assert _meta(room, "skills/review")[EPISODE_META]
+
+    async def test_what_the_hub_writes_for_itself_gets_no_thread(self):
+        # An agent manifest is the runtime's, and a log record is already the
+        # record of a conversation; neither is a thing to have one about.
+        room = _room("u-write-system")
+        await _write(room, "agents/sec", "A manifest")
+        await _write(room, "log/episodes/a1b2c3d4", "A closed negotiation")
+        assert EPISODE_META not in _meta(room, "agents/sec")
+        assert EPISODE_META not in _meta(room, "log/episodes/a1b2c3d4")
 
     async def test_a_later_write_never_moves_the_thread(self):
         room = _room("u-write-stable")
@@ -251,15 +308,26 @@ class TestMigration:
         assert tasks.backfill_room(room) == 0
         assert _meta(room, "work/legacy")[EPISODE_META] == bound
 
-    async def test_every_board_row_is_bound_not_only_work(self):
-        # A decision is a task too — a board row with a thread of its own — so
-        # the backfill heals it alongside a work row. A non-board namespace (a
-        # plain context note) is left alone: it is not a board row.
+    async def test_every_threadable_memory_is_bound_not_only_the_board(self):
+        # #872: a room written before this gets a thread on its context notes and
+        # procedures too, so "every memory can be discussed" is true of the ones
+        # that already exist. What the hub writes for itself is left alone.
         room = _room("u-migrate-4")
         _write_unbound(room, "decisions/db", "PostgreSQL")
         _write_unbound(room, "failed/spoke", "Thin-spoke join")
         _write_unbound(room, "context/goal", "Move off the legacy store")
-        assert tasks.backfill_room(room) == 2
-        assert _meta(room, "decisions/db")[EPISODE_META]
-        assert _meta(room, "failed/spoke")[EPISODE_META]
-        assert EPISODE_META not in _meta(room, "context/goal")
+        _write_unbound(room, "procedures/deploy", "How we ship")
+        _write_unbound(room, "agents/sec", "A manifest")
+        _write_unbound(room, "log/episodes/a1b2c3d4", "A closed negotiation")
+        assert tasks.backfill_room(room) == 4
+        for key in ("decisions/db", "failed/spoke", "context/goal", "procedures/deploy"):
+            assert _meta(room, key)[EPISODE_META], key
+        assert EPISODE_META not in _meta(room, "agents/sec")
+        assert EPISODE_META not in _meta(room, "log/episodes/a1b2c3d4")
+
+    async def test_a_backfilled_memory_gets_a_thread_of_its_own(self):
+        room = _room("u-migrate-5")
+        _write_unbound(room, "context/one", "One")
+        _write_unbound(room, "context/two", "Two")
+        tasks.backfill_room(room)
+        assert _meta(room, "context/one")[EPISODE_META] != _meta(room, "context/two")[EPISODE_META]

--- a/mycelium-cli/src/mycelium/board/model.py
+++ b/mycelium-cli/src/mycelium/board/model.py
@@ -65,13 +65,17 @@ THREAD_STATES = ["open", "converged", "resolved", "rejected", "committed"]
 #: the container-outlives-the-negotiation rule as a list.
 TASK_FIELDS = ["status", "assignment", "owner", "kind", "priority"]
 
-#: Why a projected row has no thread to speak into, keyed by what produced it.
-#: A chat verb refuses in these terms rather than falling back to the room: a
-#: message that quietly went somewhere other than where it was addressed is
-#: worse than one that did not go.
+#: Why a row has no thread to speak into, keyed by what produced it. A chat verb
+#: refuses in these terms rather than falling back to the room: a message that
+#: quietly went somewhere other than where it was addressed is worse than one
+#: that did not go.
+#:
+#: The memory refusal is not about namespace. Every memory a person authored
+#: carries a thread wherever it lives, so what is left unthreaded is what the
+#: hub wrote for itself — an ``agents/`` manifest, a ``log/`` record.
 THREAD_REFUSALS = {
     "agent": "presence is a lease the runtime renews, not a conversation to join",
-    "memory": "a thread belongs to a task; this row is in another namespace",
+    "memory": "the hub writes this memory for itself; a thread belongs to something a person authored",
 }
 
 

--- a/mycelium-cli/src/mycelium/commands/board.py
+++ b/mycelium-cli/src/mycelium/commands/board.py
@@ -635,24 +635,55 @@ def _row(room: str, row_id: str) -> LiveItem | None:
     return None
 
 
-def _thread(room: str, row_id: str) -> tuple[LiveItem, str]:
-    """The row a chat verb names and the thread inside it.
+def _memory_thread(room: str, key: str) -> tuple[bool, str | None]:
+    """The thread on a memory the board does not project, off the hub.
 
-    The resolution the board's chat verbs are: a reader types a row id and means
-    the conversation about that task. A row with nothing to speak into is
-    refused in its own terms rather than posted to the room instead — a message
-    that quietly went somewhere else is worse than one that did not go.
+    Two answers, because the caller says something different about each: whether
+    the room has this memory at all, and the thread on it if it does.
+    """
+    cfg = MyceliumConfig.load()
+    try:
+        with hub_client(cfg, timeout=30) as client:
+            resp = client.get(f"/api/rooms/{room}/memory/{key}")
+        if resp.status_code >= 400:
+            return False, None
+        episode = resp.json().get(EPISODE_FIELD)
+    except (httpx.HTTPError, ValueError):
+        return False, None
+    return True, episode or None
+
+
+def _thread(room: str, row_id: str) -> tuple[str, str]:
+    """Where a chat verb lands: what to call it, and the thread to write into.
+
+    The resolution the chat verbs are: a reader types an id and means the
+    conversation about that thing. The board is one way to name it and not the
+    only one — every memory a person authored carries a thread, so a
+    ``context/`` note or a ``skills/`` doc is addressable by its key even though
+    the board never projects it. **Everything can be discussed; only the board
+    namespaces are worked.**
+
+    Something with nothing to speak into is refused in its own terms rather than
+    posted to the room instead — a message that quietly went somewhere else is
+    worse than one that did not go.
     """
     item = _row(room, row_id)
-    if item is None:
-        console.print(f"[dim]No row '{row_id}' on this board.[/dim]")
+    if item is not None:
+        episode = item.text(EPISODE_FIELD)
+        if not episode:
+            why = THREAD_REFUSALS.get(item.source.kind, THREAD_REFUSALS["memory"])
+            console.print(f"[yellow]·[/yellow] {row_id} has no thread — {why}.")
+            raise typer.Exit(1)
+        return _thread_label(room, item.text("thread") or row_id), episode
+
+    exists, episode = _memory_thread(room, row_id)
+    if not exists:
+        console.print(f"[dim]No row '{row_id}' on this board, and no memory by that key.[/dim]")
         raise typer.Exit(1)
-    episode = item.text(EPISODE_FIELD)
     if not episode:
-        why = THREAD_REFUSALS.get(item.source.kind, THREAD_REFUSALS["memory"])
-        console.print(f"[yellow]·[/yellow] {row_id} has no thread — {why}.")
+        console.print(f"[yellow]·[/yellow] {row_id} has no thread — {THREAD_REFUSALS['memory']}.")
         raise typer.Exit(1)
-    return item, episode
+    return _thread_label(room, episode.rsplit(":", 1)[-1]), episode
 
 
 def _parent_key(room: str, row_id: str) -> str:
@@ -670,9 +701,9 @@ def _parent_key(room: str, row_id: str) -> str:
     return key
 
 
-def _thread_label(room: str, item: LiveItem, row_id: str) -> str:
-    """What a chat verb calls where it landed: the room, then the row in it."""
-    return f"{room}/{item.text('thread') or row_id}"
+def _thread_label(room: str, thread: str) -> str:
+    """What a chat verb calls where it landed: the room, then the thread in it."""
+    return f"{room}/{thread}"
 
 
 def _write_assignment(cfg: MyceliumConfig, room: str, action: str, **body: Any) -> None:
@@ -815,68 +846,78 @@ def board_new(
 
 @doc_ref(
     usage='mycelium board send <id> "<text>"',
-    desc="Post into the thread inside a row. The room sees that the task moved, not what was said.",
+    desc="Post into the thread on a row or any memory. The room sees that it moved, not what was said.",
     group="board",
 )
 @app.command(name="send")
 def board_send(
-    row_id: str = typer.Argument(..., help="Row id as shown on the board (e.g. t3, work/auth)"),
+    row_id: str = typer.Argument(
+        ..., help="Row id, thread id, or any memory key (e.g. t3, work/auth, context/api)"
+    ),
     content: str = typer.Argument(..., help="What to say. @handle mentions address agents."),
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
     handle: str | None = typer.Option(
         None, "--handle", "-H", help="Your sender handle (defaults to identity config)"
     ),
 ) -> None:
-    """Say something in a row's thread.
+    """Say something in a thread.
 
-    Exactly ``mycelium room send``, scoped to one task. Everyone who may write in
-    the room may write in its threads — a thread separates attention, not access
-    — with one exception the hub enforces: a negotiation running inside a task
-    has frozen its roster, and an outsider dropping a position into that would
-    be scoring an exchange they were not part of.
+    Exactly ``mycelium room send``, scoped to one thing. That thing is usually a
+    task, but every memory a person authored carries a thread of its own, so a
+    ``context/`` design note or a ``skills/`` doc is addressable by its key —
+    the argument about a piece of room knowledge lives attached to it rather
+    than scrolling past in the room.
+
+    Everyone who may write in the room may write in its threads — a thread
+    separates attention, not access — with one exception the hub enforces: a
+    negotiation running inside a task has frozen its roster, and an outsider
+    dropping a position into that would be scoring an exchange they were not
+    part of.
     """
     cfg = MyceliumConfig.load()
     name = _resolve_room(cfg, room)
-    item, episode = _thread(name, row_id)
+    where, episode = _thread(name, row_id)
     chat.post(
         cfg,
         name,
         sender_handle=handle or cfg.get_current_identity(),
         content=content,
         episode=episode,
-        destination=_thread_label(name, item, row_id),
+        destination=where,
     )
 
 
 @doc_ref(
     usage="mycelium board messages <id> [--limit N]",
-    desc="Read one row's thread: the conversation about that task, and nothing else from the room.",
+    desc="Read one thread: the conversation about that row or memory, and nothing else from the room.",
     group="board",
 )
 @app.command(name="messages")
 def board_messages(
-    row_id: str = typer.Argument(..., help="Row id as shown on the board (e.g. t3, work/auth)"),
+    row_id: str = typer.Argument(
+        ..., help="Row id, thread id, or any memory key (e.g. t3, work/auth, context/api)"
+    ),
     limit: int = typer.Option(20, "--limit", "-l", help="Max messages to show (newest first)"),
     sender: str | None = typer.Option(
         None, "--sender", "-s", help="Only messages from this handle"
     ),
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
 ) -> None:
-    """Read a row's thread.
+    """Read a thread.
 
-    This is what a ping is for. The room said a task moved; this is what moved
-    in it.
+    This is what a ping is for. The room said something moved; this is what
+    moved in it — a row's conversation, or a memory's.
     """
     cfg = MyceliumConfig.load()
     name = _resolve_room(cfg, room)
-    item, episode = _thread(name, row_id)
+    where, episode = _thread(name, row_id)
     chat.read(
         cfg,
         name,
         limit=limit,
         sender=sender,
         episode=episode,
-        label=_thread_label(name, item, row_id),
+        label=where,
         empty_note="nothing said in this thread yet",
     )
 
@@ -888,7 +929,9 @@ def board_messages(
 )
 @app.command(name="coordinate")
 def board_coordinate(
-    row_id: str = typer.Argument(..., help="Row id as shown on the board (e.g. t3, work/auth)"),
+    row_id: str = typer.Argument(
+        ..., help="Row id, thread id, or any memory key (e.g. t3, work/auth, context/api)"
+    ),
     engine: str = typer.Argument(..., help="Engine handle to run it (e.g. aligner)"),
     ask: str = typer.Argument(
         "please mediate us to an agreement.", help="What you're asking it to do"
@@ -921,7 +964,7 @@ def board_coordinate(
 
     cfg = MyceliumConfig.load()
     name = _resolve_room(cfg, room)
-    item, episode = _thread(name, row_id)
+    where, episode = _thread(name, row_id)
     target = engine.lstrip("@")
 
     with typed_client(cfg) as client:
@@ -945,10 +988,10 @@ def board_coordinate(
         sender_handle=handle or cfg.get_current_identity(),
         content=f"@{manifest.handle} {ask}",
         episode=episode,
-        destination=_thread_label(name, item, row_id),
+        destination=where,
     )
     console.print(
-        f"  [dim]the ask is in {item.text('thread') or row_id}'s thread; the "
+        f"  [dim]the ask is in {where.split('/', 1)[-1]}'s thread; the "
         f"{manifest.kind} engine opens its negotiation from there and addresses "
         "agents one at a time[/dim]"
     )

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -355,8 +355,16 @@ def memory_get(
         )
         return
 
-    console.print(f"[cyan]{mem.key}[/cyan]  [dim]v{mem.version}  {mem.created_by}[/dim]")
+    thread = _unset_to_none(mem.episode)
+    header = f"[cyan]{mem.key}[/cyan]  [dim]v{mem.version}  {mem.created_by}"
+    console.print(
+        f"{header}  thread {thread.rsplit(':', 1)[-1]}[/dim]" if thread else f"{header}[/dim]"
+    )
     console.print(content)
+    # Every memory a person wrote carries a thread, and nothing else in the CLI
+    # says so — a reader who does not know the verb has no way to find it.
+    if thread:
+        console.print(f'\n[dim]discuss it: mycelium board send {mem.key} "…"[/dim]')
 
 
 def _fetch_memories(room_name: str, prefix: str | None, limit: int) -> list[dict[str, Any]]:

--- a/mycelium-cli/src/mycelium/docs/concepts/board.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/board.md
@@ -108,6 +108,12 @@ This is the habit worth forming. Use the room for things that belong to no
 particular task, a heads-up or an open question, and use a task's thread for
 everything attached to a piece of work.
 
+The same verbs reach anything else in the room worth arguing about. Every
+memory a person writes carries a thread, so `board send context/api-shape "…"`
+lands in that note's conversation even though the board never shows it as a row.
+Everything can be discussed; only the four namespaces above are worked. See
+[memory](#memory) for what that covers and what it does not.
+
 ### The room's timeline
 
 The room's channel is its timeline: what people and agents said, and what

--- a/mycelium-cli/src/mycelium/docs/concepts/memory.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/memory.md
@@ -107,6 +107,29 @@ curl -s $HUB/api/rooms/atlas/memory/work/api-server | jq .meta
 > index also rebuilds when the backend starts and follows on-disk changes while
 > it runs.
 
+## Every memory can be discussed
+
+A memory is not only something to read. Every memory a person writes carries a
+**thread** of its own — the same threads the [board](#board) uses, minted the
+moment the memory exists — so the argument about a design note lives attached to
+the note rather than scrolling past in the room:
+
+```bash
+mycelium board send context/api-shape "this predates the v2 routes — still true?"
+mycelium board messages context/api-shape
+```
+
+The verbs are the board's because a thread is a thread; what you put in front of
+them is a row id, a thread id, or any memory key. The room sees one line saying
+that memory moved, never the prose.
+
+Two limits. **Everything can be discussed; only `decisions/`, `status/`,
+`work/` and `failed/` are worked** — a threaded `skills/` doc never shows up on
+the board as something to claim. And what the hub writes for itself carries no
+thread: an `agents/` manifest is a runtime's, a `log/` record is already the
+record of a conversation, and `context/synthesis` is rewritten on the
+synthesizer's schedule rather than yours.
+
 ## Linking memories
 
 Memories can point at each other, which turns a room's flat set of files into an

--- a/mycelium-cli/tests/test_board_threads.py
+++ b/mycelium-cli/tests/test_board_threads.py
@@ -37,6 +37,8 @@ runner = CliRunner()
 ROOM = "atlas"
 THREAD = "urn:ioc:mycelium:episode:atlas:t3aa11bb"
 SHORT = "t3aa11bb"
+OTHER = "urn:ioc:mycelium:episode:atlas:c0ffee42"
+OTHER_SHORT = "c0ffee42"
 
 
 def _unit(key: str = "work/passkey-login", episode: str | None = THREAD) -> dict:
@@ -51,8 +53,18 @@ def _unit(key: str = "work/passkey-login", episode: str | None = THREAD) -> dict
     }
 
 
-def _hub(monkeypatch: pytest.MonkeyPatch, *, memories: list[dict], posts: list | None = None):
-    """Stand in for every hub read the board makes, plus the write it may do."""
+def _hub(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    memories: list[dict],
+    posts: list | None = None,
+    keyed: dict[str, dict] | None = None,
+):
+    """Stand in for every hub read the board makes, plus the write it may do.
+
+    ``keyed`` is the by-key memory read, which is how a chat verb reaches a
+    memory the board never projects. A key absent from it 404s.
+    """
     fake_config = SimpleNamespace(
         server=SimpleNamespace(api_url="http://localhost:8000"),
         get_active_room=lambda: ROOM,
@@ -62,9 +74,9 @@ def _hub(monkeypatch: pytest.MonkeyPatch, *, memories: list[dict], posts: list |
     monkeypatch.setattr(board_cmd, "_resolve_room", lambda *_a, **_k: ROOM)
 
     class _Resp:
-        def __init__(self, payload):
+        def __init__(self, payload, status: int = 200):
             self._payload = payload
-            self.status_code = 200
+            self.status_code = status
             self.text = ""
 
         def raise_for_status(self):
@@ -90,6 +102,12 @@ def _hub(monkeypatch: pytest.MonkeyPatch, *, memories: list[dict], posts: list |
             return False
 
         def get(self, path, **_kw):
+            prefix = f"/api/rooms/{ROOM}/memory/"
+            if path.startswith(prefix) and "?" not in path:
+                key = path[len(prefix) :]
+                if key not in (keyed or {}):
+                    return _Resp({"detail": "Memory not found"}, status=404)
+                return _Resp({"key": key, **(keyed or {})[key]})
             return _Resp(routes.get(path, {}))
 
         def post(self, path, json=None, **_kw):  # noqa: A002 — httpx's own name
@@ -130,7 +148,7 @@ class TestResolution:
         assert result.exit_code == 0, result.output
         assert sent["post"]["episode"] == THREAD
 
-    def test_a_row_the_board_does_not_have_is_refused(
+    def test_a_key_the_room_does_not_have_at_all_is_refused(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _hub(monkeypatch, memories=[_unit()])
@@ -150,8 +168,66 @@ class TestResolution:
         result = runner.invoke(board_cmd.app, ["send", "decisions/db", "hello"])
         assert result.exit_code == 1
         assert "no thread" in result.output
-        assert "another namespace" in result.output
+        assert "the hub writes this memory for itself" in result.output
         assert sent == {}
+
+
+class TestBeyondTheBoard:
+    """Everything can be discussed; only the board namespaces are worked (#872).
+
+    A ``context/`` note carries a thread like any memory, but the board never
+    projects one, so the chat verbs have to resolve it off the store rather than
+    off the projection — and still refuse in the same terms when there is
+    nothing to speak into.
+    """
+
+    def test_a_memory_the_board_does_not_project_resolves_to_its_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _hub(monkeypatch, memories=[_unit()], keyed={"context/api-shape": {"episode": OTHER}})
+        sent = _chat(monkeypatch)
+        result = runner.invoke(board_cmd.app, ["send", "context/api-shape", "this is stale"])
+        assert result.exit_code == 0, result.output
+        assert sent["post"]["episode"] == OTHER
+        assert sent["post"]["destination"] == f"{ROOM}/{OTHER_SHORT}"
+
+    def test_reading_a_memory_s_thread_reads_that_thread_and_nothing_else(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _hub(monkeypatch, memories=[_unit()], keyed={"skills/review": {"episode": OTHER}})
+        sent = _chat(monkeypatch)
+        result = runner.invoke(board_cmd.app, ["messages", "skills/review"])
+        assert result.exit_code == 0, result.output
+        assert sent["read"]["episode"] == OTHER
+        assert sent["read"]["label"] == f"{ROOM}/{OTHER_SHORT}"
+
+    def test_a_memory_the_hub_wrote_for_itself_is_refused_not_sent_to_the_room(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _hub(monkeypatch, memories=[_unit()], keyed={"agents/sec": {}})
+        sent = _chat(monkeypatch)
+        result = runner.invoke(board_cmd.app, ["send", "agents/sec", "hello"])
+        assert result.exit_code == 1
+        assert "no thread" in result.output
+        assert sent == {}
+
+    def test_a_memory_that_is_not_there_says_neither_row_nor_memory(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _hub(monkeypatch, memories=[_unit()])
+        sent = _chat(monkeypatch)
+        result = runner.invoke(board_cmd.app, ["send", "context/ghost", "hello"])
+        assert result.exit_code == 1
+        assert "no memory by that key" in result.output
+        assert sent == {}
+
+    def test_the_board_still_wins_when_a_key_is_both(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """One round trip, not two: a projected row already carries its thread."""
+        _hub(monkeypatch, memories=[_unit()], keyed={"work/passkey-login": {"episode": OTHER}})
+        sent = _chat(monkeypatch)
+        result = runner.invoke(board_cmd.app, ["send", "work/passkey-login", "hello"])
+        assert result.exit_code == 0, result.output
+        assert sent["post"]["episode"] == THREAD
 
 
 class TestChatVerbs:

--- a/mycelium-cli/tests/test_memory_commands.py
+++ b/mycelium-cli/tests/test_memory_commands.py
@@ -195,6 +195,36 @@ def test_memory_get_reads_from_hub_without_local_files(monkeypatch: pytest.Monke
     assert "we chose postgres" in result.output
 
 
+def test_memory_get_names_the_thread_and_the_verb_that_reaches_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#872: every memory carries a thread, and nothing else in the CLI says so."""
+    _stub_get(
+        monkeypatch,
+        _memory_read(
+            "context/api-shape",
+            "the v1 routes",
+            episode="urn:ioc:mycelium:episode:demo:c0ffee42",
+        ),
+    )
+
+    result = runner.invoke(memory_cmd.app, ["get", "context/api-shape", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "c0ffee42" in result.output
+    assert "board send context/api-shape" in result.output
+
+
+def test_memory_get_says_nothing_about_a_thread_a_memory_does_not_have(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_get(monkeypatch, _memory_read("agents/sec", "a manifest"))
+
+    result = runner.invoke(memory_cmd.app, ["get", "agents/sec", "--room", "demo"])
+    assert result.exit_code == 0, result.output
+    assert "thread" not in result.output
+    assert "board send" not in result.output
+
+
 def test_memory_get_renders_structured_value(monkeypatch: pytest.MonkeyPatch) -> None:
     value = _structured(text="deploy is green", logged_at=STAMP.isoformat(), category="status")
     _stub_get(monkeypatch, _memory_read("status/deploy", value))

--- a/mycelium-cli/tests/test_slim_master_secret_config.py
+++ b/mycelium-cli/tests/test_slim_master_secret_config.py
@@ -103,9 +103,7 @@ def test_spoke_write_env_file_preserves_existing_secret(isolated_home) -> None:
     config_path = myc / "config.toml"
     env_path = myc / ".env"
 
-    env_path.write_text(
-        "MYCELIUM_SLIM_MASTER_SECRET=existing-spoke-secret-value-0123456789ab\n"
-    )
+    env_path.write_text("MYCELIUM_SLIM_MASTER_SECRET=existing-spoke-secret-value-0123456789ab\n")
 
     cfg = MyceliumConfig()
     cfg.server.api_url = "http://192.168.1.20:8000"
@@ -116,7 +114,10 @@ def test_spoke_write_env_file_preserves_existing_secret(isolated_home) -> None:
     rendered = _parse_env(env_path.read_text(encoding="utf-8"))
     assert rendered["MYCELIUM_SLIM_MASTER_SECRET"] == "existing-spoke-secret-value-0123456789ab"
     # config.toml also updated
-    assert MyceliumConfig.load(config_path).slim.master_secret == "existing-spoke-secret-value-0123456789ab"
+    assert (
+        MyceliumConfig.load(config_path).slim.master_secret
+        == "existing-spoke-secret-value-0123456789ab"
+    )
 
 
 def test_spoke_write_env_file_does_not_generate_new_secret(isolated_home) -> None:

--- a/mycelium-frontend/src/components/board/board-thread.test.tsx
+++ b/mycelium-frontend/src/components/board/board-thread.test.tsx
@@ -124,7 +124,7 @@ describe("<RoomBoard /> thread affordance", () => {
     await userEvent.keyboard("t");
     expect(onOpenThread).not.toHaveBeenCalled();
     expect(
-      await screen.findByText(/a thread belongs to a task; this row is in another namespace/),
+      await screen.findByText(/the hub writes this memory for itself/),
     ).toBeInTheDocument();
   });
 

--- a/mycelium-frontend/src/lib/board/fields.ts
+++ b/mycelium-frontend/src/lib/board/fields.ts
@@ -49,15 +49,15 @@ export const WRITABLE_SOURCE_KINDS = ["memory"];
  */
 export const THREAD_REFUSALS: Record<string, string> = {
   agent: "presence is a lease the runtime renews, not a conversation to join",
-  memory: "a thread belongs to a task; this row is in another namespace",
+  memory: "the hub writes this memory for itself; a thread belongs to something a person authored",
 };
 
 /**
  * Why this row's thread cannot be opened, or null when it can.
  *
- * Every task is minted a thread on creation, so a board row all but always has
- * one; the memory refusal is left for a memory outside the board namespaces,
- * which is genuinely in another namespace and has no thread to open.
+ * Every memory a person authored is minted a thread on creation, board
+ * namespace or not, so a row all but always has one; the memory refusal is left
+ * for what the hub writes for itself, which has no thread to open.
  */
 export function threadRefusal(item: LiveItem, episode: string | null): string | null {
   if (episode) return null;

--- a/openapi.json
+++ b/openapi.json
@@ -5130,7 +5130,7 @@
               }
             ],
             "title": "Episode",
-            "description": "The episode URN this row's coordination happens in \u2014 what makes a task a thread. Store-owned: minted by the backend, so it is absent from ``meta`` and cannot be set by a write. Null on a memory that is not a task, and on one no thread has been opened for."
+            "description": "The episode URN the conversation about this memory happens in \u2014 what makes a task a thread, and what makes every other memory discussable. Store-owned: minted by the backend on create, so it is absent from ``meta`` and cannot be set by a write. Null on what the hub writes for itself (an ``agents/`` manifest, a ``log/`` record) and on anything written before threading."
           },
           "expandable": {
             "type": "boolean",


### PR DESCRIPTION
## Summary

A thread was bound only to the four board namespaces (`decisions/`, `status/`, `work/`, `failed/`), so a `context/` design note, a `procedures/` runbook or a `skills/` doc had nowhere to be discussed — the conversation about it scrolled past in the room instead of living attached to it.

The binding is one write-once frontmatter key that costs nothing until someone posts, so what changes is the gate, not the model: **everything can be _discussed_; only the four namespaces are _worked_.**

The design call the issue flags is the exclusion policy. This ships it as a **denylist** (`tasks.is_threadable`) rather than a broader allowlist, so a namespace nobody has invented yet is discussable without anyone remembering to widen a list. What it still refuses is the hub's own writing: an `agents/` manifest (the runtime's), a `log/` record (already the record *of* a conversation), and `context/synthesis` (rewritten on the synthesizer's schedule, so a conversation attached to it would be attached to a moving target).

The board stays board-only. The projection, the leases and the `filed` notice all still gate on `is_board_row` — a threaded `skills/` doc must not start reading as work.

## Changes

**Backend**
- `services/tasks.py`: `is_threadable(key)` + `SYSTEM_NAMESPACES` / `SYSTEM_KEYS`. `is_board_row` stays as the narrower word.
- `routes/memory.py`: the mint gate is `is_threadable`; the `filed` notice stays `is_board_row`, with the reason next to it.
- `backfill_room` walks the whole room instead of four prefixes, so rooms written before this get threads on their existing notes. It reads the same files the startup index scan is about to read anyway, so it is not a new class of startup cost.
- `schemas.py`: the `episode` field's description said "null on a memory that is not a task", which is no longer what it means.

**CLI**
- `board send` / `messages` / `coordinate` resolve an id off the board first and fall back to a by-key hub read, so `mycelium board send context/api-shape "…"` lands in that note's conversation. One transport rather than a second set of three verbs on a second noun — the verbs were already thread verbs (they take a thread id too), and the board is a projection they happen to resolve through.
- `_thread` now returns the label rather than a `LiveItem`, since the item was only ever used to build one.
- `memory get` names the thread and the verb that reaches it. Nothing else in the CLI says a memory is discussable, so without it the feature is unreachable from the memory noun.

**Contract + GUI**
- `task.refusals.memory` was `"a thread belongs to a task; this row is in another namespace"`. That was never quite true (a board row is always in a board namespace) and is now plainly false. It reads `"the hub writes this memory for itself; a thread belongs to something a person authored"` in `contracts/board-vocabulary.json` and both copies of it. Contract `version` bumped to 3.
- No GUI code change: `memory-page-view.tsx` already renders the Discussion + composer for any memory whose `episode` is set, and `tasks.thread_write_refusal` was already namespace-agnostic. That is most of why this is a small diff.

**Alternative rejected:** a separate `mycelium memory send` / `memory messages` pair. It would be a second implementation of the same three verbs over the same transport (`chat.py`) on a second noun — exactly the drift `contracts/board-vocabulary.json` exists to catch — for a discoverability problem one hint line on `memory get` solves.

**Known limit:** a non-board memory's thread is addressable by its key, not by its short id (`board send c0ffee42 …` only works for a projected row). There is no episode-to-memory lookup on the hub to resolve the other direction; adding one is its own change.

**Unrelated:** `mycelium-cli/tests/test_slim_master_secret_config.py` was drifting on `main` and fails `ruff format --check`; formatted here so the gate is green.

## Testing

Verified end to end against an in-process backend: `context/api-shape` and `skills/review` mint distinct episodes, `agents/sec` and `log/episodes/*` mint none, and `episode_write_rejection` accepts a write into the context note's thread.

- [x] Unit tests pass — backend 1013 passed / 13 skipped, CLI 748 passed / 2 skipped, frontend 758 passed
- [x] Linting passes (`uv run ruff check .`, both packages; `pnpm lint` 0 errors; `tsc --noEmit` clean)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `ty check .` passes, both packages
- [x] `openapi.json` refreshed and the docs site regenerated (`docs/generate_docs.py`), so neither drift gate fires

## Related Issues

Closes #872. Part of #835.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dvwTSXxVZD8gDD2Bwceed

---
_Generated by [Claude Code](https://claude.ai/code/session_013dvwTSXxVZD8gDD2Bwceed)_