### PR TITLE
fix(frontend): one memoryTitle so the board and channel agree (#889)

### DIFF
--- a/mycelium-frontend/src/lib/board/projection.ts
+++ b/mycelium-frontend/src/lib/board/projection.ts
@@ -24,6 +24,7 @@ import type { PresenceMember } from "@/lib/api";
 import { ASSIGNMENT_FIELD, DEFAULT_TTL_MINUTES, ASSIGNABLE_NAMESPACES, assignmentOf } from "./assignment";
 import type { LiveItem } from "./item";
 import { memoryHref } from "@/lib/memory-routes";
+import { memoryTitle } from "@/lib/memory-preview";
 
 /** Namespaces whose memories read as coordination state rather than prose. */
 const LIVE_NAMESPACES = ["decisions", "status", "work", "failed"];
@@ -107,12 +108,7 @@ function memoryItem(memory: Memory, room: string): LiveItem {
   delete custom.text;
   delete custom.content;
 
-  const title =
-    typeof custom.title === "string"
-      ? custom.title
-      : typeof value === "string"
-        ? firstLine(value)
-        : firstLine(memory.content_text ?? memory.key);
+  const title = memoryTitle(memory);
 
   const derivedStatus = namespace === "decisions" ? "resolved" : "open";
 
@@ -203,11 +199,6 @@ function agentItem(agent: AgentSummary, presence: PresenceMember, now: string): 
       ttl_minutes: DEFAULT_TTL_MINUTES,
     },
   };
-}
-
-function firstLine(text: string): string {
-  const line = text.split("\n").map(l => l.trim()).find(l => l && !l.startsWith("---"));
-  return (line ?? "").replace(/^#+\s*/, "").slice(0, 120);
 }
 
 export interface ProjectionInput {

--- a/mycelium-frontend/src/lib/memory-preview.test.ts
+++ b/mycelium-frontend/src/lib/memory-preview.test.ts
@@ -2,12 +2,17 @@
 // Copyright 2026 Mycelium Contributors
 
 import { describe, expect, it } from "vitest";
+import type { Memory } from "@/lib/api";
 import {
   flattenMarkdown,
   memoryPreview,
+  memoryTitle,
   memoryValueText,
   previewCardTop,
 } from "@/lib/memory-preview";
+
+const mem = (over: Partial<Memory>): Memory =>
+  ({ key: "work/a-row", value: "", ...over }) as Memory;
 
 describe("memoryValueText", () => {
   it("returns prose as written", () => {
@@ -101,5 +106,37 @@ describe("previewCardTop", () => {
 
   it("pins to the top margin when the card is taller than the viewport", () => {
     expect(previewCardTop(300, 22, 800, 400, 12)).toBe(12);
+  });
+});
+
+describe("memoryTitle", () => {
+  it("uses an explicit title on a structured value", () => {
+    expect(memoryTitle(mem({ value: { title: "Ship the board", status: "open" } }))).toBe(
+      "Ship the board",
+    );
+  });
+
+  it("takes the first line of a bare-string prose value", () => {
+    expect(memoryTitle(mem({ value: "# Trim the install panel\nmore body" }))).toBe(
+      "Trim the install panel",
+    );
+  });
+
+  it("reads a prose value the store hands over as {text} (the #889 bug)", () => {
+    // The API rebuilds prose into { text: … }; the title must be the first line,
+    // never the key it happens to be filed under.
+    const title = memoryTitle(mem({ key: "work/cutover", value: { text: "Cut over to Redis\nnotes" } }));
+    expect(title).toBe("Cut over to Redis");
+    expect(title).not.toBe("work/cutover");
+  });
+
+  it("falls back to content_text when the value carries no readable body", () => {
+    expect(memoryTitle(mem({ key: "work/x", value: {}, content_text: "Do the thing" }))).toBe(
+      "Do the thing",
+    );
+  });
+
+  it("falls back to the key when there is nothing to read", () => {
+    expect(memoryTitle(mem({ key: "work/empty", value: "" }))).toBe("work/empty");
   });
 });

--- a/mycelium-frontend/src/lib/memory-preview.ts
+++ b/mycelium-frontend/src/lib/memory-preview.ts
@@ -14,6 +14,32 @@ export function memoryValueText(value: unknown): string {
   return String(value);
 }
 
+/** First meaningful line of some text, as a title: skips blanks and `---`,
+ *  drops a leading heading marker, capped in length. */
+export function firstLine(text: string): string {
+  const line = text.split("\n").map(l => l.trim()).find(l => l && !l.startsWith("---"));
+  return (line ?? "").replace(/^#+\s*/, "").slice(0, 120);
+}
+
+/** What a memory is called: an explicit `title` in its structured value, else the
+ *  first line of its prose, read whichever way the store hands the body over
+ *  (`{text:…}`, a bare string, or `content_text`), else its key. One derivation,
+ *  so a task named on the board and named in the channel never disagree (#889). */
+export function memoryTitle(memory: Memory): string {
+  const value = memory.value;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const title = (value as Record<string, unknown>).title;
+    if (typeof title === "string" && title.trim()) return title.trim();
+  }
+  const body =
+    typeof value === "string"
+      ? value
+      : value && typeof value === "object" && typeof (value as { text?: unknown }).text === "string"
+        ? (value as { text: string }).text
+        : (memory.content_text ?? memory.key);
+  return firstLine(body) || memory.key;
+}
+
 // The hovercard shows an excerpt, not a rendered document: markdown syntax is
 // flattened to the text it decorates so a cut-off construct can't leave a
 // dangling marker on screen.

--- a/mycelium-frontend/src/lib/room-data.ts
+++ b/mycelium-frontend/src/lib/room-data.ts
@@ -47,6 +47,7 @@ import {
   type Skill,
 } from "@/lib/api";
 import { latestPreview } from "@/lib/room-preview";
+import { memoryTitle } from "@/lib/memory-preview";
 import { useCurrentUser } from "@/components/current-user";
 
 /**
@@ -96,22 +97,8 @@ export interface ThreadOwner {
   title: string | null;
 }
 
-/** A row's own title where its frontmatter carries one, else its key.
- *
- * A task is a markdown row, so its title is the first line of its body; a
- * structured value keeps its `title` field. The key is the last resort, for a
- * row with no readable body at all. */
-function memoryTitle(memory: Memory): string {
-  const value = memory.value;
-  if (typeof value === "string" && value.trim()) {
-    return value.trim().split("\n")[0].replace(/^#+\s*/, "").trim() || memory.key;
-  }
-  const title =
-    value && typeof value === "object" && !Array.isArray(value)
-      ? (value as Record<string, unknown>).title
-      : null;
-  return typeof title === "string" && title.trim() ? title.trim() : memory.key;
-}
+// `memoryTitle` is shared with the board's projection (lib/memory-preview), so a
+// task named in the channel and named on the board can never disagree (#889).
 
 // Stable empties: a fresh `[]` per render would break every downstream memo.
 const NO_STATUS: RoomStatus = {


### PR DESCRIPTION
## Summary

Fixes #889 on current `main`. A thread-activity ping printed a `work/…` slug where the board notice one line above printed the row's name.

**Root cause:** `room-data.ts`'s `memoryTitle` checked `value` as a bare string or read its `.title`, but the store hands prose over as `{ text: … }` (rebuilt from the markdown body). That matched neither branch, so it fell through to `memory.key`. Meanwhile `board/projection.ts` derived the title a *different* way (falling back to `content_text`) and read it right — which is exactly why one surface showed the name and the other the slug.

## Change

- One shared **`memoryTitle`** (+ `firstLine`) in `lib/memory-preview.ts`, reading the body however the store hands it over: `{text:…}`, a bare string, or `content_text`; an explicit structured `title` still wins; the key is the last resort.
- `room-data.ts` and `board/projection.ts` both call it — their two private derivations are gone, so a task named on the board and named in the channel can't drift apart again.

## Tests

`memory-preview.test.ts` gains `memoryTitle` cases, including the exact `{text}` shape that was the bug (title reads as the first line, never the key). Full frontend suite green (786 passed), tsc + eslint clean.

## Note

Supersedes #893, which made the same fix on pre-#892 rendering code and so couldn't cleanly merge after the `useRoomRowNames` rework landed. This reapplies just the title-derivation fix on today's structure.