### PR TITLE
fix(frontend): wrap long inline tokens in markdown bodies

### DIFF
--- a/mycelium-frontend/src/app/globals.css
+++ b/mycelium-frontend/src/app/globals.css
@@ -262,7 +262,12 @@ body {
 .tabular { font-variant-numeric: tabular-nums; }
 
 /* ── markdown body ── */
-.markdown-body { color: inherit; }
+/* A body renders inside panes that shrink (the thread split, the rail): every
+ * ancestor is min-w-0, so the box compacts. Without this the text does not —
+ * a long unbreakable inline atom (a `code` span, a URL, a long path) keeps its
+ * intrinsic width and spills past the right edge rather than wrapping. Break on
+ * overflow so prose reflows; `pre` keeps its own `overflow-x` scroll below. */
+.markdown-body { color: inherit; overflow-wrap: break-word; }
 .markdown-body > *:first-child { margin-top: 0; }
 .markdown-body > *:last-child { margin-bottom: 0; }
 .markdown-body p { margin: 0.5em 0; line-height: 1.55; color: var(--text2); }
@@ -307,6 +312,9 @@ body {
   border: 1px solid var(--border);
   border-radius: 4px;
   color: var(--accent);
+  /* A code token has no spaces to wrap at, so break it anywhere rather than let
+   * one long identifier push the whole message past the pane's right edge. */
+  overflow-wrap: anywhere;
 }
 .markdown-body pre {
   margin: 0.5em 0;


### PR DESCRIPTION
The task/thread pane (and the memory rail) live in min-w-0 flex columns, so the box compacts in the three-pane split — but the markdown body had no `overflow-wrap`, so a long unbreakable inline atom (an inline `code` chip, a URL, a long path) kept its intrinsic width and spilled past the pane's right edge instead of wrapping. It read as 'the column refuses to go responsive, it just overflows.'

- `.markdown-body`: `overflow-wrap: break-word` so prose reflows on overflow.
- `.markdown-body code`: `overflow-wrap: anywhere` so one long identifier breaks mid-token instead of driving the pane width.
- `pre` blocks untouched — they keep their own `overflow-x: auto` scroll.

Fixes the horizontal overflow seen live in the task detail pane.