### PR TITLE
fix(frontend): bound the thread pane so it stops spilling under the rail

### DIFF
--- a/mycelium-frontend/src/app/globals.css
+++ b/mycelium-frontend/src/app/globals.css
@@ -312,9 +312,6 @@ body {
   border: 1px solid var(--border);
   border-radius: 4px;
   color: var(--accent);
-  /* A code token has no spaces to wrap at, so break it anywhere rather than let
-   * one long identifier push the whole message past the pane's right edge. */
-  overflow-wrap: anywhere;
 }
 .markdown-body pre {
   margin: 0.5em 0;

--- a/mycelium-frontend/src/components/thread-view.tsx
+++ b/mycelium-frontend/src/components/thread-view.tsx
@@ -96,7 +96,11 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
     <section
       aria-label={`Thread ${shortId}`}
       data-thread={target.episode}
-      className="flex min-h-0 flex-1 flex-col bg-bg"
+      // min-w-0 + overflow-hidden so the pane shrinks to its panel track rather
+      // than letting content set a floor and spill under the inspector rail —
+      // the same bounding the room surface has. Without it a wide message or a
+      // long metadata value pushes the whole section past its right edge.
+      className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-bg"
     >
       <header className="flex h-[48px] shrink-0 items-center gap-2 border-b border-border bg-paper px-4">
         <MessageSquare className="size-3.5 shrink-0 text-accent" strokeWidth={1.9} />


### PR DESCRIPTION
## Root cause (the real one this time)

ThreadView's root `<section>` is a flex child of the thread `ResizablePanel` (which is `flex min-w-0`), but the section itself had **neither `min-w-0` nor `overflow-hidden`**. So it took its content's intrinsic width as a floor and refused to shrink — spilling past its track, under the Members inspector rail, with no scroll to reach the clipped content.

The room surface beside it is bounded exactly this way (`flex min-w-0 flex-1 overflow-hidden`); the thread section now matches it. The pane shrinks to its panel track and the `ScrollArea` inside owns the scrolling.

## Also

Reverts `overflow-wrap: anywhere` on inline `code` from #902 — it broke identifiers mid-token and made code chips unreadable. Keeps `overflow-wrap: break-word` on `.markdown-body` as a plain long-URL backstop (only fires when a word would otherwise overflow the line).