### PR TITLE
Hijack ⌘F in the channel, with a match minimap in the scroll gutter

### DIFF
--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -159,6 +159,15 @@ function RoomWorkspace() {
   // all reachable without a pointer. The chat box focuses the textarea itself;
   // this only makes sure the pane holding it is the one on screen.
   useKeyScope("room");
+  // ⌘F belongs to the page rather than to the feed: find is a channel surface,
+  // so the pane has to be the channel before there is anything to find in. The
+  // counter is the message — the channel opens (or re-focuses) its find bar on
+  // every press, including the ones where the bar is already open.
+  const [findRequest, setFindRequest] = useState(0);
+  useKeyAction("chat.find", () => {
+    setEditorView("channel");
+    setFindRequest(n => n + 1);
+  });
   useKeyAction("pane.channel", () => setEditorView("channel"));
   useKeyAction("pane.board", () => setEditorView("board"));
   useKeyAction("pane.network", () => setEditorView("network"));
@@ -231,6 +240,7 @@ function RoomWorkspace() {
           onViewChange={setEditorView}
           focusMessageId={focus?.type === "message" ? focus.id : null}
           onFocusConsumed={clearFocus}
+          openFind={findRequest}
         />
       </div>
       <RoomChatBox roomName={roomName} className={editorView !== "channel" ? "hidden" : undefined} />

--- a/mycelium-frontend/src/components/chat-find-bar.test.tsx
+++ b/mycelium-frontend/src/components/chat-find-bar.test.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ChatFindBar } from "@/components/chat-find-bar";
+
+function bar(props: Partial<Parameters<typeof ChatFindBar>[0]> = {}) {
+  const onStep = vi.fn();
+  const onClose = vi.fn();
+  const onQueryChange = vi.fn();
+  render(
+    <ChatFindBar
+      query="deploy"
+      onQueryChange={onQueryChange}
+      count={3}
+      position={0}
+      onStep={onStep}
+      onClose={onClose}
+      inputRef={createRef<HTMLInputElement>()}
+      partial={false}
+      {...props}
+    />,
+  );
+  return { onStep, onClose, onQueryChange };
+}
+
+describe("<ChatFindBar />", () => {
+  it("counts from one, the way a find bar reads", () => {
+    bar({ count: 3, position: 0 });
+    expect(screen.getByText("1/3")).toBeInTheDocument();
+  });
+
+  it("shows nothing at all before there is a query", () => {
+    bar({ query: "", count: 0, position: null });
+    expect(screen.queryByText("No matches")).not.toBeInTheDocument();
+  });
+
+  it("steps forward on Enter and back on shift+Enter", async () => {
+    const { onStep } = bar();
+    const input = screen.getByLabelText("Find in the channel");
+
+    await userEvent.type(input, "{Enter}");
+    expect(onStep).toHaveBeenLastCalledWith(1);
+
+    await userEvent.type(input, "{Shift>}{Enter}{/Shift}");
+    expect(onStep).toHaveBeenLastCalledWith(-1);
+  });
+
+  it("closes on Escape rather than merely losing focus", async () => {
+    const { onClose } = bar();
+
+    await userEvent.type(screen.getByLabelText("Find in the channel"), "{Escape}");
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("says its reach is the loaded messages while pages remain unread", () => {
+    bar({ partial: true });
+    expect(screen.getByText("loaded only")).toBeInTheDocument();
+  });
+
+  it("does not offer to step when there is nothing to step to", () => {
+    bar({ count: 0, position: null });
+
+    expect(screen.getByText("No matches")).toBeInTheDocument();
+    expect(screen.getByLabelText("Next match")).toBeDisabled();
+    expect(screen.getByLabelText("Previous match")).toBeDisabled();
+  });
+});

--- a/mycelium-frontend/src/components/chat-find-bar.tsx
+++ b/mycelium-frontend/src/components/chat-find-bar.tsx
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { ChevronDown, ChevronUp, Search, X } from "lucide-react";
+import type { RefObject } from "react";
+import { Kbd } from "@/components/ui/kbd";
+import { Tooltip } from "@/components/ui/tooltip";
+
+interface Props {
+  query: string;
+  onQueryChange: (query: string) => void;
+  /** Messages the query hits, and which of them the reader is standing on. */
+  count: number;
+  position: number | null;
+  onStep: (delta: 1 | -1) => void;
+  onClose: () => void;
+  inputRef: RefObject<HTMLInputElement | null>;
+  /** True while the channel still has older pages it hasn't read. Find works on
+   *  what is loaded, and says so rather than implying it searched the room. */
+  partial: boolean;
+}
+
+/** The channel's find bar: a strip above the feed, not an overlay on it.
+ *
+ *  It takes the height it needs and the messages move down, because a bar that
+ *  floats over the feed covers the newest thing said at the exact moment the
+ *  reader is hunting through the older ones. */
+export function ChatFindBar({
+  query,
+  onQueryChange,
+  count,
+  position,
+  onStep,
+  onClose,
+  inputRef,
+  partial,
+}: Props) {
+  const empty = query.trim().length === 0;
+  const status = empty ? "" : count === 0 ? "No matches" : `${(position ?? 0) + 1}/${count}`;
+
+  return (
+    <div
+      data-slot="chat-find-bar"
+      className="flex shrink-0 items-center gap-2 border-b border-border bg-surface px-4 py-1.5"
+    >
+      <Search aria-hidden className="size-3.5 shrink-0 text-muted-foreground" />
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        aria-label="Find in the channel"
+        placeholder="Find in the channel…"
+        spellCheck={false}
+        autoComplete="off"
+        onChange={e => onQueryChange(e.target.value)}
+        onKeyDown={e => {
+          // Escape closes the bar rather than merely blurring it, so the key
+          // that opened a search is the key that puts it away. Claiming the
+          // event is what keeps the app-wide handler from taking it as a plain
+          // "leave the input".
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onClose();
+            return;
+          }
+          if (e.key === "Enter") {
+            e.preventDefault();
+            onStep(e.shiftKey ? -1 : 1);
+          }
+        }}
+        className="min-w-0 flex-1 bg-transparent text-body text-text outline-none placeholder:text-faint"
+      />
+      <span
+        aria-live="polite"
+        className={`shrink-0 text-micro tabular ${count === 0 && !empty ? "text-red" : "text-muted-foreground"}`}
+      >
+        {status}
+      </span>
+      {partial && !empty && (
+        <Tooltip content="Find reads the messages this channel has loaded. Scroll up to reach further back, or press / to search the room's whole history.">
+          <span className="shrink-0 cursor-default text-micro text-faint">loaded only</span>
+        </Tooltip>
+      )}
+      <div className="flex shrink-0 items-center gap-0.5">
+        <button
+          type="button"
+          onClick={() => onStep(-1)}
+          disabled={count === 0}
+          aria-label="Previous match"
+          className="rounded p-1 text-muted-foreground transition-colors enabled:hover:bg-hairline enabled:hover:text-text disabled:opacity-40"
+        >
+          <ChevronUp className="size-3.5" />
+        </button>
+        <button
+          type="button"
+          onClick={() => onStep(1)}
+          disabled={count === 0}
+          aria-label="Next match"
+          className="rounded p-1 text-muted-foreground transition-colors enabled:hover:bg-hairline enabled:hover:text-text disabled:opacity-40"
+        >
+          <ChevronDown className="size-3.5" />
+        </button>
+      </div>
+      <Tooltip content="Enter for the next match, ⇧Enter for the previous">
+        <Kbd size="xs" tone="muted" className="shrink-0">↵</Kbd>
+      </Tooltip>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close find"
+        className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/chat-minimap.tsx
+++ b/mycelium-frontend/src/components/chat-minimap.tsx
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+export interface MinimapTick {
+  /** The message the tick stands for. */
+  id: string;
+  /** Where it sits in the scrollable content, 0 at the top and 1 at the end. */
+  top: number;
+}
+
+interface Props {
+  viewportRef: RefObject<HTMLDivElement | null>;
+  ticks: MinimapTick[];
+  activeId: string | null;
+  onJump: (id: string) => void;
+}
+
+/** The scroll gutter as a map of the search: one tick per matching message,
+ *  drawn where that message actually sits in the whole scrollable feed.
+ *
+ *  This is the thing an editor's scrollbar does — it answers *where* the hits
+ *  are, and how they are clustered, before you have stepped through any of
+ *  them. Three matches at the very top of a long backlog is a different room
+ *  from thirty spread evenly down it, and the counter alone cannot say which
+ *  one you are in.
+ *
+ *  The pale box is the part of the feed currently on screen, so a tick can be
+ *  read as near or far rather than only as high or low. It is written straight
+ *  to the node's style on scroll: a rail that re-rendered the feed on every
+ *  wheel tick would cost more than it tells anyone. */
+export function ChatMinimap({ viewportRef, ticks, activeId, onJump }: Props) {
+  const windowBox = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = viewportRef.current;
+    const box = windowBox.current;
+    if (!el || !box) return;
+    const paint = () => {
+      const height = el.scrollHeight || 1;
+      box.style.top = `${Math.min(100, (el.scrollTop / height) * 100)}%`;
+      box.style.height = `${Math.min(100, (el.clientHeight / height) * 100)}%`;
+    };
+    paint();
+    el.addEventListener("scroll", paint, { passive: true });
+    const observer = new ResizeObserver(paint);
+    observer.observe(el);
+    return () => {
+      el.removeEventListener("scroll", paint);
+      observer.disconnect();
+    };
+  }, [viewportRef, ticks]);
+
+  return (
+    <div
+      data-slot="chat-minimap"
+      // Unpainted, so the viewport's own scrollbar still reads and still takes
+      // a drag through it: the ticks ride the track the way an editor's do,
+      // rather than replacing it with a second rail beside it.
+      className="pointer-events-none absolute inset-y-0 right-0 z-20 w-3"
+    >
+      {/* The part of the feed on screen. The real thumb says this too, but only
+          while it is being used; this is the version that is there at rest. */}
+      <div ref={windowBox} className="absolute inset-x-0 rounded-[1px] bg-text/[0.06]" />
+      {ticks.map((tick, i) => {
+        const active = tick.id === activeId;
+        return (
+          <button
+            key={tick.id}
+            type="button"
+            onClick={() => onJump(tick.id)}
+            aria-label={`Jump to match ${i + 1} of ${ticks.length}`}
+            style={{ top: `${(tick.top * 100).toFixed(3)}%` }}
+            className={`pointer-events-auto absolute inset-x-0.5 -translate-y-1/2 rounded-full transition-colors ${
+              active ? "h-[5px] bg-accent ring-1 ring-accent/40" : "h-[3px] bg-yellow hover:bg-yellow/70"
+            }`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/event-stream.find.test.tsx
+++ b/mycelium-frontend/src/components/event-stream.find.test.tsx
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { act } from "react";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithSWR } from "@/test/swr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FakeEventSource } from "@/test/fake-event-source";
+import { resetStreamHub } from "@/lib/stream-hub";
+
+vi.mock("@/lib/api", () => ({
+  fetchMessages: vi.fn().mockResolvedValue({ messages: [] }),
+  fetchL9History: vi.fn().mockResolvedValue([]),
+  fetchMemories: vi.fn().mockResolvedValue([]),
+  fetchRoomAgents: vi.fn().mockResolvedValue([]),
+  logFetchError: () => () => undefined,
+}));
+
+import { EventStream } from "@/components/event-stream";
+
+const CREATED = "2026-08-04T10:00:00.000000+00:00";
+
+function chat(text: string, sender = "alice") {
+  return {
+    message_type: "broadcast",
+    sender_handle: sender,
+    created_at: CREATED,
+    content: text,
+  };
+}
+
+/** Mount the channel with a room already said, then open find on it. */
+async function openFind(lines: [string, string?][]) {
+  const view = renderWithSWR(<EventStream roomName="sprint" openFind={0} />);
+  await act(async () => {});
+  const es = FakeEventSource.latest();
+  await act(async () => {
+    es.open();
+    for (const [text, sender] of lines) es.emit(chat(text, sender));
+  });
+  // The room page owns ⌘F; what reaches the channel is the bumped counter.
+  view.rerender(<EventStream roomName="sprint" openFind={1} />);
+  await act(async () => {});
+  return view;
+}
+
+const findBar = () => screen.getByLabelText("Find in the channel");
+const status = () => screen.getByRole("button", { name: "Close find" }).closest("[data-slot='chat-find-bar']")!;
+
+describe("<EventStream /> find in the channel", () => {
+  beforeEach(() => {
+    resetStreamHub();
+    FakeEventSource.reset();
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+
+  it("stays out of the way until the room's ⌘F asks for it", async () => {
+    renderWithSWR(<EventStream roomName="sprint" />);
+    await act(async () => {});
+
+    expect(screen.queryByLabelText("Find in the channel")).not.toBeInTheDocument();
+  });
+
+  it("opens on the room's find request and takes focus", async () => {
+    await openFind([["the deploy is stuck"]]);
+
+    expect(findBar()).toHaveFocus();
+  });
+
+  it("counts the messages a query hits and marks the text in them", async () => {
+    await openFind([
+      ["the deploy is stuck"],
+      ["unrelated chatter"],
+      ["deploy again after the fix"],
+    ]);
+
+    await userEvent.type(findBar(), "deploy");
+
+    // Two messages, and the reader starts on the newest — the end of the feed
+    // is where they were standing when they pressed the key.
+    expect(within(status() as HTMLElement).getByText("2/2")).toBeInTheDocument();
+    expect(screen.getAllByText("deploy", { selector: "mark" })).toHaveLength(2);
+  });
+
+  it("marks the message it has stepped to differently from the rest", async () => {
+    await openFind([["deploy one"], ["deploy two"]]);
+    await userEvent.type(findBar(), "deploy");
+
+    const marks = screen.getAllByText("deploy", { selector: "mark" });
+    expect(marks.map(m => m.dataset.findMatch)).toEqual(["hit", "active"]);
+  });
+
+  it("steps between matches with wrap-around", async () => {
+    await openFind([["deploy one"], ["deploy two"]]);
+    await userEvent.type(findBar(), "deploy");
+    const bar = status() as HTMLElement;
+
+    expect(within(bar).getByText("2/2")).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Next match"));
+    expect(within(bar).getByText("1/2")).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Previous match"));
+    expect(within(bar).getByText("2/2")).toBeInTheDocument();
+  });
+
+  it("finds a sender by name, not only what they said", async () => {
+    await openFind([["nothing to see", "alice"], ["also nothing", "bruno"]]);
+
+    await userEvent.type(findBar(), "bruno");
+
+    expect(within(status() as HTMLElement).getByText("1/1")).toBeInTheDocument();
+  });
+
+  it("says so plainly when a query hits nothing", async () => {
+    await openFind([["the deploy is stuck"]]);
+
+    await userEvent.type(findBar(), "kubernetes");
+
+    expect(screen.getByText("No matches")).toBeInTheDocument();
+    expect(screen.queryByText("kubernetes", { selector: "mark" })).not.toBeInTheDocument();
+  });
+
+  it("matches the query literally, so a metacharacter is not a pattern", async () => {
+    await openFind([["cost is $5 (net)"]]);
+
+    await userEvent.type(findBar(), "(net)");
+
+    expect(within(status() as HTMLElement).getByText("1/1")).toBeInTheDocument();
+  });
+
+  it("closes on Escape and takes its marks with it", async () => {
+    await openFind([["the deploy is stuck"]]);
+    await userEvent.type(findBar(), "deploy");
+    expect(screen.getAllByText("deploy", { selector: "mark" })).toHaveLength(1);
+
+    await userEvent.keyboard("{Escape}");
+
+    expect(screen.queryByLabelText("Find in the channel")).not.toBeInTheDocument();
+    expect(screen.queryByText("deploy", { selector: "mark" })).not.toBeInTheDocument();
+    expect(screen.getByText("the deploy is stuck")).toBeInTheDocument();
+  });
+
+  it("marks a hit inside an @mention, which is prose too", async () => {
+    await openFind([["ping @growth about the soak"]]);
+
+    await userEvent.type(findBar(), "growth");
+
+    // The mention renders as its own styled span; a find that skipped it would
+    // count a message it could not show the reader anything in.
+    expect(screen.getByText("growth", { selector: "mark" })).toBeInTheDocument();
+  });
+
+  it("claims no limit it doesn't have once the whole room is loaded", async () => {
+    await openFind([["the deploy is stuck"]]);
+    await userEvent.type(findBar(), "deploy");
+
+    // This channel has walked back to the beginning of the room, so find has
+    // genuinely searched all of it. (The reverse — a channel with pages it
+    // hasn't read saying so — is ChatFindBar's own test.)
+    expect(screen.queryByText("loaded only")).not.toBeInTheDocument();
+  });
+
+  it("puts a tick in the scroll gutter for every match", async () => {
+    await openFind([["deploy one"], ["quiet"], ["deploy two"]]);
+    await userEvent.type(findBar(), "deploy");
+
+    expect(screen.getByLabelText("Jump to match 1 of 2")).toBeInTheDocument();
+    expect(screen.getByLabelText("Jump to match 2 of 2")).toBeInTheDocument();
+  });
+
+  it("jumps to the match whose tick is clicked", async () => {
+    await openFind([["deploy one"], ["deploy two"]]);
+    await userEvent.type(findBar(), "deploy");
+    expect(within(status() as HTMLElement).getByText("2/2")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Jump to match 1 of 2"));
+
+    expect(within(status() as HTMLElement).getByText("1/2")).toBeInTheDocument();
+  });
+});

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -13,6 +13,10 @@ import { useRoomAgents, useRoomRowNames, useRoomThreads, type RowNaming, type Th
 import { NOTICE_TYPE, PING_TYPE, isLiveEpisode, noticeLabel, noticeOf, pingOf, threadShortId } from "@/lib/threads";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
 import { MarkdownContent } from "@/components/markdown-content";
+import { ChatFindBar } from "@/components/chat-find-bar";
+import { ChatMinimap, type MinimapTick } from "@/components/chat-minimap";
+import { HighlightText } from "@/components/ui/highlight-text";
+import { hasMatch, stepIndex } from "@/lib/chat-search";
 import { RoomBoard } from "@/components/board/room-board";
 import { ActivityRail, type ActivityItem } from "@/components/activity-rail";
 import { EpisodeTag } from "@/components/episode-tag";
@@ -62,6 +66,23 @@ interface Event {
 }
 
 const CHAT_TYPES = new Set(["broadcast", "direct", "announce", "delegate"]);
+
+/** Stable empties: find writes these back on every close, and a fresh array
+ *  each time would re-run the effects that read them. */
+const NO_MATCHES: string[] = [];
+const NO_TICKS: MinimapTick[] = [];
+
+/** The rendered row for a message, found by the id it carries in the DOM.
+ *  A scan rather than a selector: an event id is synthesized, and escaping one
+ *  into an attribute selector is a sharper edge than walking a handful of
+ *  nodes. */
+function rowNode(root: HTMLElement | null, id: string): HTMLElement | null {
+  if (!root) return null;
+  for (const node of root.querySelectorAll<HTMLElement>("[data-event-id]")) {
+    if (node.dataset.eventId === id) return node;
+  }
+  return null;
+}
 
 // The L9 "raise-up" whitelist: message types promoted from the L9 inspector
 // into the primary channel/chat surface. This must mirror
@@ -557,9 +578,13 @@ interface Props {
   /** A message to reveal in the channel, arrived at from search. */
   focusMessageId?: string | null;
   onFocusConsumed?: () => void;
+  /** Bumped by the room's ⌘F binding to open (or re-focus) the find bar. The
+   *  page owns the key because it owns the pane switch that has to happen
+   *  first; the channel owns the search itself. */
+  openFind?: number;
 }
 
-export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onOpenMemory, onOpenThread, view: viewProp, onViewChange, focusMessageId = null, onFocusConsumed }: Props) {
+export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onOpenMemory, onOpenThread, view: viewProp, onViewChange, focusMessageId = null, onFocusConsumed, openFind = 0 }: Props) {
   const [events, setEvents] = useState<Event[]>([]);
   const [historyLoaded, setHistoryLoaded] = useState(false);
   const connected = useRoomConnected(roomName);
@@ -779,6 +804,102 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
     onFocusConsumed?.();
   }, [focusMessageId, onFocusConsumed]);
 
+  // ── Find in the channel ────────────────────────────────────────────────
+  //
+  // ⌘F is taken off the browser here rather than left alone, because the
+  // browser's own find reads the DOM and the channel is a window onto a paged
+  // feed: it would search whatever happened to be mounted, silently, with no
+  // way to say so. This one searches the messages the channel has actually
+  // loaded, says which ones, and can walk between them.
+  const [findOpen, setFindOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  // The hit the reader is standing on, held as the message rather than as an
+  // ordinal: a page of older messages lands at the *front* of the list, and an
+  // ordinal would then be pointing at somebody else's sentence. Null means they
+  // have not stepped yet and get the newest hit — the channel reads
+  // oldest-first, so the first match in the room is the furthest thing from
+  // where they were looking when they pressed the key.
+  const [standing, setStanding] = useState<string | null>(null);
+  const findInput = useRef<HTMLInputElement>(null);
+  const [ticks, setTicks] = useState<MinimapTick[]>(NO_TICKS);
+
+  const needle = query.trim();
+  const matches = useMemo(() => {
+    if (!findOpen || !needle) return NO_MATCHES;
+    // System notices are the feed's own narration, not what anyone said, and
+    // several carry an envelope rather than prose. Find searches messages.
+    return visible
+      .filter(e => !SYSTEM_TYPES.has(e.type) && (hasMatch(e.content, needle) || hasMatch(e.sender, needle)))
+      .map(e => e.id);
+  }, [findOpen, needle, visible]);
+
+  const matchSet = useMemo(() => new Set(matches), [matches]);
+  // Resolved at read time rather than corrected in an effect, so a message
+  // arriving or an amendment folding away cannot leave a stale count on screen
+  // for a frame. A standing hit that is no longer in the list falls back to the
+  // newest one rather than to nothing.
+  const standingAt = standing === null ? -1 : matches.indexOf(standing);
+  const position = matches.length === 0 ? null : standingAt === -1 ? matches.length - 1 : standingAt;
+  const activeId = position === null ? null : matches[position];
+
+  useEffect(() => {
+    if (!openFind) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setFindOpen(true);
+  }, [openFind]);
+
+  // Focus follows the bar opening, and a second ⌘F selects what is in it, so
+  // the key that opens a search is also the key that starts a new one.
+  useEffect(() => {
+    if (!findOpen) return;
+    const input = findInput.current;
+    input?.focus();
+    input?.select();
+  }, [findOpen, openFind]);
+
+  const closeFind = useCallback(() => setFindOpen(false), []);
+
+  const stepMatch = (delta: 1 | -1) => {
+    if (matches.length === 0) return;
+    setStanding(matches[stepIndex(position ?? 0, matches.length, delta)]);
+  };
+
+  useEffect(() => {
+    if (!activeId) return;
+    rowNode(scrollRef.current, activeId)?.scrollIntoView({ block: "center", behavior: "smooth" });
+  }, [activeId]);
+
+  // Where each hit sits in the whole scrollable feed, as a fraction of it —
+  // measured off the live boxes rather than estimated from row counts, since a
+  // one-line reply and a forty-line write-up are both one message. Remeasured
+  // whenever the feed changes shape under it.
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !findOpen || matches.length === 0) {
+      setTicks(NO_TICKS);
+      return;
+    }
+    const measure = () => {
+      const base = el.getBoundingClientRect().top;
+      const height = el.scrollHeight || 1;
+      const next: MinimapTick[] = [];
+      for (const id of matches) {
+        const row = rowNode(el, id);
+        if (!row) continue;
+        const top = row.getBoundingClientRect().top - base + el.scrollTop;
+        next.push({ id, top: Math.min(1, Math.max(0, top / height)) });
+      }
+      setTicks(next);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    // The content, too: a message rendering taller moves every hit below it
+    // without changing the viewport at all.
+    if (el.firstElementChild) observer.observe(el.firstElementChild);
+    return () => observer.disconnect();
+  }, [findOpen, matches, visible]);
+
   // The feed follows new messages only while the reader is on the tail; scroll
   // up and it holds still. A jump-back button carries the count of what landed
   // meanwhile, so leaving the tail doesn't read as a quiet room.
@@ -853,9 +974,11 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
   // over history they scrolled up to read.
   useEffect(() => {
     lastVisible.current = visible[visible.length - 1]?.id ?? null;
-    if (highlight || !atBottomRef.current) return;
+    // A live message must not pull the view off the hit the reader stepped to,
+    // any more than it may off a message they arrived at from search.
+    if (highlight || activeId || !atBottomRef.current) return;
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
-  }, [visible, highlight]);
+  }, [visible, highlight, activeId]);
 
   useEffect(() => {
     if (!highlight) return;
@@ -920,10 +1043,28 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
         </div>
       ) : (
       <div className="relative flex flex-1 min-h-0 flex-col">
+      {findOpen && (
+        <ChatFindBar
+          query={query}
+          onQueryChange={value => {
+            setQuery(value);
+            // A new query is a new search: back to the newest hit rather than
+            // to wherever the last one had got to.
+            setStanding(null);
+          }}
+          count={matches.length}
+          position={position}
+          onStep={stepMatch}
+          onClose={closeFind}
+          inputRef={findInput}
+          partial={!reachedStart}
+        />
+      )}
       {historyLoaded && (
         <ActivityRail items={activity} onOpenThread={onOpenThread} onOpenMemory={onOpenMemory} />
       )}
-      <ScrollArea className="flex-1 min-h-0" viewportRef={scrollRef}>
+      <div className="relative flex-1 min-h-0">
+      <ScrollArea className="h-full" viewportRef={scrollRef}>
         {!historyLoaded ? (
           <ChannelSkeleton />
         ) : visible.length === 0 ? (
@@ -1132,13 +1273,17 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
               const color = isAgent ? undefined : "var(--avatar-neutral)";
               const marked = highlight !== null && ev.messageId === highlight;
               const owner = isAgent ? agentOwners.get(ev.sender) : undefined;
+              // The row's own share of the open find: whether to mark its prose
+              // at all, and whether it is the hit being stood on.
+              const hit = needle && matchSet.has(ev.id) ? { query: needle, active: ev.id === activeId } : undefined;
               return (
                 <div
                   key={ev.id}
+                  data-event-id={ev.id}
                   ref={marked ? highlightRow : undefined}
                   className={`group relative flex gap-3 px-5 hover:bg-hairline ${grouped ? "py-0.5" : "mt-3 pt-1 first:mt-0"} ${
                     marked ? "bg-accent/15" : ""
-                  }`}
+                  } ${hit?.active ? "bg-yellow/10 ring-1 ring-inset ring-yellow/40" : ""}`}
                 >
                   {/* Timestamp low-signal: right gutter, hover-revealed. */}
                   <span className="pointer-events-none absolute right-5 top-1.5 text-micro tabular text-faint opacity-0 transition-opacity group-hover:opacity-100">
@@ -1158,7 +1303,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
                     {!grouped && (
                       <div className="flex items-center gap-1.5 pr-12">
                         <span className="text-label font-semibold text-text truncate">
-                          {ev.sender}
+                          <HighlightText text={ev.sender} highlight={hit} />
                         </span>
                         {isAgent && (
                           <Bot aria-label="agent" className="size-3 flex-shrink-0 text-accent" />
@@ -1170,7 +1315,11 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
                         )}
                       </div>
                     )}
-                    <MarkdownContent className="contrast text-body leading-relaxed" onLinkClick={onOpenMemory}>
+                    <MarkdownContent
+                      className="contrast text-body leading-relaxed"
+                      onLinkClick={onOpenMemory}
+                      highlight={hit}
+                    >
                       {ev.content}
                     </MarkdownContent>
                     {ev.edited && (
@@ -1185,6 +1334,10 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
         </div>
         )}
       </ScrollArea>
+      {findOpen && ticks.length > 0 && (
+        <ChatMinimap viewportRef={scrollRef} ticks={ticks} activeId={activeId} onJump={setStanding} />
+      )}
+      </div>
       {!atBottom && visible.length > 0 && (
         <div className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center">
           <Button

--- a/mycelium-frontend/src/components/markdown-content.tsx
+++ b/mycelium-frontend/src/components/markdown-content.tsx
@@ -8,6 +8,7 @@ import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkBreaks from "remark-breaks";
 import { Tooltip } from "@/components/ui/tooltip";
+import { useHighlighter, type Highlight } from "@/components/ui/highlight-text";
 
 // Mentions, memory links, transclusions, and skill references, in one pass so a
 // body is split once. `![[…]]` is listed before `[[…]]` so the transclusion form
@@ -21,6 +22,21 @@ const TOKEN_RE =
 // syntax, not a link. A word followed by a colon *and whitespace* is a
 // directive; memory keys never contain ": ".
 const DIRECTIVE_RE = /^[A-Za-z][\w-]*:\s/;
+
+/** The plain text under a node.
+ *
+ *  A `[label](myc://key)` link is rendered as a chip, and the chip needs the
+ *  label as a string — but by the time the component runs, the walk above it
+ *  may already have replaced that text with the nodes it split it into. Reading
+ *  the text back out is what keeps the label the author's word rather than
+ *  whatever the last pass wrapped it in. */
+function nodeText(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(nodeText).join("");
+  if (React.isValidElement(node)) return nodeText((node.props as { children?: React.ReactNode }).children);
+  return "";
+}
 
 interface ParsedLink {
   target: string;
@@ -134,19 +150,24 @@ interface Props {
   onLinkClick?: (key: string) => void;
   /** Targets known not to resolve, styled as broken rather than navigable. */
   brokenLinks?: Set<string>;
+  /** A find-in-page query to mark in the prose. `active` says this is the
+   *  message the find bar has stepped to, so its marks are drawn louder. */
+  highlight?: Highlight;
 }
 
-export function MarkdownContent({ children, className, onLinkClick, brokenLinks }: Props) {
+export function MarkdownContent({ children, className, onLinkClick, brokenLinks, highlight }: Props) {
+  const marked = useHighlighter(highlight);
+
   const renderText = React.useCallback(
     (text: string): React.ReactNode => {
       const parts = text.split(TOKEN_RE);
       return parts.map((part, i) => {
         // Odd indices are the captured tokens; even indices are plain text.
-        if (i % 2 === 0) return part;
+        if (i % 2 === 0) return highlight?.query ? <React.Fragment key={i}>{marked(part)}</React.Fragment> : part;
         if (part.startsWith("@")) {
           return (
             <span key={i} className="text-accent font-semibold">
-              {part}
+              {marked(part)}
             </span>
           );
         }
@@ -175,7 +196,7 @@ export function MarkdownContent({ children, className, onLinkClick, brokenLinks 
         );
       });
     },
-    [onLinkClick, brokenLinks],
+    [onLinkClick, brokenLinks, marked, highlight?.query],
   );
 
   const processNode = React.useCallback(
@@ -207,7 +228,7 @@ export function MarkdownContent({ children, className, onLinkClick, brokenLinks 
       if (href?.startsWith("myc://")) {
         const link = parseLink(href);
         if (link) {
-          const labelled = { ...link, label: link.label ?? String(children ?? link.target) };
+          const labelled = { ...link, label: link.label ?? (nodeText(children) || link.target) };
           return (
             <MemoryLinkChip
               link={labelled}

--- a/mycelium-frontend/src/components/ui/highlight-text.tsx
+++ b/mycelium-frontend/src/components/ui/highlight-text.tsx
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import React from "react";
+import { splitOnMatches } from "@/lib/chat-search";
+
+/** The one mark the app draws for a find hit.
+ *
+ *  Yellow because that is what a marked hit looks like everywhere else a person
+ *  reads text, and the accent is already spoken for by links and mentions. The
+ *  occurrence the reader is standing on is the same mark, filled: same hue, so
+ *  a jump between matches reads as a move rather than as two different things. */
+const MARK = "rounded-[2px] px-px text-text";
+const REST = `${MARK} bg-yellow/25`;
+const ACTIVE = `${MARK} bg-yellow/60 ring-1 ring-yellow/70`;
+
+export interface Highlight {
+  query: string;
+  /** True on the occurrence run the find bar has stepped to. */
+  active?: boolean;
+}
+
+/** Mark every occurrence of `highlight.query` in `text`.
+ *
+ *  Returns the string untouched when there is nothing to mark, so a message
+ *  with no hit renders exactly the nodes it rendered before find was opened. */
+export function highlightText(text: string, highlight?: Highlight): React.ReactNode {
+  if (!highlight?.query || !text) return text;
+  const segments = splitOnMatches(text, highlight.query);
+  if (!segments.some(s => s.match)) return text;
+  return segments.map((segment, i) =>
+    segment.match ? (
+      <mark key={i} data-find-match={highlight.active ? "active" : "hit"} className={highlight.active ? ACTIVE : REST}>
+        {segment.text}
+      </mark>
+    ) : (
+      <React.Fragment key={i}>{segment.text}</React.Fragment>
+    ),
+  );
+}
+
+/** `highlightText` bound to one query, stable while that query is. */
+export function useHighlighter(highlight?: Highlight): (text: string) => React.ReactNode {
+  const query = highlight?.query ?? "";
+  const active = highlight?.active ?? false;
+  return React.useCallback(
+    (text: string) => (query ? highlightText(text, { query, active }) : text),
+    [query, active],
+  );
+}
+
+/** The component form, for a plain string in the middle of a layout. */
+export function HighlightText({ text, highlight }: { text: string; highlight?: Highlight }) {
+  return <>{highlightText(text, highlight)}</>;
+}

--- a/mycelium-frontend/src/lib/chat-search.test.ts
+++ b/mycelium-frontend/src/lib/chat-search.test.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import { countMatches, hasMatch, splitOnMatches, stepIndex } from "@/lib/chat-search";
+
+/** The invariant the whole feature rests on: a split is the text, rearranged. */
+const rejoin = (text: string, query: string) =>
+  splitOnMatches(text, query)
+    .map(s => s.text)
+    .join("");
+
+describe("splitOnMatches", () => {
+  it("splits around every occurrence, keeping the original casing", () => {
+    expect(splitOnMatches("Deploy the deployment", "deploy")).toEqual([
+      { text: "Deploy", match: true },
+      { text: " the ", match: false },
+      { text: "deploy", match: true },
+      { text: "ment", match: false },
+    ]);
+  });
+
+  it("never loses or invents a character", () => {
+    for (const query of ["a", "the", "z", "  ", "deploy"]) {
+      expect(rejoin("The deploy ran; a deploy again", query)).toBe("The deploy ran; a deploy again");
+    }
+  });
+
+  it("matches the query literally, so regex metacharacters are just text", () => {
+    expect(countMatches("cost is $5 (net) [approx]", "(net)")).toBe(1);
+    expect(countMatches("a.b axb", ".")).toBe(1);
+    expect(countMatches("aaa", "a+")).toBe(0);
+  });
+
+  it("does not overlap its own matches", () => {
+    expect(countMatches("aaaa", "aa")).toBe(2);
+  });
+
+  it("treats an empty or blank query as no search at all", () => {
+    expect(splitOnMatches("anything", "")).toEqual([{ text: "anything", match: false }]);
+    expect(splitOnMatches("anything", "   ")).toEqual([{ text: "anything", match: false }]);
+    expect(hasMatch("anything", "")).toBe(false);
+  });
+
+  it("keeps a query that is blank only at its edges", () => {
+    // " the " is a real thing to search for — the guard is against a query with
+    // nothing in it, not against one with spaces in it.
+    expect(countMatches("in the room", " the ")).toBe(1);
+  });
+
+  it("handles empty text", () => {
+    expect(splitOnMatches("", "x")).toEqual([]);
+    expect(hasMatch("", "x")).toBe(false);
+  });
+});
+
+describe("hasMatch", () => {
+  it("agrees with countMatches on whether there is anything to find", () => {
+    for (const [text, query] of [
+      ["hello world", "WORLD"],
+      ["hello world", "nope"],
+      ["", "x"],
+      ["x", ""],
+    ] as const) {
+      expect(hasMatch(text, query)).toBe(countMatches(text, query) > 0);
+    }
+  });
+});
+
+describe("stepIndex", () => {
+  it("wraps past the last match back to the first", () => {
+    expect(stepIndex(2, 3, 1)).toBe(0);
+    expect(stepIndex(0, 3, 1)).toBe(1);
+  });
+
+  it("wraps before the first match back to the last", () => {
+    expect(stepIndex(0, 3, -1)).toBe(2);
+  });
+
+  it("stays at zero when there is nothing to step through", () => {
+    expect(stepIndex(0, 0, 1)).toBe(0);
+    expect(stepIndex(0, 0, -1)).toBe(0);
+  });
+});

--- a/mycelium-frontend/src/lib/chat-search.ts
+++ b/mycelium-frontend/src/lib/chat-search.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/** Find-in-channel: what counts as a hit, decided once.
+ *
+ *  Two surfaces read this — the marks drawn inside a message, and the ticks
+ *  drawn in the scroll gutter beside it — so the gutter can never claim a hit
+ *  the text doesn't show, and a tick always lands on something a reader can
+ *  see when they jump to it.
+ *
+ *  The query is matched as literal text, folded for case. A reader who types
+ *  `(` into a find bar means a parenthesis, not a group, so nothing here
+ *  compiles a regex out of what they typed. */
+
+/** A run of text, marked or not. Concatenating `text` reproduces the input. */
+export interface Segment {
+  text: string;
+  match: boolean;
+}
+
+/** Split `text` into alternating plain/matched runs.
+ *
+ *  An empty or whitespace-only query matches nothing: a find bar is open long
+ *  before it has a query in it, and lighting up every character in the room the
+ *  moment it opens is not a search result. */
+export function splitOnMatches(text: string, query: string): Segment[] {
+  const needle = query.toLowerCase();
+  if (!needle.trim() || !text) return text ? [{ text, match: false }] : [];
+
+  const hay = text.toLowerCase();
+  const segments: Segment[] = [];
+  let cursor = 0;
+  for (;;) {
+    const at = hay.indexOf(needle, cursor);
+    if (at === -1) break;
+    if (at > cursor) segments.push({ text: text.slice(cursor, at), match: false });
+    segments.push({ text: text.slice(at, at + needle.length), match: true });
+    cursor = at + needle.length;
+  }
+  if (segments.length === 0) return [{ text, match: false }];
+  if (cursor < text.length) segments.push({ text: text.slice(cursor), match: false });
+  return segments;
+}
+
+/** How many times the query occurs in the text. */
+export function countMatches(text: string, query: string): number {
+  return splitOnMatches(text, query).reduce((n, s) => n + (s.match ? 1 : 0), 0);
+}
+
+/** Whether the text carries the query at all — the cheap half of the split. */
+export function hasMatch(text: string, query: string): boolean {
+  const needle = query.toLowerCase();
+  if (!needle.trim() || !text) return false;
+  return text.toLowerCase().includes(needle);
+}
+
+/** Step through matches with wrap-around, the way a find bar does: past the
+ *  last one is the first, and before the first one is the last. */
+export function stepIndex(current: number, total: number, delta: number): number {
+  if (total <= 0) return 0;
+  return (((current + delta) % total) + total) % total;
+}

--- a/mycelium-frontend/src/lib/keymap.ts
+++ b/mycelium-frontend/src/lib/keymap.ts
@@ -62,6 +62,17 @@ export const KEYMAP: Binding[] = [
     scope: "global",
   },
 
+  // The browser's own find is the one it hijacks, so it only fires where the
+  // app genuinely answers it: the dispatcher leaves an unclaimed binding alone,
+  // and nothing registers this outside a room's channel.
+  {
+    id: "chat.find",
+    keys: ["mod+f"],
+    label: "Find in the channel",
+    group: "Search",
+    scope: "room",
+  },
+
   {
     id: "rooms.digit",
     keys: ROOM_DIGIT_KEYS,


### PR DESCRIPTION
## Summary

⌘F/Ctrl+F in a room now opens the channel's own find bar instead of the browser's.

The browser's find reads the DOM, and the channel is a window onto a paged feed — so it searched whatever happened to be mounted, silently, with no way to say so. This one searches the messages the channel has actually loaded, says when that is less than the room, and can walk between hits.

Every hit is marked in place and gets a tick in the **scroll gutter**, drawn where its message sits in the whole scrollable feed — the thing an editor's scrollbar does. Three hits at the top of a long backlog is a different room from thirty spread evenly down it, and a counter alone cannot say which one you are in. A pale box tracks the part of the feed on screen, so a tick reads as near or far rather than only as high or low; clicking one jumps to it.

## Changes

- **`lib/chat-search.ts`** — what counts as a hit, decided once. The query is matched as **literal text**, case-folded: a `(` typed into a find bar is a parenthesis, not a group. Both the marks in the prose and the ticks in the gutter read it, so the gutter can never claim a hit the text doesn't show.
- **`components/chat-find-bar.tsx`** — a strip above the feed, not an overlay on it: a bar that floats over the messages covers the newest thing said at the exact moment you are hunting through the older ones. `Enter`/`⇧Enter` step, `Esc` closes (claiming the event, so the app-wide handler doesn't take it as a plain "leave the input").
- **`components/chat-minimap.tsx`** — the tick rail. It paints **no background**, so the viewport's real scrollbar still reads and still takes a drag through it; only the ticks take pointer events. The viewport box is written straight to the node's style on scroll — a rail that re-rendered the feed on every wheel tick would cost more than it tells anyone.
- **`components/ui/highlight-text.tsx`** + a `highlight` prop on `MarkdownContent` — marks land inside the rendered prose, including inside an `@mention`, rather than beside it. Without a query the node shape is byte-for-byte what it was.
- **`lib/keymap.ts`** — `chat.find` on `mod+f`, scope `room`. The dispatcher leaves an unclaimed binding alone, so the browser's find is suppressed only where the app genuinely answers it. `isCommandChord` already keeps ⌘/Ctrl chords live while a text input has focus, so the hijack works from inside the composer with no special-casing — verified in the running app by clicking into the textarea first and then pressing the chord.
- **`app/room/[name]/page.tsx`** — the page owns the key because it owns the pane switch that has to happen first; the channel owns the search.

### Two judgement calls worth arguing with

- **Navigation is message-granular, not occurrence-granular.** `4/12` means the fourth matching *message*. Chat is not a document, and stepping occurrence-by-occurrence through one long write-up is not what a reader wants here. A message may show several marks.
- **The active hit is held as the message, not as an ordinal.** A page of older messages lands at the *front* of the list, so an ordinal would silently start pointing at somebody else's sentence. A standing hit that leaves the list falls back to the newest.

### Also fixed

A latent bug this uncovered: `[label](myc://key)` took its chip label from `String(children)`, which only worked while the walk above it happened to leave the text as a bare string. The moment anything wrapped that text, the chip read `[object Object]`. It reads the text back out of the nodes now (`nodeText`).

### Honest boundary

Find reads the **loaded** messages. When the channel has pages it hasn't walked back to, the bar says `loaded only` and points at `/` (the room's global search) rather than implying it searched the room.

## Testing

- `pnpm test` — **810 passed**, 66 files (24 new: `chat-search`, `chat-find-bar`, `event-stream.find`)
- `tsc --noEmit` clean · `eslint .` clean (2 pre-existing warnings, both untouched) · `next build` clean
- Driven in the running mock app via `shotkit`: opened from the composer, dark + light, 900px and 2880px wide; stepping, wrap-around, tick-click, Escape.

- [ ] ~~Unit tests pass (`uv run pytest tests/ -x -q`)~~ — frontend-only change; the Python gates are untouched
- [ ] ~~Linting passes (`uv run ruff check .`)~~ — frontend-only
- [ ] ~~Format check passes (`uv run ruff format --check .`)~~ — frontend-only

## Related Issues

None — asked for directly.