### PR TITLE
fix(cli): one identity resolver; stop defaulting writes to a placeholder a gated hub rejects

### DIFF
--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -26,7 +26,7 @@ from typing import Any
 os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
 os.environ.setdefault("HF_HUB_OFFLINE", "1")
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routes.a2a_agents import router as a2a_agents_router
@@ -286,6 +286,33 @@ app.include_router(users_router, prefix="/api")
 app.include_router(search_router, prefix="/api")
 app.include_router(skills_router, prefix="/api")
 app.include_router(status_router, prefix="/api")
+
+
+@app.get("/api/whoami", tags=["auth"])
+async def whoami(request: Request):
+    """Who the hub resolves this caller to, from the bearer token it verified.
+
+    The single source of truth for write attribution. A client defaults
+    ``created_by`` to the ``handle`` returned here, so the value it stamps is
+    exactly the one the gate enforces — both derive from the same
+    ``AUTH_HANDLE_CLAIM``, so a client never has to guess which claim a hub
+    trusts. ``gated`` is false when this hub runs no auth gate, where a caller
+    names itself and there is no principal to report; a client then falls back
+    to its local identity config.
+
+    A gated hub with no valid token never reaches here — ``auth_gate`` 401s
+    first — which a client reads as "the hub can't tell who I am" and also
+    falls back to local identity.
+    """
+    principal = getattr(request.state, "principal", None)
+    if principal is None:
+        return {"gated": settings.AUTH_ENABLED, "handle": None, "subject": None, "role": None}
+    return {
+        "gated": True,
+        "handle": principal.handle,
+        "subject": principal.subject,
+        "role": principal.role,
+    }
 
 
 @app.get("/", tags=["health"])

--- a/fastapi-backend/tests/test_auth_gate.py
+++ b/fastapi-backend/tests/test_auth_gate.py
@@ -565,3 +565,36 @@ async def test_a2a_rpc_endpoint_is_gated_when_gate_on(client: AsyncClient, auth_
     }
     resp = await client.post("/api/rooms/ghost/a2a", json=rpc)
     assert resp.status_code == 401
+
+
+# ── /api/whoami: the one source of truth a client defaults its author to ───────
+
+
+@pytest.mark.asyncio
+async def test_whoami_ungated_reports_no_principal(client: AsyncClient):
+    """Gate off: a caller names itself, so there is no principal to report."""
+    resp = await client.get("/api/whoami")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["gated"] is False
+    assert body["handle"] is None
+
+
+@pytest.mark.asyncio
+async def test_whoami_gated_returns_the_token_principal(client: AsyncClient, auth_on, signing_key):
+    """The handle here is exactly what the gate enforces created_by against —
+    derived from the same claim, and normalized the same way — so a client that
+    defaults its write author to it never trips the mismatch."""
+    resp = await client.get("/api/whoami", headers=_bearer(_sign(signing_key, sub="@Julia")))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["gated"] is True
+    assert body["handle"] == "julia"
+
+
+@pytest.mark.asyncio
+async def test_whoami_gated_without_token_is_401(client: AsyncClient, auth_on):
+    """Gated and unauthenticated: the gate 401s before the handler, which a
+    client reads as "can't tell who I am" and falls back to local identity."""
+    resp = await client.get("/api/whoami")
+    assert resp.status_code == 401

--- a/mycelium-cli/src/mycelium/commands/agent.py
+++ b/mycelium-cli/src/mycelium/commands/agent.py
@@ -33,6 +33,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
+from mycelium import identity
 from mycelium.client import hub_client
 from mycelium.client import typed_client as _typed_client
 from mycelium.config import MyceliumConfig
@@ -777,13 +778,15 @@ def agent_create(
     team: str | None = typer.Option(
         None, "--team", help="Team slug this agent is fielded by. Self-asserted."
     ),
-    handle_flag: str = typer.Option(
-        "cli-user",
+    handle_flag: str | None = typer.Option(
+        None,
         "--as",
+        "--handle",
         "-H",
         help=(
             "Your own handle (recorded as created_by, and made --owner by default "
-            "so you can act on the agent you just created; pass --owner to override)."
+            "so you can act on the agent you just created; pass --owner to override). "
+            "Defaults to your hub identity."
         ),
     ),
 ) -> None:
@@ -800,6 +803,7 @@ def agent_create(
     """
     try:
         config = MyceliumConfig.load()
+        handle_flag = identity.resolve_actor(config, override=handle_flag)
 
         # No handle in a terminal → interactive create form (mirrors the
         # `agent add` picker). Non-interactive with no handle → actionable
@@ -1103,7 +1107,7 @@ def agent_invoke(
         None, "--room", "-r", help="Room to send into (defaults to active room)."
     ),
     handle_flag: str | None = typer.Option(
-        None, "--as", "-H", help="Your sender handle (defaults to identity config)."
+        None, "--as", "--handle", "-H", help="Your sender handle (defaults to identity config)."
     ),
 ) -> None:
     """Send an @-addressed message to a registered agent.

--- a/mycelium-cli/src/mycelium/commands/board.py
+++ b/mycelium-cli/src/mycelium/commands/board.py
@@ -857,7 +857,7 @@ def board_send(
     content: str = typer.Argument(..., help="What to say. @handle mentions address agents."),
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
     handle: str | None = typer.Option(
-        None, "--handle", "-H", help="Your sender handle (defaults to identity config)"
+        None, "--as", "--handle", "-H", help="Your sender handle (defaults to identity config)"
     ),
 ) -> None:
     """Say something in a thread.
@@ -938,7 +938,7 @@ def board_coordinate(
     ),
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
     handle: str | None = typer.Option(
-        None, "--handle", "-H", help="Your sender handle (defaults to identity config)"
+        None, "--as", "--handle", "-H", help="Your sender handle (defaults to identity config)"
     ),
 ) -> None:
     """Open a coordination phase on a row, run by an engine.

--- a/mycelium-cli/src/mycelium/commands/engine.py
+++ b/mycelium-cli/src/mycelium/commands/engine.py
@@ -23,6 +23,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
+from mycelium import identity
 from mycelium.commands.agent import (
     _load_manifest_remote,
     _persist_and_describe,
@@ -59,8 +60,12 @@ def engine_create(
         "--allow-from",
         help="Comma-separated sender handles allowed to summon (e.g. '@avery').",
     ),
-    handle_flag: str = typer.Option(
-        "cli-user", "--as", "-H", help="Your own handle (recorded as created_by)."
+    handle_flag: str | None = typer.Option(
+        None,
+        "--as",
+        "--handle",
+        "-H",
+        help="Your own handle (recorded as created_by). Defaults to your hub identity.",
     ),
 ) -> None:
     """Create a first-party cognition engine in a room.
@@ -70,6 +75,7 @@ def engine_create(
     """
     try:
         config = MyceliumConfig.load()
+        handle_flag = identity.resolve_actor(config, override=handle_flag)
         if kind not in ENGINE_KINDS:
             known = ", ".join(sorted(ENGINE_KINDS))
             typer.secho(f"Unknown engine kind '{kind}'. Known: {known}.", fg=typer.colors.RED)
@@ -159,7 +165,7 @@ def engine_invoke(
         None, "--room", "-r", help="Room to summon in (defaults to active room)."
     ),
     handle_flag: str | None = typer.Option(
-        None, "--as", "-H", help="Your sender handle (defaults to identity config)."
+        None, "--as", "--handle", "-H", help="Your sender handle (defaults to identity config)."
     ),
 ) -> None:
     """Summon a registered cognition engine by posting an ``@handle`` message.

--- a/mycelium-cli/src/mycelium/commands/memory.py
+++ b/mycelium-cli/src/mycelium/commands/memory.py
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
+from mycelium import identity
 from mycelium.client import hub_client, hub_error_detail, typed_client
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
@@ -184,7 +185,13 @@ def memory_set(
     room: str | None = typer.Option(
         None, "--room", "-r", help="Room name (defaults to active room)"
     ),
-    handle: str = typer.Option("cli-user", "--handle", "-H", help="Agent handle"),
+    handle: str | None = typer.Option(
+        None,
+        "--as",
+        "--handle",
+        "-H",
+        help="Author to attribute this to (created_by). Defaults to your hub identity.",
+    ),
     no_embed: bool = typer.Option(False, "--no-embed", help="Skip vector embedding"),
     tags: str | None = typer.Option(None, "--tags", "-t", help="Comma-separated tags"),
     expandable: bool = typer.Option(
@@ -223,6 +230,7 @@ def memory_set(
 
     value = _resolve_value(value, file)
     room_name = _get_active_room(room)
+    handle = identity.resolve_actor(MyceliumConfig.load(), override=handle)
 
     # Validate structured keys when category prefix is recognized
     entry: MemoryLogEntry | None = None
@@ -719,7 +727,13 @@ def memory_reindex(
 def memory_subscribe(
     pattern: str = typer.Argument(..., help="Key glob pattern (e.g. 'project/*')"),
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
-    handle: str = typer.Option("cli-user", "--handle", "-H", help="Subscriber agent handle"),
+    handle: str | None = typer.Option(
+        None,
+        "--as",
+        "--handle",
+        "-H",
+        help="Subscriber handle. Defaults to your hub identity.",
+    ),
 ) -> None:
     """Subscribe to memory change notifications."""
     from mycelium_backend_client.api.memory import (
@@ -728,6 +742,7 @@ def memory_subscribe(
     from mycelium_backend_client.models import SubscriptionCreate, SubscriptionRead
 
     room_name = _get_active_room(room)
+    handle = identity.resolve_actor(MyceliumConfig.load(), override=handle)
 
     with _get_client() as client:
         body = SubscriptionCreate(key_pattern=pattern, subscriber=handle)

--- a/mycelium-cli/src/mycelium/commands/participate.py
+++ b/mycelium-cli/src/mycelium/commands/participate.py
@@ -183,7 +183,7 @@ def _run_exec(exec_cmd: str, turn: dict, room_name: str, handle: str) -> None:
 def await_room(
     ctx: typer.Context,
     room: str | None = typer.Option(None, "--room", "-r", help="Room (default: active room)"),
-    handle: str = typer.Option("", "--handle", help="Handle to participate as"),
+    handle: str = typer.Option("", "--as", "--handle", "-H", help="Handle to participate as"),
     lease: str | None = typer.Option(
         None,
         "--lease",
@@ -372,7 +372,9 @@ def respond(
     ctx: typer.Context,
     text: str = typer.Argument(..., help="The reply / position text to publish"),
     room: str | None = typer.Option(None, "--room", "-r", help="Room (default: active room)"),
-    handle: str = typer.Option(..., "--handle", help="Handle to publish the reply as"),
+    handle: str = typer.Option(
+        ..., "--as", "--handle", "-H", help="Handle to publish the reply as"
+    ),
     task: str | None = typer.Option(
         None,
         "--task",

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -847,6 +847,7 @@ def send(
     ),
     handle: str | None = typer.Option(
         None,
+        "--as",
         "--handle",
         "-H",
         help="Your sender handle (defaults to identity config)",
@@ -910,7 +911,7 @@ def amend(
         None, "--room", "-r", help="Room the message is in (defaults to active room)"
     ),
     handle: str | None = typer.Option(
-        None, "--handle", "-H", help="Your sender handle (defaults to identity config)"
+        None, "--as", "--handle", "-H", help="Your sender handle (defaults to identity config)"
     ),
 ) -> None:
     """

--- a/mycelium-cli/src/mycelium/commands/skill.py
+++ b/mycelium-cli/src/mycelium/commands/skill.py
@@ -23,6 +23,7 @@ import httpx
 import typer
 from rich.console import Console
 
+from mycelium import identity
 from mycelium.client import hub_error_detail, typed_client
 from mycelium.config import MyceliumConfig
 from mycelium.doc_ref import doc_ref
@@ -122,7 +123,13 @@ def skill_set(
     description: str = typer.Option(
         "", "--desc", "-d", help="One-line summary shown in listings and the composer"
     ),
-    handle: str = typer.Option("cli-user", "--handle", "-H", help="Author handle"),
+    handle: str | None = typer.Option(
+        None,
+        "--as",
+        "--handle",
+        "-H",
+        help="Author to attribute this to (created_by). Defaults to your hub identity.",
+    ),
     tags: str | None = typer.Option(None, "--tags", "-t", help="Comma-separated tags"),
 ) -> None:
     """Create or upsert a skill in a room's skills/ namespace. Always upserts; version bumps."""
@@ -133,6 +140,7 @@ def skill_set(
 
     body_text = _resolve_body(body, file)
     room_name = _get_active_room(room)
+    handle = identity.resolve_actor(MyceliumConfig.load(), override=handle)
     tag_list = [t.strip() for t in tags.split(",")] if tags else None
 
     item = SkillCreate(

--- a/mycelium-cli/src/mycelium/commands/user.py
+++ b/mycelium-cli/src/mycelium/commands/user.py
@@ -26,6 +26,7 @@ from pydantic import ValidationError
 from rich.console import Console
 from rich.table import Table
 
+from mycelium import identity
 from mycelium.client import current_token
 from mycelium.client import typed_client as _typed_client
 from mycelium.config import MyceliumConfig
@@ -201,8 +202,12 @@ def user_create(
     notify: str | None = typer.Option(
         None, "--notify", help="Where to route 'needs you' escalations (email/webhook)."
     ),
-    handle_flag: str = typer.Option(
-        "cli-user", "--as", "-H", help="Your own handle (recorded as created_by)."
+    handle_flag: str | None = typer.Option(
+        None,
+        "--as",
+        "--handle",
+        "-H",
+        help="Your own handle (recorded as created_by). Defaults to your hub identity.",
     ),
 ) -> None:
     """Create (or upsert) a user in the global store.
@@ -210,6 +215,7 @@ def user_create(
     Examples:
         mycelium user create avery --name "Avery Quinn" --team core
     """
+    handle_flag = identity.resolve_actor(MyceliumConfig.load(), override=handle_flag)
     try:
         try:
             user = UserManifest(

--- a/mycelium-cli/src/mycelium/config.py
+++ b/mycelium-cli/src/mycelium/config.py
@@ -795,22 +795,15 @@ class MyceliumConfig(BaseModel):
         self.save()
 
     def get_current_identity(self) -> str:
-        import os
+        """This machine's acting identity, for a sender handle.
 
-        from mycelium.identity import get_current_handle
+        A thin wrapper over the one resolver (:func:`mycelium.identity.resolve_actor`)
+        so a sender and a write's author are found the same way: an explicit
+        override the caller passes, then ``MYCELIUM_AGENT_HANDLE``, then the hub's
+        own view of our token, then local ``iam`` config, then ``"unknown"``.
+        ``require=False`` because a sender read must not raise — the caller decides
+        what an unresolved sender means.
+        """
+        from mycelium.identity import resolve_actor
 
-        # Env var set by Mycelium plugin (or Docker Compose) takes highest priority
-        env_handle = os.environ.get("MYCELIUM_AGENT_HANDLE", "").strip()
-        if env_handle:
-            return env_handle
-
-        try:
-            handle = get_current_handle(self)
-            if handle:
-                return handle
-        except Exception:
-            pass
-
-        if self.identity.name:
-            return self.identity.name
-        return "unknown"
+        return resolve_actor(self, require=False, fallback="unknown")

--- a/mycelium-cli/src/mycelium/identity.py
+++ b/mycelium-cli/src/mycelium/identity.py
@@ -8,6 +8,7 @@ Generates and manages handles for agent identification.
 Format: DisplayName#session (e.g., "julvalen#a8f3")
 """
 
+import os
 import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -51,3 +52,95 @@ def get_current_handle(config: "MyceliumConfig") -> str | None:
         return None
 
     return generate_handle(config.identity.name, session_id)
+
+
+#: The old hardcoded default author. Kept only so a script that still passes it
+#: explicitly is treated as "unset" and resolves to the real caller, rather than
+#: a placeholder a gated hub rejects. Every write command used to default to it.
+LEGACY_ACTOR_SENTINEL = "cli-user"
+
+
+#: Per-process cache of ``/api/whoami`` keyed by hub URL. One CLI invocation is
+#: one process against one hub with one credential, so the answer is stable for
+#: the run; without this, a command that asks "who am I" several times (a board
+#: verb reads it per sub-call) would re-hit the hub each time.
+_WHOAMI_CACHE: dict[str, dict | None] = {}
+
+
+def _hub_whoami(config: "MyceliumConfig") -> dict | None:
+    """The hub's ``GET /api/whoami``, or None when the hub can't be reached.
+
+    Called with whatever credential the CLI holds (or none). The hub derives the
+    reported ``handle`` from the same claim it enforces ``created_by`` against, so
+    a client never has to guess which claim a gated hub trusts. A 401 means the
+    hub is gated and we presented no valid token, which is reported as
+    ``{gated: True, handle: None}`` so the caller can tell "log in first" apart
+    from "ungated, name yourself". Cached per hub for the process.
+    """
+    url = config.server.api_url
+    if url in _WHOAMI_CACHE:
+        return _WHOAMI_CACHE[url]
+
+    from mycelium import client
+
+    result: dict | None
+    try:
+        with client.hub_client(config, timeout=5.0) as http:
+            resp = http.get("/api/whoami")
+        if resp.status_code == 401:
+            result = {"gated": True, "handle": None}
+        elif resp.status_code != 200:
+            result = None
+        else:
+            result = resp.json()
+    except Exception:
+        result = None
+    _WHOAMI_CACHE[url] = result
+    return result
+
+
+def resolve_actor(
+    config: "MyceliumConfig",
+    override: str | None = None,
+    *,
+    require: bool = True,
+    fallback: str = LEGACY_ACTOR_SENTINEL,
+) -> str:
+    """The one seam every command uses to answer "who am I acting as".
+
+    Precedence:
+
+    1. an explicit ``--as`` override (acting-as, when the hub authorizes it),
+    2. ``MYCELIUM_AGENT_HANDLE`` — the identity a resident runtime declares for
+       itself (set by an adapter or the remote-agent bootstrap),
+    3. the principal the hub resolves our token to (``/api/whoami``) — exactly the
+       value a gated hub enforces ``created_by`` against,
+    4. the locally-configured identity (``mycelium iam``), for an ungated hub,
+    5. ``fallback`` (the ``cli-user`` sentinel for a write's author, ``"unknown"``
+       for a sender), so a zero-config local hub keeps working — *unless* the hub
+       is gated and we're not signed in, where ``require`` raises a clear "log in"
+       error rather than stamping a placeholder the gate is guaranteed to reject.
+
+    The ``cli-user`` sentinel is also treated as "unset" if passed as ``override``,
+    so an old script resolves to the real caller.
+    """
+    if override and override != LEGACY_ACTOR_SENTINEL:
+        return override
+    env_handle = os.environ.get("MYCELIUM_AGENT_HANDLE", "").strip()
+    if env_handle:
+        return env_handle
+    who = _hub_whoami(config)
+    if who and who.get("handle"):
+        return who["handle"]
+    local = get_current_handle(config) or config.identity.name
+    if local:
+        return local
+    if require and who and who.get("gated"):
+        import typer
+
+        raise typer.BadParameter(
+            "this hub is gated and you are not signed in, so there is no identity "
+            "to attribute this to. Run `mycelium login`, or set one with "
+            "`mycelium iam <handle>`, or pass `--as <handle>` explicitly."
+        )
+    return fallback

--- a/mycelium-cli/tests/test_resolve_actor.py
+++ b/mycelium-cli/tests/test_resolve_actor.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The one identity seam: :func:`mycelium.identity.resolve_actor`.
+
+Every write's author and every sender handle resolve through this, so its
+precedence (override -> env -> hub principal -> local iam -> fallback) is the
+contract the whole CLI leans on.
+"""
+
+import pytest
+
+from mycelium import identity
+from mycelium.config import MyceliumConfig
+
+
+@pytest.fixture
+def config() -> MyceliumConfig:
+    cfg = MyceliumConfig()
+    cfg.server.api_url = "http://hub.example:8000"
+    cfg.identity.name = None
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def _clear(monkeypatch: pytest.MonkeyPatch):
+    # A fresh whoami cache and no ambient agent handle per test.
+    identity._WHOAMI_CACHE.clear()
+    monkeypatch.delenv("MYCELIUM_AGENT_HANDLE", raising=False)
+    # No session file, so get_current_handle is driven only by identity.name.
+    monkeypatch.setattr(identity, "load_session", lambda: None)
+
+
+def _whoami(monkeypatch: pytest.MonkeyPatch, value: dict | None) -> None:
+    monkeypatch.setattr(identity, "_hub_whoami", lambda _cfg: value)
+
+
+def test_override_wins_over_everything(config, monkeypatch):
+    _whoami(monkeypatch, {"gated": True, "handle": "principal@x"})
+    monkeypatch.setenv("MYCELIUM_AGENT_HANDLE", "env-agent")
+    assert identity.resolve_actor(config, override="design-agent") == "design-agent"
+
+
+def test_legacy_sentinel_override_is_treated_as_unset(config, monkeypatch):
+    _whoami(monkeypatch, {"gated": True, "handle": "principal@x"})
+    # An old script passing the retired default resolves to the real caller.
+    assert identity.resolve_actor(config, override="cli-user") == "principal@x"
+
+
+def test_env_handle_beats_hub_and_local(config, monkeypatch):
+    _whoami(monkeypatch, {"gated": True, "handle": "principal@x"})
+    config.identity.name = "local-name"
+    monkeypatch.setenv("MYCELIUM_AGENT_HANDLE", "env-agent")
+    assert identity.resolve_actor(config) == "env-agent"
+
+
+def test_hub_principal_is_the_default_on_a_gated_hub(config, monkeypatch):
+    # The value a gated hub enforces created_by against, so a write just works.
+    _whoami(monkeypatch, {"gated": True, "handle": "juliarvalenti@gmail.com"})
+    config.identity.name = "some-local"
+    assert identity.resolve_actor(config) == "juliarvalenti@gmail.com"
+
+
+def test_local_identity_when_ungated(config, monkeypatch):
+    _whoami(monkeypatch, {"gated": False, "handle": None})
+    config.identity.name = "local-name"
+    assert identity.resolve_actor(config) == "local-name"
+
+
+def test_sentinel_fallback_keeps_zero_config_local_working(config, monkeypatch):
+    # Ungated hub, no identity anywhere: the write still lands (author defaults).
+    _whoami(monkeypatch, {"gated": False, "handle": None})
+    assert identity.resolve_actor(config) == identity.LEGACY_ACTOR_SENTINEL
+
+
+def test_gated_and_unauthenticated_raises_when_required(config, monkeypatch):
+    import typer
+
+    # 401 -> gated with no principal: stamping a placeholder would just 403, so
+    # guide the caller instead of failing obscurely later.
+    _whoami(monkeypatch, {"gated": True, "handle": None})
+    with pytest.raises(typer.BadParameter):
+        identity.resolve_actor(config)
+
+
+def test_gated_unauthenticated_falls_back_when_not_required(config, monkeypatch):
+    _whoami(monkeypatch, {"gated": True, "handle": None})
+    assert identity.resolve_actor(config, require=False) == identity.LEGACY_ACTOR_SENTINEL
+
+
+def test_unreachable_hub_does_not_block_a_local_identity(config, monkeypatch):
+    _whoami(monkeypatch, None)  # couldn't reach the hub
+    config.identity.name = "local-name"
+    assert identity.resolve_actor(config) == "local-name"
+
+
+def test_get_current_identity_delegates_with_unknown_fallback(config, monkeypatch):
+    _whoami(monkeypatch, {"gated": False, "handle": None})
+    # No identity anywhere -> the sender fallback, not the author sentinel.
+    assert config.get_current_identity() == "unknown"
+
+
+def test_get_current_identity_uses_hub_principal(config, monkeypatch):
+    _whoami(monkeypatch, {"gated": True, "handle": "principal@x"})
+    assert config.get_current_identity() == "principal@x"

--- a/openapi.json
+++ b/openapi.json
@@ -3272,6 +3272,26 @@
         }
       }
     },
+    "/api/whoami": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Whoami",
+        "description": "Who the hub resolves this caller to, from the bearer token it verified.\n\nThe single source of truth for write attribution. A client defaults\n``created_by`` to the ``handle`` returned here, so the value it stamps is\nexactly the one the gate enforces \u2014 both derive from the same\n``AUTH_HANDLE_CLAIM``, so a client never has to guess which claim a hub\ntrusts. ``gated`` is false when this hub runs no auth gate, where a caller\nnames itself and there is no principal to report; a client then falls back\nto its local identity config.\n\nA gated hub with no valid token never reaches here \u2014 ``auth_gate`` 401s\nfirst \u2014 which a client reads as \"the hub can't tell who I am\" and also\nfalls back to local identity.",
+        "operationId": "whoami_api_whoami_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "tags": [


### PR DESCRIPTION
## The alarm this fixes

Every write command defaulted `created_by` to the literal **`"cli-user"`** sentinel and shipped it as real data. On a gated hub the backend asserts `created_by == authenticated principal`, so the most basic write (`memory set`, `skill set`, `user/engine/agent create`, `memory subscribe`) **self-rejected with a 403**. On an ungated local hub there's no assertion, so it silently "worked" — which is why it went unnoticed until the hosted box.

Underneath, the CLI held **two disconnected notions of identity**: the local `iam` handle and the token principal the backend actually enforces, with nothing deriving a write's author from the token.

## The fix

**One source of truth (backend).** `GET /api/whoami` returns the principal the gate resolved from the bearer token — the same claim it enforces `created_by` against — or `{gated:false}` when ungated. A client never has to guess which claim a hub trusts.

**One resolver (CLI).** `identity.resolve_actor`:
```
override (--as)  ->  MYCELIUM_AGENT_HANDLE  ->  hub /whoami principal  ->  local iam  ->  fallback
```
with a clear "run `mycelium login`" error only when a *gated* hub can't identify an unauthenticated caller (instead of stamping a placeholder guaranteed to 403). Cached per hub for the process. `config.get_current_identity()` now **delegates to it**, so sender handles and write authors resolve through the *same* function — collapsing the second resolver.

**One flag.** `--as` is canonical, `--handle` a kept alias, `-H` the short, on every command (was split `--handle` vs `--as`).

## Behavior

- Signed in on a gated hub: `memory set` just works, authored as you — no `--handle` gymnastics.
- Gated but not signed in: a clear "log in" error, not a confusing 403 later.
- Ungated local hub with no identity: still works (zero-config quickstart preserved).
- `MYCELIUM_AGENT_HANDLE` (remote-agent bootstrap) still wins for a resident runtime.

## Tests

- `test_resolve_actor.py`: full precedence (override, env, hub principal, local, gated-unauth raise, ungated fallback, delegation).
- `test_auth_gate.py`: `/api/whoami` gated / ungated / unauthenticated.
- `openapi.json` regenerated for the new route; no docs drift.

Closes the entry-point half of #879; unblocks writing memory as a real identity on the hosted hub.