### PR TITLE
Remove the integrity banner from the memory detail panel

### DIFF
--- a/mycelium-frontend/src/components/memory-detail.test.tsx
+++ b/mycelium-frontend/src/components/memory-detail.test.tsx
@@ -54,67 +54,18 @@ describe("MemoryDetail", () => {
     expect(related.getByRole("button", { name: "plan/title" })).toBeInTheDocument();
   });
 
-  it("shows integrity banner when this memory has broken outbound links", async () => {
-    render(
-      <MemoryDetail
-        memory={memory}
-        roomName="demo"
-        variant="page"
-        integrity={{
-          broken: [
-            {
-              source: memory.key,
-              target: "gone",
-              kind: "wikilink",
-              raw: "[[gone]]",
-              resolved: false,
-            },
-          ],
-          orphans: [],
-          roots: [],
-          leaves: [],
-          total_memories: 1,
-          total_links: 1,
-        }}
-      />,
-    );
-    expect(await screen.findByRole("status")).toHaveTextContent(/broken outbound link/i);
-  });
-
-  it("shows the integrity banner on the rail (default) variant too", async () => {
-    render(
-      <MemoryDetail
-        memory={memory}
-        roomName="demo"
-        integrity={{
-          broken: [],
-          orphans: [memory.key],
-          roots: [],
-          leaves: [],
-          total_memories: 1,
-          total_links: 0,
-        }}
-      />,
-    );
-    expect(await screen.findByRole("status")).toHaveTextContent(/orphan/i);
-  });
-
-  it("shows a leaf banner when nothing links out from this memory", async () => {
-    render(
-      <MemoryDetail
-        memory={memory}
-        roomName="demo"
-        integrity={{
-          broken: [],
-          orphans: [],
-          roots: [],
-          leaves: [memory.key],
-          total_memories: 2,
-          total_links: 1,
-        }}
-      />,
-    );
-    expect(await screen.findByRole("status")).toHaveTextContent(/leaf/i);
+  it("draws no warning banner over a memory nothing links to", async () => {
+    // An unlinked memory is the normal state of a note somebody just wrote, and
+    // a broken link is already marked on the link itself — in the body and in
+    // the Links list. Neither earns a warning banner over the body.
+    vi.mocked(fetchMemoryLinks).mockResolvedValue({
+      key: memory.key,
+      outbound: [],
+      backlinks: [],
+    });
+    render(<MemoryDetail memory={memory} roomName="demo" variant="page" />);
+    expect(await screen.findByText("Version")).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
   });
 
   it("uses renderedBody in Rendered mode", async () => {

--- a/mycelium-frontend/src/components/memory-detail.tsx
+++ b/mycelium-frontend/src/components/memory-detail.tsx
@@ -8,14 +8,9 @@ import { ArrowUpRight, CornerDownLeft, Share2 } from "lucide-react";
 import { highlightJson } from "@/components/l9-inspector";
 import { MarkdownContent } from "@/components/markdown-content";
 import { Expandable } from "@/components/ui/expandable";
-import { fetchMemoryLinks, type MemoryLink, type MemoryLinksIntegrity } from "@/lib/api";
+import { fetchMemoryLinks, type MemoryLink } from "@/lib/api";
 import { isJsonRawText, prettyPrintJsonRawText } from "@/lib/json-text";
-import {
-  integrityNotesForMemory,
-  linkErrorLabel,
-  neighborKeys,
-  type MemoryIntegrityNotes,
-} from "@/lib/memory-links";
+import { linkErrorLabel, neighborKeys } from "@/lib/memory-links";
 
 export interface MemoryLike {
   key: string;
@@ -144,34 +139,12 @@ interface Props {
   /** When set, Rendered mode shows expanded transclusions instead of raw
    *  `![[…]]` markers. */
   renderedBody?: string | null;
-  /** Room integrity report; surfaces this memory's broken-link / graph-role
-   *  notes in either variant when supplied. */
-  integrity?: MemoryLinksIntegrity | null;
   /** Clamp a body taller than this many pixels behind an Expand button. Set by
    *  surfaces that put a conversation under the body, where a long body would
    *  otherwise push it out of reach. Unset renders the body whole. */
   collapseBodyAt?: number | null;
   /** The surface the body sits on, so its fade matches. */
   bodyFade?: "bg" | "paper" | "surface" | "elevated";
-}
-
-function IntegrityBanner({ notes }: { notes: MemoryIntegrityNotes }) {
-  const parts: string[] = [];
-  if (notes.brokenOutbound > 0) {
-    parts.push(
-      `${notes.brokenOutbound} broken outbound link${notes.brokenOutbound === 1 ? "" : "s"}`,
-    );
-  }
-  if (notes.isOrphan) parts.push("no connections at all (orphan)");
-  else if (notes.isLeaf) parts.push("nothing is reachable from here (leaf)");
-  return (
-    <div
-      role="status"
-      className="mx-5 mt-4 rounded-lg border border-yellow/30 bg-yellow/10 px-3 py-2 text-label text-yellow"
-    >
-      {parts.join(" · ")}
-    </div>
-  );
 }
 
 function NeighborChips({
@@ -242,7 +215,6 @@ export function MemoryDetail({
   onNavigate,
   variant = "rail",
   renderedBody = null,
-  integrity = null,
   collapseBodyAt = null,
   bodyFade = "bg",
 }: Props) {
@@ -303,15 +275,9 @@ export function MemoryDetail({
     () => (variant === "page" ? neighborKeys(memory.key, outbound, backlinks) : []),
     [variant, memory.key, outbound, backlinks],
   );
-  // Integrity banner shows in both variants when a report is supplied.
-  const integrityNotes = useMemo(
-    () => integrityNotesForMemory(memory.key, integrity),
-    [memory.key, integrity],
-  );
 
   return (
     <div>
-      {integrityNotes && <IntegrityBanner notes={integrityNotes} />}
       {/* A skill is just a `skills/…` memory — no special pane, just a tag. */}
       {memory.key.startsWith("skills/") && (
         <div className={`${pad} pt-4`}>

--- a/mycelium-frontend/src/components/memory-graph-view.test.tsx
+++ b/mycelium-frontend/src/components/memory-graph-view.test.tsx
@@ -12,10 +12,6 @@ vi.mock("@/lib/api", () => ({
   fetchMemoryExpanded: vi.fn().mockResolvedValue({ found: false, rendered: "", expansions: [], key: "" }),
   // MemoryDetail loads the selected memory's links on mount.
   fetchMemoryLinks: vi.fn().mockResolvedValue({ outbound: [], backlinks: [] }),
-  // useRoomMemoryIntegrity (room-data) calls this; give it a stable no-op so
-  // it doesn't throw in the test environment. Banner behaviour is tested via
-  // <MemoryDetail> directly in memory-detail.test.tsx.
-  fetchMemoryIntegrity: vi.fn().mockResolvedValue({ broken: [], orphans: [], roots: [], leaves: [], total_memories: 0, total_links: 0 }),
 }));
 
 import { MemoryGraphView } from "@/components/memory-graph-view";

--- a/mycelium-frontend/src/components/memory-graph-view.tsx
+++ b/mycelium-frontend/src/components/memory-graph-view.tsx
@@ -12,7 +12,6 @@ import {
   type Memory,
   type MemoryGraph as MemoryGraphData,
 } from "@/lib/api";
-import { useRoomMemoryIntegrity } from "@/lib/room-data";
 import { MemoryGraph } from "@/components/memory-graph";
 import { DetailDrawer } from "@/components/detail-drawer";
 import { MemoryDetail } from "@/components/memory-detail";
@@ -32,7 +31,6 @@ export function MemoryGraphView({ roomName }: Props) {
   const [graph, setGraph] = useState<MemoryGraphData | null>(null);
   const [selected, setSelected] = useState<Memory | null>(null);
   const [renderedBody, setRenderedBody] = useState<string | null>(null);
-  const { integrity } = useRoomMemoryIntegrity(roomName);
 
   useEffect(() => {
     let live = true;
@@ -115,7 +113,6 @@ export function MemoryGraphView({ roomName }: Props) {
             roomName={roomName}
             onNavigate={openKey}
             renderedBody={renderedBody}
-            integrity={integrity}
           />
         )}
       </DetailDrawer>

--- a/mycelium-frontend/src/components/memory-graph.test.tsx
+++ b/mycelium-frontend/src/components/memory-graph.test.tsx
@@ -99,8 +99,8 @@ describe("<MemoryGraph />", () => {
     const canvas = screen.getByRole("group", { name: /memory link graph/i });
     expect(canvas.querySelectorAll("line")).toHaveLength(1);
     // Dead references (no target node) don't appear in the broken-link count —
-    // the strip only reflects what's drawn. The integrity system (IntegrityBanner,
-    // `mycelium memory --check`) is where dead refs surface.
+    // the strip only reflects what's drawn. `mycelium memory --check` is where
+    // dead refs surface.
     expect(screen.queryByText(wholeText("1 broken link"))).not.toBeInTheDocument();
     expect(screen.getByText(wholeText("1 link"))).toBeInTheDocument();
   });

--- a/mycelium-frontend/src/components/memory-graph.tsx
+++ b/mycelium-frontend/src/components/memory-graph.tsx
@@ -188,8 +188,7 @@ export function MemoryGraph({ graph, onNavigate, roomName, className }: Props) {
   // Every count below describes what's on screen, so the strip and the canvas
   // never disagree. "Links" counts drawn resolved arcs; "broken" counts drawn
   // broken arcs. Dead references (not_found targets that aren't nodes) aren't
-  // drawn and so don't appear here — they're surfaced by the integrity system
-  // (IntegrityBanner in the detail drawer; `mycelium memory --check`).
+  // drawn and so don't appear here — `mycelium memory --check` reports them.
   const linkCount = useMemo(() => visibleEdges.filter(e => e.resolved).length, [visibleEdges]);
   // A broken arc is only drawn when its target is also a real node, so we
   // derive brokenCount from visibleEdges (the drawn set) rather than from

--- a/mycelium-frontend/src/components/memory-page-view.test.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.test.tsx
@@ -37,10 +37,9 @@ vi.mock("@/lib/api", () => ({
   logFetchError: () => () => undefined,
   fetchMemory: vi.fn(),
   fetchMemoryExpanded: vi.fn(),
-  fetchMemoryIntegrity: vi.fn(),
 }));
 
-import { fetchMemory, fetchMemoryExpanded, fetchMemoryIntegrity } from "@/lib/api";
+import { fetchMemory, fetchMemoryExpanded } from "@/lib/api";
 import { MemoryPageView } from "@/components/memory-page-view";
 
 const MEMORY = {
@@ -59,14 +58,6 @@ describe("<MemoryPageView />", () => {
       rendered: "",
       expansions: [],
       found: false,
-    });
-    vi.mocked(fetchMemoryIntegrity).mockResolvedValue({
-      broken: [],
-      orphans: [],
-      roots: [],
-      leaves: [],
-      total_memories: 1,
-      total_links: 0,
     });
   });
 

--- a/mycelium-frontend/src/components/memory-page-view.tsx
+++ b/mycelium-frontend/src/components/memory-page-view.tsx
@@ -12,7 +12,7 @@ import {
   fetchMemoryExpanded,
   type Memory,
 } from "@/lib/api";
-import { useRoomMemoryIntegrity, useRoomRevalidate } from "@/lib/room-data";
+import { useRoomRevalidate } from "@/lib/room-data";
 import { memoryHref } from "@/lib/memory-routes";
 import { isLiveEpisode } from "@/lib/threads";
 import { MemoryDetail } from "@/components/memory-detail";
@@ -40,7 +40,6 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
   const [memory, setMemory] = useState<Memory | null | undefined>(undefined);
   const [renderedBody, setRenderedBody] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
-  const { integrity } = useRoomMemoryIntegrity(roomName);
   const { principal } = useCurrentUser();
   const revalidate = useRoomRevalidate(roomName);
   const { setDirty, guard, dialog: unsavedDialog } = useUnsavedGuard();
@@ -151,9 +150,9 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
             actor={principal}
             onDirtyChange={setDirty}
             onSaved={() => {
-              // revalidate() refreshes every SWR-backed room resource, which
-              // covers integrity. The memory and its expanded body are local
-              // state, so refetch those directly.
+              // revalidate() refreshes every SWR-backed room resource. The
+              // memory and its expanded body are local state, so refetch those
+              // directly.
               revalidate();
               setIsEditing(false);
               fetchMemory(roomName, memoryKey).then(m => { if (m) setMemory(m); });
@@ -171,7 +170,6 @@ export function MemoryPageView({ roomName, memoryKey }: Props) {
             onNavigate={onNavigate}
             variant="page"
             renderedBody={renderedBody}
-            integrity={integrity}
             // Only where a discussion follows the body: on a page that is body
             // and nothing else, clamping would hide the whole point of opening
             // it full screen.

--- a/mycelium-frontend/src/components/memory-panel.test.tsx
+++ b/mycelium-frontend/src/components/memory-panel.test.tsx
@@ -27,13 +27,11 @@ vi.mock("next/link", () => ({
 
 vi.mock("@/components/memory-detail", () => ({
   MemoryDetail: (props: {
-    integrity?: unknown;
     renderedBody?: string | null;
     collapseBodyAt?: number | null;
   }) => (
     <div
       data-testid="memory-detail"
-      data-has-integrity={props.integrity ? "yes" : "no"}
       data-rendered-body={props.renderedBody ?? ""}
       data-collapse-body-at={props.collapseBodyAt ?? ""}
     />
@@ -68,7 +66,6 @@ vi.mock("@/lib/api", () => ({
   fetchMemories: vi.fn(),
   fetchMemory: vi.fn(),
   fetchMemoryExpanded: vi.fn(),
-  fetchMemoryIntegrity: vi.fn(),
   searchMemories: vi.fn(),
   fetchMemoryLinks: vi.fn(),
 }));
@@ -77,18 +74,9 @@ import {
   fetchMemories,
   fetchMemory,
   fetchMemoryExpanded,
-  fetchMemoryIntegrity,
   fetchMemoryLinks,
 } from "@/lib/api";
 
-const EMPTY_INTEGRITY = {
-  broken: [],
-  orphans: [],
-  roots: [],
-  leaves: [],
-  total_memories: 0,
-  total_links: 0,
-};
 const EMPTY_EXPAND = { key: "", rendered: "", expansions: [], found: false };
 
 const offTree = {
@@ -110,7 +98,6 @@ describe("<MemoryPanel /> peek navigation", () => {
       outbound: [],
       backlinks: [],
     });
-    vi.mocked(fetchMemoryIntegrity).mockResolvedValue(EMPTY_INTEGRITY);
     vi.mocked(fetchMemoryExpanded).mockResolvedValue(EMPTY_EXPAND);
   });
 
@@ -149,24 +136,8 @@ describe("<MemoryPanel /> peek navigation", () => {
     expect(push).not.toHaveBeenCalled();
   });
 
-  it("passes the room integrity report and expanded body into the drawer's MemoryDetail (#599)", async () => {
+  it("passes the expanded body into the drawer's MemoryDetail (#599)", async () => {
     vi.mocked(fetchMemory).mockResolvedValue(offTree);
-    vi.mocked(fetchMemoryIntegrity).mockResolvedValue({
-      broken: [
-        {
-          source: offTree.key,
-          target: "gone",
-          kind: "wikilink",
-          raw: "[[gone]]",
-          resolved: false,
-        },
-      ],
-      orphans: [],
-      roots: [],
-      leaves: [],
-      total_memories: 1,
-      total_links: 1,
-    });
     vi.mocked(fetchMemoryExpanded).mockResolvedValue({
       key: offTree.key,
       rendered: "expanded transclusion body",
@@ -183,7 +154,6 @@ describe("<MemoryPanel /> peek navigation", () => {
 
     const detail = await screen.findByTestId("memory-detail");
     await waitFor(() => expect(fetchMemoryExpanded).toHaveBeenCalledWith("demo", offTree.key));
-    await waitFor(() => expect(detail).toHaveAttribute("data-has-integrity", "yes"));
     expect(detail).toHaveAttribute("data-rendered-body", "expanded transclusion body");
   });
 
@@ -227,7 +197,6 @@ describe("<MemoryPanel /> preview hovercard", () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.mocked(fetchMemories).mockResolvedValue([treeMemory]);
     vi.mocked(fetchMemory).mockReset();
-    vi.mocked(fetchMemoryIntegrity).mockResolvedValue(EMPTY_INTEGRITY);
     vi.mocked(fetchMemoryExpanded).mockResolvedValue(EMPTY_EXPAND);
   });
 

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -25,7 +25,7 @@ import {
   type Memory,
   type MemorySearchResult,
 } from "@/lib/api";
-import { useRoomMemories, useRoomMemoryIntegrity, useRoomRevalidate } from "@/lib/room-data";
+import { useRoomMemories, useRoomRevalidate } from "@/lib/room-data";
 import { memoryGraphHref, memoryHref } from "@/lib/memory-routes";
 import { expandedPathsForKey, resolveMemoryPeekNavigation } from "@/lib/memory-panel-nav";
 import { MemoryPreviewCard, type PreviewAnchor } from "@/components/memory-preview-card";
@@ -284,11 +284,9 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
     [endPeek, guard],
   );
 
-  // The tree, plus the room-wide integrity report the drawer reads to flag a
-  // broken or orphaned memory without a per-open round trip. Both revalidate
-  // when a memory write reaches the room, so neither needs a refresh prop.
+  // The tree revalidates when a memory write reaches the room, so it needs no
+  // refresh prop.
   const { memories, loading } = useRoomMemories(roomName);
-  const { integrity } = useRoomMemoryIntegrity(roomName);
   const memoriesRef = useRef(memories);
   useLayoutEffect(() => { memoriesRef.current = memories; }, [memories]);
 
@@ -579,8 +577,7 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
                 roomName={roomName}
                 onNavigate={openMemoryByKey}
                 renderedBody={renderedBody}
-                integrity={integrity}
-                // Only where a discussion follows the body — see the full page.
+                    // Only where a discussion follows the body — see the full page.
                 collapseBodyAt={hasDiscussion ? BODY_CLAMP_PX : null}
                 bodyFade="elevated"
               />

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -362,39 +362,6 @@ export async function fetchMemoryLinks(roomName: string, key: string): Promise<M
   return { key, outbound: data.outbound ?? [], backlinks: data.backlinks ?? [] };
 }
 
-export interface BrokenLink extends MemoryLink {
-  source: string;
-}
-
-export interface MemoryLinksIntegrity {
-  broken: BrokenLink[];
-  /** Fully isolated: inbound === 0 AND outbound === 0. */
-  orphans: string[];
-  /** Entry points: inbound === 0 AND outbound > 0. Nothing links here yet. */
-  roots: string[];
-  /** Dead ends: inbound > 0 AND outbound === 0. Links arrive but go no further. */
-  leaves: string[];
-  total_memories: number;
-  total_links: number;
-}
-
-const EMPTY_INTEGRITY: MemoryLinksIntegrity = {
-  broken: [],
-  orphans: [],
-  roots: [],
-  leaves: [],
-  total_memories: 0,
-  total_links: 0,
-};
-
-/** Room-wide link integrity — broken edges, orphans, roots, and leaves. Degrades to empty. */
-export async function fetchMemoryIntegrity(roomName: string): Promise<MemoryLinksIntegrity> {
-  return apiFetch<MemoryLinksIntegrity>(`/api/rooms/${roomName}/links/integrity`, {
-    cache: "no-store",
-    fallback: EMPTY_INTEGRITY,
-  });
-}
-
 export interface MemoryExpanded {
   key: string;
   rendered: string;
@@ -417,10 +384,10 @@ export async function fetchMemoryExpanded(roomName: string, key: string): Promis
 // ── Memory graph ─────────────────────────────────────────────────────────────
 // The whole room as a graph — one node per memory, one edge per link — for the
 // full-page graph view (#599). A thin read over the same link index that backs
-// `fetchMemoryLinks`/integrity, so graph-role facts (orphan = `inbound===0 &&
+// `fetchMemoryLinks`, so graph-role facts (orphan = `inbound===0 &&
 // outbound===0`, root = `inbound===0 && outbound>0`, leaf = `inbound>0 &&
 // outbound===0`) and broken-link facts (`resolved === false`) are derived
-// client-side from this one payload instead of a second integrity fetch.
+// client-side from this one payload.
 
 export interface MemoryGraphNode {
   key: string;

--- a/mycelium-frontend/src/lib/memory-links.test.ts
+++ b/mycelium-frontend/src/lib/memory-links.test.ts
@@ -2,8 +2,8 @@
 // Copyright 2026 Mycelium Contributors
 
 import { describe, expect, it } from "vitest";
-import { integrityNotesForMemory, neighborKeys } from "@/lib/memory-links";
-import type { MemoryLink, MemoryLinksIntegrity } from "@/lib/api";
+import { neighborKeys } from "@/lib/memory-links";
+import type { MemoryLink } from "@/lib/api";
 
 const link = (over: Partial<MemoryLink>): MemoryLink => ({
   target: "b",
@@ -23,68 +23,5 @@ describe("neighborKeys", () => {
   it("dedupes when the same key appears twice", () => {
     const outbound = [link({ target: "a" }), link({ target: "a" })];
     expect(neighborKeys("here", outbound, [])).toEqual(["a"]);
-  });
-});
-
-describe("integrityNotesForMemory", () => {
-  const integrity: MemoryLinksIntegrity = {
-    broken: [{ source: "here", target: "gone", kind: "wikilink", raw: "[[gone]]", resolved: false }],
-    orphans: ["lonely"],
-    roots: ["top"],
-    leaves: ["bottom"],
-    total_memories: 4,
-    total_links: 1,
-  };
-
-  it("returns null when the memory has no integrity issues", () => {
-    expect(integrityNotesForMemory("ok", integrity)).toBeNull();
-  });
-
-  it("returns null for a root with no broken links (roots are intentional entry points)", () => {
-    expect(integrityNotesForMemory("top", integrity)).toBeNull();
-  });
-
-  it("counts broken outbound from this key", () => {
-    expect(integrityNotesForMemory("here", integrity)).toEqual({
-      brokenOutbound: 1,
-      isOrphan: false,
-      isRoot: false,
-      isLeaf: false,
-    });
-  });
-
-  it("flags orphans (no connections at all)", () => {
-    expect(integrityNotesForMemory("lonely", integrity)).toEqual({
-      brokenOutbound: 0,
-      isOrphan: true,
-      isRoot: false,
-      isLeaf: false,
-    });
-  });
-
-  it("flags leaves (links arrive but go no further)", () => {
-    expect(integrityNotesForMemory("bottom", integrity)).toEqual({
-      brokenOutbound: 0,
-      isOrphan: false,
-      isRoot: false,
-      isLeaf: true,
-    });
-  });
-
-  it("tolerates an integrity report without roots/leaves (older backend)", () => {
-    const legacyIntegrity: MemoryLinksIntegrity = {
-      broken: [],
-      orphans: ["lonely"],
-      roots: [],
-      leaves: [],
-      total_memories: 1,
-      total_links: 0,
-    };
-    expect(integrityNotesForMemory("lonely", legacyIntegrity)).toEqual({
-      brokenOutbound: 0,
-      isOrphan: true,
-      isRoot: false,
-      isLeaf: false,
-    });
   });
 });

--- a/mycelium-frontend/src/lib/memory-links.ts
+++ b/mycelium-frontend/src/lib/memory-links.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 Mycelium Contributors
 
-import type { MemoryLink, MemoryLinksIntegrity } from "@/lib/api";
+import type { MemoryLink } from "@/lib/api";
 
 /** One-hop neighbors for the full-page "Related" section.
  *
@@ -42,33 +42,4 @@ export function linkErrorLabel(error?: string | null): string {
  */
 export function isBrokenLinkError(error?: string | null): boolean {
   return error !== "cross_room";
-}
-
-export interface MemoryIntegrityNotes {
-  brokenOutbound: number;
-  /** inbound === 0 AND outbound === 0 — fully isolated, no connections. */
-  isOrphan: boolean;
-  /** inbound === 0 AND outbound > 0 — entry point, nothing links here yet. */
-  isRoot: boolean;
-  /** inbound > 0 AND outbound === 0 — dead end, links arrive but go no further. */
-  isLeaf: boolean;
-}
-
-/** Per-memory slice of a room integrity report for inline banners.
- *
- * Returns null when there is nothing notable to surface — no broken outbound
- * links and the memory is neither orphaned nor a leaf. Roots (inbound === 0
- * with outbound links) are included in the notes but do not trigger a banner
- * on their own, since being an entry point is intentional, not a problem. */
-export function integrityNotesForMemory(
-  key: string,
-  integrity: MemoryLinksIntegrity | null,
-): MemoryIntegrityNotes | null {
-  if (!integrity) return null;
-  const brokenOutbound = integrity.broken.filter(b => b.source === key).length;
-  const isOrphan = integrity.orphans.includes(key);
-  const isRoot = (integrity.roots ?? []).includes(key);
-  const isLeaf = (integrity.leaves ?? []).includes(key);
-  if (brokenOutbound === 0 && !isOrphan && !isLeaf) return null;
-  return { brokenOutbound, isOrphan, isRoot, isLeaf };
 }

--- a/mycelium-frontend/src/lib/room-data.test.tsx
+++ b/mycelium-frontend/src/lib/room-data.test.tsx
@@ -10,7 +10,6 @@ vi.mock("@/lib/api", () => ({
   fetchRoomMembers: vi.fn(),
   fetchMessages: vi.fn(),
   fetchMemories: vi.fn(),
-  fetchMemoryIntegrity: vi.fn(),
   fetchSkills: vi.fn(),
   fetchPlan: vi.fn(),
   fetchEpisodes: vi.fn(),

--- a/mycelium-frontend/src/lib/room-data.ts
+++ b/mycelium-frontend/src/lib/room-data.ts
@@ -25,7 +25,6 @@ import {
   fetchA2aBridge,
   fetchEpisodes,
   fetchMemories,
-  fetchMemoryIntegrity,
   fetchMessages,
   fetchNetworkStatus,
   fetchRoom,
@@ -39,7 +38,6 @@ import {
   type AgentSummary,
   type EpisodeSummary,
   type Memory,
-  type MemoryLinksIntegrity,
   type NetworkStatus,
   type PresenceMember,
   type Room,
@@ -127,7 +125,6 @@ type RoomResource =
   | "memories"
   | "skills"
   | "episodes"
-  | "integrity"
   | "status"
   | "a2a";
 
@@ -392,14 +389,6 @@ export function useRoomMemories(room: string, opts: RoomQueryOptions = {}) {
     room, "memories", fetchMemories, NO_MEMORIES, POLL.memories, opts,
   );
   return { memories: data, loading, refresh };
-}
-
-/** Not polled; memory writes revalidate the room. */
-export function useRoomMemoryIntegrity(room: string, opts: RoomQueryOptions = {}) {
-  const { data, loading, refresh } = useRoomQuery(
-    room, "integrity", fetchMemoryIntegrity, null as MemoryLinksIntegrity | null, 0, opts,
-  );
-  return { integrity: data, loading, refresh };
 }
 
 export function useRoomSkills(room: string, opts: RoomQueryOptions = {}) {


### PR DESCRIPTION
## Summary

The yellow box over a memory's body said one of three things, and none of them earned a warning there.

**"no connections at all (orphan)"** and **"nothing is reachable from here (leaf)"** are graph roles, not defects. An unlinked memory is the normal state of a note somebody just wrote; flagging it tells the author they did something wrong for writing one. Those roles already have a surface that treats them as facts rather than faults — the graph view counts orphans and leaves in its legend strip, where a graph role is the subject.

**"N broken outbound links"** is a real defect, and it was already stated more precisely fifteen rows below. See the before/after: the banner says `1 broken outbound link`; the Links list names the link and its error (`work/cutover-runbook · wikilink · no such memory`), and the body marks the same link inline. A vaguer count of a list on the same screen is not a second warning — it is the same one, worse.

| before | after |
| --- | --- |
| yellow banner over the body, plus the labelled link below it | the labelled link, and nothing over the body |

## Changes

- **`memory-detail.tsx`** — `IntegrityBanner` and its render are gone; the `integrity` prop with them.
- **The whole client-side integrity read follows it, because nothing else was using it.** `integrityNotesForMemory` + `MemoryIntegrityNotes` (`lib/memory-links.ts`), `useRoomMemoryIntegrity` and the `"integrity"` resource key (`lib/room-data.ts`), `fetchMemoryIntegrity` + `MemoryLinksIntegrity` + `BrokenLink` (`lib/api.ts`). Three surfaces — the memory rail, the full page, the graph drawer — each fetched `/links/integrity` on mount solely to feed this banner, and each drops that read.
- **Backend untouched.** `GET /api/rooms/{room}/links/integrity` and `mycelium memory --check` still exist; a room-wide integrity report is a real thing, and that is where it belongs. The mock handler for the route stays too, still derived from the fixture edge list.
- **Stale comments corrected** where they named `IntegrityBanner` or "a second integrity fetch" (`memory-graph.tsx`, `api.ts`).

## Testing

Frontend only — backend and CLI are not touched, so the Python gates in this template don't apply here.

- `npx vitest run` — **802 tests across 66 files, all passing**
- `npx tsc --noEmit` — clean
- `npx eslint .` — clean (2 pre-existing warnings in `use-collapsible-rail.ts`, untouched)
- `npx next build` — compiles
- **Verified in the running app**, not only in the suite: `shot app /room/atlas-migration/memory/decisions/cutover --mock`, which is the fixture memory with a genuinely broken outbound link. That is where the before/after above comes from.

The three banner tests are replaced by **one** that pins the removal rather than deleting coverage: an unlinked memory draws no `role="status"` element in the detail panel. **Mutation-checked** — a `role="status"` div restored at the top of `MemoryDetail` fails it, and only it.

## Related Issues

None — this is a direct request, not a filed issue. Worth arguing with if you disagree that a broken link deserves no summary line of its own; the case for removing it is that the Links list is on the same screen and says more.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYx8cnmZZ4M2Vyen5Pndwu)_