### PR TITLE
fix: eight correctness bugs from code review

### DIFF
--- a/fastapi-backend/app/routes/messages.py
+++ b/fastapi-backend/app/routes/messages.py
@@ -158,6 +158,13 @@ async def send_message(room_name: str, payload: MessageCreate, request: Request)
             # Correlation key: the same envelope the persister records to the
             # transcript, so a cold read dedups this row against its transcript copy.
             msg.message_id = result.message_id
+            if result.unrecognized:
+                logger.warning(
+                    "send_message: @-mentioned handles not present and not registered "
+                    "in room %s — no delivery: %s",
+                    channel,
+                    result.unrecognized,
+                )
     # The human's message always lands in ``in_memory_store`` — its id backs PATCH /
     # event semantics and it's the live view. The persister records the same
     # message to the durable transcript (the read path's source of truth); the two

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -236,12 +236,16 @@ async def await_message(
         while i < len(records):
             record = records[i]
             i += 1
-            if scoped and record_episode(record) != scoped:
+            ep = record_episode(record)
+            if scoped:
+                if ep != scoped:
+                    continue
+            elif ep and not l9.is_live_episode(room_name, ep):
+                # Thread records belong exclusively to thread-scoped calls; the
+                # room-wide inbox only holds live-episode messages.
                 continue
             if _addressed_to(record.content, handle):
                 _commit(i)
-                if scoped:
-                    persister.advance_cursor(handle, i)
                 _last_tick[key] = record.content
                 room_channels.manager.refresh_lease(room_name, handle)
                 return _describe(room_name, handle, record)

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -240,6 +240,8 @@ async def await_message(
                 continue
             if _addressed_to(record.content, handle):
                 _commit(i)
+                if scoped:
+                    persister.advance_cursor(handle, i)
                 _last_tick[key] = record.content
                 room_channels.manager.refresh_lease(room_name, handle)
                 return _describe(room_name, handle, record)

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -310,7 +310,11 @@ class A2aResponder:
         # handles may trigger a remote call (and spend its bearer token / quota).
         # The agent's owner is always permitted — a restrictive allowlist must
         # not lock the operator out of their own agent.
-        if ref.allow_from and sender_bare not in ref.allow_from and not (ref.owner and sender_bare == ref.owner):
+        if (
+            ref.allow_from
+            and sender_bare not in ref.allow_from
+            and not (ref.owner and sender_bare == ref.owner)
+        ):
             logger.debug(
                 "a2a responder: @%s not in allow_from for @%s — ignoring summon", sender, handle
             )

--- a/fastapi-backend/app/services/a2a_bridge.py
+++ b/fastapi-backend/app/services/a2a_bridge.py
@@ -310,7 +310,7 @@ class A2aResponder:
         # handles may trigger a remote call (and spend its bearer token / quota).
         # The agent's owner is always permitted — a restrictive allowlist must
         # not lock the operator out of their own agent.
-        if ref.allow_from and sender_bare not in ref.allow_from and sender_bare != ref.owner:
+        if ref.allow_from and sender_bare not in ref.allow_from and not (ref.owner and sender_bare == ref.owner):
             logger.debug(
                 "a2a responder: @%s not in allow_from for @%s — ignoring summon", sender, handle
             )
@@ -418,9 +418,11 @@ class A2aResponder:
             return
         summoner = envelope_sender(in_reply_to)
         parent = envelope_message_id(in_reply_to)
+        msg = in_reply_to.header.message
+        episode = (msg.episode if msg and msg.episode else None) or l9.episode_urn(room, "live")
         env = l9.build_envelope(
             kind=l9.Kind.exchange,
-            episode=l9.episode_urn(room, "live"),
+            episode=episode,
             parents=[parent] if parent else None,
             sender=handle,
             sender_role="agent",

--- a/fastapi-backend/app/services/assignments.py
+++ b/fastapi-backend/app/services/assignments.py
@@ -189,19 +189,16 @@ async def _write(
     return _describe(key, fresh_meta, datetime.now(UTC))
 
 
-async def _raise_notice(
-    room: str, key: str, meta: dict, content: str, subkind: str, by: str
-) -> None:
+async def _raise_notice(room: str, key: str, subkind: str, by: str) -> None:
     """Tell the room the board moved: a task was claimed, handed back or resolved.
 
     A custody write is news the timeline should carry, so it raises a notice the
-    same way a thread write raises a ping — through the manager, waking nobody. The
-    episode is the row's own (stable across a custody write, so the pre-write meta
-    has it), and the title is the row's first line, so the notice can name the task
-    and open its thread.
+    same way a thread write raises a ping — through the manager, waking nobody. Reads
+    fresh state so the episode URN is present even when the write just minted it.
     """
     from app.services.room_channels import manager
 
+    meta, content = _load(room, key)
     episode = system_meta(meta).get(EPISODE_META)
     first = next((ln.strip() for ln in (content or "").splitlines() if ln.strip()), key)
     await manager.raise_notice(
@@ -244,7 +241,7 @@ async def claim(room: str, key: str, handle: str, ttl_minutes: int, now: datetim
         "assignment_note_by": None,
     }
     described = await _write(room, key, meta, content, patch, handle)
-    await _raise_notice(room, key, meta, content, "claimed", handle)
+    await _raise_notice(room, key, "claimed", handle)
     return described
 
 
@@ -265,7 +262,7 @@ async def release(room: str, key: str, handle: str, note: str | None, now: datet
         "assignment_note_by": handle.lstrip("@"),
     }
     described = await _write(room, key, meta, content, patch, handle)
-    await _raise_notice(room, key, meta, content, "released", handle)
+    await _raise_notice(room, key, "released", handle)
     return described
 
 
@@ -280,7 +277,7 @@ async def resolve(room: str, key: str, handle: str, now: datetime) -> dict:
         "assignment_note_by": handle.lstrip("@"),
     }
     described = await _write(room, key, meta, content, patch, handle)
-    await _raise_notice(room, key, meta, content, "resolved", handle)
+    await _raise_notice(room, key, "resolved", handle)
     return described
 
 

--- a/fastapi-backend/app/services/filesystem.py
+++ b/fastapi-backend/app/services/filesystem.py
@@ -295,7 +295,7 @@ def delete_memory_file(base_dir: Path, key: str) -> bool:
 def list_memory_files(
     base_dir: Path,
     prefix: str | None = None,
-    limit: int = 1000,
+    limit: int | None = 1000,
 ) -> list[tuple[str, dict[str, Any], str]]:
     """List memory files, optionally filtered by key prefix.
 

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -204,6 +204,9 @@ class HumanPublishResult:
 
     mentioned: list[str]
     recipients: list[str]
+    # Handles that were @-mentioned but are neither present in the room nor a
+    # registered agent — they received no delivery and triggered no action.
+    unrecognized: list[str] = field(default_factory=list)
     # The published envelope's L9 message id — the correlation key the POST route
     # stamps on its ``in_memory_store`` row so a cold read from the durable transcript
     # dedups against it instead of showing the human's message twice.
@@ -868,10 +871,12 @@ class RoomChannelManager:
         # turn is delivered via the durable transcript cursor its poll reads, not a
         # SLIM broadcast — so an @-mention of it is a wake, not an invite.
         present = set(self.members(room))
+        unrecognized: list[str] = []
         for handle in mentioned:
             if handle in present or handle == BACKEND_AGENT:
                 continue
             if not _is_own_registered_agent(room, handle):
+                unrecognized.append(handle)
                 continue
             if managed.lifecycle.frozen:
                 # Adding a member mid-negotiation would abort it (L9's
@@ -883,7 +888,12 @@ class RoomChannelManager:
                 self.invite_in_background(room, handle)
 
         recipients = [h for h in mentioned if h != BACKEND_AGENT]
-        return HumanPublishResult(mentioned=mentioned, recipients=recipients, message_id=message_id)
+        return HumanPublishResult(
+            mentioned=mentioned,
+            recipients=recipients,
+            unrecognized=unrecognized,
+            message_id=message_id,
+        )
 
     async def raise_ping(
         self,

--- a/fastapi-backend/app/services/tasks.py
+++ b/fastapi-backend/app/services/tasks.py
@@ -360,7 +360,7 @@ def backfill_room(room: str) -> int:
     """
     base = get_room_dir(room)
     bound = 0
-    for key, meta, content in list_memory_files(base, limit=BACKFILL_SCAN_LIMIT):
+    for key, meta, _content in list_memory_files(base, limit=BACKFILL_SCAN_LIMIT):
         if system_meta(meta).get(EPISODE_META):
             continue
         # Re-read and re-check under an exclusive lock so two instances starting

--- a/fastapi-backend/app/services/tasks.py
+++ b/fastapi-backend/app/services/tasks.py
@@ -35,6 +35,7 @@ namespaces are *worked*.
 
 from __future__ import annotations
 
+import fcntl
 import logging
 import re
 import uuid
@@ -47,6 +48,7 @@ from app.services.filesystem import (
     EPISODE_META,
     get_room_dir,
     list_memory_files,
+    parse_memory,
     read_memory_file,
     serialize_memory,
     system_meta,
@@ -106,7 +108,7 @@ _REWRITTEN_META = frozenset({"key", "created_by", "updated_by", "version", "tags
 
 def _norm(handle: str) -> str:
     """A handle as it compares: the roster and the caller may spell it differently."""
-    return handle.strip().lstrip("@").casefold()
+    return handle.strip().lstrip("@").lower()
 
 
 def slugify(title: str) -> str:
@@ -165,7 +167,7 @@ def bound_episodes(room: str) -> set[str]:
     to, which stays a row of its own rather than being hidden or deleted.
     """
     urns: set[str] = set()
-    for _key, meta, _content in list_memory_files(get_room_dir(room)):
+    for _key, meta, _content in list_memory_files(get_room_dir(room), limit=None):
         urn = system_meta(meta).get(EPISODE_META)
         if isinstance(urn, str) and urn:
             urns.add(urn)
@@ -361,22 +363,32 @@ def backfill_room(room: str) -> int:
     for key, meta, content in list_memory_files(base, limit=BACKFILL_SCAN_LIMIT):
         if system_meta(meta).get(EPISODE_META):
             continue
-        # Everything serialize_memory does not write from its own arguments,
-        # timestamps included, so the URN is the only thing that changes.
-        extra = {k: v for k, v in meta.items() if k not in _REWRITTEN_META}
-        extra[EPISODE_META] = mint_episode_urn(room)
-        (base / f"{key}.md").write_text(
-            serialize_memory(
-                content,
-                key=meta.get("key", key),
-                created_by=meta.get("created_by", l9.SYSTEM_ACTOR_ID),
-                updated_by=meta.get("updated_by"),
-                version=meta.get("version", 1),
-                tags=meta.get("tags"),
-                extra_meta=extra,
-            ),
-            encoding="utf-8",
-        )
+        # Re-read and re-check under an exclusive lock so two instances starting
+        # concurrently (rolling restart) cannot each mint a different URN for the
+        # same file: the second opener finds the URN the first already wrote and skips.
+        path = base / f"{key}.md"
+        try:
+            with path.open("r+", encoding="utf-8") as fh:
+                fcntl.flock(fh, fcntl.LOCK_EX)
+                locked_meta, locked_content = parse_memory(fh.read())
+                if system_meta(locked_meta).get(EPISODE_META):
+                    continue
+                extra = {k: v for k, v in locked_meta.items() if k not in _REWRITTEN_META}
+                extra[EPISODE_META] = mint_episode_urn(room)
+                new_text = serialize_memory(
+                    locked_content,
+                    key=locked_meta.get("key", key),
+                    created_by=locked_meta.get("created_by", l9.SYSTEM_ACTOR_ID),
+                    updated_by=locked_meta.get("updated_by"),
+                    version=locked_meta.get("version", 1),
+                    tags=locked_meta.get("tags"),
+                    extra_meta=extra,
+                )
+                fh.seek(0)
+                fh.write(new_text)
+                fh.truncate()
+        except FileNotFoundError:
+            continue
         bound += 1
     if bound:
         logger.info("bound %d pre-existing memories in %s to a thread", bound, room)


### PR DESCRIPTION
## Summary

Correctness bugs found during a high-effort code review of the task-board / A2A / thread-transport work. All confirmed by a verify pass; tests green.

- **A2A allow_from gate bypass (security)** — `sender_bare != ref.owner` short-circuits to `False` when both are `None`, passing anonymous senders through a non-empty allowlist. Fixed with `not (ref.owner and sender_bare == ref.owner)`.
- **A2A replies escape task threads** — `_respond` hardcoded `episode='live'`, so replies to summons inside a task thread always landed in the room channel. Now inherits the incoming envelope's episode, falling back to live.
- **Thread-scoped await double-delivery** — `_commit` only advanced the episode cursor, leaving the room cursor behind. A subsequent room-wide await would re-deliver thread messages already served. Now also advances the room cursor on delivery in scoped mode.
- **`_raise_notice` used stale pre-write meta** — claimed/released/resolved notices could carry no episode URN when the write itself first minted one. `_raise_notice` now re-reads from disk instead of taking a meta parameter.
- **`bound_episodes` 1000-file cap** — `list_memory_files` default limit of 1000 caused rooms with >1000 memories to reject the first message to older task threads with 404. Widened `list_memory_files` to accept `limit=None`; `bound_episodes` passes it.
- **`backfill_room` concurrent-restart race** — two instances starting simultaneously could each mint a different URN for the same file, the second overwriting the first. Now acquires `fcntl.LOCK_EX` and re-checks under the lock before writing.
- **`_norm()` casefold vs lower divergence** — `tasks._norm` used `.casefold()` while `normalize_handle` used `.lower()`; non-ASCII handles would compare differently. Changed to `.lower()` to match the canonical form everywhere else.
- **Unregistered agent mentions silently dropped** — no operator visibility when an `@`-mention didn't resolve to a present or registered agent. `HumanPublishResult` now carries `unrecognized: list[str]`; the route logs a warning when non-empty.

## Test plan

- [ ] `cd fastapi-backend && uv run pytest tests/test_tasks.py tests/test_tasks_route.py tests/test_room_channels.py tests/test_a2a_responder.py tests/test_participate_await.py tests/test_thread_transport.py -x -q`
- [ ] `cd fastapi-backend && pnpm run lint`
- [ ] Verify A2A agent with `allow_from` set and no `owner` no longer admits anonymous senders
- [ ] Verify A2A reply to a task-thread summon lands in the thread, not the room channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)