### PR TITLE
Screenshots: room-channel slide instead of room-thread

### DIFF
--- a/mycelium-frontend/screenshots/shots.ts
+++ b/mycelium-frontend/screenshots/shots.ts
@@ -56,6 +56,13 @@ export interface Shot {
 
 export const SHOTS: Shot[] = [
   {
+    id: "room-channel",
+    route: "/room/atlas-migration",
+    theme: "dark",
+    viewport: "desktop",
+    caption: "The room channel: people and agents in one conversation, with the work narrated as it happens.",
+  },
+  {
     id: "room-board",
     route: "/room/atlas-migration",
     theme: "dark",
@@ -69,14 +76,6 @@ export const SHOTS: Shot[] = [
     theme: "dark",
     viewport: "desktop",
     caption: "A fresh, empty room — the starting state.",
-  },
-  {
-    id: "room-thread",
-    route: "/room/atlas-migration",
-    theme: "dark",
-    viewport: "desktop",
-    steps: ["Board", "flip reads behind a flag"],
-    caption: "A task and its thread: the row, its markdown, and the conversation working it out — people and agents in one place.",
   },
   {
     id: "room-memory",

--- a/mycelium-frontend/screenshots/targets.ts
+++ b/mycelium-frontend/screenshots/targets.ts
@@ -43,12 +43,12 @@ export interface Target {
  * but not published (useful while iterating on a new fixture).
  */
 export const TARGETS: Record<string, Target[]> = {
+  "room-channel": [{ dir: SPLASH_DIR, name: "app-channel", retina: true }],
   "room-board": [
     { dir: DOCS_DIR, name: "app-room-board", retina: true },
     { dir: SPLASH_DIR, name: "app-hero", retina: true },
   ],
   "room-empty": [{ dir: DOCS_DIR, name: "app-room-empty", retina: true }],
-  "room-thread": [{ dir: SPLASH_DIR, name: "app-thread", retina: true }],
   "room-memory": [{ dir: SPLASH_DIR, name: "app-memory", retina: true }],
   "room-network": [{ dir: SPLASH_DIR, name: "app-network", retina: true }],
 };


### PR DESCRIPTION
Follow-up to #914. The `room-thread` shot put a mock task title front-and-center on the splash. Replace it with `room-channel` (the room's default channel view), so `pnpm screenshots` publishes `app-channel` and the splash carousel reads **Channel / Board / Memory / Network**. The splash repo (`mycelium-io.github.io`) is already updated to match.