### PR TITLE
Extract the message summarizer out of event-stream.tsx

### DIFF
--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -10,7 +10,8 @@ import {
   logFetchError,
 } from "@/lib/api";
 import { useRoomAgents, useRoomRowNames, useRoomThreads, type RowNaming, type ThreadOwner } from "@/lib/room-data";
-import { NOTICE_TYPE, PING_TYPE, isLiveEpisode, noticeLabel, noticeOf, pingOf, threadShortId } from "@/lib/threads";
+import { NOTICE_TYPE, PING_TYPE, isLiveEpisode, noticeLabel, threadShortId } from "@/lib/threads";
+import { CHAT_TYPES, parseEvent, type Event } from "@/lib/room-events";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
 import { MarkdownContent } from "@/components/markdown-content";
 import { ChatFindBar } from "@/components/chat-find-bar";
@@ -31,41 +32,6 @@ import { Monogram } from "@/components/ui/monogram";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { ArrowDown, Bot, Loader2, MessageSquare, MessagesSquare } from "lucide-react";
-
-interface Event {
-  /** Render key only — synthesized, so a message republished by a status
-   *  transition can't collide with the row it updates. */
-  id: string;
-  /** The backend's id for this message, where it has one. Stable across reads
-   *  (the transcript derives it from the envelope id), which is what a search
-   *  result points at. */
-  messageId: string | null;
-  type: string;
-  content: string;
-  sender: string;
-  recipient: string | null;
-  time: string;
-  /** The full stamp, for ordering two reads into one feed. */
-  at: string;
-  // The L9 episode URN this event belongs to, when it rode one. Negotiation
-  // turns share their mediator's episode; casual chat carries the room default
-  // or none. Lets the feed group/fold one negotiation's turns together.
-  episode: string | null;
-  /** The id of the message this one revises, when it is an amendment. The feed
-   *  folds it into that message rather than showing it as a row of its own. */
-  amends: string | null;
-  /** True once an amendment has revised this message's text. */
-  edited: boolean;
-  /** The thread a **ping** is about — never the episode the ping itself rode,
-   *  which is the room. Null on everything that is not a ping. */
-  thread: string | null;
-  /** Who wrote in the thread, on a ping. The row's own sender is the system
-   *  that raised it, which is nobody, so the writer is read from the payload. */
-  pingSenders: string[];
-  raw: Record<string, unknown>;
-}
-
-const CHAT_TYPES = new Set(["broadcast", "direct", "announce", "delegate"]);
 
 /** Stable empties: find writes these back on every close, and a fresh array
  *  each time would re-run the effects that read them. */
@@ -170,199 +136,6 @@ function SystemNotice({
       </span>
     </div>
   );
-}
-
-function parseEvent(msg: Record<string, unknown>, room: string): Event {
-  let mtype = (msg.message_type as string) || (msg.type as string) || "unknown";
-  const sender = (msg.sender_handle as string) || (msg.updated_by as string) || "?";
-  const recipient = (msg.recipient_handle as string) || null;
-  const created = (msg.created_at as string) || new Date().toISOString();
-  const time = created.slice(11, 19);
-
-  let content = "";
-  let raw: Record<string, unknown> = {};
-  let thread: string | null = null;
-  let pingSender: string | null = null;
-
-  try {
-    if (typeof msg.content === "string") {
-      // Chat messages carry a plain string in content; coordination events
-      // carry a JSON blob. Try to parse, fall back to the raw string.
-      if (CHAT_TYPES.has(mtype)) {
-        raw = { text: msg.content };
-      } else {
-        raw = JSON.parse(msg.content);
-      }
-    } else if (msg.content) {
-      raw = msg.content as Record<string, unknown>;
-    } else {
-      raw = msg;
-    }
-  } catch {
-    raw = CHAT_TYPES.has(mtype) ? { text: msg.content } : msg;
-  }
-
-  switch (mtype) {
-    case "broadcast":
-    case "direct":
-    case "announce":
-    case "delegate":
-      content = (raw.text as string) || (msg.content as string) || "";
-      break;
-    case "coordination_join": {
-      const handle = (raw.handle as string) || sender;
-      const intent = raw.intent as string;
-      content = `${handle} joined${intent ? `: ${intent}` : ""}`;
-      break;
-    }
-    case "coordination_start":
-      content = `Episode started with ${raw.agent_count || "?"} agents`;
-      break;
-    case "coordination_tick": {
-      // Ticks wrap their fields under .payload
-      const tick = (raw.payload as Record<string, unknown>) || raw;
-      const round = tick.round ?? "?";
-      const action = tick.action ?? "tick";
-      const participant = tick.participant_id ?? "?";
-      content = `Round ${round}: ${participant} → ${action}`;
-      if (tick.current_offer) content += ` ${JSON.stringify(tick.current_offer)}`;
-      break;
-    }
-    case "coordination_consensus": {
-      const broken = raw.broken === true;
-      const assignments = raw.assignments as Record<string, string>;
-      const tasks = Array.isArray(raw.tasks) ? (raw.tasks as string[]) : [];
-      content = "";
-      if (assignments) content += Object.entries(assignments).map(([k, v]) => `${k}=${v}`).join(", ");
-      // Consensus isn't the end; it compiles into work the room can pick up.
-      if (!broken && tasks.length) {
-        content += ` · compiled → ${tasks.length} ${tasks.length === 1 ? "row" : "rows"}`;
-      }
-      {
-        const metrics = raw.metrics as Record<string, unknown> | undefined;
-        const gar = metrics && typeof metrics === "object" ? metrics.gar : undefined;
-        if (typeof gar === "number" && Number.isFinite(gar)) content += ` · GAR ${gar.toFixed(2)}`;
-      }
-      break;
-    }
-    case "memory_changed": {
-      const key = (raw.key || msg.key) as string;
-      const version = (raw.version || msg.version) as number;
-      const by = (raw.updated_by || msg.updated_by) as string;
-      content = `${key} v${version} by ${by}`;
-      break;
-    }
-    case "l9_exchange": {
-      // A ping rides the exchange kind like everything else, so it has to be
-      // recognised before the prose unwrap below — which would otherwise turn
-      // it into an empty chat row from `system`, the one shape a thread exists
-      // to keep out of the room.
-      const ping = pingOf(raw);
-      if (ping) {
-        thread = ping.episode;
-        pingSender = ping.sender;
-        mtype = PING_TYPE;
-        break;
-      }
-      // A board event — a task filed, claimed, handed back, resolved — rides the
-      // same exchange kind, named before the prose unwrap for the same reason a
-      // ping is: it is a notice about the board, not a chat row. `thread` holds
-      // the task's own thread to open.
-      const notice = noticeOf(raw);
-      if (notice) {
-        thread = notice.episode;
-        content = notice.title ?? notice.key;
-        mtype = NOTICE_TYPE;
-        raw = { ...raw, taskKey: notice.key, by: notice.by, kind: notice.kind, subkind: notice.subkind, for: notice.assignee };
-        break;
-      }
-      // The live SSE stream wraps human/agent messages as an L9 exchange
-      // envelope, while the REST snapshot (loaded on mount/refresh) delivers the
-      // same message as a plain "broadcast". Unwrap the prose and normalise to
-      // the chat shape so the live feed matches a refresh instead of silently
-      // dropping the message.
-      content = (raw.content as string) || "";
-      mtype = recipient ? "direct" : "broadcast";
-      break;
-    }
-    case "l9_commit": {
-      // Unwrap the L9 commit envelope into the coordination_consensus shape
-      // the channel notice row and the L9 inspector both read.
-      const l9env = (raw.l9 as Record<string, unknown> | undefined) ?? {};
-      const header = (l9env.header as Record<string, unknown> | undefined) ?? {};
-      const payload = (l9env.payload as Record<string, unknown> | undefined) ?? {};
-      const data = (payload.data as Record<string, unknown> | undefined) ?? {};
-      const message = header.message as Record<string, unknown> | undefined;
-      content = (raw.content as string) || "";
-      raw = {
-        ...raw,
-        broken: header.subkind !== "converged",
-        assignments: data.assignments,
-        metrics: data.metrics,
-        episode: message?.episode,
-      };
-      mtype = "coordination_consensus";
-      break;
-    }
-    case "l9_knowledge": {
-      // A memory push (e.g. a compiled task landing in the room) rides as
-      // an L9 "knowledge" envelope. Recognized as its own system notice rather
-      // than falling to the unhandled-type fallback.
-      const l9env = (raw.l9 as Record<string, unknown> | undefined) ?? {};
-      const payload = (l9env.payload as Record<string, unknown> | undefined) ?? {};
-      const data = (payload.data as Record<string, unknown> | undefined) ?? {};
-      content = (raw.content as string) || `${(data.key as string) ?? "memory"} updated`;
-      raw = { ...raw, key: data.key, updated_by: data.updated_by, version: data.version };
-      break;
-    }
-    default:
-      // A message type nothing above handles would otherwise vanish from the
-      // channel view without a trace (exactly how l9_exchange hid). Surface it
-      // loudly so an unsupported/renamed type can't fail silently again.
-      console.warn(
-        `[mycelium] EventStream: unhandled message_type "${mtype}" — ` +
-          "rendered as a raw fallback and likely hidden from the channel view",
-        msg,
-      );
-      content = (msg.content as string) || JSON.stringify(msg).slice(0, 100);
-  }
-
-  const episode =
-    (msg.episode as string) ||
-    ((raw.header as Record<string, unknown> | undefined)?.message as
-      | Record<string, unknown>
-      | undefined)?.episode as string ||
-    null;
-
-  // An amendment names the message it revises: over SSE that's the L9 envelope's
-  // subkind + parents, on the REST snapshot the backend has already folded it and
-  // only the `edited_at` stamp survives.
-  const l9header = ((raw.l9 as Record<string, unknown> | undefined)?.header ??
-    {}) as Record<string, unknown>;
-  const parents = (l9header.message as Record<string, unknown> | undefined)?.parents;
-  const amends =
-    l9header.subkind === "amend" && Array.isArray(parents) && typeof parents[0] === "string"
-      ? (parents[0] as string)
-      : typeof msg.amends === "string"
-        ? msg.amends
-        : null;
-
-  return {
-    id: `${Date.now()}-${Math.random()}`,
-    messageId: typeof msg.id === "string" ? msg.id : null,
-    type: mtype,
-    content,
-    sender,
-    recipient,
-    time,
-    at: created,
-    episode,
-    amends,
-    edited: typeof msg.edited_at === "string",
-    thread,
-    pingSenders: pingSender ? [pingSender] : [],
-    raw,
-  };
 }
 
 /**
@@ -646,9 +419,9 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
         fetchMessages(roomName, CHANNEL_PAGE, { before }),
         fetchL9History(roomName, CHANNEL_PAGE, before),
       ]);
-      const said = (data.messages || []).map((m) => parseEvent(m, roomName));
+      const said = (data.messages || []).map((m) => parseEvent(m));
       const notices = frames
-        .map((frame) => parseEvent(frame, roomName))
+        .map((frame) => parseEvent(frame))
         .filter((e) => e.type === PING_TYPE || e.type === NOTICE_TYPE);
       // `total` counts everything older than the cursor, so a page shorter than
       // it is the honest end of the prose. The replay carries no such count, so
@@ -717,7 +490,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
   // Live room messages, off the app's one multiplexed connection.
   useRoomStream(roomName, (data) => {
     const msg = data as Record<string, unknown>;
-    const event = parseEvent(msg, roomName);
+    const event = parseEvent(msg);
     setEvents(prev => (event.amends ? foldAmendment(prev, event) : [...prev, event]));
     if (event.type === "memory_changed") onMemoryChanged?.();
     // A consensus compiles the negotiation into work rows, so nudge the

--- a/mycelium-frontend/src/components/l9-inspector.tsx
+++ b/mycelium-frontend/src/components/l9-inspector.tsx
@@ -26,6 +26,7 @@ import {
   type L9Envelope,
 } from "@/lib/api";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
+import { unwrapContent } from "@/lib/room-events";
 
 // The L9 protocol inspector renders the AOP layer legibly: the live L9 payloads
 // crossing a room's channel (exchange ticks/replies, commit verdicts with
@@ -99,16 +100,7 @@ export function toL9Frame(msg: Record<string, unknown>): L9Frame | null {
   const created = String(msg.created_at ?? "");
   const time = created.length >= 19 ? created.slice(11, 19) : "";
 
-  let content: Record<string, unknown> = {};
-  if (typeof msg.content === "string") {
-    try {
-      content = JSON.parse(msg.content);
-    } catch {
-      content = {};
-    }
-  } else {
-    content = asRecord(msg.content);
-  }
+  const content = unwrapContent(msg);
 
   // The envelope may be embedded under `l9`, OR be the content itself (the
   // persister feeds the bus a bare `{header, payload}` envelope as `l9_<kind>`),

--- a/mycelium-frontend/src/lib/board/activity.test.ts
+++ b/mycelium-frontend/src/lib/board/activity.test.ts
@@ -115,7 +115,9 @@ describe("projectActivity", () => {
         },
       ],
     });
-    expect(events[0]).toMatchObject({ action: "negotiated", title: "round 4 · @risk accept" });
+    // The line is the shared summarizer's (lib/room-events.ts): the log adopts
+    // what the channel would print rather than deriving its own.
+    expect(events[0]).toMatchObject({ action: "negotiated", title: "Round 4: risk → accept" });
     expect(events[0].title).not.toContain("{");
   });
 

--- a/mycelium-frontend/src/lib/board/activity.ts
+++ b/mycelium-frontend/src/lib/board/activity.ts
@@ -16,7 +16,7 @@
 
 import type { EpisodeSummary, Memory, RoomMessage } from "@/lib/api";
 import { memoryHref } from "@/lib/memory-routes";
-import { parseJsonRawText } from "@/lib/json-text";
+import { CHAT_TYPES, parseEvent } from "@/lib/room-events";
 
 export type ActorKind = "agent" | "engine" | "human";
 
@@ -177,7 +177,7 @@ export function projectActivity(input: ActivityInput): ActivityEvent[] {
     const actor = (message.sender_handle ?? "").replace(/^@/, "");
     const type = (message.message_type ?? message.type ?? "") as string;
     if (!actor || !message.created_at || SKIP_TYPES.has(type)) continue;
-    const said = describe(type, message.content);
+    const said = describe(type, message);
     if (!said) continue;
     push({
       id: `msg:${message.id ?? i}`,
@@ -331,8 +331,6 @@ export function digest(days: Map<DayKey, ActivityEvent[]>, from: DayKey, to: Day
 /** How full today's log is. A target to fill, not a quota anyone is held to. */
 export const DAILY_GOAL = 6;
 
-const CHAT_TYPES = new Set(["broadcast", "direct", "announce", "delegate"]);
-
 /**
  * Facts the log reads from a truer source than the wire.
  *
@@ -347,32 +345,28 @@ const SKIP_TYPES = new Set([
 ]);
 
 /**
- * What a message says, in the log's terms. Coordination payloads are JSON on
- * the wire, so they're read by type rather than printed — a log line is who did
- * what, not the envelope they did it in.
+ * What a message says, in the log's terms. The envelope unwrap and the per-type
+ * line live in parseEvent — shared with the channel, so a coordination payload
+ * can never reach the log as printed JSON again. What stays here is the log's
+ * own ledger vocabulary: a past-tense verb per type, and a title shaped for a
+ * ledger row rather than for the conversation.
  */
-function describe(type: string, content: unknown): { action: string; title: string } | null {
+function describe(type: string, message: RoomMessage): { action: string; title: string } | null {
   if (CHAT_TYPES.has(type)) {
-    const text = typeof content === "string" ? content : "";
+    const text = parseEvent(message).content;
     return { action: "posted", title: firstLine(text) || "a message" };
   }
   if (!type.startsWith("coordination_")) return null;
 
-  const raw =
-    typeof content === "string"
-      ? ((parseJsonRawText(content) as Record<string, unknown> | null) ?? {})
-      : ((content as Record<string, unknown>) ?? {});
-
   if (type === "coordination_tick") {
-    const tick = (raw.payload as Record<string, unknown>) ?? raw;
-    const round = tick.round ?? "?";
-    const who = tick.participant_id ? `@${tick.participant_id}` : "a participant";
-    return { action: "negotiated", title: `round ${round} · ${who} ${tick.action ?? "replied"}` };
+    return { action: "negotiated", title: parseEvent(message).content };
   }
   if (type === "coordination_join") {
+    const { raw } = parseEvent(message);
     return { action: "joined", title: String(raw.intent ?? "the episode") };
   }
   if (type === "coordination_start") {
+    const { raw } = parseEvent(message);
     return { action: "opened", title: `an episode with ${raw.agent_count ?? "?"} agents` };
   }
   return { action: type.replace("coordination_", ""), title: "" };

--- a/mycelium-frontend/src/lib/notifications.ts
+++ b/mycelium-frontend/src/lib/notifications.ts
@@ -7,6 +7,8 @@
 // Framework-agnostic on purpose — `notifications-provider.tsx` is the only
 // React-aware consumer, so this stays unit-testable without rendering.
 
+import { unwrapContent } from "@/lib/room-events";
+
 export type NotificationKind = "mention" | "direct" | "consensus" | "knowledge" | "join" | "message";
 
 export interface ClassifiedNotification {
@@ -105,13 +107,7 @@ export function classify(raw: Record<string, unknown>, principal: string): Class
   const id = (raw.id as string) || `${room}:${mtype}:${time}:${sender}`;
   const handle = principal.trim().replace(/^@/, "").toLowerCase();
 
-  let content: Record<string, unknown> = {};
-  try {
-    if (typeof raw.content === "string") content = JSON.parse(raw.content);
-    else if (raw.content && typeof raw.content === "object") content = raw.content as Record<string, unknown>;
-  } catch {
-    content = {};
-  }
+  const content = unwrapContent(raw);
 
   switch (mtype) {
     case "l9_exchange": {

--- a/mycelium-frontend/src/lib/room-events.test.ts
+++ b/mycelium-frontend/src/lib/room-events.test.ts
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it, vi } from "vitest";
+import { parseEvent, unwrapContent } from "@/lib/room-events";
+import { NOTICE_TYPE, PING_TYPE } from "@/lib/threads";
+
+const CREATED = "2026-08-04T10:00:00.000000+00:00";
+
+describe("unwrapContent", () => {
+  it("wraps a chat message's plain string as {text} instead of parsing it", () => {
+    expect(unwrapContent({ message_type: "broadcast", content: "hello room" })).toEqual({
+      text: "hello room",
+    });
+  });
+
+  it("parses a coordination event's JSON blob", () => {
+    expect(
+      unwrapContent({ message_type: "coordination_join", content: '{"handle":"growth"}' }),
+    ).toEqual({ handle: "growth" });
+  });
+
+  it("passes an object content through", () => {
+    const content = { round: 2 };
+    expect(unwrapContent({ message_type: "coordination_tick", content })).toBe(content);
+  });
+
+  it("treats the message itself as the payload when there is no content", () => {
+    // Route-level events carry their fields flat on the message.
+    const msg = { message_type: "memory_changed", key: "decisions/scope", version: 3 };
+    expect(unwrapContent(msg)).toBe(msg);
+  });
+
+  it("falls back rather than throwing on a malformed blob", () => {
+    const msg = { message_type: "l9_exchange", content: "{not json" };
+    expect(unwrapContent(msg)).toBe(msg);
+  });
+
+  it("keeps the raw string on a chat type even when it looks like JSON", () => {
+    expect(unwrapContent({ message_type: "direct", content: '{"a":1}' })).toEqual({
+      text: '{"a":1}',
+    });
+  });
+});
+
+describe("parseEvent", () => {
+  it("reads a chat message straight through", () => {
+    const ev = parseEvent({
+      id: "m1",
+      message_type: "direct",
+      sender_handle: "growth",
+      recipient_handle: "risk",
+      content: "cut over tonight?",
+      created_at: CREATED,
+    });
+    expect(ev).toMatchObject({
+      messageId: "m1",
+      type: "direct",
+      content: "cut over tonight?",
+      sender: "growth",
+      recipient: "risk",
+      time: CREATED.slice(11, 19),
+      at: CREATED,
+      episode: null,
+      amends: null,
+      edited: false,
+      thread: null,
+      pingSenders: [],
+    });
+  });
+
+  it("reads a tick's fields out of the nested payload", () => {
+    const ev = parseEvent({
+      message_type: "coordination_tick",
+      sender_handle: "aligner",
+      content: JSON.stringify({
+        payload: { round: 4, participant_id: "risk", action: "accept", current_offer: { window: "night" } },
+      }),
+      created_at: CREATED,
+    });
+    expect(ev.type).toBe("coordination_tick");
+    expect(ev.content).toBe('Round 4: risk → accept {"window":"night"}');
+  });
+
+  it("renders a join with its intent", () => {
+    const ev = parseEvent({
+      message_type: "coordination_join",
+      sender_handle: "growth",
+      content: JSON.stringify({ handle: "growth", intent: "argue for the phased cutover" }),
+      created_at: CREATED,
+    });
+    expect(ev.content).toBe("growth joined: argue for the phased cutover");
+  });
+
+  it("summarizes a consensus with assignments, compiled rows and GAR", () => {
+    const ev = parseEvent({
+      message_type: "coordination_consensus",
+      sender_handle: "aligner",
+      content: JSON.stringify({
+        assignments: { cutover: "phased", owner: "growth" },
+        tasks: ["t1", "t2"],
+        metrics: { gar: 1 },
+      }),
+      created_at: CREATED,
+    });
+    expect(ev.content).toBe("cutover=phased, owner=growth · compiled → 2 rows · GAR 1.00");
+  });
+
+  it("reads memory_changed fields from the message itself when there is no content", () => {
+    const ev = parseEvent({
+      message_type: "memory_changed",
+      key: "decisions/scope",
+      version: 3,
+      updated_by: "aligner",
+      created_at: CREATED,
+    });
+    expect(ev.content).toBe("decisions/scope v3 by aligner");
+  });
+
+  it("unwraps a live l9_exchange back into the chat shape a refresh would show", () => {
+    const ev = parseEvent({
+      message_type: "l9_exchange",
+      sender_handle: "growth",
+      content: JSON.stringify({ content: "dual-write is live" }),
+      created_at: CREATED,
+    });
+    expect(ev.type).toBe("broadcast");
+    expect(ev.content).toBe("dual-write is live");
+  });
+
+  it("names a ping for its thread and writer, not the system that raised it", () => {
+    const ev = parseEvent({
+      message_type: "l9_exchange",
+      sender_handle: "system",
+      content: JSON.stringify({
+        l9: { payload: { type: "ping", data: { episode: "urn:ioc:mycelium:episode:atlas:abc123", sender: "growth", message: "m9" } } },
+      }),
+      created_at: CREATED,
+    });
+    expect(ev.type).toBe(PING_TYPE);
+    expect(ev.thread).toBe("urn:ioc:mycelium:episode:atlas:abc123");
+    expect(ev.pingSenders).toEqual(["growth"]);
+  });
+
+  it("reads a board notice as a notice, with the task's thread to open", () => {
+    const ev = parseEvent({
+      message_type: "l9_exchange",
+      sender_handle: "system",
+      content: JSON.stringify({
+        l9: {
+          payload: {
+            type: "notice",
+            data: {
+              key: "work/cache-sweep",
+              subkind: "resolved",
+              title: "cache sweep",
+              episode: "urn:ioc:mycelium:episode:atlas:t1",
+              by: "growth",
+            },
+          },
+        },
+      }),
+      created_at: CREATED,
+    });
+    expect(ev.type).toBe(NOTICE_TYPE);
+    expect(ev.content).toBe("cache sweep");
+    expect(ev.thread).toBe("urn:ioc:mycelium:episode:atlas:t1");
+    expect(ev.raw.taskKey).toBe("work/cache-sweep");
+    expect(ev.raw.by).toBe("growth");
+  });
+
+  it("normalizes an l9_commit into the coordination_consensus shape", () => {
+    const ev = parseEvent({
+      message_type: "l9_commit",
+      sender_handle: "aligner",
+      content: JSON.stringify({
+        l9: {
+          header: { subkind: "converged", message: { episode: "urn:e:s1" } },
+          payload: { data: { assignments: { scope: "mvp" }, metrics: { gar: 0.5 } } },
+        },
+      }),
+      created_at: CREATED,
+    });
+    expect(ev.type).toBe("coordination_consensus");
+    expect(ev.raw.broken).toBe(false);
+    expect(ev.raw.assignments).toEqual({ scope: "mvp" });
+    expect(ev.raw.metrics).toEqual({ gar: 0.5 });
+    expect(ev.raw.episode).toBe("urn:e:s1");
+  });
+
+  it("marks a non-converged commit as broken", () => {
+    const ev = parseEvent({
+      message_type: "l9_commit",
+      sender_handle: "aligner",
+      content: JSON.stringify({ l9: { header: { subkind: "rejected" } } }),
+      created_at: CREATED,
+    });
+    expect(ev.raw.broken).toBe(true);
+  });
+
+  it("reads an l9_knowledge push as its own notice with the memory fields kept", () => {
+    const ev = parseEvent({
+      message_type: "l9_knowledge",
+      sender_handle: "synthesizer",
+      content: JSON.stringify({
+        l9: { payload: { data: { key: "context/synthesis", updated_by: "synthesizer", version: 2 } } },
+      }),
+      created_at: CREATED,
+    });
+    expect(ev.type).toBe("l9_knowledge");
+    expect(ev.content).toBe("context/synthesis updated");
+    expect(ev.raw.key).toBe("context/synthesis");
+    expect(ev.raw.version).toBe(2);
+  });
+
+  it("reads the episode off the message or the envelope header", () => {
+    expect(
+      parseEvent({ message_type: "broadcast", sender_handle: "a", content: "hi", episode: "urn:e:1" }).episode,
+    ).toBe("urn:e:1");
+    expect(
+      parseEvent({
+        message_type: "l9_exchange",
+        sender_handle: "a",
+        content: JSON.stringify({ content: "hi", header: { message: { episode: "urn:e:2" } } }),
+      }).episode,
+    ).toBe("urn:e:2");
+    expect(parseEvent({ message_type: "broadcast", sender_handle: "a", content: "hi" }).episode).toBeNull();
+  });
+
+  it("reads an amendment's target off the L9 header, and a folded edit off edited_at", () => {
+    const amendment = parseEvent({
+      message_type: "l9_exchange",
+      sender_handle: "growth",
+      content: JSON.stringify({
+        content: "actually, Friday",
+        l9: { header: { subkind: "amend", message: { parents: ["m42"] } } },
+      }),
+      created_at: CREATED,
+    });
+    expect(amendment.amends).toBe("m42");
+
+    const folded = parseEvent({
+      message_type: "broadcast",
+      sender_handle: "growth",
+      content: "actually, Friday",
+      edited_at: CREATED,
+    });
+    expect(folded.amends).toBeNull();
+    expect(folded.edited).toBe(true);
+  });
+
+  it("warns loudly on an unhandled type rather than dropping it silently", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const ev = parseEvent({
+        message_type: "a_future_type",
+        sender_handle: "growth",
+        content: "the future",
+        created_at: CREATED,
+      });
+      expect(ev.content).toBe("the future");
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0][0]).toContain("a_future_type");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/mycelium-frontend/src/lib/room-events.ts
+++ b/mycelium-frontend/src/lib/room-events.ts
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * What a room message says, in a line.
+ *
+ * Every surface that renders a room message as prose — the channel feed, the
+ * board's daily log — reads it through {@link parseEvent}, and every surface
+ * that needs the parsed envelope without the prose (the notification
+ * classifier, the L9 inspector) shares {@link unwrapContent}, the
+ * parse-and-fall-back preamble: content may be a JSON string or an object,
+ * the payload may be nested under `.payload`, fall back rather than throw.
+ * A change to a payload's shape lands here once, not once per surface.
+ */
+
+import { NOTICE_TYPE, PING_TYPE, noticeOf, pingOf } from "@/lib/threads";
+
+export interface Event {
+  /** Render key only — synthesized, so a message republished by a status
+   *  transition can't collide with the row it updates. */
+  id: string;
+  /** The backend's id for this message, where it has one. Stable across reads
+   *  (the transcript derives it from the envelope id), which is what a search
+   *  result points at. */
+  messageId: string | null;
+  type: string;
+  content: string;
+  sender: string;
+  recipient: string | null;
+  time: string;
+  /** The full stamp, for ordering two reads into one feed. */
+  at: string;
+  // The L9 episode URN this event belongs to, when it rode one. Negotiation
+  // turns share their mediator's episode; casual chat carries the room default
+  // or none. Lets the feed group/fold one negotiation's turns together.
+  episode: string | null;
+  /** The id of the message this one revises, when it is an amendment. The feed
+   *  folds it into that message rather than showing it as a row of its own. */
+  amends: string | null;
+  /** True once an amendment has revised this message's text. */
+  edited: boolean;
+  /** The thread a **ping** is about — never the episode the ping itself rode,
+   *  which is the room. Null on everything that is not a ping. */
+  thread: string | null;
+  /** Who wrote in the thread, on a ping. The row's own sender is the system
+   *  that raised it, which is nobody, so the writer is read from the payload. */
+  pingSenders: string[];
+  raw: Record<string, unknown>;
+}
+
+export const CHAT_TYPES = new Set(["broadcast", "direct", "announce", "delegate"]);
+
+const messageType = (msg: Record<string, unknown>): string =>
+  (msg.message_type as string) || (msg.type as string) || "unknown";
+
+/**
+ * The envelope a wire message carries, unwrapped.
+ *
+ * Chat messages carry a plain string in `content` (returned as `{text}` — the
+ * shape the chat branches read); coordination events carry a JSON blob, as a
+ * string or already an object. Nothing to unwrap means the message itself is
+ * the payload (route-level events carry their fields flat), and an unparseable
+ * blob falls back the same way rather than throwing — a reader never fails
+ * because one frame was malformed.
+ */
+export function unwrapContent(msg: Record<string, unknown>): Record<string, unknown> {
+  const mtype = messageType(msg);
+  try {
+    if (typeof msg.content === "string") {
+      if (CHAT_TYPES.has(mtype)) return { text: msg.content };
+      return JSON.parse(msg.content) as Record<string, unknown>;
+    }
+    if (msg.content) return msg.content as Record<string, unknown>;
+    return msg;
+  } catch {
+    return CHAT_TYPES.has(mtype) ? { text: msg.content } : msg;
+  }
+}
+
+export function parseEvent(msg: Record<string, unknown>): Event {
+  let mtype = messageType(msg);
+  const sender = (msg.sender_handle as string) || (msg.updated_by as string) || "?";
+  const recipient = (msg.recipient_handle as string) || null;
+  const created = (msg.created_at as string) || new Date().toISOString();
+  const time = created.slice(11, 19);
+
+  let content = "";
+  let raw = unwrapContent(msg);
+  let thread: string | null = null;
+  let pingSender: string | null = null;
+
+  switch (mtype) {
+    case "broadcast":
+    case "direct":
+    case "announce":
+    case "delegate":
+      content = (raw.text as string) || (msg.content as string) || "";
+      break;
+    case "coordination_join": {
+      const handle = (raw.handle as string) || sender;
+      const intent = raw.intent as string;
+      content = `${handle} joined${intent ? `: ${intent}` : ""}`;
+      break;
+    }
+    case "coordination_start":
+      content = `Episode started with ${raw.agent_count || "?"} agents`;
+      break;
+    case "coordination_tick": {
+      // Ticks wrap their fields under .payload
+      const tick = (raw.payload as Record<string, unknown>) || raw;
+      const round = tick.round ?? "?";
+      const action = tick.action ?? "tick";
+      const participant = tick.participant_id ?? "?";
+      content = `Round ${round}: ${participant} → ${action}`;
+      if (tick.current_offer) content += ` ${JSON.stringify(tick.current_offer)}`;
+      break;
+    }
+    case "coordination_consensus": {
+      const broken = raw.broken === true;
+      const assignments = raw.assignments as Record<string, string>;
+      const tasks = Array.isArray(raw.tasks) ? (raw.tasks as string[]) : [];
+      content = "";
+      if (assignments) content += Object.entries(assignments).map(([k, v]) => `${k}=${v}`).join(", ");
+      // Consensus isn't the end; it compiles into work the room can pick up.
+      if (!broken && tasks.length) {
+        content += ` · compiled → ${tasks.length} ${tasks.length === 1 ? "row" : "rows"}`;
+      }
+      {
+        const metrics = raw.metrics as Record<string, unknown> | undefined;
+        const gar = metrics && typeof metrics === "object" ? metrics.gar : undefined;
+        if (typeof gar === "number" && Number.isFinite(gar)) content += ` · GAR ${gar.toFixed(2)}`;
+      }
+      break;
+    }
+    case "memory_changed": {
+      const key = (raw.key || msg.key) as string;
+      const version = (raw.version || msg.version) as number;
+      const by = (raw.updated_by || msg.updated_by) as string;
+      content = `${key} v${version} by ${by}`;
+      break;
+    }
+    case "l9_exchange": {
+      // A ping rides the exchange kind like everything else, so it has to be
+      // recognised before the prose unwrap below — which would otherwise turn
+      // it into an empty chat row from `system`, the one shape a thread exists
+      // to keep out of the room.
+      const ping = pingOf(raw);
+      if (ping) {
+        thread = ping.episode;
+        pingSender = ping.sender;
+        mtype = PING_TYPE;
+        break;
+      }
+      // A board event — a task filed, claimed, handed back, resolved — rides the
+      // same exchange kind, named before the prose unwrap for the same reason a
+      // ping is: it is a notice about the board, not a chat row. `thread` holds
+      // the task's own thread to open.
+      const notice = noticeOf(raw);
+      if (notice) {
+        thread = notice.episode;
+        content = notice.title ?? notice.key;
+        mtype = NOTICE_TYPE;
+        raw = { ...raw, taskKey: notice.key, by: notice.by, kind: notice.kind, subkind: notice.subkind, for: notice.assignee };
+        break;
+      }
+      // The live SSE stream wraps human/agent messages as an L9 exchange
+      // envelope, while the REST snapshot (loaded on mount/refresh) delivers the
+      // same message as a plain "broadcast". Unwrap the prose and normalise to
+      // the chat shape so the live feed matches a refresh instead of silently
+      // dropping the message.
+      content = (raw.content as string) || "";
+      mtype = recipient ? "direct" : "broadcast";
+      break;
+    }
+    case "l9_commit": {
+      // Unwrap the L9 commit envelope into the coordination_consensus shape
+      // the channel notice row and the L9 inspector both read.
+      const l9env = (raw.l9 as Record<string, unknown> | undefined) ?? {};
+      const header = (l9env.header as Record<string, unknown> | undefined) ?? {};
+      const payload = (l9env.payload as Record<string, unknown> | undefined) ?? {};
+      const data = (payload.data as Record<string, unknown> | undefined) ?? {};
+      const message = header.message as Record<string, unknown> | undefined;
+      content = (raw.content as string) || "";
+      raw = {
+        ...raw,
+        broken: header.subkind !== "converged",
+        assignments: data.assignments,
+        metrics: data.metrics,
+        episode: message?.episode,
+      };
+      mtype = "coordination_consensus";
+      break;
+    }
+    case "l9_knowledge": {
+      // A memory push (e.g. a compiled task landing in the room) rides as
+      // an L9 "knowledge" envelope. Recognized as its own system notice rather
+      // than falling to the unhandled-type fallback.
+      const l9env = (raw.l9 as Record<string, unknown> | undefined) ?? {};
+      const payload = (l9env.payload as Record<string, unknown> | undefined) ?? {};
+      const data = (payload.data as Record<string, unknown> | undefined) ?? {};
+      content = (raw.content as string) || `${(data.key as string) ?? "memory"} updated`;
+      raw = { ...raw, key: data.key, updated_by: data.updated_by, version: data.version };
+      break;
+    }
+    default:
+      // A message type nothing above handles would otherwise vanish from the
+      // channel view without a trace (exactly how l9_exchange hid). Surface it
+      // loudly so an unsupported/renamed type can't fail silently again.
+      console.warn(
+        `[mycelium] EventStream: unhandled message_type "${mtype}" — ` +
+          "rendered as a raw fallback and likely hidden from the channel view",
+        msg,
+      );
+      content = (msg.content as string) || JSON.stringify(msg).slice(0, 100);
+  }
+
+  const episode =
+    (msg.episode as string) ||
+    ((raw.header as Record<string, unknown> | undefined)?.message as
+      | Record<string, unknown>
+      | undefined)?.episode as string ||
+    null;
+
+  // An amendment names the message it revises: over SSE that's the L9 envelope's
+  // subkind + parents, on the REST snapshot the backend has already folded it and
+  // only the `edited_at` stamp survives.
+  const l9header = ((raw.l9 as Record<string, unknown> | undefined)?.header ??
+    {}) as Record<string, unknown>;
+  const parents = (l9header.message as Record<string, unknown> | undefined)?.parents;
+  const amends =
+    l9header.subkind === "amend" && Array.isArray(parents) && typeof parents[0] === "string"
+      ? (parents[0] as string)
+      : typeof msg.amends === "string"
+        ? msg.amends
+        : null;
+
+  return {
+    id: `${Date.now()}-${Math.random()}`,
+    messageId: typeof msg.id === "string" ? msg.id : null,
+    type: mtype,
+    content,
+    sender,
+    recipient,
+    time,
+    at: created,
+    episode,
+    amends,
+    edited: typeof msg.edited_at === "string",
+    thread,
+    pingSenders: pingSender ? [pingSender] : [],
+    raw,
+  };
+}


### PR DESCRIPTION
## What

`parseEvent` — the frontend's one real answer to "what does this room message say, in a line" — lived module-private inside `event-stream.tsx`. Building the daily log (PR #752) needed exactly that, and unable to reach it, re-derived a subset whose first draft printed coordination payloads as raw JSON.

New **`src/lib/room-events.ts`** holds `parseEvent`, the `Event` type, `CHAT_TYPES`, and a small exported **`unwrapContent(msg)`** for the parse-and-fall-back step:

- **`event-stream.tsx`** imports both and keeps only rendering (−237 lines). `L9_RAISE_UP_TYPES` stays on the component, so the `l9-surface` contract test is untouched.
- **The board's log** (`lib/board/activity.ts`) drops `describe()`'s envelope unwrap and narrates from `parseEvent`. The log keeps its past-tense ledger verbs; a coordination payload can now structurally never reach it as printed JSON. A tick's log line becomes the channel's own line (`Round 4: risk → accept`) — one summarizer, both surfaces.
- **`notifications.classify`** and **`toL9Frame`** (l9-inspector) adopt `unwrapContent` and keep their own routing. The no-content fallback is the message itself rather than `{}`, so a bare frame's top-level `episode`/`key` fields are now reachable on those surfaces too.

Two things fall out, as the issue predicted: the summarizer is unit-testable on its own (new `room-events.test.ts`, 20 tests — it previously required mounting `EventStream`), and a new coordination type now has one place to be taught rather than four.

## Deviations from the issue text

- `parseEvent` shed its **dead `room` parameter** (verified unused — comments only). One place fewer to pass a room believing it affects parsing.

## Verification

- `pnpm test` — 828 tests / 68 files green (incl. the untouched `event-stream.contract.test.ts`)
- `pnpm lint` (`tsc --noEmit && eslint .`) clean; the one eslint warning is pre-existing in `use-viewport.ts`

Closes #759