### PR TITLE
Streamline agent onboarding

### DIFF
--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -3,31 +3,33 @@
 
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { Users } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { Check, ChevronDown, Users } from "lucide-react";
 import { createEngine, registerA2aAgent, type EngineKind, type PresenceMember } from "@/lib/api";
-import { useRoomRoster } from "@/lib/room-data";
+import { useNetworkStatus, useRoomRoster } from "@/lib/room-data";
+import { agentHandoffPrompt } from "@/lib/install";
 import { Button } from "@/components/ui/button";
 import { Chip } from "@/components/ui/chip";
+import { CopyAction } from "@/components/ui/copy-field";
 import { Input } from "@/components/ui/input";
 import { Monogram } from "@/components/ui/monogram";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip } from "@/components/ui/tooltip";
 import { useCurrentUser } from "@/components/current-user";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 
 interface Props {
   roomName: string;
-  /** One-shot request to open the Add dialog on its engines tab — how the
-   *  command palette reaches the invite form from anywhere in the room. */
+  /** One-shot request to open the engine invite form — how the command palette
+   * reaches it from anywhere in the room. */
   engineInvite?: boolean;
   onEngineInviteShown?: () => void;
   /** A handle to reveal, arrived at from search. The roster has no detail view,
@@ -66,10 +68,9 @@ function subtext(...parts: (string | null | undefined | false)[]): string {
  * visible. Humans and agents share the monogram avatar, told apart by tint
  * (muted for people, accent for agents).
  *
- * Engines (aligner / synthesizer / hello) can be invited from the Add dialog — they're
- * backend-owned, so registration is a pure manifest write. Agent registration /
- * teardown stay CLI-only: those have spoke-local side effects (resident session,
- * workspace assets) the hub can't perform. Use `mycelium agent create` / `rm`.
+ * Engines (aligner / synthesizer / hello) are backend-owned, so their separate
+ * invitation action is a pure manifest write. Coding-agent registration stays
+ * CLI-driven because it has spoke-local side effects the hub cannot perform.
  */
 export function AgentsPanel({
   roomName,
@@ -79,9 +80,18 @@ export function AgentsPanel({
   onFocusConsumed,
 }: Props) {
   const [mineOnly, setMineOnly] = useState(false);
-  const [addTab, setAddTab] = useState<"agents" | "engines" | "a2a">("agents");
-  const [addOpen, setAddOpen] = useState(false);
+  const [agentOpen, setAgentOpen] = useState(false);
+  const [engineOpen, setEngineOpen] = useState(false);
+  const [a2aOpen, setA2aOpen] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
   const { principal } = useCurrentUser();
+  const { network } = useNetworkStatus();
+  const noSubscribe = () => () => {};
+  const hubUrl = useSyncExternalStore(
+    noSubscribe,
+    () => window.location.origin,
+    () => "<this-hub-url>",
+  );
 
   // Who's here, shared with the composer's `@` popover: agents from the room's
   // manifests, people from agent owners ∪ posters ∪ live presence ∪ you, and a
@@ -90,10 +100,10 @@ export function AgentsPanel({
 
   useEffect(() => {
     if (!engineInvite) return;
-    // One-shot: the parent flips engineInvite, and clears it once the tab is shown.
+    // One-shot: the parent asks specifically for an engine, rather than opening
+    // the coding-agent handoff first.
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setAddTab("engines");
-    setAddOpen(true);
+    setEngineOpen(true);
     onEngineInviteShown?.();
   }, [engineInvite, onEngineInviteShown]);
 
@@ -156,106 +166,93 @@ export function AgentsPanel({
             mine
           </Chip>
         )}
-        <Dialog open={addOpen} onOpenChange={setAddOpen}>
-          <DialogTrigger
-            render={<Button variant="secondary" size="sm" className="ml-auto" />}
-          >
-            Add
-          </DialogTrigger>
+        <Popover open={inviteOpen} onOpenChange={setInviteOpen}>
+          <PopoverTrigger render={<Button variant="secondary" size="sm" className="ml-auto" />}>
+            Invite <ChevronDown className="size-3" />
+          </PopoverTrigger>
+          <PopoverContent className="w-64 p-1">
+            <InviteOption
+              label="Coding agent"
+              hint="Copy room-aware setup"
+              onClick={() => {
+                setInviteOpen(false);
+                setAgentOpen(true);
+              }}
+            />
+            <InviteOption
+              label="Engine"
+              hint="Add a room capability"
+              onClick={() => {
+                setInviteOpen(false);
+                setEngineOpen(true);
+              }}
+            />
+            <InviteOption
+              label="A2A agent"
+              hint="Connect an external agent service"
+              onClick={() => {
+                setInviteOpen(false);
+                setA2aOpen(true);
+              }}
+            />
+          </PopoverContent>
+        </Popover>
+        <Dialog open={agentOpen} onOpenChange={setAgentOpen}>
           <DialogContent className="sm:max-w-lg">
             <DialogHeader>
               <DialogTitle className="text-ui font-semibold text-text">
-                Add an agent or engine
+                Invite a coding agent
               </DialogTitle>
               <DialogDescription className="text-label text-muted-foreground leading-relaxed">
-                <span className="text-text">Engines</span> are backend-owned and{" "}
-                <span className="text-text">A2A agents</span> are external services,
-                so you can register either right here.{" "}
-                <span className="text-text">Agents</span> are registered from the
-                CLI, because they have machine-local side effects (resident session,
-                workspace assets) the web UI can&apos;t perform.
+                Paste this into the coding agent you already have open. It connects to this
+                hub, registers in this room, and starts by reading the board.
               </DialogDescription>
             </DialogHeader>
-            <div className="flex items-center gap-1.5 mt-2">
-              <Chip
-                variant="accent"
-                active={addTab === "agents"}
-                onClick={() => setAddTab("agents")}
-                className="px-2.5 py-0.5 text-micro"
-              >
-                Agents
-              </Chip>
-              <Chip
-                variant="accent"
-                active={addTab === "engines"}
-                onClick={() => setAddTab("engines")}
-                className="px-2.5 py-0.5 text-micro"
-              >
-                Engines
-              </Chip>
-              <Chip
-                variant="accent"
-                active={addTab === "a2a"}
-                onClick={() => setAddTab("a2a")}
-                className="px-2.5 py-0.5 text-micro"
-              >
-                A2A agent
-              </Chip>
-            </div>
-            {addTab === "agents" && (
-              <div className="space-y-6 mt-2">
-                <section>
-                  <div className="text-label font-semibold text-text mb-1.5">
-                    Create a new agent
-                  </div>
-                  <pre className="font-mono text-micro text-muted-foreground bg-surface border border-border px-2.5 py-2 overflow-x-auto whitespace-pre-wrap break-words">
-                    {"mycelium agent create <handle>                  # claude_code\nmycelium agent create <handle> --adapter cursor  # cursor"}
-                  </pre>
-                  <p className="text-micro text-muted-foreground mt-1 leading-snug">
-                    claude_code is proven; cursor is supported but less
-                    travelled. Optional:{" "}
-                    <code className="font-mono">--cwd &lt;path&gt;</code> for the session&apos;s
-                    working dir, and{" "}
-                    <code className="font-mono">--owner &lt;you&gt; --team &lt;slug&gt;</code>{" "}
-                    to attribute it from creation.
-                  </p>
-                </section>
-                <section>
-                  <div className="text-label font-semibold text-text mb-1.5">
-                    Keep the session resident
-                  </div>
-                  <pre className="font-mono text-micro text-muted-foreground bg-surface border border-border px-2.5 py-2 overflow-x-auto whitespace-pre-wrap break-words">
-                    {"mycelium await --loop --handle <handle> --exec <cmd>"}
-                  </pre>
-                  <p className="text-micro text-muted-foreground mt-1 leading-snug">
-                    An agent is your own claude_code / cursor session, kept woken
-                    by the loop: it <span className="text-text">await</span>s each
-                    @-mention, reasons, and <span className="text-text">respond</span>s
-                    on the same turn. The loop is the wake — no daemon, no
-                    cold-spawn.
-                  </p>
-                </section>
-              </div>
-            )}
-            {addTab === "engines" && (
-              <EngineInviteForm
-                roomName={roomName}
-                createdBy={principal}
-                onCreated={() => {
-                  refresh();
-                  setAddOpen(false);
-                }}
-              />
-            )}
-            {addTab === "a2a" && (
-              <A2aAgentForm
-                roomName={roomName}
-                onCreated={() => {
-                  refresh();
-                  setAddOpen(false);
-                }}
-              />
-            )}
+            <CopyAction
+              value={agentHandoffPrompt({
+                hubUrl,
+                roomName,
+                principal,
+                authRequired: network?.auth?.enabled ?? null,
+              })}
+              label="Copy setup"
+              className="mt-4 w-fit"
+            />
+          </DialogContent>
+        </Dialog>
+        <Dialog open={engineOpen} onOpenChange={setEngineOpen}>
+          <DialogContent className="sm:max-w-lg">
+            <DialogHeader>
+              <DialogTitle className="text-ui font-semibold text-text">Invite an engine</DialogTitle>
+              <DialogDescription className="text-label text-muted-foreground leading-relaxed">
+                Engines are backend-owned room capabilities, not local coding-agent sessions.
+              </DialogDescription>
+            </DialogHeader>
+            <EngineInviteForm
+              roomName={roomName}
+              createdBy={principal}
+              onCreated={() => {
+                refresh();
+                setEngineOpen(false);
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+        <Dialog open={a2aOpen} onOpenChange={setA2aOpen}>
+          <DialogContent className="sm:max-w-lg">
+            <DialogHeader>
+              <DialogTitle className="text-ui font-semibold text-text">Connect an A2A agent</DialogTitle>
+              <DialogDescription className="text-label text-muted-foreground leading-relaxed">
+                Connect an external Agent2Agent service to this room.
+              </DialogDescription>
+            </DialogHeader>
+            <A2aAgentForm
+              roomName={roomName}
+              onCreated={() => {
+                refresh();
+                setA2aOpen(false);
+              }}
+            />
           </DialogContent>
         </Dialog>
       </div>
@@ -388,6 +385,19 @@ export function AgentsPanel({
   );
 }
 
+function InviteOption({ label, hint, onClick }: { label: string; hint: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full flex-col gap-0.5 rounded-lg px-3 py-2 text-left transition-colors hover:bg-hairline"
+    >
+      <span className="text-label font-medium text-text">{label}</span>
+      <span className="text-micro text-muted-foreground">{hint}</span>
+    </button>
+  );
+}
+
 /** Small uppercase divider between the People and Agents groups, with a count. */
 function SectionLabel({ children, count }: { children: React.ReactNode; count?: number }) {
   return (
@@ -401,7 +411,7 @@ function SectionLabel({ children, count }: { children: React.ReactNode; count?: 
 const ENGINE_KINDS: { kind: EngineKind; blurb: string }[] = [
   { kind: "aligner", blurb: "Mediates negotiation to consensus." },
   { kind: "synthesizer", blurb: "Distills the room to memory." },
-  { kind: "hello", blurb: "Answers once, writes nothing — proves the path." },
+  { kind: "hello", blurb: "Answers once, writes nothing, and proves the path." },
 ];
 
 /** Invite a first-party cognition engine into the room — a native manifest
@@ -420,7 +430,6 @@ function EngineInviteForm({
   // "aligner"). It tracks the kind until the user edits it, then it's theirs.
   const [handle, setHandle] = useState<EngineKind | string>("aligner");
   const [handleTouched, setHandleTouched] = useState(false);
-  const [description, setDescription] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -435,7 +444,7 @@ function EngineInviteForm({
       await createEngine(roomName, {
         handle: trimmed,
         kind,
-        description: description.trim(),
+        description: "",
         created_by: createdBy || "web-ui",
       });
       onCreated();
@@ -447,24 +456,29 @@ function EngineInviteForm({
   };
 
   return (
-    <div className="space-y-4 mt-2">
-      <div className="grid grid-cols-2 gap-2">
+    <div className="mt-2 space-y-4">
+      <div className="space-y-1.5" role="radiogroup" aria-label="Engine kind">
         {ENGINE_KINDS.map(({ kind: k, blurb }) => (
           <button
             key={k}
             type="button"
+            role="radio"
+            aria-checked={kind === k}
             onClick={() => {
               setKind(k);
               if (!handleTouched) setHandle(k);
             }}
-            className={`flex flex-col gap-0.5 rounded-lg border px-3 py-2 text-left transition-colors ${
+            className={`flex w-full items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors ${
               kind === k ? "border-accent bg-accent/10" : "border-border hover:bg-hairline"
             }`}
           >
-            <span className={`text-label font-medium ${kind === k ? "text-text" : "text-muted-foreground"}`}>
-              {k}
+            <span className="min-w-0 flex-1">
+              <span className={`block text-label font-medium ${kind === k ? "text-text" : "text-muted-foreground"}`}>
+                {k}
+              </span>
+              <span className="block text-micro leading-snug text-muted-foreground">{blurb}</span>
             </span>
-            <span className="text-micro leading-snug text-muted-foreground">{blurb}</span>
+            {kind === k && <Check className="size-4 flex-shrink-0 text-accent" />}
           </button>
         ))}
       </div>
@@ -491,26 +505,12 @@ function EngineInviteForm({
         </p>
       </div>
 
-      <div className="space-y-1.5">
-        <label className="text-label font-medium text-text">
-          Description <span className="text-faint">(optional)</span>
-        </label>
-        <Input
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          placeholder="What this engine does in the room"
-        />
-      </div>
-
       {error && <p className="text-micro text-[#f87171] leading-snug">{error}</p>}
 
       <div className="flex items-center gap-2">
         <Button variant="default" size="sm" onClick={submit} disabled={!canSubmit}>
-          {submitting ? "Registering…" : "Invite engine"}
+          {submitting ? "Inviting…" : `Invite ${kind}`}
         </Button>
-        <span className="text-micro text-muted-foreground">
-          or <code className="font-mono">mycelium engine create</code> from the CLI
-        </span>
       </div>
     </div>
   );
@@ -616,4 +616,3 @@ function A2aAgentForm({
     </div>
   );
 }
-

--- a/mycelium-frontend/src/components/install-panel.test.tsx
+++ b/mycelium-frontend/src/components/install-panel.test.tsx
@@ -6,7 +6,6 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithSWR } from "@/test/swr";
 import { InstallPanel } from "@/components/install-panel";
-import { CLI_INSTALL_COMMAND, LOGIN_COMMAND, PROMPT_COMMAND, configSetCommand } from "@/lib/install";
 
 /** The panel's only server read is the health probe. */
 function stubHub(reachable: boolean) {
@@ -18,29 +17,19 @@ function stubHub(reachable: boolean) {
   );
 }
 
-/** The commands are read-only inputs, so they're findable by value. */
-function commandField(value: string) {
-  return screen.getByDisplayValue(value);
-}
-
 describe("<InstallPanel />", () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("hands over the CLI, config, and login commands, and says the hub is unreachable", async () => {
+  it("hands over one hub-aware terminal setup and says the hub is unreachable", async () => {
     const user = userEvent.setup();
     stubHub(false);
     renderWithSWR(<InstallPanel />);
 
-    // Prompt is the default tab; switch to a manual one to see the three steps.
-    await user.click(screen.getByRole("button", { name: "macOS" }));
+    await user.click(screen.getByRole("button", { name: "Terminal" }));
 
-    expect(commandField(CLI_INSTALL_COMMAND)).toBeInTheDocument();
-    await waitFor(() =>
-      expect(commandField(configSetCommand(window.location.origin))).toBeInTheDocument(),
-    );
-    expect(commandField(LOGIN_COMMAND)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy setup" })).toBeInTheDocument();
     await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Hub unreachable"));
     // The honest framing: this isn't "not installed yet", it's down.
     expect(screen.getByText(/isn't answering right now/i)).toBeInTheDocument();
@@ -54,64 +43,30 @@ describe("<InstallPanel />", () => {
     await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Hub reachable"));
     expect(screen.queryByText(/isn't answering right now/i)).not.toBeInTheDocument();
 
-    // The install commands stay reachable — a second machine still needs them.
-    await user.click(screen.getByRole("button", { name: "macOS" }));
-    expect(commandField(CLI_INSTALL_COMMAND)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(screen.getByText(/Install, connect, and verify in one paste/i)).toBeInTheDocument();
   });
 
-  it("shows the WSL note when Windows is selected", async () => {
+  it("shows a hub-aware coding-agent prompt by default", async () => {
+    stubHub(false);
+    renderWithSWR(<InstallPanel />);
+
+    expect(screen.getByRole("button", { name: "Copy setup" })).toBeInTheDocument();
+    expect(screen.getByText(/already have open/i)).toBeInTheDocument();
+  });
+
+  it("switches between the coding-agent and terminal handoffs", async () => {
     const user = userEvent.setup();
     stubHub(false);
     renderWithSWR(<InstallPanel />);
 
-    expect(screen.queryByText(/WSL/)).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Windows" }));
-    expect(screen.getByText(/Run both commands inside WSL/)).toBeInTheDocument();
-  });
+    const codingAgent = screen.getByRole("button", { name: "Coding agent" });
+    const terminal = screen.getByRole("button", { name: "Terminal" });
+    expect(codingAgent).toHaveAttribute("aria-pressed", "true");
+    expect(terminal).toHaveAttribute("aria-pressed", "false");
 
-  it("shows the agent prompt by default, and the manual steps once an OS tab is picked", async () => {
-    const user = userEvent.setup();
-    stubHub(false);
-    renderWithSWR(<InstallPanel />);
-
-    expect(commandField(PROMPT_COMMAND)).toBeInTheDocument();
-    expect(screen.queryByText("Install the CLI")).not.toBeInTheDocument();
-    expect(screen.queryByDisplayValue(CLI_INSTALL_COMMAND)).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "macOS" }));
-    expect(commandField(CLI_INSTALL_COMMAND)).toBeInTheDocument();
-    expect(screen.queryByDisplayValue(PROMPT_COMMAND)).not.toBeInTheDocument();
-  });
-
-  it("highlights one tab at a time, and drops into the detected OS when Prompt is switched off", async () => {
-    const user = userEvent.setup();
-    stubHub(false);
-    vi.spyOn(navigator, "userAgent", "get").mockReturnValue(
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
-    );
-    renderWithSWR(<InstallPanel />);
-
-    const prompt = screen.getByRole("button", { name: "Prompt" });
-    const macos = screen.getByRole("button", { name: "macOS" });
-    expect(prompt).toHaveAttribute("aria-pressed", "true");
-    expect(macos).toHaveAttribute("aria-pressed", "false");
-
-    // Switching Prompt off lands on the detected OS, and only that one.
-    await user.click(prompt);
-    await waitFor(() => expect(macos).toHaveAttribute("aria-pressed", "true"));
-    expect(prompt).toHaveAttribute("aria-pressed", "false");
-    expect(commandField(CLI_INSTALL_COMMAND)).toBeInTheDocument();
-  });
-
-  it("deselects Prompt when an OS tab is picked", async () => {
-    const user = userEvent.setup();
-    stubHub(false);
-    renderWithSWR(<InstallPanel />);
-
-    await user.click(screen.getByRole("button", { name: "Linux" }));
-
-    expect(screen.getByRole("button", { name: "Prompt" })).toHaveAttribute("aria-pressed", "false");
-    expect(screen.getByRole("button", { name: "Linux" })).toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByRole("button", { name: "macOS" })).toHaveAttribute("aria-pressed", "false");
+    await user.click(terminal);
+    expect(codingAgent).toHaveAttribute("aria-pressed", "false");
+    expect(terminal).toHaveAttribute("aria-pressed", "true");
   });
 });

--- a/mycelium-frontend/src/components/install-panel.test.tsx
+++ b/mycelium-frontend/src/components/install-panel.test.tsx
@@ -4,6 +4,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CurrentUserProvider } from "@/components/current-user";
 import { renderWithSWR } from "@/test/swr";
 import { InstallPanel } from "@/components/install-panel";
 
@@ -17,6 +18,14 @@ function stubHub(reachable: boolean) {
   );
 }
 
+function renderInstallPanel() {
+  return renderWithSWR(
+    <CurrentUserProvider>
+      <InstallPanel />
+    </CurrentUserProvider>,
+  );
+}
+
 describe("<InstallPanel />", () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
@@ -25,7 +34,7 @@ describe("<InstallPanel />", () => {
   it("hands over one hub-aware terminal setup and says the hub is unreachable", async () => {
     const user = userEvent.setup();
     stubHub(false);
-    renderWithSWR(<InstallPanel />);
+    renderInstallPanel();
 
     await user.click(screen.getByRole("button", { name: "Terminal" }));
 
@@ -38,7 +47,7 @@ describe("<InstallPanel />", () => {
   it("drops the unreachable note once the hub answers, keeping only the commands", async () => {
     const user = userEvent.setup();
     stubHub(true);
-    renderWithSWR(<InstallPanel />);
+    renderInstallPanel();
 
     await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Hub reachable"));
     expect(screen.queryByText(/isn't answering right now/i)).not.toBeInTheDocument();
@@ -49,7 +58,7 @@ describe("<InstallPanel />", () => {
 
   it("shows a hub-aware coding-agent prompt by default", async () => {
     stubHub(false);
-    renderWithSWR(<InstallPanel />);
+    renderInstallPanel();
 
     expect(screen.getByRole("button", { name: "Copy setup" })).toBeInTheDocument();
     expect(screen.getByText(/already have open/i)).toBeInTheDocument();
@@ -58,7 +67,7 @@ describe("<InstallPanel />", () => {
   it("switches between the coding-agent and terminal handoffs", async () => {
     const user = userEvent.setup();
     stubHub(false);
-    renderWithSWR(<InstallPanel />);
+    renderInstallPanel();
 
     const codingAgent = screen.getByRole("button", { name: "Coding agent" });
     const terminal = screen.getByRole("button", { name: "Terminal" });

--- a/mycelium-frontend/src/components/install-panel.tsx
+++ b/mycelium-frontend/src/components/install-panel.tsx
@@ -5,16 +5,16 @@
 
 import { useState, useSyncExternalStore } from "react";
 import { Terminal } from "lucide-react";
-import { CopyField } from "@/components/ui/copy-field";
+import { CopyAction } from "@/components/ui/copy-field";
 import { useBackendHealth } from "@/lib/use-status";
+import { useCurrentUser } from "@/components/current-user";
+import { useNetworkStatus } from "@/lib/room-data";
 import {
-  CLI_INSTALL_COMMAND,
   DOCS_URL,
-  LOGIN_COMMAND,
   PLATFORMS,
-  PROMPT_COMMAND,
-  configSetCommand,
   detectPlatform,
+  hubSetupCommand,
+  hubSetupPrompt,
   type Platform,
 } from "@/lib/install";
 import { cn } from "@/lib/utils";
@@ -48,28 +48,14 @@ function ConnectionPill({ healthy }: { healthy: boolean | null }) {
   );
 }
 
-function Step({ n, title, children }: { n: number; title: string; children: React.ReactNode }) {
-  return (
-    <li className="flex gap-3">
-      <span className="mt-0.5 flex size-6 flex-shrink-0 items-center justify-center rounded-md bg-surface font-mono text-micro font-semibold text-muted-foreground">
-        {n}
-      </span>
-      <div className="min-w-0 flex-1">
-        <div className="text-label font-medium text-text">{title}</div>
-        {children}
-      </div>
-    </li>
-  );
-}
-
 interface Props {
   className?: string;
 }
 
 /**
  * The guided client-only setup surface (`docs/agents.md` Steps 1 + 4): get
- * the CLI, point it at this hub, and sign in if the hub asks for it. It never
- * offers to stand up a new hub, since this page is already served by one.
+ * a coding agent or a terminal user: configure the CLI against this already
+ * running hub, then verify it. It never offers to stand up another hub.
  *
  * The pill reflects whether this hub is answering right now. That's an
  * operator concern, not something the commands below can fix themselves:
@@ -77,12 +63,11 @@ interface Props {
  */
 export function InstallPanel({ className }: Props) {
   const healthy = useBackendHealth(WAITING_POLL);
+  const { network } = useNetworkStatus();
+  const { principal } = useCurrentUser();
 
-  // Server-rendered markup can't know the OS or this page's own origin: until
-  // the client snapshot arrives, no platform tab is preselected and the config
-  // command shows a placeholder host. The origin is only a first guess, since
-  // some deployments front the API on a different port than the UI, so it's
-  // there to edit — and the OS tabs override the detected platform.
+  // Server-rendered markup cannot know the OS or the page origin. Until the
+  // client snapshot arrives, the prompt carries a placeholder host.
   const noSubscribe = () => () => {};
   const detectedPlatform = useSyncExternalStore(
     noSubscribe,
@@ -94,19 +79,12 @@ export function InstallPanel({ className }: Props) {
     () => window.location.origin,
     () => "<this-hub-url>",
   );
-  const [platformOverride, setPlatform] = useState<Platform | null>(null);
-  const platform = platformOverride ?? detectedPlatform;
-  const note = PLATFORMS.find(p => p.id === platform)?.note;
+  const note = PLATFORMS.find(p => p.id === detectedPlatform)?.note;
 
-  // "Prompt" is a fourth tab alongside the OS ones, not a fifth platform: it
-  // swaps the manual steps for one line to hand a coding agent instead, same
-  // as the landing page's prompt/curl toggle. Selected by default, same as
-  // there. Pressing it again drops into the manual steps for the detected OS,
-  // which is what makes the detection above worth doing.
+  // This is a choice of recipient, not a platform picker: a running coding
+  // agent gets a direct hub-aware handoff, while a human gets one terminal block.
   const [usePrompt, setUsePrompt] = useState(true);
-
-  // One row, one selection: an OS tab reads as active only while Prompt isn't.
-  const osSelected = (id: Platform) => !usePrompt && platform === id;
+  const setup = { hubUrl, authRequired: network?.auth?.enabled ?? null, principal };
 
   return (
     <section className={cn("rounded-xl border border-border bg-paper p-5", className)}>
@@ -116,16 +94,16 @@ export function InstallPanel({ className }: Props) {
             <Terminal className="size-4" strokeWidth={1.75} />
           </span>
           <div className="min-w-0">
-            <h2 className="text-ui font-medium text-text">Connect your CLI to this hub</h2>
+            <h2 className="text-ui font-medium text-text">Connect to this hub</h2>
             <p className="mt-0.5 text-label text-muted-foreground">
-              A few terminal commands to join the hub.
+              This hub is already running. Hand the setup to your agent or run it yourself.
             </p>
           </div>
         </div>
         <ConnectionPill healthy={healthy} />
       </header>
 
-      <div className="mt-4 flex items-center gap-1.5" role="group" aria-label="Install method">
+      <div className="mt-4 flex items-center gap-1.5" role="group" aria-label="Setup method">
         <button
           type="button"
           aria-pressed={usePrompt}
@@ -137,57 +115,38 @@ export function InstallPanel({ className }: Props) {
               : "border-transparent text-muted-foreground hover:bg-hairline hover:text-text",
           )}
         >
-          Prompt
+          Coding agent
         </button>
-        {PLATFORMS.map(p => (
-          <button
-            key={p.id}
-            type="button"
-            aria-pressed={osSelected(p.id)}
-            onClick={() => {
-              setUsePrompt(false);
-              setPlatform(p.id);
-            }}
-            className={cn(
-              "rounded-md border px-2.5 py-1 text-micro font-medium transition-colors",
-              osSelected(p.id)
-                ? "border-border2 bg-surface text-text"
-                : "border-transparent text-muted-foreground hover:bg-hairline hover:text-text",
-            )}
-          >
-            {p.label}
-          </button>
-        ))}
+        <button
+          type="button"
+          aria-pressed={!usePrompt}
+          onClick={() => setUsePrompt(false)}
+          className={cn(
+            "rounded-md border px-2.5 py-1 text-micro font-medium transition-colors",
+            !usePrompt
+              ? "border-border2 bg-surface text-text"
+              : "border-transparent text-muted-foreground hover:bg-hairline hover:text-text",
+          )}
+        >
+          Terminal
+        </button>
       </div>
 
       {usePrompt ? (
         <div className="mt-4">
           <p className="text-micro text-muted-foreground">
-            Give this to a coding agent instead of a terminal. It reads{" "}
-            <code className="font-mono">agents.md</code> and does the setup itself.
+            Give this to the coding agent you already have open. It configures this hub directly.
           </p>
-          <CopyField value={PROMPT_COMMAND} className="mt-2" />
+          <CopyAction value={hubSetupPrompt(setup)} label="Copy setup" className="mt-3" />
         </div>
       ) : (
         <>
-          <ol className="mt-4 space-y-4">
-            <Step n={1} title="Install the CLI">
-              <p className="mt-0.5 text-micro text-muted-foreground">
-                Drops the <code className="font-mono">mycelium</code> binary on your PATH.
-              </p>
-              <CopyField value={CLI_INSTALL_COMMAND} className="mt-2" />
-            </Step>
-            <Step n={2} title="Point it at this hub">
-              <p className="mt-0.5 text-micro text-muted-foreground">This hub&apos;s address.</p>
-              <CopyField value={configSetCommand(hubUrl)} className="mt-2" />
-            </Step>
-            <Step n={3} title="Sign in">
-              <p className="mt-0.5 text-micro text-muted-foreground">
-                Only needed if this hub requires it. The CLI will tell you if it doesn&apos;t.
-              </p>
-              <CopyField value={LOGIN_COMMAND} className="mt-2" />
-            </Step>
-          </ol>
+          <div className="mt-4">
+            <p className="text-micro text-muted-foreground">
+              Install, connect, and verify in one paste.
+            </p>
+            <CopyAction value={hubSetupCommand(setup)} label="Copy setup" className="mt-3" />
+          </div>
 
           {note && (
             <p className="mt-3 rounded-lg bg-surface px-3 py-2 text-micro text-muted-foreground">

--- a/mycelium-frontend/src/components/ui/copy-field.tsx
+++ b/mycelium-frontend/src/components/ui/copy-field.tsx
@@ -6,10 +6,47 @@
 import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 
-/** A read-only, monospace input with a copy button — for a command or value the
- *  user should copy rather than retype. Selects on focus; shows a check on copy. */
+/** A read-only field with a copy button for text the user should copy rather
+ * than retype. */
 export function CopyField({ value, className }: { value: string; className?: string }) {
+  const { copy, copied } = useCopy(value);
+
+  return (
+    <div className={cn("flex items-stretch gap-1.5", className)}>
+      <input
+        readOnly
+        value={value}
+        onFocus={(e) => e.currentTarget.select()}
+        className="w-full min-w-0 rounded-lg bg-bg border border-border px-2 py-1.5 text-micro text-text outline-none focus:border-accent"
+      />
+      <CopyIconButton copied={copied} onClick={copy} />
+    </div>
+  );
+}
+
+/** A named action for a large handoff the user should copy but does not need to
+ * read in a scrollable field. */
+export function CopyAction({
+  value,
+  label,
+  className,
+}: {
+  value: string;
+  label: string;
+  className?: string;
+}) {
+  const { copy, copied } = useCopy(value);
+  return (
+    <Button type="button" variant="secondary" size="sm" onClick={copy} className={className}>
+      {copied ? <Check className="size-3.5 text-green" /> : <Copy className="size-3.5" />}
+      {copied ? "Copied" : label}
+    </Button>
+  );
+}
+
+function useCopy(value: string) {
   const [copied, setCopied] = useState(false);
 
   const copy = async () => {
@@ -21,27 +58,22 @@ export function CopyField({ value, className }: { value: string; className?: str
       // clipboard blocked (insecure context) — the field is still selectable
     }
   };
+  return { copy, copied };
+}
 
+function CopyIconButton({ copied, onClick }: { copied: boolean; onClick: () => void }) {
   return (
-    <div className={cn("flex items-stretch gap-1.5", className)}>
-      <input
-        readOnly
-        value={value}
-        onFocus={(e) => e.currentTarget.select()}
-        className="w-full min-w-0 bg-bg border border-border px-2 py-1.5 font-mono text-micro text-text outline-none focus:border-accent"
-      />
-      <button
-        type="button"
-        onClick={copy}
-        aria-label={copied ? "Copied" : "Copy"}
-        className="flex-shrink-0 flex items-center justify-center border border-border px-2 text-muted-foreground hover:bg-surface hover:text-text transition-colors"
-      >
-        {copied ? (
-          <Check className="size-3.5" style={{ color: "var(--green)" }} />
-        ) : (
-          <Copy className="size-3.5" />
-        )}
-      </button>
-    </div>
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={copied ? "Copied" : "Copy"}
+      className="flex-shrink-0 flex items-center justify-center rounded-lg border border-border px-2 text-muted-foreground hover:bg-surface hover:text-text transition-colors"
+    >
+      {copied ? (
+        <Check className="size-3.5" style={{ color: "var(--green)" }} />
+      ) : (
+        <Copy className="size-3.5" />
+      )}
+    </button>
   );
 }

--- a/mycelium-frontend/src/components/ui/input.tsx
+++ b/mycelium-frontend/src/components/ui/input.tsx
@@ -9,8 +9,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "w-full min-w-0 bg-bg border border-border px-3 py-2",
-        "font-mono text-label text-text placeholder:text-muted-foreground",
+        "w-full min-w-0 rounded-lg bg-bg border border-border px-3 py-2",
+        "text-label text-text placeholder:text-muted-foreground",
         "transition-colors outline-none",
         "hover:border-border2",
         "focus:border-accent focus-visible:border-accent",

--- a/mycelium-frontend/src/lib/install.test.ts
+++ b/mycelium-frontend/src/lib/install.test.ts
@@ -3,12 +3,13 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  agentHandoffPrompt,
   CLI_INSTALL_COMMAND,
-  LOGIN_COMMAND,
   PLATFORMS,
-  PROMPT_COMMAND,
   configSetCommand,
   detectPlatform,
+  hubSetupCommand,
+  hubSetupPrompt,
 } from "@/lib/install";
 
 const UA = {
@@ -43,17 +44,45 @@ describe("install content", () => {
     );
   });
 
-  it("points the config command at whatever hub URL it's given, and never stands up a stack", () => {
+  it("points the config command at whatever hub URL it's given", () => {
     expect(configSetCommand("http://hub.example.com:8000")).toBe(
       "mycelium config set server.api_url http://hub.example.com:8000 && mycelium config apply",
     );
-    expect(LOGIN_COMMAND).toBe("mycelium login");
   });
 
-  it("carries the same prompt one-liner the landing page's prompt tab publishes", () => {
-    expect(PROMPT_COMMAND).toBe(
-      "Use curl to read https://mycelium-io.github.io/mycelium/agents.md and perform the setup to install Mycelium",
-    );
+  it("generates a hub-aware setup handoff instead of a generic documentation link", () => {
+    const prompt = hubSetupPrompt({
+      hubUrl: "https://hub.example.com",
+      authRequired: false,
+      principal: "avery",
+    });
+    expect(prompt).toContain("https://hub.example.com");
+    expect(prompt).toContain("mycelium iam avery");
+    expect(prompt).not.toContain("agents.md");
+  });
+
+  it("uses the signed-in identity rather than a browser-selected one on a gated hub", () => {
+    const setup = hubSetupCommand({
+      hubUrl: "https://hub.example.com",
+      authRequired: true,
+      principal: "avery",
+    });
+    expect(setup).toContain("mycelium login");
+    expect(setup).toContain("mycelium whoami");
+    expect(setup).not.toContain("mycelium iam avery");
+  });
+
+  it("hands an existing coding session the room, hub, and first collaboration step", () => {
+    const prompt = agentHandoffPrompt({
+      hubUrl: "https://hub.example.com",
+      authRequired: false,
+      principal: "avery",
+      roomName: "atlas",
+    });
+    expect(prompt).toContain("room `atlas`");
+    expect(prompt).toContain("--room atlas --owner avery");
+    expect(prompt).toContain("mycelium board --room atlas");
+    expect(prompt).toContain("--timeout 30");
   });
 
   it("notes the WSL constraint on Windows only", () => {

--- a/mycelium-frontend/src/lib/install.ts
+++ b/mycelium-frontend/src/lib/install.ts
@@ -16,22 +16,72 @@ export const DOCS_URL = "https://mycelium-io.github.io/mycelium";
 /** Step 1: fetch the CLI, the same one-liner the README and docs site carry. */
 export const CLI_INSTALL_COMMAND = `curl -fsSL ${DOCS_URL}/install.sh | bash`;
 
-/** Alternative to Step 1 for a coding agent instead of a human at a terminal:
- *  the same one-liner the landing page's "prompt" tab hands over. The agent
- *  reads `agents.md` and does the setup itself, interactive branching (Step 2)
- *  included, so nothing else here needs a prompt-specific version. */
-export const PROMPT_COMMAND = `Use curl to read ${DOCS_URL}/agents.md and perform the setup to install Mycelium`;
-
-/** Step 2: point the CLI at the hub this page is served from, and pick it up. */
+/** Point the CLI at the hub this page is served from. */
 export function configSetCommand(hubUrl: string): string {
   return `mycelium config set server.api_url ${hubUrl} && mycelium config apply`;
 }
 
-/** Step 3: OIDC sign-in, only needed if this hub's auth gate is on. Most
- *  hubs don't have one, and the CLI errors plainly ("no OIDC issuer
- *  configured") rather than hanging, so the panel says to skip it on that
- *  error instead of gating the step behind a client-side guess. */
 export const LOGIN_COMMAND = "mycelium login";
+
+export interface HubSetupOptions {
+  hubUrl: string;
+  authRequired: boolean | null;
+  principal?: string;
+}
+
+/** A complete, copyable terminal setup. Login is only included when the hub
+ * reports its auth requirement; a browser-picked identity never overrides it. */
+export function hubSetupCommand({ hubUrl, authRequired, principal }: HubSetupOptions): string {
+  const lines = [CLI_INSTALL_COMMAND, configSetCommand(hubUrl)];
+  if (authRequired) {
+    lines.push(LOGIN_COMMAND, "mycelium whoami");
+  } else if (authRequired === false && principal) {
+    lines.push(`mycelium iam ${principal}`);
+  }
+  lines.push("mycelium room ls");
+  return lines.join("\n");
+}
+
+/** Give a coding agent the concrete hub it must join rather than asking it to
+ * discover a generic public guide. */
+export function hubSetupPrompt(options: HubSetupOptions): string {
+  const auth = options.authRequired
+    ? `This hub requires sign-in: run \`${LOGIN_COMMAND}\`, then confirm the signed-in identity with \`mycelium whoami\`.`
+    : options.authRequired === false && options.principal
+      ? `This open hub is currently acting as @${options.principal}; after configuring the CLI, run \`mycelium iam ${options.principal}\`.`
+      : options.authRequired === false
+        ? "This hub is open. Choose a local identity with `mycelium iam <your-handle>` if you need attribution."
+        : `If the hub asks you to authenticate, run \`${LOGIN_COMMAND}\` and use the identity it confirms.`;
+  return [
+    `Set up Mycelium to use the already-running hub at ${options.hubUrl}.`,
+    `Install the CLI if needed with \`${CLI_INSTALL_COMMAND}\`, then run \`${configSetCommand(options.hubUrl)}\`.`,
+    auth,
+    "Verify the connection with `mycelium room ls`, then return control to me.",
+  ].join("\n\n");
+}
+
+export interface AgentHandoffOptions extends HubSetupOptions {
+  roomName: string;
+}
+
+/** The handoff a human pastes into an agent that is already running locally.
+ * Mycelium configures and registers it; it never starts another agent process. */
+export function agentHandoffPrompt(options: AgentHandoffOptions): string {
+  const owner = options.authRequired === false && options.principal ? ` --owner ${options.principal}` : "";
+  const auth = options.authRequired
+    ? `Sign in with \`${LOGIN_COMMAND}\` first and use the identity it confirms; do not invent or override an identity.`
+    : options.authRequired === false && options.principal
+      ? `The room's human owner is @${options.principal}.`
+      : "If the hub asks you to sign in, use the identity it confirms. Otherwise ask the human for an owner if you need one.";
+  return [
+    `You are joining the Mycelium room \`${options.roomName}\` on the already-running hub at ${options.hubUrl} as a coding-agent collaborator.`,
+    `Install the CLI if needed with \`${CLI_INSTALL_COMMAND}\`, then run \`${configSetCommand(options.hubUrl)}\`.`,
+    auth,
+    `Choose a short handle and register yourself with \`mycelium agent create <handle> --room ${options.roomName}${owner}\`.`,
+    `Read \`mycelium room messages --room ${options.roomName} --limit 20\` and \`mycelium board --room ${options.roomName}\`. Claim a suitable task or ask me which task to take.`,
+    `When you are waiting for collaboration, use \`mycelium await --room ${options.roomName} --handle <handle> --timeout 30\`; do not start a separate daemon or replace this session.`,
+  ].join("\n\n");
+}
 
 export type Platform = "macos" | "linux" | "windows" | "unknown";
 


### PR DESCRIPTION
## Summary
- replace generic install guidance with hub-aware setup handoffs
- consolidate coding agents, engines, and A2A into an Invite menu
- simplify engine selection and align form-control styling

## Verification
- `pnpm lint` (passes with two existing unrelated warnings)
- inspected the Invite menu and dialogs with Shotkit