### PR TITLE
fix(episodes): include HTTP-lease members in episode roster

### DIFF
--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -1048,7 +1048,7 @@ class RoomChannelManager:
         managed = self._channels.get(room)
         if managed is None:
             return False
-        managed.lifecycle.open(episode, managed.members, negotiation=negotiation)
+        managed.lifecycle.open(episode, set(self.members(room)), negotiation=negotiation)
         return True
 
     async def close_episode(self, room: str) -> bool:
@@ -1066,7 +1066,7 @@ class RoomChannelManager:
 
     async def _enforce_membership_change(self, managed: ManagedRoomChannel) -> None:
         """Abort the active negotiation if membership changed under it."""
-        if not managed.lifecycle.on_membership_change(managed.members):
+        if not managed.lifecycle.on_membership_change(set(self.members(managed.room))):
             return
         episode = managed.lifecycle.episode
         managed.lifecycle.close()


### PR DESCRIPTION
## Summary

- `open_episode` passed `managed.members` (SLIM-socket-only set) as the negotiation roster, silently excluding every pure-HTTP participant
- Server-held agents that use `await`/`respond` never hold a SLIM socket — they appear only in the live-lease set returned by `RoomChannelManager.members()`
- The aligner's reply gate checks the frozen roster and 403s anyone not in it, so HTTP-only agents got rejected immediately after the episode opened
- `_enforce_membership_change` had the same mismatch: a frozen set that now includes lease holders compared against a SLIM-only current set would always diverge and spuriously abort every negotiation on the first SLIM join/leave event

Both call sites updated to `set(self.members(room))`, which is the union the moderator's own docstring describes as authoritative.

## Root cause

`RoomChannelManager.members()` (line 287) has always computed SLIM ∪ live-leases and its docstring explicitly says "the mediator's roster is this union, so both kinds are first-class participants." `open_episode` bypassed it and read `managed.members` directly — the raw SLIM-only set on `ManagedRoomChannel`.

The bug was dormant because `engine_invoke` was 404-ing before `open_episode` ever ran. Once that was fixed, pure-HTTP stub agents hit the 403 on every reply.

## Test plan

- [ ] `uv run pytest tests/ -x -q` — 1038 passed, 6 skipped (confirmed)
- [ ] End-to-end: run a negotiation with a pure HTTP `await`/`respond` agent and confirm replies are accepted and the aligner scores them normally
- [ ] Verify a SLIM-member join mid-negotiation still aborts the episode (membership-change path unchanged in behaviour, just using the correct comparand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)