### PR TITLE
Make the Members rail and Memory panel legible at scale

### DIFF
--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -59,7 +59,7 @@ function DetailRow({
   if (value == null || value === "") return null;
   return (
     <div className="flex gap-2 text-micro leading-relaxed">
-      <span className="w-12 shrink-0 text-faint">{label}</span>
+      <span className="w-16 shrink-0 whitespace-nowrap text-faint">{label}</span>
       <span className="min-w-0 flex-1 break-words" style={color ? { color } : undefined}>
         {value}
       </span>
@@ -536,7 +536,7 @@ function PersonRow({
   return (
     <Tooltip
       side="left"
-      className="w-60 p-3"
+      className="w-72 max-w-72 p-3"
       content={
         <MemberTooltipCard handle={p.handle} color="var(--avatar-neutral)" presence={memberPresence}>
           <DetailRow label="role" value={p.owns ? "owner" : "posted here"} />
@@ -599,7 +599,7 @@ function AgentRow({
   return (
     <Tooltip
       side="left"
-      className="w-60 p-3"
+      className="w-72 max-w-72 p-3"
       content={
         <MemberTooltipCard handle={a.handle} presence={memberPresence}>
           <DetailRow label="owner" value={a.owner ? `@${a.owner}` : undefined} />

--- a/mycelium-frontend/src/components/agents-panel.tsx
+++ b/mycelium-frontend/src/components/agents-panel.tsx
@@ -4,12 +4,11 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import { Check, ChevronDown, Users } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Users } from "lucide-react";
 import { createEngine, registerA2aAgent, type EngineKind, type PresenceMember } from "@/lib/api";
 import { useNetworkStatus, useRoomRoster } from "@/lib/room-data";
 import { agentHandoffPrompt } from "@/lib/install";
 import { Button } from "@/components/ui/button";
-import { Chip } from "@/components/ui/chip";
 import { CopyAction } from "@/components/ui/copy-field";
 import { Input } from "@/components/ui/input";
 import { Monogram } from "@/components/ui/monogram";
@@ -47,17 +46,74 @@ function relativeTime(iso: string): string | null {
   return `${Math.floor(mins / 60)}h ago`;
 }
 
-/** A presence *note* to append after the role — only the part the avatar badge
- *  can't convey. A live SLIM socket is already the solid badge, so it adds
- *  nothing here (null); a polling lease adds "awaiting" + last-seen age. */
-function presenceNote(member?: PresenceMember): string | null {
-  if (!member || member.kind === "slim") return null;
-  const age = member.last_seen ? relativeTime(member.last_seen) : null;
-  return age ? `awaiting · seen ${age}` : "awaiting";
+/** One label/value line in a member card. Rendered only when it has a value. */
+function DetailRow({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value?: React.ReactNode;
+  color?: string;
+}) {
+  if (value == null || value === "") return null;
+  return (
+    <div className="flex gap-2 text-micro leading-relaxed">
+      <span className="w-12 shrink-0 text-faint">{label}</span>
+      <span className="min-w-0 flex-1 break-words" style={color ? { color } : undefined}>
+        {value}
+      </span>
+    </div>
+  );
 }
 
-function subtext(...parts: (string | null | undefined | false)[]): string {
-  return parts.filter(Boolean).join(" · ");
+/** How a member is hosted, in words — the honest expansion of the presence kind. */
+function hostingLabel(member: PresenceMember): string {
+  return member.kind === "slim" ? "SLIM socket" : "server-held await lease";
+}
+
+/** The presence half of a member card: how it's hosted and when it was last
+ *  seen — the detail behind the compact row's halo. */
+function presenceDetail(member?: PresenceMember): React.ReactNode {
+  if (!member) return null;
+  const age = member.last_seen ? relativeTime(member.last_seen) : null;
+  return (
+    <>
+      <DetailRow label="hosting" value={hostingLabel(member)} />
+      <DetailRow
+        label="last seen"
+        value={member.kind === "slim" ? "now (live socket)" : (age ?? "awaiting")}
+      />
+    </>
+  );
+}
+
+/** The hover card shown for any roster row: a monogram header plus a detail list
+ *  (identity rows the caller passes + the shared presence rows). Ported from the
+ *  herdr roster spike (#540), adapted to the fields on main. */
+function MemberTooltipCard({
+  handle,
+  color,
+  presence,
+  children,
+}: {
+  handle: string;
+  color?: string;
+  presence?: PresenceMember;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Monogram handle={handle} color={color} className="size-6" presence={presence?.kind} mutePresence />
+        <span className="font-mono text-label font-semibold text-text">@{handle}</span>
+      </div>
+      <div className="flex flex-col gap-0.5">
+        {children}
+        {presenceDetail(presence)}
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -79,7 +135,8 @@ export function AgentsPanel({
   focusHandle = null,
   onFocusConsumed,
 }: Props) {
-  const [mineOnly, setMineOnly] = useState(false);
+  // People collapse to a facepile and the idle swarm folds away — both by default.
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set(["people", "idle"]));
   const [agentOpen, setAgentOpen] = useState(false);
   const [engineOpen, setEngineOpen] = useState(false);
   const [a2aOpen, setA2aOpen] = useState(false);
@@ -119,10 +176,17 @@ export function AgentsPanel({
     setHighlight(focusHandle);
     onFocusConsumed?.();
   }, [focusHandle, onFocusConsumed]);
+  // A highlighted row can live in a folded group (the idle swarm), so reveal
+  // every group first, then scroll once it has mounted.
+  useEffect(() => {
+    if (!highlight) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCollapsedGroups(new Set());
+  }, [highlight]);
   useEffect(() => {
     if (!highlight) return;
     highlightRow.current?.scrollIntoView({ block: "center" });
-  }, [highlight, loading]);
+  }, [highlight, loading, collapsedGroups]);
 
   // Re-tick once a minute so the minute-granular "seen Xm ago" labels advance
   // without a refetch (matches the label resolution — no sub-minute churn).
@@ -132,22 +196,35 @@ export function AgentsPanel({
     return () => clearInterval(t);
   }, []);
 
-  // "Mine" scopes the agent list to the acting-as user: agents they own, plus
-  // any agent fielded by a team their own agents claim.
-  const myTeams = useMemo(
-    () =>
-      new Set(
-        agents.filter((a) => a.owner === principal && a.team).map((a) => a.team as string),
-      ),
-    [agents, principal],
-  );
-  const visibleAgents = useMemo(
-    () =>
-      !mineOnly || !principal
-        ? agents
-        : agents.filter((a) => a.owner === principal || (a.team && myTeams.has(a.team))),
-    [agents, mineOnly, principal, myTeams],
-  );
+  // Agents by where they are in their life, not who owns them (a room's swarm is
+  // nearly all one owner): **Engines** are the backend capabilities (aligner,
+  // synthesizer), kept apart because they persist; every other agent — coding
+  // agents and bridged A2A ones alike — is **Active** when it holds a live socket
+  // or an await lease and **Idle** otherwise. Idle folds by default so the handful
+  // working now leads, while the group count still says how large the room is.
+  const agentGroups = useMemo(() => {
+    const active: AgentSummary[] = [];
+    const engines: AgentSummary[] = [];
+    const idle: AgentSummary[] = [];
+    for (const a of agents) {
+      if (a.adapter === "engine") engines.push(a);
+      else if (presence.get(a.handle.toLowerCase())) active.push(a);
+      else idle.push(a);
+    }
+    return [
+      { id: "active", label: "Active agents", agents: active },
+      { id: "engines", label: "Engines", agents: engines },
+      { id: "idle", label: "Idle agents", agents: idle },
+    ].filter((g) => g.agents.length > 0);
+  }, [agents, presence]);
+
+  const toggleGroup = (id: string) =>
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
@@ -156,16 +233,6 @@ export function AgentsPanel({
         <span className="text-micro tabular text-muted-foreground">
           {people.length + agents.length}
         </span>
-        {principal && (
-          <Chip
-            variant="accent"
-            active={mineOnly}
-            onClick={() => setMineOnly((v) => !v)}
-            className="ml-1 px-2 py-0.5 text-micro"
-          >
-            mine
-          </Chip>
-        )}
         <Popover open={inviteOpen} onOpenChange={setInviteOpen}>
           <PopoverTrigger render={<Button variant="secondary" size="sm" className="ml-auto" />}>
             Invite <ChevronDown className="size-3" />
@@ -282,101 +349,69 @@ export function AgentsPanel({
           />
         )}
 
-        {people.length > 0 && (
-          <>
-            <SectionLabel count={people.length}>People</SectionLabel>
-            {people.map((p) => {
-              const memberPresence = presence.get(p.handle);
-              const marked = highlight === p.handle;
-              return (
-                <div
-                  key={`person-${p.handle}`}
-                  ref={marked ? highlightRow : undefined}
-                  className={`flex items-center gap-2.5 px-3 py-2 transition-colors hover:bg-hairline ${
-                    marked ? "bg-accent/15" : ""
-                  }`}
-                >
-                  <Monogram handle={p.handle} color="var(--avatar-neutral)" presence={memberPresence?.kind} />
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5">
-                      <span className="truncate font-mono text-label font-semibold text-text">
-                        @{p.handle}
-                      </span>
-                      {p.you && <span className="text-micro font-medium text-accent">you</span>}
-                    </div>
-                    <div className="mt-0.5 truncate text-micro text-muted-foreground">
-                      {subtext(
-                        p.owns ? "owner" : "posted here",
-                        presenceNote(memberPresence),
-                        p.teams.length > 0 && p.teams.join(", "),
-                      )}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </>
-        )}
-
-        {agents.length > 0 && <SectionLabel count={visibleAgents.length}>Agents</SectionLabel>}
-        {visibleAgents.map((a) => {
-          const mine = principal !== "" && a.owner === principal;
-          const memberPresence = presence.get(a.handle.toLowerCase());
-          const marked = highlight === a.handle;
+        {people.length > 0 && (() => {
+          const collapsed = collapsedGroups.has("people");
           return (
-            <div
-              key={`agent-${a.handle}`}
-              ref={marked ? highlightRow : undefined}
-              className={`flex items-center gap-2.5 px-3 py-2 transition-colors hover:bg-hairline ${
-                marked ? "bg-accent/15" : ""
-              }`}
-            >
-              <Monogram handle={a.handle} presence={memberPresence?.kind} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-1.5">
-                  <span className="truncate font-mono text-label font-semibold text-text">
-                    {a.handle}
-                  </span>
-                  {a.owner && (
-                    <Tooltip content={`owner: @${a.owner}`}>
-                      <span
-                        className="truncate font-mono text-micro"
-                        style={{ color: mine ? "var(--accent)" : "var(--muted-foreground)" }}
-                        aria-description={`owner: @${a.owner}`}
-                      >
-                        @{a.owner}
-                      </span>
-                    </Tooltip>
-                  )}
-                  {a.team && (
-                    <Tooltip content={`team: ${a.team}`}>
-                      <span
-                        className="truncate text-micro text-muted-foreground"
-                        aria-description={`team: ${a.team}`}
-                      >
-                        · {a.team}
-                      </span>
-                    </Tooltip>
-                  )}
-                  {a.adapter === "a2a" && (
-                    <span
-                      className="inline-flex items-center rounded-md border border-accent/30 bg-accent-soft/40 px-1.5 py-0 text-micro font-medium text-accent"
-                      title={a.a2a_endpoint ?? a.a2a_card ?? "external A2A agent"}
-                    >
-                      a2a
-                    </span>
-                  )}
-                </div>
-                <div className="mt-0.5 truncate text-micro text-muted-foreground">
-                  {subtext(
-                    a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter,
-                    presenceNote(memberPresence),
-                    a.adapter === "a2a" && a.a2a_skills && a.a2a_skills.length > 0
-                      ? a.a2a_skills.join(", ")
-                      : a.description,
-                  )}
-                </div>
-              </div>
+            <>
+              <SectionLabel
+                collapsible
+                collapsed={collapsed}
+                onToggle={() => toggleGroup("people")}
+                count={people.length}
+              >
+                People
+              </SectionLabel>
+              {collapsed ? (
+                <Facepile people={people} presence={presence} />
+              ) : (
+                people.map((p) => {
+                  const marked = highlight === p.handle;
+                  return (
+                    <PersonRow
+                      key={`person-${p.handle}`}
+                      person={p}
+                      memberPresence={presence.get(p.handle)}
+                      marked={marked}
+                      rowRef={marked ? highlightRow : undefined}
+                    />
+                  );
+                })
+              )}
+            </>
+          );
+        })()}
+
+        {agentGroups.map((group) => {
+          const collapsed = collapsedGroups.has(group.id);
+          // The owner the whole group shares, shown once in the header instead of
+          // repeated down every row. Null when the group's owners differ.
+          const owners = new Set(group.agents.map((a) => a.owner).filter(Boolean));
+          const groupOwner = owners.size === 1 ? [...owners][0]! : null;
+          return (
+            <div key={group.id}>
+              <SectionLabel
+                collapsible
+                collapsed={collapsed}
+                onToggle={() => toggleGroup(group.id)}
+                count={group.agents.length}
+                hint={groupOwner ? `@${groupOwner}` : undefined}
+              >
+                {group.label}
+              </SectionLabel>
+              {!collapsed &&
+                group.agents.map((a) => {
+                  const marked = highlight === a.handle;
+                  return (
+                    <AgentRow
+                      key={`agent-${a.handle}`}
+                      agent={a}
+                      groupOwner={groupOwner}
+                      memberPresence={presence.get(a.handle.toLowerCase())}
+                      marked={marked}
+                      rowRef={marked ? highlightRow : undefined}
+                    />
+                  );
+                })}
             </div>
           );
         })}
@@ -398,13 +433,205 @@ function InviteOption({ label, hint, onClick }: { label: string; hint: string; o
   );
 }
 
-/** Small uppercase divider between the People and Agents groups, with a count. */
-function SectionLabel({ children, count }: { children: React.ReactNode; count?: number }) {
-  return (
-    <div className="flex items-center gap-2 px-3 pt-4 pb-1 text-micro font-semibold uppercase tracking-wide text-faint">
+/** Small uppercase divider between roster groups, with a count. When `onToggle`
+ *  is given it becomes a collapse control with a chevron — how the idle swarm is
+ *  folded away by default. */
+function SectionLabel({
+  children,
+  count,
+  hint,
+  collapsible = false,
+  collapsed = false,
+  onToggle,
+}: {
+  children: React.ReactNode;
+  count?: number;
+  /** A normal-case aside after the count, e.g. the owner a whole group shares. */
+  hint?: string;
+  collapsible?: boolean;
+  collapsed?: boolean;
+  onToggle?: () => void;
+}) {
+  const inner = (
+    <>
+      {collapsible && (
+        <ChevronRight
+          className={`size-3 transition-transform ${collapsed ? "" : "rotate-90"}`}
+        />
+      )}
       <span>{children}</span>
       {count !== undefined && <span className="font-normal tabular">{count}</span>}
+      {hint && (
+        <span className="ml-auto min-w-0 truncate font-mono text-micro font-normal normal-case tracking-normal text-faint">
+          {hint}
+        </span>
+      )}
+    </>
+  );
+  const cls =
+    "flex w-full items-center gap-2 px-3 pt-4 pb-1 text-micro font-semibold uppercase tracking-wide text-faint";
+  return collapsible ? (
+    <button type="button" onClick={onToggle} className={`${cls} text-left hover:text-muted-foreground`}>
+      {inner}
+    </button>
+  ) : (
+    <div className={cls}>{inner}</div>
+  );
+}
+
+type AgentSummary = ReturnType<typeof useRoomRoster>["agents"][number];
+type RosterPerson = ReturnType<typeof useRoomRoster>["people"][number];
+
+/** People as an overlapping avatar stack: who's around, at a glance, in one row
+ *  instead of a dozen. Live/awaiting rides each face as its halo; the rest is a
+ *  hover tooltip. Overflow past `max` collapses to a `+N` disc. */
+function Facepile({
+  people,
+  presence,
+  max = 16,
+}: {
+  people: RosterPerson[];
+  presence: Map<string, PresenceMember>;
+  max?: number;
+}) {
+  const shown = people.slice(0, max);
+  const extra = people.length - shown.length;
+  return (
+    <div className="flex flex-wrap items-center gap-y-1.5 px-3 py-2">
+      {shown.map((p) => (
+        <Tooltip key={p.handle} content={`@${p.handle}${p.you ? " (you)" : ""}${p.owns ? " · owner" : ""}`}>
+          <div className="-ml-1.5 first:ml-0">
+            <Monogram
+              handle={p.handle}
+              color={p.you ? "var(--accent)" : "var(--avatar-neutral)"}
+              className="size-6 text-[9px] ring-2 ring-paper"
+              presence={presence.get(p.handle)?.kind}
+            />
+          </div>
+        </Tooltip>
+      ))}
+      {extra > 0 && (
+        <div className="-ml-1.5 flex size-6 items-center justify-center rounded-full border border-border bg-surface text-[9px] font-medium text-muted-foreground ring-2 ring-paper">
+          +{extra}
+        </div>
+      )}
     </div>
+  );
+}
+
+/** One person, one line — the expanded form of the facepile, matching the agent
+ *  rows' density. Owns/posted/teams live in the hover tooltip. */
+function PersonRow({
+  person: p,
+  memberPresence,
+  marked,
+  rowRef,
+}: {
+  person: RosterPerson;
+  memberPresence?: PresenceMember;
+  marked: boolean;
+  rowRef?: React.Ref<HTMLDivElement>;
+}) {
+  const meta = memberPresence?.kind === "slim" ? "live" : memberPresence?.kind === "lease" ? "awaiting" : null;
+  return (
+    <Tooltip
+      side="left"
+      className="w-60 p-3"
+      content={
+        <MemberTooltipCard handle={p.handle} color="var(--avatar-neutral)" presence={memberPresence}>
+          <DetailRow label="role" value={p.owns ? "owner" : "posted here"} />
+          <DetailRow label="teams" value={p.teams.length > 0 ? p.teams.join(", ") : undefined} />
+          {p.you && <DetailRow label="you" value="acting as this handle" color="var(--accent)" />}
+        </MemberTooltipCard>
+      }
+    >
+      <div
+        ref={rowRef}
+        className={`flex h-7 items-center gap-2 px-3 transition-colors hover:bg-hairline ${
+          marked ? "bg-accent/15" : ""
+        }`}
+      >
+        <Monogram handle={p.handle} color="var(--avatar-neutral)" className="size-5 text-[9px]" presence={memberPresence?.kind} mutePresence />
+        <span className="truncate font-mono text-label text-text">@{p.handle}</span>
+        {p.you && <span className="flex-shrink-0 text-micro font-medium text-accent">you</span>}
+        {meta && <span className="ml-auto flex-shrink-0 text-micro text-faint">{meta}</span>}
+      </div>
+    </Tooltip>
+  );
+}
+
+/** The one terse thing to show at the end of a compact row: what an engine is,
+ *  or how present a worker is. The avatar halo already carries live/awaiting, so
+ *  this stays short — the full story is in the row's hover tooltip. */
+function rowMeta(a: AgentSummary, presence?: PresenceMember): string | null {
+  if (a.adapter === "engine") return a.kind ?? "engine";
+  if (a.adapter === "a2a") return null; // the a2a badge already labels it
+  if (presence?.kind === "slim") return "live";
+  if (presence?.kind === "lease") return "awaiting";
+  return null;
+}
+
+/**
+ * One agent, one line. The dense roster reads as a scannable column of handles,
+ * not a stack of cards: a small avatar, the handle, and a terse right-aligned
+ * status. The owner is hoisted to the group header (nearly every agent in a room
+ * shares one), so a row only tags an owner when it breaks from the group's; the
+ * description and full owner/team live in the hover tooltip rather than on every
+ * row.
+ */
+function AgentRow({
+  agent: a,
+  groupOwner,
+  memberPresence,
+  marked,
+  rowRef,
+}: {
+  agent: AgentSummary;
+  /** The owner shared by the row's group, if any — omitted from the row itself. */
+  groupOwner: string | null;
+  memberPresence?: PresenceMember;
+  marked: boolean;
+  rowRef?: React.Ref<HTMLDivElement>;
+}) {
+  const meta = rowMeta(a, memberPresence);
+  const oddOwner = a.owner && a.owner !== groupOwner ? a.owner : null;
+  const adapter = a.adapter === "engine" && a.kind ? `engine · ${a.kind}` : a.adapter;
+  return (
+    <Tooltip
+      side="left"
+      className="w-60 p-3"
+      content={
+        <MemberTooltipCard handle={a.handle} presence={memberPresence}>
+          <DetailRow label="owner" value={a.owner ? `@${a.owner}` : undefined} />
+          <DetailRow label="team" value={a.team ?? undefined} />
+          <DetailRow label="adapter" value={adapter} />
+          <DetailRow
+            label="skills"
+            value={a.adapter === "a2a" && a.a2a_skills?.length ? a.a2a_skills.join(", ") : undefined}
+          />
+          <DetailRow label="about" value={a.description} />
+        </MemberTooltipCard>
+      }
+    >
+      <div
+        ref={rowRef}
+        className={`flex h-7 items-center gap-2 px-3 transition-colors hover:bg-hairline ${
+          marked ? "bg-accent/15" : ""
+        }`}
+      >
+        <Monogram handle={a.handle} className="size-5 text-[9px]" presence={memberPresence?.kind} mutePresence />
+        <span className="truncate font-mono text-label text-text">{a.handle}</span>
+        {a.adapter === "a2a" && (
+          <span className="inline-flex flex-shrink-0 items-center rounded border border-accent/30 bg-accent-soft/40 px-1 text-[9px] font-medium leading-tight text-accent">
+            a2a
+          </span>
+        )}
+        {oddOwner && (
+          <span className="truncate font-mono text-micro text-faint">@{oddOwner}</span>
+        )}
+        {meta && <span className="ml-auto flex-shrink-0 text-micro text-faint">{meta}</span>}
+      </div>
+    </Tooltip>
   );
 }
 

--- a/mycelium-frontend/src/components/memory-panel.test.tsx
+++ b/mycelium-frontend/src/components/memory-panel.test.tsx
@@ -204,7 +204,13 @@ describe("<MemoryPanel /> preview hovercard", () => {
     vi.useRealTimers();
   });
 
+  // The tree opens folded to its namespaces, so reveal the folder before the leaf.
+  const expandDecisions = async () => {
+    fireEvent.click(await screen.findByText("decisions"));
+  };
+
   const hoverRow = async () => {
+    await expandDecisions();
     const row = (await screen.findByText("ship-it.md")).closest("div")!;
     fireEvent.mouseEnter(row);
     return row;

--- a/mycelium-frontend/src/components/memory-panel.tsx
+++ b/mycelium-frontend/src/components/memory-panel.tsx
@@ -17,6 +17,10 @@ import {
   Network,
   Pencil,
   Eye,
+  Filter,
+  X,
+  Search,
+  Loader2,
 } from "lucide-react";
 import {
   fetchMemory,
@@ -93,6 +97,29 @@ function buildTree(memories: Memory[]): TreeNode[] {
   return root.children;
 }
 
+// Every memory-bearing node below this one — the count a collapsed folder shows,
+// so its weight is legible without expanding it.
+function countMemories(node: TreeNode): number {
+  let n = 0;
+  for (const child of node.children) {
+    if (child.memory) n += 1;
+    n += countMemories(child);
+  }
+  return n;
+}
+
+// Every folder path in the tree — used to seed the collapsed set so the panel
+// opens folded to its top-level namespaces rather than fully expanded.
+function folderPaths(nodes: TreeNode[], into: Set<string> = new Set()): Set<string> {
+  for (const node of nodes) {
+    if (node.children.length > 0) {
+      into.add(node.path);
+      folderPaths(node.children, into);
+    }
+  }
+  return into;
+}
+
 // Filename for a memory leaf, with its extension. Keys usually omit it (they're
 // stored as markdown); a structured value with no `text` field is really JSON.
 // A key that already carries an extension is shown as-is.
@@ -119,6 +146,9 @@ interface TreeRowsProps {
   selected: Memory | null;
   onPeek: (mem: Memory, row: HTMLElement) => void;
   onPeekEnd: () => void;
+  /** Paths on the way to a find-file match. When set, anything not in it is
+   *  dimmed (the row stays put and clickable, just faded). Null = no filter. */
+  activePaths: Set<string> | null;
 }
 
 function TreeRows({
@@ -130,6 +160,7 @@ function TreeRows({
   selected,
   onPeek,
   onPeekEnd,
+  activePaths,
 }: TreeRowsProps) {
   return (
     <>
@@ -137,6 +168,7 @@ function TreeRows({
         const isFolder = node.children.length > 0;
         const isOpen = isFolder && !collapsed.has(node.path);
         const isSelected = selected?.key === node.path;
+        const dimmed = activePaths !== null && !activePaths.has(node.path);
         const paddingLeft = 8 + depth * INDENT;
 
         return (
@@ -147,7 +179,8 @@ function TreeRows({
               onMouseLeave={onPeekEnd}
               onFocus={e => node.memory && onPeek(node.memory, e.currentTarget)}
               onBlur={onPeekEnd}
-              className={`flex w-full items-center gap-1.5 pr-3 transition-colors
+              className={`flex w-full items-center gap-1.5 pr-3 transition-[color,background,opacity]
+                ${dimmed ? "opacity-35" : ""}
                 ${isSelected ? "bg-accent/15 text-text" : "hover:bg-muted text-muted-foreground hover:text-text"}`}
             >
               {/* chevron — separate click target so it only toggles */}
@@ -194,6 +227,12 @@ function TreeRows({
                 </span>
               )}
 
+              {isFolder && (
+                <span className="flex-shrink-0 font-mono text-[10px] tabular text-faint">
+                  {countMemories(node)}
+                </span>
+              )}
+
               {node.memory && !isFolder && (
                 <span className="flex-shrink-0 font-mono text-[10px] tabular text-faint">
                   v{node.memory.version}
@@ -211,6 +250,7 @@ function TreeRows({
                 selected={selected}
                 onPeek={onPeek}
                 onPeekEnd={onPeekEnd}
+                activePaths={activePaths}
               />
             )}
           </div>
@@ -223,6 +263,9 @@ function TreeRows({
 export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusMemory }: Props) {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
+  // Find-file: a live, client-side filter on the key path — the plain "I know the
+  // name" complement to the semantic Search below it.
+  const [nameFilter, setNameFilter] = useState("");
   const [searchResults, setSearchResults] = useState<MemorySearchResult[] | null>(null);
   const [searching, setSearching] = useState(false);
   const [searchError, setSearchError] = useState<string | null>(null);
@@ -377,6 +420,47 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
 
   const tree = useMemo(() => buildTree(memories), [memories]);
 
+  // Find-file, dim style: the tree stays whole and in place; matches keep their
+  // ink while everything else fades. `activePaths` is every path on the way to a
+  // match — the matched keys plus their ancestor folders — so a match is never
+  // dimmed and never hidden behind a folded parent. Null when no filter is set.
+  const trimmedFilter = nameFilter.trim().toLowerCase();
+  const activePaths = useMemo(() => {
+    if (!trimmedFilter) return null;
+    const paths = new Set<string>();
+    for (const m of memories) {
+      if (!m.key.toLowerCase().includes(trimmedFilter)) continue;
+      const parts = m.key.split("/");
+      for (let i = 0; i < parts.length; i++) paths.add(parts.slice(0, i + 1).join("/"));
+    }
+    return paths;
+  }, [memories, trimmedFilter]);
+  const matchCount = useMemo(
+    () => (trimmedFilter ? memories.filter(m => m.key.toLowerCase().includes(trimmedFilter)).length : 0),
+    [memories, trimmedFilter],
+  );
+
+  // While filtering, fold every folder that leads to no match and open every one
+  // that does, so matches are revealed without disturbing the reader's own
+  // expansion when they clear the filter.
+  const filterCollapsed = useMemo(() => {
+    if (!activePaths) return null;
+    const collapsedSet = new Set<string>();
+    for (const path of folderPaths(tree)) if (!activePaths.has(path)) collapsedSet.add(path);
+    return collapsedSet;
+  }, [activePaths, tree]);
+
+  // Open folded: seed every folder into the collapsed set the first time
+  // memories arrive, so the panel starts as a scannable list of namespaces
+  // rather than a fully-expanded wall. Seeded during render (not in an effect) so
+  // the expanded tree never paints for a frame before it folds. Only seeds once —
+  // later folder toggles and search reveals own the set from then on.
+  const [collapseSeeded, setCollapseSeeded] = useState(false);
+  if (!collapseSeeded && memories.length > 0) {
+    setCollapseSeeded(true);
+    setCollapsed(folderPaths(tree));
+  }
+
   // A chat `[[wikilink]]` (or any external focus request) selects that memory.
   // The nonce re-fires the same key on a repeat click.
   useEffect(() => {
@@ -413,38 +497,31 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
             </Link>
           </Tooltip>
         </div>
-        {contributors.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mt-2.5">
-            {contributors.map(c => (
-              <span
-                key={c}
-                className="font-mono text-micro rounded-full px-2 py-0.5 text-muted-foreground bg-surface border border-border"
-              >
-                {c}
-              </span>
-            ))}
-          </div>
-        )}
       </div>
 
       <div className="flex-1 overflow-y-auto" onScroll={endPeek}>
-        {/* Search */}
+        {/* Semantic search — one quiet field, run on Enter. The leading glyph
+            turns to a spinner while it queries; a ↵ hint appears once there's
+            something to submit. */}
         <div className="px-4 py-3 border-b border-border bg-paper">
-          <div className="flex gap-2">
+          <div className="group flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2 transition-colors focus-within:border-accent focus-within:bg-bg">
+            {searching ? (
+              <Loader2 className="size-4 flex-shrink-0 animate-spin text-accent" />
+            ) : (
+              <Search className="size-4 flex-shrink-0 text-faint transition-colors group-focus-within:text-accent" />
+            )}
             <input
-              className="min-w-0 flex-1 rounded-lg bg-surface border border-border px-3 py-2 text-label text-text placeholder:text-muted-foreground focus:border-accent focus:bg-bg focus:outline-none transition-colors"
-              placeholder="Search memory…"
+              className="min-w-0 flex-1 bg-transparent text-label text-text placeholder:text-muted-foreground focus:outline-none"
+              placeholder="Search by meaning…"
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               onKeyDown={e => e.key === "Enter" && handleSearch()}
             />
-            <button
-              onClick={handleSearch}
-              disabled={searching}
-              className="flex-shrink-0 rounded-lg px-3.5 py-2 text-label font-medium bg-accent text-accent-fg transition-opacity hover:opacity-90 disabled:opacity-50"
-            >
-              {searching ? "…" : "Search"}
-            </button>
+            {searchQuery.trim() && !searching && (
+              <kbd className="flex-shrink-0 rounded border border-border bg-bg px-1 text-micro leading-tight text-faint">
+                ↵
+              </kbd>
+            )}
           </div>
           {searchError && (
             <p role="alert" className="mt-2 flex items-center gap-1.5 text-micro text-red">
@@ -488,6 +565,37 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
           </div>
         )}
 
+        {/* Find file — a live filter on the key path, distinct from the semantic
+            search above. Hidden while semantic results are showing (they replace
+            the tree) and while the room is empty. */}
+        {!searchResults && !loading && memories.length > 0 && (
+          <div className="flex items-center gap-2 border-b border-border px-4 py-1.5">
+            <Filter className="size-3.5 flex-shrink-0 text-faint" />
+            <input
+              id="memory-find-file"
+              className="min-w-0 flex-1 bg-transparent text-label text-text placeholder:text-muted-foreground focus:outline-none"
+              placeholder="Find a file by name…"
+              value={nameFilter}
+              onChange={e => setNameFilter(e.target.value)}
+              onKeyDown={e => e.key === "Escape" && setNameFilter("")}
+            />
+            {trimmedFilter && (
+              <>
+                <span className="flex-shrink-0 text-micro tabular text-faint">
+                  {matchCount} {matchCount === 1 ? "match" : "matches"}
+                </span>
+                <button
+                  onClick={() => setNameFilter("")}
+                  aria-label="Clear file filter"
+                  className="flex-shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-hairline hover:text-text"
+                >
+                  <X className="size-3.5" />
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
         {/* File tree */}
         {!searchResults && (
           <div className="py-1">
@@ -509,12 +617,13 @@ export function MemoryPanel({ roomName, focusKey = null, onFocusConsumed, focusM
               <TreeRows
                 nodes={tree}
                 depth={0}
-                collapsed={collapsed}
+                collapsed={filterCollapsed ?? collapsed}
                 onToggle={toggleNs}
                 onSelect={selectMemory}
                 selected={selected}
                 onPeek={startPeek}
                 onPeekEnd={endPeek}
+                activePaths={activePaths}
               />
             )}
           </div>

--- a/mycelium-frontend/src/components/ui/monogram.tsx
+++ b/mycelium-frontend/src/components/ui/monogram.tsx
@@ -21,6 +21,10 @@ interface Props {
   className?: string;
   /** Optional live-presence halo. */
   presence?: Presence;
+  /** Drop the presence dot's own tooltip. Set where the avatar sits inside a
+   *  larger hover target (a roster row's card, a facepile chip) that already
+   *  names the presence — otherwise the dot's bubble intercepts that hover. */
+  mutePresence?: boolean;
 }
 
 interface Halo {
@@ -45,7 +49,7 @@ function halo(presence: Presence): Halo {
  *  column of identical chips. Presence rides as a **halo** around it — colour
  *  for the tier, a breathing ring for a poll in flight — plus a corner dot that
  *  carries the tier on its own for anyone the ring's colour doesn't reach. */
-export function Monogram({ handle, color, className, presence }: Props) {
+export function Monogram({ handle, color, className, presence, mutePresence }: Props) {
   const tint = color ?? avatarTint(handle);
   const ring = presence ? halo(presence) : null;
   return (
@@ -72,7 +76,7 @@ export function Monogram({ handle, color, className, presence }: Props) {
       >
         {initials(handle)}
       </div>
-      {ring && <PresenceDot halo={ring} />}
+      {ring && <PresenceDot halo={ring} mute={mutePresence} />}
     </div>
   );
 }
@@ -80,15 +84,16 @@ export function Monogram({ handle, color, className, presence }: Props) {
 /** The corner dot. The halo is a colour, and colour alone shouldn't be the only
  *  carrier of a tier, so the dot names itself for screen readers rather than
  *  leaning on the tooltip a pointer reveals. */
-function PresenceDot({ halo: ring }: { halo: Halo }) {
-  return (
-    <Tooltip content={ring.label}>
-      <span
-        role="img"
-        aria-label={ring.label}
-        className="absolute -bottom-0.5 -right-0.5 block size-2.5 rounded-full ring-2 ring-paper"
-        style={{ background: ring.color }}
-      />
-    </Tooltip>
+function PresenceDot({ halo: ring, mute }: { halo: Halo; mute?: boolean }) {
+  const dot = (
+    <span
+      role="img"
+      aria-label={ring.label}
+      className="absolute -bottom-0.5 -right-0.5 block size-2.5 rounded-full ring-2 ring-paper"
+      style={{ background: ring.color }}
+    />
   );
+  // Muted: keep the dot and its accessible name, drop the hover bubble so it does
+  // not intercept an enclosing hover target.
+  return mute ? dot : <Tooltip content={ring.label}>{dot}</Tooltip>;
 }

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -36,7 +36,7 @@ import type { RoomStatus } from "@/lib/board/upstream";
 // ages rows against the reader's real clock, so a stale anchor makes a lively
 // room look abandoned (drained TTL bars, "seen 10d ago") — pull this forward
 // when it drifts too far behind the present.
-const NOW = Date.parse("2026-08-22T17:30:00Z");
+const NOW = Date.parse("2026-08-28T17:30:00Z");
 const iso = (minsAgo: number): string => new Date(NOW - minsAgo * 60_000).toISOString();
 
 export interface MockRoom {
@@ -141,8 +141,8 @@ function buildMockGraph(
 
 // ── agent manifests (YAML strings — the UI parses description/adapter) ─────────
 
-const agentManifest = (description: string, adapter = "claude_code"): string =>
-  `adapter: ${adapter}\ndescription: "${description}"\n`;
+const agentManifest = (description: string, adapter = "claude_code", owner?: string): string =>
+  `adapter: ${adapter}\ndescription: "${description}"\n` + (owner ? `owner: ${owner}\n` : "");
 
 /** An external A2A agent's manifest: the card the hub resolved plus what it
  *  advertises, the fields the roster and the Network pane read. */
@@ -956,7 +956,7 @@ const generalMemories: MockMemory[] = [
   {
     key: "work/860-retire-the-negotiate-pane-channel-board-netw",
     value: "860: retire the Negotiate pane — Channel · Board · Network",
-    meta: { kind: "action", status: "open", assignee: "@fix-860" },
+    meta: { kind: "action", status: "in_progress", owner: "@fix-860", assignment: "held", ttl_minutes: 1440 },
     created_by: "fix-860",
     version: 3,
     updated_at: iso(63),
@@ -965,7 +965,7 @@ const generalMemories: MockMemory[] = [
   {
     key: "work/872-every-memory-can-be-discussed-widen-thread-m",
     value: "872: every memory can be discussed",
-    meta: { kind: "action", status: "open", assignee: "@task-872" },
+    meta: { kind: "action", status: "in_progress", owner: "@task-872", assignment: "held", ttl_minutes: 1440 },
     created_by: "task-872",
     version: 3,
     updated_at: iso(62),
@@ -974,7 +974,7 @@ const generalMemories: MockMemory[] = [
   {
     key: "work/881-mycelium-login-auto-discovers-the-oidc-issue",
     value: "881: mycelium login auto-discovers the OIDC issuer from the hub",
-    meta: { kind: "action", status: "open", assignee: "@fix-881" },
+    meta: { kind: "action", status: "in_progress", owner: "@fix-881", assignment: "held", ttl_minutes: 1440 },
     created_by: "fix-881",
     version: 3,
     updated_at: iso(68),
@@ -983,7 +983,7 @@ const generalMemories: MockMemory[] = [
   {
     key: "work/886-activity-feed-needs-real-coalescing-group-kn",
     value: "886: activity feed needs real coalescing — group Knowledge/pings/notices",
-    meta: { kind: "action", status: "open", assignee: "@task-886" },
+    meta: { kind: "action", status: "in_progress", owner: "@task-886", assignment: "held", ttl_minutes: 1440 },
     created_by: "task-886",
     version: 3,
     updated_at: iso(67),
@@ -992,7 +992,7 @@ const generalMemories: MockMemory[] = [
   {
     key: "work/887-task-view-has-a-double-scroll-one-scroll-col",
     value: "887: task view has a double-scroll — one scroll, collapsible markdown over the chat",
-    meta: { kind: "action", status: "open", assignee: "@task-887" },
+    meta: { kind: "action", status: "in_progress", owner: "@task-887", assignment: "held", ttl_minutes: 1440 },
     created_by: "task-887",
     version: 3,
     updated_at: iso(60),
@@ -1001,7 +1001,7 @@ const generalMemories: MockMemory[] = [
   {
     key: "work/888-markdown-headings-are-uppercased-and-the-bod",
     value: "888: markdown headings are uppercased and the body styling looks poor",
-    meta: { kind: "action", status: "open", assignee: "@task-888" },
+    meta: { kind: "action", status: "in_progress", owner: "@task-888", assignment: "held", ttl_minutes: 1440 },
     created_by: "task-888",
     version: 3,
     updated_at: iso(6),
@@ -1010,7 +1010,7 @@ const generalMemories: MockMemory[] = [
   {
     key: "work/889-channel-ping-notice-rendering-slug-instead-o",
     value: "889: channel ping/notice rendering — slug instead of title, ragged type",
-    meta: { kind: "action", status: "open", assignee: "@task-889" },
+    meta: { kind: "action", status: "in_progress", owner: "@task-889", assignment: "held", ttl_minutes: 1440 },
     created_by: "task-889",
     version: 3,
     updated_at: iso(63),
@@ -1018,7 +1018,7 @@ const generalMemories: MockMemory[] = [
   },
   {
     key: "agents/fix-860",
-    value: agentManifest("Working 860."),
+    value: agentManifest("Working 860.", "claude_code", "operator@example.com"),
     created_by: "claude-web",
     version: 1,
     updated_at: iso(75),
@@ -1026,7 +1026,7 @@ const generalMemories: MockMemory[] = [
   },
   {
     key: "agents/task-872",
-    value: agentManifest("Working 872."),
+    value: agentManifest("Working 872.", "claude_code", "operator@example.com"),
     created_by: "claude-web",
     version: 1,
     updated_at: iso(79),
@@ -1034,7 +1034,7 @@ const generalMemories: MockMemory[] = [
   },
   {
     key: "agents/task-886",
-    value: agentManifest("Working 886."),
+    value: agentManifest("Working 886.", "claude_code", "operator@example.com"),
     created_by: "claude-web",
     version: 1,
     updated_at: iso(86),
@@ -1042,7 +1042,7 @@ const generalMemories: MockMemory[] = [
   },
   {
     key: "agents/task-887",
-    value: agentManifest("Working 887."),
+    value: agentManifest("Working 887.", "claude_code", "operator@example.com"),
     created_by: "claude-web",
     version: 1,
     updated_at: iso(81),
@@ -1050,7 +1050,7 @@ const generalMemories: MockMemory[] = [
   },
   {
     key: "agents/task-888",
-    value: agentManifest("Working 888."),
+    value: agentManifest("Working 888.", "claude_code", "operator@example.com"),
     created_by: "claude-web",
     version: 1,
     updated_at: iso(80),
@@ -1058,11 +1058,208 @@ const generalMemories: MockMemory[] = [
   },
   {
     key: "agents/task-889",
-    value: agentManifest("Working 889."),
+    value: agentManifest("Working 889.", "claude_code", "operator@example.com"),
     created_by: "claude-web",
     version: 1,
     updated_at: iso(80),
     episode: generalEpisode("a889ff"),
+  },
+];
+
+// The room at true scale: `mycelium-general` under load — a dozen people each
+// fielding a few one-shot task workers, plus the two engines and a bridged agent.
+// The Members rail has to stay legible at three dozen agents and a dozen owners,
+// and the Memory tree has to survive as many `agents/*` manifests plus the work
+// they file. That pressure is the design target, so the fixture carries it.
+
+// The humans fielding the swarm. Agents are handed out round-robin across them so
+// the People group fills the way a busy shared room's does — many owners, each
+// running a few workers — rather than the single-operator degenerate case.
+const GENERAL_PEOPLE = [
+  "operator@example.com",
+  "june@example.com",
+  "kesh@example.com",
+  "milo@example.com",
+  "priya@example.com",
+  "dre@example.com",
+  "sol@example.com",
+  "wen@example.com",
+  "tomas@example.com",
+  "ada@example.com",
+  "nour@example.com",
+  "bex@example.com",
+];
+
+interface GeneralAgent {
+  handle: string;
+  description: string;
+  adapter?: string;
+  minsAgo: number;
+}
+
+// The one-shot workers beyond the seven already wired into the L9 chain above.
+// Handles mirror the live hub: a `task-NNN`/`fix-NNN` per board item, plus a few
+// human-named one-offs. All owned by the one operator — the single-owner reality
+// the roster redesign has to handle.
+const generalExtraAgents: GeneralAgent[] = [
+  { handle: "fix-881", description: "Working 881: OIDC issuer auto-discovery.", minsAgo: 82 },
+  { handle: "promo-audio", description: "Compose a synthetic ambient backing track for the mycelium-promo video.", minsAgo: 300 },
+  { handle: "mobile-layout-fix", description: "Fixing mobile view layout issues in the frontend.", minsAgo: 620 },
+  { handle: "rm-integrity-banner", description: "Remove the memory-detail integrity banner from the GUI.", minsAgo: 410 },
+  { handle: "chat-search-minimap", description: "Ctrl+F in-chat search with an IDE-style match minimap on the scrollbar.", minsAgo: 355 },
+  { handle: "token-refresh-docs", description: "Document access-token lifetime and refresh cadence in the login guide.", minsAgo: 240 },
+  { handle: "fix-891", description: "Remove the consent / incoming-agent-request flow (#891).", minsAgo: 190 },
+  { handle: "fix-899", description: "Reverse-scroll pagination for the room channel (#899).", minsAgo: 175 },
+  { handle: "fix-907", description: "Thread every memory: drop the threading blocklist (#907).", minsAgo: 160 },
+  { handle: "task-902", description: "Board grouping: collapse resolved rows by default.", minsAgo: 145 },
+  { handle: "task-903", description: "Roster rail: group members and collapse idle agents.", minsAgo: 130 },
+  { handle: "task-905", description: "Memory tree: fold namespaces by default with per-folder counts.", minsAgo: 120 },
+  { handle: "task-908", description: "Search palette: rank agents above stale memories.", minsAgo: 110 },
+  { handle: "task-911", description: "Presence lease: stop expiring mid-turn on slow replies.", minsAgo: 95 },
+  { handle: "task-912", description: "Notice rendering: title over slug in the activity feed.", minsAgo: 88 },
+  { handle: "task-915", description: "Install panel: trim to the CLI-connect section.", minsAgo: 84 },
+  { handle: "task-918", description: "Command palette: jump to a room by fuzzy name.", minsAgo: 72 },
+  { handle: "task-921", description: "Streamline agent onboarding into one paste.", minsAgo: 66 },
+  { handle: "task-922", description: "Empty-state copy pass across the rails.", minsAgo: 58 },
+  { handle: "task-925", description: "Board promo: task-first, score cued to the board.", minsAgo: 44 },
+  { handle: "task-928", description: "Graph view: dim orphan memories, highlight roots.", minsAgo: 33 },
+  { handle: "task-931", description: "Thread pane: collapse the markdown body over the chat.", minsAgo: 21 },
+  { handle: "task-934", description: "Keycap sizing on the 24px status rail.", minsAgo: 14 },
+  { handle: "task-937", description: "A2A bridge: surface a slow peer as awaiting, not dead.", minsAgo: 9 },
+  { handle: "fix-940", description: "Reindex after import so search answers new rows.", minsAgo: 6 },
+  { handle: "fix-941", description: "Config apply picks up a hand-set model.", minsAgo: 4 },
+  { handle: "task-944", description: "Screenshot workflow renders the roster at scale.", minsAgo: 3 },
+  { handle: "task-947", description: "Docs: consumer-first ordering on the concepts pages.", minsAgo: 2 },
+  { handle: "aligner", description: "First-party mediator (NEGMAS SAO).", adapter: "engine", minsAgo: 500 },
+  { handle: "synthesizer", description: "Distills room memory into a shared briefing.", adapter: "engine", minsAgo: 500 },
+];
+
+const generalExtraAgentMemories: MockMemory[] = generalExtraAgents.map((a, i) => ({
+  key: `agents/${a.handle}`,
+  value: agentManifest(
+    a.description,
+    a.adapter ?? "claude_code",
+    a.adapter === "engine" ? undefined : GENERAL_PEOPLE[i % GENERAL_PEOPLE.length],
+  ),
+  created_by: a.adapter === "engine" ? "operator" : "claude-web",
+  version: 1,
+  updated_at: iso(a.minsAgo),
+  episode: generalEpisode(`x${a.handle}`),
+}));
+
+// A bridged external agent, so the roster's "Services" group is not just engines.
+generalExtraAgentMemories.push({
+  key: "agents/echo",
+  value: a2aManifest("Hello-world A2A agent, for smoke tests.", "https://echo.example", ["greet"]),
+  created_by: "operator",
+  version: 1,
+  updated_at: iso(700),
+  episode: generalEpisode("xecho"),
+});
+
+// The non-`agents/` memories the swarm produced — decisions, context, status,
+// a couple of promoted skills, and a parked failure — so the Memory tree has
+// every namespace the real room grew, not just `work/` and `agents/`.
+const generalExtraMemories: MockMemory[] = [
+  {
+    key: "context/goal",
+    value: "Keep the app legible while a swarm of agents works the board.",
+    content_text: "Keep the app legible while a swarm of agents works the board.",
+    created_by: "operator",
+    version: 1,
+    updated_at: iso(60 * 90),
+    episode: generalEpisode("cgoal"),
+  },
+  {
+    key: "context/conventions",
+    value: "No em dashes in user copy. Plain prose. No design docs in the repo.",
+    content_text: "No em dashes in user copy. Plain prose. No design docs in the repo.",
+    created_by: "operator",
+    version: 4,
+    updated_at: iso(60 * 40),
+    episode: generalEpisode("cconv"),
+  },
+  {
+    key: "context/synthesis",
+    value:
+      "# mycelium-general — room briefing\n\n" +
+      "**Theme.** UX at scale: the rails buckle when three dozen agents work at once.\n\n" +
+      "**In flight.** 886 (activity coalescing), 887 (task double-scroll), roster + memory-tree grouping.\n\n" +
+      "**Landed.** 881 issuer discovery, 889 notice rendering, onboarding streamlined.",
+    content_text:
+      "Room briefing: UX at scale. In flight — activity coalescing, task scroll, roster + memory grouping. Landed — issuer discovery, notice rendering, onboarding.",
+    created_by: "synthesizer",
+    version: 1,
+    updated_at: iso(40),
+    episode: generalEpisode("csynth"),
+  },
+  {
+    key: "decisions/roster-grouping",
+    value: "Group the Members rail by lifecycle (live / awaiting / idle), not owner — one operator owns nearly all of them.",
+    content_text: "Group the roster by lifecycle, not owner: a single owner makes owner-grouping useless.",
+    created_by: "operator",
+    version: 1,
+    updated_at: iso(128),
+    episode: generalEpisode("droster"),
+  },
+  {
+    key: "decisions/memory-tree-default",
+    value: "Memory tree folds namespaces by default, with a per-folder count. Search bypasses the tree.",
+    content_text: "Fold the memory tree by default with folder counts.",
+    created_by: "operator",
+    version: 1,
+    updated_at: iso(118),
+    episode: generalEpisode("dtree"),
+  },
+  {
+    key: "decisions/drop-contributor-pills",
+    value: "Drop the contributor pill wall in the Memory panel; keep the count. Per-memory attribution already lives in the drawer.",
+    content_text: "Drop the contributor pills; keep the count.",
+    created_by: "operator",
+    version: 1,
+    updated_at: iso(112),
+    episode: generalEpisode("dpills"),
+  },
+  {
+    key: "status/sprint",
+    value: "Swarm working the UX backlog. 886 gates readability; land it first.",
+    content_text: "Swarm on the UX backlog; 886 gates readability.",
+    created_by: "operator@example.com",
+    version: 6,
+    updated_at: iso(8),
+    episode: generalEpisode("ssprint"),
+  },
+  {
+    key: "skills/take-a-task",
+    value:
+      "---\ndescription: Take a task off the board, work it in its own thread, resolve it.\n---\n\n" +
+      "Claim an open `work/` row, coordinate in its thread, and resolve it when the PR lands.",
+    content_text: "Take a task off the board, work it in its thread, resolve it.",
+    created_by: "operator",
+    version: 2,
+    updated_at: iso(60 * 30),
+    episode: generalEpisode("sktask"),
+  },
+  {
+    key: "skills/screenshot",
+    value:
+      "---\ndescription: Capture the running app or CLI output with shotkit.\n---\n\n" +
+      "Use `node shotkit/bin/shot.mjs app <route> --mock` to shoot a panel at scale.",
+    content_text: "Capture the app or CLI output with shotkit.",
+    created_by: "operator",
+    version: 1,
+    updated_at: iso(60 * 28),
+    episode: generalEpisode("skshot"),
+  },
+  {
+    key: "failed/coalescing-spike",
+    value: "First activity-coalescing spike over-grouped and hid the human's lines. Parked; see 886.",
+    meta: { kind: "concern", status: "blocked", owner: "@task-886", blocked_by: ["#886"] },
+    content_text: "Coalescing spike over-grouped and buried human messages. Parked.",
+    created_by: "task-886",
+    version: 1,
+    updated_at: iso(70),
+    episode: generalEpisode("fcoal"),
   },
 ];
 
@@ -1107,9 +1304,9 @@ const generalL9: Record<string, unknown>[] = [
   generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "task-887", "m67-0", 62),
   generalPing("work/872-every-memory-can-be-discussed-widen-thread-m", "task-872", "m69-0", 62),
   generalNotice("resolved", "work/872-every-memory-can-be-discussed-widen-thread-m", "872: every memory can be discussed", "task-872", 62),
-  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "juliarvalenti@gmail.com", "m73-0", 60),
-  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "juliarvalenti@gmail.com", "m73-1", 60),
-  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "juliarvalenti@gmail.com", "m73-2", 60),
+  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "operator@example.com", "m73-0", 60),
+  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "operator@example.com", "m73-1", 60),
+  generalPing("work/887-task-view-has-a-double-scroll-one-scroll-col", "operator@example.com", "m73-2", 60),
   generalNotice("claimed", "work/888-markdown-headings-are-uppercased-and-the-bod", "888: markdown headings are uppercased and the body styling looks poor", "task-888", 6),
 ];
 
@@ -1224,7 +1421,7 @@ function generalKnowledge(key: string, updatedBy: string, minutesAgo: number): M
 const generalSaid: MockMessage[] = [
   {
     id: "gs-1",
-    sender_handle: "juliarvalenti@gmail.com",
+    sender_handle: "operator@example.com",
     message_type: "broadcast",
     created_at: iso(70),
     episode: GENERAL_LIVE,
@@ -1232,7 +1429,7 @@ const generalSaid: MockMessage[] = [
   },
   {
     id: "gs-2",
-    sender_handle: "juliarvalenti@gmail.com",
+    sender_handle: "operator@example.com",
     message_type: "broadcast",
     created_at: iso(30),
     episode: GENERAL_LIVE,
@@ -1240,7 +1437,7 @@ const generalSaid: MockMessage[] = [
   },
   {
     id: "gs-3",
-    sender_handle: "juliarvalenti@gmail.com",
+    sender_handle: "operator@example.com",
     message_type: "broadcast",
     created_at: iso(8),
     episode: GENERAL_LIVE,
@@ -1261,13 +1458,17 @@ const generalBacklog: MockMessage[] = Array.from({ length: 260 }, (_, i) => {
   const said = [
     "Rebased onto main; the compose smoke build is green again.",
     "The presence lease expiring mid-turn is what dropped that reply, not SLIM.",
-    "Reindexed after the import — search is answering for the new rows now.",
+    "Reindexed after the import, search is answering for the new rows now.",
     "Anyone else seeing the aligner take two rounds to notice the agreement?",
-    "That was a stale .env — config apply and it picked the model up.",
+    "That was a stale .env, config apply and it picked the model up.",
   ];
+  // The backlog is attributed to handles that are actually in the room — the one
+  // operator and a handful of registered agents — so replaying it does not mint
+  // phantom "people" who only ever appear as a backlog sender.
+  const senders = ["operator@example.com", "task-872", "fix-860", "task-888", "task-889", "task-886"];
   return {
     id: `gb-${i}`,
-    sender_handle: i % 3 === 0 ? "juliarvalenti@gmail.com" : `task-${800 + (i % 40)}`,
+    sender_handle: senders[i % senders.length],
     message_type: "broadcast",
     created_at: iso(60 * 26 - i * 5),
     episode: GENERAL_LIVE,
@@ -1284,13 +1485,26 @@ const general: RoomFixture = {
     is_persistent: true,
     mas_id: "mas_9f3c02de",
   },
-  memories: generalMemories,
+  memories: [...generalMemories, ...generalExtraAgentMemories, ...generalExtraMemories],
   messages: [...generalBacklog, ...generalKnowledgePushes, ...generalSaid].sort(
     (a, b) => Date.parse(a.created_at) - Date.parse(b.created_at),
   ),
   episodes: [],
   episodeDetails: {},
   l9: generalL9,
+  // A handful live or awaiting; the rest of the swarm reads as idle. This is what
+  // splits the roster into its lifecycle groups.
+  presence: [
+    { handle: "task-937", kind: "slim", last_seen: null },
+    { handle: "fix-940", kind: "slim", last_seen: null },
+    { handle: "fix-941", kind: "slim", last_seen: null },
+    { handle: "task-944", kind: "slim", last_seen: null },
+    { handle: "task-888", kind: "slim", last_seen: null },
+    { handle: "task-931", kind: "lease", last_seen: iso(2) },
+    { handle: "task-934", kind: "lease", last_seen: iso(4) },
+    { handle: "task-947", kind: "lease", last_seen: iso(1) },
+    { handle: "aligner", kind: "lease", last_seen: iso(5) },
+  ],
 };
 
 export const ROOM_FIXTURES: Record<string, RoomFixture> = {


### PR DESCRIPTION
The room roster and memory tree were built for a handful of entries and buckle when a room has three dozen agents and fifty memories. This reworks both surfaces to stay scannable at that scale, and grows the mock so the state is reachable in `--mock`.

## Members rail
- **Dense single-line rows**, grouped by lifecycle — **Active agents / Engines / Idle agents** — with **People collapsed to a facepile** and the idle swarm **folded by default**. Group counts keep the room's real size legible (the header still shows the full member count).
- The **shared owner is hoisted to the group header** instead of repeated down every row (a room's swarm is nearly all one owner); a row only tags an owner when it breaks from the group's.
- A **whole-row hover card** — ported from the herdr roster spike (#540), adapted to the fields on `main`: monogram header + identity and presence detail (hosting, last seen).
- `Monogram` gains **`mutePresence`** so the presence dot keeps its accessible name but drops its own tooltip when it sits inside a larger hover target — otherwise it intercepted the row's card.

## Memory panel
- The **namespace tree opens folded** with **per-folder counts** (seeded during render, so the expanded tree never flashes before it folds).
- A **find-file filter**: a live, client-side **dim** filter on the key path. Matches keep their ink and their folders open; everything else fades in place — the tree never jumps or disappears. Distinct from the semantic search.
- The **semantic search is restyled** from a loud accent button to one quiet field with a leading icon (spinner while querying, run on Enter).
- The **contributor pill wall is dropped**; the count stays in the stats row.

## Mock
- `mycelium-general` grown to the shape of the live hub: ~37 agents across a dozen owners, 54 memories across every namespace, presence split into live/awaiting/idle, work rows genuinely claimed by their workers. `NOW` pulled forward so leases don't read as expired. Real email removed.

## Testing
- `pnpm exec vitest run` — 808 passed
- `pnpm tsc --noEmit` + `eslint` clean
- Verified visually via shotkit against the `mycelium-general` mock (roster groups + facepile, hover card, folded/dim memory tree, restyled search).