### PR TITLE
Clamp long chat messages behind a Show more toggle

### DIFF
--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -12,7 +12,7 @@ import {
 import { useRoomAgents, useRoomRowNames, useRoomThreads, type RowNaming, type ThreadOwner } from "@/lib/room-data";
 import { NOTICE_TYPE, PING_TYPE, isLiveEpisode, noticeLabel, noticeOf, pingOf, threadShortId } from "@/lib/threads";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
-import { MarkdownContent } from "@/components/markdown-content";
+import { MessageBody } from "@/components/message-body";
 import { ChatFindBar } from "@/components/chat-find-bar";
 import { ChatMinimap, type MinimapTick } from "@/components/chat-minimap";
 import { HighlightText } from "@/components/ui/highlight-text";
@@ -1315,13 +1315,7 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
                         )}
                       </div>
                     )}
-                    <MarkdownContent
-                      className="contrast text-body leading-relaxed"
-                      onLinkClick={onOpenMemory}
-                      highlight={hit}
-                    >
-                      {ev.content}
-                    </MarkdownContent>
+                    <MessageBody content={ev.content} hit={hit} onOpenMemory={onOpenMemory} />
                     {ev.edited && (
                       <span className="text-micro text-faint" title="revised by a later message">
                         (edited)

--- a/mycelium-frontend/src/components/message-body.tsx
+++ b/mycelium-frontend/src/components/message-body.tsx
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { MarkdownContent } from "@/components/markdown-content";
+import type { Highlight } from "@/components/ui/highlight-text";
+
+/** How tall a message's prose gets before it clamps behind a "Show more" —
+ *  roughly eight lines of body text. Long enough that ordinary messages never
+ *  clamp, short enough that a wall of text can't swallow the timeline. */
+const CLAMP_PX = 168;
+
+/**
+ * A message's prose, clamped when it runs long.
+ *
+ * Both the room channel and a task's discussion are scannable logs, so one
+ * message shouldn't be able to fill the viewport. Past ~eight lines the body is
+ * capped with a soft fade and a muted "Show more" toggle; expanding is in place
+ * and reversible, and nothing is summarized or thrown away — the reader still
+ * gets every word on demand. Only the measured-too-tall case grows the control,
+ * so short messages are untouched. Shared by the channel (`event-stream`) and
+ * the thread pane (`task-conversation`) so the affordance is identical in both.
+ */
+export function MessageBody({
+  content,
+  hit,
+  onOpenMemory,
+}: {
+  content: string;
+  hit?: Highlight;
+  onOpenMemory?: (key: string) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [overflows, setOverflows] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  // Measure the natural height (scrollHeight ignores the clamp) and re-measure on
+  // width changes, since re-wrapping changes how tall the prose is.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || typeof ResizeObserver === "undefined") {
+      if (el) setOverflows(el.scrollHeight > CLAMP_PX + 24);
+      return;
+    }
+    const measure = () => setOverflows(el.scrollHeight > CLAMP_PX + 24);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [content]);
+
+  // A find match forces the message open: the hit could be in the clamped-off
+  // tail, and a highlight the reader can't see is a broken search. The manual
+  // toggle steps aside while a match holds it open.
+  const forceOpen = Boolean(hit);
+  const clamped = overflows && !expanded && !forceOpen;
+
+  return (
+    <>
+      <div
+        ref={ref}
+        className="relative overflow-hidden"
+        style={clamped ? { maxHeight: CLAMP_PX } : undefined}
+      >
+        <MarkdownContent className="contrast text-body leading-relaxed" onLinkClick={onOpenMemory} highlight={hit}>
+          {content}
+        </MarkdownContent>
+        {clamped && (
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-bg to-transparent" />
+        )}
+      </div>
+      {overflows && !forceOpen && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-1 inline-flex items-center gap-0.5 text-micro font-medium text-muted-foreground transition-colors hover:text-text"
+        >
+          {expanded ? (
+            <>Show less <ChevronUp className="size-3" /></>
+          ) : (
+            <>Show more <ChevronDown className="size-3" /></>
+          )}
+        </button>
+      )}
+    </>
+  );
+}

--- a/mycelium-frontend/src/components/task/task-conversation.tsx
+++ b/mycelium-frontend/src/components/task/task-conversation.tsx
@@ -9,7 +9,7 @@ import type { RoomMessage } from "@/lib/api";
 import { useRoomAgents, useThreadMessages } from "@/lib/room-data";
 import { useRoomStream } from "@/lib/stream-hub";
 import { pingOf } from "@/lib/threads";
-import { MarkdownContent } from "@/components/markdown-content";
+import { MessageBody } from "@/components/message-body";
 import { EmptyState } from "@/components/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Monogram } from "@/components/ui/monogram";
@@ -193,12 +193,7 @@ export function TaskConversation({ roomName, episode, onOpenMemory, onReady }: P
                   {!grouped && (
                     <span className="text-label font-semibold text-text">{sender}</span>
                   )}
-                  <MarkdownContent
-                    className="contrast text-body leading-relaxed"
-                    onLinkClick={onOpenMemory}
-                  >
-                    {text}
-                  </MarkdownContent>
+                  <MessageBody content={text} onOpenMemory={onOpenMemory} />
                 </div>
               </div>
             );

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -691,6 +691,31 @@ const atlas: RoomFixture = {
     // The backfill row's own thread: the reconciliation chased down.
     { id: "r1", sender_handle: "backfill", message_type: "broadcast", content: "reconciliation found 12 rows out of sync, all in the archived partition.", created_at: iso(16), episode: ATLAS_RETIRE_THREAD },
     { id: "r2", sender_handle: "backfill", message_type: "broadcast", content: "dual-write gap during the 09:14 deploy. patched the 12 by hand, counts match now.", created_at: iso(15), episode: ATLAS_RETIRE_THREAD },
+    // Two deliberately long, multi-paragraph messages — the wall-of-text case the
+    // channel has to handle without swallowing everything around it.
+    {
+      id: "long1",
+      sender_handle: "backfill",
+      message_type: "broadcast",
+      created_at: iso(13),
+      content:
+        "Full reconciliation write-up before we flip, so it's on the record and not just in my head.\n\n" +
+        "What I did: ran a row-by-row checksum of the catalog table between the old store and the new one, partitioned by month so I could parallelize it and so a mismatch would point at a date range rather than the whole 2M rows. Old store is the source of truth for anything written before dual-write went on (#499); the new store is authoritative only for the window since. The checksum is a SHA over the business columns (sku, price_cents, updated_at, status) — deliberately not the surrogate id, because the new store re-sequences those and I didn't want a billion false positives.\n\n" +
+        "What it found: 12 rows out of sync, every one of them in the archived partition (2019 and older). All 12 trace to the 09:14 deploy window, where dual-write dropped writes for about ninety seconds while the connection pool recycled. So this is not a copy bug — the historical copy is clean — it's a dual-write gap, which is exactly the failure mode we said we'd watch for.\n\n" +
+        "What I changed: patched the 12 by hand from the old store's values (they hadn't been touched since 2019, so the old store is unambiguously right), then re-ran the checksum for that partition only. Counts and checksums match now. I also added a standing job that re-checksums the archived partition every hour until cutover, so if the pool recycles again we hear about it in an hour instead of at the flip.\n\n" +
+        "What this means for Friday: I'm comfortable signing off on the read switch as far as data integrity goes. The one thing I'd still want before we flip is a clean run of the hourly checksum with zero new mismatches across a full 24h — that's the soak. If that's green Thursday night, flip Friday am as planned. If it's not, we hold and I dig into why the pool is still dropping writes.",
+    },
+    {
+      id: "long2",
+      sender_handle: "operator",
+      message_type: "broadcast",
+      created_at: iso(11),
+      content:
+        "Thanks, that's exactly the level of detail I wanted. Two follow-ups and then a decision.\n\n" +
+        "First: the ninety-second dual-write gap worries me more than the 12 rows do. The rows are fixed, but the gap is a class of bug — it'll happen again every time the pool recycles under load, and cutover day is the highest-load day we'll have. Can we pin the pool or bump the recycle timeout so it doesn't churn during the flip window? I'd rather spend an hour hardening that than discover a fresh gap at 09:00 Friday.\n\n" +
+        "Second: the hourly checksum job is great but it's checking the archived partition only. The rows most likely to move on cutover day are the hot ones, not the 2019 archive. Can we widen it to the last-30-days partition too, even if that's more expensive? I'll take the cost.\n\n" +
+        "Decision: we're go for Friday am pending a clean 24h soak, as backfill laid out. I'm adding one gate — the pool-recycle fix has to land and be verified before we flip, not after. If it's not in by Thursday evening we slip to Monday. I'd rather ship a day late than ship into a known write-dropping window. Filing both follow-ups as tasks now.",
+    },
   ],
   episodes: [atlasEpisodeSummary],
   episodeDetails: { e4f1a2: { ...atlasEpisodeSummary, messages: atlasL9Chain } },


### PR DESCRIPTION
A single long message could fill the whole viewport and turn the channel into a wall of text you scroll past a screen at a time. Past ~8 lines a message's prose now **clamps** with a soft fade and a muted, left-aligned **Show more** toggle. Expanding is in place and reversible — nothing is summarized or dropped, the reader still gets every word on demand.

### Why clamp, not LLM synthesis
Per-message LLM summary is expensive, adds latency, and presumes to reword a human's own message back at them. Room-level "too much" is already handled by the synthesizer engine. For an individual message, a cheap, honest, offline, reversible clamp is the right tool.

### Details
- **Shared `MessageBody` component** so the channel (`event-stream`) and a task's discussion (`task-conversation`, embedded by `thread-view`) get the *identical* affordance — both previously rendered prose unclamped, so the discussion pane had the same wall-of-text problem.
- **A find match forces the message open.** The hit can live in the clamped-off tail, and a highlight the reader can't see is a broken search — so a matched message expands and the toggle steps aside.
- **Only the measured-too-tall case** (via `ResizeObserver`, re-measured on width changes) grows the control; ordinary messages are untouched.
- **Muted, left-aligned toggle** to fit the surface — not an accent link, not centered.

### Mock
- Two long multi-paragraph messages added to `atlas-migration` so the case is reachable in `--mock`.

### Testing
- `pnpm exec vitest run` — 808 passed
- `tsc` + `eslint` clean (one pre-existing unrelated warning)
- Verified visually via shotkit (clamped, expanded, and the muted left-aligned toggle).