### PR TITLE
Lease-side join aborts a frozen negotiation, mock skills route, one handle normalizer

### DIFF
--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -40,6 +40,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from app.services import actor, l9, principals, room_channels, tasks
+from app.services.agent_registry import norm_handle
 from app.services.filesystem import room_exists
 from app.services.l9_models import Kind
 from app.services.l9_slim import serialize_content, serialize_envelope
@@ -83,7 +84,7 @@ _STANCE_TO_ACTION = {
 
 
 def _norm(handle: str) -> str:
-    return handle.strip().lstrip("@").lower()
+    return norm_handle(handle) or ""
 
 
 def _parse_marker(text: str) -> tuple[dict[str, Any], str]:

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, Any
 
 from app.config import settings
 from app.services import l9, l9_episode
+from app.services.agent_registry import norm_handle
 from app.services.room_channels import BACKEND_AGENT
 
 if TYPE_CHECKING:
@@ -112,7 +113,7 @@ def _registered_engine_kind(room: str, handle: str) -> str | None:
 
 
 def _norm(handle: str) -> str:
-    return handle.strip().lower()
+    return norm_handle(handle) or ""
 
 
 def _new_episode_id() -> str:

--- a/fastapi-backend/app/services/auth.py
+++ b/fastapi-backend/app/services/auth.py
@@ -34,6 +34,7 @@ import jwt
 from fastapi import HTTPException, Request
 
 from app.config import PrincipalRole, TrustedIssuer, settings
+from app.services.agent_registry import norm_handle
 
 logger = logging.getLogger(__name__)
 
@@ -272,10 +273,8 @@ def _resolve_role(claims: dict[str, Any], entry: TrustedIssuer) -> PrincipalRole
 
 
 def normalize_handle(raw: object) -> str | None:
-    """Match ``principals._norm`` so token and stored handles compare equal."""
-    if not isinstance(raw, str):
-        return None
-    return raw.strip().lstrip("@").lower() or None
+    """The canonical handle normalizer, so token and stored handles compare equal."""
+    return norm_handle(raw)
 
 
 async def verify_token(token: str) -> Principal:

--- a/fastapi-backend/app/services/principals.py
+++ b/fastapi-backend/app/services/principals.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import yaml
 
+from app.services.agent_registry import norm_handle as _norm
 from app.services.filesystem import (
     get_room_dir,
     get_users_dir,
@@ -35,13 +36,6 @@ logger = logging.getLogger(__name__)
 #: Manifest adapter marking a first-party cognition engine (aligner, synthesizer).
 #: Engines speak only through their own runtime, never an external participation call.
 ENGINE_ADAPTER = "engine"
-
-
-def _norm(handle: str | None) -> str | None:
-    if not handle:
-        return None
-    cleaned = handle.strip().lstrip("@").lower()
-    return cleaned or None
 
 
 def _read_agent_manifest(room: str, handle: str) -> dict[str, Any] | None:

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -259,8 +259,9 @@ class RoomChannelManager:
         self._default_workspace = default_workspace
         self._channels: dict[str, ManagedRoomChannel] = {}
         self._lock = asyncio.Lock()
-        # Strong refs to in-flight background invites (see invite_in_background).
-        self._tasks: set[asyncio.Task[bool]] = set()
+        # Strong refs to in-flight background work: invites (invite_in_background) and
+        # the frozen-roster checks a lease-side join schedules.
+        self._tasks: set[asyncio.Task[object]] = set()
         # Handles an @-mention would have invited while an episode held the
         # membership frozen, applied once it closes (see flush_deferred_invites).
         self._deferred_invites: dict[str, set[str]] = {}
@@ -568,13 +569,36 @@ class RoomChannelManager:
         Called on every ``await``/``reply`` so an actively-participating agent stays
         in the roster; a generous TTL keeps it present through its own think time
         (and avoids a mid-episode membership flap) while a truly-gone agent lapses.
-        Emits a coordination_join notice on the not-present → present edge.
+        The not-present → present edge is a join: it emits a coordination_join
+        notice and, like a SLIM join, is checked against a frozen negotiation's
+        roster (:meth:`_enforce_membership_change`, scheduled off the poll).
         """
         was_present = handle in self._live_leases(room)
         self._leases.setdefault(room, {})[handle] = time.monotonic() + ttl_s
         self._last_seen.setdefault(room, {})[handle] = time.time()
         if not was_present:
             self.announce_join(room, handle)
+            self._enforce_membership_change_in_background(room)
+
+    def _enforce_membership_change_in_background(self, room: str) -> None:
+        """Schedule the frozen-roster check for a lease-side join.
+
+        :meth:`refresh_lease` is sync and runs on every poll, so the check is a
+        fire-and-forget task (the ``invite_in_background`` shape) fired only on
+        the join edge, and only when there is something to check: a live channel
+        whose lifecycle is frozen. Without a running loop (a sync caller outside
+        the server) there is nothing to schedule on, and no negotiation to guard.
+        """
+        managed = self._channels.get(room)
+        if managed is None or not managed.lifecycle.frozen:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        task = loop.create_task(self._enforce_membership_change(managed))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
 
     def announce_join(self, room: str, handle: str, intent: str = "") -> bool:
         """Emit a coordination_join notice on the first not-present → present transition.
@@ -1255,10 +1279,13 @@ class RoomChannelManager:
 
         Compared against the same :meth:`members` union ``open_episode`` froze
         on — a lease-only participant refreshing/holding its lease is not a
-        membership change, only a real SLIM join/leave is. This runs only from
-        the invite (``_register_member``) and ``remove`` paths, so a lease that
-        simply expires mid-negotiation, with no other join/leave happening
-        after it, is not detected here.
+        membership change; a join or leave on either half of the union is. This
+        runs from the SLIM invite (``_register_member``) and ``remove`` paths and
+        from a lease-side join (``refresh_lease``'s not-present → present edge).
+        A lease that simply expires mid-negotiation, with no join/leave after
+        it, is still not detected here: expiry is derived by the clock, never
+        written, and the mediator's round timeout is what covers a participant
+        that has gone silent.
         """
         current_members = self.members(managed.room)
         if not managed.lifecycle.on_membership_change(set(current_members)):

--- a/fastapi-backend/app/services/tasks.py
+++ b/fastapi-backend/app/services/tasks.py
@@ -44,6 +44,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from app.services import l9
+from app.services.agent_registry import norm_handle
 from app.services.filesystem import (
     EPISODE_META,
     get_room_dir,
@@ -108,7 +109,7 @@ _REWRITTEN_META = frozenset({"key", "created_by", "updated_by", "version", "tags
 
 def _norm(handle: str) -> str:
     """A handle as it compares: the roster and the caller may spell it differently."""
-    return handle.strip().lstrip("@").lower()
+    return norm_handle(handle) or ""
 
 
 def slugify(title: str) -> str:

--- a/fastapi-backend/tests/test_handle_normalizer.py
+++ b/fastapi-backend/tests/test_handle_normalizer.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""One handle normalizer, everywhere a handle is compared.
+
+``agent_registry.norm_handle`` is the canonical spelling of "the same handle":
+strip, drop a leading ``@``, lowercase. Every module that used to carry its own
+private copy now routes through it, so the rules cannot drift per caller — the
+aligner's copy had quietly stopped stripping ``@`` (#738).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+from app.routes import participate
+from app.services import aligner, auth, principals, tasks
+from app.services.agent_registry import norm_handle
+
+APP = pathlib.Path(__file__).resolve().parents[1] / "app"
+
+#: The inline shape a private copy takes. Only the canonical module may spell it.
+_INLINE_NORMALIZER = re.compile(r"\.strip\(\)\.lstrip\(\"@\"\)\.lower\(\)")
+
+
+def test_every_private_norm_is_the_canonical_one() -> None:
+    for spelling in ("Alice", "@alice", " alice ", "@ALICE "):
+        assert principals._norm(spelling) == "alice"
+        assert tasks._norm(spelling) == "alice"
+        assert participate._norm(spelling) == "alice"
+        assert aligner._norm(spelling) == "alice"
+        assert auth.normalize_handle(spelling) == "alice"
+        assert norm_handle(spelling) == "alice"
+
+
+def test_a_blank_handle_is_blank_in_every_spelling() -> None:
+    assert norm_handle("  @ ") is None
+    assert principals._norm("") is None
+    assert auth.normalize_handle(None) is None
+    assert tasks._norm("@") == ""
+    assert participate._norm("") == ""
+    assert aligner._norm(" ") == ""
+
+
+def test_no_module_reimplements_the_normalizer_inline() -> None:
+    offenders = sorted(
+        str(path.relative_to(APP))
+        for path in APP.rglob("*.py")
+        if path.name != "agent_registry.py" and _INLINE_NORMALIZER.search(path.read_text())
+    )
+    assert offenders == [], f"private handle normalizers: {offenders}"

--- a/fastapi-backend/tests/test_room_channels.py
+++ b/fastapi-backend/tests/test_room_channels.py
@@ -11,6 +11,7 @@ logic. The live-node slices stay in ``test_slim_roundtrip.py`` (guarded on a nod
 
 from __future__ import annotations
 
+import asyncio
 from typing import cast
 
 import pytest
@@ -319,6 +320,71 @@ async def test_a_real_slim_join_still_aborts_a_frozen_negotiation(
 
     await manager.invite("room-a", "agent-slim")  # a real join mid-negotiation
     assert not managed.lifecycle.active
+
+
+async def _settle(manager: room_channels.RoomChannelManager) -> None:
+    """Let the fire-and-forget roster check a lease join schedules run to completion."""
+    if manager._tasks:
+        await asyncio.gather(*manager._tasks)
+
+
+@pytest.mark.asyncio
+async def test_a_lease_only_join_mid_negotiation_aborts_it(
+    manager: room_channels.RoomChannelManager,
+) -> None:
+    """The roster is frozen on the SLIM-plus-lease union, so a change on the lease
+    half is a change too: a brand-new headless ``await`` caller appearing
+    mid-negotiation aborts it, exactly as a SLIM join does (#932)."""
+    managed = await manager.provision("room-a")
+    assert managed is not None
+    manager.refresh_lease("room-a", "agent-http")
+    assert manager.open_episode("room-a", "urn:ioc:mycelium:episode:room-a:e1") is True
+    assert managed.lifecycle.active
+
+    manager.refresh_lease("room-a", "agent-new")  # a lease-only join mid-negotiation
+    await _settle(manager)
+
+    assert not managed.lifecycle.active
+
+
+@pytest.mark.asyncio
+async def test_a_frozen_participant_refreshing_its_lease_is_not_a_join(
+    manager: room_channels.RoomChannelManager,
+) -> None:
+    """Every ``await`` poll refreshes the lease; only the not-present → present
+    edge is a join. A participant holding its lease through the negotiation must
+    not abort it."""
+    managed = await manager.provision("room-a")
+    assert managed is not None
+    manager.refresh_lease("room-a", "agent-http")
+    assert manager.open_episode("room-a", "urn:ioc:mycelium:episode:room-a:e1") is True
+
+    manager.refresh_lease("room-a", "agent-http")
+    manager.refresh_lease("room-a", "agent-http")
+    await _settle(manager)
+
+    assert managed.lifecycle.active
+    assert not manager._tasks  # nothing was even scheduled
+
+
+@pytest.mark.asyncio
+async def test_a_lease_only_join_leaves_a_task_thread_running(
+    manager: room_channels.RoomChannelManager,
+) -> None:
+    """A task's thread is a container, not a negotiation: someone arriving must
+    not end it, from the lease side any more than from the SLIM side."""
+    managed = await manager.provision("room-a")
+    assert managed is not None
+    manager.refresh_lease("room-a", "agent-http")
+    assert (
+        manager.open_episode("room-a", "urn:ioc:mycelium:episode:room-a:t1", negotiation=False)
+        is True
+    )
+
+    manager.refresh_lease("room-a", "agent-new")
+    await _settle(manager)
+
+    assert managed.lifecycle.active
 
 
 @pytest.mark.asyncio

--- a/mycelium-frontend/src/mocks/handlers.test.ts
+++ b/mycelium-frontend/src/mocks/handlers.test.ts
@@ -104,6 +104,36 @@ describe("mock links handlers (#599)", () => {
   });
 });
 
+describe("mock skills handler (#755)", () => {
+  it("projects the room's skills/ memories into the skills list shape", async () => {
+    // `useRoomSkills` runs on every room page; without this route the request
+    // fell through to a real backend and 502'd under `pnpm dev:mock`.
+    const { status, body } = await mockGet("/api/rooms/mycelium-general/skills");
+    expect(status).toBe(200);
+    const { skills, total } = body as {
+      skills: { name: string; description: string; body: string; created_by: string; version: number }[];
+      total: number;
+    };
+    expect(total).toBe(skills.length);
+    expect(skills.length).toBeGreaterThan(0);
+    const take = skills.find((s) => s.name === "take-a-task");
+    expect(take).toBeDefined();
+    // The description is the frontmatter line, the body is the prose after it,
+    // and neither carries the `---` fence into the composer's popover.
+    expect(take?.description).toBe("Take a task off the board, work it in its own thread, resolve it.");
+    expect(take?.body.startsWith("Claim an open")).toBe(true);
+    expect(take?.body).not.toContain("---");
+    expect(take?.created_by).toBe("operator");
+    expect(take?.version).toBe(2);
+  });
+
+  it("answers an empty list for a room with no skills rather than proxying", async () => {
+    const { status, body } = await mockGet("/api/rooms/scratch/skills");
+    expect(status).toBe(200);
+    expect(body).toEqual({ skills: [], total: 0 });
+  });
+});
+
 describe("mock memory write handler", () => {
   async function post(room: string, items: unknown[]) {
     const res = await handleMock(new Request(`http://localhost/api/rooms/${room}/memory`, {

--- a/mycelium-frontend/src/mocks/handlers.ts
+++ b/mycelium-frontend/src/mocks/handlers.ts
@@ -418,6 +418,36 @@ export async function handleMock(req: Request): Promise<Response | null> {
       return json(agents);
     }
 
+    case "skills": {
+      // GET /skills — the composer's `/` autocomplete. A skill is a `skills/…`
+      // memory promoted, so this is the same projection the backend's skills
+      // route makes: the name is the key past the prefix, the one-line
+      // description is frontmatter, the body is what follows it. Served here
+      // so a mock room never falls through to a real backend (#755).
+      if (sub.length !== 1 || method !== "GET") return null;
+      const skills = fx.memories
+        .filter((m) => m.key.startsWith("skills/"))
+        .map((m) => {
+          const text = manifestText(m);
+          const fm = /^---\n([\s\S]*?)\n---\n?/.exec(text);
+          const description = fm ? /^description:\s*"?(.*?)"?\s*$/m.exec(fm[1])?.[1] ?? "" : "";
+          const body = fm ? text.slice(fm[0].length).replace(/^\n+/, "") : text;
+          const updated = m.updated_at ?? MOCK_EPOCH;
+          return {
+            name: m.key.slice("skills/".length),
+            description,
+            body,
+            tags: m.tags ?? null,
+            created_by: m.created_by,
+            updated_by: m.updated_by ?? null,
+            version: m.version,
+            created_at: updated,
+            updated_at: updated,
+          };
+        });
+      return json({ skills, total: skills.length });
+    }
+
     case "a2a": {
       // GET /a2a/state — the Network pane's bridge strip. A room with no
       // bridge answers with an empty one, exactly like the backend does.


### PR DESCRIPTION
## Summary

Three self-contained fixes, each against an open issue, each verifiable with the local unit gates (no live GitHub or SLIM node needed).

1. **A lease-only participant joining mid-negotiation now aborts it (#932).** `open_episode` freezes the roster on the SLIM-plus-lease union, but `_enforce_membership_change` only ran from the SLIM invite and `remove` paths. A headless `await` caller appearing mid-negotiation left the frozen negotiation running as if nobody had joined. `refresh_lease`'s not-present → present edge now schedules the same check as a fire-and-forget task (the `invite_in_background` shape), gated on a live channel whose lifecycle is frozen so the per-poll hot path is untouched. Lease *expiry* is still not detected proactively, as the issue suggests deciding separately; the docstring now says so and names the mediator's round timeout as the covering mechanism.
2. **`pnpm dev:mock` serves `/api/rooms/{room}/skills` (#755).** There was no mock branch for skills, so `useRoomSkills` (which runs on every room page for the composer's `/` autocomplete) fell through to `localhost:8000` and 502'd. The `skills/…` fixture memories are now projected into the `SkillListResponse` shape the same way the backend route does (name past the prefix, description from frontmatter, body after it). The presence half of that issue had already landed.
3. **One handle normalizer (#738, first bullet).** `principals`, `tasks`, `participate`, `aligner` and `auth` each carried a private copy of strip / drop `@` / lowercase. They now route through `agent_registry.norm_handle`. The aligner's copy had quietly stopped stripping a leading `@`, so `@alice` and `alice` compared unequal there. A source-scan test keeps a new inline copy from appearing.

## Changes

- `fastapi-backend/app/services/room_channels.py`: `_enforce_membership_change_in_background`, called from `refresh_lease` on the join edge; `_tasks` widened to hold both invite and roster-check tasks; docstrings updated to describe both halves of the union.
- `fastapi-backend/tests/test_room_channels.py`: a lease-only join aborts a frozen negotiation; a frozen participant refreshing its lease does not; a lease-only join leaves a task thread (`negotiation=False`) running.
- `mycelium-frontend/src/mocks/handlers.ts`: `case "skills"`; `handlers.test.ts`: populated room projects its skills, empty room answers an empty list.
- `fastapi-backend/app/{routes/participate,services/aligner,services/auth,services/principals,services/tasks}.py`: delegate to `norm_handle`.
- `fastapi-backend/tests/test_handle_normalizer.py`: every spelling agrees; blank handles agree; no module reimplements the normalizer inline.

## Testing

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 1054 passed, 13 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `uv run ty check .` clean
- [x] Frontend: `pnpm vitest run` 830 passed; `pnpm lint` 0 errors (2 pre-existing warnings in an unrelated file)
- [x] The new lease-join test was confirmed to fail without the `room_channels.py` change

## Related Issues

Closes #932. Closes #755. Part of #738 (the `_norm` bullet; the manifest-write and `channel.send` + `ingest_local` consolidation are left for their own change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcVQNRFr94KupPMhw8iVYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcVQNRFr94KupPMhw8iVYm)_