### PR TITLE
Walk back through a room's history with `room messages --before`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -382,6 +382,13 @@
 <span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">watch</span>                    # stream live room activity
 <span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">delete</span> design-review     # delete a room and its data
 <span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">clone</span> design-review <span class="flag">--from</span> <span class="url">http://hub-ip:8000</span>  # pull a room from a remote backend</code></pre>
+      <h2 id="rooms-reading-history">Reading History</h2>
+      <p><code>mycelium room messages</code> is a point-in-time read, newest first. History is paged by content rather than position: when older messages exist, the footer names the <code>--before</code> cursor that reads the next page back, so a walk through a busy room does not shift under messages arriving live. A stamp is ISO 8601 as printed, or an age like <code>2h</code>, <code>30m</code>, <code>1d</code>.</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">messages</span> design-review <span class="flag">--limit</span> 50          # the latest page …
+<span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">messages</span> design-review <span class="flag">--limit</span> 50 <span class="flag">--before</span> 2026-09-03T16:40:00Z  # … and the one before it
+<span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">messages</span> design-review <span class="flag">--since</span> 1d <span class="flag">--before</span> 2h   # a window
+<span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">messages</span> t3 <span class="flag">--before</span> 1h                    # one thread pages the same way</code></pre>
+      <p>With <code>--json</code> the same cursor comes back as <code>older_before</code> (null when the page is the whole history), for a script that walks a room to its start.</p>
       <h2 id="rooms-editing-a-message">Editing a Message</h2>
       <p>An agent that got something wrong has an alternative to posting a correction thread: amend the message.</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">messages</span>                  # each line carries the message&#x27;s short id

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -272,6 +272,24 @@ mycelium room delete design-review     # delete a room and its data
 mycelium room clone design-review --from http://hub-ip:8000  # pull a room from a remote backend
 ```
 
+## Reading History
+
+`mycelium room messages` is a point-in-time read, newest first. History is
+paged by content rather than position: when older messages exist, the footer
+names the `--before` cursor that reads the next page back, so a walk through a
+busy room does not shift under messages arriving live. A stamp is ISO 8601 as
+printed, or an age like `2h`, `30m`, `1d`.
+
+```bash
+mycelium room messages design-review --limit 50          # the latest page …
+mycelium room messages design-review --limit 50 --before 2026-09-03T16:40:00Z  # … and the one before it
+mycelium room messages design-review --since 1d --before 2h   # a window
+mycelium board messages t3 --before 1h                    # one thread pages the same way
+```
+
+With `--json` the same cursor comes back as `older_before` (null when the page
+is the whole history), for a script that walks a room to its start.
+
 ## Editing a Message
 
 An agent that got something wrong has an alternative to posting a correction

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -647,9 +647,9 @@
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">messages</span> [<span class="arg">&lt;room&gt;</span>] [<span class="flag">--limit</span> N] [<span class="flag">--sender</span> <span class="arg">&lt;handle&gt;</span>] [<span class="flag">--type</span> <span class="arg">&lt;type&gt;</span>]</code>
+          <code><span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">messages</span> [<span class="arg">&lt;room&gt;</span>] [<span class="flag">--limit</span> N] [<span class="flag">--sender</span> <span class="arg">&lt;handle&gt;</span>] [<span class="flag">--type</span> <span class="arg">&lt;type&gt;</span>] [<span class="flag">--before</span> &lt;stamp|age&gt;] [<span class="flag">--since</span> &lt;stamp|age&gt;]</code>
         </div>
-        <div class="cmd-ref-body">Read recent messages in a room (point-in-time, newest first). Filter with <code>--sender</code> / <code>--type</code>.</div>
+        <div class="cmd-ref-body">Read recent messages in a room (point-in-time, newest first). Filter with <code>--sender</code> / <code>--type</code>; walk back through history with <code>--before</code>.</div>
       </div>
 
       <div class="cmd-ref">
@@ -712,7 +712,7 @@
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
-          <code><span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">messages</span> <span class="arg">&lt;id&gt;</span> [<span class="flag">--limit</span> N]</code>
+          <code><span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">messages</span> <span class="arg">&lt;id&gt;</span> [<span class="flag">--limit</span> N] [<span class="flag">--before</span> &lt;stamp|age&gt;]</code>
         </div>
         <div class="cmd-ref-body">Read one thread: the conversation about that row or memory, and nothing else from the room.</div>
       </div>

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -84,6 +84,13 @@ window.MYCELIUM_SEARCH_INDEX = [
     "p": "Guide"
   },
   {
+    "u": "index.html#rooms-reading-history",
+    "t": "Reading History",
+    "s": "Concepts › Rooms",
+    "x": "mycelium room messages is a point-in-time read, newest first. History is paged by content rather than position: when older messages exist, the footer names the --before cursor that reads the next page back, so a walk through a busy room does not shift under messages arriving live. A stamp is ISO 8601 as printed, or an age like 2h, 30m, 1d. mycelium room messages design-review --limit 50 # the latest page … mycelium r",
+    "p": "Guide"
+  },
+  {
     "u": "index.html#rooms-editing-a-message",
     "t": "Editing a Message",
     "s": "Concepts › Rooms",
@@ -1033,9 +1040,9 @@ window.MYCELIUM_SEARCH_INDEX = [
   },
   {
     "u": "reference.html#cli-room",
-    "t": "mycelium room messages [<room>] [--limit N] [--sender <handle>] [--type <type>]",
+    "t": "mycelium room messages [<room>] [--limit N] [--sender <handle>] [--type <type>] [--before <stamp|age>] [--since <stamp|age>]",
     "s": "CLI Reference",
-    "x": "Read recent messages in a room (point-in-time, newest first). Filter with --sender / --type.",
+    "x": "Read recent messages in a room (point-in-time, newest first). Filter with --sender / --type; walk back through history with --before.",
     "k": "cmd",
     "p": "Reference"
   },
@@ -1112,7 +1119,7 @@ window.MYCELIUM_SEARCH_INDEX = [
   },
   {
     "u": "reference.html#cli-board",
-    "t": "mycelium board messages <id> [--limit N]",
+    "t": "mycelium board messages <id> [--limit N] [--before <stamp|age>]",
     "s": "CLI Reference",
     "x": "Read one thread: the conversation about that row or memory, and nothing else from the room.",
     "k": "cmd",

--- a/mycelium-cli/src/mycelium/chat.py
+++ b/mycelium-cli/src/mycelium/chat.py
@@ -18,6 +18,8 @@ verbs are the room's verbs, scoped to a row.
 from __future__ import annotations
 
 import json as json_module
+import re
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 import typer
@@ -67,6 +69,33 @@ def post(
     typer.echo(f"  ↑  {sender_handle} → {destination or room_name}: {preview}")
 
 
+_RELATIVE = re.compile(r"^(\d+)\s*([smhd])$")
+_UNITS = {"s": "seconds", "m": "minutes", "h": "hours", "d": "days"}
+
+
+def parse_stamp(text: str, *, now: datetime | None = None) -> datetime:
+    """A point in time as a reader types one: an ISO 8601 stamp, or an age.
+
+    ``2026-09-03T16:40:00Z`` is the shape every message line's cursor comes back
+    in, so a stamp copied off one page pastes straight into the next. ``2h``,
+    ``30m``, ``1d`` mean that long ago, for the common "what happened before
+    lunch" read where nobody has a stamp yet. Naive stamps are taken as UTC,
+    which is how the hub records them.
+    """
+    raw = text.strip()
+    match = _RELATIVE.match(raw)
+    if match:
+        amount, unit = int(match.group(1)), match.group(2)
+        return (now or datetime.now(UTC)) - timedelta(**{_UNITS[unit]: amount})
+    try:
+        stamp = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise typer.BadParameter(
+            f"{text!r} is neither an ISO 8601 stamp nor an age like 2h, 30m or 1d"
+        ) from exc
+    return stamp.replace(tzinfo=UTC) if stamp.tzinfo is None else stamp
+
+
 def read(
     config: MyceliumConfig,
     room_name: str,
@@ -75,8 +104,11 @@ def read(
     sender: str | None = None,
     message_type: str | None = None,
     episode: str | None = None,
+    since: datetime | None = None,
+    before: datetime | None = None,
     label: str | None = None,
     empty_note: str | None = None,
+    older_with: str | None = None,
     json_output: bool = False,
 ) -> None:
     """Print a channel's recent messages, newest first.
@@ -84,6 +116,13 @@ def read(
     With ``episode`` this is one thread's transcript and nothing else — the point
     of a thread being that the room stays legible while the argument happens
     somewhere a reader can still open.
+
+    ``before`` is the backward cursor: a page defined by content rather than
+    position, so walking back does not shift under messages arriving live.
+    ``since`` bounds the other end. When the page is full and older messages
+    exist, the footer names the command that reads the next page back
+    (``older_with`` is that command's stem; the cursor is appended), and the
+    JSON shape carries the same cursor as ``older_before``.
     """
     from mycelium.commands.room import _agent_owner_map
     from mycelium_backend_client.api.messages import (
@@ -100,9 +139,15 @@ def read(
             sender=sender or UNSET,
             message_type=message_type or UNSET,
             episode=episode or UNSET,
+            since=since or UNSET,
+            before=before or UNSET,
         )
 
     msgs = [] if not result or isinstance(result, HTTPValidationError) else result.messages
+    # Newest first, so the last line is the oldest shown; ``total`` counts every
+    # message the filters matched, so a total past the page means older ones exist.
+    total = getattr(result, "total", len(msgs)) if msgs else 0
+    older_before = msgs[-1].created_at.isoformat() if msgs and total > len(msgs) else None
 
     if json_output:
         payload: dict[str, Any] = (
@@ -110,6 +155,7 @@ def read(
             if result and not isinstance(result, HTTPValidationError)
             else {"messages": [], "total": 0}
         )
+        payload["older_before"] = older_before
         typer.echo(json_module.dumps(payload, indent=2, default=str))
         return
 
@@ -137,4 +183,10 @@ def read(
         )
         for line in rest:
             typer.echo(f"              {line}")
+    if older_before and older_with:
+        remaining = total - len(msgs)
+        typer.secho(
+            f"\n  {remaining} older · {older_with} --before {older_before}",
+            fg=typer.colors.BRIGHT_BLACK,
+        )
     typer.echo()

--- a/mycelium-cli/src/mycelium/commands/board.py
+++ b/mycelium-cli/src/mycelium/commands/board.py
@@ -888,7 +888,7 @@ def board_send(
 
 
 @doc_ref(
-    usage="mycelium board messages <id> [--limit N]",
+    usage="mycelium board messages <id> [--limit N] [--before <stamp|age>]",
     desc="Read one thread: the conversation about that row or memory, and nothing else from the room.",
     group="board",
 )
@@ -901,24 +901,41 @@ def board_messages(
     sender: str | None = typer.Option(
         None, "--sender", "-s", help="Only messages from this handle"
     ),
+    before: str | None = typer.Option(
+        None,
+        "--before",
+        "-b",
+        help="Only messages before this ISO stamp or age (2h, 30m, 1d): the cursor to walk back",
+    ),
+    since: str | None = typer.Option(
+        None, "--since", help="Only messages at/after this ISO stamp or age (2h, 30m, 1d)"
+    ),
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
 ) -> None:
     """Read a thread.
 
     This is what a ping is for. The room said something moved; this is what
-    moved in it — a row's conversation, or a memory's.
+    moved in it — a row's conversation, or a memory's. A long thread pages the
+    way the room does: the footer names the `--before` cursor for the next
+    page back.
     """
     cfg = MyceliumConfig.load()
     name = _resolve_room(cfg, room)
     where, episode = _thread(name, row_id)
+    stem = f"mycelium board messages {row_id} --room {name} --limit {limit}"
+    if sender:
+        stem += f" --sender {sender}"
     chat.read(
         cfg,
         name,
         limit=limit,
         sender=sender,
         episode=episode,
+        since=chat.parse_stamp(since) if since else None,
+        before=chat.parse_stamp(before) if before else None,
         label=where,
         empty_note="nothing said in this thread yet",
+        older_with=stem,
     )
 
 

--- a/mycelium-cli/src/mycelium/commands/room.py
+++ b/mycelium-cli/src/mycelium/commands/room.py
@@ -972,8 +972,8 @@ def amend(
 
 
 @doc_ref(
-    usage="mycelium room messages [<room>] [--limit N] [--sender <handle>] [--type <type>]",
-    desc="Read recent messages in a room (point-in-time, newest first). Filter with <code>--sender</code> / <code>--type</code>.",
+    usage="mycelium room messages [<room>] [--limit N] [--sender <handle>] [--type <type>] [--before <stamp|age>] [--since <stamp|age>]",
+    desc="Read recent messages in a room (point-in-time, newest first). Filter with <code>--sender</code> / <code>--type</code>; walk back through history with <code>--before</code>.",
     group="room",
 )
 @app.command("messages")
@@ -987,6 +987,15 @@ def messages(
     message_type: str | None = typer.Option(
         None, "--type", "-t", help="Only this message type (e.g. direct, broadcast, announce)"
     ),
+    before: str | None = typer.Option(
+        None,
+        "--before",
+        "-b",
+        help="Only messages before this ISO stamp or age (2h, 30m, 1d): the cursor to walk back",
+    ),
+    since: str | None = typer.Option(
+        None, "--since", help="Only messages at/after this ISO stamp or age (2h, 30m, 1d)"
+    ),
 ) -> None:
     """
     Read recent messages in a room: a point-in-time snapshot, newest first.
@@ -995,11 +1004,17 @@ def messages(
     with the most recent messages and exits. Handy for scripts and for checking
     whether an agent's reply has landed.
 
+    History is paged by content, not position: when older messages exist the
+    footer names the `--before` cursor that reads the next page back, so a
+    walk through a busy room does not shift under messages arriving live.
+
     Examples:
         mycelium room messages
         mycelium room messages design-review --limit 5
         mycelium room messages cc-e2e --sender cc-x
         mycelium room messages my-room --type broadcast
+        mycelium room messages my-room --before 2h
+        mycelium room messages my-room --since 2026-09-03T09:00:00Z --before 2026-09-03T12:00:00Z
     """
     try:
         verbose = ctx.obj.get("verbose", False) if ctx.obj else False  # noqa: F841
@@ -1007,12 +1022,20 @@ def messages(
 
         config = MyceliumConfig.load()
         room_name = _resolve_room(config, room)
+        stem = f"mycelium room messages {room_name} --limit {limit}"
+        if sender:
+            stem += f" --sender {sender}"
+        if message_type:
+            stem += f" --type {message_type}"
         chat.read(
             config,
             room_name,
             limit=limit,
             sender=sender,
             message_type=message_type,
+            since=chat.parse_stamp(since) if since else None,
+            before=chat.parse_stamp(before) if before else None,
+            older_with=stem,
             json_output=json_output,
         )
 

--- a/mycelium-cli/src/mycelium/docs/concepts/rooms.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/rooms.md
@@ -43,6 +43,24 @@ mycelium room delete design-review     # delete a room and its data
 mycelium room clone design-review --from http://hub-ip:8000  # pull a room from a remote backend
 ```
 
+## Reading History
+
+`mycelium room messages` is a point-in-time read, newest first. History is
+paged by content rather than position: when older messages exist, the footer
+names the `--before` cursor that reads the next page back, so a walk through a
+busy room does not shift under messages arriving live. A stamp is ISO 8601 as
+printed, or an age like `2h`, `30m`, `1d`.
+
+```bash
+mycelium room messages design-review --limit 50          # the latest page …
+mycelium room messages design-review --limit 50 --before 2026-09-03T16:40:00Z  # … and the one before it
+mycelium room messages design-review --since 1d --before 2h   # a window
+mycelium board messages t3 --before 1h                    # one thread pages the same way
+```
+
+With `--json` the same cursor comes back as `older_before` (null when the page
+is the whole history), for a script that walks a room to its start.
+
 ## Editing a Message
 
 An agent that got something wrong has an alternative to posting a correction

--- a/mycelium-cli/tests/test_room_messages.py
+++ b/mycelium-cli/tests/test_room_messages.py
@@ -174,3 +174,142 @@ def test_room_messages_indents_multiline_content(monkeypatch: pytest.MonkeyPatch
     assert result.exit_code == 0, result.output
     assert "first line" in result.output
     assert "second line" in result.output
+
+
+def test_room_messages_passes_the_cursors_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mycelium_backend_client.models import MessageListResponse
+
+    captured: dict = {}
+
+    def fake_sync(**kwargs):
+        captured.update(kwargs)
+        return MessageListResponse(messages=[], total=0)
+
+    _patch_common(monkeypatch, fake_sync)
+
+    result = CliRunner().invoke(
+        room_cmd.app,
+        [
+            "messages",
+            "msgtest",
+            "--since",
+            "2026-09-03T09:00:00Z",
+            "--before",
+            "2026-09-03T12:00:00+00:00",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["since"] == datetime.datetime(2026, 9, 3, 9, 0, tzinfo=datetime.UTC)
+    assert captured["before"] == datetime.datetime(2026, 9, 3, 12, 0, tzinfo=datetime.UTC)
+
+
+def test_room_messages_takes_an_age_as_a_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mycelium_backend_client.models import MessageListResponse
+
+    captured: dict = {}
+
+    def fake_sync(**kwargs):
+        captured.update(kwargs)
+        return MessageListResponse(messages=[], total=0)
+
+    _patch_common(monkeypatch, fake_sync)
+
+    started = datetime.datetime.now(datetime.UTC)
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest", "--before", "2h"])
+
+    assert result.exit_code == 0, result.output
+    before = captured["before"]
+    assert before.tzinfo is not None
+    # "2h" means two hours before the command ran, give or take the run itself.
+    assert abs((started - before) - datetime.timedelta(hours=2)) < datetime.timedelta(seconds=5)
+
+
+def test_room_messages_rejects_a_stamp_it_cannot_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    from mycelium_backend_client.models import MessageListResponse
+
+    _patch_common(monkeypatch, lambda **_kw: MessageListResponse(messages=[], total=0))
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest", "--before", "yesterday"])
+
+    assert result.exit_code != 0
+    assert "neither an ISO 8601 stamp nor an age" in result.output
+
+
+def test_room_messages_names_the_cursor_for_the_page_before(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mycelium_backend_client.models import MessageListResponse
+
+    msgs = _make_messages()
+    # Newest first: the second line is the oldest shown, so its stamp is the cursor.
+    msgs[1].created_at = datetime.datetime(2026, 6, 11, 21, 20, 0, tzinfo=datetime.UTC)
+    _patch_common(monkeypatch, lambda **_kw: MessageListResponse(messages=msgs, total=7))
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest", "--limit", "2"])
+
+    assert result.exit_code == 0, result.output
+    assert "5 older" in result.output
+    assert (
+        "mycelium room messages msgtest --limit 2 --before 2026-06-11T21:20:00+00:00"
+        in result.output
+    )
+
+
+def test_room_messages_says_nothing_about_older_when_the_page_is_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from mycelium_backend_client.models import MessageListResponse
+
+    msgs = _make_messages()
+    _patch_common(monkeypatch, lambda **_kw: MessageListResponse(messages=msgs, total=len(msgs)))
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest"])
+
+    assert result.exit_code == 0, result.output
+    assert "older" not in result.output
+    assert "--before" not in result.output
+
+
+def test_room_messages_json_carries_the_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+
+    from mycelium_backend_client.models import MessageListResponse
+
+    msgs = _make_messages()
+    msgs[1].created_at = datetime.datetime(2026, 6, 11, 21, 20, 0, tzinfo=datetime.UTC)
+    _patch_common(monkeypatch, lambda **_kw: MessageListResponse(messages=msgs, total=7))
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest"], obj={"json": True})
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["total"] == 7
+    assert payload["older_before"] == "2026-06-11T21:20:00+00:00"
+
+
+def test_json_cursor_is_null_when_the_page_is_everything(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+
+    from mycelium_backend_client.models import MessageListResponse
+
+    msgs = _make_messages()
+    _patch_common(monkeypatch, lambda **_kw: MessageListResponse(messages=msgs, total=len(msgs)))
+
+    result = CliRunner().invoke(room_cmd.app, ["messages", "msgtest"], obj={"json": True})
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["older_before"] is None
+
+
+def test_parse_stamp_reads_iso_and_ages() -> None:
+    from mycelium import chat
+
+    now = datetime.datetime(2026, 9, 3, 12, 0, tzinfo=datetime.UTC)
+    assert chat.parse_stamp("2026-09-03T09:00:00Z") == now.replace(hour=9)
+    # A naive stamp is what the hub writes; it is read back as UTC, not local time.
+    assert chat.parse_stamp("2026-09-03T09:00:00") == now.replace(hour=9)
+    assert chat.parse_stamp("30m", now=now) == now - datetime.timedelta(minutes=30)
+    assert chat.parse_stamp("2h", now=now) == now - datetime.timedelta(hours=2)
+    assert chat.parse_stamp("1d", now=now) == now - datetime.timedelta(days=1)
+    assert chat.parse_stamp(" 15 s ", now=now) == now - datetime.timedelta(seconds=15)


### PR DESCRIPTION
## Summary

The backend pages a room's messages by content: `GET /messages?before=<stamp>` is the backward cursor the GUI's reverse scroll already walks, defined relative to a message rather than a position so a page does not shift under messages arriving live. The CLI never exposed it: `mycelium room messages` read the latest page and stopped there, and a reader who wanted what happened before lunch had to raise `--limit` and scroll.

`mycelium room messages` and `mycelium board messages` now take `--before` and `--since`. A stamp is ISO 8601 (the shape the footer prints, so it pastes straight into the next command) or an age like `2h`, `30m`, `1d`. When a page is full and older messages exist, the footer names the exact command that reads the next page back:

```
  design-review  (20 messages, newest first)
  16:40:12  growth [broadcast]  a1b2c3d4: …
  …

  37 older · mycelium room messages design-review --limit 20 --before 2026-09-03T16:21:07+00:00
```

With `--json` the same cursor comes back as `older_before` (null when the page is the whole history), for a script that walks a room to its start. The board surface pages the same way because it is the same read (`chat.read`, one implementation for both verbs, per the module's own note).

## Changes

- `mycelium-cli/src/mycelium/chat.py`: `parse_stamp` (ISO or age; naive stamps read as UTC, which is what the hub writes; anything else is a `BadParameter` naming both accepted shapes); `read` takes `since`/`before`, passes them to the generated client, and prints the footer / `older_before` off the response's `total`.
- `mycelium-cli/src/mycelium/commands/room.py`, `board.py`: `--before`/`-b`, `--since`; the footer's command stem carries the filters the page was read with.
- `mycelium-cli/src/mycelium/docs/concepts/rooms.md`: a "Reading History" section. `docs/*` regenerated.
- `mycelium-cli/tests/test_room_messages.py`: cursors pass through (ISO, `+00:00`, age), an unreadable stamp is refused, the footer appears only when older messages exist and names the oldest shown stamp, JSON carries the cursor (and null when it is everything), `parse_stamp` unit cases.

## Testing

- [x] CLI gate: `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check .` clean
- [x] `uv run pytest tests/` — 801 passed, 2 skipped; the 6 failures in `test_memory_commands.py` / `test_skill_commands.py` (`set` commands: "this hub is gated and you are not signed in") fail identically on `main` in this sandbox, which carries `MYCELIUM_AGENT_AUTH_*` in its environment, and are untouched by this change
- [x] Docs regenerated from source (`docs/generate_docs.py`), committed

## Related Issues

Part of #654: the CLI walk-back. The GUI half (reverse scroll in the event stream) already ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcVQNRFr94KupPMhw8iVYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcVQNRFr94KupPMhw8iVYm)_