### PR TITLE
Hold a thread's floor: a code-enforced turn policy on an episode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,16 @@ is no litellm dependency.
   print raw envelopes at `mycelium room messages`; and a notice carries no
   `content`, so `mycelium room watch` drops it and the terminal draws no timeline
   line.
+- **A thread's floor is held by code, never chosen by a writer.** Two things
+  narrow who may write into a thread, and both are enforced at the one gate
+  `/messages` and `/reply` share (`tasks.thread_write_refusal`): a frozen
+  negotiation admits only the roster it froze on (403), and a **floor**
+  (`app/services/floor.py`, held per episode on the managed channel via
+  `manager.hold_floor`/`release_floor`) admits only the handles its holder gave
+  it to (409, naming whose turn it is). A refused write never reaches the
+  transcript, so it wakes nobody and `await` needs no change. The room itself
+  (`live`) never holds a floor. `app/services/turns.py` is the one-agent turn
+  the aligner brokers with, lifted out so a protocol step asks the same way.
 - **The aligner mediates, inside a task.** Agents never talk to each other directly;
   all coordination flows through the aligner. It's a first-party engine registered
   as a room citizen (`mycelium engine create aligner --kind aligner`) and summoned

--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -51,7 +51,7 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from app.config import settings
-from app.services import activity, l9, l9_episode
+from app.services import activity, l9, l9_episode, turns
 from app.services.agent_registry import norm_handle
 from app.services.room_channels import BACKEND_AGENT
 
@@ -70,15 +70,11 @@ logger = logging.getLogger(__name__)
 # moderator, and the system actor the backend signs its own envelopes with.
 _NON_PARTICIPANTS = frozenset({BACKEND_AGENT, l9.SYSTEM_ACTOR_ID})
 
-# The mediator addresses exactly ONE agent per turn via the L9 ``recipients``
-# field. Its prompt *text*, though, embeds the broker's summary which names the
-# other participants — and the connector's ``should_wake`` also wakes on a raw
-# ``@handle`` token in the human-facing text. Left as-is, every turn would
-# spuriously wake *every* named agent, doubling cold-spawns and serializing the
-# connectors until the addressed agent's real reply misses the round window (the
-# turn then falls back to a reject). Neutralizing the ``@`` means only the
-# L9-addressed agent wakes; the names stay readable.
-_AT_MENTION = re.compile(r"@(?=\w)")
+# The mediator addresses exactly ONE agent per turn; the sigil-stripping that
+# keeps the other names in its prose from waking anyone lives with the turn
+# primitive (:mod:`app.services.turns`). Kept under this name for the engines
+# that strip a summon's ``@`` the same way.
+_AT_MENTION = turns.MENTION_SIGIL
 
 # Round number stamped on the pre-negotiation clarifying tick. SAO steps are
 # NEGMAS's own, counted from 1, so round 0 marks the turn that ran before the
@@ -585,41 +581,19 @@ class AlignerEngine:
         what the tick asks for: an SAO ``position``, or a ``clarify`` definition on
         the pre-negotiation round.
         """
-        before = len(persister.log.records)
-        env = l9.build_envelope(
-            kind=l9.Kind.exchange,
-            episode=episode,
+        return await turns.addressed_turn(
+            managed,
+            persister,
             sender=sender,
-            recipients=[handle],
+            handle=handle,
+            episode=episode,
             topic=topic,
-            payload_type="tick",
+            prompt=prompt,
             payload_data={"round": round_n, "action": action},
+            is_reply=self._is_position,
+            timeout_s=self._round_timeout_s,
+            poll_interval_s=self._poll_interval_s,
         )
-        # Neutralize ``@`` tokens so the broker's summary (which names the other
-        # agents) doesn't spuriously wake them — only the L9 ``recipients=[handle]``
-        # above should wake, one agent per turn.
-        safe_prompt = _AT_MENTION.sub("", prompt)
-        # Record the mediator's turn-prompt into the room transcript + UI bus, the
-        # same way ``publish_human`` records a human's message. Without this the
-        # negotiation is invisible in the room (the prompt only rides SLIM), so
-        # humans can't follow along and debugging falls back to backend logs. The
-        # persister de-dupes by id, so a SLIM loop-back to the sender is harmless.
-        try:
-            await managed.post(env, safe_prompt, raise_on_send_failure=True)
-        except Exception:
-            logger.warning("mediator failed to prompt @%s (step %d)", handle, round_n)
-            return ""
-
-        pending = _norm(handle)
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + self._round_timeout_s
-        while True:
-            for record in persister.log.records[before:]:
-                if self._is_position(record) and _norm(record.sender) == pending:
-                    return record.content.get("content") or ""
-            if loop.time() >= deadline:
-                return ""
-            await asyncio.sleep(self._poll_interval_s)
 
     async def _explain_stall(
         self, managed: ManagedRoomChannel, room: str, sender: str, participants: list[str]

--- a/fastapi-backend/app/services/floor.py
+++ b/fastapi-backend/app/services/floor.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The floor: who may write into a thread right now.
+
+A thread separates attention, not access — everyone who may write in the room
+may write in its threads. Two things narrow that, and both are held by backend
+code rather than chosen by a writer. A frozen negotiation admits only the roster
+it froze on (:class:`~app.services.l9_slim.EpisodeLifecycle`). A **floor**
+admits only the handles its holder has given it to, and it is how a protocol
+running inside a task says whose turn it is.
+
+The floor is enforced at the hub's write routes — the one gate ``/messages``
+and ``/reply`` both pass (:func:`app.services.tasks.thread_write_refusal`) — so
+a write it refuses never reaches the transcript, and since the transcript is
+the only delivery path, it wakes nobody. ``await`` needs no change to honor it.
+
+A floor is process-local, like an open negotiation: its holder is a run of
+backend code, and a floor dies with the process rather than outliving the run
+that would have released it. The room itself (the ``live`` episode) never holds
+one: the room stays open, and a floor narrows exactly one thread.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.services.agent_registry import norm_handle
+
+
+def _norm(handle: str) -> str:
+    """A handle as the floor compares it: bare, so a session of ``@alice``
+    (``alice#a8f3``) is ``@alice`` — the floor is given to a member, not to one
+    of its sessions."""
+    return norm_handle(handle.partition("#")[0]) or ""
+
+
+@dataclass(frozen=True)
+class Floor:
+    """One thread's floor: who holds it, and who it has been given to.
+
+    ``holder`` is the handle that set the floor and may always write — the
+    engine running a protocol in the thread. ``speakers`` are the handles it has
+    given the floor to for the current step; empty means the holder alone.
+    """
+
+    episode: str
+    holder: str
+    speakers: frozenset[str] = frozenset()
+
+    def admits(self, handle: str) -> bool:
+        """Whether ``handle`` may write into the thread right now."""
+        h = _norm(handle)
+        return bool(h) and (h == _norm(self.holder) or h in {_norm(s) for s in self.speakers})
+
+    def describe(self) -> str:
+        """The floor as a refusal reads it: who holds it, and who may speak."""
+        if self.speakers:
+            names = ", ".join(f"@{s}" for s in sorted(self.speakers))
+            return f"@{self.holder} holds the floor; {names} may speak"
+        return f"@{self.holder} holds the floor; no one else may speak right now"

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -32,13 +32,15 @@ import contextlib
 import json
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from app.config import settings
 from app.services import custody, l9, slim_identity
+from app.services.agent_registry import norm_handle
+from app.services.floor import Floor
 from app.services.l9_models import Kind
 from app.services.l9_slim import (
     EpisodeLifecycle,
@@ -142,6 +144,11 @@ class ManagedRoomChannel:
     channel: L9SlimChannel
     members: set[str] = field(default_factory=set)
     lifecycle: EpisodeLifecycle = field(default_factory=EpisodeLifecycle)
+    # Threads whose floor a run of backend code holds, keyed by episode URN
+    # (:mod:`app.services.floor`). Independent of ``lifecycle``: a negotiation
+    # freezes a roster, a floor names whose turn it is, and a room may hold
+    # several floors at once — one per thread a protocol is running in.
+    floors: dict[str, Floor] = field(default_factory=dict)
     persister: RoomPersister | None = None
     persister_task: asyncio.Task[None] | None = None
     # Per-actor custodial MLS sessions this backend holds for the room (#666), keyed by
@@ -1260,6 +1267,43 @@ class RoomChannelManager:
             return False
         managed.lifecycle.open(episode, set(self.members(room)), negotiation=negotiation)
         return True
+
+    # -- the floor --
+
+    def hold_floor(
+        self, room: str, episode: str, *, holder: str, speakers: Iterable[str] = ()
+    ) -> Floor | None:
+        """Give ``speakers`` the floor in ``episode``, held by ``holder``.
+
+        Replaces whatever floor the thread held, so a runner moving from one
+        step to the next calls this once per step. ``None`` when the room has
+        no live channel, or when ``episode`` is the room itself — the room never
+        holds a floor, so a protocol cannot close the room around itself.
+        """
+        managed = self._channels.get(room)
+        if managed is None or l9.is_live_episode(room, episode):
+            return None
+        floor = Floor(
+            episode=episode,
+            holder=norm_handle(holder) or holder,
+            speakers=frozenset(h for h in (norm_handle(s) for s in speakers) if h),
+        )
+        managed.floors[episode] = floor
+        return floor
+
+    def release_floor(self, room: str, episode: str) -> bool:
+        """Open ``episode`` back up; True when a floor was actually held."""
+        managed = self._channels.get(room)
+        if managed is None:
+            return False
+        return managed.floors.pop(episode, None) is not None
+
+    def floor(self, room: str, episode: str | None) -> Floor | None:
+        """The floor ``episode`` holds, or ``None`` when anyone may write."""
+        managed = self._channels.get(room)
+        if managed is None or episode is None:
+            return None
+        return managed.floors.get(episode)
 
     async def close_episode(self, room: str) -> bool:
         """Close the room's active episode normally and flush deferred invites.

--- a/fastapi-backend/app/services/tasks.py
+++ b/fastapi-backend/app/services/tasks.py
@@ -57,6 +57,7 @@ from app.services.filesystem import (
 
 if TYPE_CHECKING:
     from app.schemas import MemoryRead
+    from app.services.floor import Floor
 
 logger = logging.getLogger(__name__)
 
@@ -207,10 +208,11 @@ def episode_write_rejection(
     frozen_episode: str | None = None,
     frozen_members: Iterable[str] = (),
     transcript: Iterable[str] = (),
+    floor: Floor | None = None,
 ) -> ThreadRefusal | None:
     """Why ``handle`` may not write into ``episode``, or ``None`` if it may.
 
-    Two refusals, and the difference between them is the whole model:
+    Three refusals, and the difference between them is the whole model:
 
     A thread the room does not have is refused (404) — naming a URN must not be
     how one comes into being, or the transcript grows threads nobody opened.
@@ -220,15 +222,23 @@ def episode_write_rejection(
     offer/counter exchange scored across a set of participants means nothing if
     an outsider can drop a position into it.
 
-    A **container** — a task's thread — refuses neither, and that is
-    deliberate rather than unfinished. Freezing membership is a negotiation's
+    A thread whose **floor** is held (409) is refused to anyone the holder has
+    not given it to. That is a protocol saying whose turn it is
+    (:mod:`app.services.floor`); the refusal names who holds the floor and who
+    may speak, so a handle that tried early knows to keep awaiting rather than
+    to give up. A floor is held by a run of backend code, never chosen by a
+    writer, and it narrows one thread — the room itself never holds one.
+
+    A **container** — a task's thread — refuses none of these on its own, and
+    that is deliberate rather than unfinished. Freezing membership is a negotiation's
     policy, not an episode's (:class:`~app.services.l9_slim.EpisodeLifecycle`):
     a task outlives what happens inside it, so an agent that claims a row after
     the thread opened must be able to speak in it.  The honest boundary: a task's
     thread is scoped to the room, not narrower.  Everyone who may write in the
     room may write in its threads — threads separate *attention*, not access, and
     the room's own guards (membership, principal, delegation) are what a write
-    still has to pass.
+    still has to pass.  The two narrowings above are the only exceptions, and
+    both are held by a run of backend code for as long as it runs.
     """
     if episode is None or l9.is_live_episode(room, episode):
         return None
@@ -238,6 +248,12 @@ def episode_write_rejection(
         return ThreadRefusal(
             403,
             f"@{handle} is not a member of the negotiation in thread {short_id_of(episode)!r}",
+        )
+    if floor is not None and floor.episode == episode and not floor.admits(handle):
+        return ThreadRefusal(
+            409,
+            f"@{handle} does not have the floor in thread {short_id_of(episode)!r}: "
+            f"{floor.describe()}",
         )
     return None
 
@@ -272,6 +288,7 @@ def thread_write_refusal(room: str, handle: str, episode: str | None) -> ThreadR
         frozen_episode=(lifecycle.episode if lifecycle is not None and lifecycle.frozen else None),
         frozen_members=lifecycle.members if lifecycle is not None else (),
         transcript=spoken,
+        floor=manager.floor(room, episode),
     )
 
 

--- a/fastapi-backend/app/services/turns.py
+++ b/fastapi-backend/app/services/turns.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""One addressed turn over a room's channel: ask one handle, wait for its answer.
+
+The primitive the aligner brokers a negotiation with, lifted out so anything
+that puts a question to one member and needs that member's reply — a mediator
+round, a step of a protocol, a review gate — asks it the same way.
+
+Two properties are the whole contract. **One wake:** the prompt names exactly
+one L9 recipient, and every ``@`` in the prose is neutralized, so the room reads
+who was asked while only that handle's ``await`` returns. **Silence yields
+nothing:** the wait is bounded, an empty string comes back on timeout, and the
+caller decides what silence means (the mediator reads it as a reject and never
+invents a position for a handle that did not speak).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from app.services import l9
+from app.services.agent_registry import norm_handle
+from app.services.l9_models import Kind
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from app.services.persister import TranscriptRecord
+
+logger = logging.getLogger(__name__)
+
+#: The ``@`` sigil in front of a handle. The prompt a turn carries names the
+#: other members in its prose (a broker's summary, a step's context); left as
+#: is, every one of them would wake on the mention-in-text match. Stripping the
+#: sigil keeps the names readable and the wake single.
+MENTION_SIGIL = re.compile(r"@(?=\w)")
+
+
+def neutralize_mentions(text: str) -> str:
+    """``text`` with every ``@handle`` reduced to ``handle``."""
+    return MENTION_SIGIL.sub("", text)
+
+
+async def addressed_turn(
+    managed: Any,
+    persister: Any,
+    *,
+    sender: str,
+    handle: str,
+    episode: str,
+    topic: str,
+    prompt: str,
+    is_reply: Callable[[TranscriptRecord], bool],
+    timeout_s: float,
+    poll_interval_s: float,
+    payload_type: str = "tick",
+    payload_data: dict[str, Any] | None = None,
+) -> str:
+    """Post ``prompt`` to ``handle`` alone, wait for its reply, return the prose.
+
+    The prompt is recorded into the transcript like any message, so the room can
+    follow along; the reply is the first record past it from ``handle`` that
+    ``is_reply`` accepts. ``""`` when the send fails or ``timeout_s`` passes
+    with no such record.
+    """
+    before = len(persister.log.records)
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=episode,
+        sender=sender,
+        recipients=[handle],
+        topic=topic,
+        payload_type=payload_type,
+        payload_data=payload_data,
+    )
+    try:
+        await managed.post(env, neutralize_mentions(prompt), raise_on_send_failure=True)
+    except Exception:
+        logger.warning("failed to put a turn to @%s in %s", handle, episode)
+        return ""
+
+    pending = norm_handle(handle) or ""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while True:
+        for record in persister.log.records[before:]:
+            if (norm_handle(record.sender) or "") == pending and is_reply(record):
+                return record.content.get("content") or ""
+        if loop.time() >= deadline:
+            return ""
+        await asyncio.sleep(poll_interval_s)

--- a/fastapi-backend/tests/test_floor.py
+++ b/fastapi-backend/tests/test_floor.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The floor: a thread narrowed to whose turn it is, held by backend code.
+
+Node-free. The policy is a value, the manager holds one per thread, and the
+one write gate both routes pass reads it — a refused write never reaches the
+transcript, so the wake side needs nothing. With no floor held, every rule
+here answers exactly as it did before the floor existed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services import l9, tasks
+from app.services.floor import Floor
+from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
+
+ROOM = "floored"
+THREAD = l9.episode_urn(ROOM, "t3")
+OTHER = l9.episode_urn(ROOM, "t9")
+
+
+def _manager() -> tuple[RoomChannelManager, ManagedRoomChannel]:
+    manager = RoomChannelManager(endpoint="http://127.0.0.1:46357", default_workspace="mycelium")
+    channel = MagicMock()
+    channel.send = AsyncMock()
+    managed = ManagedRoomChannel(
+        room=ROOM, workspace="mycelium", client=MagicMock(), channel=channel
+    )
+    manager._channels[ROOM] = managed
+    return manager, managed
+
+
+class TestFloorPolicy:
+    def test_the_holder_always_has_the_floor(self):
+        assert Floor(THREAD, "conductor").admits("conductor")
+        assert Floor(THREAD, "conductor").admits("@Conductor")
+
+    def test_a_session_of_a_speaker_is_the_speaker(self):
+        """The floor is given to a member; any session of that member holds it."""
+        assert Floor(THREAD, "conductor", frozenset({"api"})).admits("api#a8f3")
+        assert Floor(THREAD, "conductor").admits("conductor#b2c4")
+
+    def test_a_speaker_has_it_and_nobody_else_does(self):
+        floor = Floor(THREAD, "conductor", frozenset({"api"}))
+        assert floor.admits("api")
+        assert not floor.admits("sec")
+        assert not floor.admits("")
+
+    def test_the_refusal_names_who_holds_it_and_who_may_speak(self):
+        assert Floor(THREAD, "conductor", frozenset({"sec", "api"})).describe() == (
+            "@conductor holds the floor; @api, @sec may speak"
+        )
+        assert Floor(THREAD, "conductor").describe() == (
+            "@conductor holds the floor; no one else may speak right now"
+        )
+
+
+class TestHoldingTheFloor:
+    def test_a_room_with_no_channel_holds_nothing(self):
+        manager = RoomChannelManager(endpoint="http://x", default_workspace="mycelium")
+        assert manager.hold_floor(ROOM, THREAD, holder="conductor") is None
+        assert manager.floor(ROOM, THREAD) is None
+        assert manager.release_floor(ROOM, THREAD) is False
+
+    def test_the_room_itself_never_holds_a_floor(self):
+        manager, managed = _manager()
+        assert manager.hold_floor(ROOM, l9.live_episode_urn(ROOM), holder="conductor") is None
+        assert managed.floors == {}
+
+    def test_holding_replaces_and_releasing_opens(self):
+        manager, _managed = _manager()
+        first = manager.hold_floor(ROOM, THREAD, holder="@Conductor", speakers=["@API", "sec"])
+        assert first == Floor(THREAD, "conductor", frozenset({"api", "sec"}))
+        assert manager.floor(ROOM, THREAD) == first
+
+        second = manager.hold_floor(ROOM, THREAD, holder="conductor", speakers=["sec"])
+        assert manager.floor(ROOM, THREAD) == second
+        assert second is not None
+        assert second.speakers == frozenset({"sec"})
+
+        assert manager.release_floor(ROOM, THREAD) is True
+        assert manager.floor(ROOM, THREAD) is None
+        assert manager.release_floor(ROOM, THREAD) is False
+
+    def test_floors_are_per_thread(self):
+        """One room, two protocols, two floors — a thread's floor is its own."""
+        manager, _managed = _manager()
+        manager.hold_floor(ROOM, THREAD, holder="conductor", speakers=["api"])
+        manager.hold_floor(ROOM, OTHER, holder="reviewer", speakers=["sec"])
+        assert manager.floor(ROOM, THREAD) == Floor(THREAD, "conductor", frozenset({"api"}))
+        assert manager.floor(ROOM, OTHER) == Floor(OTHER, "reviewer", frozenset({"sec"}))
+        assert manager.floor(ROOM, None) is None
+
+
+class TestTheWriteGate:
+    """The floor joins the two refusals the gate already had, after them."""
+
+    def _refusal(self, handle: str, floor: Floor | None, **kw):
+        return tasks.episode_write_rejection(
+            ROOM, handle, THREAD, transcript={THREAD}, floor=floor, **kw
+        )
+
+    def test_no_floor_changes_nothing(self):
+        assert self._refusal("anyone", None) is None
+
+    def test_the_holder_and_the_speakers_write(self):
+        floor = Floor(THREAD, "conductor", frozenset({"api"}))
+        assert self._refusal("conductor", floor) is None
+        assert self._refusal("@API", floor) is None
+
+    def test_everyone_else_is_told_to_wait(self):
+        floor = Floor(THREAD, "conductor", frozenset({"api"}))
+        refusal = self._refusal("sec", floor)
+        assert refusal is not None
+        assert refusal.status == 409
+        assert "@sec does not have the floor" in refusal.detail
+        assert "@conductor holds the floor; @api may speak" in refusal.detail
+
+    def test_another_threads_floor_is_not_this_ones(self):
+        assert self._refusal("sec", Floor(OTHER, "conductor", frozenset({"api"}))) is None
+
+    def test_the_room_itself_is_never_floored(self):
+        live = l9.live_episode_urn(ROOM)
+        floor = Floor(live, "conductor")
+        assert tasks.episode_write_rejection(ROOM, "sec", live, floor=floor) is None
+
+    def test_a_frozen_roster_answers_first(self):
+        """An outsider to a negotiation is refused as an outsider, whatever the
+        floor says: the roster is the stronger rule and its answer is the one
+        that tells the writer what it is outside of."""
+        refusal = self._refusal(
+            "sec",
+            Floor(THREAD, "conductor", frozenset({"sec"})),
+            frozen_episode=THREAD,
+            frozen_members={"api"},
+        )
+        assert refusal is not None
+        assert refusal.status == 403
+
+    def test_an_unknown_thread_is_still_unknown(self):
+        refusal = tasks.episode_write_rejection(
+            ROOM, "api", THREAD, floor=Floor(THREAD, "conductor", frozenset({"api"}))
+        )
+        assert refusal is not None
+        assert refusal.status == 404
+
+
+class TestTheLiveGate:
+    """``thread_write_refusal`` reads the floor off the room's live channel."""
+
+    @pytest.fixture
+    def held(self, monkeypatch):
+        from app.services import room_channels
+
+        manager, _managed = _manager()
+        monkeypatch.setattr(room_channels, "manager", manager)
+        monkeypatch.setattr(tasks, "bound_episodes", lambda _room: {THREAD})
+        manager.hold_floor(ROOM, THREAD, holder="conductor", speakers=["api"])
+        return manager
+
+    def test_it_refuses_off_the_live_floor(self, held):
+        refusal = tasks.thread_write_refusal(ROOM, "sec", THREAD)
+        assert refusal is not None
+        assert refusal.status == 409
+
+    def test_it_admits_the_speaker(self, held):
+        assert tasks.thread_write_refusal(ROOM, "api", THREAD) is None
+
+    def test_releasing_opens_the_thread(self, held):
+        held.release_floor(ROOM, THREAD)
+        assert tasks.thread_write_refusal(ROOM, "sec", THREAD) is None

--- a/fastapi-backend/tests/test_thread_transport.py
+++ b/fastapi-backend/tests/test_thread_transport.py
@@ -659,6 +659,48 @@ class TestReplyTargeting:
         assert (await self._reply(client)).status_code == 200
         assert self._replied(replying).header.message.episode == thread
 
+    @pytest.mark.asyncio
+    async def test_a_reply_off_the_floor_is_told_to_wait(self, client, replying):
+        """A held floor answers the same way a frozen roster does — before
+        anything is recorded — but with a 409 that names whose turn it is, so
+        a resident loop reads it as "not yet" rather than "not you"."""
+        thread = await _unit_thread(ROOM, "pick a token store")
+        room_channels.manager.hold_floor(ROOM, thread, holder="conductor", speakers=["sec"])
+        self._woke(thread, sender="conductor")
+
+        resp = await self._reply(client)
+        assert resp.status_code == 409
+        assert "@conductor holds the floor; @sec may speak" in resp.json()["detail"]
+        assert [e for e, _c, _lw in replying.persister.ingested if e.payload.type == "reply"] == []
+        assert replying.persister.pings == []
+
+    @pytest.mark.asyncio
+    async def test_the_handle_given_the_floor_replies(self, client, replying):
+        thread = await _unit_thread(ROOM, "pick a token store")
+        room_channels.manager.hold_floor(ROOM, thread, holder="conductor", speakers=["api"])
+        self._woke(thread, sender="conductor")
+
+        assert (await self._reply(client)).status_code == 200
+        assert self._replied(replying).header.message.episode == thread
+
+    @pytest.mark.asyncio
+    async def test_a_released_floor_takes_anyone_again(self, client, replying):
+        thread = await _unit_thread(ROOM, "pick a token store")
+        room_channels.manager.hold_floor(ROOM, thread, holder="conductor", speakers=["sec"])
+        room_channels.manager.release_floor(ROOM, thread)
+        self._woke(thread, sender="conductor")
+
+        assert (await self._reply(client)).status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_the_room_is_open_however_many_floors_are_held(self, client, replying):
+        """A floor narrows one thread; the room itself takes every write."""
+        thread = await _unit_thread(ROOM, "pick a token store")
+        room_channels.manager.hold_floor(ROOM, thread, holder="conductor", speakers=["sec"])
+        self._woke(l9.live_episode_urn(ROOM))
+
+        assert (await self._reply(client)).status_code == 200
+
 
 class TestWriteRoutes:
     """The two write surfaces take a thread target, and refuse the same way."""
@@ -683,6 +725,29 @@ class TestWriteRoutes:
         )
         assert resp.status_code == 404
         assert "t3" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_posting_off_the_floor_is_refused_the_same_way(self, client, room, monkeypatch):
+        """The human write route passes the one gate ``/reply`` does, so a
+        ``board send`` into a held thread waits its turn too — which is how a
+        human-in-the-loop step works: the runner gives the person the floor."""
+        monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+        manager, _managed = _live_room()
+        monkeypatch.setattr(room_channels, "manager", manager)
+        thread = await _unit_thread(room, "pick a token store")
+        manager.hold_floor(room, thread, holder="conductor", speakers=["julia"])
+
+        body = {"message_type": "broadcast", "content": "hi", "episode": thread}
+        refused = await client.post(
+            f"/api/rooms/{room}/messages", json={**body, "sender_handle": "api"}
+        )
+        assert refused.status_code == 409
+        assert "@conductor holds the floor; @julia may speak" in refused.json()["detail"]
+
+        admitted = await client.post(
+            f"/api/rooms/{room}/messages", json={**body, "sender_handle": "julia"}
+        )
+        assert admitted.status_code == 201
 
     @pytest.mark.asyncio
     async def test_a_refused_post_stores_nothing(self, client, room):

--- a/fastapi-backend/tests/test_turns.py
+++ b/fastapi-backend/tests/test_turns.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""One addressed turn: ask one handle, wake only it, take only its answer.
+
+Node-free, over the shared fakes. This is the primitive the aligner brokers
+with and a protocol step will ask with; the tests hold its contract rather
+than either caller's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.services import l9, turns
+from tests.fakes import DEFAULT_ROOM, FakeChannel, FakeManaged, FakePersister, position_record
+
+EPISODE = l9.episode_urn(DEFAULT_ROOM, "e1")
+TOPIC = l9.topic_urn(DEFAULT_ROOM)
+
+
+def _is_position(record) -> bool:
+    return record.kind == "exchange" and record.sender not in {"mediator", "system"}
+
+
+async def _turn(managed, persister, *, handle="a", prompt="@a your move; @b is waiting", **kw):
+    return await turns.addressed_turn(
+        managed,
+        persister,
+        sender="mediator",
+        handle=handle,
+        episode=EPISODE,
+        topic=TOPIC,
+        prompt=prompt,
+        is_reply=_is_position,
+        timeout_s=kw.pop("timeout_s", 0.5),
+        poll_interval_s=0.01,
+        **kw,
+    )
+
+
+def _wired(reply_conf: float | None = 0.9):
+    persister = FakePersister()
+    channel = FakeChannel(persister, reply_conf=reply_conf)
+    return FakeManaged(channel=channel, persister=persister), persister, channel
+
+
+def test_neutralizing_keeps_the_names_and_drops_the_sigil():
+    assert turns.neutralize_mentions("@a, then @b (and @ alone)") == "a, then b (and @ alone)"
+
+
+@pytest.mark.asyncio
+async def test_one_recipient_and_no_sigils_in_the_prose():
+    managed, persister, channel = _wired()
+    await _turn(managed, persister)
+
+    env, extra = channel.sent[0]
+    assert [a.id for a in env.header.participants.actors] == ["mediator", "a"]
+    assert extra == {"content": "a your move; b is waiting"}
+    assert env.payload.type == "tick"
+    # The prompt is in the transcript, so the room can follow along.
+    assert persister.ingested[0][1]["content"] == "a your move; b is waiting"
+
+
+@pytest.mark.asyncio
+async def test_the_addressed_handles_reply_comes_back():
+    managed, persister, _channel = _wired()
+    assert await _turn(managed, persister) == "a position"
+
+
+@pytest.mark.asyncio
+async def test_payload_type_and_data_ride_the_tick():
+    managed, persister, channel = _wired()
+    await _turn(managed, persister, payload_type="review", payload_data={"step": "gate"})
+    env, _extra = channel.sent[0]
+    assert env.payload.type == "review"
+    assert env.payload.data == {"step": "gate"}
+
+
+@pytest.mark.asyncio
+async def test_silence_yields_nothing():
+    managed, persister, _channel = _wired(reply_conf=None)
+    assert await _turn(managed, persister, timeout_s=0.05) == ""
+
+
+@pytest.mark.asyncio
+async def test_another_handles_reply_is_not_the_answer():
+    managed, persister, _channel = _wired(reply_conf=None)
+
+    async def _b_speaks_then_a():
+        await asyncio.sleep(0.02)
+        persister.log.record(position_record("b", prose="b butting in"), delivered_to=set())
+        await asyncio.sleep(0.02)
+        persister.log.record(position_record("a", prose="a, at last"), delivered_to=set())
+
+    task = asyncio.create_task(_b_speaks_then_a())
+    assert await _turn(managed, persister) == "a, at last"
+    await task
+
+
+@pytest.mark.asyncio
+async def test_a_reply_the_predicate_rejects_is_skipped():
+    managed, persister, _channel = _wired(reply_conf=None)
+    persister.log.record(position_record("a", role="human", prose="human a"), delivered_to=set())
+
+    def only_agents(record) -> bool:
+        actors = record.content["l9"]["header"]["participants"]["actors"]
+        return actors[0].get("role") != "human"
+
+    out = await turns.addressed_turn(
+        managed,
+        persister,
+        sender="mediator",
+        handle="a",
+        episode=EPISODE,
+        topic=TOPIC,
+        prompt="go",
+        is_reply=only_agents,
+        timeout_s=0.05,
+        poll_interval_s=0.01,
+    )
+    assert out == ""
+
+
+@pytest.mark.asyncio
+async def test_a_failed_send_is_a_silent_turn():
+    class _Down:
+        async def send(self, _env, *, extra=None):
+            raise RuntimeError("node away")
+
+    persister = FakePersister()
+    managed = FakeManaged(channel=_Down(), persister=persister)
+    assert await _turn(managed, persister) == ""
+    assert persister.ingested == []


### PR DESCRIPTION
## Summary

First of the stacked PRs into [#953](https://github.com/mycelium-io/mycelium/pull/953). It adds the one primitive everything else in that branch stands on: a **code-enforced answer to "who may write into this thread right now"**, and lifts the aligner's one-agent turn into a shared module so a protocol step can ask a question the same way the mediator does.

Nothing user-visible changes in this PR. No route, no CLI flag, no wire constant, no docs page. With no floor held, every rule answers byte-for-byte as before (the full suite passes unchanged, plus 32 new tests).

### The floor

A thread separates attention, not access. Two things narrow that, and both are held by a run of backend code, never chosen by a writer:

- a **frozen negotiation** admits only the roster it froze on (403, already there);
- a **floor** admits only the handles its holder has given it to (409, new).

Both are enforced at the one gate `/messages` and `/reply` already share (`tasks.thread_write_refusal`). A refused write never reaches the transcript, and the transcript is the only delivery path, so it wakes nobody and `await` needs no change. The 409 names who holds the floor and who may speak, so a resident loop reads it as "not yet", not "not you". A session-qualified handle (`alice#a8f3`) counts as `alice`.

Floors are held **per episode** on the managed channel (`manager.hold_floor` / `release_floor` / `floor`), independent of the room-wide negotiation lifecycle: a negotiation freezes a roster, a floor names whose turn it is, and a room may hold several floors at once. The room itself (`live`) can never hold one, so a protocol cannot close the room around itself. A floor is process-local like an open negotiation: its holder is a run of backend code, and it dies with the process rather than outliving the run that would have released it.

### The turn primitive

`app/services/turns.py:addressed_turn` is the aligner's `_slim_turn` lifted out: post a prompt to exactly one L9 recipient with every other `@` in the prose neutralized, wait (bounded) for that handle's reply, yield `""` on silence and let the caller decide what silence means. The aligner now brokers through it; its behavior and its tests are unchanged.

## Changes

- `app/services/floor.py` (new): the `Floor` value and its refusal text.
- `app/services/turns.py` (new): `addressed_turn` and `neutralize_mentions`.
- `app/services/room_channels.py`: `floors` on `ManagedRoomChannel`; `hold_floor`, `release_floor`, `floor` on the manager.
- `app/services/tasks.py`: the floor as the third refusal in `episode_write_rejection`, read off the live channel in `thread_write_refusal`.
- `app/services/aligner.py`: `_slim_turn` delegates to the primitive; `_AT_MENTION` kept as an alias for the engines that share it.
- `CLAUDE.md`: one bullet under key design decisions.
- Tests: `test_floor.py`, `test_turns.py`, and route-level cases in `test_thread_transport.py` (a reply off the floor is refused before anything is recorded; the speaker replies; a released floor takes anyone; the room stays open; the human write route refuses the same way, which is how a human-in-the-loop step will work).

## Testing

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 1099 passed, 13 skipped
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `uv run ty check .`

## Related Issues

Stacked on #953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk)_