### PR TITLE
Add the conductor: an engine that runs a protocol inside a task, in code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,17 @@ is no litellm dependency.
   transcript, so it wakes nobody and `await` needs no change. The room itself
   (`live`) never holds a floor. `app/services/turns.py` is the one-agent turn
   the aligner brokers with, lifted out so a protocol step asks the same way.
+- **The conductor runs a protocol inside a task, in code.** A fourth engine
+  kind (`app/services/conductor.py`) with no model of its own: summoned as
+  `board coordinate <row> conductor "gated @a @b: …"`, it walks a
+  `protocols.Protocol` (three built in: `gated`, `fan-out`, `round-robin`; a
+  room's `protocols/<name>` memory overrides or adds one) in the thread it was
+  summoned in, holding the floor for whoever each step addresses, asking
+  through `turns.addressed_turn`, and following the edge the reply's stance
+  takes (`markers.stance_of`, read off the payload or a marker left in prose so
+  a person's `board send` counts). It opens no negotiation and never commits
+  `converged`, so nothing it does compiles into rows. A model in the nodes,
+  code on the edges: the judgment is the members', the routing is the hub's.
 - **The aligner mediates, inside a task.** Agents never talk to each other directly;
   all coordination flows through the aligner. It's a first-party engine registered
   as a room citizen (`mycelium engine create aligner --kind aligner`) and summoned

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Repo layout:
 ```
 .mycelium/            Memory storage (rooms are folders, memories are markdown files)
 mycelium-cli/         CLI + adapters
-fastapi-backend/      FastAPI moderator + engines (aligner, synthesizer, hello)
+fastapi-backend/      FastAPI moderator + engines (aligner, synthesizer, hello, conductor)
 mycelium-client/      Generated typed OpenAPI client
 mycelium-frontend/    Next.js UI
 contracts/            Frozen JSON contracts shared across components

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Adapters · mycelium</title>
-<meta name="description" content="Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer and hello.">
+<meta name="description" content="Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer, hello and the conductor.">
 <meta property="og:title" content="Adapters · mycelium">
-<meta property="og:description" content="Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer and hello.">
+<meta property="og:description" content="Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer, hello and the conductor.">
 <meta property="og:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <meta property="og:url" content="https://mycelium-io.github.io/mycelium/adapters.html">
 <meta property="og:type" content="website">
@@ -117,6 +117,7 @@
           <a href="#aligner" class="nav-link sub">Aligner</a>
           <a href="#synthesizer" class="nav-link sub">Synthesizer</a>
           <a href="#hello" class="nav-link sub">Hello</a>
+          <a href="#conductor" class="nav-link sub">Conductor</a>
         </div>
       </div>
     </div>
@@ -584,7 +585,7 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
       <h1>Engines</h1>
       <p>An <strong>engine</strong> is a first-party task of cognition that lives inside a room. Where your agents are the participants, engines are the room&#x27;s <em>reasoning citizens</em>. They read what the room knows and act on it: mediate a decision, distill the memory, and (in time) more.</p>
       <p>Engines exist because some work isn&#x27;t any single agent&#x27;s job. Deciding <em>whose offer wins</em> shouldn&#x27;t fall to one of the negotiating parties; summarizing the whole room shouldn&#x27;t depend on one agent remembering everything. An engine is a neutral, first-party actor the room owns.</p>
-      <p>Three of them exist today; the first thing to try on a new hub is <code>hello</code>, which answers a summon and owns nothing, so it is safe to fire into a live room just to see whether cognition runs at all.</p>
+      <p>Four of them exist today; the first thing to try on a new hub is <code>hello</code>, which answers a summon and owns nothing, so it is safe to fire into a live room just to see whether cognition runs at all.</p>
       <p>Two properties define every engine:</p>
       <ul>
         <li><strong>Summoned explicitly.</strong> An engine is dormant until you register it in a room and <code>@</code>-summon it. There is no join window, no polling, and no held LLM connection, so it has zero idle cost. Cognition runs because you asked for it.</li>
@@ -612,6 +613,10 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
             <tr>
               <td><code>hello</code></td>
               <td>Answers one summon with one Pi turn and writes nothing anywhere — the cheap proof the engine path works on this hub. See <a href="#hello">Hello</a>.</td>
+            </tr>
+            <tr>
+              <td><code>conductor</code></td>
+              <td>Runs a protocol inside a task — a gated review, a fan-out, a round robin — walking the steps in code and giving the floor to whoever each step addresses. It has no model of its own. See <a href="#conductor">Conductor</a>.</td>
             </tr>
           </tbody>
         </table>
@@ -766,6 +771,74 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
       <h2 id="hello-holding-nothing">Holding nothing</h2>
       <p>Hello keeps no state between summons and answers each one from scratch, so it is not a chat partner — it is a probe with a personality. Ask it something twice and it will not remember the first time. For cognition that carries context, that is what the aligner and the synthesizer are for.</p>
       <p class="edit-page"><a href="https://github.com/mycelium-io/mycelium/blob/main/mycelium-cli/src/mycelium/docs/concepts/hello.md" target="_blank" rel="noopener"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>Edit this page on GitHub</a></p>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="conductor">
+      <h1>Conductor</h1>
+      <p>The conductor is the <a href="#engines">engine</a> that runs a <strong>protocol</strong> inside a task: a fixed shape of who speaks to whom, in what order, and what happens on each answer. Where the <a href="#aligner">aligner</a> brokers a negotiation, the conductor walks a graph. It is the engine to reach for when a piece of work has a shape you already know: a proposal that a reviewer must approve, a lead asking every worker at once, a round where each member speaks in turn.</p>
+      <p>It is the one engine with no model of its own. Every judgment in a run, what to propose and whether to block it, is made by the members it addresses. The conductor only decides whose turn it is, and it enforces that in code: while a step is open, only the member it addressed can write into the thread. That is the split the whole design rests on. A model sits in each node, and code sits on the edges.</p>
+      <pre><code><span class="comment"># Register it once per room</span>
+<span class="bin">mycelium</span> <span class="cmd">engine</span> <span class="cmd">create</span> conductor <span class="flag">--kind</span> conductor <span class="flag">--room</span> sprint-plan
+
+<span class="comment"># Run the gated protocol inside a task: @api proposes, @sec approves or blocks</span>
+<span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">coordinate</span> work/rotate-signing-key conductor \
+  <span class="str">&quot;gated @api @sec: rotate the signing key without downtime&quot;</span></code></pre>
+      <p>The summon names the protocol first, then the members in the order the protocol&#x27;s roles expect, then the question. The run happens in the thread the summon was made in, so the row&#x27;s conversation carries the whole thing and <code>board messages</code> reads it back. A summon from the room itself (<code>engine invoke</code>) opens a thread of its own, because the room is never narrowed to one speaker.</p>
+      <h2 id="conductor-the-built-in-protocols">The built-in protocols</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Protocol</th>
+              <th>Roles</th>
+              <th>Shape</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>gated</code></td>
+              <td>proposer, guardian</td>
+              <td>The proposer states what it intends to do. The guardian approves or blocks, ending its reply with <code>[[mycelium: stance=accept]]</code> or <code>[[mycelium: stance=reject]]</code>. A block sends the proposal back with the objection attached, until an approval or the step cap.</td>
+            </tr>
+            <tr>
+              <td><code>fan-out</code></td>
+              <td>lead</td>
+              <td>Every other member is asked at once. The lead then gets all the answers and combines them into one plan.</td>
+            </tr>
+            <tr>
+              <td><code>round-robin</code></td>
+              <td>none</td>
+              <td>Each member speaks in turn, seeing what the others said, for two rounds.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>Any member can fill a role: a registered agent kept awake with <code>mycelium await --loop</code>, an engine such as <a href="#hello">hello</a>, or a person. A person answers a step the way they answer anything in a thread, with <code>board send</code>, and a stance marker left in the text is read the same as one an agent&#x27;s reply carried. That is how a human-in-the-loop step works: the conductor gives the person the floor and waits.</p>
+      <h2 id="conductor-whose-turn-it-is">Whose turn it is</h2>
+      <p>While a run is open, the thread has a <strong>floor</strong>. The conductor holds it, and gives it to whoever the current step addresses: one member for a role step, everyone at once for a fan-out. A write from anyone else is refused with a <code>409</code> that says who holds the floor and who may speak, so an agent that tried early keeps awaiting rather than giving up. A refused write never reaches the transcript, which means it wakes nobody.</p>
+      <p>Nothing else narrows. The room stays open throughout, other threads are untouched, and a member joining the room mid-run aborts nothing, because a protocol run is not a negotiation and freezes no roster. When the run ends, the floor is released and the thread takes anyone again.</p>
+      <h2 id="conductor-how-a-run-ends">How a run ends</h2>
+      <p>A run ends at one of the protocol&#x27;s end steps, <code>resolved</code> or <code>rejected</code>, or at the step cap, which counts as <code>rejected</code>. The outcome is committed onto the thread and recorded at <code>log/episodes/{id}.md</code> like any coordination phase: who took part, each step&#x27;s prompt and reply, and how it ended. A resolved run does not resolve the task it ran in, and does not compile anything into new rows. It is a phase inside the task, and <code>board resolve</code> still finishes the task.</p>
+      <h2 id="conductor-writing-your-own">Writing your own</h2>
+      <p>A protocol is a memory under <code>protocols/</code>, promoted the way a skill is. A room that writes <code>protocols/gated</code> reshapes the built-in under that name; a new name adds a protocol. The body is YAML:</p>
+      <pre><code>description: A reviewer signs off before the author ships.
+roles: [author, reviewer]
+max_steps: 6
+steps:
+  - id: draft
+    to: author
+    prompt: &quot;{ask}\n\nSay what you will ship.\n\n{reply}&quot;
+    next: review
+  - id: review
+    to: reviewer
+    prompt: &quot;On the table:\n\n{reply}\n\nApprove or block, ending with a stance marker.&quot;
+    next: {accept: done, reject: draft, default: draft}
+  - id: done
+    end: resolved</code></pre>
+      <p>A step addresses a role, or <code>each</code> (every member, one at a time), <code>all</code> (every member, at once) or <code>workers</code> (every member not bound to a role). <code>wait: none</code> makes a step fire and forget. <code>rounds</code> repeats an <code>each</code> or <code>all</code> step. <code>next</code> is one step id, or a map from <code>accept</code>, <code>reject</code>, <code>silent</code> and <code>default</code> to step ids. Prompts can carry <code>{ask}</code>, <code>{reply}</code> (the most recent answer), <code>{replies}</code> (everyone&#x27;s latest, one per line), <code>{handles}</code>, <code>{round}</code> and <code>{rounds}</code>. Every step must lead somewhere, and every protocol needs an end step; a spec that does not hold together is refused rather than run half-read.</p>
+      <p class="edit-page"><a href="https://github.com/mycelium-io/mycelium/blob/main/mycelium-cli/src/mycelium/docs/concepts/conductor.md" target="_blank" rel="noopener"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>Edit this page on GitHub</a></p>
     </section>
   </div>
   </main>

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -38,7 +38,7 @@ PAGES: list[tuple[str, str, str, str, str, str, str]] = [
      "A shared space for humans and agents. Install Mycelium and learn the core concepts: rooms, memory, the board, episodes, and the L9 protocol."),
     ("adapters", "adapters.html", "Adapters · mycelium", "Adapters",
      "ADP-001", "ADAPTERS · CLAUDE CODE · CURSOR · A2A BRIDGE · REST API · ENGINES",
-     "Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer and hello."),
+     "Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer, hello and the conductor."),
     ("reference", "reference.html", "Reference · mycelium", "Reference",
      "REF-001", "REFERENCE · ARCHITECTURE · CLI · CONFIG · DEPENDENCIES · GUIDES · HELP",
      "Architecture, CLI reference, configuration, dependencies and compatibility, guides, and troubleshooting for Mycelium."),
@@ -73,6 +73,7 @@ SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
     ("concepts/aligner.md",           "aligner",            "adapters",  "Engines",      "Aligner"),
     ("concepts/synthesizer.md",       "synthesizer",        "adapters",  "Engines",      "Synthesizer"),
     ("concepts/hello.md",             "hello",              "adapters",  "Engines",      "Hello"),
+    ("concepts/conductor.md",         "conductor",          "adapters",  "Engines",      "Conductor"),
     # ── reference (reference.html) ──
     ("reference/architecture.md",     "architecture",       "reference", "Architecture", "Architecture"),
     # CLI + Config blocks injected after architecture, before guides/troubleshooting.

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,6 +117,7 @@
           <a href="adapters.html#aligner" class="nav-link sub">Aligner</a>
           <a href="adapters.html#synthesizer" class="nav-link sub">Synthesizer</a>
           <a href="adapters.html#hello" class="nav-link sub">Hello</a>
+          <a href="adapters.html#conductor" class="nav-link sub">Conductor</a>
         </div>
       </div>
     </div>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1663,7 +1663,7 @@ offer wins* shouldn't fall to one of the negotiating parties; summarizing the
 whole room shouldn't depend on one agent remembering everything. An engine is a
 neutral, first-party actor the room owns.
 
-Three of them exist today; the first thing to try on a new hub is `hello`,
+Four of them exist today; the first thing to try on a new hub is `hello`,
 which answers a summon and owns nothing, so it is safe to fire into a live
 room just to see whether cognition runs at all.
 
@@ -1687,6 +1687,7 @@ commands host all of them.
 | `aligner` | Mediates a disagreement inside a task to one shared answer, running a real NEGMAS negotiation. See [Aligner](#aligner). |
 | `synthesizer` | Distills the room's conversation into a briefing at `context/synthesis`, incrementally. See [Synthesizer](#synthesizer). |
 | `hello` | Answers one summon with one Pi turn and writes nothing anywhere — the cheap proof the engine path works on this hub. See [Hello](#hello). |
+| `conductor` | Runs a protocol inside a task — a gated review, a fan-out, a round robin — walking the steps in code and giving the floor to whoever each step addresses. It has no model of its own. See [Conductor](#conductor). |
 
 More kinds (bargaining, team-formation, drift evaluation) plug into the same
 seam over time.
@@ -1946,6 +1947,113 @@ Hello keeps no state between summons and answers each one from scratch, so it is
 not a chat partner — it is a probe with a personality. Ask it something twice
 and it will not remember the first time. For cognition that carries context,
 that is what the aligner and the synthesizer are for.
+
+
+---
+
+# Conductor
+
+The conductor is the [engine](#engines) that runs a **protocol** inside a
+task: a fixed shape of who speaks to whom, in what order, and what happens on
+each answer. Where the [aligner](#aligner) brokers a negotiation, the
+conductor walks a graph. It is the engine to reach for when a piece of work
+has a shape you already know: a proposal that a reviewer must approve, a lead
+asking every worker at once, a round where each member speaks in turn.
+
+It is the one engine with no model of its own. Every judgment in a run, what
+to propose and whether to block it, is made by the members it addresses. The
+conductor only decides whose turn it is, and it enforces that in code: while a
+step is open, only the member it addressed can write into the thread. That is
+the split the whole design rests on. A model sits in each node, and code sits
+on the edges.
+
+```bash
+# Register it once per room
+mycelium engine create conductor --kind conductor --room sprint-plan
+
+# Run the gated protocol inside a task: @api proposes, @sec approves or blocks
+mycelium board coordinate work/rotate-signing-key conductor \
+  "gated @api @sec: rotate the signing key without downtime"
+```
+
+The summon names the protocol first, then the members in the order the
+protocol's roles expect, then the question. The run happens in the thread the
+summon was made in, so the row's conversation carries the whole thing and
+`board messages` reads it back. A summon from the room itself
+(`engine invoke`) opens a thread of its own, because the room is never
+narrowed to one speaker.
+
+## The built-in protocols
+
+| Protocol | Roles | Shape |
+|---|---|---|
+| `gated` | proposer, guardian | The proposer states what it intends to do. The guardian approves or blocks, ending its reply with `[[mycelium: stance=accept]]` or `[[mycelium: stance=reject]]`. A block sends the proposal back with the objection attached, until an approval or the step cap. |
+| `fan-out` | lead | Every other member is asked at once. The lead then gets all the answers and combines them into one plan. |
+| `round-robin` | none | Each member speaks in turn, seeing what the others said, for two rounds. |
+
+Any member can fill a role: a registered agent kept awake with
+`mycelium await --loop`, an engine such as [hello](#hello), or a person. A
+person answers a step the way they answer anything in a thread, with
+`board send`, and a stance marker left in the text is read the same as one an
+agent's reply carried. That is how a human-in-the-loop step works: the
+conductor gives the person the floor and waits.
+
+## Whose turn it is
+
+While a run is open, the thread has a **floor**. The conductor holds it, and
+gives it to whoever the current step addresses: one member for a role step,
+everyone at once for a fan-out. A write from anyone else is refused with a
+`409` that says who holds the floor and who may speak, so an agent that tried
+early keeps awaiting rather than giving up. A refused write never reaches the
+transcript, which means it wakes nobody.
+
+Nothing else narrows. The room stays open throughout, other threads are
+untouched, and a member joining the room mid-run aborts nothing, because a
+protocol run is not a negotiation and freezes no roster. When the run ends,
+the floor is released and the thread takes anyone again.
+
+## How a run ends
+
+A run ends at one of the protocol's end steps, `resolved` or `rejected`, or at
+the step cap, which counts as `rejected`. The outcome is committed onto the
+thread and recorded at `log/episodes/{id}.md` like any coordination phase:
+who took part, each step's prompt and reply, and how it ended. A resolved run
+does not resolve the task it ran in, and does not compile anything into new
+rows. It is a phase inside the task, and `board resolve` still finishes the
+task.
+
+## Writing your own
+
+A protocol is a memory under `protocols/`, promoted the way a skill is. A room
+that writes `protocols/gated` reshapes the built-in under that name; a new
+name adds a protocol. The body is YAML:
+
+```yaml
+description: A reviewer signs off before the author ships.
+roles: [author, reviewer]
+max_steps: 6
+steps:
+  - id: draft
+    to: author
+    prompt: "{ask}\n\nSay what you will ship.\n\n{reply}"
+    next: review
+  - id: review
+    to: reviewer
+    prompt: "On the table:\n\n{reply}\n\nApprove or block, ending with a stance marker."
+    next: {accept: done, reject: draft, default: draft}
+  - id: done
+    end: resolved
+```
+
+A step addresses a role, or `each` (every member, one at a time), `all`
+(every member, at once) or `workers` (every member not bound to a role).
+`wait: none` makes a step fire and forget. `rounds` repeats an `each` or `all`
+step. `next` is one step id, or a map from `accept`, `reject`, `silent` and
+`default` to step ids. Prompts can carry `{ask}`, `{reply}` (the most recent
+answer), `{replies}` (everyone's latest, one per line), `{handles}`, `{round}`
+and `{rounds}`. Every step must lead somewhere, and every protocol needs an
+end step; a spec that does not hold together is refused rather than run
+half-read.
 
 
 ---

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -117,6 +117,7 @@
           <a href="adapters.html#aligner" class="nav-link sub">Aligner</a>
           <a href="adapters.html#synthesizer" class="nav-link sub">Synthesizer</a>
           <a href="adapters.html#hello" class="nav-link sub">Hello</a>
+          <a href="adapters.html#conductor" class="nav-link sub">Conductor</a>
         </div>
       </div>
     </div>

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -730,6 +730,41 @@ window.MYCELIUM_SEARCH_INDEX = [
     "p": "Adapters"
   },
   {
+    "u": "adapters.html#conductor",
+    "t": "Conductor",
+    "s": "Engines",
+    "x": "The conductor is the engine that runs a protocol inside a task: a fixed shape of who speaks to whom, in what order, and what happens on each answer. Where the aligner brokers a negotiation, the conductor walks a graph. It is the engine to reach for when a piece of work has a shape you already know: a proposal that a reviewer must approve, a lead asking every worker at once, a round where each member speaks in turn. I",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#conductor-the-built-in-protocols",
+    "t": "The built-in protocols",
+    "s": "Engines › Conductor",
+    "x": "Protocol Roles Shape gated proposer, guardian The proposer states what it intends to do. The guardian approves or blocks, ending its reply with [[mycelium: stance=accept]] or [[mycelium: stance=reject]]. A block sends the proposal back with the objection attached, until an approval or the step cap. fan-out lead Every other member is asked at once. The lead then gets all the answers and combines them into one plan. ro",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#conductor-whose-turn-it-is",
+    "t": "Whose turn it is",
+    "s": "Engines › Conductor",
+    "x": "While a run is open, the thread has a floor. The conductor holds it, and gives it to whoever the current step addresses: one member for a role step, everyone at once for a fan-out. A write from anyone else is refused with a 409 that says who holds the floor and who may speak, so an agent that tried early keeps awaiting rather than giving up. A refused write never reaches the transcript, which means it wakes nobody. N",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#conductor-how-a-run-ends",
+    "t": "How a run ends",
+    "s": "Engines › Conductor",
+    "x": "A run ends at one of the protocol's end steps, resolved or rejected, or at the step cap, which counts as rejected. The outcome is committed onto the thread and recorded at log/episodes/{id}.md like any coordination phase: who took part, each step's prompt and reply, and how it ended. A resolved run does not resolve the task it ran in, and does not compile anything into new rows. It is a phase inside the task, and boa",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#conductor-writing-your-own",
+    "t": "Writing your own",
+    "s": "Engines › Conductor",
+    "x": "A protocol is a memory under protocols/, promoted the way a skill is. A room that writes protocols/gated reshapes the built-in under that name; a new name adds a protocol. The body is YAML: description: A reviewer signs off before the author ships. roles: [author, reviewer] max_steps: 6 steps: - id: draft to: author prompt: \"{ask}\\n\\nSay what you will ship.\\n\\n{reply}\" next: review - id: review to: reviewer prompt: \"",
+    "p": "Adapters"
+  },
+  {
     "u": "reference.html#architecture",
     "t": "Architecture",
     "s": "Architecture",

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -185,6 +185,17 @@ class Settings(BaseSettings):
     # Per-turn wall-clock bound (seconds) on the hello engine's one-shot pi call.
     HELLO_PI_TIMEOUT_S: float = 60.0
 
+    # Conductor engine (kind ``conductor``) — runs a protocol's steps over a
+    # thread in code, holding the floor for whoever each step addresses. No
+    # model of its own, so no Pi settings: only its handle default, how long
+    # one step waits on a member (generous, since a step may be a person's),
+    # how often it polls, and a hard cap on steps per run that a protocol's
+    # own cap can only lower.
+    CONDUCTOR_HANDLE: str = "conductor"
+    CONDUCTOR_STEP_TIMEOUT_S: float = 300.0
+    CONDUCTOR_POLL_INTERVAL_S: float = 0.2
+    CONDUCTOR_MAX_STEPS: int = 24
+
     # Where a registered `engine` (kind aligner) runs its NEGMAS drive — selects
     # the engine runtime. "backend" (default):
     # this backend owns the run via its summon seam. "host": the host daemon owns

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -133,13 +133,14 @@ async def lifespan(app: FastAPI):
     # Wire the SIEP aligner into every room's summon seam before any
     # channel is provisioned, so all persisters pick it up. Dormant until an
     # @-summon of its reserved handle arrives — zero idle cost.
-    # Several handlers share the one summon seam: two engine kinds (aligner,
-    # synthesizer) plus the A2A responder. Each self-selects by the summoned
+    # Several handlers share the one summon seam: the engine kinds (aligner,
+    # synthesizer, hello, conductor) plus the A2A responder. Each self-selects by the summoned
     # handle's manifest (kind for engines, adapter=a2a for the responder), so a
     # fan-out dispatcher is enough — no central table. Only one ever acts per
     # summon since a handle maps to a single runtime.
     from app.services.a2a_bridge import A2aResponder
     from app.services.aligner import AlignerEngine
+    from app.services.conductor import ConductorEngine
     from app.services.probe_engine import ProbeEngine
     from app.services.room_channels import manager as room_channel_manager
     from app.services.synthesizer import SynthesizerEngine
@@ -148,6 +149,7 @@ async def lifespan(app: FastAPI):
     app.state.aligner = AlignerEngine(room_channel_manager)
     app.state.synthesizer = SynthesizerEngine(room_channel_manager)
     app.state.hello = ProbeEngine(room_channel_manager)
+    app.state.conductor = ConductorEngine(room_channel_manager)
     # The A2A responder shares the seam too: it answers @-mentions of a
     # registered a2a agent by calling the remote endpoint, gating on the manifest
     # like the engines gate on their kind, so only one handler ever acts.
@@ -156,6 +158,7 @@ async def lifespan(app: FastAPI):
         app.state.aligner.handle_summon,
         app.state.synthesizer.handle_summon,
         app.state.hello.handle_summon,
+        app.state.conductor.handle_summon,
         app.state.a2a_responder.handle_summon,
     )
 
@@ -174,10 +177,11 @@ async def lifespan(app: FastAPI):
 
     room_channel_manager.on_summon = _dispatch_summon
     logger.info(
-        "engines wired (aligner @%s, synthesizer @%s, hello @%s; llm=pi via %s)",
+        "engines wired (aligner @%s, synthesizer @%s, hello @%s, conductor @%s; llm=pi via %s)",
         app.state.aligner.handle,
         app.state.synthesizer.handle,
         app.state.hello.handle,
+        app.state.conductor.handle,
         settings.ALIGNER_PI_BINARY,
     )
 

--- a/fastapi-backend/app/routes/engines.py
+++ b/fastapi-backend/app/routes/engines.py
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/rooms/{room_name}/engines", tags=["engines"])
 
 # The engine kinds the backend knows how to run. Mirrors the CLI's
 # ``mycelium.protocol.ENGINE_KINDS``; the summon seam self-selects by ``kind``.
-ENGINE_KINDS = frozenset({"aligner", "hello", "synthesizer"})
+ENGINE_KINDS = frozenset({"aligner", "conductor", "hello", "synthesizer"})
 
 _HANDLE_RE = re.compile(HANDLE_PATTERN)
 

--- a/fastapi-backend/app/routes/participate.py
+++ b/fastapi-backend/app/routes/participate.py
@@ -33,13 +33,12 @@ commands, which is all a headless/allowlisted agent can safely issue.
 from __future__ import annotations
 
 import asyncio
-import re
 from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
-from app.services import activity, actor, l9, principals, room_channels, tasks
+from app.services import activity, actor, l9, markers, principals, room_channels, tasks
 from app.services.agent_registry import norm_handle
 from app.services.filesystem import room_exists
 from app.services.l9_models import Kind
@@ -60,10 +59,6 @@ _last_tick: dict[tuple[str, str], dict[str, Any]] = {}
 _POLL_INTERVAL_S = 0.4
 _MAX_WAIT_S = 3600.0
 
-# An agent may end a reply with a position marker like
-# ``[[mycelium: confidence=0.85 stance=accept]]``; those fields are lifted onto the
-# L9 payload so the aligner can score convergence, and stripped from the prose.
-_MARKER_RE = re.compile(r"\[\[\s*mycelium\s*:(.*?)\]\]", re.IGNORECASE | re.DOTALL)
 # Payloads that are never an addressed turn however they are actor-labeled:
 # presence/keepalive are liveness, a ``ping`` is the signal that a *thread* moved,
 # and a ``notice`` is the signal that the *board* moved (a task filed, claimed,
@@ -73,39 +68,15 @@ _UNADDRESSED_PAYLOADS = frozenset(
     {"presence", "keepalive", l9.PING_PAYLOAD_TYPE, l9.NOTICE_PAYLOAD_TYPE}
 )
 
-_STANCE_TO_ACTION = {
-    "accept": "accept",
-    "agree": "accept",
-    "yes": "accept",
-    "reject": "reject",
-    "block": "reject",
-    "no": "reject",
-}
-
 
 def _norm(handle: str) -> str:
     return norm_handle(handle) or ""
 
 
-def _parse_marker(text: str) -> tuple[dict[str, Any], str]:
-    """Lift ``confidence``/``stance`` out of any ``[[mycelium: …]]`` marker; strip it."""
-    payload: dict[str, Any] = {}
-    for match in _MARKER_RE.finditer(text):
-        for key, raw in re.findall(r"(\w+)\s*=\s*(\S+)", match.group(1)):
-            k = key.lower()
-            if k == "confidence":
-                try:
-                    val = float(raw)
-                except ValueError:
-                    continue
-                if 0.0 <= val <= 1.0:
-                    payload["confidence"] = val
-            elif k in ("stance", "action"):
-                action = _STANCE_TO_ACTION.get(raw.lower())
-                if action:
-                    payload["action"] = action
-    clean = _MARKER_RE.sub("", text).strip() or text.strip()
-    return payload, clean
+# An agent may end a reply with a position marker like
+# ``[[mycelium: confidence=0.85 stance=accept]]``; those fields are lifted onto the
+# L9 payload so the aligner can score convergence, and stripped from the prose.
+_parse_marker = markers.parse_marker
 
 
 def _addressed_to(content: dict[str, Any], handle: str) -> bool:

--- a/fastapi-backend/app/services/conductor.py
+++ b/fastapi-backend/app/services/conductor.py
@@ -1,0 +1,511 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The conductor — the engine that runs a protocol inside a thread.
+
+A fourth engine ``kind`` beside the aligner, the synthesizer and hello, and
+the first with no model of its own. Summoned into a thread with the name of a
+:mod:`~app.services.protocols` and the members to run it over, it walks that
+protocol's steps in code: it holds the thread's floor for whoever the step
+addresses, puts the step's prompt to them through the same one-agent turn the
+aligner brokers with, reads the stance their reply took, and follows the edge.
+Every judgment in a run — what to propose, whether to block it — is made by
+the members it addresses. The conductor only decides who speaks next, and
+that is the point: a model in the nodes, code on the edges.
+
+What it shares with the other engines: dormant until a registered engine of
+its kind is summoned, runs as that handle, and leaves a record at
+``log/episodes/{id}.md``. What it does not share: it opens no negotiation,
+so joining the room mid-run aborts nothing, and it never calls Pi.
+
+Where it runs: in the thread it was summoned in. A summon from a task's
+thread (``board coordinate <row> conductor "gated @a @b: …"``) runs there, so
+the row's conversation carries the whole run and a person can answer a step
+with ``board send``. A summon from the room itself opens a fresh thread,
+since the room never holds a floor.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from app.config import settings
+from app.services import l9, l9_episode, markers, protocols, turns
+from app.services.agent_registry import norm_handle
+from app.services.aligner import _NON_PARTICIPANTS, _registered_engine_kind
+from app.services.l9_models import Kind
+from app.services.persister import record_episode
+from app.services.tasks import mint_episode_id
+
+if TYPE_CHECKING:
+    from app.services.l9_models import L9
+    from app.services.persister import TranscriptRecord
+    from app.services.protocols import Protocol, Step
+    from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
+
+logger = logging.getLogger(__name__)
+
+#: The engine kind this class owns.
+ENGINE_KIND = "conductor"
+
+#: Payloads that are never a member's answer to a step.
+_NOT_A_REPLY = frozenset(
+    {"presence", "keepalive", "tick", l9.PING_PAYLOAD_TYPE, l9.NOTICE_PAYLOAD_TYPE}
+)
+
+_MENTION = re.compile(r"@[\w.@-]+")
+_LEADING_PUNCT = re.compile(r"^[\s:,;\u2014\u2013-]+")
+
+
+def _norm(handle: str) -> str:
+    return norm_handle(handle) or ""
+
+
+def split_directive(text: str) -> tuple[str, str]:
+    """``(protocol name, the ask)`` from a summon's text.
+
+    The first word that is not a mention names the protocol; everything after
+    it, mentions removed, is the ask the prompts carry as ``{ask}``.
+    """
+    words = _MENTION.sub(" ", text).split()
+    if not words:
+        return "", ""
+    name = words[0].strip(":,;").lower()
+    ask = _LEADING_PUNCT.sub("", " ".join(words[1:])).strip()
+    return name, ask
+
+
+class _Fields(dict[str, str]):
+    """Template fields that render empty rather than raising when absent."""
+
+    def __missing__(self, key: str) -> str:
+        return ""
+
+
+@dataclass
+class Run:
+    """One protocol run: what it is over, and what has been said in it."""
+
+    protocol: Protocol
+    ask: str
+    handles: list[str]
+    bound: dict[str, str]
+    episode: str
+    #: handle -> its most recent reply in this run.
+    replies: dict[str, str] = field(default_factory=dict)
+    #: The most recent reply anyone gave.
+    recent: str = ""
+    steps_taken: int = 0
+
+    def targets(self, step: Step) -> list[str]:
+        to = step.to or ""
+        if to == "workers":
+            named = set(self.bound.values())
+            return [h for h in self.handles if h not in named]
+        if to in protocols.GROUP_TARGETS:
+            return list(self.handles)
+        return [self.bound[to]]
+
+    def fields(self, *, round_n: int = 1, rounds: int = 1) -> _Fields:
+        said = [(h, self.replies[h]) for h in self.handles if self.replies.get(h)]
+        return _Fields(
+            ask=self.ask,
+            reply=self.recent,
+            replies="\n".join(f"- {h}: {p}" for h, p in said) or "(nothing yet)",
+            handles=", ".join(self.handles),
+            round=str(round_n),
+            rounds=str(rounds),
+        )
+
+
+def bind_roles(protocol: Protocol, handles: list[str]) -> dict[str, str] | None:
+    """Roles bound to ``handles`` in order, or ``None`` when there are too few."""
+    if len(handles) < len(protocol.roles):
+        return None
+    return dict(zip(protocol.roles, handles, strict=False))
+
+
+def stance_of_step(replies: list[tuple[str, str | None]]) -> str | None:
+    """The stance a step took across everyone it asked.
+
+    One reply's stance is its own. Across several, a single block is a
+    block, everyone accepting is an accept, and anything else states none.
+    ``"silent"`` when nobody answered at all.
+    """
+    if not replies:
+        return None
+    stances = [s for _h, s in replies]
+    if all(s == "silent" for s in stances):
+        return "silent"
+    if any(s == "reject" for s in stances):
+        return "reject"
+    if all(s == "accept" for s in stances):
+        return "accept"
+    return None
+
+
+class ConductorEngine:
+    """Walk a protocol's steps over a thread, holding its floor as it goes."""
+
+    def __init__(
+        self,
+        manager: RoomChannelManager,
+        *,
+        handle: str | None = None,
+        step_timeout_s: float | None = None,
+        poll_interval_s: float | None = None,
+        max_steps: int | None = None,
+    ) -> None:
+        self._manager = manager
+        self._handle = handle if handle is not None else settings.CONDUCTOR_HANDLE
+        self._step_timeout_s = (
+            step_timeout_s if step_timeout_s is not None else settings.CONDUCTOR_STEP_TIMEOUT_S
+        )
+        self._poll_interval_s = (
+            poll_interval_s if poll_interval_s is not None else settings.CONDUCTOR_POLL_INTERVAL_S
+        )
+        self._max_steps = max_steps if max_steps is not None else settings.CONDUCTOR_MAX_STEPS
+        # Threads with a run in flight: a re-summon into one is ignored while a
+        # second thread in the same room runs its own.
+        self._active: set[tuple[str, str]] = set()
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    @property
+    def handle(self) -> str:
+        return self._handle
+
+    # -- the summon seam --
+
+    def handle_summon(
+        self,
+        room: str,
+        handle: str,
+        envelope: L9,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
+    ) -> None:
+        """Run a protocol when a registered engine of kind ``conductor`` is
+        summoned; else ignore."""
+        if _registered_engine_kind(room, handle) != ENGINE_KIND:
+            return
+        if settings.ENGINE_RUNTIME == "host":
+            logger.info("engine @%s summoned in %s but ENGINE_RUNTIME=host", handle, room)
+            return
+        from app.services.persister import envelope_sender
+
+        sender = envelope_sender(envelope)
+        if sender is not None and _norm(sender) in {_norm(self._handle), _norm(handle)}:
+            return
+        summoned_in = (envelope.header.message.episode if envelope.header.message else None) or ""
+        in_thread = bool(summoned_in) and not l9.is_live_episode(room, summoned_in)
+        episode = summoned_in if in_thread else l9.episode_urn(room, mint_episode_id())
+        key = (room, episode)
+        if key in self._active:
+            logger.debug("conductor already running in %s; ignoring re-summon", episode)
+            return
+        drop = {_norm(handle), _norm(self._handle), *(_norm(h) for h in _NON_PARTICIPANTS)}
+        named = [h for h in (co_summons or []) if _norm(h) not in drop]
+        directive = _MENTION.sub(
+            lambda m: "" if _norm(m.group(0)) == _norm(handle) else m.group(0), message_text
+        )
+        self._active.add(key)
+        task = asyncio.create_task(
+            self._run_and_release(room, handle, episode, summoned_in, directive, named, key)
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _run_and_release(
+        self,
+        room: str,
+        engine_handle: str,
+        episode: str,
+        summoned_in: str,
+        directive: str,
+        named: list[str],
+        key: tuple[str, str],
+    ) -> None:
+        try:
+            await self.run(
+                room,
+                engine_handle=engine_handle,
+                episode=episode,
+                summoned_in=summoned_in,
+                directive=directive,
+                named=named,
+            )
+        except Exception:
+            logger.exception("conductor @%s failed in %s", engine_handle, episode)
+        finally:
+            self._active.discard(key)
+
+    # -- the run --
+
+    async def run(
+        self,
+        room: str,
+        *,
+        episode: str,
+        directive: str,
+        engine_handle: str | None = None,
+        summoned_in: str = "",
+        named: list[str] | None = None,
+    ) -> str | None:
+        """Run the protocol ``directive`` names over ``episode``; return the outcome.
+
+        ``named`` are the handles the summon mentioned, bound to the protocol's
+        roles in order; with none named, every other member of the room takes
+        part. ``None`` when the run could not start — the reason is posted
+        where the summon was made.
+        """
+        managed = self._manager.get(room)
+        if managed is None or managed.persister is None:
+            logger.info("conductor summoned for %s but no live channel", room)
+            return None
+        me = engine_handle or self._handle
+        where = summoned_in or episode
+
+        name, ask = split_directive(directive)
+        protocol = protocols.load_protocol(room, name) if name else None
+        if protocol is None:
+            known = ", ".join(protocols.builtin_names())
+            await self._say(
+                managed,
+                where,
+                me,
+                "I need a protocol to run: name it first, then who takes part, for "
+                "example `gated proposer-handle guardian-handle: the question`. "
+                f"Built in: {known}; a room adds its own under protocols/.",
+            )
+            return None
+        drop = {_norm(me), *(_norm(h) for h in _NON_PARTICIPANTS)}
+        handles = [h for h in (named or []) if _norm(h) not in drop] or [
+            m for m in self._manager.members(room) if _norm(m) not in drop
+        ]
+        bound = bind_roles(protocol, handles)
+        if bound is None or not handles:
+            roles = ", ".join(protocol.roles) or "its steps"
+            await self._say(
+                managed,
+                where,
+                me,
+                f"`{protocol.name}` needs {max(len(protocol.roles), 1)} member(s) for {roles} "
+                f"and {len(handles)} were named. Summon me again with the handles in that order.",
+            )
+            return None
+
+        run = Run(protocol=protocol, ask=ask, handles=handles, bound=bound, episode=episode)
+        ep = l9_episode.EpisodeState(
+            episode=episode,
+            topic=l9.topic_urn(room),
+            parent_room=room,
+            short_id=mint_episode_id(),
+            workspace_id=managed.workspace,
+            mas_id="",
+            agents=list(handles),
+            engine_handle=me,
+        )
+        intent = l9.build_envelope(
+            kind=Kind.intent,
+            subkind="mission",
+            episode=episode,
+            sender=me,
+            recipients=handles,
+            topic=ep.topic,
+            payload_type="utterance",
+            payload_data={"content": f"run {protocol.name}: {ask}", "roles": bound},
+        )
+        ep.intent_id = intent.header.message.id if intent.header.message else ""
+        ep.messages.append(l9.envelope_to_dict(intent))
+        logger.info("conductor @%s runs %s in %s over %s", me, protocol.name, episode, handles)
+        # The floor is the run's from the first instant, so a member the summon
+        # woke cannot slip a reply in ahead of the first step.
+        self._manager.hold_floor(room, episode, holder=me)
+        try:
+            outcome, why = await self._walk(managed, run, ep, me)
+        finally:
+            self._manager.release_floor(room, episode)
+        await self._close(managed, run, ep, me, outcome, why)
+        return outcome
+
+    async def _walk(
+        self, managed: ManagedRoomChannel, run: Run, ep: l9_episode.EpisodeState, me: str
+    ) -> tuple[str, str]:
+        """Follow the steps until an end step or the cap; ``(outcome, reason)``."""
+        protocol = run.protocol
+        cap = min(protocol.max_steps, self._max_steps)
+        step = protocol.first
+        while True:
+            if step.end is not None:
+                return step.end, f"reached `{step.id}`"
+            if run.steps_taken >= cap:
+                return "rejected", f"hit the step cap ({cap}) at `{step.id}`"
+            run.steps_taken += 1
+            stances = await self._take(managed, run, ep, me, step)
+            step = protocol.step(step.edge(stance_of_step(stances)))
+
+    async def _take(
+        self,
+        managed: ManagedRoomChannel,
+        run: Run,
+        ep: l9_episode.EpisodeState,
+        me: str,
+        step: Step,
+    ) -> list[tuple[str, str | None]]:
+        """Put one step to its targets; return each target's stance."""
+        room = managed.room
+        targets = run.targets(step)
+        stances: list[tuple[str, str | None]] = []
+        for round_n in range(1, step.rounds + 1):
+            if step.wait == "none":
+                self._manager.hold_floor(room, run.episode, holder=me)
+                prompt = step.prompt.format_map(run.fields(round_n=round_n, rounds=step.rounds))
+                for handle in targets:
+                    await self._tell(managed, ep, me, run, step, handle, prompt)
+                return []
+            if step.to in ("all", "workers"):
+                prompt = step.prompt.format_map(run.fields(round_n=round_n, rounds=step.rounds))
+                self._manager.hold_floor(room, run.episode, holder=me, speakers=targets)
+                stances = list(
+                    await asyncio.gather(
+                        *(self._turn(managed, ep, me, run, step, h, prompt) for h in targets)
+                    )
+                )
+                continue
+            # A role, or each member in turn: one speaker at a time, each seeing
+            # what the ones before it said.
+            stances = []
+            for handle in targets:
+                prompt = step.prompt.format_map(run.fields(round_n=round_n, rounds=step.rounds))
+                self._manager.hold_floor(room, run.episode, holder=me, speakers=[handle])
+                stances.append(await self._turn(managed, ep, me, run, step, handle, prompt))
+        return stances
+
+    async def _turn(
+        self,
+        managed: ManagedRoomChannel,
+        ep: l9_episode.EpisodeState,
+        me: str,
+        run: Run,
+        step: Step,
+        handle: str,
+        prompt: str,
+    ) -> tuple[str, str | None]:
+        """Ask ``handle`` one step; ``(handle, stance)`` with ``"silent"`` for no reply."""
+        assert managed.persister is not None  # checked by run()
+        episode = run.episode
+        pending = _norm(handle)
+        answered: list[TranscriptRecord] = []
+
+        def is_reply(record: TranscriptRecord) -> bool:
+            if record.kind != "exchange" or _norm(record.sender) != pending:
+                return False
+            if record_episode(record) != episode:
+                return False
+            payload = (record.content.get("l9") or {}).get("payload") or {}
+            return payload.get("type") not in _NOT_A_REPLY
+
+        def on_reply(record: TranscriptRecord) -> None:
+            answered.append(record)
+            env = record.content.get("l9")
+            if isinstance(env, dict):
+                ep.messages.append(env)
+
+        prose = await turns.addressed_turn(
+            managed,
+            managed.persister,
+            sender=me,
+            handle=handle,
+            episode=episode,
+            topic=ep.topic,
+            prompt=prompt,
+            payload_data={"step": step.id, "protocol": run.protocol.name},
+            is_reply=is_reply,
+            timeout_s=self._step_timeout_s,
+            poll_interval_s=self._poll_interval_s,
+            on_tick=lambda env: ep.messages.append(l9.envelope_to_dict(env)),
+            on_reply=on_reply,
+        )
+        if not answered:
+            return handle, "silent"
+        run.replies[handle] = prose
+        run.recent = prose
+        return handle, markers.stance_of(answered[-1].content)
+
+    async def _tell(
+        self,
+        managed: ManagedRoomChannel,
+        ep: l9_episode.EpisodeState,
+        me: str,
+        run: Run,
+        step: Step,
+        handle: str,
+        prompt: str,
+    ) -> None:
+        """A fire-and-forget step: say it to one member and move on."""
+        env = l9.build_envelope(
+            kind=Kind.exchange,
+            episode=run.episode,
+            sender=me,
+            recipients=[handle],
+            topic=ep.topic,
+            payload_type="tick",
+            payload_data={"step": step.id, "protocol": run.protocol.name},
+        )
+        ep.messages.append(l9.envelope_to_dict(env))
+        try:
+            await managed.post(env, turns.neutralize_mentions(prompt))
+        except Exception:
+            logger.warning("conductor failed to post step %s to @%s", step.id, handle)
+
+    async def _close(
+        self,
+        managed: ManagedRoomChannel,
+        run: Run,
+        ep: l9_episode.EpisodeState,
+        me: str,
+        outcome: str,
+        why: str,
+    ) -> None:
+        """Commit the outcome onto the thread and write the record."""
+        commit = l9.build_envelope(
+            kind=Kind.commit,
+            subkind=outcome,
+            episode=run.episode,
+            sender=me,
+            recipients=run.handles,
+            topic=ep.topic,
+            payload_type="outcome",
+            payload_data={
+                "protocol": run.protocol.name,
+                "steps": run.steps_taken,
+                "reason": why,
+                "roles": run.bound,
+            },
+        )
+        ep.messages.append(l9.envelope_to_dict(commit))
+        mark = "✓" if outcome == "resolved" else "✗"
+        text = f"{mark} {run.protocol.name}: {outcome} after {run.steps_taken} step(s), {why}."
+        try:
+            await managed.post(commit, text, list_write=True)
+        except Exception:
+            logger.warning("conductor failed to post the outcome for %s", run.episode)
+        l9_episode.write_episode_record(ep, outcome=outcome, metrics=None, tasks=None)
+
+    async def _say(self, managed: ManagedRoomChannel, episode: str, sender: str, text: str) -> None:
+        """Post a plain message from the engine into ``episode``."""
+        env = l9.build_envelope(
+            kind=Kind.exchange,
+            episode=episode,
+            sender=sender,
+            topic=l9.topic_urn(managed.room),
+            payload_type="message",
+        )
+        try:
+            await managed.post(env, text, list_write=True)
+        except Exception:
+            logger.warning("conductor failed to post on room %s", managed.room)

--- a/fastapi-backend/app/services/markers.py
+++ b/fastapi-backend/app/services/markers.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The position marker an agent may end a reply with.
+
+``[[mycelium: confidence=0.85 stance=accept]]`` is the one convention a
+participant speaks: how sure it is, and whether it can live with what is on
+the table. The reply route lifts the fields onto the L9 payload (so the
+aligner scores them) and strips the marker from the prose; the conductor
+reads a stance back off either place, since a human writing into a thread
+through the message route leaves the marker in the text.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+MARKER_RE = re.compile(r"\[\[\s*mycelium\s*:(.*?)\]\]", re.IGNORECASE | re.DOTALL)
+
+STANCE_TO_ACTION = {
+    "accept": "accept",
+    "agree": "accept",
+    "yes": "accept",
+    "approve": "accept",
+    "reject": "reject",
+    "block": "reject",
+    "no": "reject",
+}
+
+
+def parse_marker(text: str) -> tuple[dict[str, Any], str]:
+    """Lift ``confidence``/``stance`` out of any marker in ``text``; strip it.
+
+    Returns the payload fields found and the prose without the marker. A text
+    that is nothing but a marker keeps its original form rather than
+    becoming empty.
+    """
+    payload: dict[str, Any] = {}
+    for match in MARKER_RE.finditer(text):
+        for key, raw in re.findall(r"(\w+)\s*=\s*(\S+)", match.group(1)):
+            k = key.lower()
+            if k == "confidence":
+                try:
+                    val = float(raw)
+                except ValueError:
+                    continue
+                if 0.0 <= val <= 1.0:
+                    payload["confidence"] = val
+            elif k in ("stance", "action"):
+                action = STANCE_TO_ACTION.get(raw.lower())
+                if action:
+                    payload["action"] = action
+    clean = MARKER_RE.sub("", text).strip() or text.strip()
+    return payload, clean
+
+
+def stance_of(content: dict[str, Any]) -> str | None:
+    """``accept`` / ``reject`` as a transcript record states it, or ``None``.
+
+    The L9 payload's ``action`` wins — that is where the reply route put a
+    marker it stripped. A marker still in the prose (a human's write through
+    the message route) is read next. Anything else stated no stance.
+    """
+    payload = ((content.get("l9") or {}).get("payload") or {}).get("data") or {}
+    action = payload.get("action") if isinstance(payload, dict) else None
+    if action in ("accept", "reject"):
+        return action
+    text = content.get("content")
+    if not isinstance(text, str):
+        return None
+    found, _clean = parse_marker(text)
+    action = found.get("action")
+    return action if action in ("accept", "reject") else None

--- a/fastapi-backend/app/services/protocols.py
+++ b/fastapi-backend/app/services/protocols.py
@@ -1,0 +1,291 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Protocols — the shapes a conductor runs a thread through.
+
+A protocol is a small graph of **steps**. Each step puts a prompt to one
+member, to each in turn, or to several at once, waits for what comes back,
+and names the step after it — by one edge, or by one edge per stance the
+reply took. The graph is data, not cognition: the conductor walks it in code
+and the only judgment in a run is inside the members it addresses.
+
+Three protocols ship built in, and a room can add its own or override one
+of these by writing a ``protocols/<name>`` memory whose body is the same YAML
+(:func:`load_protocol`). Like skills, a protocol is a memory promoted: no
+separate store, and one is readable as a memory too.
+
+Step targets: a **role** the summon bound (``@conductor gated @a @b`` binds
+``a`` and ``b`` to the protocol's roles in order), ``each`` (every member,
+one at a time), ``all`` (every member, at once), or ``workers`` (every
+member not bound to a named role, at once).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+logger = logging.getLogger(__name__)
+
+#: The memory namespace protocols live in.
+PROTOCOLS_PREFIX = "protocols/"
+
+#: What a step may be put to besides a role.
+GROUP_TARGETS = frozenset({"each", "all", "workers"})
+
+#: The stances an edge can branch on, plus the two fallbacks.
+EDGE_KEYS = frozenset({"accept", "reject", "silent", "default"})
+
+Outcome = Literal["resolved", "rejected"]
+
+
+class Step(BaseModel):
+    """One step: who is asked what, and where the reply leads."""
+
+    id: str = Field(..., min_length=1)
+    to: str | None = Field(
+        None, description="A role, or each / all / workers. Absent on an end step."
+    )
+    prompt: str = ""
+    wait: Literal["reply", "none"] = "reply"
+    rounds: int = Field(1, ge=1, description="How many times an each/all step repeats.")
+    next: str | dict[str, str] | None = Field(
+        None,
+        description=(
+            "The step after this one: a step id, or a map of accept / reject / "
+            "silent / default to step ids."
+        ),
+    )
+    end: Outcome | None = Field(None, description="Set on a terminal step: how the run ends.")
+
+    @model_validator(mode="after")
+    def _terminal_or_addressed(self) -> Step:
+        if self.end is not None:
+            if self.to is not None or self.next is not None:
+                msg = f"step {self.id!r} ends the run and cannot also address or continue"
+                raise ValueError(msg)
+            return self
+        if not self.to:
+            msg = f"step {self.id!r} addresses nobody and ends nothing"
+            raise ValueError(msg)
+        if self.next is None:
+            msg = f"step {self.id!r} names no next step"
+            raise ValueError(msg)
+        if isinstance(self.next, dict):
+            unknown = set(self.next) - EDGE_KEYS
+            if unknown:
+                msg = (
+                    f"step {self.id!r} branches on {sorted(unknown)}; edges are {sorted(EDGE_KEYS)}"
+                )
+                raise ValueError(msg)
+            if not self.next:
+                msg = f"step {self.id!r} has an empty branch map"
+                raise ValueError(msg)
+        return self
+
+    def edge(self, stance: str | None) -> str:
+        """The next step id for a reply that took ``stance`` (``None`` = none stated,
+        ``"silent"`` = no reply at all)."""
+        if isinstance(self.next, str):
+            return self.next
+        assert self.next is not None  # validated on construction
+        if stance and stance in self.next:
+            return self.next[stance]
+        if "default" in self.next:
+            return self.next["default"]
+        # No fallback named: a branch map with only accept/reject reads a
+        # non-answer as the reject edge when it has one, else the first edge.
+        return self.next.get("reject") or next(iter(self.next.values()))
+
+
+class Protocol(BaseModel):
+    """A named, validated step graph."""
+
+    name: str = Field(..., min_length=1)
+    description: str = ""
+    roles: list[str] = Field(default_factory=list)
+    steps: list[Step] = Field(..., min_length=1)
+    max_steps: int = Field(12, ge=1, description="Hard cap on steps taken in one run.")
+
+    @field_validator("roles")
+    @classmethod
+    def _roles_are_distinct_names(cls, roles: list[str]) -> list[str]:
+        clean = [r.strip().lower() for r in roles]
+        if any(not r for r in clean):
+            msg = "a role name cannot be empty"
+            raise ValueError(msg)
+        if len(set(clean)) != len(clean):
+            msg = "role names must be distinct"
+            raise ValueError(msg)
+        if set(clean) & GROUP_TARGETS:
+            msg = f"a role cannot be named {sorted(set(clean) & GROUP_TARGETS)}"
+            raise ValueError(msg)
+        return clean
+
+    @model_validator(mode="after")
+    def _graph_is_closed(self) -> Protocol:
+        ids = [s.id for s in self.steps]
+        if len(set(ids)) != len(ids):
+            msg = "step ids must be distinct"
+            raise ValueError(msg)
+        known = set(ids)
+        for step in self.steps:
+            if step.to is not None and step.to not in GROUP_TARGETS and step.to not in self.roles:
+                msg = f"step {step.id!r} addresses {step.to!r}, which is neither a role nor a group"
+                raise ValueError(msg)
+            targets = (
+                [step.next] if isinstance(step.next, str) else list((step.next or {}).values())
+            )
+            for target in targets:
+                if target not in known:
+                    msg = f"step {step.id!r} continues to {target!r}, which is not a step"
+                    raise ValueError(msg)
+        if not any(s.end for s in self.steps):
+            msg = "a protocol needs at least one end step"
+            raise ValueError(msg)
+        return self
+
+    @property
+    def first(self) -> Step:
+        return self.steps[0]
+
+    def step(self, step_id: str) -> Step:
+        for step in self.steps:
+            if step.id == step_id:
+                return step
+        raise KeyError(step_id)
+
+
+# ── the built-ins ─────────────────────────────────────────────────────────────
+
+BUILTIN_PROTOCOLS: dict[str, dict[str, Any]] = {
+    "round-robin": {
+        "name": "round-robin",
+        "description": "Every member speaks in turn, for a fixed number of rounds.",
+        "roles": [],
+        "max_steps": 12,
+        "steps": [
+            {
+                "id": "round",
+                "to": "each",
+                "rounds": 2,
+                "prompt": (
+                    "Round {round} of {rounds}.\n\nThe question: {ask}\n\n"
+                    "What has been said so far:\n{replies}\n\n"
+                    "Give your position in a few sentences, answering what the "
+                    "others said where it matters."
+                ),
+                "next": "done",
+            },
+            {"id": "done", "end": "resolved"},
+        ],
+    },
+    "fan-out": {
+        "name": "fan-out",
+        "description": "A lead asks every worker at once, then combines what came back.",
+        "roles": ["lead"],
+        "max_steps": 6,
+        "steps": [
+            {
+                "id": "gather",
+                "to": "workers",
+                "prompt": (
+                    "{ask}\n\nAnswer with what you can contribute, what you would "
+                    "need, and any blocker you see. A few sentences."
+                ),
+                "next": "combine",
+            },
+            {
+                "id": "combine",
+                "to": "lead",
+                "prompt": (
+                    "You asked the team: {ask}\n\nThey answered:\n{replies}\n\n"
+                    "Combine those into one plan: say who does what, and name "
+                    "anything that is still unresolved."
+                ),
+                "next": "done",
+            },
+            {"id": "done", "end": "resolved"},
+        ],
+    },
+    "gated": {
+        "name": "gated",
+        "description": "A proposer proposes, a guardian approves or blocks; a block sends it back.",
+        "roles": ["proposer", "guardian"],
+        "max_steps": 6,
+        "steps": [
+            {
+                "id": "propose",
+                "to": "proposer",
+                "prompt": (
+                    "{ask}\n\nState exactly what you intend to do, in a few "
+                    "sentences. If a reviewer already objected, the objection "
+                    "follows and your proposal has to answer it.\n\n{reply}"
+                ),
+                "next": "review",
+            },
+            {
+                "id": "review",
+                "to": "guardian",
+                "prompt": (
+                    "A proposal is on the table:\n\n{reply}\n\nApprove it or block "
+                    "it, and say why in a sentence or two. End your reply with "
+                    "[[mycelium: stance=accept]] to approve or "
+                    "[[mycelium: stance=reject]] to block."
+                ),
+                "next": {"accept": "approved", "reject": "propose", "default": "propose"},
+            },
+            {"id": "approved", "end": "resolved"},
+        ],
+    },
+}
+
+
+def builtin(name: str) -> Protocol | None:
+    spec = BUILTIN_PROTOCOLS.get(name)
+    return Protocol.model_validate(spec) if spec else None
+
+
+def builtin_names() -> list[str]:
+    return sorted(BUILTIN_PROTOCOLS)
+
+
+def parse_protocol(name: str, body: str) -> Protocol:
+    """A protocol from the YAML body of a ``protocols/<name>`` memory.
+
+    The memory key is the name; a ``name`` inside the body is ignored so a
+    copied spec cannot answer to a different name than the one it is filed
+    under.
+    """
+    data = yaml.safe_load(body) or {}
+    if not isinstance(data, dict):
+        msg = f"protocol {name!r} is not a mapping"
+        raise ValueError(msg)
+    data["name"] = name
+    return Protocol.model_validate(data)
+
+
+def load_protocol(room: str, name: str) -> Protocol | None:
+    """The room's ``protocols/<name>`` memory if it has one, else the built-in.
+
+    A room's own spec wins, so a team can reshape a built-in under the same
+    name. A spec that does not parse is logged and treated as absent rather
+    than run half-read.
+    """
+    from app.services.filesystem import get_room_dir, read_memory_file, room_exists
+
+    key = name.strip().lower()
+    if not key:
+        return None
+    if room_exists(room):
+        found = read_memory_file(get_room_dir(room), f"{PROTOCOLS_PREFIX}{key}")
+        if found is not None:
+            try:
+                return parse_protocol(key, found[1])
+            except (ValueError, yaml.YAMLError):
+                logger.warning("room %s: protocols/%s does not parse", room, key, exc_info=True)
+                return None
+    return builtin(key)

--- a/fastapi-backend/app/services/turns.py
+++ b/fastapi-backend/app/services/turns.py
@@ -29,6 +29,7 @@ from app.services.l9_models import Kind
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from app.services.l9_models import L9
     from app.services.persister import TranscriptRecord
 
 logger = logging.getLogger(__name__)
@@ -59,13 +60,17 @@ async def addressed_turn(
     poll_interval_s: float,
     payload_type: str = "tick",
     payload_data: dict[str, Any] | None = None,
+    on_tick: Callable[[L9], None] | None = None,
+    on_reply: Callable[[TranscriptRecord], None] | None = None,
 ) -> str:
     """Post ``prompt`` to ``handle`` alone, wait for its reply, return the prose.
 
     The prompt is recorded into the transcript like any message, so the room can
     follow along; the reply is the first record past it from ``handle`` that
     ``is_reply`` accepts. ``""`` when the send fails or ``timeout_s`` passes
-    with no such record.
+    with no such record. ``on_tick`` sees the envelope once it is posted and
+    ``on_reply`` the record that answered it, for a caller keeping its own
+    episode record.
     """
     before = len(persister.log.records)
     env = l9.build_envelope(
@@ -82,6 +87,8 @@ async def addressed_turn(
     except Exception:
         logger.warning("failed to put a turn to @%s in %s", handle, episode)
         return ""
+    if on_tick is not None:
+        on_tick(env)
 
     pending = norm_handle(handle) or ""
     loop = asyncio.get_running_loop()
@@ -89,6 +96,8 @@ async def addressed_turn(
     while True:
         for record in persister.log.records[before:]:
             if (norm_handle(record.sender) or "") == pending and is_reply(record):
+                if on_reply is not None:
+                    on_reply(record)
                 return record.content.get("content") or ""
         if loop.time() >= deadline:
             return ""

--- a/fastapi-backend/tests/fakes.py
+++ b/fastapi-backend/tests/fakes.py
@@ -191,6 +191,8 @@ class FakeManager:
         self._members = list(members) if members is not None else ["a", "b"]
         self.opened: list[str] = []
         self.closed: list[str] = []
+        self.floors: dict[str, Any] = {}
+        self.floor_log: list[Any] = []
 
     def get(self, room: str) -> FakeManaged | None:
         return self._managed
@@ -201,6 +203,22 @@ class FakeManager:
     def open_episode(self, room: str, episode: str) -> bool:
         self.opened.append(episode)
         return True
+
+    # The floor, as ``RoomChannelManager`` holds it: one per thread, and a log
+    # of every hold so a test can read back whose turn each step gave.
+    def hold_floor(self, room: str, episode: str, *, holder: str, speakers=()) -> Any:
+        from app.services.floor import Floor
+
+        floor = Floor(episode=episode, holder=holder, speakers=frozenset(speakers))
+        self.floors[episode] = floor
+        self.floor_log.append(floor)
+        return floor
+
+    def release_floor(self, room: str, episode: str) -> bool:
+        return self.floors.pop(episode, None) is not None
+
+    def floor(self, room: str, episode: str | None) -> Any:
+        return self.floors.get(episode) if episode else None
 
     async def close_episode(self, room: str) -> bool:
         self.closed.append(room)

--- a/fastapi-backend/tests/test_conductor.py
+++ b/fastapi-backend/tests/test_conductor.py
@@ -1,0 +1,534 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The conductor: a protocol walked in code, the floor moving with each step.
+
+Node-free and model-free. A scripted channel answers each step the way a
+member would — through the transcript, as a reply in the run's thread — so
+the tests hold the whole contract: who gets the floor when, which edge a
+stance takes, what the record says, and where the run happens.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+import yaml
+
+from app.services import conductor, l9, protocols
+from app.services.filesystem import (
+    get_room_dir,
+    list_memory_files,
+    read_memory_file,
+    write_memory_file,
+)
+from app.services.l9_models import Kind
+from app.services.l9_slim import serialize_content
+from app.services.persister import record_from
+from tests.fakes import FakeManaged, FakeManager, FakePersister
+
+ROOM = "conducted"
+THREAD = l9.episode_urn(ROOM, "t3aa11bb")
+LIVE = l9.live_episode_urn(ROOM)
+
+
+def _reply(handle: str, prose: str, *, episode: str, action: str | None, role: str = "agent"):
+    """A member's reply as the transcript records it."""
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=episode,
+        sender=handle,
+        sender_role=role,
+        recipients=["conductor"],
+        topic=l9.topic_urn(ROOM),
+        payload_type="reply",
+        payload_data={"action": action} if action else {"note": "no stance"},
+    )
+    return record_from(env, serialize_content(env, extra={"content": prose}))
+
+
+class ScriptedChannel:
+    """Answers each tick from a per-handle script; an exhausted script is silence.
+
+    A script entry is ``(prose, action)`` or ``(prose, action, role)``; the
+    reply lands in the tick's own episode, as a real member's would.
+    """
+
+    def __init__(self, persister: FakePersister, script: dict[str, list[tuple]]) -> None:
+        self.sent: list[tuple[Any, dict[str, Any] | None]] = []
+        self._persister = persister
+        self._script = {h: list(entries) for h, entries in script.items()}
+        self.stray: dict[str, list[Any]] = {}
+
+    async def send(self, envelope: Any, *, extra: dict[str, Any] | None = None) -> None:
+        self.sent.append((envelope, extra))
+        if envelope.header.kind != Kind.exchange or envelope.payload.type != "tick":
+            return
+        episode = envelope.header.message.episode
+        for actor in envelope.header.participants.actors[1:]:
+            entries = self._script.get(actor.id) or []
+            if not entries:
+                continue
+            prose, action, *rest = entries.pop(0)
+            role = rest[0] if rest else "agent"
+            self._persister.log.record(
+                _reply(actor.id, prose, episode=episode, action=action, role=role),
+                delivered_to=set(),
+            )
+
+    def ticks(self) -> list[tuple[str, str, str]]:
+        """``(step, recipient, prose)`` for every tick, in order."""
+        return [
+            (
+                env.payload.data["step"],
+                env.header.participants.actors[1].id,
+                (extra or {})["content"],
+            )
+            for env, extra in self.sent
+            if env.header.kind == Kind.exchange and env.payload.type == "tick"
+        ]
+
+    def commit(self) -> Any:
+        commits = [env for env, _x in self.sent if env.header.kind == Kind.commit]
+        assert len(commits) == 1
+        return commits[0]
+
+    def said(self) -> list[str]:
+        return [
+            (extra or {}).get("content", "")
+            for env, extra in self.sent
+            if env.payload.type == "message"
+        ]
+
+
+def _engine(script: dict[str, list[tuple]], members: list[str] | None = None):
+    persister = FakePersister()
+    channel = ScriptedChannel(persister, script)
+    managed = FakeManaged(ROOM, "mycelium", channel, persister)
+    manager = FakeManager(managed, members if members is not None else [])
+    engine = conductor.ConductorEngine(
+        manager,  # type: ignore[arg-type]
+        handle="conductor",
+        step_timeout_s=0.05,
+        poll_interval_s=0.005,
+    )
+    return engine, manager, channel
+
+
+def _register(handle: str, kind: str) -> None:
+    write_memory_file(
+        get_room_dir(ROOM),
+        f"agents/{handle}",
+        yaml.safe_dump({"adapter": "engine", "kind": kind}),
+        created_by="julia",
+    )
+
+
+def _records() -> list[str]:
+    return [key for key, _m, _c in list_memory_files(get_room_dir(ROOM), prefix="log/episodes/")]
+
+
+@pytest.fixture(autouse=True)
+def _backend_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "ENGINE_RUNTIME", "backend")
+    get_room_dir(ROOM)
+
+
+# ── reading the summon ────────────────────────────────────────────────────────
+
+
+def test_the_first_bare_word_names_the_protocol_and_the_rest_is_the_ask():
+    assert conductor.split_directive("gated @sec @julia: pick a token store") == (
+        "gated",
+        "pick a token store",
+    )
+    assert conductor.split_directive("  @a round-robin — what next?") == (
+        "round-robin",
+        "what next?",
+    )
+    assert conductor.split_directive("@a @b") == ("", "")
+
+
+def test_roles_bind_in_order_and_too_few_is_none():
+    gated = protocols.builtin("gated")
+    assert gated is not None
+    assert conductor.bind_roles(gated, ["api", "sec", "extra"]) == {
+        "proposer": "api",
+        "guardian": "sec",
+    }
+    assert conductor.bind_roles(gated, ["api"]) is None
+
+
+def test_a_steps_stance_is_the_strictest_answer():
+    assert conductor.stance_of_step([("a", "accept")]) == "accept"
+    assert conductor.stance_of_step([("a", "accept"), ("b", "reject")]) == "reject"
+    assert conductor.stance_of_step([("a", "accept"), ("b", None)]) is None
+    assert conductor.stance_of_step([("a", "silent"), ("b", "silent")]) == "silent"
+    assert conductor.stance_of_step([("a", "silent"), ("b", "accept")]) is None
+    assert conductor.stance_of_step([]) is None
+
+
+# ── the gated protocol: a guardian that blocks sends it back ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_gated_loops_on_a_block_and_ends_on_an_approval():
+    engine, manager, channel = _engine(
+        {
+            "api": [("rotate the key in place", None), ("rotate with a rollback window", None)],
+            "sec": [("no rollback plan", "reject"), ("fine with the window", "accept")],
+        }
+    )
+
+    outcome = await engine.run(
+        ROOM,
+        episode=THREAD,
+        directive="gated @api @sec: rotate the signing key",
+        named=["api", "sec"],
+    )
+
+    assert outcome == "resolved"
+    assert [(s, to) for s, to, _p in channel.ticks()] == [
+        ("propose", "api"),
+        ("review", "sec"),
+        ("propose", "api"),
+        ("review", "sec"),
+    ]
+    # The proposer's second turn carries the objection it has to answer.
+    assert "no rollback plan" in channel.ticks()[2][2]
+    # The guardian's turns carry the proposal on the table, and no @ sigils.
+    assert "rotate the key in place" in channel.ticks()[1][2]
+    assert "@" not in channel.ticks()[1][2].replace("[[mycelium", "")
+    commit = channel.commit()
+    assert commit.header.subkind == "resolved"
+    assert commit.payload.data["steps"] == 4
+    assert commit.payload.data["roles"] == {"proposer": "api", "guardian": "sec"}
+
+
+@pytest.mark.asyncio
+async def test_the_floor_follows_the_step_and_is_released_at_the_end():
+    engine, manager, _channel = _engine(
+        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
+    )
+
+    await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+
+    holds = [(f.holder, sorted(f.speakers)) for f in manager.floor_log]
+    assert holds == [("conductor", []), ("conductor", ["api"]), ("conductor", ["sec"])]
+    assert manager.floors == {}, "the thread is open again once the run ends"
+
+
+@pytest.mark.asyncio
+async def test_a_guardian_that_never_yields_hits_the_cap():
+    engine, _manager, channel = _engine({"api": [("v1", None)] * 6, "sec": [("no", "reject")] * 6})
+
+    outcome = await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+
+    assert outcome == "rejected"
+    commit = channel.commit()
+    assert commit.header.subkind == "rejected"
+    assert "step cap" in commit.payload.data["reason"]
+    assert commit.payload.data["steps"] == 6
+
+
+@pytest.mark.asyncio
+async def test_a_person_blocks_with_a_marker_left_in_the_prose():
+    """A human answers a step through the message route, which strips no
+    marker; the stance is read off the text."""
+    engine, _manager, channel = _engine(
+        {
+            "api": [("ship it", None), ("ship it with a canary", None)],
+            "julia": [
+                ("Not without a canary. [[mycelium: stance=reject]]", None, "human"),
+                ("Good. [[mycelium: stance=accept]]", None, "human"),
+            ],
+        }
+    )
+
+    outcome = await engine.run(
+        ROOM, episode=THREAD, directive="gated: ship", named=["api", "julia"]
+    )
+
+    assert outcome == "resolved"
+    assert len(channel.ticks()) == 4
+
+
+@pytest.mark.asyncio
+async def test_silence_takes_the_fallback_edge():
+    """A guardian that never answers is neither an approval nor a block: the
+    review's fallback edge sends the proposal round again until the cap."""
+    engine, _manager, channel = _engine({"api": [("v1", None)] * 6, "sec": []})
+
+    outcome = await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+
+    assert outcome == "rejected"
+    assert [s for s, _to, _p in channel.ticks()][:4] == ["propose", "review", "propose", "review"]
+
+
+@pytest.mark.asyncio
+async def test_a_reply_in_the_room_is_not_an_answer_in_the_thread():
+    """The addressed member speaking somewhere else is not its turn here."""
+    engine, _manager, channel = _engine({"api": [("v1", None)], "sec": []})
+    # The guardian talks in the room before and during the run; none of it counts.
+    channel._persister.log.record(
+        _reply("sec", "approved!", episode=LIVE, action="accept"), delivered_to=set()
+    )
+
+    outcome = await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+
+    assert outcome == "rejected"
+
+
+# ── fan-out and round-robin ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fan_out_asks_the_workers_at_once_then_the_lead():
+    engine, manager, channel = _engine(
+        {
+            "brazil": [("40 bags, ready Monday", None)],
+            "colombia": [("25 bags, weather permitting", None)],
+            "exchange": [("Brazil ships Monday, Colombia follows.", None)],
+        }
+    )
+
+    outcome = await engine.run(
+        ROOM,
+        episode=THREAD,
+        directive="fan-out @exchange @brazil @colombia: fill the 60-bag order",
+        named=["exchange", "brazil", "colombia"],
+    )
+
+    assert outcome == "resolved"
+    ticks = channel.ticks()
+    assert [(s, to) for s, to, _p in ticks] == [
+        ("gather", "brazil"),
+        ("gather", "colombia"),
+        ("combine", "exchange"),
+    ]
+    # One floor for the whole fan-out, both workers on it; then the lead alone.
+    assert [sorted(f.speakers) for f in manager.floor_log] == [
+        [],
+        ["brazil", "colombia"],
+        ["exchange"],
+    ]
+    assert "brazil: 40 bags" in ticks[2][2]
+    assert "colombia: 25 bags" in ticks[2][2]
+    assert channel.commit().payload.data["steps"] == 2
+
+
+@pytest.mark.asyncio
+async def test_round_robin_gives_everyone_the_floor_in_turn_each_round():
+    engine, manager, channel = _engine(
+        {
+            "a": [("a1", None), ("a2", None)],
+            "b": [("b1", None), ("b2", None)],
+            "c": [("c1", None), ("c2", None)],
+        }
+    )
+
+    outcome = await engine.run(
+        ROOM, episode=THREAD, directive="round-robin: where next?", named=["a", "b", "c"]
+    )
+
+    assert outcome == "resolved"
+    assert [to for _s, to, _p in channel.ticks()] == ["a", "b", "c", "a", "b", "c"]
+    # The second speaker in round one hears the first; everyone in round two
+    # hears the whole first round.
+    assert "a: a1" in channel.ticks()[1][2]
+    assert "c: c1" in channel.ticks()[3][2] and "Round 2 of 2" in channel.ticks()[3][2]
+    assert [sorted(f.speakers) for f in manager.floor_log][1:] == [["a"], ["b"], ["c"]] * 2
+    # One step, however many members it turned through.
+    assert channel.commit().payload.data["steps"] == 1
+
+
+@pytest.mark.asyncio
+async def test_with_nobody_named_the_room_takes_part():
+    engine, _manager, channel = _engine(
+        {"a": [("a1", None), ("a2", None)], "b": [("b1", None), ("b2", None)]},
+        members=["conductor", "a", "b"],
+    )
+
+    outcome = await engine.run(ROOM, episode=THREAD, directive="round-robin: go")
+
+    assert outcome == "resolved"
+    assert [to for _s, to, _p in channel.ticks()] == ["a", "b", "a", "b"]
+
+
+# ── the record, and what it does not do ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_the_run_leaves_an_episode_record_on_the_thread():
+    from app.services.episode_records import episode_summary, parse_envelopes
+
+    engine, _manager, _channel = _engine(
+        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
+    )
+    before = set(_records())
+
+    await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+
+    new = set(_records()) - before
+    assert len(new) == 1
+    key = new.pop()
+    found = read_memory_file(get_room_dir(ROOM), key)
+    assert found is not None
+    meta, content = found
+    summary = episode_summary(key, meta, content)
+    assert summary["episode"] == THREAD, "the record is the thread's, not a new episode's"
+    assert summary["outcome"] == "resolved"
+    assert {"api", "sec"} <= set(summary["participants"])
+    # Intent, two ticks, two replies, the commit.
+    assert len(parse_envelopes(content)) == 6
+
+
+@pytest.mark.asyncio
+async def test_it_opens_no_negotiation_and_never_converges():
+    """A protocol run is not a negotiation: nothing freezes, and nothing it
+    commits compiles into tasks."""
+    engine, manager, channel = _engine(
+        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
+    )
+
+    await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+
+    assert manager.opened == []
+    assert channel.commit().header.subkind != "converged"
+
+
+# ── refusing to start ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_protocol_is_answered_where_it_was_asked():
+    engine, manager, channel = _engine({})
+
+    outcome = await engine.run(
+        ROOM, episode=THREAD, summoned_in=LIVE, directive="waltz @a @b: go", named=["a", "b"]
+    )
+
+    assert outcome is None
+    assert manager.floor_log == []
+    said = channel.said()
+    assert len(said) == 1
+    assert "gated" in said[0] and "round-robin" in said[0]
+    assert channel.sent[0][0].header.message.episode == LIVE
+
+
+@pytest.mark.asyncio
+async def test_too_few_members_is_said_plainly():
+    engine, _manager, channel = _engine({})
+
+    outcome = await engine.run(ROOM, episode=THREAD, directive="gated @api: go", named=["api"])
+
+    assert outcome is None
+    assert "proposer, guardian" in channel.said()[0]
+    assert "1 were named" in channel.said()[0]
+
+
+@pytest.mark.asyncio
+async def test_a_rooms_own_protocol_runs_under_its_name():
+    write_memory_file(
+        get_room_dir(ROOM),
+        "protocols/nudge",
+        yaml.safe_dump(
+            {
+                "roles": ["who"],
+                "steps": [
+                    {"id": "ask", "to": "who", "prompt": "{ask}", "wait": "none", "next": "done"},
+                    {"id": "done", "end": "resolved"},
+                ],
+            }
+        ),
+        created_by="julia",
+    )
+    engine, manager, channel = _engine({})
+
+    outcome = await engine.run(
+        ROOM, episode=THREAD, directive="nudge @api: look at #12", named=["api"]
+    )
+
+    assert outcome == "resolved"
+    assert channel.ticks() == [("ask", "api", "look at #12")]
+    # Fire-and-forget gives nobody the floor and waits on nothing.
+    assert [sorted(f.speakers) for f in manager.floor_log] == [[], []]
+
+
+# ── the summon seam ───────────────────────────────────────────────────────────
+
+
+def _summon(text: str, *, episode: str, sender: str = "julia") -> Any:
+    from app.services.persister import find_summons
+
+    env = l9.build_envelope(
+        kind=Kind.exchange,
+        episode=episode,
+        sender=sender,
+        sender_role="human",
+        topic=l9.topic_urn(ROOM),
+        payload_type="message",
+    )
+    return env, find_summons({"content": text}), text
+
+
+@pytest.mark.asyncio
+async def test_a_summon_runs_in_the_thread_it_was_made_in():
+    _register("conductor", "conductor")
+    engine, _manager, channel = _engine(
+        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
+    )
+    env, summons, text = _summon("@conductor gated @api @sec: rotate the key", episode=THREAD)
+
+    engine.handle_summon(ROOM, "conductor", env, summons, text)
+    await asyncio.sleep(0.1)
+
+    assert channel.commit().header.message.episode == THREAD
+    assert channel.commit().payload.data["roles"] == {"proposer": "api", "guardian": "sec"}
+
+
+@pytest.mark.asyncio
+async def test_a_summon_from_the_room_opens_a_thread_of_its_own():
+    _register("conductor", "conductor")
+    engine, _manager, channel = _engine(
+        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
+    )
+    env, summons, text = _summon("@conductor gated @api @sec: rotate the key", episode=LIVE)
+
+    engine.handle_summon(ROOM, "conductor", env, summons, text)
+    await asyncio.sleep(0.1)
+
+    ran_in = channel.commit().header.message.episode
+    assert ran_in != LIVE
+    assert ran_in.startswith(l9.episode_urn(ROOM, ""))
+
+
+@pytest.mark.asyncio
+async def test_only_a_conductor_manifest_fires():
+    _register("mediator", "aligner")
+    engine, _manager, channel = _engine({})
+    env, summons, text = _summon("@mediator gated @api @sec: go", episode=THREAD)
+
+    engine.handle_summon(ROOM, "mediator", env, summons, text)
+    engine.handle_summon(ROOM, "ghost", env, summons, text)
+    await asyncio.sleep(0.05)
+
+    assert channel.sent == []
+
+
+@pytest.mark.asyncio
+async def test_a_re_summon_into_a_running_thread_is_ignored():
+    _register("conductor", "conductor")
+    engine, _manager, channel = _engine({"api": [("v1", None)], "sec": []})
+    env, summons, text = _summon("@conductor gated @api @sec: go", episode=THREAD)
+
+    engine.handle_summon(ROOM, "conductor", env, summons, text)
+    await asyncio.sleep(0.01)
+    engine.handle_summon(ROOM, "conductor", env, summons, text)
+    await asyncio.sleep(0.5)
+
+    assert len([e for e, _x in channel.sent if e.header.kind == Kind.commit]) == 1

--- a/fastapi-backend/tests/test_markers.py
+++ b/fastapi-backend/tests/test_markers.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The position marker: lifted off a reply, and read back off a record."""
+
+from __future__ import annotations
+
+from app.services import markers
+
+
+def test_parse_lifts_the_fields_and_strips_the_marker():
+    payload, clean = markers.parse_marker(
+        "I can live with 30%.\n\n[[mycelium: confidence=0.85 stance=accept]]"
+    )
+    assert payload == {"confidence": 0.85, "action": "accept"}
+    assert clean == "I can live with 30%."
+
+
+def test_parse_keeps_a_marker_only_text_rather_than_emptying_it():
+    payload, clean = markers.parse_marker("[[mycelium: stance=reject]]")
+    assert payload == {"action": "reject"}
+    assert clean == "[[mycelium: stance=reject]]"
+
+
+def test_parse_ignores_what_it_cannot_read():
+    payload, _clean = markers.parse_marker("[[mycelium: confidence=high stance=maybe]]")
+    assert payload == {}
+
+
+def test_stance_prefers_the_payload_the_reply_route_wrote():
+    content = {
+        "content": "sure [[mycelium: stance=reject]]",
+        "l9": {"payload": {"type": "reply", "data": {"action": "accept"}}},
+    }
+    assert markers.stance_of(content) == "accept"
+
+
+def test_stance_falls_back_to_a_marker_left_in_the_prose():
+    content = {"content": "Blocked: no rollback plan. [[mycelium: stance=block]]", "l9": {}}
+    assert markers.stance_of(content) == "reject"
+
+
+def test_no_stance_is_none():
+    assert markers.stance_of({"content": "thinking about it", "l9": {}}) is None
+    assert markers.stance_of({}) is None

--- a/fastapi-backend/tests/test_protocols.py
+++ b/fastapi-backend/tests/test_protocols.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""Protocol specs: the built-ins are sound, a bad graph is refused, a room's own wins."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from app.services import protocols
+from app.services.filesystem import get_room_dir, write_memory_file
+
+ROOM = "spec-room"
+
+
+@pytest.mark.parametrize("name", protocols.builtin_names())
+def test_every_builtin_validates(name: str):
+    spec = protocols.builtin(name)
+    assert spec is not None
+    assert spec.name == name
+    assert any(s.end for s in spec.steps)
+
+
+def test_the_gated_review_branches_on_stance():
+    gated = protocols.builtin("gated")
+    assert gated is not None
+    review = gated.step("review")
+    assert review.edge("accept") == "approved"
+    assert review.edge("reject") == "propose"
+    assert review.edge(None) == "propose"
+    assert review.edge("silent") == "propose"
+
+
+def test_a_plain_edge_ignores_the_stance():
+    step = protocols.Step(id="a", to="each", next="b")
+    assert step.edge("reject") == "b"
+
+
+def test_a_branch_with_no_fallback_reads_a_non_answer_as_reject():
+    step = protocols.Step(id="a", to="each", next={"accept": "yes", "reject": "no"})
+    assert step.edge(None) == "no"
+    assert step.edge("silent") == "no"
+
+
+@pytest.mark.parametrize(
+    ("spec", "message"),
+    [
+        (
+            {"name": "x", "steps": [{"id": "a", "to": "each", "next": "a"}]},
+            "at least one end step",
+        ),
+        (
+            {
+                "name": "x",
+                "steps": [{"id": "a", "to": "each", "next": "zz"}, {"id": "d", "end": "resolved"}],
+            },
+            "not a step",
+        ),
+        (
+            {
+                "name": "x",
+                "steps": [{"id": "a", "to": "boss", "next": "d"}, {"id": "d", "end": "resolved"}],
+            },
+            "neither a role nor a group",
+        ),
+        (
+            {"name": "x", "steps": [{"id": "a", "end": "resolved", "to": "each"}]},
+            "cannot also address",
+        ),
+        (
+            {
+                "name": "x",
+                "steps": [
+                    {"id": "a", "to": "each", "next": {"maybe": "d"}},
+                    {"id": "d", "end": "resolved"},
+                ],
+            },
+            "branches on",
+        ),
+        (
+            {"name": "x", "roles": ["each"], "steps": [{"id": "d", "end": "resolved"}]},
+            "cannot be named",
+        ),
+        (
+            {
+                "name": "x",
+                "steps": [{"id": "d", "end": "resolved"}, {"id": "d", "end": "rejected"}],
+            },
+            "distinct",
+        ),
+    ],
+)
+def test_a_bad_graph_is_refused(spec, message):
+    with pytest.raises(ValueError, match=message):
+        protocols.Protocol.model_validate(spec)
+
+
+def test_parse_takes_the_name_from_the_key_not_the_body():
+    body = yaml.safe_dump(
+        {"name": "impostor", "roles": ["r"], "steps": [{"id": "d", "end": "resolved"}]}
+    )
+    assert protocols.parse_protocol("mine", body).name == "mine"
+
+
+def test_load_falls_back_to_the_builtin():
+    get_room_dir(ROOM)
+    spec = protocols.load_protocol(ROOM, "Gated")
+    assert spec is not None
+    assert spec.name == "gated"
+    assert protocols.load_protocol(ROOM, "nope") is None
+    assert protocols.load_protocol(ROOM, "") is None
+
+
+def test_a_rooms_own_spec_wins_under_the_same_name():
+    write_memory_file(
+        get_room_dir(ROOM),
+        "protocols/gated",
+        yaml.safe_dump(
+            {
+                "roles": ["author"],
+                "max_steps": 2,
+                "steps": [
+                    {"id": "ask", "to": "author", "prompt": "go", "next": "done"},
+                    {"id": "done", "end": "resolved"},
+                ],
+            }
+        ),
+        created_by="julia",
+    )
+    spec = protocols.load_protocol(ROOM, "gated")
+    assert spec is not None
+    assert spec.roles == ["author"]
+    assert spec.max_steps == 2
+
+
+def test_a_spec_that_does_not_parse_is_absent_not_half_read():
+    write_memory_file(
+        get_room_dir(ROOM), "protocols/broken", "steps: [nonsense", created_by="julia"
+    )
+    assert protocols.load_protocol(ROOM, "broken") is None
+    write_memory_file(
+        get_room_dir(ROOM), "protocols/loose", yaml.safe_dump({"steps": []}), created_by="julia"
+    )
+    assert protocols.load_protocol(ROOM, "loose") is None

--- a/mycelium-cli/src/mycelium/docs/concepts/conductor.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/conductor.md
@@ -1,0 +1,103 @@
+# Conductor
+
+The conductor is the [engine](#engines) that runs a **protocol** inside a
+task: a fixed shape of who speaks to whom, in what order, and what happens on
+each answer. Where the [aligner](#aligner) brokers a negotiation, the
+conductor walks a graph. It is the engine to reach for when a piece of work
+has a shape you already know: a proposal that a reviewer must approve, a lead
+asking every worker at once, a round where each member speaks in turn.
+
+It is the one engine with no model of its own. Every judgment in a run, what
+to propose and whether to block it, is made by the members it addresses. The
+conductor only decides whose turn it is, and it enforces that in code: while a
+step is open, only the member it addressed can write into the thread. That is
+the split the whole design rests on. A model sits in each node, and code sits
+on the edges.
+
+```bash
+# Register it once per room
+mycelium engine create conductor --kind conductor --room sprint-plan
+
+# Run the gated protocol inside a task: @api proposes, @sec approves or blocks
+mycelium board coordinate work/rotate-signing-key conductor \
+  "gated @api @sec: rotate the signing key without downtime"
+```
+
+The summon names the protocol first, then the members in the order the
+protocol's roles expect, then the question. The run happens in the thread the
+summon was made in, so the row's conversation carries the whole thing and
+`board messages` reads it back. A summon from the room itself
+(`engine invoke`) opens a thread of its own, because the room is never
+narrowed to one speaker.
+
+## The built-in protocols
+
+| Protocol | Roles | Shape |
+|---|---|---|
+| `gated` | proposer, guardian | The proposer states what it intends to do. The guardian approves or blocks, ending its reply with `[[mycelium: stance=accept]]` or `[[mycelium: stance=reject]]`. A block sends the proposal back with the objection attached, until an approval or the step cap. |
+| `fan-out` | lead | Every other member is asked at once. The lead then gets all the answers and combines them into one plan. |
+| `round-robin` | none | Each member speaks in turn, seeing what the others said, for two rounds. |
+
+Any member can fill a role: a registered agent kept awake with
+`mycelium await --loop`, an engine such as [hello](#hello), or a person. A
+person answers a step the way they answer anything in a thread, with
+`board send`, and a stance marker left in the text is read the same as one an
+agent's reply carried. That is how a human-in-the-loop step works: the
+conductor gives the person the floor and waits.
+
+## Whose turn it is
+
+While a run is open, the thread has a **floor**. The conductor holds it, and
+gives it to whoever the current step addresses: one member for a role step,
+everyone at once for a fan-out. A write from anyone else is refused with a
+`409` that says who holds the floor and who may speak, so an agent that tried
+early keeps awaiting rather than giving up. A refused write never reaches the
+transcript, which means it wakes nobody.
+
+Nothing else narrows. The room stays open throughout, other threads are
+untouched, and a member joining the room mid-run aborts nothing, because a
+protocol run is not a negotiation and freezes no roster. When the run ends,
+the floor is released and the thread takes anyone again.
+
+## How a run ends
+
+A run ends at one of the protocol's end steps, `resolved` or `rejected`, or at
+the step cap, which counts as `rejected`. The outcome is committed onto the
+thread and recorded at `log/episodes/{id}.md` like any coordination phase:
+who took part, each step's prompt and reply, and how it ended. A resolved run
+does not resolve the task it ran in, and does not compile anything into new
+rows. It is a phase inside the task, and `board resolve` still finishes the
+task.
+
+## Writing your own
+
+A protocol is a memory under `protocols/`, promoted the way a skill is. A room
+that writes `protocols/gated` reshapes the built-in under that name; a new
+name adds a protocol. The body is YAML:
+
+```yaml
+description: A reviewer signs off before the author ships.
+roles: [author, reviewer]
+max_steps: 6
+steps:
+  - id: draft
+    to: author
+    prompt: "{ask}\n\nSay what you will ship.\n\n{reply}"
+    next: review
+  - id: review
+    to: reviewer
+    prompt: "On the table:\n\n{reply}\n\nApprove or block, ending with a stance marker."
+    next: {accept: done, reject: draft, default: draft}
+  - id: done
+    end: resolved
+```
+
+A step addresses a role, or `each` (every member, one at a time), `all`
+(every member, at once) or `workers` (every member not bound to a role).
+`wait: none` makes a step fire and forget. `rounds` repeats an `each` or `all`
+step. `next` is one step id, or a map from `accept`, `reject`, `silent` and
+`default` to step ids. Prompts can carry `{ask}`, `{reply}` (the most recent
+answer), `{replies}` (everyone's latest, one per line), `{handles}`, `{round}`
+and `{rounds}`. Every step must lead somewhere, and every protocol needs an
+end step; a spec that does not hold together is refused rather than run
+half-read.

--- a/mycelium-cli/src/mycelium/docs/concepts/engines.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/engines.md
@@ -10,7 +10,7 @@ offer wins* shouldn't fall to one of the negotiating parties; summarizing the
 whole room shouldn't depend on one agent remembering everything. An engine is a
 neutral, first-party actor the room owns.
 
-Three of them exist today; the first thing to try on a new hub is `hello`,
+Four of them exist today; the first thing to try on a new hub is `hello`,
 which answers a summon and owns nothing, so it is safe to fire into a live
 room just to see whether cognition runs at all.
 
@@ -34,6 +34,7 @@ commands host all of them.
 | `aligner` | Mediates a disagreement inside a task to one shared answer, running a real NEGMAS negotiation. See [Aligner](#aligner). |
 | `synthesizer` | Distills the room's conversation into a briefing at `context/synthesis`, incrementally. See [Synthesizer](#synthesizer). |
 | `hello` | Answers one summon with one Pi turn and writes nothing anywhere — the cheap proof the engine path works on this hub. See [Hello](#hello). |
+| `conductor` | Runs a protocol inside a task — a gated review, a fan-out, a round robin — walking the steps in code and giving the floor to whoever each step addresses. It has no model of its own. See [Conductor](#conductor). |
 
 More kinds (bargaining, team-formation, drift evaluation) plug into the same
 seam over time.

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -303,7 +303,7 @@ AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "engine", "
 #: memory → structured summary) and ``hello`` (one Pi turn, no side effects — the
 #: cheap proof the engine path works) today; ``bargainer`` (SAB), ``team_former``
 #: (TFP), a drift evaluator, etc. later; no new adapter per CE.
-ENGINE_KINDS: frozenset[str] = frozenset({"aligner", "hello", "synthesizer"})
+ENGINE_KINDS: frozenset[str] = frozenset({"aligner", "conductor", "hello", "synthesizer"})
 
 
 class AgentManifest(BaseModel):

--- a/mycelium-cli/tests/test_engine.py
+++ b/mycelium-cli/tests/test_engine.py
@@ -23,6 +23,7 @@ def test_engine_is_a_registered_family() -> None:
     assert "aligner" in ENGINE_KINDS
     assert "synthesizer" in ENGINE_KINDS
     assert "hello" in ENGINE_KINDS
+    assert "conductor" in ENGINE_KINDS
 
 
 def test_manifest_accepts_synthesizer() -> None:


### PR DESCRIPTION
## Summary

Second of the stacked PRs into [#953](https://github.com/mycelium-io/mycelium/pull/953), on top of the floor from [#954](https://github.com/mycelium-io/mycelium/pull/954). It adds the **conductor**, a fourth engine kind and the first with no model of its own: it runs a **protocol** (a small step graph) inside a task's thread, in code, giving the floor to whoever each step addresses. Every judgment in a run, what to propose and whether to block it, is made by the members it addresses. The conductor only decides whose turn it is. A model in the nodes, code on the edges.

```bash
mycelium engine create conductor --kind conductor --room sprint-plan
mycelium board coordinate work/rotate-signing-key conductor \
  "gated @api @sec: rotate the signing key without downtime"
```

The run happens **in the thread it was summoned in**, so the row's conversation carries the whole thing and a person can answer a step with `board send` (a stance marker left in their text is read the same as one an agent's reply carried). A summon from the room itself opens a thread of its own, since the room never holds a floor.

### Protocols

Three ship built in: `gated` (proposer, guardian; a block sends the proposal back with the objection attached until an approval or the step cap), `fan-out` (a lead asks every worker at once, then combines the answers), `round-robin` (each member speaks in turn for two rounds). A room's `protocols/<name>` memory overrides or adds one, the way a skill is a memory promoted. Steps address a role, `each`, `all` or `workers`; `next` is one step id or a map on `accept` / `reject` / `silent` / `default`; a spec that does not hold together (an edge to nowhere, no end step, a role named like a group) is refused rather than run half-read.

### What a run is not

It opens no negotiation, so nothing freezes and a member joining the room mid-run aborts nothing. It commits `resolved` or `rejected`, never `converged`, so nothing it does compiles into rows. It never calls Pi. It leaves a `log/episodes/{id}.md` record on the thread it ran in, so the existing episode inspector shows it.

### Opt-in

Nothing runs until a `conductor` engine is registered and summoned. No route, no wire constant, no CLI verb. The only change to an existing path is that the reply route's marker parser now lives in `services/markers.py` (and accepts `approve` as an accept), and the turn primitive gains two optional callbacks.

## Changes

- `app/services/conductor.py` (new): the engine — summon parsing, role binding, the step walk, the floor per step, the commit and the record.
- `app/services/protocols.py` (new): the `Protocol`/`Step` models, validation, the three built-ins, and `load_protocol` (room memory first, built-in second).
- `app/services/markers.py` (new): `parse_marker` and `stance_of`, moved out of `routes/participate.py`.
- `app/services/turns.py`: `on_tick` / `on_reply` callbacks.
- `app/config.py`: `CONDUCTOR_HANDLE`, `CONDUCTOR_STEP_TIMEOUT_S`, `CONDUCTOR_POLL_INTERVAL_S`, `CONDUCTOR_MAX_STEPS`.
- `app/main.py`, `routes/engines.py`, CLI `protocol.py`: the kind registered and wired.
- Docs: `concepts/conductor.md`, a row on the engines page, the regenerated site. `CLAUDE.md` and README updated.
- Tests: `test_conductor.py` (gated loops on a block and ends on an approval; the floor follows the step and is released; the cap; a person blocking with a marker in prose; silence takes the fallback edge; a reply in the room is not an answer in the thread; fan-out and round-robin floors and prompts; the record; no negotiation and never converged; refusals; the summon seam runs in the summoning thread or opens its own), `test_protocols.py`, `test_markers.py`. `fakes.FakeManager` grows the floor verbs.

## Testing

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — backend 1144 passed, 13 skipped; CLI 807 passed, 2 skipped (with the container's hub credentials unset; one pre-existing CLI test reads `MYCELIUM_*` from the environment)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `uv run ty check .` on both packages
- [x] Docs regenerated (`docs/generate_docs.py`); the diff is the conductor page and its search entries only

## Related Issues

Stacked on #953, after #954.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk)_