### PR TITLE
Add the persona engine: a member played by a model, in character

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,18 @@ is no litellm dependency.
   transcript, so it wakes nobody and `await` needs no change. The room itself
   (`live`) never holds a floor. `app/services/turns.py` is the one-agent turn
   the aligner brokers with, lifted out so a protocol step asks the same way.
+- **A persona is a member played by a model, in character.** Engine kind
+  `persona` (`app/services/persona_engine.py`): the `agents/<handle>/notes`
+  memory is its system prompt, its Pi session is kept per (room, handle) so it
+  remembers, and it answers on two seams — a text mention (the summon hook)
+  and an **addressed turn** (`persister.on_addressed`, fired once per L9
+  recipient of an exchange that mentioned nobody in its text, which is how the
+  aligner and the conductor address one member). Only the persona is wired to
+  the addressed seam; the other engines act on mentions alone. A stance marker
+  in its answer is lifted onto the payload like `/reply` does, and every `@` in
+  what it says is neutralized, so personas cannot summon anything or each
+  other. Not a roster member: the aligner negotiates with one only when the
+  summon names it.
 - **The conductor runs a protocol inside a task, in code.** A fourth engine
   kind (`app/services/conductor.py`) with no model of its own: summoned as
   `board coordinate <row> conductor "gated @a @b: …"`, it walks a

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Repo layout:
 ```
 .mycelium/            Memory storage (rooms are folders, memories are markdown files)
 mycelium-cli/         CLI + adapters
-fastapi-backend/      FastAPI moderator + engines (aligner, synthesizer, hello, conductor)
+fastapi-backend/      FastAPI moderator + engines (aligner, synthesizer, hello, persona, conductor)
 mycelium-client/      Generated typed OpenAPI client
 mycelium-frontend/    Next.js UI
 contracts/            Frozen JSON contracts shared across components

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <title>Adapters · mycelium</title>
-<meta name="description" content="Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer, hello and the conductor.">
+<meta name="description" content="Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer, hello, a persona and the conductor.">
 <meta property="og:title" content="Adapters · mycelium">
-<meta property="og:description" content="Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer, hello and the conductor.">
+<meta property="og:description" content="Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer, hello, a persona and the conductor.">
 <meta property="og:image" content="https://mycelium-io.github.io/mycelium/og.png">
 <meta property="og:url" content="https://mycelium-io.github.io/mycelium/adapters.html">
 <meta property="og:type" content="website">
@@ -117,6 +117,7 @@
           <a href="#aligner" class="nav-link sub">Aligner</a>
           <a href="#synthesizer" class="nav-link sub">Synthesizer</a>
           <a href="#hello" class="nav-link sub">Hello</a>
+          <a href="#persona" class="nav-link sub">Persona</a>
           <a href="#conductor" class="nav-link sub">Conductor</a>
         </div>
       </div>
@@ -585,7 +586,7 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
       <h1>Engines</h1>
       <p>An <strong>engine</strong> is a first-party task of cognition that lives inside a room. Where your agents are the participants, engines are the room&#x27;s <em>reasoning citizens</em>. They read what the room knows and act on it: mediate a decision, distill the memory, and (in time) more.</p>
       <p>Engines exist because some work isn&#x27;t any single agent&#x27;s job. Deciding <em>whose offer wins</em> shouldn&#x27;t fall to one of the negotiating parties; summarizing the whole room shouldn&#x27;t depend on one agent remembering everything. An engine is a neutral, first-party actor the room owns.</p>
-      <p>Four of them exist today; the first thing to try on a new hub is <code>hello</code>, which answers a summon and owns nothing, so it is safe to fire into a live room just to see whether cognition runs at all.</p>
+      <p>Five of them exist today; the first thing to try on a new hub is <code>hello</code>, which answers a summon and owns nothing, so it is safe to fire into a live room just to see whether cognition runs at all.</p>
       <p>Two properties define every engine:</p>
       <ul>
         <li><strong>Summoned explicitly.</strong> An engine is dormant until you register it in a room and <code>@</code>-summon it. There is no join window, no polling, and no held LLM connection, so it has zero idle cost. Cognition runs because you asked for it.</li>
@@ -613,6 +614,10 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
             <tr>
               <td><code>hello</code></td>
               <td>Answers one summon with one Pi turn and writes nothing anywhere — the cheap proof the engine path works on this hub. See <a href="#hello">Hello</a>.</td>
+            </tr>
+            <tr>
+              <td><code>persona</code></td>
+              <td>Plays a room member in character, from the persona written to its notes, on a Pi session it keeps so it remembers. Answers a mention or an addressed turn, so it can fill a protocol role. See <a href="#persona">Persona</a>.</td>
             </tr>
             <tr>
               <td><code>conductor</code></td>
@@ -771,6 +776,35 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
       <h2 id="hello-holding-nothing">Holding nothing</h2>
       <p>Hello keeps no state between summons and answers each one from scratch, so it is not a chat partner — it is a probe with a personality. Ask it something twice and it will not remember the first time. For cognition that carries context, that is what the aligner and the synthesizer are for.</p>
       <p class="edit-page"><a href="https://github.com/mycelium-io/mycelium/blob/main/mycelium-cli/src/mycelium/docs/concepts/hello.md" target="_blank" rel="noopener"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>Edit this page on GitHub</a></p>
+    </section>
+
+    <hr class="divider">
+
+    <section class="doc-section" id="persona">
+      <h1>Persona</h1>
+      <p>A persona is an <a href="#engines">engine</a> that plays a room member in character. Give it a character, and it answers as that character whenever it is addressed, on a Pi session kept for it alone, so it remembers what it said the last time it was asked. A room can register as many as a demonstration needs: a cautious security reviewer, a proposer with a deadline, a supplier with limited stock. None of them needs a resident session behind it.</p>
+      <pre><code><span class="comment"># Register the persona, then write its character to its notes</span>
+<span class="bin">mycelium</span> <span class="cmd">engine</span> <span class="cmd">create</span> sec <span class="flag">--kind</span> persona <span class="flag">--room</span> sprint-plan \
+  <span class="flag">--description</span> <span class="str">&quot;The security reviewer.&quot;</span>
+<span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">set</span> agents/sec/notes <span class="flag">--room</span> sprint-plan \
+  <span class="str">&quot;You are the security reviewer. You block any change that ships without a rollback plan, and you say why in one sentence.&quot;</span>
+
+<span class="comment"># Talk to it</span>
+<span class="bin">mycelium</span> <span class="cmd">engine</span> <span class="cmd">invoke</span> sec <span class="str">&quot;what do you make of rotating the signing key in place?&quot;</span> <span class="flag">-r</span> sprint-plan</code></pre>
+      <p>The notes memory is the whole character: it is the system prompt of every turn the persona takes. With no notes, the manifest&#x27;s description stands in, and with neither the persona is a plain, thoughtful teammate.</p>
+      <h2 id="persona-how-it-is-addressed">How it is addressed</h2>
+      <p>A persona answers on two seams, and that is what makes it useful beyond chat. A text mention (<code>@sec</code>) summons it like any engine. An <strong>addressed turn</strong>, a message naming it as recipient with nobody mentioned in the text, also reaches it, and that is how the <a href="#conductor">conductor</a> puts a step to one member and how the <a href="#aligner">aligner</a> addresses a participant. So a persona can hold a role in a protocol:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">engine</span> <span class="cmd">create</span> api <span class="flag">--kind</span> persona <span class="flag">--room</span> sprint-plan
+<span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">set</span> agents/api/notes <span class="flag">-r</span> sprint-plan <span class="str">&quot;You are the API engineer. You want to ship today.&quot;</span>
+<span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">coordinate</span> work/rotate-signing-key conductor \
+  <span class="str">&quot;gated @api @sec: rotate the signing key without downtime&quot;</span></code></pre>
+      <p>Both roles are now played by personas, the guardian blocks what the proposer puts up until it has a rollback plan, and the whole exchange runs in the task&#x27;s thread with no session resident anywhere.</p>
+      <h2 id="persona-what-it-says">What it says</h2>
+      <p>It answers where it was asked: in the thread the turn rode, or in the room. A reply that ends in a stance marker (<code>[[mycelium: stance=accept]]</code> or <code>reject</code>) has the stance lifted onto the message the way an agent&#x27;s <code>mycelium respond</code> does, so a conductor step or an aligner round reads it the same as a resident agent&#x27;s. Every <code>@</code> in what it says is removed before posting, so a persona can never summon anything, and two personas can never set each other off.</p>
+      <p>Like hello, it is fail-loud: a Pi error or an empty answer is posted as a readable reason rather than silence, so a quiet persona is never mistaken for one still thinking.</p>
+      <h2 id="persona-honest-boundaries">Honest boundaries</h2>
+      <p>A persona is an engine, not a member with a presence lease: it is not in the room&#x27;s roster, so the aligner only negotiates with it when the summon names it (<code>@aligner @api @sec</code>), and a bare <code>@aligner</code> over the whole room does not find it. Its memory is its Pi session file, which lives with the backend process and does not survive a rebuild of the container. And it holds no keys: like every engine, it speaks through the hub.</p>
+      <p class="edit-page"><a href="https://github.com/mycelium-io/mycelium/blob/main/mycelium-cli/src/mycelium/docs/concepts/persona.md" target="_blank" rel="noopener"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>Edit this page on GitHub</a></p>
     </section>
 
     <hr class="divider">

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -38,7 +38,7 @@ PAGES: list[tuple[str, str, str, str, str, str, str]] = [
      "A shared space for humans and agents. Install Mycelium and learn the core concepts: rooms, memory, the board, episodes, and the L9 protocol."),
     ("adapters", "adapters.html", "Adapters · mycelium", "Adapters",
      "ADP-001", "ADAPTERS · CLAUDE CODE · CURSOR · A2A BRIDGE · REST API · ENGINES",
-     "Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer, hello and the conductor."),
+     "Connect Claude Code, Cursor, any A2A agent, or any HTTP client to the Mycelium coordination layer, and summon the first-party engines: the aligner, the synthesizer, hello, a persona and the conductor."),
     ("reference", "reference.html", "Reference · mycelium", "Reference",
      "REF-001", "REFERENCE · ARCHITECTURE · CLI · CONFIG · DEPENDENCIES · GUIDES · HELP",
      "Architecture, CLI reference, configuration, dependencies and compatibility, guides, and troubleshooting for Mycelium."),
@@ -73,6 +73,7 @@ SECTION_CONFIG: list[tuple[str | None, str, str, str, str]] = [
     ("concepts/aligner.md",           "aligner",            "adapters",  "Engines",      "Aligner"),
     ("concepts/synthesizer.md",       "synthesizer",        "adapters",  "Engines",      "Synthesizer"),
     ("concepts/hello.md",             "hello",              "adapters",  "Engines",      "Hello"),
+    ("concepts/persona.md",           "persona",            "adapters",  "Engines",      "Persona"),
     ("concepts/conductor.md",         "conductor",          "adapters",  "Engines",      "Conductor"),
     # ── reference (reference.html) ──
     ("reference/architecture.md",     "architecture",       "reference", "Architecture", "Architecture"),

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,6 +117,7 @@
           <a href="adapters.html#aligner" class="nav-link sub">Aligner</a>
           <a href="adapters.html#synthesizer" class="nav-link sub">Synthesizer</a>
           <a href="adapters.html#hello" class="nav-link sub">Hello</a>
+          <a href="adapters.html#persona" class="nav-link sub">Persona</a>
           <a href="adapters.html#conductor" class="nav-link sub">Conductor</a>
         </div>
       </div>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1663,7 +1663,7 @@ offer wins* shouldn't fall to one of the negotiating parties; summarizing the
 whole room shouldn't depend on one agent remembering everything. An engine is a
 neutral, first-party actor the room owns.
 
-Four of them exist today; the first thing to try on a new hub is `hello`,
+Five of them exist today; the first thing to try on a new hub is `hello`,
 which answers a summon and owns nothing, so it is safe to fire into a live
 room just to see whether cognition runs at all.
 
@@ -1687,6 +1687,7 @@ commands host all of them.
 | `aligner` | Mediates a disagreement inside a task to one shared answer, running a real NEGMAS negotiation. See [Aligner](#aligner). |
 | `synthesizer` | Distills the room's conversation into a briefing at `context/synthesis`, incrementally. See [Synthesizer](#synthesizer). |
 | `hello` | Answers one summon with one Pi turn and writes nothing anywhere — the cheap proof the engine path works on this hub. See [Hello](#hello). |
+| `persona` | Plays a room member in character, from the persona written to its notes, on a Pi session it keeps so it remembers. Answers a mention or an addressed turn, so it can fill a protocol role. See [Persona](#persona). |
 | `conductor` | Runs a protocol inside a task — a gated review, a fan-out, a round robin — walking the steps in code and giving the floor to whoever each step addresses. It has no model of its own. See [Conductor](#conductor). |
 
 More kinds (bargaining, team-formation, drift evaluation) plug into the same
@@ -1947,6 +1948,76 @@ Hello keeps no state between summons and answers each one from scratch, so it is
 not a chat partner — it is a probe with a personality. Ask it something twice
 and it will not remember the first time. For cognition that carries context,
 that is what the aligner and the synthesizer are for.
+
+
+---
+
+# Persona
+
+A persona is an [engine](#engines) that plays a room member in character.
+Give it a character, and it answers as that character whenever it is
+addressed, on a Pi session kept for it alone, so it remembers what it said
+the last time it was asked. A room can register as many as a demonstration
+needs: a cautious security reviewer, a proposer with a deadline, a supplier
+with limited stock. None of them needs a resident session behind it.
+
+```bash
+# Register the persona, then write its character to its notes
+mycelium engine create sec --kind persona --room sprint-plan \
+  --description "The security reviewer."
+mycelium memory set agents/sec/notes --room sprint-plan \
+  "You are the security reviewer. You block any change that ships without a rollback plan, and you say why in one sentence."
+
+# Talk to it
+mycelium engine invoke sec "what do you make of rotating the signing key in place?" -r sprint-plan
+```
+
+The notes memory is the whole character: it is the system prompt of every
+turn the persona takes. With no notes, the manifest's description stands in,
+and with neither the persona is a plain, thoughtful teammate.
+
+## How it is addressed
+
+A persona answers on two seams, and that is what makes it useful beyond
+chat. A text mention (`@sec`) summons it like any engine. An **addressed
+turn**, a message naming it as recipient with nobody mentioned in the text,
+also reaches it, and that is how the [conductor](#conductor) puts a step to
+one member and how the [aligner](#aligner) addresses a participant. So a
+persona can hold a role in a protocol:
+
+```bash
+mycelium engine create api --kind persona --room sprint-plan
+mycelium memory set agents/api/notes -r sprint-plan "You are the API engineer. You want to ship today."
+mycelium board coordinate work/rotate-signing-key conductor \
+  "gated @api @sec: rotate the signing key without downtime"
+```
+
+Both roles are now played by personas, the guardian blocks what the
+proposer puts up until it has a rollback plan, and the whole exchange runs in
+the task's thread with no session resident anywhere.
+
+## What it says
+
+It answers where it was asked: in the thread the turn rode, or in the room.
+A reply that ends in a stance marker (`[[mycelium: stance=accept]]` or
+`reject`) has the stance lifted onto the message the way an agent's
+`mycelium respond` does, so a conductor step or an aligner round reads it
+the same as a resident agent's. Every `@` in what it says is removed before
+posting, so a persona can never summon anything, and two personas can never
+set each other off.
+
+Like hello, it is fail-loud: a Pi error or an empty answer is posted as a
+readable reason rather than silence, so a quiet persona is never mistaken
+for one still thinking.
+
+## Honest boundaries
+
+A persona is an engine, not a member with a presence lease: it is not in the
+room's roster, so the aligner only negotiates with it when the summon names
+it (`@aligner @api @sec`), and a bare `@aligner` over the whole room does
+not find it. Its memory is its Pi session file, which lives with the backend
+process and does not survive a rebuild of the container. And it holds no
+keys: like every engine, it speaks through the hub.
 
 
 ---

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -117,6 +117,7 @@
           <a href="adapters.html#aligner" class="nav-link sub">Aligner</a>
           <a href="adapters.html#synthesizer" class="nav-link sub">Synthesizer</a>
           <a href="adapters.html#hello" class="nav-link sub">Hello</a>
+          <a href="adapters.html#persona" class="nav-link sub">Persona</a>
           <a href="adapters.html#conductor" class="nav-link sub">Conductor</a>
         </div>
       </div>

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -730,6 +730,34 @@ window.MYCELIUM_SEARCH_INDEX = [
     "p": "Adapters"
   },
   {
+    "u": "adapters.html#persona",
+    "t": "Persona",
+    "s": "Engines",
+    "x": "A persona is an engine that plays a room member in character. Give it a character, and it answers as that character whenever it is addressed, on a Pi session kept for it alone, so it remembers what it said the last time it was asked. A room can register as many as a demonstration needs: a cautious security reviewer, a proposer with a deadline, a supplier with limited stock. None of them needs a resident session behin",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#persona-how-it-is-addressed",
+    "t": "How it is addressed",
+    "s": "Engines › Persona",
+    "x": "A persona answers on two seams, and that is what makes it useful beyond chat. A text mention (@sec) summons it like any engine. An addressed turn, a message naming it as recipient with nobody mentioned in the text, also reaches it, and that is how the conductor puts a step to one member and how the aligner addresses a participant. So a persona can hold a role in a protocol: mycelium engine create api --kind persona -",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#persona-what-it-says",
+    "t": "What it says",
+    "s": "Engines › Persona",
+    "x": "It answers where it was asked: in the thread the turn rode, or in the room. A reply that ends in a stance marker ([[mycelium: stance=accept]] or reject) has the stance lifted onto the message the way an agent's mycelium respond does, so a conductor step or an aligner round reads it the same as a resident agent's. Every @ in what it says is removed before posting, so a persona can never summon anything, and two person",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#persona-honest-boundaries",
+    "t": "Honest boundaries",
+    "s": "Engines › Persona",
+    "x": "A persona is an engine, not a member with a presence lease: it is not in the room's roster, so the aligner only negotiates with it when the summon names it (@aligner @api @sec), and a bare @aligner over the whole room does not find it. Its memory is its Pi session file, which lives with the backend process and does not survive a rebuild of the container. And it holds no keys: like every engine, it speaks through the ",
+    "p": "Adapters"
+  },
+  {
     "u": "adapters.html#conductor",
     "t": "Conductor",
     "s": "Engines",

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -185,6 +185,14 @@ class Settings(BaseSettings):
     # Per-turn wall-clock bound (seconds) on the hello engine's one-shot pi call.
     HELLO_PI_TIMEOUT_S: float = 60.0
 
+    # Persona engine (kind ``persona``) — answers in character, from the
+    # persona written to its ``agents/<handle>/notes`` memory, on a Pi session
+    # kept per handle so it remembers across turns. Dormant like the others.
+    # Reuses the shared LLM_* + ALIGNER_PI_* runtime settings; only its handle
+    # default and per-turn timeout live here.
+    PERSONA_HANDLE: str = "persona"
+    PERSONA_PI_TIMEOUT_S: float = 120.0
+
     # Conductor engine (kind ``conductor``) — runs a protocol's steps over a
     # thread in code, holding the floor for whoever each step addresses. No
     # model of its own, so no Pi settings: only its handle default, how long

--- a/fastapi-backend/app/main.py
+++ b/fastapi-backend/app/main.py
@@ -134,13 +134,14 @@ async def lifespan(app: FastAPI):
     # channel is provisioned, so all persisters pick it up. Dormant until an
     # @-summon of its reserved handle arrives — zero idle cost.
     # Several handlers share the one summon seam: the engine kinds (aligner,
-    # synthesizer, hello, conductor) plus the A2A responder. Each self-selects by the summoned
+    # synthesizer, hello, conductor, persona) plus the A2A responder. Each self-selects by the summoned
     # handle's manifest (kind for engines, adapter=a2a for the responder), so a
     # fan-out dispatcher is enough — no central table. Only one ever acts per
     # summon since a handle maps to a single runtime.
     from app.services.a2a_bridge import A2aResponder
     from app.services.aligner import AlignerEngine
     from app.services.conductor import ConductorEngine
+    from app.services.persona_engine import PersonaEngine
     from app.services.probe_engine import ProbeEngine
     from app.services.room_channels import manager as room_channel_manager
     from app.services.synthesizer import SynthesizerEngine
@@ -150,6 +151,7 @@ async def lifespan(app: FastAPI):
     app.state.synthesizer = SynthesizerEngine(room_channel_manager)
     app.state.hello = ProbeEngine(room_channel_manager)
     app.state.conductor = ConductorEngine(room_channel_manager)
+    app.state.persona = PersonaEngine(room_channel_manager)
     # The A2A responder shares the seam too: it answers @-mentions of a
     # registered a2a agent by calling the remote endpoint, gating on the manifest
     # like the engines gate on their kind, so only one handler ever acts.
@@ -159,6 +161,7 @@ async def lifespan(app: FastAPI):
         app.state.synthesizer.handle_summon,
         app.state.hello.handle_summon,
         app.state.conductor.handle_summon,
+        app.state.persona.handle_summon,
         app.state.a2a_responder.handle_summon,
     )
 
@@ -176,12 +179,18 @@ async def lifespan(app: FastAPI):
                 logger.exception("engine summon handler failed for @%s in %s", handle, room)
 
     room_channel_manager.on_summon = _dispatch_summon
+    # A persona also answers when it is the L9 recipient of a turn whose text
+    # names nobody — the way the aligner and the conductor address one member.
+    # The other engines act only on a mention, so this seam is the persona's.
+    room_channel_manager.on_addressed = app.state.persona.handle_addressed
     logger.info(
-        "engines wired (aligner @%s, synthesizer @%s, hello @%s, conductor @%s; llm=pi via %s)",
+        "engines wired (aligner @%s, synthesizer @%s, hello @%s, conductor @%s, "
+        "persona @%s; llm=pi via %s)",
         app.state.aligner.handle,
         app.state.synthesizer.handle,
         app.state.hello.handle,
         app.state.conductor.handle,
+        app.state.persona.handle,
         settings.ALIGNER_PI_BINARY,
     )
 

--- a/fastapi-backend/app/routes/engines.py
+++ b/fastapi-backend/app/routes/engines.py
@@ -29,7 +29,7 @@ router = APIRouter(prefix="/rooms/{room_name}/engines", tags=["engines"])
 
 # The engine kinds the backend knows how to run. Mirrors the CLI's
 # ``mycelium.protocol.ENGINE_KINDS``; the summon seam self-selects by ``kind``.
-ENGINE_KINDS = frozenset({"aligner", "conductor", "hello", "synthesizer"})
+ENGINE_KINDS = frozenset({"aligner", "conductor", "hello", "persona", "synthesizer"})
 
 _HANDLE_RE = re.compile(HANDLE_PATTERN)
 

--- a/fastapi-backend/app/services/persister.py
+++ b/fastapi-backend/app/services/persister.py
@@ -101,6 +101,21 @@ def envelope_message_id(envelope: L9) -> str | None:
     return message.id if message is not None else None
 
 
+#: Payloads an exchange carries that are signals rather than turns: nothing
+#: to answer, so the addressed hook never fires for them.
+_SIGNAL_PAYLOADS = frozenset(
+    {"presence", "keepalive", l9.PING_PAYLOAD_TYPE, l9.NOTICE_PAYLOAD_TYPE}
+)
+
+
+def is_addressed_turn(envelope: L9) -> bool:
+    """True for an ``exchange`` that puts something to its recipients."""
+    header = envelope.header
+    if header.kind.value != "exchange":
+        return False
+    return envelope.payload.type not in _SIGNAL_PAYLOADS
+
+
 def is_converged(envelope: L9) -> bool:
     """True for a ``commit:converged`` envelope (the plan-compile trigger)."""
     header = envelope.header
@@ -785,6 +800,11 @@ def write_episode_cursors(room: str, cursors: dict[str, dict[str, int]]) -> None
 # ── The receive loop ─────────────────────────────────────────────────────────
 
 SummonHook = Callable[[str, "L9", list[str], str], None]
+# Called once per L9 recipient of an exchange that named nobody in its text —
+# an addressed turn, the way the aligner and the conductor put a question to
+# one member. A mention in the text is a summon and fires the summon hook
+# instead, so a handle is never told twice about one message.
+AddressedHook = Callable[[str, "L9", str], None]
 ConvergedHook = Callable[["L9"], None]
 # Called with the handle of a member that dropped off the channel, so the
 # moderator can update its membership — presence, not a fatal error.
@@ -878,12 +898,14 @@ class RoomPersister:
         on_summon: SummonHook | None = None,
         on_converged: ConvergedHook | None = None,
         on_member_left: MemberLeftHook | None = None,
+        on_addressed: AddressedHook | None = None,
         feed_bus: bool = True,
     ) -> None:
         self.room = room
         self._channel = channel
         self._members_provider = members_provider
         self.on_summon = on_summon or _default_summon_hook
+        self.on_addressed = on_addressed
         self.on_converged = on_converged or _default_converged_hook
         self.on_member_left = on_member_left
         self._feed_bus = feed_bus
@@ -1166,6 +1188,14 @@ class RoomPersister:
                 self.on_summon(handle, envelope, summons, message_text)
             except Exception:
                 logger.exception("summon hook failed for @%s", handle)
+        if self.on_addressed is not None and is_addressed_turn(envelope):
+            for handle in envelope_recipients(envelope):
+                if handle in summons:
+                    continue
+                try:
+                    self.on_addressed(handle, envelope, message_text)
+                except Exception:
+                    logger.exception("addressed hook failed for @%s", handle)
         if is_converged(envelope):
             try:
                 self.on_converged(envelope)

--- a/fastapi-backend/app/services/persona_engine.py
+++ b/fastapi-backend/app/services/persona_engine.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The persona engine — a room member played by a model, in character.
+
+A fifth engine ``kind``. Where hello answers once and forgets, a persona is a
+standing member with a character: the persona text written to its
+``agents/<handle>/notes`` memory is the system prompt of every turn, and its
+Pi session is kept per handle, so it remembers what it said last time it was
+asked. Register one per character a demonstration needs (a cautious
+guardian, a proposer with a deadline, a supplier with limited stock), seed
+each one's notes, and the room has members that answer without a resident
+session behind any of them.
+
+It answers on two seams. A text ``@``-mention is a summon, like any engine's.
+An **addressed turn** — an exchange naming it as an L9 recipient with nobody
+mentioned in the text, which is how the aligner and the conductor put a
+question to one member — reaches it through the persister's addressed hook,
+so a persona can fill a protocol role or a negotiation seat. Either way it
+answers where it was asked, in the thread the turn rode.
+
+A reply ending in a position marker is lifted the way the reply route lifts
+one: the stance lands on the L9 payload and the prose is posted clean, so a
+guardian played by a persona blocks a gated step the same as a resident agent
+would. Every ``@`` in what it says is neutralized before posting, so a persona
+can never summon anything, and two personas cannot ping-pong.
+
+Dormant by default and fail-loud like the other engines: a Pi error or an
+empty answer is posted as a readable reason rather than silence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from app.config import settings
+from app.services import activity, l9, markers, turns
+from app.services.aligner import _norm, _registered_engine_kind
+from app.services.l9_models import Kind
+from app.services.synthesizer import _strip_fences
+
+if TYPE_CHECKING:
+    from app.services.l9_models import L9
+    from app.services.room_channels import ManagedRoomChannel, RoomChannelManager
+
+logger = logging.getLogger(__name__)
+
+#: The engine kind this class owns.
+ENGINE_KIND = "persona"
+
+#: Where a persona's character lives: the notes memory every agent has.
+NOTES_SUFFIX = "/notes"
+
+#: What a persona with no notes and no description is told it is.
+DEFAULT_PERSONA = (
+    "You are a thoughtful member of a working team. You have opinions, you state "
+    "them plainly, and you change your mind when given a good reason."
+)
+
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _build_prompt(room: str, handle: str, sender: str, text: str, *, in_thread: bool) -> str:
+    """Assemble the turn prompt. Pure — no I/O, directly unit-testable."""
+    where = "in a task's thread" if in_thread else "in the room"
+    return (
+        f"You are @{handle}, a member of the Mycelium coordination room '{room}', "
+        f"speaking {where}. Stay in character as described in your instructions.\n\n"
+        f"{sender} said to you:\n\n{text}\n\n"
+        "Reply directly, in a few sentences, as plain markdown with no preamble and no "
+        "code fences. Do not put @ in front of anyone's name. If you are being asked "
+        "to approve or block something, end your reply with exactly one of "
+        "[[mycelium: stance=accept]] or [[mycelium: stance=reject]]; if you are "
+        "stating a position in a negotiation, end with [[mycelium: confidence=<0-1>]]."
+    )
+
+
+def _persona_text(room: str, handle: str) -> str:
+    """The character a persona plays: its notes, else its description, else the default."""
+    import yaml
+
+    from app.services.filesystem import get_room_dir, read_memory_file
+
+    room_dir = get_room_dir(room)
+    notes = read_memory_file(room_dir, f"agents/{handle}{NOTES_SUFFIX}")
+    if notes is not None and notes[1].strip():
+        return notes[1].strip()
+    manifest = read_memory_file(room_dir, f"agents/{handle}")
+    if manifest is not None:
+        try:
+            data = yaml.safe_load(manifest[1]) or {}
+        except yaml.YAMLError:
+            data = {}
+        description = data.get("description") if isinstance(data, dict) else None
+        if isinstance(description, str) and description.strip():
+            return description.strip()
+    return DEFAULT_PERSONA
+
+
+def _session_path(room: str, handle: str) -> Path:
+    """One session file per (room, handle), so a persona remembers across turns."""
+    session_dir = Path(tempfile.gettempdir()) / "mycelium-pi-sessions"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    slug = _UNSAFE.sub("-", f"persona-{room}-{handle}").strip("-")
+    return session_dir / f"{slug}.jsonl"
+
+
+def _pi_complete(room: str, handle: str, prompt: str, system: str, timeout_s: float) -> str:
+    """One blocking Pi turn on the persona's own persistent session.
+
+    Isolated so tests can patch it without a live Pi.
+    """
+    from app.services.pi_session import PiSession
+
+    llm_session = PiSession(
+        session_path=_session_path(room, handle),
+        model=settings.LLM_MODEL,
+        api_key=settings.LLM_API_KEY,
+        base_url=settings.LLM_BASE_URL,
+        binary=settings.ALIGNER_PI_BINARY,
+        timeout_s=timeout_s,
+        openshell=settings.ALIGNER_PI_OPENSHELL,
+    )
+    return llm_session(prompt, system=system)
+
+
+class PersonaEngine:
+    """Answer a mention or an addressed turn in character, and remember it."""
+
+    def __init__(
+        self,
+        manager: RoomChannelManager,
+        *,
+        handle: str | None = None,
+        timeout_s: float | None = None,
+    ) -> None:
+        self._manager = manager
+        self._handle = handle if handle is not None else settings.PERSONA_HANDLE
+        self._timeout_s = timeout_s if timeout_s is not None else settings.PERSONA_PI_TIMEOUT_S
+        # (room, handle) pairs with a turn in flight — a second ask waits for no
+        # one; it is dropped, and the asker's timeout says so.
+        self._active: set[tuple[str, str]] = set()
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    @property
+    def handle(self) -> str:
+        return self._handle
+
+    # -- the two seams --
+
+    def handle_summon(
+        self,
+        room: str,
+        handle: str,
+        envelope: L9,
+        co_summons: list[str] | None = None,
+        message_text: str = "",
+    ) -> None:
+        """A text mention of a registered persona: answer it."""
+        self._fire(room, handle, envelope, message_text)
+
+    def handle_addressed(self, room: str, handle: str, envelope: L9, message_text: str) -> None:
+        """An addressed turn naming a registered persona as recipient: answer it."""
+        self._fire(room, handle, envelope, message_text)
+
+    def _fire(self, room: str, handle: str, envelope: L9, message_text: str) -> None:
+        if _registered_engine_kind(room, handle) != ENGINE_KIND:
+            return
+        if settings.ENGINE_RUNTIME == "host":
+            logger.info("engine @%s summoned in %s but ENGINE_RUNTIME=host", handle, room)
+            return
+        from app.services.persister import envelope_sender
+
+        sender = envelope_sender(envelope)
+        if sender is None or _norm(sender) in {_norm(self._handle), _norm(handle)}:
+            return
+        key = (room, _norm(handle))
+        if key in self._active:
+            logger.debug("persona @%s already answering in %s; dropping this ask", handle, room)
+            return
+        self._active.add(key)
+        episode = (envelope.header.message.episode if envelope.header.message else None) or ""
+        text = turns.neutralize_mentions(message_text).strip()
+        task = asyncio.create_task(
+            self._run_and_release(
+                room, handle, episode or l9.live_episode_urn(room), sender, text, key
+            )
+        )
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _run_and_release(
+        self,
+        room: str,
+        handle: str,
+        episode: str,
+        sender: str,
+        text: str,
+        key: tuple[str, str],
+    ) -> None:
+        try:
+            await self.answer(room, engine_handle=handle, episode=episode, sender=sender, text=text)
+        except Exception:
+            logger.exception("persona @%s failed in room %s", handle, room)
+        finally:
+            self._active.discard(key)
+
+    # -- the one path: persona + what was said → one Pi turn → say it --
+
+    async def answer(
+        self,
+        room: str,
+        *,
+        engine_handle: str | None = None,
+        episode: str | None = None,
+        sender: str = "someone",
+        text: str = "",
+    ) -> str | None:
+        """Answer ``text`` in character and post it into ``episode``; return the prose.
+
+        ``None`` when the Pi turn fails or comes back empty, in which case the
+        reason is posted instead so a silent persona never looks like a
+        thinking one.
+        """
+        me = engine_handle or self._handle
+        managed = self._manager.get(room)
+        where = episode or l9.live_episode_urn(room)
+        in_thread = not l9.is_live_episode(room, where)
+        system = _persona_text(room, me)
+        prompt = _build_prompt(room, me, sender, text, in_thread=in_thread)
+        activity.signal(room, me, "responding", episode=where)
+        try:
+            raw = await asyncio.wait_for(
+                asyncio.to_thread(_pi_complete, room, me, prompt, system, self._timeout_s),
+                timeout=self._timeout_s + 5.0,
+            )
+        except Exception:
+            logger.exception("persona @%s: Pi turn failed in room %s", me, room)
+            await self._say(managed, where, me, "Pi turn timed out or errored; ask me again.")
+            return None
+        finally:
+            activity.signal(room, me, "done", episode=where)
+
+        reply = _strip_fences(raw or "")
+        if not reply.strip():
+            logger.warning("persona @%s: Pi returned an empty response in %s", me, room)
+            await self._say(managed, where, me, "Pi returned an empty response; ask me again.")
+            return None
+        payload, clean = markers.parse_marker(reply)
+        clean = turns.neutralize_mentions(clean)
+        await self._say(managed, where, me, clean, payload=payload)
+        return clean
+
+    async def _say(
+        self,
+        managed: ManagedRoomChannel | None,
+        episode: str,
+        sender: str,
+        text: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        """Post ``text`` as the persona into ``episode``, a stance on the payload."""
+        if managed is None:
+            logger.warning("persona @%s: no channel for room; dropping reply", sender)
+            return
+        env = l9.build_envelope(
+            kind=Kind.exchange,
+            episode=episode,
+            sender=sender,
+            sender_role="agent",
+            topic=l9.topic_urn(managed.room),
+            payload_type="reply",
+            payload_data=payload or {"action": "reply"},
+        )
+        try:
+            await managed.post(env, text, list_write=True)
+        except Exception:
+            logger.warning("persona @%s failed to post on room %s", sender, managed.room)

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -49,6 +49,7 @@ from app.services.l9_slim import (
     serialize_content,
 )
 from app.services.persister import (
+    AddressedHook,
     ConvergedHook,
     RoomPersister,
     SummonHook,
@@ -80,6 +81,9 @@ RoomSummonHook = Callable[[str, str, "L9", list[str], str], None]
 # it (the plan-sync consumer) needs the room to compile that room's plan + sync its
 # memory. ``_converged_adapter`` binds the room down to the persister signature.
 RoomConvergedHook = Callable[[str, "L9"], None]
+# The room-aware addressed hook: ``(room, handle, envelope, message_text)`` for
+# each L9 recipient of a turn that named nobody in its text.
+RoomAddressedHook = Callable[[str, str, "L9", str], None]
 
 logger = logging.getLogger(__name__)
 
@@ -278,6 +282,7 @@ class RoomChannelManager:
         # ``handle_converged``. Unset → the persister's log-only defaults.
         self.on_summon: RoomSummonHook | None = None
         self.on_converged: RoomConvergedHook | None = None
+        self.on_addressed: RoomAddressedHook | None = None
         self._metrics = ChannelMetrics()
         # Server-held presence: a handle that participates over HTTP (the CLI
         # ``await``/``respond`` long-poll) never holds a client SLIM connection,
@@ -727,6 +732,7 @@ class RoomChannelManager:
             members_provider=lambda: set(managed.members),
             on_summon=self._summon_adapter(room),
             on_converged=self._converged_adapter(room),
+            on_addressed=self._addressed_adapter(room),
             on_member_left=lambda handle, _room=room: self._drop_member(_room, handle),
         )
         managed.persister_task = asyncio.create_task(managed.persister.run())
@@ -823,6 +829,18 @@ class RoomChannelManager:
             _room: str = room,
         ) -> None:
             hook(_room, handle, envelope, co_summons, message_text)
+
+        return adapter
+
+    def _addressed_adapter(self, room: str) -> AddressedHook | None:
+        """Bind ``room`` onto the room-aware ``on_addressed`` hook, like
+        :meth:`_summon_adapter`; ``None`` keeps the persister silent."""
+        hook = self.on_addressed
+        if hook is None:
+            return None
+
+        def adapter(handle: str, envelope: L9, message_text: str = "", _room: str = room) -> None:
+            hook(_room, handle, envelope, message_text)
 
         return adapter
 

--- a/fastapi-backend/tests/test_addressed_hook.py
+++ b/fastapi-backend/tests/test_addressed_hook.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The addressed hook: an L9 recipient of a turn that named nobody in its text.
+
+The summon hook fires on a mention in the prose; this one fires on the
+envelope's recipients, which is how the aligner and the conductor put a
+question to one member. A handle is never told twice about one message, and
+a signal payload (presence, a ping, a notice) tells nobody anything.
+"""
+
+from __future__ import annotations
+
+from app.services import l9, persister
+from app.services.l9_models import Kind
+from app.services.l9_slim import serialize_content
+
+ROOM = "addressed-room"
+
+
+def _persister(addressed: list, summoned: list) -> persister.RoomPersister:
+    return persister.RoomPersister(
+        ROOM,
+        channel=None,  # ty: ignore[invalid-argument-type]  # _ingest is called directly
+        members_provider=lambda: set(),
+        on_summon=lambda handle, env, co, msg="": summoned.append(handle),
+        on_addressed=lambda handle, env, msg: addressed.append((handle, msg)),
+        feed_bus=False,
+    )
+
+
+def _ingest(
+    p: persister.RoomPersister, *, kind=Kind.exchange, payload_type="tick", recipients=(), text=""
+):
+    env = l9.build_envelope(
+        kind=kind,
+        subkind="resolved" if kind == Kind.commit else None,
+        episode=l9.live_episode_urn(ROOM),
+        sender="conductor",
+        recipients=list(recipients),
+        topic=l9.topic_urn(ROOM),
+        payload_type=payload_type,
+    )
+    p._ingest(env, serialize_content(env, extra={"content": text}), list_write=False)
+
+
+def test_a_recipient_of_a_turn_is_told_once():
+    addressed: list = []
+    summoned: list = []
+    p = _persister(addressed, summoned)
+
+    _ingest(p, recipients=["sec"], text="approve or block this")
+
+    assert addressed == [("sec", "approve or block this")]
+    assert summoned == []
+
+
+def test_a_mention_is_a_summon_and_not_also_an_address():
+    addressed: list = []
+    summoned: list = []
+    p = _persister(addressed, summoned)
+
+    _ingest(p, recipients=["sec", "api"], text="@sec what do you think?")
+
+    assert summoned == ["sec"]
+    assert addressed == [("api", "@sec what do you think?")]
+
+
+def test_signals_and_commits_address_nobody():
+    addressed: list = []
+    p = _persister(addressed, [])
+
+    _ingest(p, payload_type="presence", recipients=["sec"])
+    _ingest(p, payload_type=l9.PING_PAYLOAD_TYPE, recipients=["sec"])
+    _ingest(p, payload_type=l9.NOTICE_PAYLOAD_TYPE, recipients=["sec"])
+    _ingest(p, kind=Kind.commit, payload_type="outcome", recipients=["sec"])
+
+    assert addressed == []
+
+
+def test_no_hook_is_silent():
+    p = persister.RoomPersister(
+        ROOM,
+        channel=None,  # ty: ignore[invalid-argument-type]
+        members_provider=lambda: set(),
+        feed_bus=False,
+    )
+    _ingest(p, recipients=["sec"], text="hello")  # must not raise

--- a/fastapi-backend/tests/test_persona_engine.py
+++ b/fastapi-backend/tests/test_persona_engine.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The persona engine: a member played by a model, in character, that remembers.
+
+Node-free; the Pi turn is patched. What these hold: the character comes from
+the notes memory (then the description, then a default); the answer lands
+where the ask was made with any stance lifted onto the payload and every
+sigil neutralized; both seams gate on the manifest kind; and a persona is
+fail-loud rather than silent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+import yaml
+
+from app.services import l9, persona_engine
+from app.services.filesystem import get_room_dir, write_memory_file
+from app.services.l9_models import Kind
+from tests.fakes import FakeChannel, FakeManaged, FakeManager, FakePersister
+
+_ROOM = "persona-room"
+_LIVE = l9.live_episode_urn(_ROOM)
+_THREAD = l9.episode_urn(_ROOM, "t1")
+
+
+def _engine() -> tuple[persona_engine.PersonaEngine, FakeManaged]:
+    managed = FakeManaged(_ROOM, "mycelium", FakeChannel(), FakePersister())
+    return persona_engine.PersonaEngine(FakeManager(managed, [])), managed  # type: ignore[arg-type]
+
+
+def _register(handle: str, kind: str, description: str = "") -> None:
+    write_memory_file(
+        get_room_dir(_ROOM),
+        f"agents/{handle}",
+        yaml.safe_dump({"adapter": "engine", "kind": kind, "description": description}),
+        created_by="julia",
+    )
+
+
+def _notes(handle: str, text: str) -> None:
+    write_memory_file(get_room_dir(_ROOM), f"agents/{handle}/notes", text, created_by="julia")
+
+
+def _env(sender: str, *, episode: str = _LIVE, recipients: list[str] | None = None) -> Any:
+    return l9.build_envelope(
+        kind=Kind.exchange,
+        episode=episode,
+        sender=sender,
+        recipients=recipients,
+        topic=l9.topic_urn(_ROOM),
+        payload_type="tick" if recipients else "message",
+    )
+
+
+def _posted(managed: FakeManaged) -> list[tuple[Any, str]]:
+    return [(env, (extra or {}).get("content", "")) for env, extra in managed.channel.sent]
+
+
+@pytest.fixture(autouse=True)
+def _backend_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "ENGINE_RUNTIME", "backend")
+    get_room_dir(_ROOM)
+
+
+def _patch_pi(monkeypatch: pytest.MonkeyPatch, reply: str) -> list[dict[str, str]]:
+    seen: list[dict[str, str]] = []
+
+    def fake(room: str, handle: str, prompt: str, system: str, _t: float) -> str:
+        seen.append({"room": room, "handle": handle, "prompt": prompt, "system": system})
+        return reply
+
+    monkeypatch.setattr(persona_engine, "_pi_complete", fake)
+    return seen
+
+
+# ── the character ──────────────────────────────────────────────────────────────
+
+
+def test_the_notes_memory_is_the_character():
+    _register("sec", "persona", description="a reviewer")
+    _notes("sec", "You are the security reviewer. You block anything without a rollback plan.")
+    assert persona_engine._persona_text(_ROOM, "sec").startswith("You are the security reviewer")
+
+
+def test_without_notes_the_description_is_and_then_a_default():
+    _register("brazil", "persona", description="A coffee farm with 40 bags in stock.")
+    assert persona_engine._persona_text(_ROOM, "brazil") == "A coffee farm with 40 bags in stock."
+    _register("blank", "persona")
+    assert persona_engine._persona_text(_ROOM, "blank") == persona_engine.DEFAULT_PERSONA
+
+
+def test_the_session_is_per_room_and_handle():
+    a = persona_engine._session_path(_ROOM, "sec")
+    assert a == persona_engine._session_path(_ROOM, "sec")
+    assert a != persona_engine._session_path(_ROOM, "api")
+    assert a != persona_engine._session_path("other-room", "sec")
+    assert a.suffix == ".jsonl"
+
+
+# ── answering ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_it_answers_in_character_where_it_was_asked(monkeypatch: pytest.MonkeyPatch):
+    _register("sec", "persona")
+    _notes("sec", "You are the security reviewer.")
+    seen = _patch_pi(monkeypatch, "No rollback plan, so no. [[mycelium: stance=reject]]")
+    engine, managed = _engine()
+
+    reply = await engine.answer(
+        _ROOM,
+        engine_handle="sec",
+        episode=_THREAD,
+        sender="conductor",
+        text="Approve or block: rotate the key in place",
+    )
+
+    assert reply == "No rollback plan, so no."
+    assert seen[0]["system"] == "You are the security reviewer."
+    assert "rotate the key in place" in seen[0]["prompt"]
+    assert "in a task's thread" in seen[0]["prompt"]
+    env, text = _posted(managed)[0]
+    assert text == "No rollback plan, so no."
+    assert env.header.message.episode == _THREAD
+    assert env.header.participants.actors[0].id == "sec"
+    # The stance rides the payload, the way the reply route lifts it, so the
+    # conductor and the aligner read it off the same place.
+    assert env.payload.data == {"action": "reject"}
+
+
+@pytest.mark.asyncio
+async def test_it_never_puts_a_sigil_in_front_of_a_name(monkeypatch: pytest.MonkeyPatch):
+    _register("sec", "persona")
+    _patch_pi(monkeypatch, "Ask @api to add a canary first, @julia.")
+    engine, managed = _engine()
+
+    reply = await engine.answer(_ROOM, engine_handle="sec", sender="julia", text="thoughts?")
+
+    assert reply == "Ask api to add a canary first, julia."
+    assert "@" not in _posted(managed)[0][1]
+
+
+@pytest.mark.asyncio
+async def test_a_plain_answer_carries_no_stance(monkeypatch: pytest.MonkeyPatch):
+    _register("sec", "persona")
+    _patch_pi(monkeypatch, "```\nStill thinking it over.\n```")
+    engine, managed = _engine()
+
+    await engine.answer(_ROOM, engine_handle="sec", sender="julia", text="thoughts?")
+
+    env, text = _posted(managed)[0]
+    assert text == "Still thinking it over."
+    assert env.payload.data == {"action": "reply"}
+    assert env.header.message.episode == _LIVE
+
+
+@pytest.mark.asyncio
+async def test_pi_error_and_empty_answer_are_said_plainly(monkeypatch: pytest.MonkeyPatch):
+    _register("sec", "persona")
+    engine, managed = _engine()
+
+    def boom(*_a: Any) -> str:
+        raise RuntimeError("pi exploded")
+
+    monkeypatch.setattr(persona_engine, "_pi_complete", boom)
+    assert await engine.answer(_ROOM, engine_handle="sec", text="hi") is None
+    assert "timed out or errored" in _posted(managed)[0][1]
+
+    monkeypatch.setattr(persona_engine, "_pi_complete", lambda *_a: "  \n")
+    assert await engine.answer(_ROOM, engine_handle="sec", text="hi") is None
+    assert "empty response" in _posted(managed)[1][1]
+
+
+# ── the two seams ──────────────────────────────────────────────────────────────
+
+
+def _capture(engine: persona_engine.PersonaEngine) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_answer(room: str, **kw: Any) -> str:
+        calls.append({"room": room, **kw})
+        return "ok"
+
+    engine.answer = fake_answer  # type: ignore[method-assign]
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_a_mention_fires_only_a_registered_persona():
+    _register("sec", "persona")
+    _register("hi", "hello")
+    _register("api", "conductor")
+    engine, _managed = _engine()
+    calls = _capture(engine)
+
+    engine.handle_summon(
+        _ROOM, "sec", _env("julia"), ["sec"], "@sec what do you think of @api's plan?"
+    )
+    engine.handle_summon(_ROOM, "hi", _env("julia"), ["hi"], "@hi hello")
+    engine.handle_summon(_ROOM, "api", _env("julia"), ["api"], "@api go")
+    engine.handle_summon(_ROOM, "nobody", _env("julia"), ["nobody"], "@nobody go")
+    await asyncio.sleep(0.02)
+
+    assert [c["engine_handle"] for c in calls] == ["sec"]
+    assert calls[0]["sender"] == "julia"
+    assert calls[0]["text"] == "sec what do you think of api's plan?"
+    assert calls[0]["episode"] == _LIVE
+
+
+@pytest.mark.asyncio
+async def test_an_addressed_turn_reaches_it_in_its_thread():
+    """The conductor's tick names the persona as recipient and nobody in the
+    text; the persona answers it in the thread the tick rode."""
+    _register("sec", "persona")
+    engine, _managed = _engine()
+    calls = _capture(engine)
+
+    engine.handle_addressed(
+        _ROOM,
+        "sec",
+        _env("conductor", episode=_THREAD, recipients=["sec"]),
+        "Approve or block this",
+    )
+    engine.handle_addressed(
+        _ROOM, "api", _env("conductor", episode=_THREAD, recipients=["api"]), "go"
+    )
+    await asyncio.sleep(0.02)
+
+    assert len(calls) == 1
+    assert calls[0]["episode"] == _THREAD
+    assert calls[0]["sender"] == "conductor"
+
+
+@pytest.mark.asyncio
+async def test_it_never_answers_itself_and_drops_a_second_ask_while_busy():
+    _register("sec", "persona")
+    _register("api", "persona")
+    engine, _managed = _engine()
+    started: list[str] = []
+    release = asyncio.Event()
+
+    async def slow(room: str, **kw: Any) -> str:
+        started.append(kw["engine_handle"])
+        await release.wait()
+        return "ok"
+
+    engine.answer = slow  # type: ignore[method-assign]
+
+    engine.handle_summon(_ROOM, "sec", _env("sec"), ["sec"], "@sec talking to myself")
+    engine.handle_summon(_ROOM, "sec", _env("julia"), ["sec"], "@sec one")
+    engine.handle_summon(_ROOM, "sec", _env("julia"), ["sec"], "@sec two")
+    engine.handle_addressed(_ROOM, "api", _env("conductor", recipients=["api"]), "go")
+    await asyncio.sleep(0.02)
+    release.set()
+
+    assert started == ["sec", "api"]
+
+
+@pytest.mark.asyncio
+async def test_host_runtime_leaves_it_to_the_host(monkeypatch: pytest.MonkeyPatch):
+    from app.config import settings
+
+    _register("sec", "persona")
+    monkeypatch.setattr(settings, "ENGINE_RUNTIME", "host")
+    engine, _managed = _engine()
+    calls = _capture(engine)
+
+    engine.handle_summon(_ROOM, "sec", _env("julia"), ["sec"], "@sec hi")
+    await asyncio.sleep(0.02)
+
+    assert calls == []

--- a/mycelium-cli/src/mycelium/docs/concepts/engines.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/engines.md
@@ -10,7 +10,7 @@ offer wins* shouldn't fall to one of the negotiating parties; summarizing the
 whole room shouldn't depend on one agent remembering everything. An engine is a
 neutral, first-party actor the room owns.
 
-Four of them exist today; the first thing to try on a new hub is `hello`,
+Five of them exist today; the first thing to try on a new hub is `hello`,
 which answers a summon and owns nothing, so it is safe to fire into a live
 room just to see whether cognition runs at all.
 
@@ -34,6 +34,7 @@ commands host all of them.
 | `aligner` | Mediates a disagreement inside a task to one shared answer, running a real NEGMAS negotiation. See [Aligner](#aligner). |
 | `synthesizer` | Distills the room's conversation into a briefing at `context/synthesis`, incrementally. See [Synthesizer](#synthesizer). |
 | `hello` | Answers one summon with one Pi turn and writes nothing anywhere — the cheap proof the engine path works on this hub. See [Hello](#hello). |
+| `persona` | Plays a room member in character, from the persona written to its notes, on a Pi session it keeps so it remembers. Answers a mention or an addressed turn, so it can fill a protocol role. See [Persona](#persona). |
 | `conductor` | Runs a protocol inside a task — a gated review, a fan-out, a round robin — walking the steps in code and giving the floor to whoever each step addresses. It has no model of its own. See [Conductor](#conductor). |
 
 More kinds (bargaining, team-formation, drift evaluation) plug into the same

--- a/mycelium-cli/src/mycelium/docs/concepts/persona.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/persona.md
@@ -1,0 +1,66 @@
+# Persona
+
+A persona is an [engine](#engines) that plays a room member in character.
+Give it a character, and it answers as that character whenever it is
+addressed, on a Pi session kept for it alone, so it remembers what it said
+the last time it was asked. A room can register as many as a demonstration
+needs: a cautious security reviewer, a proposer with a deadline, a supplier
+with limited stock. None of them needs a resident session behind it.
+
+```bash
+# Register the persona, then write its character to its notes
+mycelium engine create sec --kind persona --room sprint-plan \
+  --description "The security reviewer."
+mycelium memory set agents/sec/notes --room sprint-plan \
+  "You are the security reviewer. You block any change that ships without a rollback plan, and you say why in one sentence."
+
+# Talk to it
+mycelium engine invoke sec "what do you make of rotating the signing key in place?" -r sprint-plan
+```
+
+The notes memory is the whole character: it is the system prompt of every
+turn the persona takes. With no notes, the manifest's description stands in,
+and with neither the persona is a plain, thoughtful teammate.
+
+## How it is addressed
+
+A persona answers on two seams, and that is what makes it useful beyond
+chat. A text mention (`@sec`) summons it like any engine. An **addressed
+turn**, a message naming it as recipient with nobody mentioned in the text,
+also reaches it, and that is how the [conductor](#conductor) puts a step to
+one member and how the [aligner](#aligner) addresses a participant. So a
+persona can hold a role in a protocol:
+
+```bash
+mycelium engine create api --kind persona --room sprint-plan
+mycelium memory set agents/api/notes -r sprint-plan "You are the API engineer. You want to ship today."
+mycelium board coordinate work/rotate-signing-key conductor \
+  "gated @api @sec: rotate the signing key without downtime"
+```
+
+Both roles are now played by personas, the guardian blocks what the
+proposer puts up until it has a rollback plan, and the whole exchange runs in
+the task's thread with no session resident anywhere.
+
+## What it says
+
+It answers where it was asked: in the thread the turn rode, or in the room.
+A reply that ends in a stance marker (`[[mycelium: stance=accept]]` or
+`reject`) has the stance lifted onto the message the way an agent's
+`mycelium respond` does, so a conductor step or an aligner round reads it
+the same as a resident agent's. Every `@` in what it says is removed before
+posting, so a persona can never summon anything, and two personas can never
+set each other off.
+
+Like hello, it is fail-loud: a Pi error or an empty answer is posted as a
+readable reason rather than silence, so a quiet persona is never mistaken
+for one still thinking.
+
+## Honest boundaries
+
+A persona is an engine, not a member with a presence lease: it is not in the
+room's roster, so the aligner only negotiates with it when the summon names
+it (`@aligner @api @sec`), and a bare `@aligner` over the whole room does
+not find it. Its memory is its Pi session file, which lives with the backend
+process and does not survive a rebuild of the container. And it holds no
+keys: like every engine, it speaks through the hub.

--- a/mycelium-cli/src/mycelium/protocol.py
+++ b/mycelium-cli/src/mycelium/protocol.py
@@ -303,7 +303,9 @@ AGENT_ADAPTERS: frozenset[str] = frozenset({"claude_code", "cursor", "engine", "
 #: memory → structured summary) and ``hello`` (one Pi turn, no side effects — the
 #: cheap proof the engine path works) today; ``bargainer`` (SAB), ``team_former``
 #: (TFP), a drift evaluator, etc. later; no new adapter per CE.
-ENGINE_KINDS: frozenset[str] = frozenset({"aligner", "conductor", "hello", "synthesizer"})
+ENGINE_KINDS: frozenset[str] = frozenset(
+    {"aligner", "conductor", "hello", "persona", "synthesizer"}
+)
 
 
 class AgentManifest(BaseModel):

--- a/mycelium-cli/tests/test_engine.py
+++ b/mycelium-cli/tests/test_engine.py
@@ -24,6 +24,7 @@ def test_engine_is_a_registered_family() -> None:
     assert "synthesizer" in ENGINE_KINDS
     assert "hello" in ENGINE_KINDS
     assert "conductor" in ENGINE_KINDS
+    assert "persona" in ENGINE_KINDS
 
 
 def test_manifest_accepts_synthesizer() -> None:


### PR DESCRIPTION
## Summary

Third of the stacked PRs into [#953](https://github.com/mycelium-io/mycelium/pull/953), after the floor ([#954](https://github.com/mycelium-io/mycelium/pull/954)) and the conductor ([#955](https://github.com/mycelium-io/mycelium/pull/955)). It adds the **persona**, a fifth engine kind: a room member played by a model, in character, that remembers. This is what makes a demonstration self-contained: register one persona per character (a cautious guardian, a proposer with a deadline, a supplier with limited stock), seed each one's notes, and the room has members that answer with no resident session behind any of them.

```bash
mycelium engine create sec --kind persona --room sprint-plan --description "The security reviewer."
mycelium memory set agents/sec/notes -r sprint-plan \
  "You are the security reviewer. You block any change that ships without a rollback plan."

mycelium engine create api --kind persona --room sprint-plan
mycelium memory set agents/api/notes -r sprint-plan "You are the API engineer. You want to ship today."

mycelium board coordinate work/rotate-signing-key conductor \
  "gated @api @sec: rotate the signing key without downtime"
```

Both roles are played by personas; the guardian blocks until the proposal has a rollback plan; the whole run lands in the task's thread.

### Two seams

A text mention summons a persona like any engine. But the aligner and the conductor address one member as an **L9 recipient with every `@` in the text neutralized**, which no engine could answer until now. This PR adds a second persister hook, `on_addressed`: fired once per recipient of an exchange, never for a handle the text already summoned (so nobody is told twice about one message), never for a signal payload (presence, ping, notice), never for a commit. Only the persona is wired to it; the other engines act on mentions alone, so nothing changes for them or for the A2A responder.

### Character and memory

The `agents/<handle>/notes` memory is the system prompt of every turn (the manifest description stands in without notes, then a default). The Pi session is kept per `(room, handle)`, so a persona remembers what it said last time. A stance marker in its answer is lifted onto the L9 payload the way `/reply` lifts one, so the conductor and the aligner read a persona's `reject` off the same place as a resident agent's. Every `@` in what it says is neutralized before posting, so a persona can summon nothing and two personas can never set each other off. Fail-loud like hello.

### Honest boundaries

A persona is not in the room's roster (no lease, no SLIM membership), so a bare `@aligner` over the whole room does not find it; the aligner negotiates with one only when the summon names it. Its memory lives in the backend's temp dir with the other Pi session files and does not survive a container rebuild.

## Changes

- `app/services/persona_engine.py` (new): the engine, its two seams, the character lookup, the per-handle session.
- `app/services/persister.py`: `AddressedHook`, `on_addressed`, `is_addressed_turn`; fired from `_ingest` after the summon loop.
- `app/services/room_channels.py`: `RoomAddressedHook`, `manager.on_addressed`, the room-binding adapter, passed into every persister.
- `app/config.py`: `PERSONA_HANDLE`, `PERSONA_PI_TIMEOUT_S`.
- `app/main.py`, `routes/engines.py`, CLI `protocol.py`: the kind registered and wired.
- Docs: `concepts/persona.md`, a row on the engines page, the regenerated site. `CLAUDE.md` and README updated.
- Tests: `test_persona_engine.py` (character from notes, description, default; answers in the thread it was asked in with the stance on the payload; sigils neutralized; fail-loud; both seams gate on the manifest kind; never answers itself; drops a second ask while busy; host runtime), `test_addressed_hook.py` (told once; a mention is a summon and not also an address; signals and commits address nobody; no hook is silent).

## Testing

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — backend 1159 passed, 13 skipped; CLI 807 passed, 2 skipped (hub credentials unset)
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `uv run ty check .` on both packages
- [x] Docs regenerated; the diff is the persona page and its search entries only

## Related Issues

Stacked on #953, after #954 and #955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk)_