### PR TITLE
A row waits on its dependencies, derived and never stored

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,6 +346,16 @@ is no litellm dependency.
   the negotiation engine. It runs a one-shot `pi` turn
   (a throwaway session, off the event loop via `asyncio.to_thread`), like every
   other mycelium cognition call.
+- **A row waits on its dependencies, derived and never stored.** A `work/`
+  row whose `depends-on` names a live board row that is not settled reads as
+  waiting on it: `assignments.waiting_on` on the hub (in every assignment read
+  and in the lease watcher's signature, so `await --lease` wakes when a row
+  becomes claimable), and a `waiting_on` fold in both board projections, frozen
+  in `contracts/board-vocabulary.json` under `task`. Resolving a row raises an
+  `unblocked` notice for each dependent that now waits on nothing. Refusing a
+  claim on a waiting row is `BOARD_DEPENDENCY_GATE`, off by default; `force`
+  on the claim overrides it. A target outside the live namespaces or that
+  names no memory is a reference, not a prerequisite.
 - **Server-held membership.** A turn-based agent (Claude, a subagent, a shell) can't
   hold a SLIM socket between turns, so the backend holds membership: `await`
   long-polls off a durable transcript cursor and refreshes a presence lease;

--- a/contracts/board-vocabulary.json
+++ b/contracts/board-vocabulary.json
@@ -86,6 +86,13 @@
       "kind",
       "priority"
     ],
+    "_dependencies_comment": "A row waits on the board rows its `dependency_relation` names that are not yet settled. `waiting_field` is derived on both surfaces and on the hub's assignment read, never stored: a dependency resolving changes what its dependents wait on with nobody writing a byte, the same way a lease drains. A target is settled when its status is one of `settled_statuses` or its assignment is resolved; a target outside the live namespaces, or that names no memory, is a reference rather than a prerequisite and is not waited on. Whether a claim on a waiting row is refused is the hub's BOARD_DEPENDENCY_GATE, off by default; `force` on the claim overrides it.",
+    "dependency_relation": "depends-on",
+    "waiting_field": "waiting_on",
+    "settled_statuses": [
+      "resolved",
+      "dismissed"
+    ],
     "_refusals_comment": "Why a row has no thread to speak into, keyed by the source that produced it. A chat verb refuses in these terms rather than falling back to the room: a message that quietly went somewhere other than where it was addressed is worse than one that did not go. Keyed by source kind, so an episode row is absent — an episode IS a thread, and speaking into a recorded negotiation is a write the hub judges (a frozen roster refuses an outsider), not one the surface guesses at. The memory refusal is not about what the memory is: EVERY memory carries a thread, whatever its namespace and whoever wrote it, so an unthreaded memory is a gap rather than a category — one written before threading and not yet backfilled. The copy says so, because a surface that refuses in terms of a rule nobody can see reads as a bug.",
     "refusals": {
       "agent": "presence is a lease the runtime renews, not a conversation to join",

--- a/docs/index.html
+++ b/docs/index.html
@@ -529,6 +529,14 @@ Resolved    Pick token storage                          @sec</code></pre>
 <span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">new</span> <span class="str">&quot;Migrate existing sessions&quot;</span> <span class="flag">--parent</span> work/ship-passkey-login</code></pre>
       <p><code>--parent</code> records a real relation on the child, the same kind of link any memory can carry, so the parent lists its children and each child names its parent. A parent that does not exist is refused rather than stored as a dangling link.</p>
       <p>Each child is a full task with its own thread, so a sub-problem gets its own conversation instead of crowding the parent&#x27;s.</p>
+      <h3 id="board-order-the-pieces">Order the pieces</h3>
+      <p>When one piece cannot start before another is done, say so with the same kind of relation:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">new</span> <span class="str">&quot;Write the migration&quot;</span> <span class="flag">--parent</span> work/ship-passkey-login
+<span class="bin">mycelium</span> <span class="cmd">memory</span> <span class="cmd">set</span> work/run-the-migration <span class="str">&quot;Run the migration&quot;</span> \
+  <span class="flag">--meta</span> depends-on=work/write-the-migration</code></pre>
+      <p>The board reads what a row still waits on off the rows it names, and shows it (<code>after work/write-the-migration</code>). Nothing stores that: when the dependency resolves, its dependents stop waiting with nobody writing a byte, the room&#x27;s timeline says the row was unblocked, and an agent sitting in <code>mycelium await --lease</code> on it wakes because the row it watches just became claimable. A dependency that is not a task on this board, a note or a key nobody filed, is a reference rather than a prerequisite and is not waited on.</p>
+      <p>By default a waiting row can still be claimed: showing the order is the board&#x27;s job, enforcing it is a choice. A hub with <code>BOARD_DEPENDENCY_GATE</code> on refuses the claim and names what the row waits on; <code>board claim --force</code> takes it anyway.</p>
+      <p>This is how a supervisor shape runs on a board: file the pieces with their order, and each agent takes the next piece the moment the one before it resolves.</p>
       <h2 id="board-hand-work-off">Hand work off</h2>
       <p>Two different questions get two different answers, and the board keeps them apart:</p>
       <ul>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -595,6 +595,34 @@ link.
 Each child is a full task with its own thread, so a sub-problem gets its own
 conversation instead of crowding the parent's.
 
+### Order the pieces
+
+When one piece cannot start before another is done, say so with the same kind
+of relation:
+
+```bash
+mycelium board new "Write the migration" --parent work/ship-passkey-login
+mycelium memory set work/run-the-migration "Run the migration" \
+  --meta depends-on=work/write-the-migration
+```
+
+The board reads what a row still waits on off the rows it names, and shows
+it (`after work/write-the-migration`). Nothing stores that: when the
+dependency resolves, its dependents stop waiting with nobody writing a byte,
+the room's timeline says the row was unblocked, and an agent sitting in
+`mycelium await --lease` on it wakes because the row it watches just became
+claimable. A dependency that is not a task on this board, a note or a key
+nobody filed, is a reference rather than a prerequisite and is not waited on.
+
+By default a waiting row can still be claimed: showing the order is the
+board's job, enforcing it is a choice. A hub with `BOARD_DEPENDENCY_GATE`
+on refuses the claim and names what the row waits on; `board claim --force`
+takes it anyway.
+
+This is how a supervisor shape runs on a board: file the pieces with their
+order, and each agent takes the next piece the moment the one before it
+resolves.
+
 ## Hand work off
 
 Two different questions get two different answers, and the board keeps them

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -168,6 +168,13 @@ window.MYCELIUM_SEARCH_INDEX = [
     "p": "Guide"
   },
   {
+    "u": "index.html#board-order-the-pieces",
+    "t": "Order the pieces",
+    "s": "Concepts › Board",
+    "x": "When one piece cannot start before another is done, say so with the same kind of relation: mycelium board new \"Write the migration\" --parent work/ship-passkey-login mycelium memory set work/run-the-migration \"Run the migration\" \\ --meta depends-on=work/write-the-migration The board reads what a row still waits on off the rows it names, and shows it (after work/write-the-migration). Nothing stores that: when the depen",
+    "p": "Guide"
+  },
+  {
     "u": "index.html#board-hand-work-off",
     "t": "Hand work off",
     "s": "Concepts › Board",

--- a/fastapi-backend/app/config.py
+++ b/fastapi-backend/app/config.py
@@ -185,6 +185,14 @@ class Settings(BaseSettings):
     # Per-turn wall-clock bound (seconds) on the hello engine's one-shot pi call.
     HELLO_PI_TIMEOUT_S: float = 60.0
 
+    # The board's dependency gate. A ``work/`` row whose ``depends-on`` names a
+    # board row that is not yet resolved reads as waiting on it — always derived,
+    # always shown. Whether a claim on such a row is *refused* is this switch,
+    # off by default: a room that has been writing ``depends-on`` descriptively
+    # must not find its rows unclaimable one morning. ``force`` on the claim
+    # overrides it for the caller who knows better.
+    BOARD_DEPENDENCY_GATE: bool = False
+
     # Persona engine (kind ``persona``) — answers in character, from the
     # persona written to its ``agents/<handle>/notes`` memory, on a Pi session
     # kept per handle so it remembers across turns. Dormant like the others.

--- a/fastapi-backend/app/routes/assignments.py
+++ b/fastapi-backend/app/routes/assignments.py
@@ -56,6 +56,13 @@ class ClaimBody(BaseModel):
         ge=1,
         description="Minutes the claim holds without a renewal before it drains",
     )
+    force: bool = Field(
+        False,
+        description=(
+            "Take the row even while it waits on an unresolved dependency "
+            "(only refused when the room's dependency gate is on)"
+        ),
+    )
 
 
 class ReleaseBody(BaseModel):
@@ -80,7 +87,7 @@ async def claim_assignment(room_name: str, body: ClaimBody, request: Request):
     handle = actor.bind_delegated_actor(request, room_name, body.handle, field="handle")
     try:
         return await assignments.claim(
-            room_name, body.key, handle, body.ttl_minutes, datetime.now(UTC)
+            room_name, body.key, handle, body.ttl_minutes, datetime.now(UTC), force=body.force
         )
     except assignments.AssignmentError as e:
         raise _fail(e) from e

--- a/fastapi-backend/app/services/assignments.py
+++ b/fastapi-backend/app/services/assignments.py
@@ -44,6 +44,7 @@ import asyncio
 from datetime import UTC, datetime
 from typing import Any
 
+from app.config import settings
 from app.services.filesystem import (
     EPISODE_META,
     get_room_dir,
@@ -64,6 +65,18 @@ DEFAULT_TTL_MINUTES = 30
 
 RUNTIME_AUTHOR = "runtime"
 ASSIGNABLE_NAMESPACES = ("work",)
+
+#: The relation a row waits on: the typed ``depends-on`` link any memory can
+#: carry (:data:`app.services.links.RELATION_KEYS`), read here as "cannot start
+#: before these rows are done". Only a target that is a board row counts — a
+#: ``context/`` note is never resolved, so waiting on one would wait forever.
+DEPENDENCY_RELATION = "depends-on"
+#: The derived field: the dependencies still open. Never stored, like expiry —
+#: it is read off the targets' own state each time, so it needs no process to
+#: be alive when a dependency resolves.
+WAITING_FIELD = "waiting_on"
+#: Statuses a row's dependents read as done with.
+SETTLED_STATUSES = frozenset({"resolved", "dismissed"})
 
 #: How often a lease watch re-reads the row it is watching.
 POLL_INTERVAL_S = 1.0
@@ -137,6 +150,50 @@ def assignable(key: str) -> bool:
     return key.split("/")[0] in ASSIGNABLE_NAMESPACES
 
 
+def dependencies(meta: dict) -> list[str]:
+    """The row keys ``meta`` says this row waits on, as written."""
+    raw = meta.get(DEPENDENCY_RELATION)
+    values = raw if isinstance(raw, list) else [raw]
+    return [v.strip() for v in values if isinstance(v, str) and v.strip()]
+
+
+def settled(meta: dict, now: datetime) -> bool:
+    """Whether a row is done as far as anything waiting on it is concerned."""
+    return meta.get("status") in SETTLED_STATUSES or state_of(meta, now) == "resolved"
+
+
+def waiting_on(room: str, meta: dict, now: datetime) -> list[str]:
+    """The board rows ``meta``'s dependencies name that are not yet settled.
+
+    A dependency that names no memory, or names one outside the board
+    namespaces, is not waited on: the link index already reports the first as
+    broken, and the second is a reference rather than a prerequisite.
+    """
+    from app.services.tasks import is_board_row
+
+    room_dir = get_room_dir(room)
+    open_rows: list[str] = []
+    for key in dependencies(meta):
+        if not is_board_row(key):
+            continue
+        found = read_memory_file(room_dir, key)
+        if found is None or settled(found[0], now):
+            continue
+        open_rows.append(key)
+    return open_rows
+
+
+def dependents_of(room: str, key: str) -> list[tuple[str, dict]]:
+    """Every assignable row that names ``key`` as a dependency, with its frontmatter."""
+    room_dir = get_room_dir(room)
+    found: list[tuple[str, dict]] = []
+    for namespace in ASSIGNABLE_NAMESPACES:
+        for row_key, meta, _content in list_memory_files(room_dir, prefix=f"{namespace}/"):
+            if key in dependencies(meta):
+                found.append((row_key, meta))
+    return found
+
+
 def _load(room: str, key: str) -> tuple[dict, str]:
     if not assignable(key):
         raise AssignmentError(
@@ -150,13 +207,14 @@ def _load(room: str, key: str) -> tuple[dict, str]:
     return found
 
 
-def _describe(key: str, meta: dict, now: datetime) -> dict:
+def _describe(room: str, key: str, meta: dict, now: datetime) -> dict:
     """The row's assignment, as the wire says it."""
     state = state_of(meta, now)
     owner = meta.get("owner")
     body = {
         "key": key,
         "assignment": state,
+        WAITING_FIELD: waiting_on(room, meta, now),
         "owner": str(owner).lstrip("@") if owner else None,
         "claimed_at": meta.get("claimed_at"),
         "ttl_minutes": meta.get("ttl_minutes"),
@@ -186,7 +244,7 @@ async def _write(
     from app.services.fields import upsert_patch
 
     fresh_meta = await upsert_patch(room, key, meta, content, patch, handle, notify=notify)
-    return _describe(key, fresh_meta, datetime.now(UTC))
+    return _describe(room, key, fresh_meta, datetime.now(UTC))
 
 
 async def raise_notice(room: str, key: str, subkind: str, by: str) -> None:
@@ -211,13 +269,20 @@ async def raise_notice(room: str, key: str, subkind: str, by: str) -> None:
     )
 
 
-async def claim(room: str, key: str, handle: str, ttl_minutes: int, now: datetime) -> dict:
+async def claim(
+    room: str, key: str, handle: str, ttl_minutes: int, now: datetime, *, force: bool = False
+) -> dict:
     """Take assignment of a row, for as long as the lease runs.
 
     A live claim is not stealable — that is the point of holding one — but an
     expired one is: the row is back in the pool, and refusing the next taker
     because a dead session's handle is still in the file would be the original
     failure with extra steps.
+
+    A row still waiting on a dependency is refused too, when the room's
+    dependency gate is on (:attr:`~app.config.Settings.BOARD_DEPENDENCY_GATE`,
+    off by default): the refusal names what it waits on, and ``force`` takes
+    the row anyway for the caller who knows better.
     """
     meta, content = _load(room, key)
     current = state_of(meta, now)
@@ -231,6 +296,15 @@ async def claim(room: str, key: str, handle: str, ttl_minutes: int, now: datetim
             claimed_at=meta.get("claimed_at"),
             ttl_minutes=meta.get("ttl_minutes"),
         )
+    if settings.BOARD_DEPENDENCY_GATE and not force:
+        open_rows = waiting_on(room, meta, now)
+        if open_rows:
+            raise AssignmentError(
+                f"'{key}' waits on {', '.join(open_rows)}",
+                status=409,
+                key=key,
+                **{WAITING_FIELD: open_rows},
+            )
     patch = {
         FIELD: "held",
         "owner": f"@{handle.lstrip('@')}",
@@ -278,7 +352,21 @@ async def resolve(room: str, key: str, handle: str, now: datetime) -> dict:
     }
     described = await _write(room, key, meta, content, patch, handle)
     await raise_notice(room, key, "resolved", handle)
+    await _release_dependents(room, key, handle, now)
     return described
+
+
+async def _release_dependents(room: str, key: str, handle: str, now: datetime) -> None:
+    """Tell the room which rows ``key`` resolving just unblocked.
+
+    Derived state is never written, so the only trace a dependency's resolve
+    leaves on its dependents is this notice — raised for each one that now
+    waits on nothing and is not itself done.
+    """
+    for row_key, meta in dependents_of(room, key):
+        if settled(meta, now) or waiting_on(room, meta, now):
+            continue
+        await raise_notice(room, row_key, "unblocked", handle)
 
 
 async def renew(room: str, handle: str, now: datetime) -> list[dict]:
@@ -312,7 +400,7 @@ async def renew(room: str, handle: str, now: datetime) -> list[dict]:
 def read(room: str, key: str, now: datetime) -> dict:
     """The row's assignment right now, without changing anything."""
     meta, _ = _load(room, key)
-    return _describe(key, meta, now)
+    return _describe(room, key, meta, now)
 
 
 def signature(body: dict) -> str:
@@ -322,9 +410,11 @@ def signature(body: dict) -> str:
     without anyone writing a byte, and a watcher that keyed on the version would
     sleep through the one transition nobody sends.
     """
-    return "|".join(
-        str(body.get(part) or "") for part in ("assignment", "owner", "claimed_at", "version")
-    )
+    parts = [str(body.get(part) or "") for part in ("assignment", "owner", "claimed_at", "version")]
+    # A dependency resolving is a transition of this lease too: the row just
+    # became claimable, which is exactly what a watcher on a waiting row wants.
+    parts.append(",".join(body.get(WAITING_FIELD) or []))
+    return "|".join(parts)
 
 
 async def watch(room: str, key: str, since: str | None, timeout: int, now_fn=None) -> dict:

--- a/fastapi-backend/tests/test_dependencies.py
+++ b/fastapi-backend/tests/test_dependencies.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""A row that depends on another waits on it, and the board says so.
+
+``depends-on`` is a typed link any memory can carry; on a ``work/`` row it
+reads as a prerequisite. What a row waits on is derived off its targets'
+own state, never written, so nothing has to be alive when a dependency
+resolves. Refusing a claim on a waiting row is a room switch, off by default.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+
+from app.services import assignments
+from tests.test_assignments import make_room, make_work
+
+NOW = datetime(2026, 9, 3, 12, 0, tzinfo=UTC)
+
+
+def test_dependencies_read_a_string_or_a_list():
+    assert assignments.dependencies({"depends-on": "work/a"}) == ["work/a"]
+    assert assignments.dependencies({"depends-on": ["work/a", " work/b ", 3, ""]}) == [
+        "work/a",
+        "work/b",
+    ]
+    assert assignments.dependencies({}) == []
+
+
+def test_settled_is_a_done_status_or_a_resolved_lease():
+    assert assignments.settled({"status": "resolved"}, NOW)
+    assert assignments.settled({"status": "dismissed"}, NOW)
+    assert assignments.settled({"assignment": "resolved"}, NOW)
+    assert not assignments.settled({"status": "open"}, NOW)
+    assert not assignments.settled({}, NOW)
+
+
+class TestWaiting:
+    @pytest.mark.asyncio
+    async def test_a_row_waits_on_its_open_dependencies_and_not_its_done_ones(
+        self, client: AsyncClient
+    ):
+        await make_room(client, "deps")
+        await make_work(client, "deps", "work/schema")
+        await make_work(client, "deps", "work/migrate", status="resolved")
+        await make_work(
+            client, "deps", "work/api", **{"depends-on": ["work/schema", "work/migrate"]}
+        )
+
+        read = await client.get("/api/rooms/deps/assignments/work/api")
+        assert read.status_code == 200
+        assert read.json()["waiting_on"] == ["work/schema"]
+
+    @pytest.mark.asyncio
+    async def test_a_note_and_a_missing_key_are_not_waited_on(self, client: AsyncClient):
+        await make_room(client, "deps-refs")
+        await client.post(
+            "/api/rooms/deps-refs/memory",
+            json={
+                "items": [
+                    {
+                        "key": "context/design",
+                        "value": "the design",
+                        "created_by": "julia",
+                        "embed": False,
+                    }
+                ]
+            },
+        )
+        await make_work(
+            client,
+            "deps-refs",
+            "work/api",
+            **{"depends-on": ["context/design", "work/never-filed"]},
+        )
+
+        read = await client.get("/api/rooms/deps-refs/assignments/work/api")
+        assert read.json()["waiting_on"] == []
+
+    @pytest.mark.asyncio
+    async def test_a_row_with_no_dependencies_waits_on_nothing(self, client: AsyncClient):
+        await make_room(client, "deps-none")
+        await make_work(client, "deps-none", "work/api")
+        read = await client.get("/api/rooms/deps-none/assignments/work/api")
+        assert read.json()["waiting_on"] == []
+
+
+class TestTheGate:
+    @pytest.mark.asyncio
+    async def test_with_the_gate_off_a_waiting_row_is_claimable(self, client: AsyncClient):
+        await make_room(client, "gate-off")
+        await make_work(client, "gate-off", "work/schema")
+        await make_work(client, "gate-off", "work/api", **{"depends-on": "work/schema"})
+
+        resp = await client.post(
+            "/api/rooms/gate-off/assignments/claim", json={"key": "work/api", "handle": "api"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["waiting_on"] == ["work/schema"]
+
+    @pytest.mark.asyncio
+    async def test_with_the_gate_on_the_refusal_names_what_it_waits_on(
+        self, client: AsyncClient, monkeypatch
+    ):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "BOARD_DEPENDENCY_GATE", True)
+        await make_room(client, "gate-on")
+        await make_work(client, "gate-on", "work/schema")
+        await make_work(client, "gate-on", "work/api", **{"depends-on": "work/schema"})
+
+        resp = await client.post(
+            "/api/rooms/gate-on/assignments/claim", json={"key": "work/api", "handle": "api"}
+        )
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert detail["waiting_on"] == ["work/schema"]
+        assert "waits on work/schema" in detail["message"]
+
+        forced = await client.post(
+            "/api/rooms/gate-on/assignments/claim",
+            json={"key": "work/api", "handle": "api", "force": True},
+        )
+        assert forced.status_code == 200
+        assert forced.json()["assignment"] == "held"
+
+    @pytest.mark.asyncio
+    async def test_the_gate_opens_when_the_dependency_resolves(
+        self, client: AsyncClient, monkeypatch
+    ):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "BOARD_DEPENDENCY_GATE", True)
+        await make_room(client, "gate-opens")
+        await make_work(client, "gate-opens", "work/schema")
+        await make_work(client, "gate-opens", "work/api", **{"depends-on": "work/schema"})
+        await client.post(
+            "/api/rooms/gate-opens/assignments/claim", json={"key": "work/schema", "handle": "db"}
+        )
+        await client.post(
+            "/api/rooms/gate-opens/assignments/resolve", json={"key": "work/schema", "handle": "db"}
+        )
+
+        resp = await client.post(
+            "/api/rooms/gate-opens/assignments/claim", json={"key": "work/api", "handle": "api"}
+        )
+        assert resp.status_code == 200
+
+
+class TestResolving:
+    @pytest.mark.asyncio
+    async def test_resolving_a_dependency_unblocks_its_dependents_in_the_timeline(
+        self, client: AsyncClient, monkeypatch
+    ):
+        from app.services import room_channels
+
+        raised: list[dict] = []
+
+        async def _notice(room, **kw):
+            raised.append(kw)
+
+        monkeypatch.setattr(room_channels.manager, "raise_notice", _notice)
+        await make_room(client, "unblocks")
+        await make_work(client, "unblocks", "work/schema")
+        await make_work(client, "unblocks", "work/api", **{"depends-on": "work/schema"})
+        # Waits on two, so resolving one is not enough to unblock it.
+        await make_work(client, "unblocks", "work/other")
+        await make_work(
+            client, "unblocks", "work/deploy", **{"depends-on": ["work/schema", "work/other"]}
+        )
+        # Already done itself: nothing to unblock.
+        await make_work(
+            client, "unblocks", "work/old", status="resolved", **{"depends-on": "work/schema"}
+        )
+
+        await client.post(
+            "/api/rooms/unblocks/assignments/resolve", json={"key": "work/schema", "handle": "db"}
+        )
+
+        unblocked = [n["key"] for n in raised if n["subkind"] == "unblocked"]
+        assert unblocked == ["work/api"]
+        assert [n["by"] for n in raised if n["subkind"] == "unblocked"] == ["db"]
+
+    @pytest.mark.asyncio
+    async def test_a_lease_watcher_wakes_when_the_row_becomes_claimable(self, client: AsyncClient):
+        await make_room(client, "deps-watch")
+        await make_work(client, "deps-watch", "work/schema")
+        await make_work(client, "deps-watch", "work/api", **{"depends-on": "work/schema"})
+
+        first = await client.get(
+            "/api/rooms/deps-watch/assignments/await", params={"key": "work/api"}
+        )
+        since = first.json()["since"]
+        await client.post(
+            "/api/rooms/deps-watch/assignments/resolve", json={"key": "work/schema", "handle": "db"}
+        )
+        woke = await client.get(
+            "/api/rooms/deps-watch/assignments/await",
+            params={"key": "work/api", "since": since, "timeout": 2},
+        )
+        assert woke.json()["changed"] is True
+        assert woke.json()["waiting_on"] == []

--- a/mycelium-cli/src/mycelium/board/model.py
+++ b/mycelium-cli/src/mycelium/board/model.py
@@ -57,6 +57,14 @@ EPISODE_FIELD = "episode"
 #: converges inside a row must not resolve the row or take it off its holder.
 THREAD_FIELDS = ["episode", "thread", "thread_state", "participants", "rounds"]
 
+#: The relation a row waits on, and the derived field that says what it still
+#: waits on. A ``work/`` row whose ``depends-on`` names a live row that is not
+#: settled is waiting; the projection reads that off the other rows on the
+#: board and stores nothing, the way a lease's expiry is read off the clock.
+DEPENDENCY_RELATION = "depends-on"
+WAITING_FIELD = "waiting_on"
+SETTLED_STATUSES = ["resolved", "dismissed"]
+
 #: How the thread inside a task reads. ``open`` while it is still running;
 #: the rest are the commit subkinds a negotiation closes on.
 THREAD_STATES = ["open", "converged", "resolved", "rejected", "committed"]

--- a/mycelium-cli/src/mycelium/board/projection.py
+++ b/mycelium-cli/src/mycelium/board/projection.py
@@ -24,7 +24,16 @@ from datetime import datetime
 from typing import Any
 
 from mycelium.board import assignment
-from mycelium.board.model import EPISODE_FIELD, LIVE_NAMESPACES, ItemSource, LiveItem
+from mycelium.board import fields as board_fields
+from mycelium.board.model import (
+    DEPENDENCY_RELATION,
+    EPISODE_FIELD,
+    LIVE_NAMESPACES,
+    SETTLED_STATUSES,
+    WAITING_FIELD,
+    ItemSource,
+    LiveItem,
+)
 
 
 def _pretty_topic(topic: str) -> str:
@@ -174,6 +183,30 @@ def _thread_fields(episode: dict) -> dict[str, Any]:
     }
 
 
+def _settled(row: LiveItem) -> bool:
+    """Done, as far as a row waiting on this one is concerned."""
+    return row.status in SETTLED_STATUSES or row.text(assignment.FIELD) == "resolved"
+
+
+def fold_waiting(rows: list[LiveItem]) -> None:
+    """Write onto each row what it still waits on, read off the other rows.
+
+    Only a dependency that is itself a row here counts: a note or a key the
+    board does not carry is a reference, not a prerequisite. A row with no
+    dependencies gets no field, so the column exists only where it says
+    something.
+    """
+    by_key = {board_fields.memory_key_of(row): row for row in rows}
+    by_key.pop(None, None)
+    for row in rows:
+        named = row.strings(DEPENDENCY_RELATION)
+        if not named:
+            continue
+        row.fields[WAITING_FIELD] = [
+            key for key in named if (dep := by_key.get(key)) is not None and not _settled(dep)
+        ]
+
+
 def project_items(
     *,
     episodes: list[dict],
@@ -200,6 +233,8 @@ def project_items(
             continue
         folded.add(str(episode.get("episode")))
         row.fields.update(_thread_fields(episode))
+
+    fold_waiting(rows)
 
     items += [_episode_item(e) for e in episodes if str(e.get("episode")) not in folded]
     items += rows

--- a/mycelium-cli/src/mycelium/commands/board.py
+++ b/mycelium-cli/src/mycelium/commands/board.py
@@ -53,6 +53,7 @@ from mycelium.board.model import (
     PRIORITIES,
     STATUSES,
     THREAD_REFUSALS,
+    WAITING_FIELD,
     format_age,
 )
 from mycelium.board.schema import groupable_fields
@@ -319,6 +320,9 @@ def _row_lines(item: LiveItem, now: datetime) -> Text:
         meta.append(f"  {pr}", style="dim")
     if blocked_by := item.strings("blocked_by"):
         meta.append(f"  waiting on {', '.join(blocked_by)}", style="red")
+    if waiting := item.strings(WAITING_FIELD):
+        # What the board itself still has to finish first, read off those rows.
+        meta.append(f"  after {', '.join(waiting)}", style="yellow")
     if choices := item.strings("choices"):
         meta.append(f"  [{'] ['.join(choices)}]", style="cyan")
     meta.append(f"  {format_age(item.age_minutes(now))}", style="dim")
@@ -537,9 +541,19 @@ def board_claim(
     ttl: int = typer.Option(
         assignment.DEFAULT_TTL_MINUTES, "--ttl", help="Minutes the claim holds without a renewal"
     ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Take the row even while it waits on an unresolved dependency",
+    ),
     room: str | None = typer.Option(None, "--room", "-r", help="Room name"),
 ) -> None:
-    """Claim a row, as a lease rather than a fact."""
+    """Claim a row, as a lease rather than a fact.
+
+    A row that depends on rows not yet resolved is shown waiting on them, and a
+    room whose dependency gate is on refuses the claim until they are; ``--force``
+    takes it anyway.
+    """
     cfg = MyceliumConfig.load()
     name = _resolve_room(cfg, room)
     item = _row(name, row_id)
@@ -553,7 +567,15 @@ def board_claim(
         console.print(f"[yellow]·[/yellow] {row_id} can't be claimed — {refusal}")
         raise typer.Exit(1)
     handle = (to or cfg.get_current_identity()).lstrip("@")
-    _write_assignment(cfg, name, "claim", key=_assignment_key(item), handle=handle, ttl_minutes=ttl)
+    _write_assignment(
+        cfg,
+        name,
+        "claim",
+        key=_assignment_key(item),
+        handle=handle,
+        ttl_minutes=ttl,
+        force=force or None,
+    )
 
 
 @doc_ref(
@@ -717,6 +739,13 @@ def _write_assignment(cfg: MyceliumConfig, room: str, action: str, **body: Any) 
         raise typer.Exit(1) from e
     if resp.status_code == 409:
         detail = resp.json().get("detail", {})
+        waiting = detail.get(WAITING_FIELD) if isinstance(detail, dict) else None
+        if waiting:
+            console.print(
+                f"[yellow]·[/yellow] {payload.get('key')} still waits on {', '.join(waiting)}. "
+                "[dim]Resolve those first, or pass --force to take it anyway.[/dim]"
+            )
+            raise typer.Exit(1)
         held_by = detail.get("owner") if isinstance(detail, dict) else None
         console.print(
             f"[yellow]·[/yellow] {payload.get('key')} is already held by @{held_by}. "

--- a/mycelium-cli/src/mycelium/docs/concepts/board.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/board.md
@@ -169,6 +169,34 @@ link.
 Each child is a full task with its own thread, so a sub-problem gets its own
 conversation instead of crowding the parent's.
 
+### Order the pieces
+
+When one piece cannot start before another is done, say so with the same kind
+of relation:
+
+```bash
+mycelium board new "Write the migration" --parent work/ship-passkey-login
+mycelium memory set work/run-the-migration "Run the migration" \
+  --meta depends-on=work/write-the-migration
+```
+
+The board reads what a row still waits on off the rows it names, and shows
+it (`after work/write-the-migration`). Nothing stores that: when the
+dependency resolves, its dependents stop waiting with nobody writing a byte,
+the room's timeline says the row was unblocked, and an agent sitting in
+`mycelium await --lease` on it wakes because the row it watches just became
+claimable. A dependency that is not a task on this board, a note or a key
+nobody filed, is a reference rather than a prerequisite and is not waited on.
+
+By default a waiting row can still be claimed: showing the order is the
+board's job, enforcing it is a choice. A hub with `BOARD_DEPENDENCY_GATE`
+on refuses the claim and names what the row waits on; `board claim --force`
+takes it anyway.
+
+This is how a supervisor shape runs on a board: file the pieces with their
+order, and each agent takes the next piece the moment the one before it
+resolves.
+
 ## Hand work off
 
 Two different questions get two different answers, and the board keeps them

--- a/mycelium-cli/tests/test_board_assignment.py
+++ b/mycelium-cli/tests/test_board_assignment.py
@@ -374,3 +374,60 @@ class TestProjection:
         assert row_.status == "open"
         assert row_.kind == "blocked"
         assert assignment.attention_of_item(row_, NOW) == "needs_you"
+
+
+class TestWaiting:
+    """What a row still waits on, read off the other rows and stored nowhere."""
+
+    TASK_CONTRACT = json.loads(
+        (Path(__file__).resolve().parents[2] / "contracts" / "board-vocabulary.json").read_text()
+    )["task"]
+
+    def test_the_words_match_the_contract(self):
+        from mycelium.board import model
+
+        assert self.TASK_CONTRACT["dependency_relation"] == model.DEPENDENCY_RELATION
+        assert self.TASK_CONTRACT["waiting_field"] == model.WAITING_FIELD
+        assert self.TASK_CONTRACT["settled_statuses"] == model.SETTLED_STATUSES
+
+    @staticmethod
+    def memory(key: str, **meta):
+        return {
+            "key": key,
+            "value": "Spike the auth rewrite",
+            "created_by": "julia",
+            "updated_by": "julia",
+            "updated_at": ago(5),
+            "meta": meta,
+        }
+
+    def project(self, *memories):
+        rows = project_items(episodes=[], memories=list(memories), agents=[], members=[], now=NOW)
+        return {row.source.label: row for row in rows}
+
+    def test_a_row_waits_on_its_open_dependencies_and_not_its_settled_ones(self):
+        rows = self.project(
+            self.memory("work/schema"),
+            self.memory("work/migrate", status="resolved"),
+            self.memory("work/deploy", assignment="resolved"),
+            self.memory(
+                "work/api", **{"depends-on": ["work/schema", "work/migrate", "work/deploy"]}
+            ),
+        )
+        assert rows["work/api"].strings("waiting_on") == ["work/schema"]
+
+    def test_a_reference_is_not_a_prerequisite(self):
+        rows = self.project(
+            self.memory("work/api", **{"depends-on": ["context/design", "work/never-filed"]}),
+        )
+        assert rows["work/api"].strings("waiting_on") == []
+
+    def test_a_row_with_no_dependencies_carries_no_column(self):
+        rows = self.project(self.memory("work/api"))
+        assert "waiting_on" not in rows["work/api"].fields
+
+    def test_a_single_dependency_reads_as_one(self):
+        rows = self.project(
+            self.memory("work/schema"), self.memory("work/api", **{"depends-on": "work/schema"})
+        )
+        assert rows["work/api"].strings("waiting_on") == ["work/schema"]

--- a/mycelium-frontend/src/lib/board/assignment.test.ts
+++ b/mycelium-frontend/src/lib/board/assignment.test.ts
@@ -35,6 +35,8 @@ import {
 } from "@/lib/board/assignment";
 import { attentionFilterOf, type LiveItem, type SourceKind } from "@/lib/board/item";
 import { projectItems } from "@/lib/board/projection";
+import { DEPENDENCY_RELATION, SETTLED_STATUSES, WAITING_FIELD, waitingOnRows } from "@/lib/board/assignment";
+import { waitingOn } from "@/lib/board/view";
 import type { AgentSummary, Memory, PresenceMember } from "@/lib/api";
 
 const CONTRACT = JSON.parse(
@@ -308,5 +310,72 @@ describe("the projection, once assignment is the axis", () => {
     // Nobody touched the row. It drained.
     expect(assignmentOf(item, NOW)).toBe("expired");
     expect(attentionFilterOf(item, NOW)).toBe("needs_you");
+  });
+});
+
+describe("what a row waits on", () => {
+  // Read off the other rows and stored nowhere: a dependency resolving changes
+  // what its dependents wait on with nobody writing a byte.
+  const contract = JSON.parse(
+    readFileSync(join(__dirname, "..", "..", "..", "..", "contracts", "board-vocabulary.json"), "utf8"),
+  ) as { task: { dependency_relation: string; waiting_field: string; settled_statuses: string[] } };
+
+  const memory = (key: string, meta: Record<string, unknown> = {}): Memory => ({
+    key,
+    value: "Spike the auth rewrite",
+    content_text: "Spike the auth rewrite",
+    version: 1,
+    created_by: "julia",
+    updated_by: "julia",
+    updated_at: new Date(NOW).toISOString(),
+    meta,
+  });
+
+  const project = (...memories: Memory[]) => {
+    const rows = projectItems({
+      room: "atlas",
+      episodes: [],
+      memories,
+      agents: [],
+      presence: new Map(),
+      now: new Date(NOW).toISOString(),
+    });
+    return new Map(rows.map(row => [row.source.label, row]));
+  };
+
+  it("uses the contracted words, as the CLI must too", () => {
+    expect(DEPENDENCY_RELATION).toBe(contract.task.dependency_relation);
+    expect(WAITING_FIELD).toBe(contract.task.waiting_field);
+    expect([...SETTLED_STATUSES]).toEqual(contract.task.settled_statuses);
+  });
+
+  it("waits on its open dependencies and not its settled ones", () => {
+    const rows = project(
+      memory("work/schema"),
+      memory("work/migrate", { status: "resolved" }),
+      memory("work/deploy", { assignment: "resolved" }),
+      memory("work/api", { "depends-on": ["work/schema", "work/migrate", "work/deploy"] }),
+    );
+    expect(waitingOnRows(rows.get("work/api")!)).toEqual(["work/schema"]);
+    expect(waitingOn(rows.get("work/api")!)).toBe("after work/schema");
+  });
+
+  it("does not wait on a reference", () => {
+    const rows = project(memory("work/api", { "depends-on": ["context/design", "work/never-filed"] }));
+    expect(waitingOnRows(rows.get("work/api")!)).toEqual([]);
+    expect(waitingOn(rows.get("work/api")!)).toBeNull();
+  });
+
+  it("carries no column where there is nothing to say", () => {
+    const rows = project(memory("work/api"));
+    expect(WAITING_FIELD in rows.get("work/api")!.fields).toBe(false);
+  });
+
+  it("a named blocker still reads first", () => {
+    const rows = project(
+      memory("work/schema"),
+      memory("work/api", { "depends-on": "work/schema", blocked_by: ["#502"] }),
+    );
+    expect(waitingOn(rows.get("work/api")!)).toBe("waiting on #502");
   });
 });

--- a/mycelium-frontend/src/lib/board/assignment.ts
+++ b/mycelium-frontend/src/lib/board/assignment.ts
@@ -37,7 +37,7 @@
  * file so no copy can drift alone.
  */
 
-import { fieldAsNumber, fieldAsString, ownerOf } from "./fields";
+import { fieldAsList, fieldAsNumber, fieldAsString, ownerOf } from "./fields";
 import type { LiveItem } from "./item";
 
 export const ASSIGNMENT_FIELD = "assignment";
@@ -103,6 +103,30 @@ export function reservedIn(names: string[]): string[] {
 
 /** A row is blocked because it names a blocker. Nothing stores the word. */
 export const BLOCKED_FIELD = "blocked_by";
+
+/**
+ * The relation a row waits on, and the derived field that says what it still
+ * waits on. A `work/` row whose `depends-on` names a live row that is not
+ * settled is waiting; the projection reads that off the other rows on the
+ * board and stores nothing, the way a lease's expiry is read off the clock.
+ */
+export const DEPENDENCY_RELATION = "depends-on";
+export const WAITING_FIELD = "waiting_on";
+export const SETTLED_STATUSES = ["resolved", "dismissed"] as const;
+
+/** Done, as far as a row waiting on this one is concerned. */
+export function isSettled(item: LiveItem): boolean {
+  const status = fieldAsString(item, "status") ?? "";
+  return (
+    (SETTLED_STATUSES as readonly string[]).includes(status) ||
+    fieldAsString(item, ASSIGNMENT_FIELD) === "resolved"
+  );
+}
+
+/** The rows this one still waits on, as the projection wrote them. */
+export function waitingOnRows(item: LiveItem): string[] {
+  return fieldAsList(item, WAITING_FIELD);
+}
 
 /**
  * When the holder last said it was still on this. A lease with no stamp of its

--- a/mycelium-frontend/src/lib/board/projection.ts
+++ b/mycelium-frontend/src/lib/board/projection.ts
@@ -21,7 +21,16 @@
 
 import type { AgentSummary, EpisodeSummary, Memory } from "@/lib/api";
 import type { PresenceMember } from "@/lib/api";
-import { ASSIGNMENT_FIELD, DEFAULT_TTL_MINUTES, ASSIGNABLE_NAMESPACES, assignmentOf } from "./assignment";
+import {
+  ASSIGNMENT_FIELD,
+  DEFAULT_TTL_MINUTES,
+  ASSIGNABLE_NAMESPACES,
+  DEPENDENCY_RELATION,
+  WAITING_FIELD,
+  assignmentOf,
+  isSettled,
+} from "./assignment";
+import { fieldAsList, memoryKeyOf } from "./fields";
 import type { LiveItem } from "./item";
 import { memoryHref } from "@/lib/memory-routes";
 import { memoryTitle } from "@/lib/memory-preview";
@@ -214,6 +223,29 @@ export interface ProjectionInput {
   captured?: LiveItem[];
 }
 
+/**
+ * Write onto each row what it still waits on, read off the other rows.
+ *
+ * Only a dependency that is itself a row here counts: a note or a key the board
+ * does not carry is a reference, not a prerequisite. A row with no dependencies
+ * gets no field, so the column exists only where it says something.
+ */
+export function foldWaiting(rows: LiveItem[]): void {
+  const byKey = new Map<string, LiveItem>();
+  for (const row of rows) {
+    const key = memoryKeyOf(row);
+    if (key) byKey.set(key, row);
+  }
+  for (const row of rows) {
+    const named = fieldAsList(row, DEPENDENCY_RELATION);
+    if (!named.length) continue;
+    row.fields[WAITING_FIELD] = named.filter(key => {
+      const dep = byKey.get(key);
+      return dep !== undefined && !isSettled(dep);
+    });
+  }
+}
+
 export function projectItems(input: ProjectionInput): LiveItem[] {
   const items: LiveItem[] = [];
 
@@ -230,6 +262,7 @@ export function projectItems(input: ProjectionInput): LiveItem[] {
     folded.add(ep.episode);
     Object.assign(row.fields, threadFields(ep));
   }
+  foldWaiting(rows);
   for (const ep of input.episodes) {
     if (!folded.has(ep.episode)) items.push(episodeItem(ep, input.room));
   }

--- a/mycelium-frontend/src/lib/board/view.ts
+++ b/mycelium-frontend/src/lib/board/view.ts
@@ -23,6 +23,7 @@ import {
   type AttentionFilter,
   type LiveItem,
 } from "./item";
+import { waitingOnRows } from "./assignment";
 import { fieldByName, humanize, type FieldSchema } from "./schema";
 
 export type ViewMode = "triage" | "board" | "table" | "timeline" | "daily";
@@ -288,6 +289,8 @@ export function attentionFilterCounts(items: LiveItem[], now: number = Date.now(
 export function waitingOn(item: LiveItem): string | null {
   const blockedBy = fieldAsList(item, "blocked_by");
   if (blockedBy.length) return `waiting on ${blockedBy.join(", ")}`;
+  const after = waitingOnRows(item);
+  if (after.length) return `after ${after.join(", ")}`;
   if (kindOf(item) === "decision" && statusOf(item) === "in_review") return "awaiting a call";
   return null;
 }

--- a/openapi.json
+++ b/openapi.json
@@ -4114,6 +4114,12 @@
             "title": "Ttl Minutes",
             "description": "Minutes the claim holds without a renewal before it drains",
             "default": 30
+          },
+          "force": {
+            "type": "boolean",
+            "title": "Force",
+            "description": "Take the row even while it waits on an unresolved dependency (only refused when the room's dependency gate is on)",
+            "default": false
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary

Fourth of the stacked PRs into [#953](https://github.com/mycelium-io/mycelium/pull/953). The board already derives "blocked" from a `blocked_by` field a person writes. This PR derives a second thing from a relation rows already carry: a `work/` row whose `depends-on` names a live board row that is not yet settled **waits on it**. That is what makes a task DAG a board thing rather than a protocol thing: the supervisor-and-workers and pipeline shapes are rows with their order written down, and each agent takes the next piece the moment the one before it resolves.

```bash
mycelium memory set work/run-the-migration "Run the migration" \
  --meta depends-on=work/write-the-migration
mycelium board          # …  after work/write-the-migration
mycelium await --lease work/run-the-migration --loop   # wakes when it becomes claimable
```

### Derived, never stored

`waiting_on` is read off the targets' own state every time, like a lease's expiry is read off the clock, so nothing has to be alive when a dependency resolves. It appears in every assignment read on the hub, and it is part of the lease watcher's signature, so `await --lease` on a waiting row wakes the moment its last dependency resolves. Resolving a row raises an `unblocked` timeline notice for each dependent that now waits on nothing (the existing notice subkind; no wire-contract change). Both board projections fold the same field off the other rows on the board and show it (`after work/x`, distinct from `waiting on #502` for a named blocker); the words are frozen in `contracts/board-vocabulary.json` under `task` and asserted on the CLI, the GUI and the hub.

A target outside the live namespaces (a `context/` note) or one that names no memory is a reference, not a prerequisite, and is not waited on. A row with no dependencies gets no column.

### Opt-in

Showing the order is always on. Enforcing it is `BOARD_DEPENDENCY_GATE`, off by default: with it on, a claim on a waiting row is refused with a 409 naming what it waits on, and `board claim --force` (a new `force` field on the claim body, so `openapi.json` is refreshed) takes it anyway. A room that has been writing `depends-on` descriptively finds nothing unclaimable.

## Changes

- `app/services/assignments.py`: `dependencies`, `settled`, `waiting_on`, `dependents_of`; `waiting_on` in the assignment description and the watch signature; the gated `claim`; `unblocked` notices from `resolve`.
- `app/routes/assignments.py`: `ClaimBody.force`. `app/config.py`: `BOARD_DEPENDENCY_GATE`. `openapi.json` refreshed.
- `contracts/board-vocabulary.json`: `task.dependency_relation`, `task.waiting_field`, `task.settled_statuses`.
- CLI: `board/model.py` constants, `projection.fold_waiting`, the `after …` line on a row, `board claim --force`, the 409 wording.
- GUI: `assignment.ts` constants and `isSettled`/`waitingOnRows`, `projection.foldWaiting`, the triage second line.
- Docs: an "Order the pieces" section on the board page, regenerated site, `CLAUDE.md` bullet.
- Tests: `test_dependencies.py` on the hub (derivation, references ignored, gate off, gate on with force, gate opens on resolve, unblocked notices, the lease watcher wakes); a `TestWaiting` class in the CLI's board assignment tests; a `what a row waits on` block in the GUI's; contract assertions on all three.

## Testing

- [x] Backend: `uv run pytest tests/ -x -q` — 1169 passed, 13 skipped; ruff, format, ty clean
- [x] CLI: 812 passed, 2 skipped (hub credentials unset); ruff, format, ty clean
- [x] Frontend: `npm run lint` (0 errors; one pre-existing warning in an untouched file), `npm test` — 863 passed
- [x] Docs regenerated; the diff is the new board section only

## Related Issues

Stacked on #953, after #954, #955 and #956.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk)_