### PR TITLE
Root a conductor run on its own episode, carrying its flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,25 +226,28 @@ is no litellm dependency.
   carries it; the `floor` notice and `/sessions/members` `floors` carry that
   row's `key` and `title`, and the GUI shows the title, falling back to the
   thread id only for a thread no row carries.
-- **The conductor runs a protocol inside a task, in code.** A fourth engine
-  kind (`app/services/conductor.py`) with no model of its own: summoned as
-  `board coordinate <row> conductor "gated @a @b: …"`, it walks a
-  `protocols.Protocol` (three built in: `gated`, `fan-out`, `round-robin`; a
-  room's `protocols/<name>` memory overrides or adds one) in the thread it was
-  summoned in, holding the floor for whoever each step addresses, asking
-  through `turns.addressed_turn`, and following the edge the reply's stance
-  takes (`markers.stance_of`, read off the payload or a marker left in prose so
-  a person's `board send` counts). It opens no negotiation and never commits
-  `converged`, so nothing it does compiles into rows. A model in the nodes,
-  code on the edges: the judgment is the members', the routing is the hub's.
-  The run is legible in its thread: an opening line names the cast and the
-  graph (`protocols.describe`), every tick starts with `name · step · turn
-  n of cap · handle`, a branch taken is said (`protocols.edge_line`), and a
-  built-in the room ran is written to `protocols/<name>` so it can be opened
-  and edited. The floor is taken synchronously in `handle_summon`, before the
-  run task is scheduled: the members named beside the conductor are role
-  bindings, so a persona there does not answer the summon and a resident
-  agent that replies early is refused.
+- **The conductor runs an episode with a flow, in code.** A fourth engine
+  kind (`app/services/conductor.py`) with no model of its own. Summoned as
+  `engine invoke conductor "gated @a @b: …"` (or `board coordinate <row>
+  conductor "…"` to nest the run in a task), it opens an **episode of its
+  own** and walks a `protocols.Protocol` in it (three built in: `gated`,
+  `fan-out`, `round-robin`; a room's `protocols/<name>` memory overrides or
+  adds one), holding the episode's floor for whoever each step addresses,
+  asking through `turns.addressed_turn`, and following the edge the reply's
+  stance takes (`markers.stance_of`). **The episode is the run and carries
+  its flow:** `EpisodeState.flow` (the graph plus who was bound to each role)
+  and `EpisodeState.trace` (one entry per step taken) are written onto
+  `log/episodes/{id}.md` at the opening and after every step, `within` names
+  the task thread it was opened from, and `episode_records` parses them back
+  (`flow`, `trace`, `within`, `current_step` on the episode read). The app
+  draws the graph at the top of the run's thread (`flow-panel.tsx`,
+  `flow-graph.tsx`, laid out by `lib/flow-graph.ts`), with the current step,
+  the edges taken and the member holding the floor. The floor is taken
+  synchronously in `handle_summon`; the members named beside the conductor
+  are role bindings, so a persona there does not answer the summon and a
+  resident agent that replies early is refused. A run opens no negotiation
+  and never commits `converged`, so nothing it does compiles into rows. A
+  model in the nodes, code on the edges.
 - **The aligner mediates, inside a task.** Agents never talk to each other directly;
   all coordination flows through the aligner. It's a first-party engine registered
   as a room citizen (`mycelium engine create aligner --kind aligner`) and summoned

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,8 +218,14 @@ is no litellm dependency.
   the addressed seam; the other engines act on mentions alone. A stance marker
   in its answer is lifted onto the payload like `/reply` does, and every `@` in
   what it says is neutralized, so personas cannot summon anything or each
-  other. Not a roster member: the aligner negotiates with one only when the
+  other, and it never posts into a thread whose floor was not given to it.
+  Not a roster member: the aligner negotiates with one only when the
   summon names it.
+- **A floor notice and the members' floors name the task, not the thread.**
+  `tasks.row_of_episode` is the reverse lookup from a thread to the row that
+  carries it; the `floor` notice and `/sessions/members` `floors` carry that
+  row's `key` and `title`, and the GUI shows the title, falling back to the
+  thread id only for a thread no row carries.
 - **The conductor runs a protocol inside a task, in code.** A fourth engine
   kind (`app/services/conductor.py`) with no model of its own: summoned as
   `board coordinate <row> conductor "gated @a @b: …"`, it walks a
@@ -231,6 +237,14 @@ is no litellm dependency.
   a person's `board send` counts). It opens no negotiation and never commits
   `converged`, so nothing it does compiles into rows. A model in the nodes,
   code on the edges: the judgment is the members', the routing is the hub's.
+  The run is legible in its thread: an opening line names the cast and the
+  graph (`protocols.describe`), every tick starts with `name · step · turn
+  n of cap · handle`, a branch taken is said (`protocols.edge_line`), and a
+  built-in the room ran is written to `protocols/<name>` so it can be opened
+  and edited. The floor is taken synchronously in `handle_summon`, before the
+  run task is scheduled: the members named beside the conductor are role
+  bindings, so a persona there does not answer the summon and a resident
+  agent that replies early is refused.
 - **The aligner mediates, inside a task.** Agents never talk to each other directly;
   all coordination flows through the aligner. It's a first-party engine registered
   as a room citizen (`mycelium engine create aligner --kind aligner`) and summoned

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -812,21 +812,27 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
 
     <section class="doc-section" id="conductor">
       <h1>Conductor</h1>
-      <p>The conductor is the <a href="#engines">engine</a> that runs a <strong>protocol</strong> inside a task: a fixed shape of who speaks to whom, in what order, and what happens on each answer. Where the <a href="#aligner">aligner</a> brokers a negotiation, the conductor walks a graph. It is the engine to reach for when a piece of work has a shape you already know: a proposal that a reviewer must approve, a lead asking every worker at once, a round where each member speaks in turn.</p>
-      <p>It is the one engine with no model of its own. Every judgment in a run, what to propose and whether to block it, is made by the members it addresses. The conductor only decides whose turn it is, and it enforces that in code: while a step is open, only the member it addressed can write into the thread. That is the split the whole design rests on. A model sits in each node, and code sits on the edges.</p>
+      <p>The conductor is the <a href="#engines">engine</a> that runs an <strong>episode with a flow</strong>: a fixed shape of who speaks to whom, in what order, and what happens on each answer. Where the <a href="#aligner">aligner</a> brokers a negotiation, the conductor walks a graph. It is the engine to reach for when an interaction has a shape you already know: a proposal a reviewer must approve, a lead asking every worker at once, members speaking in turn.</p>
+      <p>It is the one engine with no model of its own. Every judgment in a run, what to propose and whether to block it, is made by the members it addresses. The conductor only decides whose turn it is, and it enforces that in code: while a step is open, only the member it addressed can write into the episode. That is the split the whole design rests on. A model sits in each node, and code sits on the edges.</p>
       <pre><code><span class="comment"># Register it once per room</span>
 <span class="bin">mycelium</span> <span class="cmd">engine</span> <span class="cmd">create</span> conductor <span class="flag">--kind</span> conductor <span class="flag">--room</span> sprint-plan
 
-<span class="comment"># Run the gated protocol inside a task: @api proposes, @sec approves or blocks</span>
-<span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">coordinate</span> work/rotate-signing-key conductor \
+<span class="comment"># Open a gated run: @api proposes, @sec approves or blocks</span>
+<span class="bin">mycelium</span> <span class="cmd">engine</span> <span class="cmd">invoke</span> conductor \
+  <span class="str">&quot;gated @api @sec: rotate the signing key without downtime&quot;</span> <span class="flag">-r</span> sprint-plan</code></pre>
+      <p>The summon names the flow first, then the members in the order the flow&#x27;s roles expect, then the question.</p>
+      <h2 id="conductor-the-episode-is-the-run">The episode is the run</h2>
+      <p>Every run opens an <a href="index.html#episodes">episode</a> of its own, and the episode carries its flow. The graph the conductor walks, who was bound to each role, and the trace of every step taken are written onto the episode&#x27;s record as it goes, so an open run shows where it stands and a finished one shows the shape of the interaction, not only its messages. Open the episode in the app and the graph is drawn at the top of its thread: the current step lit, the edges taken solid, the member who has the floor marked, and the steps taken listed under it.</p>
+      <p>A run can be opened from a task, which makes it a phase inside that task the way a negotiation is:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">coordinate</span> work/rotate-signing-key conductor \
   <span class="str">&quot;gated @api @sec: rotate the signing key without downtime&quot;</span></code></pre>
-      <p>The summon names the protocol first, then the members in the order the protocol&#x27;s roles expect, then the question. The run happens in the thread the summon was made in, so the row&#x27;s conversation carries the whole thing and <code>board messages</code> reads it back. A summon from the room itself (<code>engine invoke</code>) opens a thread of its own, because the room is never narrowed to one speaker.</p>
-      <h2 id="conductor-the-built-in-protocols">The built-in protocols</h2>
+      <p>The run still gets its own episode. The task&#x27;s thread gets one line when the run opens (naming the episode and the cast) and one when it ends, and the episode&#x27;s record says which task it ran inside. A run opened from the room is nested in nothing. Either way the task is context or an output, never the container the flow lives in.</p>
+      <h2 id="conductor-the-built-in-flows">The built-in flows</h2>
       <div class="table-wrap">
         <table>
           <thead>
             <tr>
-              <th>Protocol</th>
+              <th>Flow</th>
               <th>Roles</th>
               <th>Shape</th>
             </tr>
@@ -850,9 +856,9 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
           </tbody>
         </table>
       </div>
-      <p>Any member can fill a role: a registered agent kept awake with <code>mycelium await --loop</code>, an engine such as <a href="#hello">hello</a>, or a person. A person answers a step the way they answer anything in a thread, with <code>board send</code>, and a stance marker left in the text is read the same as one an agent&#x27;s reply carried. That is how a human-in-the-loop step works: the conductor gives the person the floor and waits.</p>
-      <h2 id="conductor-watching-a-run">Watching a run</h2>
-      <p>A run is meant to be read from the outside, in the thread it runs in. The conductor opens by saying who plays what and the graph it is about to walk:</p>
+      <p>Any member can fill a role: a registered agent kept awake with <code>mycelium await --loop</code>, a <a href="#persona">persona</a>, or a person. A person answers a step the way they answer anything in a thread, and a stance marker left in the text is read the same as one an agent&#x27;s reply carried. That is how a human-in-the-loop step works: the conductor gives the person the floor and waits. Ask the conductor what it can run with <code>mycelium engine invoke conductor &quot;list&quot;</code>.</p>
+      <h2 id="conductor-reading-a-run">Reading a run</h2>
+      <p>A run is meant to be read from the outside. The conductor opens by saying who plays what and the graph it is about to walk:</p>
       <pre><code>Running gated with api as proposer, sec as guardian.
 
 **gated**: A proposer proposes, a guardian approves or blocks; a block sends it back.
@@ -861,17 +867,15 @@ roles: proposer, guardian (bound in that order)
 - review: asks guardian, then by stance (accept: approved, reject: propose, default: propose)
 - approved: ends resolved
 up to 6 steps</code></pre>
-      <p>Every turn it puts to a member starts with a line saying which step of which protocol it is (<code>gated · review · turn 2 of 6 · sec</code>), so a block reads as the guardian&#x27;s stance at the review step, not as the conductor blocking anyone. When a step branches, the conductor says which way it went (<code>review: sec blocked, on to propose</code>). A plain edge says nothing.</p>
-      <p>The first time a room runs a built-in protocol, the conductor writes it to the room as <code>protocols/&lt;name&gt;</code>, so the graph is a memory a person can open, read and edit; the room&#x27;s copy is what runs next. Ask the conductor what it can run with <code>mycelium engine invoke conductor &quot;list&quot;</code>.</p>
+      <p>Every turn it puts to a member starts with a line saying which step of which flow it is (<code>gated · review · turn 2 of 6 · sec</code>), so a block reads as the guardian&#x27;s stance at the review step, not as the conductor blocking anyone. When a step branches, the conductor says which way it went (<code>review: sec blocked, on to propose</code>).</p>
       <p>The members named in the summon are bound to roles, not asked a question: a persona mentioned there waits for its turn rather than answering the summon, and a resident agent that replies before its turn is refused.</p>
       <h2 id="conductor-whose-turn-it-is">Whose turn it is</h2>
-      <p>While a run is open, the thread has a <strong>floor</strong>. The conductor holds it, and gives it to whoever the current step addresses: one member for a role step, everyone at once for a fan-out. A write from anyone else is refused with a <code>409</code> that says who holds the floor and who may speak, so an agent that tried early keeps awaiting rather than giving up. A refused write never reaches the transcript, which means it wakes nobody.</p>
-      <p>The room can see whose turn it is. The members rail marks who has the floor and in which thread, and the room&#x27;s timeline gets one line each time the floor moves, so a person watching a run knows who everyone is waiting on.</p>
-      <p>Nothing else narrows. The room stays open throughout, other threads are untouched, and a member joining the room mid-run aborts nothing, because a protocol run is not a negotiation and freezes no roster. When the run ends, the floor is released and the thread takes anyone again.</p>
+      <p>While a run is open, its episode has a <strong>floor</strong>. The conductor holds it from the instant the summon lands, and gives it to whoever the current step addresses: one member for a role step, everyone at once for a fan-out. A write from anyone else is refused with a <code>409</code> that says who holds the floor and who may speak, so an agent that tried early keeps awaiting rather than giving up. A refused write never reaches the transcript, which means it wakes nobody. The room&#x27;s timeline gets a line each time the floor moves, and the members rail marks who has it.</p>
+      <p>Nothing else narrows. The room stays open, other threads are untouched, and a member joining the room mid-run aborts nothing, because a run is not a negotiation and freezes no roster. When the run ends, the floor is released.</p>
       <h2 id="conductor-how-a-run-ends">How a run ends</h2>
-      <p>A run ends at one of the protocol&#x27;s end steps, <code>resolved</code> or <code>rejected</code>, or at the step cap, which counts as <code>rejected</code>. The outcome is committed onto the thread and recorded at <code>log/episodes/{id}.md</code> like any coordination phase: who took part, each step&#x27;s prompt and reply, and how it ended. A resolved run does not resolve the task it ran in, and does not compile anything into new rows. It is a phase inside the task, and <code>board resolve</code> still finishes the task.</p>
-      <h2 id="conductor-writing-your-own">Writing your own</h2>
-      <p>A protocol is a memory under <code>protocols/</code>, promoted the way a skill is. A room that writes <code>protocols/gated</code> reshapes the built-in under that name; a new name adds a protocol. The body is YAML:</p>
+      <p>A run ends at one of its flow&#x27;s end steps, <code>resolved</code> or <code>rejected</code>, or at the step cap, which counts as <code>rejected</code>. The outcome is committed onto the episode and its record is final: the flow, the whole trace, and every envelope. A resolved run resolves no task and compiles nothing into rows.</p>
+      <h2 id="conductor-writing-your-own-flow">Writing your own flow</h2>
+      <p>A flow is a memory under <code>protocols/</code>. A room that writes <code>protocols/gated</code> reshapes the built-in under that name; a new name adds a flow. The body is YAML:</p>
       <pre><code>description: A reviewer signs off before the author ships.
 roles: [author, reviewer]
 max_steps: 6
@@ -886,7 +890,7 @@ steps:
     next: {accept: done, reject: draft, default: draft}
   - id: done
     end: resolved</code></pre>
-      <p>A step addresses a role, or <code>each</code> (every member, one at a time), <code>all</code> (every member, at once) or <code>workers</code> (every member not bound to a role). <code>wait: none</code> makes a step fire and forget. <code>rounds</code> repeats an <code>each</code> or <code>all</code> step. <code>next</code> is one step id, or a map from <code>accept</code>, <code>reject</code>, <code>silent</code> and <code>default</code> to step ids. Prompts can carry <code>{ask}</code>, <code>{reply}</code> (the most recent answer), <code>{replies}</code> (everyone&#x27;s latest, one per line), <code>{handles}</code>, <code>{round}</code> and <code>{rounds}</code>. Every step must lead somewhere, and every protocol needs an end step; a spec that does not hold together is refused rather than run half-read.</p>
+      <p>A step addresses a role, or <code>each</code> (every member, one at a time), <code>all</code> (every member, at once) or <code>workers</code> (every member not bound to a role). <code>wait: none</code> makes a step fire and forget. <code>rounds</code> repeats an <code>each</code> or <code>all</code> step. <code>next</code> is one step id, or a map from <code>accept</code>, <code>reject</code>, <code>silent</code> and <code>default</code> to step ids. Prompts can carry <code>{ask}</code>, <code>{reply}</code> (the most recent answer), <code>{replies}</code> (everyone&#x27;s latest, one per line), <code>{handles}</code>, <code>{round}</code> and <code>{rounds}</code>. Every step must lead somewhere, and every flow needs an end step; a spec that does not hold together is refused rather than run half-read. Each run copies the flow onto its own episode, so editing the memory changes the next run and never a record.</p>
       <p class="edit-page"><a href="https://github.com/mycelium-io/mycelium/blob/main/mycelium-cli/src/mycelium/docs/concepts/conductor.md" target="_blank" rel="noopener"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>Edit this page on GitHub</a></p>
     </section>
   </div>

--- a/docs/adapters.html
+++ b/docs/adapters.html
@@ -799,8 +799,9 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
 <span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">coordinate</span> work/rotate-signing-key conductor \
   <span class="str">&quot;gated @api @sec: rotate the signing key without downtime&quot;</span></code></pre>
       <p>Both roles are now played by personas, the guardian blocks what the proposer puts up until it has a rollback plan, and the whole exchange runs in the task&#x27;s thread with no session resident anywhere.</p>
+      <p>A mention beside a conductor is different: <code>@conductor gated @api @sec: …</code> binds <code>api</code> and <code>sec</code> to the protocol&#x27;s roles. Neither answers the summon; each waits to be addressed by its step.</p>
       <h2 id="persona-what-it-says">What it says</h2>
-      <p>It answers where it was asked: in the thread the turn rode, or in the room. A reply that ends in a stance marker (<code>[[mycelium: stance=accept]]</code> or <code>reject</code>) has the stance lifted onto the message the way an agent&#x27;s <code>mycelium respond</code> does, so a conductor step or an aligner round reads it the same as a resident agent&#x27;s. Every <code>@</code> in what it says is removed before posting, so a persona can never summon anything, and two personas can never set each other off.</p>
+      <p>It answers where it was asked: in the thread the turn rode, or in the room. A reply that ends in a stance marker (<code>[[mycelium: stance=accept]]</code> or <code>reject</code>) has the stance lifted onto the message the way an agent&#x27;s <code>mycelium respond</code> does, so a conductor step or an aligner round reads it the same as a resident agent&#x27;s. Every <code>@</code> in what it says is removed before posting, so a persona can never summon anything, and two personas can never set each other off. And a persona is a member: a reply into a thread whose floor was not given to it is dropped, the same refusal an agent&#x27;s write gets.</p>
       <p>Like hello, it is fail-loud: a Pi error or an empty answer is posted as a readable reason rather than silence, so a quiet persona is never mistaken for one still thinking.</p>
       <h2 id="persona-honest-boundaries">Honest boundaries</h2>
       <p>A persona is an engine, not a member with a presence lease: it is not in the room&#x27;s roster, so the aligner only negotiates with it when the summon names it (<code>@aligner @api @sec</code>), and a bare <code>@aligner</code> over the whole room does not find it. Its memory is its Pi session file, which lives with the backend process and does not survive a rebuild of the container. And it holds no keys: like every engine, it speaks through the hub.</p>
@@ -850,6 +851,19 @@ curl -X POST http://localhost:8000/api/rooms/my-project/a2a \
         </table>
       </div>
       <p>Any member can fill a role: a registered agent kept awake with <code>mycelium await --loop</code>, an engine such as <a href="#hello">hello</a>, or a person. A person answers a step the way they answer anything in a thread, with <code>board send</code>, and a stance marker left in the text is read the same as one an agent&#x27;s reply carried. That is how a human-in-the-loop step works: the conductor gives the person the floor and waits.</p>
+      <h2 id="conductor-watching-a-run">Watching a run</h2>
+      <p>A run is meant to be read from the outside, in the thread it runs in. The conductor opens by saying who plays what and the graph it is about to walk:</p>
+      <pre><code>Running gated with api as proposer, sec as guardian.
+
+**gated**: A proposer proposes, a guardian approves or blocks; a block sends it back.
+roles: proposer, guardian (bound in that order)
+- propose: asks proposer, then review
+- review: asks guardian, then by stance (accept: approved, reject: propose, default: propose)
+- approved: ends resolved
+up to 6 steps</code></pre>
+      <p>Every turn it puts to a member starts with a line saying which step of which protocol it is (<code>gated · review · turn 2 of 6 · sec</code>), so a block reads as the guardian&#x27;s stance at the review step, not as the conductor blocking anyone. When a step branches, the conductor says which way it went (<code>review: sec blocked, on to propose</code>). A plain edge says nothing.</p>
+      <p>The first time a room runs a built-in protocol, the conductor writes it to the room as <code>protocols/&lt;name&gt;</code>, so the graph is a memory a person can open, read and edit; the room&#x27;s copy is what runs next. Ask the conductor what it can run with <code>mycelium engine invoke conductor &quot;list&quot;</code>.</p>
+      <p>The members named in the summon are bound to roles, not asked a question: a persona mentioned there waits for its turn rather than answering the summon, and a resident agent that replies before its turn is refused.</p>
       <h2 id="conductor-whose-turn-it-is">Whose turn it is</h2>
       <p>While a run is open, the thread has a <strong>floor</strong>. The conductor holds it, and gives it to whoever the current step addresses: one member for a role step, everyone at once for a fan-out. A write from anyone else is refused with a <code>409</code> that says who holds the floor and who may speak, so an agent that tried early keeps awaiting rather than giving up. A refused write never reaches the transcript, which means it wakes nobody.</p>
       <p>The room can see whose turn it is. The members rail marks who has the floor and in which thread, and the room&#x27;s timeline gets one line each time the floor moves, so a person watching a run knows who everyone is waiting on.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -718,10 +718,11 @@ Resolved    Pick token storage                          @sec</code></pre>
     <section class="doc-section" id="episodes">
       <h1>Episodes</h1>
       <p><strong>An episode is one scoped conversation inside a room.</strong></p>
-      <p>A room has a single channel, and an episode is a tagged slice of it: a set of messages that belong together and can be read on their own. Two things are episodes.</p>
+      <p>A room has a single channel, and an episode is a tagged slice of it: a set of messages that belong together and can be read on their own. Three things are episodes.</p>
       <p>The first is a <a href="#board">task</a>&#x27;s <strong>thread</strong>. Every task gets one when it is created, no two tasks share one, and it lasts as long as the task does. That is the ordinary case, and it needs no ceremony: you talk in a task and you are talking in its episode.</p>
       <p>The second is a <strong>coordination phase</strong>: a bounded, mediated stretch of work on a disagreement, opened inside a task when talk alone is not settling it. Two or more agents disagree on a trade-off with several moving parts, someone puts a mediator on the task, and the mediator drives it to one answer or to a clean failure to agree.</p>
-      <p>So a room holds tasks, a task holds its thread, and a coordination phase is something that can happen inside that thread. The task outlives it.</p>
+      <p>The third is a <strong>run with a flow</strong>: an episode the <a href="adapters.html#conductor">conductor</a> opens to walk a fixed interaction shape, a proposer and a guardian, a lead and its workers, members speaking in turn. The flow is written onto the episode itself, along with every step taken, so the episode shows the shape of the interaction and where it stands, not only its messages. A run can be opened from a task, which nests it there, or from the room.</p>
+      <p>So a room holds tasks, a task holds its thread, and a coordination phase or a run is something that can happen inside that thread. The task outlives it.</p>
       <h2 id="episodes-opening-one">Opening one</h2>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">board</span> <span class="cmd">coordinate</span> work/pick-token-storage aligner <span class="str">&quot;converge on token storage&quot;</span></code></pre>
       <p>The ask lands in the task&#x27;s thread and the <a href="adapters.html#aligner">aligner</a> starts working. There is no session to create, join or wait for.</p>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2024,6 +2024,10 @@ Both roles are now played by personas, the guardian blocks what the
 proposer puts up until it has a rollback plan, and the whole exchange runs in
 the task's thread with no session resident anywhere.
 
+A mention beside a conductor is different: `@conductor gated @api @sec: …`
+binds `api` and `sec` to the protocol's roles. Neither answers the summon;
+each waits to be addressed by its step.
+
 ## What it says
 
 It answers where it was asked: in the thread the turn rode, or in the room.
@@ -2032,7 +2036,8 @@ A reply that ends in a stance marker (`[[mycelium: stance=accept]]` or
 `mycelium respond` does, so a conductor step or an aligner round reads it
 the same as a resident agent's. Every `@` in what it says is removed before
 posting, so a persona can never summon anything, and two personas can never
-set each other off.
+set each other off. And a persona is a member: a reply into a thread whose
+floor was not given to it is dropped, the same refusal an agent's write gets.
 
 Like hello, it is fail-loud: a Pi error or an empty answer is posted as a
 readable reason rather than silence, so a quiet persona is never mistaken
@@ -2096,6 +2101,37 @@ person answers a step the way they answer anything in a thread, with
 `board send`, and a stance marker left in the text is read the same as one an
 agent's reply carried. That is how a human-in-the-loop step works: the
 conductor gives the person the floor and waits.
+
+## Watching a run
+
+A run is meant to be read from the outside, in the thread it runs in. The
+conductor opens by saying who plays what and the graph it is about to walk:
+
+```
+Running gated with api as proposer, sec as guardian.
+
+**gated**: A proposer proposes, a guardian approves or blocks; a block sends it back.
+roles: proposer, guardian (bound in that order)
+- propose: asks proposer, then review
+- review: asks guardian, then by stance (accept: approved, reject: propose, default: propose)
+- approved: ends resolved
+up to 6 steps
+```
+
+Every turn it puts to a member starts with a line saying which step of
+which protocol it is (`gated · review · turn 2 of 6 · sec`), so a block
+reads as the guardian's stance at the review step, not as the conductor
+blocking anyone. When a step branches, the conductor says which way it went
+(`review: sec blocked, on to propose`). A plain edge says nothing.
+
+The first time a room runs a built-in protocol, the conductor writes it to
+the room as `protocols/<name>`, so the graph is a memory a person can open,
+read and edit; the room's copy is what runs next. Ask the conductor what it
+can run with `mycelium engine invoke conductor "list"`.
+
+The members named in the summon are bound to roles, not asked a question:
+a persona mentioned there waits for its turn rather than answering the
+summon, and a resident agent that replies before its turn is refused.
 
 ## Whose turn it is
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -960,7 +960,7 @@ mycelium await --lease work/auth-spike    # wake when that task changes hands
 **An episode is one scoped conversation inside a room.**
 
 A room has a single channel, and an episode is a tagged slice of it: a set of
-messages that belong together and can be read on their own. Two things are
+messages that belong together and can be read on their own. Three things are
 episodes.
 
 The first is a [task](#board)'s **thread**. Every task gets one when it is
@@ -974,8 +974,15 @@ more agents disagree on a trade-off with several moving parts, someone puts a
 mediator on the task, and the mediator drives it to one answer or to a clean
 failure to agree.
 
-So a room holds tasks, a task holds its thread, and a coordination phase is
-something that can happen inside that thread. The task outlives it.
+The third is a **run with a flow**: an episode the [conductor](#conductor)
+opens to walk a fixed interaction shape, a proposer and a guardian, a lead
+and its workers, members speaking in turn. The flow is written onto the
+episode itself, along with every step taken, so the episode shows the shape
+of the interaction and where it stands, not only its messages. A run can be
+opened from a task, which nests it there, or from the room.
+
+So a room holds tasks, a task holds its thread, and a coordination phase or a
+run is something that can happen inside that thread. The task outlives it.
 
 ## Opening one
 
@@ -2057,55 +2064,77 @@ keys: like every engine, it speaks through the hub.
 
 # Conductor
 
-The conductor is the [engine](#engines) that runs a **protocol** inside a
-task: a fixed shape of who speaks to whom, in what order, and what happens on
-each answer. Where the [aligner](#aligner) brokers a negotiation, the
-conductor walks a graph. It is the engine to reach for when a piece of work
-has a shape you already know: a proposal that a reviewer must approve, a lead
-asking every worker at once, a round where each member speaks in turn.
+The conductor is the [engine](#engines) that runs an **episode with a
+flow**: a fixed shape of who speaks to whom, in what order, and what happens
+on each answer. Where the [aligner](#aligner) brokers a negotiation, the
+conductor walks a graph. It is the engine to reach for when an interaction
+has a shape you already know: a proposal a reviewer must approve, a lead
+asking every worker at once, members speaking in turn.
 
 It is the one engine with no model of its own. Every judgment in a run, what
 to propose and whether to block it, is made by the members it addresses. The
-conductor only decides whose turn it is, and it enforces that in code: while a
-step is open, only the member it addressed can write into the thread. That is
-the split the whole design rests on. A model sits in each node, and code sits
-on the edges.
+conductor only decides whose turn it is, and it enforces that in code: while
+a step is open, only the member it addressed can write into the episode.
+That is the split the whole design rests on. A model sits in each node, and
+code sits on the edges.
 
 ```bash
 # Register it once per room
 mycelium engine create conductor --kind conductor --room sprint-plan
 
-# Run the gated protocol inside a task: @api proposes, @sec approves or blocks
+# Open a gated run: @api proposes, @sec approves or blocks
+mycelium engine invoke conductor \
+  "gated @api @sec: rotate the signing key without downtime" -r sprint-plan
+```
+
+The summon names the flow first, then the members in the order the flow's
+roles expect, then the question.
+
+## The episode is the run
+
+Every run opens an [episode](#episodes) of its own, and the episode carries
+its flow. The graph the conductor walks, who was bound to each role, and the
+trace of every step taken are written onto the episode's record as it goes,
+so an open run shows where it stands and a finished one shows the shape of
+the interaction, not only its messages. Open the episode in the app and the
+graph is drawn at the top of its thread: the current step lit, the edges
+taken solid, the member who has the floor marked, and the steps taken listed
+under it.
+
+A run can be opened from a task, which makes it a phase inside that task the
+way a negotiation is:
+
+```bash
 mycelium board coordinate work/rotate-signing-key conductor \
   "gated @api @sec: rotate the signing key without downtime"
 ```
 
-The summon names the protocol first, then the members in the order the
-protocol's roles expect, then the question. The run happens in the thread the
-summon was made in, so the row's conversation carries the whole thing and
-`board messages` reads it back. A summon from the room itself
-(`engine invoke`) opens a thread of its own, because the room is never
-narrowed to one speaker.
+The run still gets its own episode. The task's thread gets one line when the
+run opens (naming the episode and the cast) and one when it ends, and the
+episode's record says which task it ran inside. A run opened from the room
+is nested in nothing. Either way the task is context or an output, never the
+container the flow lives in.
 
-## The built-in protocols
+## The built-in flows
 
-| Protocol | Roles | Shape |
+| Flow | Roles | Shape |
 |---|---|---|
 | `gated` | proposer, guardian | The proposer states what it intends to do. The guardian approves or blocks, ending its reply with `[[mycelium: stance=accept]]` or `[[mycelium: stance=reject]]`. A block sends the proposal back with the objection attached, until an approval or the step cap. |
 | `fan-out` | lead | Every other member is asked at once. The lead then gets all the answers and combines them into one plan. |
 | `round-robin` | none | Each member speaks in turn, seeing what the others said, for two rounds. |
 
 Any member can fill a role: a registered agent kept awake with
-`mycelium await --loop`, an engine such as [hello](#hello), or a person. A
-person answers a step the way they answer anything in a thread, with
-`board send`, and a stance marker left in the text is read the same as one an
-agent's reply carried. That is how a human-in-the-loop step works: the
-conductor gives the person the floor and waits.
+`mycelium await --loop`, a [persona](#persona), or a person. A person
+answers a step the way they answer anything in a thread, and a stance marker
+left in the text is read the same as one an agent's reply carried. That is
+how a human-in-the-loop step works: the conductor gives the person the floor
+and waits. Ask the conductor what it can run with
+`mycelium engine invoke conductor "list"`.
 
-## Watching a run
+## Reading a run
 
-A run is meant to be read from the outside, in the thread it runs in. The
-conductor opens by saying who plays what and the graph it is about to walk:
+A run is meant to be read from the outside. The conductor opens by saying
+who plays what and the graph it is about to walk:
 
 ```
 Running gated with api as proposer, sec as guardian.
@@ -2119,53 +2148,42 @@ up to 6 steps
 ```
 
 Every turn it puts to a member starts with a line saying which step of
-which protocol it is (`gated · review · turn 2 of 6 · sec`), so a block
-reads as the guardian's stance at the review step, not as the conductor
-blocking anyone. When a step branches, the conductor says which way it went
-(`review: sec blocked, on to propose`). A plain edge says nothing.
+which flow it is (`gated · review · turn 2 of 6 · sec`), so a block reads as
+the guardian's stance at the review step, not as the conductor blocking
+anyone. When a step branches, the conductor says which way it went
+(`review: sec blocked, on to propose`).
 
-The first time a room runs a built-in protocol, the conductor writes it to
-the room as `protocols/<name>`, so the graph is a memory a person can open,
-read and edit; the room's copy is what runs next. Ask the conductor what it
-can run with `mycelium engine invoke conductor "list"`.
-
-The members named in the summon are bound to roles, not asked a question:
-a persona mentioned there waits for its turn rather than answering the
-summon, and a resident agent that replies before its turn is refused.
+The members named in the summon are bound to roles, not asked a question: a
+persona mentioned there waits for its turn rather than answering the summon,
+and a resident agent that replies before its turn is refused.
 
 ## Whose turn it is
 
-While a run is open, the thread has a **floor**. The conductor holds it, and
-gives it to whoever the current step addresses: one member for a role step,
-everyone at once for a fan-out. A write from anyone else is refused with a
-`409` that says who holds the floor and who may speak, so an agent that tried
-early keeps awaiting rather than giving up. A refused write never reaches the
-transcript, which means it wakes nobody.
+While a run is open, its episode has a **floor**. The conductor holds it
+from the instant the summon lands, and gives it to whoever the current step
+addresses: one member for a role step, everyone at once for a fan-out. A
+write from anyone else is refused with a `409` that says who holds the floor
+and who may speak, so an agent that tried early keeps awaiting rather than
+giving up. A refused write never reaches the transcript, which means it wakes
+nobody. The room's timeline gets a line each time the floor moves, and the
+members rail marks who has it.
 
-The room can see whose turn it is. The members rail marks who has the floor
-and in which thread, and the room's timeline gets one line each time the
-floor moves, so a person watching a run knows who everyone is waiting on.
-
-Nothing else narrows. The room stays open throughout, other threads are
-untouched, and a member joining the room mid-run aborts nothing, because a
-protocol run is not a negotiation and freezes no roster. When the run ends,
-the floor is released and the thread takes anyone again.
+Nothing else narrows. The room stays open, other threads are untouched, and a
+member joining the room mid-run aborts nothing, because a run is not a
+negotiation and freezes no roster. When the run ends, the floor is released.
 
 ## How a run ends
 
-A run ends at one of the protocol's end steps, `resolved` or `rejected`, or at
+A run ends at one of its flow's end steps, `resolved` or `rejected`, or at
 the step cap, which counts as `rejected`. The outcome is committed onto the
-thread and recorded at `log/episodes/{id}.md` like any coordination phase:
-who took part, each step's prompt and reply, and how it ended. A resolved run
-does not resolve the task it ran in, and does not compile anything into new
-rows. It is a phase inside the task, and `board resolve` still finishes the
-task.
+episode and its record is final: the flow, the whole trace, and every
+envelope. A resolved run resolves no task and compiles nothing into rows.
 
-## Writing your own
+## Writing your own flow
 
-A protocol is a memory under `protocols/`, promoted the way a skill is. A room
-that writes `protocols/gated` reshapes the built-in under that name; a new
-name adds a protocol. The body is YAML:
+A flow is a memory under `protocols/`. A room that writes `protocols/gated`
+reshapes the built-in under that name; a new name adds a flow. The body is
+YAML:
 
 ```yaml
 description: A reviewer signs off before the author ships.
@@ -2190,9 +2208,10 @@ A step addresses a role, or `each` (every member, one at a time), `all`
 step. `next` is one step id, or a map from `accept`, `reject`, `silent` and
 `default` to step ids. Prompts can carry `{ask}`, `{reply}` (the most recent
 answer), `{replies}` (everyone's latest, one per line), `{handles}`, `{round}`
-and `{rounds}`. Every step must lead somewhere, and every protocol needs an
-end step; a spec that does not hold together is refused rather than run
-half-read.
+and `{rounds}`. Every step must lead somewhere, and every flow needs an end
+step; a spec that does not hold together is refused rather than run
+half-read. Each run copies the flow onto its own episode, so editing the
+memory changes the next run and never a record.
 
 
 ---

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -779,6 +779,13 @@ window.MYCELIUM_SEARCH_INDEX = [
     "p": "Adapters"
   },
   {
+    "u": "adapters.html#conductor-watching-a-run",
+    "t": "Watching a run",
+    "s": "Engines › Conductor",
+    "x": "A run is meant to be read from the outside, in the thread it runs in. The conductor opens by saying who plays what and the graph it is about to walk: Running gated with api as proposer, sec as guardian. **gated**: A proposer proposes, a guardian approves or blocks; a block sends it back. roles: proposer, guardian (bound in that order) - propose: asks proposer, then review - review: asks guardian, then by stance (acce",
+    "p": "Adapters"
+  },
+  {
     "u": "adapters.html#conductor-whose-turn-it-is",
     "t": "Whose turn it is",
     "s": "Engines › Conductor",

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -276,7 +276,7 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "index.html#episodes",
     "t": "Episodes",
     "s": "Concepts",
-    "x": "An episode is one scoped conversation inside a room. A room has a single channel, and an episode is a tagged slice of it: a set of messages that belong together and can be read on their own. Two things are episodes. The first is a task's thread. Every task gets one when it is created, no two tasks share one, and it lasts as long as the task does. That is the ordinary case, and it needs no ceremony: you talk in a task",
+    "x": "An episode is one scoped conversation inside a room. A room has a single channel, and an episode is a tagged slice of it: a set of messages that belong together and can be read on their own. Three things are episodes. The first is a task's thread. Every task gets one when it is created, no two tasks share one, and it lasts as long as the task does. That is the ordinary case, and it needs no ceremony: you talk in a ta",
     "p": "Guide"
   },
   {
@@ -768,42 +768,49 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "adapters.html#conductor",
     "t": "Conductor",
     "s": "Engines",
-    "x": "The conductor is the engine that runs a protocol inside a task: a fixed shape of who speaks to whom, in what order, and what happens on each answer. Where the aligner brokers a negotiation, the conductor walks a graph. It is the engine to reach for when a piece of work has a shape you already know: a proposal that a reviewer must approve, a lead asking every worker at once, a round where each member speaks in turn. I",
+    "x": "The conductor is the engine that runs an episode with a flow: a fixed shape of who speaks to whom, in what order, and what happens on each answer. Where the aligner brokers a negotiation, the conductor walks a graph. It is the engine to reach for when an interaction has a shape you already know: a proposal a reviewer must approve, a lead asking every worker at once, members speaking in turn. It is the one engine with",
     "p": "Adapters"
   },
   {
-    "u": "adapters.html#conductor-the-built-in-protocols",
-    "t": "The built-in protocols",
+    "u": "adapters.html#conductor-the-episode-is-the-run",
+    "t": "The episode is the run",
     "s": "Engines › Conductor",
-    "x": "Protocol Roles Shape gated proposer, guardian The proposer states what it intends to do. The guardian approves or blocks, ending its reply with [[mycelium: stance=accept]] or [[mycelium: stance=reject]]. A block sends the proposal back with the objection attached, until an approval or the step cap. fan-out lead Every other member is asked at once. The lead then gets all the answers and combines them into one plan. ro",
+    "x": "Every run opens an episode of its own, and the episode carries its flow. The graph the conductor walks, who was bound to each role, and the trace of every step taken are written onto the episode's record as it goes, so an open run shows where it stands and a finished one shows the shape of the interaction, not only its messages. Open the episode in the app and the graph is drawn at the top of its thread: the current ",
     "p": "Adapters"
   },
   {
-    "u": "adapters.html#conductor-watching-a-run",
-    "t": "Watching a run",
+    "u": "adapters.html#conductor-the-built-in-flows",
+    "t": "The built-in flows",
     "s": "Engines › Conductor",
-    "x": "A run is meant to be read from the outside, in the thread it runs in. The conductor opens by saying who plays what and the graph it is about to walk: Running gated with api as proposer, sec as guardian. **gated**: A proposer proposes, a guardian approves or blocks; a block sends it back. roles: proposer, guardian (bound in that order) - propose: asks proposer, then review - review: asks guardian, then by stance (acce",
+    "x": "Flow Roles Shape gated proposer, guardian The proposer states what it intends to do. The guardian approves or blocks, ending its reply with [[mycelium: stance=accept]] or [[mycelium: stance=reject]]. A block sends the proposal back with the objection attached, until an approval or the step cap. fan-out lead Every other member is asked at once. The lead then gets all the answers and combines them into one plan. round-",
+    "p": "Adapters"
+  },
+  {
+    "u": "adapters.html#conductor-reading-a-run",
+    "t": "Reading a run",
+    "s": "Engines › Conductor",
+    "x": "A run is meant to be read from the outside. The conductor opens by saying who plays what and the graph it is about to walk: Running gated with api as proposer, sec as guardian. **gated**: A proposer proposes, a guardian approves or blocks; a block sends it back. roles: proposer, guardian (bound in that order) - propose: asks proposer, then review - review: asks guardian, then by stance (accept: approved, reject: prop",
     "p": "Adapters"
   },
   {
     "u": "adapters.html#conductor-whose-turn-it-is",
     "t": "Whose turn it is",
     "s": "Engines › Conductor",
-    "x": "While a run is open, the thread has a floor. The conductor holds it, and gives it to whoever the current step addresses: one member for a role step, everyone at once for a fan-out. A write from anyone else is refused with a 409 that says who holds the floor and who may speak, so an agent that tried early keeps awaiting rather than giving up. A refused write never reaches the transcript, which means it wakes nobody. T",
+    "x": "While a run is open, its episode has a floor. The conductor holds it from the instant the summon lands, and gives it to whoever the current step addresses: one member for a role step, everyone at once for a fan-out. A write from anyone else is refused with a 409 that says who holds the floor and who may speak, so an agent that tried early keeps awaiting rather than giving up. A refused write never reaches the transcr",
     "p": "Adapters"
   },
   {
     "u": "adapters.html#conductor-how-a-run-ends",
     "t": "How a run ends",
     "s": "Engines › Conductor",
-    "x": "A run ends at one of the protocol's end steps, resolved or rejected, or at the step cap, which counts as rejected. The outcome is committed onto the thread and recorded at log/episodes/{id}.md like any coordination phase: who took part, each step's prompt and reply, and how it ended. A resolved run does not resolve the task it ran in, and does not compile anything into new rows. It is a phase inside the task, and boa",
+    "x": "A run ends at one of its flow's end steps, resolved or rejected, or at the step cap, which counts as rejected. The outcome is committed onto the episode and its record is final: the flow, the whole trace, and every envelope. A resolved run resolves no task and compiles nothing into rows.",
     "p": "Adapters"
   },
   {
-    "u": "adapters.html#conductor-writing-your-own",
-    "t": "Writing your own",
+    "u": "adapters.html#conductor-writing-your-own-flow",
+    "t": "Writing your own flow",
     "s": "Engines › Conductor",
-    "x": "A protocol is a memory under protocols/, promoted the way a skill is. A room that writes protocols/gated reshapes the built-in under that name; a new name adds a protocol. The body is YAML: description: A reviewer signs off before the author ships. roles: [author, reviewer] max_steps: 6 steps: - id: draft to: author prompt: \"{ask}\\n\\nSay what you will ship.\\n\\n{reply}\" next: review - id: review to: reviewer prompt: \"",
+    "x": "A flow is a memory under protocols/. A room that writes protocols/gated reshapes the built-in under that name; a new name adds a flow. The body is YAML: description: A reviewer signs off before the author ships. roles: [author, reviewer] max_steps: 6 steps: - id: draft to: author prompt: \"{ask}\\n\\nSay what you will ship.\\n\\n{reply}\" next: review - id: review to: reviewer prompt: \"On the table:\\n\\n{reply}\\n\\nApprove o",
     "p": "Adapters"
   },
   {

--- a/fastapi-backend/app/routes/sessions.py
+++ b/fastapi-backend/app/routes/sessions.py
@@ -31,13 +31,14 @@ from app.schemas import (
     ParticipantListResponse,
     ParticipantRead,
 )
-from app.services import actor, in_memory_store, l9, room_channels
+from app.services import actor, in_memory_store, l9, room_channels, tasks
 from app.services.filesystem import (
     ensure_room_structure,
     get_room_dir,
     read_room_meta,
     room_exists,
 )
+from app.services.floor import Floor
 
 logger = logging.getLogger(__name__)
 
@@ -216,14 +217,25 @@ async def list_members(room_name: str):
         # so a member the floor was given to shows it whether or not it is
         # present — a persona engine is never in ``members`` and still speaks.
         "floors": [
-            {
-                "thread": floor.episode.rsplit(":", 1)[-1],
-                "episode": floor.episode,
-                "holder": floor.holder,
-                "speakers": sorted(floor.speakers),
-            }
-            for floor in room_channels.manager.floors_of(room_name)
+            _floor_entry(room_name, floor) for floor in room_channels.manager.floors_of(room_name)
         ],
+    }
+
+
+def _floor_entry(room_name: str, floor: Floor) -> dict[str, object]:
+    """One held floor, named by the task its thread belongs to.
+
+    A badge says the task's name rather than the thread's id; ``key`` and
+    ``title`` are both ``None`` for a thread no row carries.
+    """
+    row = tasks.row_of_episode(room_name, floor.episode)
+    return {
+        "thread": floor.episode.rsplit(":", 1)[-1],
+        "episode": floor.episode,
+        "key": row[0] if row else None,
+        "title": row[1] if row else None,
+        "holder": floor.holder,
+        "speakers": sorted(floor.speakers),
     }
 
 

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -731,6 +731,15 @@ class EpisodeSummaryRead(BaseModel):
     message_count: int = 0
     updated_at: str = ""
     updated_by: str = ""
+    #: The thread this episode was opened from, when it runs inside a task.
+    within: str | None = None
+    #: The interaction flow this episode runs (roles, steps, edges, bindings),
+    #: for an episode the conductor walks; ``None`` for a negotiation or a thread.
+    flow: dict[str, Any] | None = None
+    #: One entry per step taken, in order — written as the run walks.
+    trace: list[dict[str, Any]] = Field(default_factory=list)
+    #: Where an open run stands, read off the trace.
+    current_step: str | None = None
 
 
 class EpisodeListResponse(BaseModel):

--- a/fastapi-backend/app/services/conductor.py
+++ b/fastapi-backend/app/services/conductor.py
@@ -132,7 +132,13 @@ class Run:
     def flow(self) -> dict[str, Any]:
         """The flow as the episode record carries it: the graph plus the cast."""
         spec = protocols.spec_of(self.protocol)
-        return {"name": self.protocol.name, **spec, "bound": dict(self.bound), "ask": self.ask}
+        return {
+            "name": self.protocol.name,
+            **spec,
+            "bound": dict(self.bound),
+            "cast": list(self.handles),
+            "ask": self.ask,
+        }
 
 
 def bind_roles(protocol: Protocol, handles: list[str]) -> dict[str, str] | None:

--- a/fastapi-backend/app/services/conductor.py
+++ b/fastapi-backend/app/services/conductor.py
@@ -1,28 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2026 Mycelium Contributors
 
-"""The conductor — the engine that runs a protocol inside a thread.
+"""The conductor — the engine that runs an episode's interaction flow.
 
 A fourth engine ``kind`` beside the aligner, the synthesizer and hello, and
-the first with no model of its own. Summoned into a thread with the name of a
-:mod:`~app.services.protocols` and the members to run it over, it walks that
-protocol's steps in code: it holds the thread's floor for whoever the step
-addresses, puts the step's prompt to them through the same one-agent turn the
-aligner brokers with, reads the stance their reply took, and follows the edge.
-Every judgment in a run — what to propose, whether to block it — is made by
-the members it addresses. The conductor only decides who speaks next, and
-that is the point: a model in the nodes, code on the edges.
+the first with no model of its own. Summoned with the name of a flow
+(:mod:`~app.services.protocols`) and the members to run it over, it opens an
+**episode** of its own and walks the flow's steps in it: it holds the
+episode's floor for whoever the step addresses, puts the step's prompt to
+them through the same one-agent turn the aligner brokers with, reads the
+stance their reply took, and follows the edge. Every judgment in a run — what
+to propose, whether to block it — is made by the members it addresses. The
+conductor only decides who speaks next: a model in the nodes, code on the
+edges.
+
+**The episode is the run, and it carries its flow.** The graph the conductor
+walks and the trace of the steps it has taken are written onto the episode's
+own record (``log/episodes/{id}.md``) as it goes, so an open run shows where
+it stands and a finished one shows the shape of the interaction, not only
+its messages. A summon from a task's thread nests the episode in that task
+(the record says ``within``), and the thread gets one line when the run opens
+and one when it ends; a summon from the room nests it in nothing. Tasks are
+context or output, never the container the flow lives in.
 
 What it shares with the other engines: dormant until a registered engine of
-its kind is summoned, runs as that handle, and leaves a record at
-``log/episodes/{id}.md``. What it does not share: it opens no negotiation,
-so joining the room mid-run aborts nothing, and it never calls Pi.
-
-Where it runs: in the thread it was summoned in. A summon from a task's
-thread (``board coordinate <row> conductor "gated @a @b: …"``) runs there, so
-the row's conversation carries the whole run and a person can answer a step
-with ``board send``. A summon from the room itself opens a fresh thread,
-since the room never holds a floor.
+its kind is summoned, runs as that handle. What it does not share: it opens
+no negotiation, so joining the room mid-run aborts nothing, and it never
+calls Pi.
 """
 
 from __future__ import annotations
@@ -31,6 +35,7 @@ import asyncio
 import logging
 import re
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from app.config import settings
@@ -53,7 +58,7 @@ logger = logging.getLogger(__name__)
 ENGINE_KIND = "conductor"
 
 #: Summon words that ask for the catalogue rather than a run.
-LIST_DIRECTIVES = frozenset({"list", "protocols", "help"})
+LIST_DIRECTIVES = frozenset({"list", "protocols", "flows", "help"})
 
 #: Payloads that are never a member's answer to a step.
 _NOT_A_REPLY = frozenset(
@@ -69,9 +74,9 @@ def _norm(handle: str) -> str:
 
 
 def split_directive(text: str) -> tuple[str, str]:
-    """``(protocol name, the ask)`` from a summon's text.
+    """``(flow name, the ask)`` from a summon's text.
 
-    The first word that is not a mention names the protocol; everything after
+    The first word that is not a mention names the flow; everything after
     it, mentions removed, is the ask the prompts carry as ``{ask}``.
     """
     words = _MENTION.sub(" ", text).split()
@@ -91,7 +96,7 @@ class _Fields(dict[str, str]):
 
 @dataclass
 class Run:
-    """One protocol run: what it is over, and what has been said in it."""
+    """One run: what it is over, and what has been said in it."""
 
     protocol: Protocol
     ask: str
@@ -124,6 +129,11 @@ class Run:
             rounds=str(rounds),
         )
 
+    def flow(self) -> dict[str, Any]:
+        """The flow as the episode record carries it: the graph plus the cast."""
+        spec = protocols.spec_of(self.protocol)
+        return {"name": self.protocol.name, **spec, "bound": dict(self.bound), "ask": self.ask}
+
 
 def bind_roles(protocol: Protocol, handles: list[str]) -> dict[str, str] | None:
     """Roles bound to ``handles`` in order, or ``None`` when there are too few."""
@@ -152,7 +162,7 @@ def stance_of_step(replies: list[tuple[str, str | None]]) -> str | None:
 
 
 class ConductorEngine:
-    """Walk a protocol's steps over a thread, holding its floor as it goes."""
+    """Open an episode, walk its flow, hold its floor as it goes."""
 
     def __init__(
         self,
@@ -172,8 +182,9 @@ class ConductorEngine:
             poll_interval_s if poll_interval_s is not None else settings.CONDUCTOR_POLL_INTERVAL_S
         )
         self._max_steps = max_steps if max_steps is not None else settings.CONDUCTOR_MAX_STEPS
-        # Threads with a run in flight: a re-summon into one is ignored while a
-        # second thread in the same room runs its own.
+        # Threads a run was summoned from, with one in flight: a second summon
+        # from the same thread is ignored until it ends, while another thread
+        # (or the room) can start its own.
         self._active: set[tuple[str, str]] = set()
         self._tasks: set[asyncio.Task[Any]] = set()
 
@@ -191,7 +202,7 @@ class ConductorEngine:
         co_summons: list[str] | None = None,
         message_text: str = "",
     ) -> None:
-        """Run a protocol when a registered engine of kind ``conductor`` is
+        """Open a run when a registered engine of kind ``conductor`` is
         summoned; else ignore."""
         if _registered_engine_kind(room, handle) != ENGINE_KIND:
             return
@@ -204,24 +215,25 @@ class ConductorEngine:
         if sender is not None and _norm(sender) in {_norm(self._handle), _norm(handle)}:
             return
         summoned_in = (envelope.header.message.episode if envelope.header.message else None) or ""
-        in_thread = bool(summoned_in) and not l9.is_live_episode(room, summoned_in)
-        episode = summoned_in if in_thread else l9.episode_urn(room, mint_episode_id())
-        key = (room, episode)
+        origin = summoned_in or l9.live_episode_urn(room)
+        key = (room, origin)
         if key in self._active:
-            logger.debug("conductor already running in %s; ignoring re-summon", episode)
+            logger.debug("conductor already running from %s; ignoring re-summon", origin)
             return
         drop = {_norm(handle), _norm(self._handle), *(_norm(h) for h in _NON_PARTICIPANTS)}
         named = [h for h in (co_summons or []) if _norm(h) not in drop]
         directive = _MENTION.sub(
             lambda m: "" if _norm(m.group(0)) == _norm(handle) else m.group(0), message_text
         )
-        self._active.add(key)
-        # The floor is the run's from this instant, before anything else on the
-        # loop runs: a member the summon woke cannot slip a reply in ahead of the
-        # first step, and a persona mentioned as a role is not asked a question.
+        # The run's episode exists from this instant, floor held, before
+        # anything else on the loop runs: a member the summon woke cannot slip
+        # a reply in ahead of the first step, and a persona mentioned as a role
+        # is not asked a question.
+        episode = l9.episode_urn(room, mint_episode_id())
         self._manager.hold_floor(room, episode, holder=handle)
+        self._active.add(key)
         task = asyncio.create_task(
-            self._run_and_release(room, handle, episode, summoned_in, directive, named, key)
+            self._run_and_release(room, handle, episode, origin, directive, named, key)
         )
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
@@ -258,38 +270,40 @@ class ConductorEngine:
         self,
         room: str,
         *,
-        episode: str,
         directive: str,
         engine_handle: str | None = None,
+        episode: str | None = None,
         summoned_in: str = "",
         named: list[str] | None = None,
     ) -> str | None:
-        """Run the protocol ``directive`` names over ``episode``; return the outcome.
+        """Open an episode, run the flow ``directive`` names in it, return the outcome.
 
-        ``named`` are the handles the summon mentioned, bound to the protocol's
+        ``named`` are the handles the summon mentioned, bound to the flow's
         roles in order; with none named, every other member of the room takes
-        part. ``None`` when the run could not start — the reason is posted
-        where the summon was made.
+        part. ``summoned_in`` is where the ask was made — a task's thread, or
+        the room — and is where a refusal is answered and where the run's
+        opening and closing lines land. ``None`` when the run could not start.
         """
         managed = self._manager.get(room)
         if managed is None or managed.persister is None:
             logger.info("conductor summoned for %s but no live channel", room)
             return None
         me = engine_handle or self._handle
-        where = summoned_in or episode
+        origin = summoned_in or l9.live_episode_urn(room)
+        in_task = not l9.is_live_episode(room, origin)
 
         name, ask = split_directive(directive)
         if name in LIST_DIRECTIVES:
-            await self._say(managed, where, me, self._catalogue(room))
+            await self._say(managed, origin, me, self._catalogue(room))
             return None
         protocol = protocols.load_protocol(room, name) if name else None
         if protocol is None:
             known = ", ".join(protocols.builtin_names())
             await self._say(
                 managed,
-                where,
+                origin,
                 me,
-                "I need a protocol to run: name it first, then who takes part, for "
+                "I need a flow to run: name it first, then who takes part, for "
                 "example `gated proposer-handle guardian-handle: the question`. "
                 f"Built in: {known}; a room adds its own under protocols/.",
             )
@@ -303,23 +317,26 @@ class ConductorEngine:
             roles = ", ".join(protocol.roles) or "its steps"
             await self._say(
                 managed,
-                where,
+                origin,
                 me,
                 f"`{protocol.name}` needs {max(len(protocol.roles), 1)} member(s) for {roles} "
                 f"and {len(handles)} were named. Summon me again with the handles in that order.",
             )
             return None
 
+        episode = episode or l9.episode_urn(room, mint_episode_id())
         run = Run(protocol=protocol, ask=ask, handles=handles, bound=bound, episode=episode)
         ep = l9_episode.EpisodeState(
             episode=episode,
             topic=l9.topic_urn(room),
             parent_room=room,
-            short_id=mint_episode_id(),
+            short_id=episode.rsplit(":", 1)[-1],
             workspace_id=managed.workspace,
             mas_id="",
             agents=list(handles),
             engine_handle=me,
+            flow=run.flow(),
+            within=origin if in_task else None,
         )
         intent = l9.build_envelope(
             kind=Kind.intent,
@@ -333,25 +350,30 @@ class ConductorEngine:
         )
         ep.intent_id = intent.header.message.id if intent.header.message else ""
         ep.messages.append(l9.envelope_to_dict(intent))
-        logger.info("conductor @%s runs %s in %s over %s", me, protocol.name, episode, handles)
-        # The floor is the run's from the first instant, so a member the summon
-        # woke cannot slip a reply in ahead of the first step. (The summon seam
+        logger.info("conductor @%s runs %s as %s over %s", me, protocol.name, episode, handles)
+        # The floor is the run's from the first instant. (The summon seam
         # already held it; a direct call takes it here.)
         self._manager.hold_floor(room, episode, holder=me)
         try:
-            # A built-in the room has run becomes the room's own memory, so a
-            # person can open the graph the conductor walked and reshape it.
-            if name not in protocols.room_protocol_names(room):
-                await protocols.materialize(room, protocol, created_by=me)
+            # The record exists from the opening, so the run is an episode the
+            # room can open while it is still walking.
+            l9_episode.write_episode_record(ep, outcome="open", metrics=None, tasks=None)
             await self._say(managed, episode, me, self._opening(run))
+            if in_task:
+                await self._say(
+                    managed,
+                    origin,
+                    me,
+                    f"Running {protocol.name} as episode {ep.short_id} with {self._cast(run)}.",
+                )
             outcome, why = await self._walk(managed, run, ep, me)
         finally:
             self._manager.release_floor(room, episode)
-        await self._close(managed, run, ep, me, outcome, why)
+        await self._close(managed, run, ep, me, outcome, why, origin if in_task else None)
         return outcome
 
     def _catalogue(self, room: str) -> str:
-        """Every protocol this room can run, each with its steps."""
+        """Every flow this room can run, each with its steps."""
         blocks = []
         own = set(protocols.room_protocol_names(room))
         for name in sorted(own | set(protocols.builtin_names())):
@@ -361,20 +383,23 @@ class ConductorEngine:
             origin = "this room's" if name in own else "built in"
             blocks.append(f"{protocols.describe(spec)}\n({origin})")
         return (
-            "Protocols I can run. Summon me with the name, the members in role order, "
+            "Flows I can run. Summon me with the name, the members in role order, "
             "then the question: `gated api-handle sec-handle: rotate the key`.\n\n"
             + "\n\n".join(blocks)
         )
 
     @staticmethod
-    def _opening(run: Run) -> str:
-        """The first line of a run: who plays what, and the graph about to be walked."""
+    def _cast(run: Run) -> str:
         cast = ", ".join(f"{h} as {role}" for role, h in run.bound.items())
         others = [h for h in run.handles if h not in run.bound.values()]
         if others:
             cast = ", ".join(x for x in (cast, f"{', '.join(others)} as members") if x)
-        head = f"Running {run.protocol.name} with {cast or ', '.join(run.handles)}."
-        return f"{head}\n\n{protocols.describe(run.protocol)}"
+        return cast or ", ".join(run.handles)
+
+    @classmethod
+    def _opening(cls, run: Run) -> str:
+        """The first line of a run: who plays what, and the graph about to be walked."""
+        return f"Running {run.protocol.name} with {cls._cast(run)}.\n\n{protocols.describe(run.protocol)}"
 
     async def _walk(
         self, managed: ManagedRoomChannel, run: Run, ep: l9_episode.EpisodeState, me: str
@@ -391,13 +416,27 @@ class ConductorEngine:
             run.steps_taken += 1
             stances = await self._take(managed, run, ep, me, step, cap)
             stance = stance_of_step(stances)
+            nxt = step.edge(stance)
+            ep.trace.append(
+                {
+                    "step": step.id,
+                    "turn": run.steps_taken,
+                    "asked": [h for h, _s in stances] or run.targets(step),
+                    "stances": {h: s for h, s in stances},
+                    "stance": stance,
+                    "next": nxt,
+                    "at": datetime.now(UTC).isoformat(),
+                }
+            )
+            # The record moves with the run, so an open episode shows where it is.
+            l9_episode.write_episode_record(ep, outcome="open", metrics=None, tasks=None)
             who = ", ".join(h for h, _s in stances) or (step.to or "")
             line = protocols.edge_line(step, stance, who)
             if line is not None:
                 # A branch taken is the one thing a reader cannot infer from the
-                # replies alone, so it is said in the thread.
+                # replies alone, so it is said in the episode.
                 await self._say(managed, run.episode, me, line)
-            step = protocol.step(step.edge(stance))
+            step = protocol.step(nxt)
 
     async def _take(
         self,
@@ -414,7 +453,7 @@ class ConductorEngine:
         stances: list[tuple[str, str | None]] = []
 
         def render(handle: str, round_n: int) -> str:
-            # Every turn says which step of which protocol it is, so the thread
+            # Every turn says which step of which flow it is, so the episode
             # reads as a run and not as a conversation that happened to occur.
             head = f"{run.protocol.name} · {step.id} · turn {run.steps_taken} of {cap} · {handle}"
             body = step.prompt.format_map(run.fields(round_n=round_n, rounds=step.rounds))
@@ -532,8 +571,9 @@ class ConductorEngine:
         me: str,
         outcome: str,
         why: str,
+        within: str | None,
     ) -> None:
-        """Commit the outcome onto the thread and write the record."""
+        """Commit the outcome onto the episode, write its record, tell the task."""
         commit = l9.build_envelope(
             kind=Kind.commit,
             subkind=outcome,
@@ -557,6 +597,8 @@ class ConductorEngine:
         except Exception:
             logger.warning("conductor failed to post the outcome for %s", run.episode)
         l9_episode.write_episode_record(ep, outcome=outcome, metrics=None, tasks=None)
+        if within:
+            await self._say(managed, within, me, f"{text[:-1]} (episode {ep.short_id}).")
 
     async def _say(self, managed: ManagedRoomChannel, episode: str, sender: str, text: str) -> None:
         """Post a plain message from the engine into ``episode``."""

--- a/fastapi-backend/app/services/conductor.py
+++ b/fastapi-backend/app/services/conductor.py
@@ -52,6 +52,9 @@ logger = logging.getLogger(__name__)
 #: The engine kind this class owns.
 ENGINE_KIND = "conductor"
 
+#: Summon words that ask for the catalogue rather than a run.
+LIST_DIRECTIVES = frozenset({"list", "protocols", "help"})
+
 #: Payloads that are never a member's answer to a step.
 _NOT_A_REPLY = frozenset(
     {"presence", "keepalive", "tick", l9.PING_PAYLOAD_TYPE, l9.NOTICE_PAYLOAD_TYPE}
@@ -213,6 +216,10 @@ class ConductorEngine:
             lambda m: "" if _norm(m.group(0)) == _norm(handle) else m.group(0), message_text
         )
         self._active.add(key)
+        # The floor is the run's from this instant, before anything else on the
+        # loop runs: a member the summon woke cannot slip a reply in ahead of the
+        # first step, and a persona mentioned as a role is not asked a question.
+        self._manager.hold_floor(room, episode, holder=handle)
         task = asyncio.create_task(
             self._run_and_release(room, handle, episode, summoned_in, directive, named, key)
         )
@@ -241,6 +248,8 @@ class ConductorEngine:
         except Exception:
             logger.exception("conductor @%s failed in %s", engine_handle, episode)
         finally:
+            # A run that never started still took the floor at the summon.
+            self._manager.release_floor(room, episode)
             self._active.discard(key)
 
     # -- the run --
@@ -270,6 +279,9 @@ class ConductorEngine:
         where = summoned_in or episode
 
         name, ask = split_directive(directive)
+        if name in LIST_DIRECTIVES:
+            await self._say(managed, where, me, self._catalogue(room))
+            return None
         protocol = protocols.load_protocol(room, name) if name else None
         if protocol is None:
             known = ", ".join(protocols.builtin_names())
@@ -323,14 +335,46 @@ class ConductorEngine:
         ep.messages.append(l9.envelope_to_dict(intent))
         logger.info("conductor @%s runs %s in %s over %s", me, protocol.name, episode, handles)
         # The floor is the run's from the first instant, so a member the summon
-        # woke cannot slip a reply in ahead of the first step.
+        # woke cannot slip a reply in ahead of the first step. (The summon seam
+        # already held it; a direct call takes it here.)
         self._manager.hold_floor(room, episode, holder=me)
         try:
+            # A built-in the room has run becomes the room's own memory, so a
+            # person can open the graph the conductor walked and reshape it.
+            if name not in protocols.room_protocol_names(room):
+                await protocols.materialize(room, protocol, created_by=me)
+            await self._say(managed, episode, me, self._opening(run))
             outcome, why = await self._walk(managed, run, ep, me)
         finally:
             self._manager.release_floor(room, episode)
         await self._close(managed, run, ep, me, outcome, why)
         return outcome
+
+    def _catalogue(self, room: str) -> str:
+        """Every protocol this room can run, each with its steps."""
+        blocks = []
+        own = set(protocols.room_protocol_names(room))
+        for name in sorted(own | set(protocols.builtin_names())):
+            spec = protocols.load_protocol(room, name)
+            if spec is None:
+                continue
+            origin = "this room's" if name in own else "built in"
+            blocks.append(f"{protocols.describe(spec)}\n({origin})")
+        return (
+            "Protocols I can run. Summon me with the name, the members in role order, "
+            "then the question: `gated api-handle sec-handle: rotate the key`.\n\n"
+            + "\n\n".join(blocks)
+        )
+
+    @staticmethod
+    def _opening(run: Run) -> str:
+        """The first line of a run: who plays what, and the graph about to be walked."""
+        cast = ", ".join(f"{h} as {role}" for role, h in run.bound.items())
+        others = [h for h in run.handles if h not in run.bound.values()]
+        if others:
+            cast = ", ".join(x for x in (cast, f"{', '.join(others)} as members") if x)
+        head = f"Running {run.protocol.name} with {cast or ', '.join(run.handles)}."
+        return f"{head}\n\n{protocols.describe(run.protocol)}"
 
     async def _walk(
         self, managed: ManagedRoomChannel, run: Run, ep: l9_episode.EpisodeState, me: str
@@ -345,8 +389,15 @@ class ConductorEngine:
             if run.steps_taken >= cap:
                 return "rejected", f"hit the step cap ({cap}) at `{step.id}`"
             run.steps_taken += 1
-            stances = await self._take(managed, run, ep, me, step)
-            step = protocol.step(step.edge(stance_of_step(stances)))
+            stances = await self._take(managed, run, ep, me, step, cap)
+            stance = stance_of_step(stances)
+            who = ", ".join(h for h, _s in stances) or (step.to or "")
+            line = protocols.edge_line(step, stance, who)
+            if line is not None:
+                # A branch taken is the one thing a reader cannot infer from the
+                # replies alone, so it is said in the thread.
+                await self._say(managed, run.episode, me, line)
+            step = protocol.step(step.edge(stance))
 
     async def _take(
         self,
@@ -355,24 +406,34 @@ class ConductorEngine:
         ep: l9_episode.EpisodeState,
         me: str,
         step: Step,
+        cap: int,
     ) -> list[tuple[str, str | None]]:
         """Put one step to its targets; return each target's stance."""
         room = managed.room
         targets = run.targets(step)
         stances: list[tuple[str, str | None]] = []
+
+        def render(handle: str, round_n: int) -> str:
+            # Every turn says which step of which protocol it is, so the thread
+            # reads as a run and not as a conversation that happened to occur.
+            head = f"{run.protocol.name} · {step.id} · turn {run.steps_taken} of {cap} · {handle}"
+            body = step.prompt.format_map(run.fields(round_n=round_n, rounds=step.rounds))
+            return f"{head}\n\n{body}"
+
         for round_n in range(1, step.rounds + 1):
             if step.wait == "none":
                 self._manager.hold_floor(room, run.episode, holder=me)
-                prompt = step.prompt.format_map(run.fields(round_n=round_n, rounds=step.rounds))
                 for handle in targets:
-                    await self._tell(managed, ep, me, run, step, handle, prompt)
+                    await self._tell(managed, ep, me, run, step, handle, render(handle, round_n))
                 return []
             if step.to in ("all", "workers"):
-                prompt = step.prompt.format_map(run.fields(round_n=round_n, rounds=step.rounds))
                 self._manager.hold_floor(room, run.episode, holder=me, speakers=targets)
                 stances = list(
                     await asyncio.gather(
-                        *(self._turn(managed, ep, me, run, step, h, prompt) for h in targets)
+                        *(
+                            self._turn(managed, ep, me, run, step, h, render(h, round_n))
+                            for h in targets
+                        )
                     )
                 )
                 continue
@@ -380,9 +441,10 @@ class ConductorEngine:
             # what the ones before it said.
             stances = []
             for handle in targets:
-                prompt = step.prompt.format_map(run.fields(round_n=round_n, rounds=step.rounds))
                 self._manager.hold_floor(room, run.episode, holder=me, speakers=[handle])
-                stances.append(await self._turn(managed, ep, me, run, step, handle, prompt))
+                stances.append(
+                    await self._turn(managed, ep, me, run, step, handle, render(handle, round_n))
+                )
         return stances
 
     async def _turn(

--- a/fastapi-backend/app/services/episode_records.py
+++ b/fastapi-backend/app/services/episode_records.py
@@ -22,6 +22,8 @@ import logging
 import re
 from typing import Any
 
+import yaml
+
 from app.services.filesystem import get_room_dir, list_memory_files
 from app.services.l9 import SYSTEM_ACTOR_ID
 
@@ -29,24 +31,66 @@ logger = logging.getLogger(__name__)
 
 EPISODES_PREFIX = "log/episodes/"
 
-_JSONL_RE = re.compile(r"```jsonl\n(.*?)\n```", re.DOTALL)
+# Anchored on their headings: a record with a flow carries two jsonl blocks
+# (the trace, then the messages), so "the first fence" is no longer enough.
+_JSONL_RE = re.compile(r"## Messages\n.*?```jsonl\n(.*?)\n```", re.DOTALL)
+_TRACE_RE = re.compile(r"## Trace\n.*?```jsonl\n(.*?)\n```", re.DOTALL)
+_FLOW_RE = re.compile(r"## Flow\n.*?```yaml\n(.*?)\n```", re.DOTALL)
 _TASKS_RE = re.compile(r"^- work: (.+)$", re.MULTILINE)
+_WITHIN_RE = re.compile(r"^- within: `([^`]+)`$", re.MULTILINE)
 
 
-def parse_envelopes(content: str) -> list[dict[str, Any]]:
-    match = _JSONL_RE.search(content)
+def _parse_jsonl(match: re.Match[str] | None, what: str) -> list[dict[str, Any]]:
     if not match:
         return []
-    envelopes: list[dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     for line in match.group(1).splitlines():
         line = line.strip()
         if not line:
             continue
         try:
-            envelopes.append(json.loads(line))
+            rows.append(json.loads(line))
         except json.JSONDecodeError:
-            logger.warning("skipping malformed episode envelope line")
-    return envelopes
+            logger.warning("skipping malformed episode %s line", what)
+    return rows
+
+
+def parse_envelopes(content: str) -> list[dict[str, Any]]:
+    return _parse_jsonl(_JSONL_RE.search(content), "envelope")
+
+
+def parse_trace(content: str) -> list[dict[str, Any]]:
+    """The steps a flow episode has taken, as the record wrote them."""
+    return _parse_jsonl(_TRACE_RE.search(content), "trace")
+
+
+def parse_flow(content: str) -> dict[str, Any] | None:
+    """The interaction flow an episode runs, or ``None`` for an episode without one."""
+    match = _FLOW_RE.search(content)
+    if not match:
+        return None
+    try:
+        data = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        logger.warning("skipping a flow block that does not parse")
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def current_step(
+    flow: dict[str, Any] | None, trace: list[dict[str, Any]], outcome: str
+) -> str | None:
+    """Where an open run stands: the step its last trace entry led to, else its first."""
+    if flow is None or outcome != "open":
+        return None
+    if trace:
+        nxt = trace[-1].get("next")
+        return str(nxt) if nxt else None
+    steps = flow.get("steps")
+    if isinstance(steps, list) and steps and isinstance(steps[0], dict):
+        first = steps[0].get("id")
+        return str(first) if first else None
+    return None
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -95,6 +139,9 @@ def episode_summary(key: str, meta: dict[str, Any], content: str) -> dict[str, A
         if tasks_match
         else []
     )
+    within_match = _WITHIN_RE.search(content)
+    flow = parse_flow(content)
+    trace = parse_trace(content)
 
     return {
         "short_id": short_id,
@@ -109,6 +156,10 @@ def episode_summary(key: str, meta: dict[str, Any], content: str) -> dict[str, A
         "message_count": len(envelopes),
         "updated_at": meta.get("updated_at", ""),
         "updated_by": meta.get("updated_by", ""),
+        "within": within_match.group(1) if within_match else None,
+        "flow": flow,
+        "trace": trace,
+        "current_step": current_step(flow, trace, outcome),
     }
 
 
@@ -148,6 +199,10 @@ def live_episode_summary(room_name: str) -> dict[str, Any] | None:
         "message_count": message_count,
         "updated_at": "",
         "updated_by": "",
+        "within": None,
+        "flow": None,
+        "trace": [],
+        "current_step": None,
     }
 
 

--- a/fastapi-backend/app/services/l9_episode.py
+++ b/fastapi-backend/app/services/l9_episode.py
@@ -42,6 +42,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+import yaml
+
 from app.services import l9
 from app.services.l9_models import Kind
 
@@ -103,6 +105,18 @@ class EpisodeState:
     intent_id: str = ""
     # Ordered record of every envelope in the episode (dicts, wire shape).
     messages: list[dict[str, Any]] = field(default_factory=list)
+    # The interaction flow this episode runs, when it has one: the step graph
+    # (roles, steps, edges) and who was bound to each role. An episode with a
+    # flow is a run the conductor walks; the record carries the graph so a
+    # reader can see the shape of the interaction, not only its messages.
+    flow: dict[str, Any] | None = None
+    # One entry per step taken: which step, whose turn, what they answered
+    # with, and the edge followed. Written as the run walks, so an open episode
+    # shows where it is.
+    trace: list[dict[str, Any]] = field(default_factory=list)
+    # The thread this episode was opened from, when it was opened inside a
+    # task: the link back to the row a nested episode belongs to.
+    within: str | None = None
 
 
 @dataclass
@@ -490,6 +504,9 @@ def write_episode_record(
             )
         if tasks:
             lines.append("- work: " + ", ".join(f"`{key}`" for key in tasks))
+        if ep.within:
+            lines.append(f"- within: `{ep.within}`")
+        _append_flow(lines, ep)
         # The header and the envelope chain are any thread's; the sections below
         # exist only where a negotiation actually ran.
         if not isinstance(ep, NegotiationState):
@@ -538,6 +555,30 @@ def write_episode_record(
         _write_record(ep, lines)
     except Exception:
         logger.exception("episode record write failed for %s", ep.episode)
+
+
+def _append_flow(lines: list[str], ep: EpisodeState) -> None:
+    """The flow an episode runs and the steps it has taken, as two fenced blocks."""
+    if ep.flow is None:
+        return
+    lines += [
+        "",
+        "## Flow",
+        "",
+        "The interaction flow this episode runs — its roles, steps and edges:",
+        "",
+        "```yaml",
+        yaml.safe_dump(ep.flow, sort_keys=False, default_flow_style=False).strip(),
+        "```",
+        "",
+        "## Trace",
+        "",
+        "Each step taken, in order (one JSON entry per line):",
+        "",
+        "```jsonl",
+        *(json.dumps(t, sort_keys=True) for t in ep.trace),
+        "```",
+    ]
 
 
 def _append_messages(lines: list[str], ep: EpisodeState) -> None:

--- a/fastapi-backend/app/services/persona_engine.py
+++ b/fastapi-backend/app/services/persona_engine.py
@@ -161,7 +161,19 @@ class PersonaEngine:
         co_summons: list[str] | None = None,
         message_text: str = "",
     ) -> None:
-        """A text mention of a registered persona: answer it."""
+        """A text mention of a registered persona: answer it.
+
+        Unless the same text summons a conductor: the handles named beside one
+        are bound to its roles, not asked a question, and the conductor will
+        address each in its turn. Answering the summon would talk over the
+        floor it just took, and leave the persona busy when its real turn came.
+        """
+        for other in co_summons or ():
+            if (
+                _norm(other) != _norm(handle)
+                and _registered_engine_kind(room, other) == "conductor"
+            ):
+                return
         self._fire(room, handle, envelope, message_text)
 
     def handle_addressed(self, room: str, handle: str, envelope: L9, message_text: str) -> None:
@@ -265,9 +277,18 @@ class PersonaEngine:
         *,
         payload: dict[str, Any] | None = None,
     ) -> None:
-        """Post ``text`` as the persona into ``episode``, a stance on the payload."""
+        """Post ``text`` as the persona into ``episode``, a stance on the payload.
+
+        A persona is a member, and a member off the floor does not speak: a
+        reply into a thread whose floor was not given to it is dropped, the
+        same refusal the write routes answer with a 409.
+        """
         if managed is None:
             logger.warning("persona @%s: no channel for room; dropping reply", sender)
+            return
+        floor = self._manager.floor(managed.room, episode)
+        if floor is not None and not floor.admits(sender):
+            logger.info("persona @%s is off the floor in %s; not posting", sender, episode)
             return
         env = l9.build_envelope(
             kind=Kind.exchange,

--- a/fastapi-backend/app/services/protocols.py
+++ b/fastapi-backend/app/services/protocols.py
@@ -244,6 +244,104 @@ BUILTIN_PROTOCOLS: dict[str, dict[str, Any]] = {
 }
 
 
+def describe(protocol: Protocol) -> str:
+    """A protocol as a person reads it: its roles, then each step and its edges.
+
+    One line per step, in the protocol's own words (``propose asks proposer,
+    then review``), so a room can see the graph a run is walking without
+    opening the spec.
+    """
+    lines = [f"**{protocol.name}**: {protocol.description}".rstrip(": ")]
+    if protocol.roles:
+        lines.append(f"roles: {', '.join(protocol.roles)} (bound in that order)")
+    for step in protocol.steps:
+        if step.end is not None:
+            lines.append(f"- {step.id}: ends {step.end}")
+            continue
+        who = step.to or ""
+        turns = f", {step.rounds} rounds" if step.rounds > 1 else ""
+        asks = "tells" if step.wait == "none" else "asks"
+        if isinstance(step.next, str):
+            lines.append(f"- {step.id}: {asks} {who}{turns}, then {step.next}")
+        else:
+            edges = ", ".join(f"{k}: {v}" for k, v in (step.next or {}).items())
+            lines.append(f"- {step.id}: {asks} {who}{turns}, then by stance ({edges})")
+    lines.append(f"up to {protocol.max_steps} steps")
+    return "\n".join(lines)
+
+
+def edge_line(step: Step, stance: str | None, who: str) -> str | None:
+    """One line saying which way a branching step went, or ``None`` for a plain edge."""
+    if not isinstance(step.next, dict):
+        return None
+    target = step.edge(stance)
+    said = {
+        "accept": f"{who} accepted",
+        "reject": f"{who} blocked",
+        "silent": f"{who} did not answer",
+    }.get(stance or "", f"{who} stated no stance")
+    return f"{step.id}: {said}, on to {target}"
+
+
+def spec_of(protocol: Protocol) -> dict[str, Any]:
+    """The protocol as the YAML body of a ``protocols/<name>`` memory carries it."""
+    data = protocol.model_dump(mode="json", exclude_none=True)
+    data.pop("name", None)
+    for step in data.get("steps", []):
+        if step.get("wait") == "reply":
+            step.pop("wait", None)
+        if step.get("rounds") == 1:
+            step.pop("rounds", None)
+        if step.get("prompt") == "":
+            step.pop("prompt", None)
+    return data
+
+
+def room_protocol_names(room: str) -> list[str]:
+    """The names of the protocols a room has written under ``protocols/``."""
+    from app.services.filesystem import get_room_dir, list_memory_files, room_exists
+
+    if not room_exists(room):
+        return []
+    return sorted(
+        key.removeprefix(PROTOCOLS_PREFIX)
+        for key, _meta, _content in list_memory_files(get_room_dir(room), prefix=PROTOCOLS_PREFIX)
+    )
+
+
+async def materialize(room: str, protocol: Protocol, *, created_by: str) -> bool:
+    """Write a built-in as the room's own ``protocols/<name>`` memory, once.
+
+    A built-in the room has run is then a memory a person can open, read and
+    edit like any other, and the next run reads the room's copy. Nothing is
+    written when the room already has one. Returns whether it wrote.
+    """
+    from app.routes.memory import upsert_memories  # lazy — routes import services
+    from app.schemas import MemoryBatchCreate, MemoryCreate
+    from app.services.filesystem import get_room_dir, read_memory_file
+
+    key = f"{PROTOCOLS_PREFIX}{protocol.name}"
+    if read_memory_file(get_room_dir(room), key) is not None:
+        return False
+    body = yaml.safe_dump(spec_of(protocol), sort_keys=False, default_flow_style=False).strip()
+    await upsert_memories(
+        room,
+        MemoryBatchCreate(
+            items=[
+                MemoryCreate(
+                    key=key,
+                    value=body,
+                    created_by=created_by,
+                    embed=False,
+                    tags=["protocol"],
+                    meta={"description": protocol.description} if protocol.description else None,
+                )
+            ]
+        ),
+    )
+    return True
+
+
 def builtin(name: str) -> Protocol | None:
     spec = BUILTIN_PROTOCOLS.get(name)
     return Protocol.model_validate(spec) if spec else None

--- a/fastapi-backend/app/services/protocols.py
+++ b/fastapi-backend/app/services/protocols.py
@@ -309,39 +309,6 @@ def room_protocol_names(room: str) -> list[str]:
     )
 
 
-async def materialize(room: str, protocol: Protocol, *, created_by: str) -> bool:
-    """Write a built-in as the room's own ``protocols/<name>`` memory, once.
-
-    A built-in the room has run is then a memory a person can open, read and
-    edit like any other, and the next run reads the room's copy. Nothing is
-    written when the room already has one. Returns whether it wrote.
-    """
-    from app.routes.memory import upsert_memories  # lazy — routes import services
-    from app.schemas import MemoryBatchCreate, MemoryCreate
-    from app.services.filesystem import get_room_dir, read_memory_file
-
-    key = f"{PROTOCOLS_PREFIX}{protocol.name}"
-    if read_memory_file(get_room_dir(room), key) is not None:
-        return False
-    body = yaml.safe_dump(spec_of(protocol), sort_keys=False, default_flow_style=False).strip()
-    await upsert_memories(
-        room,
-        MemoryBatchCreate(
-            items=[
-                MemoryCreate(
-                    key=key,
-                    value=body,
-                    created_by=created_by,
-                    embed=False,
-                    tags=["protocol"],
-                    meta={"description": protocol.description} if protocol.description else None,
-                )
-            ]
-        ),
-    )
-    return True
-
-
 def builtin(name: str) -> Protocol | None:
     spec = BUILTIN_PROTOCOLS.get(name)
     return Protocol.model_validate(spec) if spec else None

--- a/fastapi-backend/app/services/room_channels.py
+++ b/fastapi-backend/app/services/room_channels.py
@@ -1314,12 +1314,27 @@ class RoomChannelManager:
             self._notice_in_background(
                 room,
                 subkind="floor",
-                key=episode.rsplit(":", 1)[-1],
-                episode=episode,
+                **self._floor_names(room, episode),
                 by=floor.holder,
                 speakers=",".join(sorted(floor.speakers)),
             )
         return floor
+
+    @staticmethod
+    def _floor_names(room: str, episode: str) -> dict[str, str | None]:
+        """How a floor notice names its thread: by the task it belongs to.
+
+        A task and its thread are one object, so a line about the thread says
+        the task's key and title; only a thread no row carries falls back to
+        the id. The lookup is the store's, done lazily so this module does not
+        import the task model at load.
+        """
+        from app.services.tasks import row_of_episode
+
+        row = row_of_episode(room, episode)
+        if row is None:
+            return {"key": episode.rsplit(":", 1)[-1], "episode": episode, "title": None}
+        return {"key": row[0], "episode": episode, "title": row[1]}
 
     def release_floor(self, room: str, episode: str) -> bool:
         """Open ``episode`` back up; True when a floor was actually held."""
@@ -1332,8 +1347,7 @@ class RoomChannelManager:
         self._notice_in_background(
             room,
             subkind="floor",
-            key=episode.rsplit(":", 1)[-1],
-            episode=episode,
+            **self._floor_names(room, episode),
             by=floor.holder,
             released="1",
         )

--- a/fastapi-backend/app/services/tasks.py
+++ b/fastapi-backend/app/services/tasks.py
@@ -162,6 +162,22 @@ def carry_thread(room: str, key: str) -> dict[str, str]:
     return {EPISODE_META: episode_of(room, key) or mint_episode_urn(room)}
 
 
+def row_of_episode(room: str, episode: str) -> tuple[str, str] | None:
+    """The ``(key, title)`` of the memory bound to ``episode``, or ``None``.
+
+    A thread is a task's when a row carries its URN; this is the reverse
+    lookup, so a notice or a badge about a thread can say the task's name
+    rather than the thread's id. One scan of the room's files, for events that
+    happen a few times per protocol step rather than per message.
+    """
+    for key, meta, content in list_memory_files(get_room_dir(room), limit=None):
+        if system_meta(meta).get(EPISODE_META) != episode:
+            continue
+        first = next((ln.strip() for ln in (content or "").splitlines() if ln.strip()), key)
+        return key, first.lstrip("# ").strip()
+    return None
+
+
 def bound_episodes(room: str) -> set[str]:
     """Every episode URN some row in the room already carries.
 

--- a/fastapi-backend/tests/test_conductor.py
+++ b/fastapi-backend/tests/test_conductor.py
@@ -454,7 +454,8 @@ async def test_a_rooms_own_protocol_runs_under_its_name():
     )
 
     assert outcome == "resolved"
-    assert channel.ticks() == [("ask", "api", "look at #12")]
+    assert [(s, to) for s, to, _p in channel.ticks()] == [("ask", "api")]
+    assert channel.ticks()[0][2].endswith("\n\nlook at #12")
     # Fire-and-forget gives nobody the floor and waits on nothing.
     assert [sorted(f.speakers) for f in manager.floor_log] == [[], []]
 
@@ -532,3 +533,121 @@ async def test_a_re_summon_into_a_running_thread_is_ignored():
     await asyncio.sleep(0.5)
 
     assert len([e for e, _x in channel.sent if e.header.kind == Kind.commit]) == 1
+
+
+# ── legible from the outside ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_run_opens_by_saying_who_plays_what_and_the_graph():
+    engine, _manager, channel = _engine(
+        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
+    )
+
+    await engine.run(ROOM, episode=THREAD, directive="gated: rotate", named=["api", "sec"])
+
+    opening = channel.said()[0]
+    assert opening.startswith("Running gated with api as proposer, sec as guardian.")
+    assert "propose: asks proposer, then review" in opening
+    assert "review: asks guardian, then by stance (accept: approved, reject: propose" in opening
+    assert "approved: ends resolved" in opening
+    assert "up to 6 steps" in opening
+
+
+@pytest.mark.asyncio
+async def test_every_turn_says_which_step_of_which_protocol_it_is():
+    engine, _manager, channel = _engine(
+        {"api": [("v1", None), ("v2", None)], "sec": [("no", "reject"), ("yes", "accept")]}
+    )
+
+    await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+
+    heads = [p.split("\n", 1)[0] for _s, _to, p in channel.ticks()]
+    assert heads == [
+        "gated · propose · turn 1 of 6 · api",
+        "gated · review · turn 2 of 6 · sec",
+        "gated · propose · turn 3 of 6 · api",
+        "gated · review · turn 4 of 6 · sec",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_branch_taken_is_said_in_the_thread_and_a_plain_edge_is_not():
+    engine, _manager, channel = _engine(
+        {"api": [("v1", None), ("v2", None)], "sec": [("no", "reject"), ("yes", "accept")]}
+    )
+
+    await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+
+    lines = [t for t in channel.said() if t.startswith("review:")]
+    assert lines == ["review: sec blocked, on to propose", "review: sec accepted, on to approved"]
+    assert not any(t.startswith("propose:") for t in channel.said())
+
+
+@pytest.mark.asyncio
+async def test_a_built_in_the_room_ran_becomes_the_rooms_own_memory(monkeypatch):
+    monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+    engine, _manager, _channel = _engine(
+        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
+    )
+    assert read_memory_file(get_room_dir(ROOM), "protocols/gated") is None
+
+    await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+
+    found = read_memory_file(get_room_dir(ROOM), "protocols/gated")
+    assert found is not None
+    written = protocols.parse_protocol("gated", found[1])
+    assert written.roles == ["proposer", "guardian"]
+    assert [s.id for s in written.steps] == ["propose", "review", "approved"]
+    # The room's copy is what runs next, so editing it reshapes the protocol.
+    assert protocols.room_protocol_names(ROOM) == ["gated"]
+
+
+@pytest.mark.asyncio
+async def test_list_says_what_it_can_run():
+    engine, manager, channel = _engine({})
+
+    outcome = await engine.run(ROOM, episode=THREAD, summoned_in=LIVE, directive="list")
+
+    assert outcome is None
+    assert manager.floor_log == []
+    said = channel.said()[0]
+    for name in protocols.builtin_names():
+        assert f"**{name}**" in said
+    assert "(built in)" in said
+    assert channel.sent[0][0].header.message.episode == LIVE
+
+
+@pytest.mark.asyncio
+async def test_the_floor_is_held_the_instant_the_summon_lands():
+    """Before anything else on the loop runs — so a member the summon woke,
+    or a persona mentioned as a role, cannot slip a reply in first."""
+    _register("conductor", "conductor")
+    engine, manager, channel = _engine(
+        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
+    )
+    env, summons, text = _summon("@conductor gated @api @sec: rotate the key", episode=THREAD)
+
+    engine.handle_summon(ROOM, "conductor", env, summons, text)
+
+    held = manager.floor(ROOM, THREAD)
+    assert held is not None
+    assert held.holder == "conductor"
+    assert not held.admits("api") and not held.admits("sec")
+    await asyncio.sleep(0.1)
+    assert manager.floor(ROOM, THREAD) is None, "released once the run ends"
+    assert channel.commit().header.subkind == "resolved"
+
+
+@pytest.mark.asyncio
+async def test_a_summon_that_cannot_start_lets_the_floor_go():
+    _register("conductor", "conductor")
+    engine, manager, channel = _engine({})
+    env, summons, text = _summon("@conductor waltz @api @sec: go", episode=THREAD)
+
+    engine.handle_summon(ROOM, "conductor", env, summons, text)
+    assert manager.floor(ROOM, THREAD) is not None
+    await asyncio.sleep(0.05)
+
+    assert manager.floor(ROOM, THREAD) is None
+    assert "Built in:" in channel.said()[0]

--- a/fastapi-backend/tests/test_conductor.py
+++ b/fastapi-backend/tests/test_conductor.py
@@ -387,6 +387,7 @@ async def test_the_episode_is_the_run_and_its_record_carries_the_flow_and_the_tr
     flow = summary["flow"]
     assert flow["name"] == "gated"
     assert flow["bound"] == {"proposer": "api", "guardian": "sec"}
+    assert flow["cast"] == ["api", "sec"]
     assert flow["ask"] == "rotate"
     assert [st["id"] for st in flow["steps"]] == ["propose", "review", "approved"]
     assert [(t["step"], t["turn"], t["stance"], t["next"]) for t in summary["trace"]] == [

--- a/fastapi-backend/tests/test_conductor.py
+++ b/fastapi-backend/tests/test_conductor.py
@@ -363,28 +363,65 @@ async def test_with_nobody_named_the_room_takes_part():
 
 
 @pytest.mark.asyncio
-async def test_the_run_leaves_an_episode_record_on_the_thread():
+async def test_the_episode_is_the_run_and_its_record_carries_the_flow_and_the_trace():
     from app.services.episode_records import episode_summary, parse_envelopes
 
     engine, _manager, _channel = _engine(
-        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
+        {"api": [("v1", None), ("v2", None)], "sec": [("no", "reject"), ("yes", "accept")]}
     )
     before = set(_records())
 
-    await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
+    outcome = await engine.run(ROOM, directive="gated: rotate", named=["api", "sec"])
 
+    assert outcome == "resolved"
     new = set(_records()) - before
-    assert len(new) == 1
+    assert len(new) == 1, "one record for the run, rewritten as it walked"
     key = new.pop()
     found = read_memory_file(get_room_dir(ROOM), key)
     assert found is not None
     meta, content = found
     summary = episode_summary(key, meta, content)
-    assert summary["episode"] == THREAD, "the record is the thread's, not a new episode's"
     assert summary["outcome"] == "resolved"
+    assert summary["within"] is None, "summoned from the room, nested in nothing"
+    assert summary["current_step"] is None, "a finished run stands nowhere"
+    flow = summary["flow"]
+    assert flow["name"] == "gated"
+    assert flow["bound"] == {"proposer": "api", "guardian": "sec"}
+    assert flow["ask"] == "rotate"
+    assert [st["id"] for st in flow["steps"]] == ["propose", "review", "approved"]
+    assert [(t["step"], t["turn"], t["stance"], t["next"]) for t in summary["trace"]] == [
+        ("propose", 1, None, "review"),
+        ("review", 2, "reject", "propose"),
+        ("propose", 3, None, "review"),
+        ("review", 4, "accept", "approved"),
+    ]
+    assert summary["trace"][1]["stances"] == {"sec": "reject"}
     assert {"api", "sec"} <= set(summary["participants"])
-    # Intent, two ticks, two replies, the commit.
-    assert len(parse_envelopes(content)) == 6
+    # Intent, four ticks, four replies, the commit.
+    assert len(parse_envelopes(content)) == 10
+
+
+@pytest.mark.asyncio
+async def test_an_open_run_records_where_it_stands():
+    """The record is written at the opening and after every step, so the
+    episode can be opened while it is still walking."""
+    from app.services.episode_records import episode_summary
+
+    seen: list[tuple[str, str | None, int]] = []
+    engine, _manager, _channel = _engine({"api": [("v1", None)], "sec": [("yes", "accept")]})
+    original = engine._turn
+
+    async def spy(managed, ep, me, run, step, handle, prompt):
+        found = read_memory_file(get_room_dir(ROOM), f"log/episodes/{ep.short_id}")
+        assert found is not None
+        summary = episode_summary(f"log/episodes/{ep.short_id}", *found)
+        seen.append((summary["outcome"], summary["current_step"], len(summary["trace"])))
+        return await original(managed, ep, me, run, step, handle, prompt)
+
+    engine._turn = spy
+    await engine.run(ROOM, directive="gated: go", named=["api", "sec"])
+
+    assert seen == [("open", "propose", 0), ("open", "review", 1)]
 
 
 @pytest.mark.asyncio
@@ -478,7 +515,12 @@ def _summon(text: str, *, episode: str, sender: str = "julia") -> Any:
 
 
 @pytest.mark.asyncio
-async def test_a_summon_runs_in_the_thread_it_was_made_in():
+async def test_a_summon_from_a_task_opens_an_episode_nested_in_it():
+    """The task is context, not the container: the run gets its own episode,
+    the record says which task it ran inside, and the task's thread gets one
+    line when it opens and one when it ends."""
+    from app.services.episode_records import episode_summary
+
     _register("conductor", "conductor")
     engine, _manager, channel = _engine(
         {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
@@ -488,12 +530,28 @@ async def test_a_summon_runs_in_the_thread_it_was_made_in():
     engine.handle_summon(ROOM, "conductor", env, summons, text)
     await asyncio.sleep(0.1)
 
-    assert channel.commit().header.message.episode == THREAD
-    assert channel.commit().payload.data["roles"] == {"proposer": "api", "guardian": "sec"}
+    commit = channel.commit()
+    run_episode = commit.header.message.episode
+    assert run_episode != THREAD
+    assert commit.payload.data["roles"] == {"proposer": "api", "guardian": "sec"}
+    short = run_episode.rsplit(":", 1)[-1]
+    found = read_memory_file(get_room_dir(ROOM), f"log/episodes/{short}")
+    assert found is not None
+    assert episode_summary(f"log/episodes/{short}", *found)["within"] == THREAD
+    in_task = [
+        (extra or {})["content"]
+        for e, extra in channel.sent
+        if e.header.message.episode == THREAD and e.payload.type == "message"
+    ]
+    assert in_task[0] == f"Running gated as episode {short} with api as proposer, sec as guardian."
+    assert in_task[-1].startswith("✓ gated: resolved after 2 step(s)")
+    assert in_task[-1].endswith(f"(episode {short}).")
 
 
 @pytest.mark.asyncio
-async def test_a_summon_from_the_room_opens_a_thread_of_its_own():
+async def test_a_summon_from_the_room_nests_in_nothing():
+    from app.services.episode_records import episode_summary
+
     _register("conductor", "conductor")
     engine, _manager, channel = _engine(
         {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
@@ -505,7 +563,12 @@ async def test_a_summon_from_the_room_opens_a_thread_of_its_own():
 
     ran_in = channel.commit().header.message.episode
     assert ran_in != LIVE
-    assert ran_in.startswith(l9.episode_urn(ROOM, ""))
+    short = ran_in.rsplit(":", 1)[-1]
+    found = read_memory_file(get_room_dir(ROOM), f"log/episodes/{short}")
+    assert found is not None
+    assert episode_summary(f"log/episodes/{short}", *found)["within"] is None
+    # Nothing is said to the room about the run beyond the room's own timeline.
+    assert [e for e, _x in channel.sent if e.header.message.episode == LIVE] == []
 
 
 @pytest.mark.asyncio
@@ -585,25 +648,6 @@ async def test_a_branch_taken_is_said_in_the_thread_and_a_plain_edge_is_not():
 
 
 @pytest.mark.asyncio
-async def test_a_built_in_the_room_ran_becomes_the_rooms_own_memory(monkeypatch):
-    monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
-    engine, _manager, _channel = _engine(
-        {"api": [("do the thing", None)], "sec": [("approved", "accept")]}
-    )
-    assert read_memory_file(get_room_dir(ROOM), "protocols/gated") is None
-
-    await engine.run(ROOM, episode=THREAD, directive="gated: go", named=["api", "sec"])
-
-    found = read_memory_file(get_room_dir(ROOM), "protocols/gated")
-    assert found is not None
-    written = protocols.parse_protocol("gated", found[1])
-    assert written.roles == ["proposer", "guardian"]
-    assert [s.id for s in written.steps] == ["propose", "review", "approved"]
-    # The room's copy is what runs next, so editing it reshapes the protocol.
-    assert protocols.room_protocol_names(ROOM) == ["gated"]
-
-
-@pytest.mark.asyncio
 async def test_list_says_what_it_can_run():
     engine, manager, channel = _engine({})
 
@@ -630,13 +674,14 @@ async def test_the_floor_is_held_the_instant_the_summon_lands():
 
     engine.handle_summon(ROOM, "conductor", env, summons, text)
 
-    held = manager.floor(ROOM, THREAD)
-    assert held is not None
+    assert len(manager.floors) == 1
+    ((run_episode, held),) = manager.floors.items()
+    assert run_episode != THREAD
     assert held.holder == "conductor"
     assert not held.admits("api") and not held.admits("sec")
     await asyncio.sleep(0.1)
-    assert manager.floor(ROOM, THREAD) is None, "released once the run ends"
-    assert channel.commit().header.subkind == "resolved"
+    assert manager.floors == {}, "released once the run ends"
+    assert channel.commit().header.message.episode == run_episode
 
 
 @pytest.mark.asyncio
@@ -646,8 +691,9 @@ async def test_a_summon_that_cannot_start_lets_the_floor_go():
     env, summons, text = _summon("@conductor waltz @api @sec: go", episode=THREAD)
 
     engine.handle_summon(ROOM, "conductor", env, summons, text)
-    assert manager.floor(ROOM, THREAD) is not None
+    assert len(manager.floors) == 1
     await asyncio.sleep(0.05)
 
-    assert manager.floor(ROOM, THREAD) is None
+    assert manager.floors == {}
     assert "Built in:" in channel.said()[0]
+    assert channel.sent[0][0].header.message.episode == THREAD, "answered where it was asked"

--- a/fastapi-backend/tests/test_episodes.py
+++ b/fastapi-backend/tests/test_episodes.py
@@ -147,3 +147,114 @@ async def test_get_missing_episode_is_404(client):
     await client.post("/api/rooms", json={"name": "sprint"})
     resp = await client.get("/api/rooms/sprint/episodes/missing")
     assert resp.status_code == 404
+
+
+# ── an episode that carries its flow ─────────────────────────────────────────
+
+
+def _flow_record(outcome: str, trace: list[dict], *, within: str | None = None) -> str:
+    from app.services import l9_episode
+
+    ep = l9_episode.EpisodeState(
+        episode="urn:ioc:mycelium:episode:r:e1",
+        topic="urn:concept:mycelium:r",
+        parent_room="r",
+        short_id="e1",
+        workspace_id="ws",
+        mas_id="",
+        agents=["api", "sec"],
+        engine_handle="conductor",
+        flow={
+            "name": "gated",
+            "roles": ["proposer", "guardian"],
+            "steps": [
+                {"id": "propose", "to": "proposer", "next": "review"},
+                {
+                    "id": "review",
+                    "to": "guardian",
+                    "next": {"accept": "approved", "reject": "propose"},
+                },
+                {"id": "approved", "end": "resolved"},
+            ],
+            "bound": {"proposer": "api", "guardian": "sec"},
+        },
+        trace=trace,
+        within=within,
+    )
+    ep.messages.append(
+        {
+            "header": {
+                "kind": "commit" if outcome != "open" else "intent",
+                "subkind": outcome if outcome != "open" else "mission",
+                "message": {"id": "m1", "episode": ep.episode},
+                "context": {"topic": ep.topic},
+                "participants": {"actors": [{"id": "conductor", "role": "agent"}]},
+            },
+            "payload": {"type": "outcome", "data": {}},
+        }
+    )
+    l9_episode.write_episode_record(ep, outcome=outcome, metrics=None, tasks=None)
+    return f"log/episodes/{ep.short_id}"
+
+
+def test_a_flow_record_reads_back_its_graph_trace_and_parent(tmp_path, monkeypatch):
+    from app.services.episode_records import episode_summary
+    from app.services.filesystem import get_room_dir, read_memory_file
+
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    get_room_dir("r")
+    trace = [
+        {
+            "step": "propose",
+            "turn": 1,
+            "asked": ["api"],
+            "stances": {"api": None},
+            "stance": None,
+            "next": "review",
+        }
+    ]
+    key = _flow_record("open", trace, within="urn:ioc:mycelium:episode:r:t3")
+
+    found = read_memory_file(get_room_dir("r"), key)
+    assert found is not None
+    summary = episode_summary(key, *found)
+    assert summary["outcome"] == "open"
+    assert summary["within"] == "urn:ioc:mycelium:episode:r:t3"
+    assert summary["flow"]["name"] == "gated"
+    assert summary["flow"]["bound"] == {"proposer": "api", "guardian": "sec"}
+    assert summary["trace"] == trace
+    assert summary["current_step"] == "review", "the step the last trace entry led to"
+
+
+def test_an_open_flow_with_no_steps_yet_stands_at_its_first(tmp_path, monkeypatch):
+    from app.services.episode_records import episode_summary
+    from app.services.filesystem import get_room_dir, read_memory_file
+
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    get_room_dir("r")
+    key = _flow_record("open", [])
+    found = read_memory_file(get_room_dir("r"), key)
+    assert found is not None
+    summary = episode_summary(key, *found)
+    assert summary["current_step"] == "propose"
+    assert summary["within"] is None
+
+
+def test_a_finished_flow_stands_nowhere_and_a_negotiation_has_no_flow(tmp_path, monkeypatch):
+    from app.services.episode_records import episode_summary
+    from app.services.filesystem import get_room_dir, read_memory_file
+
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    get_room_dir("r")
+    key = _flow_record("resolved", [{"step": "review", "turn": 2, "next": "approved"}])
+    found = read_memory_file(get_room_dir("r"), key)
+    assert found is not None
+    summary = episode_summary(key, *found)
+    assert summary["current_step"] is None
+    assert summary["outcome"] == "resolved"
+
+    plain = "# Episode x\n\n## Messages\n\n```jsonl\n\n```\n"
+    summary = episode_summary("log/episodes/x", {}, plain)
+    assert summary["flow"] is None
+    assert summary["trace"] == []
+    assert summary["within"] is None

--- a/fastapi-backend/tests/test_floor.py
+++ b/fastapi-backend/tests/test_floor.py
@@ -207,6 +207,29 @@ class TestTheRoomHears:
         assert notices[1]["speakers"] == "api"
         assert notices[2]["released"] == "1"
 
+    @pytest.mark.asyncio
+    async def test_a_notice_names_the_task_the_thread_belongs_to(self, notices, monkeypatch):
+        """A task and its thread are one object, so the timeline says the
+        task's name; only a thread no row carries is named by its id."""
+        from app.services import tasks
+        from app.services.filesystem import get_room_dir
+
+        monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+        get_room_dir(ROOM)
+        manager, _managed = _manager()
+        task = await tasks.create_task(ROOM, "Rotate the signing key", created_by="julia")
+        assert task.episode
+
+        manager.hold_floor(ROOM, task.episode, holder="conductor")
+        manager.hold_floor(ROOM, THREAD, holder="conductor")
+        await asyncio.sleep(0)
+
+        by_episode = {n["episode"]: n for n in notices}
+        assert by_episode[task.episode]["key"] == task.key
+        assert by_episode[task.episode]["title"] == "Rotate the signing key"
+        assert by_episode[THREAD]["key"] == "t3"
+        assert by_episode[THREAD]["title"] is None
+
     def test_a_floor_held_with_no_loop_running_raises_nothing_and_still_holds(self, notices):
         manager, _managed = _manager()
         assert manager.hold_floor(ROOM, THREAD, holder="conductor", speakers=["api"]) is not None
@@ -229,10 +252,19 @@ class TestTheRoomHears:
             {
                 "thread": "t3",
                 "episode": THREAD,
+                "key": None,
+                "title": None,
                 "holder": "conductor",
                 "speakers": ["api", "julia"],
             },
-            {"thread": "t9", "episode": OTHER, "holder": "reviewer", "speakers": ["sec"]},
+            {
+                "thread": "t9",
+                "episode": OTHER,
+                "key": None,
+                "title": None,
+                "holder": "reviewer",
+                "speakers": ["sec"],
+            },
         ]
         manager.release_floor(ROOM, THREAD)
         manager.release_floor(ROOM, OTHER)

--- a/fastapi-backend/tests/test_persona_engine.py
+++ b/fastapi-backend/tests/test_persona_engine.py
@@ -276,3 +276,58 @@ async def test_host_runtime_leaves_it_to_the_host(monkeypatch: pytest.MonkeyPatc
     await asyncio.sleep(0.02)
 
     assert calls == []
+
+
+# ── a role is not a question, and nobody speaks off the floor ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_mention_beside_a_conductor_binds_a_role_and_asks_nothing():
+    """`@conductor gated @api @sec: …` names the personas that fill the roles.
+    The conductor will address each in turn; answering the summon would talk
+    over the floor it just took and leave the persona busy for its real turn."""
+    _register("sec", "persona")
+    _register("maestro", "conductor")
+    engine, _managed = _engine()
+    calls = _capture(engine)
+
+    summons = ["maestro", "api", "sec"]
+    engine.handle_summon(
+        _ROOM, "sec", _env("julia", episode=_THREAD), summons, "@maestro gated @api @sec: go"
+    )
+    await asyncio.sleep(0.02)
+    assert calls == []
+
+    # The same persona, mentioned on its own, still answers.
+    engine.handle_summon(_ROOM, "sec", _env("julia"), ["sec"], "@sec thoughts?")
+    await asyncio.sleep(0.02)
+    assert [c["engine_handle"] for c in calls] == ["sec"]
+
+
+@pytest.mark.asyncio
+async def test_it_does_not_post_into_a_thread_whose_floor_it_was_not_given(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _register("sec", "persona")
+    _patch_pi(monkeypatch, "Blocked. [[mycelium: stance=reject]]")
+    engine, managed = _engine()
+    engine._manager.hold_floor(_ROOM, _THREAD, holder="conductor", speakers=["api"])
+
+    reply = await engine.answer(
+        _ROOM, engine_handle="sec", episode=_THREAD, sender="julia", text="go"
+    )
+
+    assert reply == "Blocked."
+    assert _posted(managed) == [], "the reply was dropped, not posted out of turn"
+
+
+@pytest.mark.asyncio
+async def test_it_posts_when_the_floor_is_its_own(monkeypatch: pytest.MonkeyPatch):
+    _register("sec", "persona")
+    _patch_pi(monkeypatch, "Blocked. [[mycelium: stance=reject]]")
+    engine, managed = _engine()
+    engine._manager.hold_floor(_ROOM, _THREAD, holder="conductor", speakers=["sec"])
+
+    await engine.answer(_ROOM, engine_handle="sec", episode=_THREAD, sender="conductor", text="go")
+
+    assert [t for _e, t in _posted(managed)] == ["Blocked."]

--- a/fastapi-backend/tests/test_protocols.py
+++ b/fastapi-backend/tests/test_protocols.py
@@ -143,3 +143,71 @@ def test_a_spec_that_does_not_parse_is_absent_not_half_read():
         get_room_dir(ROOM), "protocols/loose", yaml.safe_dump({"steps": []}), created_by="julia"
     )
     assert protocols.load_protocol(ROOM, "loose") is None
+
+
+def test_describe_reads_as_a_person_would():
+    gated = protocols.builtin("gated")
+    assert gated is not None
+    text = protocols.describe(gated)
+    assert text.splitlines()[0].startswith("**gated**: A proposer proposes")
+    assert "roles: proposer, guardian (bound in that order)" in text
+    assert "- propose: asks proposer, then review" in text
+    assert (
+        "- review: asks guardian, then by stance (accept: approved, reject: propose, default: propose)"
+        in text
+    )
+    assert "- approved: ends resolved" in text
+    assert text.splitlines()[-1] == "up to 6 steps"
+
+
+def test_describe_says_rounds_and_tells():
+    spec = protocols.Protocol.model_validate(
+        {
+            "name": "x",
+            "steps": [
+                {"id": "r", "to": "each", "rounds": 2, "next": "n"},
+                {"id": "n", "to": "all", "wait": "none", "next": "d"},
+                {"id": "d", "end": "resolved"},
+            ],
+        }
+    )
+    text = protocols.describe(spec)
+    assert "- r: asks each, 2 rounds, then n" in text
+    assert "- n: tells all, then d" in text
+
+
+def test_edge_line_names_the_branch_taken_and_nothing_for_a_plain_edge():
+    gated = protocols.builtin("gated")
+    assert gated is not None
+    review = gated.step("review")
+    assert protocols.edge_line(review, "reject", "sec") == "review: sec blocked, on to propose"
+    assert protocols.edge_line(review, "accept", "sec") == "review: sec accepted, on to approved"
+    assert (
+        protocols.edge_line(review, "silent", "sec") == "review: sec did not answer, on to propose"
+    )
+    assert protocols.edge_line(review, None, "sec") == "review: sec stated no stance, on to propose"
+    assert protocols.edge_line(gated.step("propose"), None, "api") is None
+
+
+def test_spec_of_round_trips_through_the_memory_body():
+    for name in protocols.builtin_names():
+        spec = protocols.builtin(name)
+        assert spec is not None
+        body = yaml.safe_dump(protocols.spec_of(spec), sort_keys=False)
+        again = protocols.parse_protocol(name, body)
+        assert again == spec
+
+
+@pytest.mark.asyncio
+async def test_materialize_writes_a_built_in_once(monkeypatch):
+    monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
+    get_room_dir(ROOM)
+    gated = protocols.builtin("gated")
+    assert gated is not None
+
+    assert await protocols.materialize(ROOM, gated, created_by="conductor") is True
+    assert protocols.room_protocol_names(ROOM) == ["gated"]
+    found = protocols.load_protocol(ROOM, "gated")
+    assert found == gated
+    # Already the room's: left alone, so an edit survives the next run.
+    assert await protocols.materialize(ROOM, gated, created_by="conductor") is False

--- a/fastapi-backend/tests/test_protocols.py
+++ b/fastapi-backend/tests/test_protocols.py
@@ -196,18 +196,3 @@ def test_spec_of_round_trips_through_the_memory_body():
         body = yaml.safe_dump(protocols.spec_of(spec), sort_keys=False)
         again = protocols.parse_protocol(name, body)
         assert again == spec
-
-
-@pytest.mark.asyncio
-async def test_materialize_writes_a_built_in_once(monkeypatch):
-    monkeypatch.setattr("app.routes.memory.embed_text", lambda _text: [0.0])
-    get_room_dir(ROOM)
-    gated = protocols.builtin("gated")
-    assert gated is not None
-
-    assert await protocols.materialize(ROOM, gated, created_by="conductor") is True
-    assert protocols.room_protocol_names(ROOM) == ["gated"]
-    found = protocols.load_protocol(ROOM, "gated")
-    assert found == gated
-    # Already the room's: left alone, so an edit survives the next run.
-    assert await protocols.materialize(ROOM, gated, created_by="conductor") is False

--- a/mycelium-cli/src/mycelium/docs/concepts/conductor.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/conductor.md
@@ -45,6 +45,37 @@ person answers a step the way they answer anything in a thread, with
 agent's reply carried. That is how a human-in-the-loop step works: the
 conductor gives the person the floor and waits.
 
+## Watching a run
+
+A run is meant to be read from the outside, in the thread it runs in. The
+conductor opens by saying who plays what and the graph it is about to walk:
+
+```
+Running gated with api as proposer, sec as guardian.
+
+**gated**: A proposer proposes, a guardian approves or blocks; a block sends it back.
+roles: proposer, guardian (bound in that order)
+- propose: asks proposer, then review
+- review: asks guardian, then by stance (accept: approved, reject: propose, default: propose)
+- approved: ends resolved
+up to 6 steps
+```
+
+Every turn it puts to a member starts with a line saying which step of
+which protocol it is (`gated · review · turn 2 of 6 · sec`), so a block
+reads as the guardian's stance at the review step, not as the conductor
+blocking anyone. When a step branches, the conductor says which way it went
+(`review: sec blocked, on to propose`). A plain edge says nothing.
+
+The first time a room runs a built-in protocol, the conductor writes it to
+the room as `protocols/<name>`, so the graph is a memory a person can open,
+read and edit; the room's copy is what runs next. Ask the conductor what it
+can run with `mycelium engine invoke conductor "list"`.
+
+The members named in the summon are bound to roles, not asked a question:
+a persona mentioned there waits for its turn rather than answering the
+summon, and a resident agent that replies before its turn is refused.
+
 ## Whose turn it is
 
 While a run is open, the thread has a **floor**. The conductor holds it, and

--- a/mycelium-cli/src/mycelium/docs/concepts/conductor.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/conductor.md
@@ -1,54 +1,76 @@
 # Conductor
 
-The conductor is the [engine](#engines) that runs a **protocol** inside a
-task: a fixed shape of who speaks to whom, in what order, and what happens on
-each answer. Where the [aligner](#aligner) brokers a negotiation, the
-conductor walks a graph. It is the engine to reach for when a piece of work
-has a shape you already know: a proposal that a reviewer must approve, a lead
-asking every worker at once, a round where each member speaks in turn.
+The conductor is the [engine](#engines) that runs an **episode with a
+flow**: a fixed shape of who speaks to whom, in what order, and what happens
+on each answer. Where the [aligner](#aligner) brokers a negotiation, the
+conductor walks a graph. It is the engine to reach for when an interaction
+has a shape you already know: a proposal a reviewer must approve, a lead
+asking every worker at once, members speaking in turn.
 
 It is the one engine with no model of its own. Every judgment in a run, what
 to propose and whether to block it, is made by the members it addresses. The
-conductor only decides whose turn it is, and it enforces that in code: while a
-step is open, only the member it addressed can write into the thread. That is
-the split the whole design rests on. A model sits in each node, and code sits
-on the edges.
+conductor only decides whose turn it is, and it enforces that in code: while
+a step is open, only the member it addressed can write into the episode.
+That is the split the whole design rests on. A model sits in each node, and
+code sits on the edges.
 
 ```bash
 # Register it once per room
 mycelium engine create conductor --kind conductor --room sprint-plan
 
-# Run the gated protocol inside a task: @api proposes, @sec approves or blocks
+# Open a gated run: @api proposes, @sec approves or blocks
+mycelium engine invoke conductor \
+  "gated @api @sec: rotate the signing key without downtime" -r sprint-plan
+```
+
+The summon names the flow first, then the members in the order the flow's
+roles expect, then the question.
+
+## The episode is the run
+
+Every run opens an [episode](#episodes) of its own, and the episode carries
+its flow. The graph the conductor walks, who was bound to each role, and the
+trace of every step taken are written onto the episode's record as it goes,
+so an open run shows where it stands and a finished one shows the shape of
+the interaction, not only its messages. Open the episode in the app and the
+graph is drawn at the top of its thread: the current step lit, the edges
+taken solid, the member who has the floor marked, and the steps taken listed
+under it.
+
+A run can be opened from a task, which makes it a phase inside that task the
+way a negotiation is:
+
+```bash
 mycelium board coordinate work/rotate-signing-key conductor \
   "gated @api @sec: rotate the signing key without downtime"
 ```
 
-The summon names the protocol first, then the members in the order the
-protocol's roles expect, then the question. The run happens in the thread the
-summon was made in, so the row's conversation carries the whole thing and
-`board messages` reads it back. A summon from the room itself
-(`engine invoke`) opens a thread of its own, because the room is never
-narrowed to one speaker.
+The run still gets its own episode. The task's thread gets one line when the
+run opens (naming the episode and the cast) and one when it ends, and the
+episode's record says which task it ran inside. A run opened from the room
+is nested in nothing. Either way the task is context or an output, never the
+container the flow lives in.
 
-## The built-in protocols
+## The built-in flows
 
-| Protocol | Roles | Shape |
+| Flow | Roles | Shape |
 |---|---|---|
 | `gated` | proposer, guardian | The proposer states what it intends to do. The guardian approves or blocks, ending its reply with `[[mycelium: stance=accept]]` or `[[mycelium: stance=reject]]`. A block sends the proposal back with the objection attached, until an approval or the step cap. |
 | `fan-out` | lead | Every other member is asked at once. The lead then gets all the answers and combines them into one plan. |
 | `round-robin` | none | Each member speaks in turn, seeing what the others said, for two rounds. |
 
 Any member can fill a role: a registered agent kept awake with
-`mycelium await --loop`, an engine such as [hello](#hello), or a person. A
-person answers a step the way they answer anything in a thread, with
-`board send`, and a stance marker left in the text is read the same as one an
-agent's reply carried. That is how a human-in-the-loop step works: the
-conductor gives the person the floor and waits.
+`mycelium await --loop`, a [persona](#persona), or a person. A person
+answers a step the way they answer anything in a thread, and a stance marker
+left in the text is read the same as one an agent's reply carried. That is
+how a human-in-the-loop step works: the conductor gives the person the floor
+and waits. Ask the conductor what it can run with
+`mycelium engine invoke conductor "list"`.
 
-## Watching a run
+## Reading a run
 
-A run is meant to be read from the outside, in the thread it runs in. The
-conductor opens by saying who plays what and the graph it is about to walk:
+A run is meant to be read from the outside. The conductor opens by saying
+who plays what and the graph it is about to walk:
 
 ```
 Running gated with api as proposer, sec as guardian.
@@ -62,53 +84,42 @@ up to 6 steps
 ```
 
 Every turn it puts to a member starts with a line saying which step of
-which protocol it is (`gated · review · turn 2 of 6 · sec`), so a block
-reads as the guardian's stance at the review step, not as the conductor
-blocking anyone. When a step branches, the conductor says which way it went
-(`review: sec blocked, on to propose`). A plain edge says nothing.
+which flow it is (`gated · review · turn 2 of 6 · sec`), so a block reads as
+the guardian's stance at the review step, not as the conductor blocking
+anyone. When a step branches, the conductor says which way it went
+(`review: sec blocked, on to propose`).
 
-The first time a room runs a built-in protocol, the conductor writes it to
-the room as `protocols/<name>`, so the graph is a memory a person can open,
-read and edit; the room's copy is what runs next. Ask the conductor what it
-can run with `mycelium engine invoke conductor "list"`.
-
-The members named in the summon are bound to roles, not asked a question:
-a persona mentioned there waits for its turn rather than answering the
-summon, and a resident agent that replies before its turn is refused.
+The members named in the summon are bound to roles, not asked a question: a
+persona mentioned there waits for its turn rather than answering the summon,
+and a resident agent that replies before its turn is refused.
 
 ## Whose turn it is
 
-While a run is open, the thread has a **floor**. The conductor holds it, and
-gives it to whoever the current step addresses: one member for a role step,
-everyone at once for a fan-out. A write from anyone else is refused with a
-`409` that says who holds the floor and who may speak, so an agent that tried
-early keeps awaiting rather than giving up. A refused write never reaches the
-transcript, which means it wakes nobody.
+While a run is open, its episode has a **floor**. The conductor holds it
+from the instant the summon lands, and gives it to whoever the current step
+addresses: one member for a role step, everyone at once for a fan-out. A
+write from anyone else is refused with a `409` that says who holds the floor
+and who may speak, so an agent that tried early keeps awaiting rather than
+giving up. A refused write never reaches the transcript, which means it wakes
+nobody. The room's timeline gets a line each time the floor moves, and the
+members rail marks who has it.
 
-The room can see whose turn it is. The members rail marks who has the floor
-and in which thread, and the room's timeline gets one line each time the
-floor moves, so a person watching a run knows who everyone is waiting on.
-
-Nothing else narrows. The room stays open throughout, other threads are
-untouched, and a member joining the room mid-run aborts nothing, because a
-protocol run is not a negotiation and freezes no roster. When the run ends,
-the floor is released and the thread takes anyone again.
+Nothing else narrows. The room stays open, other threads are untouched, and a
+member joining the room mid-run aborts nothing, because a run is not a
+negotiation and freezes no roster. When the run ends, the floor is released.
 
 ## How a run ends
 
-A run ends at one of the protocol's end steps, `resolved` or `rejected`, or at
+A run ends at one of its flow's end steps, `resolved` or `rejected`, or at
 the step cap, which counts as `rejected`. The outcome is committed onto the
-thread and recorded at `log/episodes/{id}.md` like any coordination phase:
-who took part, each step's prompt and reply, and how it ended. A resolved run
-does not resolve the task it ran in, and does not compile anything into new
-rows. It is a phase inside the task, and `board resolve` still finishes the
-task.
+episode and its record is final: the flow, the whole trace, and every
+envelope. A resolved run resolves no task and compiles nothing into rows.
 
-## Writing your own
+## Writing your own flow
 
-A protocol is a memory under `protocols/`, promoted the way a skill is. A room
-that writes `protocols/gated` reshapes the built-in under that name; a new
-name adds a protocol. The body is YAML:
+A flow is a memory under `protocols/`. A room that writes `protocols/gated`
+reshapes the built-in under that name; a new name adds a flow. The body is
+YAML:
 
 ```yaml
 description: A reviewer signs off before the author ships.
@@ -133,6 +144,7 @@ A step addresses a role, or `each` (every member, one at a time), `all`
 step. `next` is one step id, or a map from `accept`, `reject`, `silent` and
 `default` to step ids. Prompts can carry `{ask}`, `{reply}` (the most recent
 answer), `{replies}` (everyone's latest, one per line), `{handles}`, `{round}`
-and `{rounds}`. Every step must lead somewhere, and every protocol needs an
-end step; a spec that does not hold together is refused rather than run
-half-read.
+and `{rounds}`. Every step must lead somewhere, and every flow needs an end
+step; a spec that does not hold together is refused rather than run
+half-read. Each run copies the flow onto its own episode, so editing the
+memory changes the next run and never a record.

--- a/mycelium-cli/src/mycelium/docs/concepts/episodes.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/episodes.md
@@ -3,7 +3,7 @@
 **An episode is one scoped conversation inside a room.**
 
 A room has a single channel, and an episode is a tagged slice of it: a set of
-messages that belong together and can be read on their own. Two things are
+messages that belong together and can be read on their own. Three things are
 episodes.
 
 The first is a [task](#board)'s **thread**. Every task gets one when it is
@@ -17,8 +17,15 @@ more agents disagree on a trade-off with several moving parts, someone puts a
 mediator on the task, and the mediator drives it to one answer or to a clean
 failure to agree.
 
-So a room holds tasks, a task holds its thread, and a coordination phase is
-something that can happen inside that thread. The task outlives it.
+The third is a **run with a flow**: an episode the [conductor](#conductor)
+opens to walk a fixed interaction shape, a proposer and a guardian, a lead
+and its workers, members speaking in turn. The flow is written onto the
+episode itself, along with every step taken, so the episode shows the shape
+of the interaction and where it stands, not only its messages. A run can be
+opened from a task, which nests it there, or from the room.
+
+So a room holds tasks, a task holds its thread, and a coordination phase or a
+run is something that can happen inside that thread. The task outlives it.
 
 ## Opening one
 

--- a/mycelium-cli/src/mycelium/docs/concepts/persona.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/persona.md
@@ -42,6 +42,10 @@ Both roles are now played by personas, the guardian blocks what the
 proposer puts up until it has a rollback plan, and the whole exchange runs in
 the task's thread with no session resident anywhere.
 
+A mention beside a conductor is different: `@conductor gated @api @sec: …`
+binds `api` and `sec` to the protocol's roles. Neither answers the summon;
+each waits to be addressed by its step.
+
 ## What it says
 
 It answers where it was asked: in the thread the turn rode, or in the room.
@@ -50,7 +54,8 @@ A reply that ends in a stance marker (`[[mycelium: stance=accept]]` or
 `mycelium respond` does, so a conductor step or an aligner round reads it
 the same as a resident agent's. Every `@` in what it says is removed before
 posting, so a persona can never summon anything, and two personas can never
-set each other off.
+set each other off. And a persona is a member: a reply into a thread whose
+floor was not given to it is dropped, the same refusal an agent's write gets.
 
 Like hello, it is fail-loud: a Pi error or an empty answer is posted as a
 readable reason rather than silence, so a quiet persona is never mistaken

--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -281,17 +281,19 @@ function activityLine(ev: Event): { label: string; detail: string } {
     const by = ev.raw.by as string | undefined;
     const label = noticeLabel((ev.raw.subkind as string) || "filed", ev.raw.kind as string | undefined);
     if (ev.raw.subkind === "floor") {
-      // Whose turn it is in a thread: the handles it was given to, the holder
-      // alone, or the floor opening back up.
+      // Whose turn it is in a thread: the task the thread belongs to (its id
+      // only when no row carries it), then the handles it was given to, the
+      // holder alone, or the floor opening back up.
       const speakers = (ev.raw.speakers as string[] | undefined) ?? [];
-      const detail = ev.raw.released
+      const where = (ev.raw.title as string | undefined) || (ev.raw.key as string | undefined) || "";
+      const turn = ev.raw.released
         ? "released"
         : speakers.length
           ? speakers.map((h) => `@${h}`).join(", ")
           : by
             ? `held by @${by}`
             : "";
-      return { label, detail };
+      return { label, detail: [where, turn].filter(Boolean).join(" · ") };
     }
     return { label, detail: by ? `@${by}` : "" };
   }

--- a/mycelium-frontend/src/components/flow-graph.tsx
+++ b/mycelium-frontend/src/components/flow-graph.tsx
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+/**
+ * An episode's interaction flow, drawn: the steps the conductor walks, the
+ * edges between them, where the run stands, and whose turn it is.
+ *
+ * Purpose-built for a flow of a handful of steps rather than a general graph
+ * view: steps read left to right in the order they run, a branch fans out with
+ * its stance on the edge, and a loop back is an arc under the row. The run's
+ * state is drawn on top of the shape — the current step lit, taken edges
+ * solid, the member holding the floor named — so the same drawing serves an
+ * open run and a finished one.
+ */
+
+import type { EpisodeFlow, FlowTraceEntry, RoomFloor } from "@/lib/api";
+import {
+  layoutFlow,
+  stepStates,
+  takenEdges,
+  NODE_H,
+  NODE_W,
+  type FlowEdge,
+  type FlowNode,
+  type StepState,
+} from "@/lib/flow-graph";
+
+interface Props {
+  flow: EpisodeFlow;
+  trace: FlowTraceEntry[];
+  currentStep: string | null | undefined;
+  outcome: string;
+  /** The floor held on this episode right now, if any. */
+  floor?: RoomFloor | null;
+  className?: string;
+}
+
+function tone(state: StepState, end: FlowNode["end"]): { stroke: string; fill: string; text: string } {
+  if (state === "current") return { stroke: "var(--accent)", fill: "color-mix(in srgb, var(--accent) 16%, transparent)", text: "var(--text)" };
+  if (state === "reached") {
+    const c = end === "rejected" ? "var(--yellow)" : "var(--green)";
+    return { stroke: c, fill: `color-mix(in srgb, ${c} 16%, transparent)`, text: "var(--text)" };
+  }
+  if (state === "visited") return { stroke: "var(--muted-foreground)", fill: "color-mix(in srgb, var(--muted-foreground) 10%, transparent)", text: "var(--text)" };
+  return { stroke: "var(--border)", fill: "transparent", text: "var(--muted-foreground)" };
+}
+
+/** Vertical room between two loops from one source: a label's height plus air,
+ *  so a second loop's label never prints over the first's. */
+const LANE_GAP = 14;
+
+function edgePath(from: FlowNode, to: FlowNode, edge: FlowEdge, lane: number): string {
+  const y = from.y + NODE_H / 2;
+  if (!edge.back) {
+    const x1 = from.x + NODE_W;
+    const x2 = to.x;
+    // A forward edge that skips a step arches over the row so it does not
+    // run through the step between.
+    const skip = to.x - x1 > NODE_W;
+    if (!skip) return `M ${x1} ${y} L ${x2} ${y}`;
+    const top = from.y - 14;
+    return `M ${x1} ${y} C ${x1 + 40} ${top}, ${x2 - 40} ${top}, ${x2} ${y}`;
+  }
+  // A loop: down from the source, under the row, up into the target.
+  const x1 = from.x + NODE_W / 2 + lane * 10;
+  const x2 = to.x + NODE_W / 2 - lane * 10;
+  const bottom = from.y + NODE_H + 22 + lane * LANE_GAP;
+  return `M ${x1} ${from.y + NODE_H} L ${x1} ${bottom} L ${x2} ${bottom} L ${x2} ${to.y + NODE_H}`;
+}
+
+function edgeLabelPos(from: FlowNode, to: FlowNode, edge: FlowEdge, lane: number): { x: number; y: number } {
+  if (!edge.back) {
+    const skip = to.x - (from.x + NODE_W) > NODE_W;
+    return { x: (from.x + NODE_W + to.x) / 2, y: skip ? from.y - 6 : from.y + NODE_H / 2 - 6 };
+  }
+  return { x: (from.x + to.x + NODE_W) / 2, y: from.y + NODE_H + 22 + lane * LANE_GAP - 4 };
+}
+
+export function FlowGraph({ flow, trace, currentStep, outcome, floor, className }: Props) {
+  const layout = layoutFlow(flow);
+  const states = stepStates(flow, trace, currentStep, outcome);
+  const taken = takenEdges(trace);
+  const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+  const speakers = new Set((floor?.speakers ?? []).map((h) => h.toLowerCase()));
+  // Loops from the same source stack outward so two never overlap.
+  const lanes = new Map<string, number>();
+  const laneOf = (e: FlowEdge) => {
+    if (!e.back) return 0;
+    const n = lanes.get(e.from) ?? 0;
+    lanes.set(e.from, n + 1);
+    return n;
+  };
+
+  return (
+    <svg
+      viewBox={`0 0 ${layout.width} ${layout.height}`}
+      width="100%"
+      style={{ maxWidth: layout.width, display: "block", overflow: "visible" }}
+      role="img"
+      aria-label={`${flow.name} flow: ${layout.nodes.map((n) => n.id).join(", ")}`}
+      className={className}
+    >
+      <defs>
+        <marker id="flow-arrow" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+          <path d="M 0 0 L 8 4 L 0 8 z" fill="currentColor" />
+        </marker>
+      </defs>
+      {layout.edges.map((edge, i) => {
+        const from = byId.get(edge.from);
+        const to = byId.get(edge.to);
+        if (!from || !to) return null;
+        const lane = laneOf(edge);
+        const solid = taken.has(`${edge.from}→${edge.to}`);
+        const color = solid ? "var(--text)" : "var(--muted-foreground)";
+        const label = edgeLabelPos(from, to, edge, lane);
+        return (
+          <g key={i} style={{ color }}>
+            <path
+              d={edgePath(from, to, edge, lane)}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={solid ? 1.8 : 1.2}
+              strokeDasharray={solid ? undefined : "4 3"}
+              markerEnd="url(#flow-arrow)"
+            />
+            {edge.label && (
+              <text x={label.x} y={label.y} textAnchor="middle" fontSize="10" fill="currentColor" fontFamily="var(--font-mono, ui-monospace, monospace)">
+                {edge.label}
+              </text>
+            )}
+          </g>
+        );
+      })}
+      {layout.nodes.map((node) => {
+        const state = states.get(node.id) ?? "untouched";
+        const t = tone(state, node.end);
+        const hasFloor = node.who !== null && speakers.has(node.who.toLowerCase());
+        return (
+          <g key={node.id} transform={`translate(${node.x} ${node.y})`}>
+            <rect width={NODE_W} height={NODE_H} rx={8} fill={t.fill} stroke={t.stroke} strokeWidth={state === "current" ? 2 : 1.2} />
+            <text x={10} y={18} fontSize="12" fontWeight={600} fill={t.text} fontFamily="var(--font-mono, ui-monospace, monospace)">
+              {node.id}
+            </text>
+            <text x={10} y={34} fontSize="10" fill="var(--muted-foreground)">
+              {node.who ? `${node.what} · ${node.who}` : node.what}
+            </text>
+            {hasFloor && (
+              <g transform={`translate(${NODE_W - 8} -6)`}>
+                <circle r={5} fill="var(--accent)" />
+                <title>{`${node.who} has the floor`}</title>
+              </g>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}

--- a/mycelium-frontend/src/components/flow-graph.tsx
+++ b/mycelium-frontend/src/components/flow-graph.tsx
@@ -8,11 +8,12 @@
  * edges between them, where the run stands, and whose turn it is.
  *
  * Purpose-built for a flow of a handful of steps rather than a general graph
- * view: steps read left to right in the order they run, a branch fans out with
- * its stance on the edge, and a loop back is an arc under the row. The run's
- * state is drawn on top of the shape — the current step lit, taken edges
- * solid, the member holding the floor named — so the same drawing serves an
- * open run and a finished one.
+ * view: steps read in the order they run, a branch fans out with its stance
+ * on the edge, and a loop back rides a rail beside the line. A short flow is
+ * a row; a longer one is a column, the shape that fits the pane it is shown
+ * in. The run's state is drawn on top of the shape — the current step lit,
+ * taken edges solid, the member holding the floor marked — so the same
+ * drawing serves an open run and a finished one.
  */
 
 import type { EpisodeFlow, FlowTraceEntry, RoomFloor } from "@/lib/api";
@@ -20,9 +21,11 @@ import {
   layoutFlow,
   stepStates,
   takenEdges,
+  LANE_GAP,
+  LOOP_BASE,
   NODE_H,
-  NODE_W,
   type FlowEdge,
+  type FlowLayout,
   type FlowNode,
   type StepState,
 } from "@/lib/flow-graph";
@@ -47,57 +50,124 @@ function tone(state: StepState, end: FlowNode["end"]): { stroke: string; fill: s
   return { stroke: "var(--border)", fill: "transparent", text: "var(--muted-foreground)" };
 }
 
-/** Vertical room between two loops from one source: a label's height plus air,
- *  so a second loop's label never prints over the first's. */
-const LANE_GAP = 14;
-
-function edgePath(from: FlowNode, to: FlowNode, edge: FlowEdge, lane: number): string {
-  const y = from.y + NODE_H / 2;
-  if (!edge.back) {
-    const x1 = from.x + NODE_W;
-    const x2 = to.x;
-    // A forward edge that skips a step arches over the row so it does not
-    // run through the step between.
-    const skip = to.x - x1 > NODE_W;
-    if (!skip) return `M ${x1} ${y} L ${x2} ${y}`;
-    const top = from.y - 14;
-    return `M ${x1} ${y} C ${x1 + 40} ${top}, ${x2 - 40} ${top}, ${x2} ${y}`;
-  }
-  // A loop: down from the source, under the row, up into the target.
-  const x1 = from.x + NODE_W / 2 + lane * 10;
-  const x2 = to.x + NODE_W / 2 - lane * 10;
-  const bottom = from.y + NODE_H + 22 + lane * LANE_GAP;
-  return `M ${x1} ${from.y + NODE_H} L ${x1} ${bottom} L ${x2} ${bottom} L ${x2} ${to.y + NODE_H}`;
+interface Drawn {
+  d: string;
+  label: { x: number; y: number; rotate: boolean; anchor: "start" | "middle" | "end" };
 }
 
-function edgeLabelPos(from: FlowNode, to: FlowNode, edge: FlowEdge, lane: number): { x: number; y: number } {
-  if (!edge.back) {
-    const skip = to.x - (from.x + NODE_W) > NODE_W;
-    return { x: (from.x + NODE_W + to.x) / 2, y: skip ? from.y - 6 : from.y + NODE_H / 2 - 6 };
+/** A row's edge: straight between neighbours, arched over a skipped step, and
+ *  a loop down under the row in its own lane. */
+function rowEdge(from: FlowNode, to: FlowNode, edge: FlowEdge): Drawn {
+  const y = from.y + NODE_H / 2;
+  if (edge.rail === null) {
+    const x1 = from.x + from.w;
+    const x2 = to.x;
+    const skip = x2 - x1 > from.w;
+    if (!skip) return { d: `M ${x1} ${y} L ${x2} ${y}`, label: { x: (x1 + x2) / 2, y: y - 6, rotate: false, anchor: "middle" } };
+    const top = from.y - 14;
+    return {
+      d: `M ${x1} ${y} C ${x1 + 40} ${top}, ${x2 - 40} ${top}, ${x2} ${y}`,
+      label: { x: (x1 + x2) / 2, y: from.y - 6, rotate: false, anchor: "middle" },
+    };
   }
-  return { x: (from.x + to.x + NODE_W) / 2, y: from.y + NODE_H + 22 + lane * LANE_GAP - 4 };
+  // Each loop has a lane of its own, lower than the last, so lines never
+  // share a segment; a loop onto its own step is a narrow U under it.
+  const lane = edge.rail;
+  const x1 = from.x + from.w / 2 + (lane + 1) * 10;
+  const x2 = to.x + to.w / 2 - (lane + 1) * 10;
+  const bottom = from.y + NODE_H + LOOP_BASE + 6 + lane * LANE_GAP;
+  return {
+    d: `M ${x1} ${from.y + NODE_H} L ${x1} ${bottom} L ${x2} ${bottom} L ${x2} ${to.y + NODE_H}`,
+    label: { x: (x1 + x2) / 2, y: bottom - 4, rotate: false, anchor: "middle" },
+  };
+}
+
+/** Where a rail edge meets its node: the ports on one side of a node are
+ *  spread down its height so two edges never share a point. */
+type Ports = Map<string, { n: number; next: number }>;
+
+function port(ports: Ports, key: string, node: FlowNode): number {
+  const p = ports.get(key) ?? { n: 1, next: 0 };
+  const y = node.y + (NODE_H * (p.next + 1)) / (p.n + 1);
+  p.next += 1;
+  ports.set(key, p);
+  return y;
+}
+
+/** A column's edge: straight down between neighbours, out to a rail on the
+ *  right to skip ahead, out to a rail on the left to loop back. */
+function columnEdge(from: FlowNode, to: FlowNode, edge: FlowEdge, ports: Ports): Drawn {
+  if (edge.rail === null) {
+    const cx = from.x + from.w / 2;
+    const y1 = from.y + NODE_H;
+    const y2 = to.y;
+    return { d: `M ${cx} ${y1} L ${cx} ${y2}`, label: { x: cx + 8, y: (y1 + y2) / 2 + 3, rotate: false, anchor: "start" } };
+  }
+  const lane = edge.rail;
+  if (edge.back) {
+    const railX = from.x - (lane + 1) * LANE_GAP;
+    const self = from.id === to.id;
+    const ySrc = self ? from.y + NODE_H / 2 + 8 : port(ports, `L:${from.id}`, from);
+    const yDst = self ? to.y + NODE_H / 2 - 8 : port(ports, `L:${to.id}`, to);
+    return {
+      d: `M ${from.x} ${ySrc} L ${railX} ${ySrc} L ${railX} ${yDst} L ${to.x} ${yDst}`,
+      label: { x: railX - 4, y: (ySrc + yDst) / 2, rotate: true, anchor: "middle" },
+    };
+  }
+  const edgeX = from.x + from.w;
+  const railX = edgeX + (lane + 1) * LANE_GAP;
+  const ySrc = port(ports, `R:${from.id}`, from);
+  const yDst = port(ports, `R:${to.id}`, to);
+  return {
+    d: `M ${edgeX} ${ySrc} L ${railX} ${ySrc} L ${railX} ${yDst} L ${edgeX} ${yDst}`,
+    label: { x: railX + 10, y: (ySrc + yDst) / 2, rotate: true, anchor: "middle" },
+  };
+}
+
+function drawEdges(layout: FlowLayout): Map<FlowEdge, Drawn> {
+  const byId = new Map(layout.nodes.map((n) => [n.id, n]));
+  const drawn = new Map<FlowEdge, Drawn>();
+  // A node's ports are counted first so each edge can take its share.
+  const ports: Ports = new Map();
+  if (layout.direction === "column") {
+    for (const e of layout.edges) {
+      if (e.rail === null || e.from === e.to) continue;
+      const side = e.back ? "L" : "R";
+      for (const id of [e.from, e.to]) {
+        const key = `${side}:${id}`;
+        const p = ports.get(key) ?? { n: 0, next: 0 };
+        p.n += 1;
+        ports.set(key, p);
+      }
+    }
+  }
+  for (const edge of layout.edges) {
+    const from = byId.get(edge.from);
+    const to = byId.get(edge.to);
+    if (!from || !to) continue;
+    drawn.set(edge, layout.direction === "row" ? rowEdge(from, to, edge) : columnEdge(from, to, edge, ports));
+  }
+  return drawn;
 }
 
 export function FlowGraph({ flow, trace, currentStep, outcome, floor, className }: Props) {
   const layout = layoutFlow(flow);
   const states = stepStates(flow, trace, currentStep, outcome);
   const taken = takenEdges(trace);
-  const byId = new Map(layout.nodes.map((n) => [n.id, n]));
   const speakers = new Set((floor?.speakers ?? []).map((h) => h.toLowerCase()));
-  // Loops from the same source stack outward so two never overlap.
-  const lanes = new Map<string, number>();
-  const laneOf = (e: FlowEdge) => {
-    if (!e.back) return 0;
-    const n = lanes.get(e.from) ?? 0;
-    lanes.set(e.from, n + 1);
-    return n;
-  };
+  const drawn = drawEdges(layout);
+  // A row shrinks a little to fit a narrow pane and scrolls past that; a
+  // column is as wide as the pane gives it, which is what it was chosen for.
+  const sizing =
+    layout.direction === "row"
+      ? { minWidth: layout.width * 0.7, maxWidth: layout.width }
+      : { maxWidth: layout.width };
 
   return (
     <svg
       viewBox={`0 0 ${layout.width} ${layout.height}`}
       width="100%"
-      style={{ maxWidth: layout.width, display: "block", overflow: "visible" }}
+      style={{ ...sizing, display: "block", overflow: "visible" }}
       role="img"
       aria-label={`${flow.name} flow: ${layout.nodes.map((n) => n.id).join(", ")}`}
       className={className}
@@ -108,17 +178,15 @@ export function FlowGraph({ flow, trace, currentStep, outcome, floor, className 
         </marker>
       </defs>
       {layout.edges.map((edge, i) => {
-        const from = byId.get(edge.from);
-        const to = byId.get(edge.to);
-        if (!from || !to) return null;
-        const lane = laneOf(edge);
+        const shape = drawn.get(edge);
+        if (!shape) return null;
         const solid = taken.has(`${edge.from}→${edge.to}`);
         const color = solid ? "var(--text)" : "var(--muted-foreground)";
-        const label = edgeLabelPos(from, to, edge, lane);
+        const { label } = shape;
         return (
           <g key={i} style={{ color }}>
             <path
-              d={edgePath(from, to, edge, lane)}
+              d={shape.d}
               fill="none"
               stroke="currentColor"
               strokeWidth={solid ? 1.8 : 1.2}
@@ -126,7 +194,15 @@ export function FlowGraph({ flow, trace, currentStep, outcome, floor, className 
               markerEnd="url(#flow-arrow)"
             />
             {edge.label && (
-              <text x={label.x} y={label.y} textAnchor="middle" fontSize="10" fill="currentColor" fontFamily="var(--font-mono, ui-monospace, monospace)">
+              <text
+                x={label.x}
+                y={label.y}
+                textAnchor={label.anchor}
+                fontSize="10"
+                fill="currentColor"
+                fontFamily="var(--font-mono, ui-monospace, monospace)"
+                transform={label.rotate ? `rotate(-90 ${label.x} ${label.y})` : undefined}
+              >
                 {edge.label}
               </text>
             )}
@@ -136,18 +212,31 @@ export function FlowGraph({ flow, trace, currentStep, outcome, floor, className 
       {layout.nodes.map((node) => {
         const state = states.get(node.id) ?? "untouched";
         const t = tone(state, node.end);
-        const hasFloor = node.who !== null && speakers.has(node.who.toLowerCase());
+        // The floor is a fact about now, so it marks the step the run stands
+        // at, and only when the floor is with whom that step asks. A group
+        // step names several members; the floor is theirs if any hold it.
+        const hasFloor =
+          state === "current" &&
+          node.who !== null &&
+          node.who.split(", ").some((h) => speakers.has(h.toLowerCase()));
+        const line = node.who ? `${node.what} · ${node.who}` : node.what;
         return (
           <g key={node.id} transform={`translate(${node.x} ${node.y})`}>
-            <rect width={NODE_W} height={NODE_H} rx={8} fill={t.fill} stroke={t.stroke} strokeWidth={state === "current" ? 2 : 1.2} />
+            <title>{`${node.id}: ${line}`}</title>
+            <rect width={node.w} height={NODE_H} rx={8} fill={t.fill} stroke={t.stroke} strokeWidth={state === "current" ? 2 : 1.2} />
+            <clipPath id={`flow-clip-${node.id}`}>
+              <rect x={0} y={0} width={node.w - 6} height={NODE_H} />
+            </clipPath>
             <text x={10} y={18} fontSize="12" fontWeight={600} fill={t.text} fontFamily="var(--font-mono, ui-monospace, monospace)">
               {node.id}
             </text>
-            <text x={10} y={34} fontSize="10" fill="var(--muted-foreground)">
-              {node.who ? `${node.what} · ${node.who}` : node.what}
+            {/* A group step's cast can outrun the box; it clips at the edge and
+                the full line is the node's tooltip. */}
+            <text x={10} y={34} fontSize="10" fill="var(--muted-foreground)" clipPath={`url(#flow-clip-${node.id})`}>
+              {line}
             </text>
             {hasFloor && (
-              <g transform={`translate(${NODE_W - 8} -6)`}>
+              <g transform={`translate(${node.w - 8} -6)`}>
                 <circle r={5} fill="var(--accent)" />
                 <title>{`${node.who} has the floor`}</title>
               </g>

--- a/mycelium-frontend/src/components/flow-panel.tsx
+++ b/mycelium-frontend/src/components/flow-panel.tsx
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+"use client";
+
+/**
+ * The flow an episode runs, drawn at the top of its thread: the graph, where
+ * the run stands, whose turn it is, and the steps taken so far.
+ *
+ * The record is the source: the conductor writes the flow and its trace onto
+ * the episode as it walks, so this reads the same thing a person would find
+ * in `log/episodes/{id}.md`, and the floor it draws is the live one off the
+ * roster. Shown only for an episode that carries a flow.
+ */
+
+import type { EpisodeSummary, FlowTraceEntry, RoomFloor } from "@/lib/api";
+import { FlowGraph } from "@/components/flow-graph";
+
+function outcomeTone(outcome: string): string {
+  if (outcome === "resolved") return "var(--green)";
+  if (outcome === "rejected") return "var(--yellow)";
+  return "var(--accent)";
+}
+
+/** One step taken, as the trace line reads it. */
+function TraceRow({ entry }: { entry: FlowTraceEntry }) {
+  const who = entry.asked?.join(", ") ?? "";
+  const stance = entry.stance ?? (entry.asked?.length ? "no stance" : "");
+  const stanceTone =
+    entry.stance === "accept" ? "var(--green)" : entry.stance === "reject" ? "var(--yellow)" : "var(--muted-foreground)";
+  return (
+    <div className="flex items-baseline gap-2 border-b border-border/60 py-1 last:border-b-0 font-mono text-micro">
+      <span className="w-4 text-right tabular text-faint">{entry.turn}</span>
+      <span className="text-text">{entry.step}</span>
+      {who && <span className="truncate text-muted-foreground">{who}</span>}
+      {stance && <span style={{ color: stanceTone }}>{stance}</span>}
+      <span className="text-faint">→ {entry.next}</span>
+    </div>
+  );
+}
+
+export function FlowPanel({ episode, floor }: { episode: EpisodeSummary; floor: RoomFloor | null }) {
+  const flow = episode.flow;
+  if (!flow) return null;
+  const trace = episode.trace ?? [];
+  const open = episode.outcome === "open";
+  const speakers = floor?.speakers ?? [];
+  return (
+    <div className="px-4 py-3" data-testid="flow-panel">
+      <div className="mb-2 flex flex-wrap items-baseline gap-x-2 gap-y-1">
+        <span className="text-micro uppercase tracking-wide text-faint">Flow</span>
+        <span className="font-mono text-micro text-text">{flow.name}</span>
+        <span className="text-micro capitalize" style={{ color: outcomeTone(episode.outcome) }}>
+          {open ? `at ${episode.current_step ?? flow.steps[0]?.id ?? "start"}` : episode.outcome}
+        </span>
+        {open && speakers.length > 0 && (
+          <span className="text-micro" style={{ color: "var(--accent)" }}>
+            {speakers.map((h) => `@${h}`).join(", ")} {speakers.length === 1 ? "has" : "have"} the floor
+          </span>
+        )}
+        {open && floor && speakers.length === 0 && (
+          <span className="text-micro text-muted-foreground">@{floor.holder} holds the floor</span>
+        )}
+      </div>
+      {flow.ask && <div className="mb-2 text-label text-muted-foreground">{flow.ask}</div>}
+      <div className="overflow-x-auto">
+        <FlowGraph
+          flow={flow}
+          trace={trace}
+          currentStep={episode.current_step}
+          outcome={episode.outcome}
+          floor={floor}
+        />
+      </div>
+      {trace.length > 0 && (
+        <div className="mt-2">
+          {trace.map((entry, i) => <TraceRow key={i} entry={entry} />)}
+        </div>
+      )}
+      {episode.within && (
+        <div className="mt-2 text-micro text-muted-foreground">
+          opened inside thread <span className="font-mono text-text">{episode.within.split(":").pop()}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mycelium-frontend/src/components/thread-view.test.tsx
+++ b/mycelium-frontend/src/components/thread-view.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@/lib/api", () => ({
   sendRoomMessage: (...args: unknown[]) => sendRoomMessage(...args),
   fetchRoomAgents: vi.fn().mockResolvedValue([]),
   fetchRoomMembers: vi.fn().mockResolvedValue({ members: [], floors: [] }),
+  fetchEpisodes: vi.fn().mockResolvedValue([]),
   fetchMemories: (...args: unknown[]) => fetchMemories(...args),
   fetchMemoryLinks: vi.fn().mockResolvedValue({ outbound: [], backlinks: [] }),
   fetchSkills: vi.fn().mockResolvedValue([]),

--- a/mycelium-frontend/src/components/thread-view.tsx
+++ b/mycelium-frontend/src/components/thread-view.tsx
@@ -7,8 +7,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { Eye, Maximize2, MessageSquare, Pencil, X } from "lucide-react";
 import { memoryHref } from "@/lib/memory-routes";
-import { useRoomMemories, useRoomRevalidate } from "@/lib/room-data";
+import { useRoomEpisodes, useRoomMembers, useRoomMemories, useRoomRevalidate } from "@/lib/room-data";
 import { threadShortId } from "@/lib/threads";
+import { FlowPanel } from "@/components/flow-panel";
 import { MemoryDetail } from "@/components/memory-detail";
 import { MemoryEditor } from "@/components/memory-editor";
 import { RoomChatBox } from "@/components/room-chat-box";
@@ -66,6 +67,13 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
   // comments. Absent for a negotiation thread bound to no row.
   const { memories } = useRoomMemories(roomName);
   const task = memories.find(m => m.episode === target.episode) ?? null;
+  // A thread that is a run carries its flow on its episode record; the floor
+  // held on it is a live fact off the roster. Absent for a task's own thread
+  // and for a negotiation, so the pane draws nothing extra there.
+  const { episodes } = useRoomEpisodes(roomName);
+  const run = episodes.find(e => e.episode === target.episode && e.flow) ?? null;
+  const { floors } = useRoomMembers(roomName);
+  const floor = floors.find(f => f.episode === target.episode) ?? null;
   const { principal } = useCurrentUser();
   const revalidate = useRoomRevalidate(roomName);
   const shortId = threadShortId(target.episode) ?? "thread";
@@ -105,7 +113,7 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
       <header className="flex h-[48px] shrink-0 items-center gap-2 border-b border-border bg-paper px-4">
         <MessageSquare className="size-3.5 shrink-0 text-accent" strokeWidth={1.9} />
         <span className="min-w-0 truncate text-label font-semibold text-text">
-          {target.title || `Thread ${shortId}`}
+          {target.title || (run ? `${run.flow?.name} run ${shortId}` : `Thread ${shortId}`)}
         </span>
         {/* The short id only where a task's name is what the header says —
             otherwise the header is already the id, and this would repeat it. */}
@@ -186,6 +194,11 @@ export function ThreadView({ roomName, target, onClose, onOpenMemory }: Props) {
         // everywhere in the pane. A negotiation thread bound to no row is all
         // conversation.
         <ScrollArea className="min-h-0 flex-1">
+          {run && (
+            <div className="border-b border-border">
+              <FlowPanel episode={run} floor={floor} />
+            </div>
+          )}
           {task && (
             <div className="border-b border-border">
               <MemoryDetail

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -846,6 +846,50 @@ export interface EpisodeSummary {
   message_count: number;
   updated_at: string;
   updated_by: string;
+  /** The thread this episode was opened from, when it runs inside a task. */
+  within?: string | null;
+  /** The interaction flow this episode runs; null for a negotiation or a thread. */
+  flow?: EpisodeFlow | null;
+  /** The steps taken so far, in order. */
+  trace?: FlowTraceEntry[];
+  /** Where an open run stands, read off the trace. */
+  current_step?: string | null;
+}
+
+/** One step of an episode's interaction flow, as the record carries it. */
+export interface FlowStep {
+  id: string;
+  /** A role, or each / all / workers. Absent on an end step. */
+  to?: string | null;
+  prompt?: string;
+  wait?: "reply" | "none";
+  rounds?: number;
+  /** One step id, or a branch by stance (accept / reject / silent / default). */
+  next?: string | Record<string, string> | null;
+  end?: "resolved" | "rejected" | null;
+}
+
+/** The interaction flow an episode runs: the graph the conductor walks, plus
+ *  who was bound to each role and what was asked. */
+export interface EpisodeFlow {
+  name: string;
+  description?: string;
+  roles?: string[];
+  steps: FlowStep[];
+  max_steps?: number;
+  bound?: Record<string, string>;
+  ask?: string;
+}
+
+/** One step taken in a flow episode. */
+export interface FlowTraceEntry {
+  step: string;
+  turn: number;
+  asked?: string[];
+  stances?: Record<string, string | null>;
+  stance?: string | null;
+  next: string;
+  at?: string;
 }
 
 export interface EpisodeDetail extends EpisodeSummary {

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -712,6 +712,10 @@ export interface RoomFloor {
   /** The thread's short id, as the board prints it. */
   thread: string;
   episode: string;
+  /** The task the thread belongs to, when a row carries it; null for a thread
+   *  no row does. A badge names the task, and falls back to the thread id. */
+  key: string | null;
+  title: string | null;
   holder: string;
   speakers: string[];
 }

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -878,6 +878,8 @@ export interface EpisodeFlow {
   steps: FlowStep[];
   max_steps?: number;
   bound?: Record<string, string>;
+  /** Everyone the run was summoned with, in order: the pool a group step asks. */
+  cast?: string[];
   ask?: string;
 }
 

--- a/mycelium-frontend/src/lib/floors.test.ts
+++ b/mycelium-frontend/src/lib/floors.test.ts
@@ -8,6 +8,8 @@ import type { RoomFloor } from "@/lib/api";
 const floor = (over: Partial<RoomFloor> = {}): RoomFloor => ({
   thread: "t3aa11bb",
   episode: "urn:ioc:mycelium:episode:atlas:t3aa11bb",
+  key: null,
+  title: null,
   holder: "conductor",
   speakers: ["api"],
   ...over,
@@ -32,6 +34,12 @@ describe("the floor, read for the roster", () => {
     const f = floor();
     expect(floorLabel("api", f)).toBe("has the floor · t3aa11bb");
     expect(floorLabel("Conductor", f)).toBe("holds the floor · t3aa11bb");
+  });
+
+  it("names the thread by its task when a row carries it", () => {
+    const f = floor({ key: "work/rotate-the-signing-key", title: "Rotate the signing key" });
+    expect(floorLabel("api", f)).toBe("has the floor · Rotate the signing key");
+    expect(floorLabel("conductor", f)).toBe("holds the floor · Rotate the signing key");
   });
 
   it("reads nothing when no floor is held", () => {

--- a/mycelium-frontend/src/lib/floors.ts
+++ b/mycelium-frontend/src/lib/floors.ts
@@ -21,9 +21,16 @@ export function floorsByHandle(floors: RoomFloor[]): Map<string, RoomFloor> {
   return out;
 }
 
+/** What a floor's thread is called: the task it belongs to, else the thread id.
+ *  A task and its thread are one object, so the id shows only for a thread no
+ *  row carries. */
+export function floorThreadName(floor: RoomFloor): string {
+  return floor.title || floor.thread;
+}
+
 /** What the row says: the holder holds the floor, a speaker has it. */
 export function floorLabel(handle: string, floor: RoomFloor): string {
   const who = handle.toLowerCase();
   const verb = floor.speakers.some((h) => h.toLowerCase() === who) ? "has the floor" : "holds the floor";
-  return `${verb} · ${floor.thread}`;
+  return `${verb} · ${floorThreadName(floor)}`;
 }

--- a/mycelium-frontend/src/lib/flow-graph.test.ts
+++ b/mycelium-frontend/src/lib/flow-graph.test.ts
@@ -2,7 +2,20 @@
 // Copyright 2026 Mycelium Contributors
 
 import { describe, expect, it } from "vitest";
-import { layoutFlow, stepStates, stepWho, takenEdges, NODE_W, GAP_X, PAD, LOOP_H, NODE_H } from "@/lib/flow-graph";
+import {
+  layoutFlow,
+  stepStates,
+  stepWho,
+  takenEdges,
+  COLUMN_NODE_W,
+  GAP_X,
+  GAP_Y,
+  LANE_GAP,
+  LOOP_BASE,
+  NODE_H,
+  NODE_W,
+  PAD,
+} from "@/lib/flow-graph";
 import type { EpisodeFlow } from "@/lib/api";
 
 const gated: EpisodeFlow = {
@@ -34,26 +47,60 @@ describe("laying out a flow", () => {
     expect(approved.end).toBe("resolved");
   });
 
-  it("draws a branch as one edge per stance and marks the loop back", () => {
+  it("draws a branch as one edge per target, stances joined, and marks the loop back", () => {
     const layout = layoutFlow(gated);
+    expect(layout.direction).toBe("row");
     expect(layout.edges).toEqual([
-      { from: "propose", to: "review", label: null, back: false },
-      { from: "review", to: "approved", label: "accept", back: false },
-      { from: "review", to: "propose", label: "reject", back: true },
-      { from: "review", to: "propose", label: "default", back: true },
+      { from: "propose", to: "review", label: null, back: false, rail: null },
+      { from: "review", to: "approved", label: "accept", back: false, rail: null },
+      { from: "review", to: "propose", label: "reject / default", back: true, rail: 0 },
     ]);
-    expect(layout.height).toBe(PAD * 2 + NODE_H + LOOP_H);
+    expect(layout.height).toBe(PAD * 2 + NODE_H + LOOP_BASE + LANE_GAP);
   });
 
   it("leaves no room for loops when there are none", () => {
     const line: EpisodeFlow = { name: "x", steps: [{ id: "a", to: "each", next: "d" }, { id: "d", end: "resolved" }] };
     expect(layoutFlow(line).height).toBe(PAD * 2 + NODE_H);
-    expect(layoutFlow(line).edges).toEqual([{ from: "a", to: "d", label: null, back: false }]);
+    expect(layoutFlow(line).edges).toEqual([{ from: "a", to: "d", label: null, back: false, rail: null }]);
+  });
+
+  it("stands a longer flow as a column, loops on the left and skips on the right", () => {
+    const train: EpisodeFlow = {
+      name: "train",
+      steps: [
+        { id: "plan", to: "each", next: "review" },
+        { id: "review", to: "each", next: { accept: "ship", reject: "plan", silent: "escalate" } },
+        { id: "escalate", to: "each", next: { accept: "ship", default: "escalate" } },
+        { id: "ship", end: "resolved" },
+      ],
+    };
+    const layout = layoutFlow(train);
+    expect(layout.direction).toBe("column");
+    // Two loops (review→plan, escalate→escalate) take two lanes on the left,
+    // so the column starts past them; one skip (review→ship) takes a lane on
+    // the right.
+    expect(layout.nodes.map((n) => n.x)).toEqual([PAD + 2 * LANE_GAP, PAD + 2 * LANE_GAP, PAD + 2 * LANE_GAP, PAD + 2 * LANE_GAP]);
+    expect(layout.nodes.map((n) => n.y)).toEqual([PAD, PAD + NODE_H + GAP_Y, PAD + 2 * (NODE_H + GAP_Y), PAD + 3 * (NODE_H + GAP_Y)]);
+    expect(layout.width).toBe(PAD * 2 + 2 * LANE_GAP + COLUMN_NODE_W + LANE_GAP);
+    expect(layout.height).toBe(PAD * 2 + 4 * NODE_H + 3 * GAP_Y);
+    expect(layout.edges).toEqual([
+      { from: "plan", to: "review", label: null, back: false, rail: null },
+      { from: "review", to: "ship", label: "accept", back: false, rail: 0 },
+      { from: "review", to: "plan", label: "reject", back: true, rail: 0 },
+      { from: "review", to: "escalate", label: "silent", back: false, rail: null },
+      { from: "escalate", to: "ship", label: "accept", back: false, rail: null },
+      { from: "escalate", to: "escalate", label: "default", back: true, rail: 1 },
+    ]);
   });
 
   it("reads a group target in plain words", () => {
     expect(stepWho({ id: "x", to: "each" }, gated)).toBe("everyone");
     expect(stepWho({ id: "x", to: "workers" }, gated)).toBe("the workers");
+    // With a cast on the flow, a group step names who it asks: everyone for
+    // each/all, everyone not bound to a role for workers.
+    const cast = { ...gated, bound: { proposer: "api" }, cast: ["api", "sec", "ops"] };
+    expect(stepWho({ id: "x", to: "each" }, cast)).toBe("api, sec, ops");
+    expect(stepWho({ id: "x", to: "workers" }, cast)).toBe("sec, ops");
     expect(stepWho({ id: "x", to: "lead" }, { name: "f", steps: [] })).toBe("lead");
   });
 });

--- a/mycelium-frontend/src/lib/flow-graph.test.ts
+++ b/mycelium-frontend/src/lib/flow-graph.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { describe, expect, it } from "vitest";
+import { layoutFlow, stepStates, stepWho, takenEdges, NODE_W, GAP_X, PAD, LOOP_H, NODE_H } from "@/lib/flow-graph";
+import type { EpisodeFlow } from "@/lib/api";
+
+const gated: EpisodeFlow = {
+  name: "gated",
+  roles: ["proposer", "guardian"],
+  bound: { proposer: "api", guardian: "sec" },
+  steps: [
+    { id: "propose", to: "proposer", next: "review" },
+    { id: "review", to: "guardian", next: { accept: "approved", reject: "propose", default: "propose" } },
+    { id: "approved", end: "resolved" },
+  ],
+};
+
+describe("laying out a flow", () => {
+  it("ranks steps in declaration order, left to right", () => {
+    const layout = layoutFlow(gated);
+    expect(layout.nodes.map((n) => n.id)).toEqual(["propose", "review", "approved"]);
+    expect(layout.nodes.map((n) => n.x)).toEqual([PAD, PAD + NODE_W + GAP_X, PAD + 2 * (NODE_W + GAP_X)]);
+    expect(layout.width).toBe(PAD * 2 + 3 * NODE_W + 2 * GAP_X);
+  });
+
+  it("names who each step is put to, and what an end step does", () => {
+    const [propose, review, approved] = layoutFlow(gated).nodes;
+    expect(propose.who).toBe("api");
+    expect(propose.what).toBe("asks proposer");
+    expect(review.who).toBe("sec");
+    expect(approved.who).toBeNull();
+    expect(approved.what).toBe("ends resolved");
+    expect(approved.end).toBe("resolved");
+  });
+
+  it("draws a branch as one edge per stance and marks the loop back", () => {
+    const layout = layoutFlow(gated);
+    expect(layout.edges).toEqual([
+      { from: "propose", to: "review", label: null, back: false },
+      { from: "review", to: "approved", label: "accept", back: false },
+      { from: "review", to: "propose", label: "reject", back: true },
+      { from: "review", to: "propose", label: "default", back: true },
+    ]);
+    expect(layout.height).toBe(PAD * 2 + NODE_H + LOOP_H);
+  });
+
+  it("leaves no room for loops when there are none", () => {
+    const line: EpisodeFlow = { name: "x", steps: [{ id: "a", to: "each", next: "d" }, { id: "d", end: "resolved" }] };
+    expect(layoutFlow(line).height).toBe(PAD * 2 + NODE_H);
+    expect(layoutFlow(line).edges).toEqual([{ from: "a", to: "d", label: null, back: false }]);
+  });
+
+  it("reads a group target in plain words", () => {
+    expect(stepWho({ id: "x", to: "each" }, gated)).toBe("everyone");
+    expect(stepWho({ id: "x", to: "workers" }, gated)).toBe("the workers");
+    expect(stepWho({ id: "x", to: "lead" }, { name: "f", steps: [] })).toBe("lead");
+  });
+});
+
+describe("where a run stands", () => {
+  const trace = [
+    { step: "propose", turn: 1, stance: null, next: "review" },
+    { step: "review", turn: 2, stance: "reject", next: "propose" },
+  ];
+
+  it("lights the current step of an open run and dims what it has taken", () => {
+    const states = stepStates(gated, trace, "propose", "open");
+    expect(states.get("propose")).toBe("current");
+    expect(states.get("review")).toBe("visited");
+    expect(states.get("approved")).toBe("untouched");
+  });
+
+  it("marks the end a finished run reached", () => {
+    const done = [...trace, { step: "propose", turn: 3, stance: null, next: "review" }, { step: "review", turn: 4, stance: "accept", next: "approved" }];
+    const states = stepStates(gated, done, null, "resolved");
+    expect(states.get("approved")).toBe("reached");
+    expect(states.get("review")).toBe("visited");
+  });
+
+  it("stands at the first step before anything was taken", () => {
+    expect(stepStates(gated, [], "propose", "open").get("propose")).toBe("current");
+  });
+
+  it("knows which edges were taken", () => {
+    expect([...takenEdges(trace)]).toEqual(["propose→review", "review→propose"]);
+  });
+});

--- a/mycelium-frontend/src/lib/flow-graph.ts
+++ b/mycelium-frontend/src/lib/flow-graph.ts
@@ -6,9 +6,11 @@
  *
  * The flow is a small graph the conductor walks: steps in the order they were
  * written, edges as `next`, a branch as one edge per stance. This lays it out
- * left to right in declaration order — steps are declared in the order they
- * are meant to run, so the order is the rank — and marks an edge that points
- * back up the line as a loop, drawn under the row. Pure: no DOM, no layout
+ * in declaration order — steps are declared in the order they are meant to
+ * run, so the order is the rank — and marks an edge that points back up the
+ * line as a loop. A short flow reads left to right; a longer one stands as a
+ * column, since the pane that shows it is narrow and a row of eleven boxes
+ * would either scroll away or shrink to nothing. Pure: no DOM, no layout
  * library, so it is testable and the drawing is one pass over its output.
  */
 
@@ -23,18 +25,28 @@ export interface FlowNode {
   end: "resolved" | "rejected" | null;
   x: number;
   y: number;
+  w: number;
 }
 
 export interface FlowEdge {
   from: string;
   to: string;
-  /** The stance that takes this edge, or null for a plain edge. */
+  /** The stances that take this edge, joined, or null for a plain edge. */
   label: string | null;
-  /** Points back to an earlier step: a loop, drawn below the row. */
+  /** Points back to an earlier step: a loop. */
   back: boolean;
+  /**
+   * The lane this edge rides in when it leaves the line of nodes: a loop
+   * under the row, or a loop (left) or a skip (right) beside the column.
+   * Null for an edge between neighbours, drawn straight.
+   */
+  rail: number | null;
 }
 
+export type FlowDirection = "row" | "column";
+
 export interface FlowLayout {
+  direction: FlowDirection;
   nodes: FlowNode[];
   edges: FlowEdge[];
   width: number;
@@ -45,8 +57,16 @@ export const NODE_W = 132;
 export const NODE_H = 46;
 export const GAP_X = 56;
 export const PAD = 24;
-/** Room under the row for loop edges. */
-export const LOOP_H = 52;
+/** Room under a row before the first loop, and per loop after it: each loop
+ *  gets a lane of its own so two never share a line or a label. */
+export const LOOP_BASE = 16;
+export const LANE_GAP = 14;
+/** A flow with this many steps or more stands as a column. Three boxes fit
+ *  the thread pane side by side; four do not. */
+export const COLUMN_AT = 4;
+/** A column's boxes are wider — there is room, and a group step's cast is long. */
+export const COLUMN_NODE_W = 224;
+export const GAP_Y = 30;
 
 /** Who a step is put to, in the flow's own words. */
 export function stepWho(step: FlowStep, flow: EpisodeFlow): string | null {
@@ -54,8 +74,13 @@ export function stepWho(step: FlowStep, flow: EpisodeFlow): string | null {
   if (!to) return null;
   const bound = flow.bound ?? {};
   if (to in bound) return bound[to];
-  if (to === "each" || to === "all") return "everyone";
-  if (to === "workers") return "the workers";
+  const cast = flow.cast ?? [];
+  if (to === "each" || to === "all") return cast.length ? cast.join(", ") : "everyone";
+  if (to === "workers") {
+    const named = new Set(Object.values(bound));
+    const workers = cast.filter((h) => !named.has(h));
+    return workers.length ? workers.join(", ") : "the workers";
+  }
   return to;
 }
 
@@ -66,18 +91,11 @@ function stepWhat(step: FlowStep): string {
   return `${verb} ${step.to ?? "?"}${rounds}`;
 }
 
-export function layoutFlow(flow: EpisodeFlow): FlowLayout {
-  const steps = flow.steps ?? [];
+/** The edges a flow declares, one per (from, to), with the stances that take
+ *  it joined into one label — `reject / default` is one arrow, not two. */
+function flowEdges(steps: FlowStep[]): Omit<FlowEdge, "rail">[] {
   const index = new Map(steps.map((s, i) => [s.id, i]));
-  const nodes: FlowNode[] = steps.map((step, i) => ({
-    id: step.id,
-    what: stepWhat(step),
-    who: stepWho(step, flow),
-    end: step.end ?? null,
-    x: PAD + i * (NODE_W + GAP_X),
-    y: PAD,
-  }));
-  const edges: FlowEdge[] = [];
+  const edges: Omit<FlowEdge, "rail">[] = [];
   for (const step of steps) {
     const from = index.get(step.id) ?? 0;
     const targets: [string, string | null][] =
@@ -88,15 +106,70 @@ export function layoutFlow(flow: EpisodeFlow): FlowLayout {
           : [];
     for (const [to, label] of targets) {
       if (!index.has(to)) continue;
+      const seen = edges.find((e) => e.from === step.id && e.to === to);
+      if (seen) {
+        if (label) seen.label = seen.label ? `${seen.label} / ${label}` : label;
+        continue;
+      }
       edges.push({ from: step.id, to, label, back: (index.get(to) ?? 0) <= from });
     }
   }
-  const hasLoop = edges.some((e) => e.back);
+  return edges;
+}
+
+export function layoutFlow(flow: EpisodeFlow): FlowLayout {
+  const steps = flow.steps ?? [];
+  const index = new Map(steps.map((s, i) => [s.id, i]));
+  const direction: FlowDirection = steps.length >= COLUMN_AT ? "column" : "row";
+  const bare = flowEdges(steps);
+  const describe = (step: FlowStep) => ({
+    id: step.id,
+    what: stepWhat(step),
+    who: stepWho(step, flow),
+    end: step.end ?? null,
+  });
+
+  if (direction === "row") {
+    // Loops ride under the row, each in its own lane.
+    let loops = 0;
+    const edges: FlowEdge[] = bare.map((e) => ({ ...e, rail: e.back ? loops++ : null }));
+    const nodes: FlowNode[] = steps.map((step, i) => ({
+      ...describe(step),
+      x: PAD + i * (NODE_W + GAP_X),
+      y: PAD,
+      w: NODE_W,
+    }));
+    return {
+      direction,
+      nodes,
+      edges,
+      width: PAD * 2 + steps.length * NODE_W + Math.max(0, steps.length - 1) * GAP_X,
+      height: PAD * 2 + NODE_H + (loops ? LOOP_BASE + loops * LANE_GAP : 0),
+    };
+  }
+
+  // A column: neighbours join straight down; a loop rides a rail on the
+  // left, a skip over one or more steps a rail on the right.
+  let left = 0;
+  let right = 0;
+  const edges: FlowEdge[] = bare.map((e) => {
+    if (e.back) return { ...e, rail: left++ };
+    const span = (index.get(e.to) ?? 0) - (index.get(e.from) ?? 0);
+    return { ...e, rail: span > 1 ? right++ : null };
+  });
+  const x = PAD + left * LANE_GAP;
+  const nodes: FlowNode[] = steps.map((step, i) => ({
+    ...describe(step),
+    x,
+    y: PAD + i * (NODE_H + GAP_Y),
+    w: COLUMN_NODE_W,
+  }));
   return {
+    direction,
     nodes,
     edges,
-    width: PAD * 2 + Math.max(0, steps.length) * NODE_W + Math.max(0, steps.length - 1) * GAP_X,
-    height: PAD * 2 + NODE_H + (hasLoop ? LOOP_H : 0),
+    width: PAD * 2 + left * LANE_GAP + COLUMN_NODE_W + right * LANE_GAP,
+    height: PAD * 2 + steps.length * NODE_H + Math.max(0, steps.length - 1) * GAP_Y,
   };
 }
 

--- a/mycelium-frontend/src/lib/flow-graph.ts
+++ b/mycelium-frontend/src/lib/flow-graph.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+/**
+ * An episode's interaction flow, laid out to be drawn.
+ *
+ * The flow is a small graph the conductor walks: steps in the order they were
+ * written, edges as `next`, a branch as one edge per stance. This lays it out
+ * left to right in declaration order — steps are declared in the order they
+ * are meant to run, so the order is the rank — and marks an edge that points
+ * back up the line as a loop, drawn under the row. Pure: no DOM, no layout
+ * library, so it is testable and the drawing is one pass over its output.
+ */
+
+import type { EpisodeFlow, FlowStep, FlowTraceEntry } from "./api";
+
+export interface FlowNode {
+  id: string;
+  /** What the step does, as a person reads it: "asks guardian", "ends resolved". */
+  what: string;
+  /** The member bound to the step's role, when the flow says who. */
+  who: string | null;
+  end: "resolved" | "rejected" | null;
+  x: number;
+  y: number;
+}
+
+export interface FlowEdge {
+  from: string;
+  to: string;
+  /** The stance that takes this edge, or null for a plain edge. */
+  label: string | null;
+  /** Points back to an earlier step: a loop, drawn below the row. */
+  back: boolean;
+}
+
+export interface FlowLayout {
+  nodes: FlowNode[];
+  edges: FlowEdge[];
+  width: number;
+  height: number;
+}
+
+export const NODE_W = 132;
+export const NODE_H = 46;
+export const GAP_X = 56;
+export const PAD = 24;
+/** Room under the row for loop edges. */
+export const LOOP_H = 52;
+
+/** Who a step is put to, in the flow's own words. */
+export function stepWho(step: FlowStep, flow: EpisodeFlow): string | null {
+  const to = step.to;
+  if (!to) return null;
+  const bound = flow.bound ?? {};
+  if (to in bound) return bound[to];
+  if (to === "each" || to === "all") return "everyone";
+  if (to === "workers") return "the workers";
+  return to;
+}
+
+function stepWhat(step: FlowStep): string {
+  if (step.end) return `ends ${step.end}`;
+  const verb = step.wait === "none" ? "tells" : "asks";
+  const rounds = step.rounds && step.rounds > 1 ? ` ×${step.rounds}` : "";
+  return `${verb} ${step.to ?? "?"}${rounds}`;
+}
+
+export function layoutFlow(flow: EpisodeFlow): FlowLayout {
+  const steps = flow.steps ?? [];
+  const index = new Map(steps.map((s, i) => [s.id, i]));
+  const nodes: FlowNode[] = steps.map((step, i) => ({
+    id: step.id,
+    what: stepWhat(step),
+    who: stepWho(step, flow),
+    end: step.end ?? null,
+    x: PAD + i * (NODE_W + GAP_X),
+    y: PAD,
+  }));
+  const edges: FlowEdge[] = [];
+  for (const step of steps) {
+    const from = index.get(step.id) ?? 0;
+    const targets: [string, string | null][] =
+      typeof step.next === "string"
+        ? [[step.next, null]]
+        : step.next
+          ? Object.entries(step.next).map(([stance, to]) => [to, stance])
+          : [];
+    for (const [to, label] of targets) {
+      if (!index.has(to)) continue;
+      edges.push({ from: step.id, to, label, back: (index.get(to) ?? 0) <= from });
+    }
+  }
+  const hasLoop = edges.some((e) => e.back);
+  return {
+    nodes,
+    edges,
+    width: PAD * 2 + Math.max(0, steps.length) * NODE_W + Math.max(0, steps.length - 1) * GAP_X,
+    height: PAD * 2 + NODE_H + (hasLoop ? LOOP_H : 0),
+  };
+}
+
+export type StepState = "current" | "visited" | "reached" | "untouched";
+
+/**
+ * What each step is to the run right now: the one it stands at, the ones it
+ * has taken, the end it reached, or nothing yet.
+ */
+export function stepStates(
+  flow: EpisodeFlow,
+  trace: FlowTraceEntry[],
+  currentStep: string | null | undefined,
+  outcome: string,
+): Map<string, StepState> {
+  const states = new Map<string, StepState>();
+  for (const step of flow.steps ?? []) states.set(step.id, "untouched");
+  for (const entry of trace) if (states.has(entry.step)) states.set(entry.step, "visited");
+  if (outcome !== "open") {
+    // A finished run reached the end step its last edge led to, or ended at
+    // the cap on the step it stood at.
+    const last = trace[trace.length - 1];
+    const reached = last ? last.next : null;
+    if (reached && states.has(reached)) {
+      const end = (flow.steps ?? []).find((s) => s.id === reached)?.end;
+      states.set(reached, end ? "reached" : "visited");
+    }
+  } else if (currentStep && states.has(currentStep)) {
+    states.set(currentStep, "current");
+  }
+  return states;
+}
+
+/** The edges the run actually took, as "from→to" keys, so they draw solid. */
+export function takenEdges(trace: FlowTraceEntry[]): Set<string> {
+  return new Set(trace.map((t) => `${t.step}→${t.next}`));
+}

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -27,6 +27,7 @@ import type {
   MemoryGraphEdge,
   MemoryGraphNode,
   PresenceMember,
+  RoomFloor,
 } from "@/lib/api";
 import type { RoomStatus } from "@/lib/board/upstream";
 
@@ -95,6 +96,8 @@ export interface RoomFixture {
    *  (one whose handle appears here) projects a board row; without a SLIM node
    *  there is otherwise no presence, so the board's resident rows come from here. */
   presence?: PresenceMember[];
+  /** Floors held in the room's threads right now, served beside presence. */
+  floors?: RoomFloor[];
   /** The room's link graph (#599/#611) — undefined means "no link index yet",
    *  the same degrade-to-empty case the real backend serves for an unlinked room. */
   links?: MemoryGraph;
@@ -363,6 +366,44 @@ const atlasEpisodeSummary: EpisodeSummary = {
   message_count: 3,
   updated_at: iso(42),
   updated_by: "aligner",
+};
+
+// A flow the conductor is walking right now: the gated review of the key
+// rotation, opened from the read-switch task. Two steps taken (a proposal, a
+// block), standing at the proposer's second turn with the floor given to it.
+const ATLAS_FLOW_EPISODE = atlasEpisode("f10a2c");
+const atlasFlowEpisode: EpisodeSummary = {
+  short_id: "f10a2c",
+  episode: ATLAS_FLOW_EPISODE,
+  topic: "urn:concept:mycelium:atlas-migration",
+  outcome: "open",
+  subkind: null,
+  participants: ["reads", "operator", "conductor"],
+  metrics: null,
+  assignments: null,
+  tasks: [],
+  message_count: 5,
+  updated_at: iso(2),
+  updated_by: "conductor",
+  within: ATLAS_FLIP_THREAD,
+  current_step: "propose",
+  flow: {
+    name: "gated",
+    description: "A proposer proposes, a guardian approves or blocks; a block sends it back.",
+    roles: ["proposer", "guardian"],
+    max_steps: 6,
+    bound: { proposer: "reads", guardian: "operator" },
+    ask: "flip reads to the new store without a soak window",
+    steps: [
+      { id: "propose", to: "proposer", next: "review", prompt: "{ask}\n\nState exactly what you intend to do." },
+      { id: "review", to: "guardian", next: { accept: "approved", reject: "propose", default: "propose" }, prompt: "A proposal is on the table:\n\n{reply}\n\nApprove it or block it." },
+      { id: "approved", end: "resolved" },
+    ],
+  },
+  trace: [
+    { step: "propose", turn: 1, asked: ["reads"], stances: { reads: null }, stance: null, next: "review", at: iso(6) },
+    { step: "review", turn: 2, asked: ["operator"], stances: { operator: "reject" }, stance: "reject", next: "propose", at: iso(3) },
+  ],
 };
 
 // Coordination-state memories the board projects into rows. Every one is what
@@ -716,8 +757,23 @@ const atlas: RoomFixture = {
         "Decision: we're go for Friday am pending a clean 24h soak, as backfill laid out. I'm adding one gate — the pool-recycle fix has to land and be verified before we flip, not after. If it's not in by Thursday evening we slip to Monday. I'd rather ship a day late than ship into a known write-dropping window. Filing both follow-ups as tasks now.",
     },
   ],
-  episodes: [atlasEpisodeSummary],
-  episodeDetails: { e4f1a2: { ...atlasEpisodeSummary, messages: atlasL9Chain } },
+  episodes: [atlasFlowEpisode, atlasEpisodeSummary],
+  episodeDetails: {
+    e4f1a2: { ...atlasEpisodeSummary, messages: atlasL9Chain },
+    f10a2c: { ...atlasFlowEpisode, messages: [] },
+  },
+  // The floor the running flow holds: the conductor's, given to reads for its
+  // second proposal.
+  floors: [
+    {
+      thread: "f10a2c",
+      episode: ATLAS_FLOW_EPISODE,
+      key: null,
+      title: null,
+      holder: "conductor",
+      speakers: ["reads"],
+    },
+  ],
   // backfill holds an open SLIM socket; reads is present on a server-held await
   // lease. Both are agents in the roster, so the board projects a resident row
   // for each — the presence signal that a live SLIM node would otherwise supply.

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -384,7 +384,7 @@ const atlasBoardRows: MockMemory[] = [
       "Point reads at the new store\n\n" +
       "Behind `catalog.reads.newstore`, default off. Don't flip until the copy is " +
       "reconciled and backfill signs off. Waiting on the copy (#502).",
-    meta: { kind: "action", status: "open", assignee: "@reads", priority: "high", issue: "#502" },
+    meta: { "depends-on": ["work/reconcile-review", "work/backfill-metrics"],  kind: "action", status: "open", assignee: "@reads", priority: "high", issue: "#502" },
     content_text: "Point reads at the new store, behind a flag. Waiting on the copy.",
     created_by: "aligner",
     updated_by: "aligner",
@@ -395,7 +395,7 @@ const atlasBoardRows: MockMemory[] = [
   {
     key: "work/decommission-old-store",
     value: "Decommission the old store after the soak",
-    meta: { kind: "action", status: "open", assignee: "@reads", issue: "#499" },
+    meta: { "depends-on": ["work/read-switch"],  kind: "action", status: "open", assignee: "@reads", issue: "#499" },
     content_text: "Decommission the old store once the soak is clean.",
     created_by: "aligner",
     updated_by: "aligner",
@@ -443,7 +443,7 @@ const atlasBoardRows: MockMemory[] = [
   {
     key: "work/reconcile-review",
     value: "Review the reconciliation script (PR #504)",
-    meta: {
+    meta: { "depends-on": ["work/backfill-catalog"], 
       status: "in_review",
       kind: "review",
       owner: "@reads",
@@ -463,7 +463,7 @@ const atlasBoardRows: MockMemory[] = [
   {
     key: "work/backfill-catalog",
     value: "Backfill the catalog into the new store",
-    meta: {
+    meta: { "depends-on": ["work/dual-write-setup"], 
       status: "in_progress",
       kind: "action",
       owner: "@backfill",
@@ -483,7 +483,7 @@ const atlasBoardRows: MockMemory[] = [
   {
     key: "work/backfill-metrics",
     value: "Watch backfill throughput during the run",
-    meta: {
+    meta: { "depends-on": ["work/dual-write-setup"], 
       status: "in_progress",
       kind: "action",
       owner: "@operator",
@@ -806,6 +806,15 @@ const atlas: RoomFixture = {
 // referrers yet (#599's graph and #611's rail integrity banner agree on this by
 // construction, since both read the same edge list).
 const ATLAS_LINK_EDGES: MemoryGraphEdge[] = [
+  // The migration's order of work: each row waits on the ones before it, so
+  // the board reads "after …" on the rows still blocked and the graph draws
+  // the pipeline dual-write → backfill → reconcile → read switch → decommission.
+  { source: "work/backfill-catalog", target: "work/dual-write-setup", kind: "relation", relation: "depends-on", resolved: true },
+  { source: "work/backfill-metrics", target: "work/dual-write-setup", kind: "relation", relation: "depends-on", resolved: true },
+  { source: "work/reconcile-review", target: "work/backfill-catalog", kind: "relation", relation: "depends-on", resolved: true },
+  { source: "work/read-switch", target: "work/reconcile-review", kind: "relation", relation: "depends-on", resolved: true },
+  { source: "work/read-switch", target: "work/backfill-metrics", kind: "relation", relation: "depends-on", resolved: true },
+  { source: "work/decommission-old-store", target: "work/read-switch", kind: "relation", relation: "depends-on", resolved: true },
   { source: "context/synthesis", target: "decisions/cutover", kind: "wikilink", resolved: true },
   { source: "context/synthesis", target: "status/sprint", kind: "wikilink", resolved: true },
   { source: "context/synthesis", target: "context/goal", kind: "transclusion", resolved: true },

--- a/mycelium-frontend/src/mocks/fixtures.ts
+++ b/mycelium-frontend/src/mocks/fixtures.ts
@@ -393,6 +393,7 @@ const atlasFlowEpisode: EpisodeSummary = {
     roles: ["proposer", "guardian"],
     max_steps: 6,
     bound: { proposer: "reads", guardian: "operator" },
+    cast: ["reads", "operator"],
     ask: "flip reads to the new store without a soak window",
     steps: [
       { id: "propose", to: "proposer", next: "review", prompt: "{ask}\n\nState exactly what you intend to do." },
@@ -403,6 +404,132 @@ const atlasFlowEpisode: EpisodeSummary = {
   trace: [
     { step: "propose", turn: 1, asked: ["reads"], stances: { reads: null }, stance: null, next: "review", at: iso(6) },
     { step: "review", turn: 2, asked: ["operator"], stances: { operator: "reject" }, stance: "reject", next: "propose", at: iso(3) },
+  ],
+};
+
+
+// The other two built-in flows, and one a room wrote for itself, so the pane
+// has every shape a flow can take: a fan-out in progress, a round-robin that
+// finished, and a long branching one deep in its loops.
+const ATLAS_FANOUT_EPISODE = atlasEpisode("a2b3c4");
+const atlasFanOutEpisode: EpisodeSummary = {
+  short_id: "a2b3c4",
+  episode: ATLAS_FANOUT_EPISODE,
+  topic: "urn:concept:mycelium:atlas-migration",
+  outcome: "open",
+  subkind: null,
+  participants: ["operator", "backfill", "reads", "conductor"],
+  metrics: null,
+  assignments: null,
+  tasks: [],
+  message_count: 4,
+  updated_at: iso(4),
+  updated_by: "conductor",
+  within: ATLAS_RETIRE_THREAD,
+  current_step: "combine",
+  flow: {
+    name: "fan-out",
+    description: "A lead asks every worker at once, then combines what came back.",
+    roles: ["lead"],
+    max_steps: 6,
+    bound: { lead: "operator" },
+    cast: ["operator", "backfill", "reads"],
+    ask: "carve up the reconciliation day: who checks what, in what order",
+    steps: [
+      { id: "gather", to: "workers", next: "combine", prompt: "{ask}\n\nAnswer with what you can contribute, what you would need, and any blocker you see." },
+      { id: "combine", to: "lead", next: "done", prompt: "You asked the team: {ask}\n\nThey answered:\n{replies}\n\nCombine those into one plan." },
+      { id: "done", end: "resolved" },
+    ],
+  },
+  trace: [
+    { step: "gather", turn: 1, asked: ["backfill", "reads"], stances: { backfill: null, reads: null }, stance: null, next: "combine", at: iso(5) },
+  ],
+};
+
+const ATLAS_ROBIN_EPISODE = atlasEpisode("c7d8e9");
+const atlasRoundRobinEpisode: EpisodeSummary = {
+  short_id: "c7d8e9",
+  episode: ATLAS_ROBIN_EPISODE,
+  topic: "urn:concept:mycelium:atlas-migration",
+  outcome: "resolved",
+  subkind: null,
+  participants: ["backfill", "reads", "operator", "conductor"],
+  metrics: null,
+  assignments: null,
+  tasks: [],
+  message_count: 8,
+  updated_at: iso(40),
+  updated_by: "conductor",
+  within: null,
+  current_step: null,
+  flow: {
+    name: "round-robin",
+    description: "Every member speaks in turn, for a fixed number of rounds.",
+    roles: [],
+    max_steps: 12,
+    bound: {},
+    cast: ["backfill", "reads", "operator"],
+    ask: "should the old store stay readable after cutover, and for how long",
+    steps: [
+      { id: "round", to: "each", rounds: 2, next: "done", prompt: "Round {round} of {rounds}.\n\nThe question: {ask}" },
+      { id: "done", end: "resolved" },
+    ],
+  },
+  trace: [
+    { step: "round", turn: 1, asked: ["backfill", "reads", "operator"], stances: { backfill: null, reads: null, operator: null }, stance: null, next: "round", at: iso(44) },
+    { step: "round", turn: 2, asked: ["backfill", "reads", "operator"], stances: { backfill: "accept", reads: "accept", operator: "accept" }, stance: "accept", next: "done", at: iso(41) },
+  ],
+};
+
+const ATLAS_TRAIN_EPISODE = atlasEpisode("d4e5f6");
+const atlasReleaseTrainEpisode: EpisodeSummary = {
+  short_id: "d4e5f6",
+  episode: ATLAS_TRAIN_EPISODE,
+  topic: "urn:concept:mycelium:atlas-migration",
+  outcome: "open",
+  subkind: null,
+  participants: ["backfill", "reads", "operator", "conductor"],
+  metrics: null,
+  assignments: null,
+  tasks: [],
+  message_count: 14,
+  updated_at: iso(1),
+  updated_by: "conductor",
+  within: null,
+  current_step: "security",
+  flow: {
+    name: "release-train",
+    description: "Plan with the team, clear security, canary it, get sign-off; any block sends it back.",
+    roles: ["lead", "guardian", "human", "operator"],
+    max_steps: 24,
+    bound: { lead: "backfill", guardian: "reads", human: "operator", operator: "backfill" },
+    cast: ["backfill", "reads", "operator"],
+    ask: "ship the cutover as one release train",
+    steps: [
+      { id: "triage", to: "lead", next: "plan", prompt: "{ask}\n\nSay what has to be true before this ships." },
+      { id: "plan", to: "each", next: "combine", prompt: "{ask}\n\nWhat is your part, and what do you need?" },
+      { id: "combine", to: "lead", next: "security", prompt: "The team said:\n{replies}\n\nCombine into one plan." },
+      { id: "security", to: "guardian", next: { accept: "canary", reject: "revise", silent: "escalate", default: "revise" }, prompt: "Review the plan:\n{reply}" },
+      { id: "revise", to: "lead", next: "security", prompt: "Security objected:\n{reply}\n\nRevise the plan." },
+      { id: "escalate", to: "human", next: { accept: "canary", reject: "abandoned", default: "escalate" }, prompt: "Security did not answer. Proceed?" },
+      { id: "canary", to: "operator", next: { accept: "signoff", reject: "rollback" }, prompt: "Run the canary and report." },
+      { id: "signoff", to: "guardian", next: { accept: "shipped", reject: "rollback" }, prompt: "Canary is green. Sign off?" },
+      { id: "rollback", to: "operator", next: "revise", prompt: "Roll back and say what you saw." },
+      { id: "shipped", end: "resolved" },
+      { id: "abandoned", end: "rejected" },
+    ],
+  },
+  trace: [
+    { step: "triage", turn: 1, asked: ["backfill"], stances: { backfill: null }, stance: null, next: "plan", at: iso(30) },
+    { step: "plan", turn: 2, asked: ["backfill", "reads", "operator"], stances: { backfill: null, reads: null, operator: null }, stance: null, next: "combine", at: iso(27) },
+    { step: "combine", turn: 3, asked: ["backfill"], stances: { backfill: null }, stance: null, next: "security", at: iso(24) },
+    { step: "security", turn: 4, asked: ["reads"], stances: { reads: "reject" }, stance: "reject", next: "revise", at: iso(21) },
+    { step: "revise", turn: 5, asked: ["backfill"], stances: { backfill: null }, stance: null, next: "security", at: iso(18) },
+    { step: "security", turn: 6, asked: ["reads"], stances: { reads: null }, stance: "silent", next: "escalate", at: iso(15) },
+    { step: "escalate", turn: 7, asked: ["operator"], stances: { operator: "accept" }, stance: "accept", next: "canary", at: iso(12) },
+    { step: "canary", turn: 8, asked: ["backfill"], stances: { backfill: "reject" }, stance: "reject", next: "rollback", at: iso(9) },
+    { step: "rollback", turn: 9, asked: ["backfill"], stances: { backfill: null }, stance: null, next: "revise", at: iso(6) },
+    { step: "revise", turn: 10, asked: ["backfill"], stances: { backfill: null }, stance: null, next: "security", at: iso(3) },
   ],
 };
 
@@ -757,10 +884,13 @@ const atlas: RoomFixture = {
         "Decision: we're go for Friday am pending a clean 24h soak, as backfill laid out. I'm adding one gate — the pool-recycle fix has to land and be verified before we flip, not after. If it's not in by Thursday evening we slip to Monday. I'd rather ship a day late than ship into a known write-dropping window. Filing both follow-ups as tasks now.",
     },
   ],
-  episodes: [atlasFlowEpisode, atlasEpisodeSummary],
+  episodes: [atlasReleaseTrainEpisode, atlasFlowEpisode, atlasFanOutEpisode, atlasEpisodeSummary, atlasRoundRobinEpisode],
   episodeDetails: {
     e4f1a2: { ...atlasEpisodeSummary, messages: atlasL9Chain },
     f10a2c: { ...atlasFlowEpisode, messages: [] },
+    a2b3c4: { ...atlasFanOutEpisode, messages: [] },
+    c7d8e9: { ...atlasRoundRobinEpisode, messages: [] },
+    d4e5f6: { ...atlasReleaseTrainEpisode, messages: [] },
   },
   // The floor the running flow holds: the conductor's, given to reads for its
   // second proposal.
@@ -773,6 +903,8 @@ const atlas: RoomFixture = {
       holder: "conductor",
       speakers: ["reads"],
     },
+    { thread: "a2b3c4", episode: ATLAS_FANOUT_EPISODE, key: null, title: null, holder: "conductor", speakers: ["operator"] },
+    { thread: "d4e5f6", episode: ATLAS_TRAIN_EPISODE, key: null, title: null, holder: "conductor", speakers: ["reads"] },
   ],
   // backfill holds an open SLIM socket; reads is present on a server-held await
   // lease. Both are agents in the roster, so the board projects a resident row

--- a/mycelium-frontend/src/mocks/handlers.ts
+++ b/mycelium-frontend/src/mocks/handlers.ts
@@ -511,7 +511,9 @@ export async function handleMock(req: Request): Promise<Response | null> {
     case "sessions": {
       // Presence: a room's fixture may name resident members (there is no SLIM
       // node here to report them), which the board projects into resident rows.
-      if (sub[1] === "members" && method === "GET") return json({ members: fx.presence ?? [] });
+      if (sub[1] === "members" && method === "GET") {
+        return json({ members: fx.presence ?? [], floors: fx.floors ?? [] });
+      }
       return null;
     }
 

--- a/openapi.json
+++ b/openapi.json
@@ -4404,6 +4404,48 @@
             "title": "Updated By",
             "default": ""
           },
+          "within": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Within"
+          },
+          "flow": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flow"
+          },
+          "trace": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Trace"
+          },
+          "current_step": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Step"
+          },
           "messages": {
             "items": {
               "$ref": "#/components/schemas/L9EnvelopeRead"
@@ -4555,6 +4597,48 @@
             "type": "string",
             "title": "Updated By",
             "default": ""
+          },
+          "within": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Within"
+          },
+          "flow": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Flow"
+          },
+          "trace": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Trace"
+          },
+          "current_step": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Step"
           }
         },
         "type": "object",


### PR DESCRIPTION
## Summary

The v2 of the conductor: **an episode has an interaction flow.** A run no longer walks its protocol inside a task's thread. Every summon opens a fresh episode; the episode record carries the flow (the graph, who plays which role, the ask) and a per-step trace; and the app draws that graph at the top of the run's thread with the current step lit, the taken edges solid, and whose turn it is marked. A task is where a run can be opened from (recorded as `within`) or what it produces, never its root.

This supersedes the task-rooted design from #955 and closes the summon gap a reviewer found: a persona mentioned in `@conductor gated @api @sec` used to answer the summon itself, off the floor.

## Changes

- **Episode record carries the flow.** `EpisodeState` gains `flow`, `trace`, `within`; `write_episode_record` writes a `## Flow` (YAML) and `## Trace` (JSONL) block plus a `within:` line; `episode_records.py` parses them back and derives `current_step`. `EpisodeSummaryRead` exposes all four (openapi.json refreshed).
- **Conductor opens its own episode.** `handle_summon` mints the episode and holds its floor synchronously, `run` writes the record at open, every step and close, and speaks one opening and one closing line into the thread it was summoned from. Tick headers read `gated · review · turn 2 of 6 · @sec`. The flow carries the run's `cast` so a group step names who it asks.
- **Persona respects the run.** It ignores a summon that co-summons a conductor and drops any post the floor does not admit.
- **Floor notices name the task** (`key`/`title` on the notice and on the members read).
- **Frontend.** `lib/flow-graph.ts` lays a flow out (a row for up to three steps, a column with loop and skip rails beyond that; edges to one target merge their stances); `components/flow-graph.tsx` draws it; `flow-panel.tsx` puts graph, floor and trace at the top of the run's thread in `thread-view.tsx`. Mock room gains a gated, a fan-out, a finished round-robin and a room-written release-train run.
- **Docs.** `concepts/conductor.md` and `concepts/episodes.md` rewritten around the run; `CLAUDE.md` conductor bullet updated; site regenerated.

## Testing

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — backend 1190 passed; CLI 812 passed
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `ty check` clean on backend and CLI
- [x] Frontend: `npm run lint`, `tsc --noEmit`, `npm test` (878 tests, incl. new `flow-graph.test.ts` and the openapi mock contract)
- [x] Shotkit screenshots of all four flows in the thread pane

## Related Issues

Part of #953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk

---
_Generated by [Claude Code](https://claude.ai/code/session_01EqQ5h4kS76fqFLPHbW7qqk)_