### PR TITLE
Draw the responding line at notice scale, and say which thread a turn is going into

### DIFF
--- a/mycelium-frontend/src/components/event-stream.tsx
+++ b/mycelium-frontend/src/components/event-stream.tsx
@@ -18,6 +18,7 @@ import {
   isActivityFrame,
   respondingLabel,
   settleActivity,
+  splitActivity,
   type Responding,
 } from "@/lib/activity";
 import { useRoomConnected, useRoomStream } from "@/lib/stream-hub";
@@ -87,23 +88,65 @@ const CHANNEL_VIEW_TYPES = new Set([...CHAT_TYPES, ...L9_RAISE_UP_TYPES, PING_TY
  */
 const SYSTEM_TYPES = new Set([...L9_RAISE_UP_TYPES, PING_TYPE, NOTICE_TYPE]);
 
-/** "@aligner is responding…" — the breathing monograms of whoever is mid-turn,
- *  drawn under the last message and gone the moment their reply lands. Uses the
- *  lease halo (a poll in flight) rather than a new motion. */
-function RespondingLine({ entries }: { entries: Responding[] }) {
+/** One line of "who is responding": the system-notice scale the channel already
+ *  speaks in, with the dot breathing for a turn in flight. */
+function RespondingRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 py-0.5 text-micro text-muted-foreground">
+      <span
+        aria-hidden
+        className="inline-block size-1.5 flex-shrink-0 rounded-full motion-safe:animate-pulse"
+        style={{ background: "var(--accent)" }}
+      />
+      <span className="flex min-w-0 items-center gap-1.5 truncate">{children}</span>
+    </div>
+  );
+}
+
+/** "@aligner is responding…" under the last message, gone the moment the reply
+ *  lands. A turn going into a task's thread does not land here — the channel
+ *  never shows a thread's prose — so that line says where instead, and opens
+ *  it, the way the ping for the reply will: "@aligner is responding in <task>". */
+function RespondingLine({
+  entries,
+  room,
+  threads,
+  onOpenThread,
+}: {
+  entries: Responding[];
+  room: string;
+  threads: Map<string, ThreadOwner>;
+  onOpenThread?: (episode: string) => void;
+}) {
+  const { here, elsewhere } = splitActivity(entries, (episode) => !episode || isLiveEpisode(room, episode));
   return (
     <div
       role="status"
       aria-live="polite"
       data-testid="responding-line"
-      className="flex items-center gap-2.5 px-5 py-2 text-caption text-muted-foreground motion-safe:animate-in motion-safe:fade-in-0"
+      className="mt-3 flex flex-col px-5 py-1 motion-safe:animate-in motion-safe:fade-in-0"
     >
-      <div className="flex w-7 flex-shrink-0 -space-x-1.5">
-        {entries.slice(0, 3).map((r) => (
-          <Monogram key={r.handle} handle={r.handle} className="size-5 text-[9px]" presence="lease" mutePresence />
-        ))}
-      </div>
-      <span className="truncate">{respondingLabel(entries)}</span>
+      {here.length > 0 && <RespondingRow>{respondingLabel(here)}</RespondingRow>}
+      {[...elsewhere.entries()].map(([thread, group]) => {
+        const shortId = threadShortId(thread) ?? "thread";
+        const title = threads.get(thread)?.title ?? shortId;
+        return (
+          <RespondingRow key={thread}>
+            <span className="truncate">{respondingLabel(group, "elsewhere")}</span>
+            <button
+              type="button"
+              onClick={() => onOpenThread?.(thread)}
+              disabled={!onOpenThread}
+              title={thread}
+              aria-label={`Open thread ${shortId}`}
+              className="inline-flex max-w-[18rem] items-center gap-1 truncate rounded px-1 text-accent transition-colors enabled:hover:bg-accent-soft enabled:hover:underline disabled:cursor-default"
+            >
+              <MessageSquare className="size-3 shrink-0" strokeWidth={1.9} />
+              <span className="truncate">{title}</span>
+            </button>
+          </RespondingRow>
+        );
+      })}
     </div>
   );
 }
@@ -1145,7 +1188,9 @@ export function EventStream({ roomName, onMemoryChanged, onConnectionChange, onO
                 </div>
               );
             })}
-          {responding.length > 0 && <RespondingLine entries={responding} />}
+          {responding.length > 0 && (
+            <RespondingLine entries={responding} room={roomName} threads={threads} onOpenThread={onOpenThread} />
+          )}
         </div>
         )}
       </ScrollArea>

--- a/mycelium-frontend/src/components/task/task-conversation.tsx
+++ b/mycelium-frontend/src/components/task/task-conversation.tsx
@@ -3,9 +3,17 @@
 
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { MessageSquare } from "lucide-react";
 import type { RoomMessage } from "@/lib/api";
+import {
+  applyActivity,
+  expireActivity,
+  isActivityFrame,
+  respondingLabel,
+  settleActivity,
+  type Responding,
+} from "@/lib/activity";
 import { useRoomAgents, useThreadMessages } from "@/lib/room-data";
 import { useRoomStream } from "@/lib/stream-hub";
 import { pingOf } from "@/lib/threads";
@@ -90,9 +98,23 @@ export function TaskConversation({ roomName, episode, onOpenMemory, onReady }: P
   // reason to re-read; nothing else here is, so a busy room does not refetch a
   // quiet thread. The refresh is a revalidation, not an append: the region stays
   // a read of one episode rather than a second feed assembled by hand.
+  // Who is mid-turn in this thread. The same signal the channel folds, scoped
+  // to this episode: a turn going elsewhere is not this conversation's news.
+  const [responding, setResponding] = useState<Responding[]>([]);
+  useEffect(() => {
+    if (responding.length === 0) return;
+    const tick = setInterval(() => setResponding(prev => expireActivity(prev, Date.now())), 1_000);
+    return () => clearInterval(tick);
+  }, [responding.length]);
+
   useRoomStream(roomName, frame => {
     const message = frame as Record<string, unknown>;
+    if (isActivityFrame(message)) {
+      if (message.episode === episode) setResponding(prev => applyActivity(prev, message, Date.now()));
+      return;
+    }
     if (message.episode === episode) {
+      setResponding(prev => settleActivity(prev, message.sender_handle as string | undefined));
       refresh();
       return;
     }
@@ -198,6 +220,21 @@ export function TaskConversation({ roomName, episode, onOpenMemory, onReady }: P
               </div>
             );
           })}
+        </div>
+      )}
+      {responding.length > 0 && (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="responding-line"
+          className="mt-2 flex items-center gap-2 px-5 py-1 text-micro text-muted-foreground"
+        >
+          <span
+            aria-hidden
+            className="inline-block size-1.5 flex-shrink-0 rounded-full motion-safe:animate-pulse"
+            style={{ background: "var(--accent)" }}
+          />
+          <span className="truncate">{respondingLabel(responding)}</span>
         </div>
       )}
       <div ref={endRef} />

--- a/mycelium-frontend/src/lib/activity.test.ts
+++ b/mycelium-frontend/src/lib/activity.test.ts
@@ -9,7 +9,9 @@ import {
   expireActivity,
   isActivityFrame,
   respondingLabel,
+  respondingNames,
   settleActivity,
+  splitActivity,
   type Responding,
 } from "@/lib/activity";
 
@@ -91,5 +93,35 @@ describe("the line", () => {
     expect(respondingLabel(at("growth", "finance"))).toBe("@growth and @finance are responding…");
     expect(respondingLabel(at("a", "b", "c"))).toBe("@a, @b and 1 other are responding…");
     expect(respondingLabel(at("a", "b", "c", "d"))).toBe("@a, @b and 2 others are responding…");
+    expect(respondingNames(at("a", "b"))).toBe("@a and @b");
+  });
+
+  it("stops short of the thread's name when the turn is going elsewhere", () => {
+    expect(respondingLabel(at("aligner"), "elsewhere")).toBe("@aligner is responding in");
+    expect(respondingLabel(at("a", "b"), "elsewhere")).toBe("@a and @b are responding in");
+  });
+});
+
+describe("splitting by where the turn lands", () => {
+  const entry = (handle: string, episode: string | null): Responding => ({ handle, episode, since: T0, until: T0 + 1 });
+  const live = "urn:ioc:mycelium:episode:atlas:live";
+
+  it("keeps room-level turns here and groups thread turns by their thread", () => {
+    const { here, elsewhere } = splitActivity(
+      [entry("growth", null), entry("aligner", "urn:e1"), entry("finance", live), entry("risk", "urn:e1"), entry("ops", "urn:e2")],
+      (episode) => !episode || episode === live,
+    );
+    expect(here.map((r) => r.handle)).toEqual(["growth", "finance"]);
+    expect([...elsewhere.keys()]).toEqual(["urn:e1", "urn:e2"]);
+    expect(elsewhere.get("urn:e1")?.map((r) => r.handle)).toEqual(["aligner", "risk"]);
+  });
+
+  it("inside a thread, only that thread's turns are here", () => {
+    const { here, elsewhere } = splitActivity(
+      [entry("growth", null), entry("aligner", "urn:e1")],
+      (episode) => episode === "urn:e1",
+    );
+    expect(here.map((r) => r.handle)).toEqual(["aligner"]);
+    expect(elsewhere.get("")?.map((r) => r.handle)).toEqual(["growth"]);
   });
 });

--- a/mycelium-frontend/src/lib/activity.ts
+++ b/mycelium-frontend/src/lib/activity.ts
@@ -74,12 +74,44 @@ export function expireActivity(current: Responding[], now: number): Responding[]
   return current.some((r) => r.until <= now) ? current.filter((r) => r.until > now) : current;
 }
 
-/** "@x is responding…" / "@x and @y are responding…" / "@x, @y and 2 others are responding…" */
-export function respondingLabel(entries: Responding[]): string {
+/** "@x" / "@x and @y" / "@x, @y and 2 others" */
+export function respondingNames(entries: Responding[]): string {
   const names = entries.map((r) => `@${r.handle}`);
   if (names.length === 0) return "";
-  if (names.length === 1) return `${names[0]} is responding…`;
-  if (names.length === 2) return `${names[0]} and ${names[1]} are responding…`;
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
   const more = names.length - 2;
-  return `${names[0]}, ${names[1]} and ${more} ${more === 1 ? "other" : "others"} are responding…`;
+  return `${names[0]}, ${names[1]} and ${more} ${more === 1 ? "other" : "others"}`;
+}
+
+/** "@x is responding…" / "@x and @y are responding…". With `where`, the turn
+ *  is going somewhere other than the surface reading it — a task's thread — and
+ *  the line stops before naming it, so the caller can draw the name as a link:
+ *  "@x is responding in". */
+export function respondingLabel(entries: Responding[], where: "here" | "elsewhere" = "here"): string {
+  if (entries.length === 0) return "";
+  const verb = entries.length === 1 ? "is" : "are";
+  const names = respondingNames(entries);
+  return where === "here" ? `${names} ${verb} responding…` : `${names} ${verb} responding in`;
+}
+
+/** The entries whose turn lands on this surface, and those landing in a thread
+ *  it does not show. `isHere` says whether an episode is this surface's own. */
+export function splitActivity(
+  entries: Responding[],
+  isHere: (episode: string | null) => boolean,
+): { here: Responding[]; elsewhere: Map<string, Responding[]> } {
+  const here: Responding[] = [];
+  const elsewhere = new Map<string, Responding[]>();
+  for (const r of entries) {
+    if (isHere(r.episode)) {
+      here.push(r);
+      continue;
+    }
+    const key = r.episode ?? "";
+    const group = elsewhere.get(key);
+    if (group) group.push(r);
+    else elsewhere.set(key, [r]);
+  }
+  return { here, elsewhere };
 }

--- a/mycelium-frontend/src/mocks/stream.ts
+++ b/mycelium-frontend/src/mocks/stream.ts
@@ -38,19 +38,22 @@ const say = (id: string, who: string, text: string): StreamStep["message"] => ({
 // The "is responding…" signal the backend raises when a participant starts
 // generating: a presence-style frame, never a message (see `lib/activity.ts`).
 // Each agent line below is preceded by one, and the line itself settles it.
-const responding = (who: string): StreamStep["message"] => ({
+const responding = (who: string, episode: string | null = null): StreamStep["message"] => ({
   type: "agent_activity",
   message_type: "agent_activity",
   handle: who,
   sender_handle: who,
   state: "responding",
-  episode: null,
+  episode,
   ttl_s: 90,
 });
 const pricingTimeline: StreamStep[] = [
   // Round 1
   { delayMs: 1500, message: say("s1", "growth", "Opening ask: $29, 50 seats, annual term — land-and-expand. @finance") },
-  { delayMs: 1600, message: tick("s2", 1, "growth", "propose", { price: "29", seats: "50", term: "annual" }) },
+  // The aligner's turn lands in the negotiation's thread, not the channel, so
+  // the channel names where it is going; the tick that follows settles it.
+  { delayMs: 400, message: responding("aligner", PRICING_EPISODE) },
+  { delayMs: 1200, message: tick("s2", 1, "growth", "propose", { price: "29", seats: "50", term: "annual" }) },
   { delayMs: 600, message: responding("finance") },
   { delayMs: 1600, message: say("s3", "finance", "$29 kills our margin. Counter: $49, same seats.") },
   { delayMs: 1600, message: tick("s4", 1, "finance", "counter", { price: "49", seats: "50", term: "annual" }) },


### PR DESCRIPTION
## Summary

Follow-up to #951 from review of it in the room.

**Scale.** The "@x is responding…" line rendered at caption size with a monogram, which is louder than anything else the channel says between messages. Every other system line ("@growth joined b2d0", "Claimed", "Activity in …") is a 6px dot and micro text. The line is now one of those rows; the dot breathes while the turn is in flight, which is the only motion it keeps.

**Where the turn lands.** A turn going into a task's thread or a coordination episode never lands in the channel, since the channel carries no thread prose. A bare "@aligner is responding…" there read as a room reply that never arrived. The channel line now says where the turn is going and opens it, the same way the ping for that reply will once it lands:

```
●  @aligner is responding in  ▭ b2d0
```

Room-level turns keep the plain "@x is responding…"; several handles in one thread fold into one line ("@a and @b are responding in …"). Inside a task's own conversation pane, the same signal draws the plain line for that thread only, and a turn going anywhere else is not that pane's news.

## Changes

- `mycelium-frontend/src/lib/activity.ts`: `respondingNames`, `respondingLabel(entries, "here" | "elsewhere")`, `splitActivity(entries, isHere)`.
- `mycelium-frontend/src/components/event-stream.tsx`: `RespondingRow` at `SystemNotice` scale; `RespondingLine` splits by episode against `isLiveEpisode` and names the thread off the room's thread owners (title, else short id), opening it through `onOpenThread`.
- `mycelium-frontend/src/components/task/task-conversation.tsx`: folds `agent_activity` frames for its own episode, settles on a message in that episode, expires on the TTL tick, draws the line above the end anchor.
- `mycelium-frontend/src/mocks/stream.ts`: one thread-bound turn (the aligner into the negotiation episode, settled by its tick) so `pnpm dev:mock` shows both shapes.
- `activity.test.ts`: names, the "elsewhere" label, and the split for both surfaces.

## Testing

- [x] `pnpm vitest run` — 861 passed
- [x] `pnpm lint` — 0 errors (1 pre-existing warning, untouched file)
- [x] Visual: `shot app /room/pricing-model --mock --do "wait:[data-testid=responding-line]"` shows the thread-bound line at the same scale as the joined notices above it

## Related Issues

Follow-up to #951 / #513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcVQNRFr94KupPMhw8iVYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PcVQNRFr94KupPMhw8iVYm)_