### PR TITLE
fix(frontend): make the agent handoff prompt actually runnable

### DIFF
--- a/mycelium-frontend/src/lib/install.test.ts
+++ b/mycelium-frontend/src/lib/install.test.ts
@@ -83,6 +83,15 @@ describe("install content", () => {
     expect(prompt).toContain("--room atlas --owner avery");
     expect(prompt).toContain("mycelium board --room atlas");
     expect(prompt).toContain("--timeout 30");
+    // `room messages` takes the room positionally; `--room` is not an option
+    // there, so a pasted prompt carrying it fails on the agent's first read.
+    expect(prompt).toContain("mycelium room messages atlas --limit 20");
+    expect(prompt).not.toContain("room messages --room");
+    // A reader that is never told how to speak, or how to take a second turn,
+    // joins the room and then goes quiet.
+    expect(prompt).toContain("mycelium adapter add claude-code");
+    expect(prompt).toContain("mycelium respond --room atlas --handle");
+    expect(prompt).toContain("await again");
   });
 
   it("notes the WSL constraint on Windows only", () => {

--- a/mycelium-frontend/src/lib/install.ts
+++ b/mycelium-frontend/src/lib/install.ts
@@ -77,9 +77,11 @@ export function agentHandoffPrompt(options: AgentHandoffOptions): string {
     `You are joining the Mycelium room \`${options.roomName}\` on the already-running hub at ${options.hubUrl} as a coding-agent collaborator.`,
     `Install the CLI if needed with \`${CLI_INSTALL_COMMAND}\`, then run \`${configSetCommand(options.hubUrl)}\`.`,
     auth,
+    `Install the adapter for the runtime you are running in so this session can participate: \`mycelium adapter add claude-code\` (or \`cursor\`).`,
     `Choose a short handle and register yourself with \`mycelium agent create <handle> --room ${options.roomName}${owner}\`.`,
-    `Read \`mycelium room messages --room ${options.roomName} --limit 20\` and \`mycelium board --room ${options.roomName}\`. Claim a suitable task or ask me which task to take.`,
-    `When you are waiting for collaboration, use \`mycelium await --room ${options.roomName} --handle <handle> --timeout 30\`; do not start a separate daemon or replace this session.`,
+    `Read \`mycelium room messages ${options.roomName} --limit 20\` and \`mycelium board --room ${options.roomName}\`. Claim a suitable task or ask me which task to take.`,
+    `Speak in the room with \`mycelium respond --room ${options.roomName} --handle <handle> "..."\`. Address another member as \`@handle\`; summon the mediator with \`@aligner\` when you and another agent genuinely disagree.`,
+    `Then keep taking turns: run \`mycelium await --room ${options.roomName} --handle <handle> --timeout 30\`, and when it returns a message, reason about it, reply with \`mycelium respond\`, and await again. Repeat until I tell you to stop; do not start a separate daemon or replace this session.`,
   ].join("\n\n");
 }
 


### PR DESCRIPTION
## Why

The "Invite a coding agent" dialog hands a human a prompt to paste into a running coding session. Following it verbatim fails.

Found while setting up a two-agent demo against `mycelium.outshift.io` — I hit the first bug myself by following the prompt's own instructions.

## What was wrong

1. **A flag that does not exist.** The prompt said `mycelium room messages --room <room> --limit 20`. `room` is a *positional* argument; `--room` errors with `No such option: --room`. The agent's very first read step exits non-zero.
2. **Never told how to speak.** The agent was pointed at `room messages` and `board`, told to claim a task — and given no `respond`. It can join a room, read it, and then post nothing.
3. **A wait that expires and never returns.** `mycelium await ... --timeout 30`, once, with "do not start a separate daemon". Agent A's await expires while agent B is still running `install.sh`, and A goes idle permanently. Two agents never see each other.
4. **No adapter.** No `mycelium adapter add claude-code`, so the session runs raw CLI without the mycelium skill.

## What changed

`agentHandoffPrompt` only — `hubSetupPrompt` was already correct.

- Fix the read to `mycelium room messages <room> --limit 20`.
- Add `mycelium respond --room <room> --handle <handle> "..."`, plus `@handle` addressing and `@aligner` for a genuine disagreement.
- Replace the one-shot await with a turn loop: await → reason → respond → await again, until the human stops it. Still explicitly not a daemon and not a session replacement.
- Add the adapter install step.

## Tests

`install.test.ts` asserts the positional read and carries a regression guard (`not.toContain("room messages --room")`) so the bad spelling cannot come back. 8/8 pass; `pnpm lint` clean (the one warning is pre-existing in `use-viewport.ts`).

Note: needs Node 22 to run the suite locally, matching CI — Node 20.9 fails at `vitest.config.ts` with `ERR_REQUIRE_ESM` under vite 7.