### PR TITLE
docs(agents): sign in on a gated hub, and stop skipping the adapter

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -55,9 +55,9 @@ machine can have Docker for unrelated reasons).
 
 1. **Client only.** They are joining a hub someone else already runs. No
    Docker, no local stack; just point the CLI at the hub and connect your
-   runtime. Do **Step 4**, then skip to Step 6.
+   runtime. Do **Step 4**, then continue at Step 5.
 2. **Host the service.** They are standing up a new hub for their team on this
-   machine. Do **Step 3** (the Docker-backed stack), then skip to Step 6.
+   machine. Do **Step 3** (the Docker-backed stack), then continue at Step 5.
 3. **Both.** Host the hub *and* use it from this machine as a client. Do
    **Step 3**; Step 4 then resolves to a no-op because `server.api_url` already
    points at localhost. You can skip Step 4 in this case.
@@ -144,15 +144,31 @@ Skip this step on the **host** path, and on **both** (the host flow already
 pointed `server.api_url` at localhost, so this is a no-op).
 
 A spoke needs no Docker and no local stack: it just points the CLI at the hub
-the team already runs. Ask the user for the hub's API URL (host and port, e.g.
-`http://hub.example.com:8000`), then:
+the team already runs. Ask the user for the hub's API URL, then:
 
 ```bash
-mycelium config set server.api_url http://<hub-host>:8000
+mycelium config set server.api_url <hub-url>
 mycelium config apply
 ```
 
-Confirm the spoke can reach the hub:
+The URL is whatever origin the hub answers on: a host and port for a machine on
+the network (`http://hub.example.com:8000`), or just the scheme and domain when
+it sits behind TLS (`https://mycelium.example.com` — no port).
+
+A hub can be **gated**, and then every read fails with an authentication error
+until you sign in — so sign in before checking anything:
+
+```bash
+mycelium login     # opens a browser; add --device for a headless shell or SSH
+mycelium whoami    # confirm the identity the hub granted
+```
+
+Use the identity `whoami` reports. Do not invent one, and do not override it
+with `mycelium iam` on a gated hub — that sets a local handle the hub will not
+honor. If the hub is open, `login` is unnecessary and `mycelium iam <handle>`
+is how you pick an identity for attribution.
+
+Then confirm the spoke can reach the hub:
 
 ```bash
 mycelium status
@@ -180,6 +196,14 @@ woken by looping the participation calls with
 `mycelium await --loop --exec <cmd>` (await, reason, respond, await). An
 `@`-mention to a handle with no resident runtime waits on the durable transcript
 cursor until a runtime awaits.
+
+If the user would rather not keep a loop in the foreground, mention
+[herdr](reference.html#herdr): an optional layer that holds coding-agent
+sessions open in named panes and binds them to room handles, so a mention wakes
+a pane instead of waiting. One command binds a whole workspace to a room
+(`mycelium herdr sync --workspace <id> --room <room>`), and a handle comes from
+the herdr tab name. It is entirely optional and fail-soft — with no herdr
+installed, everything above still works.
 
 ## Step 6: Create a room and open the UI
 

--- a/mycelium-frontend/src/lib/install.test.ts
+++ b/mycelium-frontend/src/lib/install.test.ts
@@ -83,6 +83,15 @@ describe("install content", () => {
     expect(prompt).toContain("--room atlas --owner avery");
     expect(prompt).toContain("mycelium board --room atlas");
     expect(prompt).toContain("--timeout 30");
+    // `room messages` takes the room positionally; `--room` is not an option
+    // there, so a pasted prompt carrying it fails on the agent's first read.
+    expect(prompt).toContain("mycelium room messages atlas --limit 20");
+    expect(prompt).not.toContain("room messages --room");
+    // A reader that is never told how to speak, or how to take a second turn,
+    // joins the room and then goes quiet.
+    expect(prompt).toContain("mycelium adapter add claude-code");
+    expect(prompt).toContain("mycelium respond --room atlas --handle");
+    expect(prompt).toContain("await again");
   });
 
   it("notes the WSL constraint on Windows only", () => {

--- a/mycelium-frontend/src/lib/install.ts
+++ b/mycelium-frontend/src/lib/install.ts
@@ -77,9 +77,11 @@ export function agentHandoffPrompt(options: AgentHandoffOptions): string {
     `You are joining the Mycelium room \`${options.roomName}\` on the already-running hub at ${options.hubUrl} as a coding-agent collaborator.`,
     `Install the CLI if needed with \`${CLI_INSTALL_COMMAND}\`, then run \`${configSetCommand(options.hubUrl)}\`.`,
     auth,
+    `Install the adapter for the runtime you are running in so this session can participate: \`mycelium adapter add claude-code\` (or \`cursor\`).`,
     `Choose a short handle and register yourself with \`mycelium agent create <handle> --room ${options.roomName}${owner}\`.`,
-    `Read \`mycelium room messages --room ${options.roomName} --limit 20\` and \`mycelium board --room ${options.roomName}\`. Claim a suitable task or ask me which task to take.`,
-    `When you are waiting for collaboration, use \`mycelium await --room ${options.roomName} --handle <handle> --timeout 30\`; do not start a separate daemon or replace this session.`,
+    `Read \`mycelium room messages ${options.roomName} --limit 20\` and \`mycelium board --room ${options.roomName}\`. Claim a suitable task or ask me which task to take.`,
+    `Speak in the room with \`mycelium respond --room ${options.roomName} --handle <handle> "..."\`. Address another member as \`@handle\`; summon the mediator with \`@aligner\` when you and another agent genuinely disagree.`,
+    `Then keep taking turns: run \`mycelium await --room ${options.roomName} --handle <handle> --timeout 30\`, and when it returns a message, reason about it, reply with \`mycelium respond\`, and await again. Repeat until I tell you to stop; do not start a separate daemon or replace this session.`,
   ].join("\n\n");
 }
 


### PR DESCRIPTION
## Why

`docs/agents.md` is what the docs site's **Copy agents.md** button hands to a coding agent (`site.js` fetches the raw file), so it is the first thing a new user's agent executes. Followed verbatim against a gated hub — `mycelium.outshift.io` — it cannot finish.

Found while scripting a "bring your own agents" demo against that hub.

## What was wrong

1. **No sign-in step.** `mycelium login` occurred once in the whole file, and only inside a passage *describing what the frontend's guided install panel does* — not as an instruction. An agent on the client-only path runs `config set`, then `mycelium status`, gets an auth error, and has nothing telling it to log in.
2. **The hub URL example misleads.** `http://<hub-host>:8000` is one shape. A hub behind TLS is an origin with no port, and an agent copying the pattern gets it wrong.
3. **Both paths skipped the adapter.** Step 2 said client-only should "Do Step 4, then skip to Step 6" and host should "Do Step 3 ... then skip to Step 6" — while the summary two lines below says *"Steps 1 (CLI), 5 (adapter), and 6 (room + UI) are common to all three paths."* Following the routing skips `mycelium adapter add`, so the session never gets the mycelium skill.
4. **herdr was unmentioned**, even though it is the shipped answer (#933) to not holding an `await` loop in the foreground.

## What changed

Step 4 signs in *before* the connectivity check — on a gated hub `status` is precisely what fails, so checking first and logging in second is backwards. It also says to keep the identity `whoami` reports and why `mycelium iam` is not a substitute on a gated hub (it sets a local handle the hub will not honor).

Step 2 routes both paths through Step 5. Step 5 gains a short, explicitly optional and fail-soft pointer to the herdr guide.

## Checks

`scripts/check_docs_links.py` exits 0. The two `assets/herdr-ram.svg` warnings it prints are pre-existing on main, in `guides/herdr.md` and `guides/quickstart.md` — files this PR does not touch.

`agents.md` is hand-maintained (nothing in `generate_docs.py` emits it), so there is no generated-docs drift to refresh.