### PR TITLE
fix(herdr): select a workspace by its label, and add unbind

### DIFF
--- a/mycelium-cli/src/mycelium/commands/herdr.py
+++ b/mycelium-cli/src/mycelium/commands/herdr.py
@@ -132,6 +132,54 @@ def herdr_unmap(
         raise typer.Exit(1) from None
 
 
+@doc_ref(
+    usage="mycelium herdr unbind <workspace>",
+    desc="Remove a workspace → room binding so sync stops reconciling it.",
+    group="agent",
+)
+@app.command("unbind")
+def herdr_unbind(
+    ctx: typer.Context,
+    workspace: str = typer.Argument(..., help="herdr workspace, by label or id."),
+) -> None:
+    """Forget a ``workspace -> room`` binding.
+
+    The counterpart to ``sync --workspace … --room …``. Binding a workspace
+    enrolls every live agent in it, so the way back out has to be a command
+    rather than a hand-edit of the registry file.
+    """
+    try:
+        bridge = _bridge()
+        bindings = bridge.registry.bindings()
+        target = workspace
+        if target not in bindings:
+            # Accept the label here too, but never require herdr to be up to
+            # undo something: a closed workspace can still be unbound by id.
+            try:
+                target = bridge.resolve_workspace(workspace)
+            except HerdrError:
+                target = workspace
+        room_name = bindings.get(target)
+        if bridge.registry.unbind(target):
+            shown = f"{workspace} ({target})" if workspace != target else target
+            console.print(
+                f"[green]Unbound[/green] workspace [cyan]{shown}[/cyan]"
+                f"{f' [dim]from {room_name}[/dim]' if room_name else ''}."
+            )
+            console.print(
+                "[dim]Members it enrolled stay in the room; remove them with[/dim] "
+                "[cyan]mycelium agent rm <handle> --room <room>[/cyan]"
+            )
+        else:
+            console.print(f"[yellow]No binding[/yellow] for workspace {workspace!r}")
+            raise typer.Exit(1)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        print_error(e, verbose=bool(ctx.obj and ctx.obj.get("verbose")))
+        raise typer.Exit(1) from None
+
+
 def _room_members(config: MyceliumConfig, room_name: str) -> dict[str, str] | None:
     """The backend's live presence for a room: ``{handle: kind}`` (``slim``/``lease``).
 
@@ -605,7 +653,7 @@ def _drain_wakes(config: MyceliumConfig, bridge: HerdrBridge, room: str) -> int:
 
 
 @doc_ref(
-    usage="mycelium herdr sync [--workspace <id> --room <room>] [--once] [--interval N]",
+    usage="mycelium herdr sync [--workspace <label> --room <room>] [--once] [--interval N]",
     desc="Bind a herdr workspace to a room and reconcile membership, liveness, and wakes.",
     group="agent",
 )
@@ -613,7 +661,10 @@ def _drain_wakes(config: MyceliumConfig, bridge: HerdrBridge, room: str) -> int:
 def herdr_sync(
     ctx: typer.Context,
     workspace: str | None = typer.Option(
-        None, "--workspace", "-w", help="herdr workspace id to bind to --room (e.g. w2)."
+        None,
+        "--workspace",
+        "-w",
+        help="herdr workspace to bind to --room, by label or id (e.g. 'Mycelium' or w2).",
     ),
     room: str | None = typer.Option(
         None, "--room", "-r", help="Room to bind/reconcile (scopes to bound workspaces)."
@@ -665,10 +716,20 @@ def herdr_sync(
             raise typer.Exit(1)
 
         room_name = _resolve_room(config, room) if room else None
+        selector = workspace
+        if workspace:
+            try:
+                workspace = bridge.resolve_workspace(workspace)
+            except HerdrError:
+                # A workspace that has since closed can still be named to scope
+                # a reconcile, so accept the literal when it is already bound.
+                if workspace not in bridge.registry.bindings():
+                    raise
         if workspace and room_name:
             bridge.registry.bind(workspace, room_name)
+            shown = f"{selector} ({workspace})" if selector != workspace else workspace
             console.print(
-                f"[green]Bound[/green] workspace [cyan]{workspace}[/cyan] → "
+                f"[green]Bound[/green] workspace [cyan]{shown}[/cyan] → "
                 f"room [cyan]{room_name}[/cyan]."
             )
         elif workspace or room_name:
@@ -687,7 +748,7 @@ def herdr_sync(
         if not targets:
             console.print(
                 "[dim]No workspace bindings. Bind one:[/dim] "
-                "[cyan]mycelium herdr sync --workspace <id> --room <room>[/cyan]"
+                "[cyan]mycelium herdr sync --workspace <label> --room <room>[/cyan]"
             )
             raise typer.Exit(1)
 

--- a/mycelium-cli/src/mycelium/integrations/herdr/bridge.py
+++ b/mycelium-cli/src/mycelium/integrations/herdr/bridge.py
@@ -333,6 +333,51 @@ class HerdrBridge:
             if isinstance(t, dict) and t.get("tab_id")
         }
 
+    # ── workspace surface ────────────────────────────────────────────────────
+
+    def list_workspaces(self) -> list[dict]:
+        """Live workspaces as dicts (``workspace_id``, ``label``, ``tab_count``, …)."""
+        result = self._run_json(["workspace", "list"]).get("result", {})
+        workspaces = result.get("workspaces", [])
+        return workspaces if isinstance(workspaces, list) else []
+
+    def resolve_workspace(self, selector: str) -> str:
+        """Return the ``workspace_id`` that ``selector`` names.
+
+        The label is what a person actually knows — they typed it when they named
+        the workspace ("Mycelium") — while the id (``w4``) is a counter they have
+        no reason to have seen. So the label matches first, and an id is still
+        accepted for a script that already carries one.
+
+        The match on a label is exact (bar case) rather than a substring: binding
+        enrolls every live agent in the workspace, so a short selector quietly
+        reaching a bigger workspace than the caller pictured is worse than being
+        made to type the name out.
+
+        Raising on a miss is the point. An unresolvable selector used to bind
+        cleanly and then match zero live agents, so the run reported success and
+        enrolled nobody, which reads as herdr being broken rather than as a typo.
+        """
+        workspaces = self.list_workspaces()
+        if not workspaces:
+            raise HerdrError("herdr reports no open workspaces")
+
+        wanted = selector.strip()
+        folded = wanted.casefold()
+
+        exact = [w for w in workspaces if _ws_label(w).casefold() == folded]
+        if len(exact) == 1:
+            return _ws_id(exact[0])
+        if exact:
+            raise HerdrError(_ambiguous_workspace(wanted, exact))
+
+        for w in workspaces:
+            if _ws_id(w) == wanted:
+                return _ws_id(w)
+
+        known = ", ".join(f"{_ws_label(w)!r} ({_ws_id(w)})" for w in workspaces)
+        raise HerdrError(f"no herdr workspace matches {wanted!r}. Open workspaces: {known}")
+
     def get_agent(self, target: str) -> dict | None:
         """One agent's live state, or ``None`` if no agent occupies ``target``."""
         try:
@@ -406,6 +451,19 @@ class HerdrBridge:
             detail=f"woke agent at {mapping.pane}" + (f" (settled: {settled})" if settled else ""),
             raw=result,
         )
+
+
+def _ws_id(workspace: dict) -> str:
+    return str(workspace.get("workspace_id") or "")
+
+
+def _ws_label(workspace: dict) -> str:
+    return str(workspace.get("label") or "")
+
+
+def _ambiguous_workspace(selector: str, matches: list[dict]) -> str:
+    names = ", ".join(f"{_ws_label(w)!r} ({_ws_id(w)})" for w in matches)
+    return f"{selector!r} matches more than one herdr workspace: {names}. Use the id."
 
 
 def _extract_error(stderr: str | None) -> str | None:

--- a/mycelium-cli/tests/test_herdr_bridge.py
+++ b/mycelium-cli/tests/test_herdr_bridge.py
@@ -559,3 +559,85 @@ def test_collect_presence_maps_live_panes_per_room(
     assert _collect_presence(bridge, room_filter="ops") == {
         "ops": {"ci": {"status": "blocked", "title": "Fix CI"}}
     }
+
+
+# ── workspace resolution ─────────────────────────────────────────────────────
+#
+# `--workspace` is the one selector a person types from memory, and the id (w4)
+# is a counter they have never seen. These pin the label as the primary key and,
+# more importantly, pin that a miss RAISES: the old behavior bound the bad
+# selector, matched zero agents, and reported a successful sync of nobody.
+
+_WORKSPACES = [
+    {"workspace_id": "w1", "label": "TOME / Platform Engineering"},
+    {"workspace_id": "w4", "label": "Mycelium"},
+    {"workspace_id": "w5", "label": "kona"},
+]
+
+
+def _ws_bridge(workspaces: list[dict] | None = None) -> HerdrBridge:
+    listing = _WORKSPACES if workspaces is None else workspaces
+    return HerdrBridge(
+        runner=ScriptedRunner({"workspace list": _proc(_ok({"workspaces": listing}))})
+    )
+
+
+def test_resolve_workspace_by_label() -> None:
+    assert _ws_bridge().resolve_workspace("Mycelium") == "w4"
+
+
+def test_resolve_workspace_label_is_case_insensitive() -> None:
+    assert _ws_bridge().resolve_workspace("mycelium") == "w4"
+    assert _ws_bridge().resolve_workspace("KONA") == "w5"
+
+
+def test_resolve_workspace_still_accepts_an_id() -> None:
+    assert _ws_bridge().resolve_workspace("w4") == "w4"
+
+
+def test_resolve_workspace_does_not_match_a_substring() -> None:
+    """Binding enrolls every agent in the workspace, so a short selector must
+    not quietly reach a bigger workspace than the caller pictured."""
+    bridge = _ws_bridge(
+        [
+            {"workspace_id": "w1", "label": "demo"},
+            {"workspace_id": "w2", "label": "demo overflow"},
+        ]
+    )
+    assert bridge.resolve_workspace("demo") == "w1"
+    with pytest.raises(HerdrError, match="no herdr workspace matches"):
+        bridge.resolve_workspace("over")
+
+
+def test_resolve_workspace_rejects_two_workspaces_sharing_a_label() -> None:
+    """Now that the match is exact, this is the only way a label is ambiguous."""
+    bridge = _ws_bridge(
+        [
+            {"workspace_id": "w1", "label": "demo"},
+            {"workspace_id": "w2", "label": "demo"},
+        ]
+    )
+    with pytest.raises(HerdrError, match="more than one"):
+        bridge.resolve_workspace("demo")
+
+
+def test_resolve_workspace_raises_on_a_miss_and_names_the_options() -> None:
+    with pytest.raises(HerdrError, match="Mycelium") as excinfo:
+        _ws_bridge().resolve_workspace("myclium")  # typo
+    assert "no herdr workspace matches" in str(excinfo.value)
+
+
+def test_resolve_workspace_raises_when_nothing_is_open() -> None:
+    with pytest.raises(HerdrError, match="no open workspaces"):
+        _ws_bridge([]).resolve_workspace("Mycelium")
+
+
+def test_registry_unbind_removes_only_the_named_workspace(isolated_home: Path) -> None:
+    """`sync` can create a binding, so something has to be able to remove one."""
+    registry = HerdrRegistry()
+    registry.bind("w4", "demo-agents")
+    registry.bind("w1", "platform")
+
+    assert registry.unbind("w4") is True
+    assert registry.bindings() == {"w1": "platform"}
+    assert registry.unbind("w4") is False


### PR DESCRIPTION
## Why

`mycelium herdr sync --workspace` matched the caller's string against the agent's `workspace_id` (`herdr.py:396`), so it accepted `w4` — an internal counter — and rejected `Mycelium`, the name the user gave the workspace themselves.

"Rejected" is generous. `registry.bind()` stores whatever string it is handed, so an unresolvable selector **bound cleanly**, then matched zero live agents:

```
$ mycelium herdr sync --workspace Mycelium --room demo
Bound workspace Mycelium → room demo.
Synced 0 live state(s) across 1 binding(s) (+0 enrolled, -0 retired)
```

A successful sync of nobody, plus a junk binding. That reads as herdr being broken rather than as a typo.

## What changed

- **Label first.** `HerdrBridge.resolve_workspace()` resolves an exact (case-insensitive) label, still accepts an id for scripts that carry one, and **raises** on a miss — listing the open workspaces instead of binding nothing.
- **Exact, not substring.** Binding enrolls *every* live agent in the workspace, so a short selector quietly reaching a bigger workspace than the caller pictured is worse than being made to type the name out. I found this the hard way: a substring test matched a 9-pane workspace and enrolled all of it into the wrong room.
- **`mycelium herdr unbind <workspace>`.** `sync` could create a binding that no command could remove — `HerdrRegistry.unbind()` existed but nothing exposed it, so a hand-edit of the registry file was the only way back out. Takes a label or an id, and does not require herdr to be reachable to undo something.

## Verified live

Against a running herdr with three workspaces:

```
$ mycelium herdr sync --workspace Mycelium --room herdr-test --once
Bound workspace Mycelium (w4) → room herdr-test.

$ mycelium herdr sync --workspace myclium --room herdr-test --once
Error: no herdr workspace matches 'myclium'. Open workspaces:
  'TOME / Platform Engineering' (w1), 'Mycelium' (w4), 'kona' (w5), 'my-project' (w7)
```

Gate: `ruff check`, `ruff format --check`, `ty check` clean; 815 passed, 2 skipped.