### PR TITLE
fix(aligner): broker between the room's agents, not just the connected ones

### DIFF
--- a/fastapi-backend/app/services/aligner.py
+++ b/fastapi-backend/app/services/aligner.py
@@ -303,7 +303,7 @@ class AlignerEngine:
             return None
         persister = managed.persister
         me = engine_handle or self._handle
-        participants = [m for m in self._manager.members(room) if _norm(m) != _norm(me)]
+        participants = self._roster(room, me)
         if scoped_participants:
             scoped = {_norm(h) for h in scoped_participants}
             participants = [m for m in participants if _norm(m) in scoped]
@@ -474,6 +474,41 @@ class AlignerEngine:
             openshell=settings.ALIGNER_PI_OPENSHELL,
         )
 
+    def _roster(self, room: str, me: str) -> list[str]:
+        """The agents this run may broker between: ``room``'s registered roster.
+
+        The union of the room's **registered** agents and whoever is currently
+        connected — because each set alone misses real participants.
+
+        ``members()`` answers "who holds a live SLIM socket or presence lease
+        right now", which is connectivity, not membership: an agent parked in a
+        herdr pane, or simply between turns, is a full member of the room that
+        ``members()`` omits. Brokering is not delivery — a mention wakes a herdr
+        pane and otherwise waits on the durable cursor, and every round already
+        has its own turn window — so gating the run on who happened to be
+        connected at summon time rejected rooms well able to negotiate.
+
+        The registry alone is not enough either: ``await``/``respond`` let any
+        awake caller join without ``agent create``, so a connected participant
+        may have no manifest at all.
+
+        Engines are excluded — the aligner brokers between teammates, and an
+        engine (itself, the synthesizer) is never a party to the deal.
+        """
+        from app.services.agent_registry import room_agents
+
+        drop = {_norm(me), _norm(self._handle), *(_norm(h) for h in _NON_PARTICIPANTS)}
+        roster: dict[str, str] = {}
+        for agent in room_agents(room):
+            if _norm(agent.handle) in drop or agent.adapter == "engine":
+                continue
+            roster[_norm(agent.handle)] = agent.handle
+        for handle in self._manager.members(room):
+            if _norm(handle) in drop:
+                continue
+            roster.setdefault(_norm(handle), handle)
+        return [roster[k] for k in sorted(roster)]
+
     def _opening_positions(
         self, persister: RoomPersister, participants: list[str]
     ) -> dict[str, str]:
@@ -634,12 +669,12 @@ class AlignerEngine:
         roster = ", ".join(participants) if participants else "no other agents"
         prompt = (
             "You are this room's alignment mediator, just summoned to help it align, "
-            "but you cannot run a negotiation right now: it needs at least two agents "
-            "that are present in the room and holding opening positions, and the current "
-            f"roster is: {roster}. Write a short, friendly message to the room (2-3 "
-            "sentences) that explains you can't align yet and says what to do next — have "
-            "at least two agents join and post their opening positions (e.g. with "
-            "'mycelium respond'), then summon you again. Plain prose, no @-mentions."
+            "but you cannot run a negotiation right now: brokering needs at least two "
+            "agents registered in the room besides you, and the room's roster is: "
+            f"{roster}. Write a short, friendly message to the room (2-3 sentences) that "
+            "explains you can't align yet and says what to do next — register a second "
+            "agent in this room (e.g. with 'mycelium agent create <handle> --room "
+            "<room>'), then summon you again. Plain prose, no @-mentions."
         )
         text = ""
         try:
@@ -652,9 +687,9 @@ class AlignerEngine:
             )
         if not text:
             text = (
-                "I can't align the room yet — a negotiation needs at least two agents "
-                "present with opening positions to broker between. Have the agents join "
-                "and post their positions, then summon me again."
+                "I can't align the room yet — brokering needs at least two agents "
+                "registered here besides me. Add another agent to the room, then "
+                "summon me again."
             )
         await self._say(managed, room, sender, text)
 

--- a/fastapi-backend/tests/test_aligner.py
+++ b/fastapi-backend/tests/test_aligner.py
@@ -331,3 +331,61 @@ async def test_a_failing_pi_call_still_ends_its_signal():
         bus.unsubscribe(room_channel(_ROOM), queue)
 
     assert states == ["responding", "done"]
+
+
+# ── the roster the mediator brokers between ──────────────────────────────────
+
+
+def _register(room: str, handle: str, **manifest: object) -> None:
+    """Write an ``agents/<handle>`` manifest, the way `agent create` does."""
+    import yaml
+
+    from app.services.filesystem import get_room_dir, write_memory_file
+
+    body = yaml.safe_dump({"adapter": "claude_code", **manifest})
+    write_memory_file(get_room_dir(room), f"agents/{handle}", body, created_by="test")
+
+
+def test_roster_is_the_registered_agents_not_who_is_connected(tmp_path, monkeypatch) -> None:
+    """The regression this exists for: agents parked in herdr panes (or simply
+    between turns) hold no SLIM socket and no lease, so ``manager.members()``
+    reports an empty room while ``agent ls`` shows a full one. Brokering is not
+    delivery, so the roster must come from the registry, not from connectivity —
+    otherwise a summon in a herdr-only room could never reach two participants.
+    """
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    room = "roster-room"
+    _register(room, "reviewer")
+    _register(room, "pm")
+
+    managed = FakeManaged(room, "mycelium", FakeChannel(), FakePersister())
+    engine = _engine(FakeManager(managed, []))  # nobody connected at all
+
+    assert engine._roster(room, "aligner") == ["pm", "reviewer"]
+
+
+def test_roster_keeps_a_connected_agent_that_was_never_registered(tmp_path, monkeypatch) -> None:
+    """`await`/`respond` join a room without `agent create`, so the registry is
+    not the whole story either — the roster is the union of both."""
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    room = "union-room"
+    _register(room, "reviewer")
+
+    managed = FakeManaged(room, "mycelium", FakeChannel(), FakePersister())
+    engine = _engine(FakeManager(managed, ["ad-hoc", "reviewer"]))  # one has no manifest
+
+    assert engine._roster(room, "aligner") == ["ad-hoc", "reviewer"]
+
+
+def test_roster_excludes_engines_and_the_summoned_handle(tmp_path, monkeypatch) -> None:
+    """An engine is never a party to the deal it brokers."""
+    monkeypatch.setenv("MYCELIUM_DATA_DIR", str(tmp_path))
+    room = "engine-room"
+    _register(room, "reviewer")
+    _register(room, "aligner", adapter="engine", kind="aligner")
+    _register(room, "synthesizer", adapter="engine", kind="synthesizer")
+
+    managed = FakeManaged(room, "mycelium", FakeChannel(), FakePersister())
+    engine = _engine(FakeManager(managed, []))
+
+    assert engine._roster(room, "aligner") == ["reviewer"]


### PR DESCRIPTION
## The symptom

Summoned in a room whose agents were enrolled from herdr panes, the aligner said this:

> Happy to help this room find alignment, but we're not quite ready to begin — a negotiation needs at least two agents present and holding opening positions, and right now **the roster is empty**.

`mycelium agent ls --room` listed five agents. The Members rail showed them. One of them replied in the same thread seconds later.

## The cause

There are two different readings of "in the room", and the mediator used the wrong one.

`manager.members()` is `slim_members | live_leases` (`room_channels.py:368-377`) — who holds a live SLIM socket or an active presence lease **right now**. That is connectivity, not membership. `presence()` even has a distinct `kind="herdr"` for a handle that is *"alive in a herdr-managed pane but not currently joined"* (`room_channels.py:221`), and `members()` deliberately omits it.

So every herdr-enrolled agent was invisible to the mediator, and a herdr-only room could **never** converge on a first summon — making herdr and the aligner mutually unusable.

## Why gating on connectivity was wrong anyway

Brokering is not delivery, and the surrounding machinery already handles absence:

- a mention to a herdr-present handle enqueues a wake (`enqueue_herdr_wakes_for_mentions`, `messages.py:191`) that the host-side `herdr sync` drains;
- a mention to anyone else waits on the durable transcript cursor;
- and each negotiation round already has its own turn window (`mediator._turn_timeout_s`), so the round loop tolerates an agent that is not instantly responsive.

The upfront presence check duplicated none of that usefully. It only rejected rooms that were well able to negotiate — and it evaluated at t=0, in the same ingest that had not yet even queued the wakes.

## The change

`AlignerEngine._roster()` returns the **union** of the room's registered agents and its connected members, minus the summoned engine, the aligner, and `_NON_PARTICIPANTS`.

The union matters in both directions: the registry alone would break the other case, since `await`/`respond` let any awake caller join a room without `agent create`, so a connected participant may have no manifest at all. (I found that by breaking ten existing tests with a registry-only version.)

Engines are excluded — the aligner brokers between teammates, and an engine (itself, the synthesizer) is never a party to the deal.

**The two-participant guard is unchanged.** It is structurally required — there is no stacked-alternating-offers protocol with one party — and it was only ever applied to the wrong set. Its stall message now names the real gate (register a second agent) instead of telling the user to have agents "join", which was never what was missing.

## Tests

Three new, pinning each direction:

- registered-but-unconnected agents are brokered (the herdr regression, with `members()` empty);
- a connected agent with no manifest is kept (the union's other half);
- engines and the summoned handle are dropped.

Gate: `ruff check`, `ruff format --check`, `ty check` clean; 1070 passed, 13 skipped.

## Known gap, not fixed here

`handle_summon` accepts `message_text` and never passes it to `mediate`, so the `ask` in `board coordinate <row> aligner "…"` reaches nothing — positions come only from each participant's most recent prose in the transcript (`_opening_positions`). Worth either wiring through or deleting from the signature; left out of this change deliberately.