### PR TITLE
Add `mycelium onboard`: a guided first run with your own coding agents

### DIFF
--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -542,6 +542,7 @@ def _generate_cli_reference() -> tuple[str, list[tuple[str, str]]]:
     import mycelium.commands.instance  # noqa: F401
     import mycelium.commands.login  # noqa: F401
     import mycelium.commands.memory  # noqa: F401
+    import mycelium.commands.onboard  # noqa: F401
     import mycelium.commands.participate  # noqa: F401
     import mycelium.commands.room  # noqa: F401
     import mycelium.commands.skill  # noqa: F401

--- a/docs/index.html
+++ b/docs/index.html
@@ -302,6 +302,10 @@
 
     <section class="doc-section" id="quickstart">
       <h1>Quick Start</h1>
+      <h2 id="quickstart-the-guided-tour">The guided tour</h2>
+      <p>If you&#x27;d rather be walked through it, run the tour:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">onboard</span></code></pre>
+      <p>It points this machine at a hub (yours, or one someone already runs for you), signs you in if the hub asks, puts a task on a board, hands two of your coding agents a briefing each, lets the aligner mediate them to an agreement, and files the follow-up work. The agents are your own sessions: Claude Code, Cursor, anything with a shell. Every step prints the command it runs, so the tour is also the tutorial. <code>mycelium onboard --list</code> shows the scenarios; <code>--briefings</code> prints the agents&#x27; briefings again if you lost them. Everything below is the same ground by hand.</p>
       <p>Mycelium runs on a server your team connects to. You don&#x27;t have to stand that up by hand, though: the easiest way in is to let an agent do it for you.</p>
       <h2 id="quickstart-start-with-a-prompt">Start with a prompt</h2>
       <p>Paste this into your coding agent (Claude Code, Cursor, anything with a shell):</p>

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -95,6 +95,23 @@ get a short list to glance at rather than a backlog to groom.
 
 # Quick Start
 
+## The guided tour
+
+If you'd rather be walked through it, run the tour:
+
+```bash
+mycelium onboard
+```
+
+It points this machine at a hub (yours, or one someone already runs for you),
+signs you in if the hub asks, puts a task on a board, hands two of your coding
+agents a briefing each, lets the aligner mediate them to an agreement, and files
+the follow-up work. The agents are your own sessions: Claude Code, Cursor,
+anything with a shell. Every step prints the command it runs, so the tour is also
+the tutorial. `mycelium onboard --list` shows the scenarios; `--briefings` prints
+the agents' briefings again if you lost them. Everything below is the same ground
+by hand.
+
 Mycelium runs on a server your team connects to. You don't have to stand that up
 by hand, though: the easiest way in is to let an agent do it for you.
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -582,6 +582,13 @@
 
       <div class="cmd-ref">
         <div class="cmd-ref-header">
+          <code><span class="bin">mycelium</span> <span class="cmd">onboard</span> [<span class="flag">--hub</span> <span class="arg">&lt;url&gt;</span>] [<span class="flag">--scenario</span> <span class="arg">&lt;id&gt;</span>] [<span class="flag">--room</span> <span class="arg">&lt;name&gt;</span>] [<span class="flag">--yes</span>] [<span class="flag">--list</span>] [<span class="flag">--briefings</span>]</code>
+        </div>
+        <div class="cmd-ref-body">Guided first run: point at a hub, sign in, put a task on a board, brief two of your coding agents, watch the aligner mediate them, and work the board.</div>
+      </div>
+
+      <div class="cmd-ref">
+        <div class="cmd-ref-header">
           <code><span class="bin">mycelium</span> <span class="cmd">ui</span> <span class="cmd">open</span> [<span class="flag">-y</span>]</code>
         </div>
         <div class="cmd-ref-body">Open the frontend in your default browser.</div>

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -10,7 +10,14 @@ window.MYCELIUM_SEARCH_INDEX = [
     "u": "index.html#quickstart",
     "t": "Quick Start",
     "s": "Get Started",
-    "x": "Mycelium runs on a server your team connects to. You don't have to stand that up by hand, though: the easiest way in is to let an agent do it for you.",
+    "x": "",
+    "p": "Guide"
+  },
+  {
+    "u": "index.html#quickstart-the-guided-tour",
+    "t": "The guided tour",
+    "s": "Get Started › Quick Start",
+    "x": "If you'd rather be walked through it, run the tour: mycelium onboard It points this machine at a hub (yours, or one someone already runs for you), signs you in if the hub asks, puts a task on a board, hands two of your coding agents a briefing each, lets the aligner mediate them to an agreement, and files the follow-up work. The agents are your own sessions: Claude Code, Cursor, anything with a shell. Every step prin",
     "p": "Guide"
   },
   {
@@ -956,6 +963,14 @@ window.MYCELIUM_SEARCH_INDEX = [
     "t": "mycelium logout",
     "s": "CLI Reference",
     "x": "Drop the cached OIDC session; the CLI goes back to sending no token.",
+    "k": "cmd",
+    "p": "Reference"
+  },
+  {
+    "u": "reference.html#cli-setup",
+    "t": "mycelium onboard [--hub <url>] [--scenario <id>] [--room <name>] [--yes] [--list] [--briefings]",
+    "s": "CLI Reference",
+    "x": "Guided first run: point at a hub, sign in, put a task on a board, brief two of your coding agents, watch the aligner mediate them, and work the board.",
     "k": "cmd",
     "p": "Reference"
   },

--- a/mycelium-cli/src/mycelium/cli.py
+++ b/mycelium-cli/src/mycelium/cli.py
@@ -24,6 +24,7 @@ from mycelium.commands import (
     memory,
     metrics,
     network,
+    onboard,
     openshell,
     participate,
     room,
@@ -89,6 +90,7 @@ app.command(name="network")(network.network)
 app.command(name="logs")(instance.logs)
 
 # Top-level shortcuts
+app.command(name="onboard")(onboard.onboard)
 app.command(name="login")(login_cmd.login)
 app.command(name="logout")(login_cmd.logout)
 app.command(name="whoami")(user.whoami)

--- a/mycelium-cli/src/mycelium/client.py
+++ b/mycelium-cli/src/mycelium/client.py
@@ -161,6 +161,45 @@ def typed_client(config: MyceliumConfig | None = None, *, handle: str | None = N
     return client.with_headers(headers) if headers else client
 
 
+#: Where a hub answers its health check. The backend serves ``/health`` at its
+#: root; behind a reverse proxy that serves the frontend at ``/`` and the backend
+#: under ``/api``, only the prefixed path exists, so both are tried.
+HEALTH_PATHS = ("/health", "/api/health")
+
+
+def probe_health(api_url: str, *, timeout: float = 5.0) -> tuple[dict[str, Any] | None, str]:
+    """The hub's health document, under whichever prefix the hub answers on.
+
+    Returns ``(body, "")`` on the first path that answers with a JSON object,
+    else ``(None, why)`` with the last failure spelled out. A 404 on the bare
+    path is the reverse-proxy case, not a dead hub, so it falls through to the
+    prefixed path rather than being reported.
+    """
+    base = api_url.rstrip("/")
+    why = f"couldn't reach {base}"
+    for path in HEALTH_PATHS:
+        url = f"{base}{path}"
+        try:
+            resp = httpx.get(url, timeout=timeout)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            why = f"{url} answered HTTP {exc.response.status_code}"
+            continue
+        except httpx.HTTPError as exc:
+            why = f"couldn't reach {url} ({exc.__class__.__name__})"
+            continue
+        try:
+            body = resp.json()
+        except ValueError:
+            why = f"{url} did not answer with JSON"
+            continue
+        if not isinstance(body, dict):
+            why = f"{url} did not answer with a health document"
+            continue
+        return body, ""
+    return None, why
+
+
 def hub_error_detail(content: bytes) -> str:
     """Extract a human-readable message from a hub HTTP error response body.
 

--- a/mycelium-cli/src/mycelium/commands/demo.py
+++ b/mycelium-cli/src/mycelium/commands/demo.py
@@ -3,7 +3,8 @@
 
 """``mycelium demo``: run a real sample coordination end-to-end.
 
-A guided onboarding command. It is pure glue over the real
+The dataset-driven sibling of ``mycelium onboard``, which is the guided first
+run with built-in scenarios and no adapter to pick up front. This one It is pure glue over the real
 system, with no mirrored data: it discovers scenarios and agent personas from
 the public ``agent-personas`` dataset at run time, creates a room, runs
 ``mycelium agent create`` for each persona on your chosen adapter, seeds the

--- a/mycelium-cli/src/mycelium/commands/login.py
+++ b/mycelium-cli/src/mycelium/commands/login.py
@@ -81,16 +81,12 @@ def _hub_issuers(config: MyceliumConfig) -> tuple[list[str], str | None]:
     issuer up and copy it back in. Returns the issuers and, when the list is
     empty, a reason to print instead of a bare "no issuer configured".
     """
-    import httpx
+    from mycelium.client import probe_health
 
-    url = f"{config.server.api_url.rstrip('/')}/health"
-    try:
-        resp = httpx.get(url, timeout=5)
-        resp.raise_for_status()
-        body = resp.json()
-    except (httpx.HTTPError, ValueError):
-        return [], f"couldn't reach {url} to ask it"
-    auth = body.get("auth") or {} if isinstance(body, dict) else {}
+    body, why = probe_health(config.server.api_url)
+    if body is None:
+        return [], f"{why}, so it couldn't be asked"
+    auth = body.get("auth") or {}
     if not auth.get("enabled"):
         return [], f"{config.server.api_url} has its gate off, so it needs no login"
     issuers = [str(i).strip().rstrip("/") for i in auth.get("issuers") or [] if str(i).strip()]

--- a/mycelium-cli/src/mycelium/commands/onboard.py
+++ b/mycelium-cli/src/mycelium/commands/onboard.py
@@ -1,0 +1,1142 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""``mycelium onboard``: a guided first run, on a real hub, with your own coding agents.
+
+The tour a new user would otherwise assemble by hand from six doc pages: point
+the CLI at a hub, sign in if the hub asks, pick a scenario, put a task on the
+board, hand two of your coding agents a briefing each, watch the aligner mediate
+them to an agreement, and file the follow-up work. Every step runs the real
+command and prints it first, so what the user watches is what they will type
+next time.
+
+Nothing is canned. The agents are the user's own sessions (Claude Code, Cursor,
+anything with a shell): the wizard writes each one a briefing and either types
+it into a herdr pane or hands it over on the clipboard, then waits for them to
+turn up in the room. The scenarios (``mycelium.scenarios``) are ordinary
+disagreements on a software team, written in plain language.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, NoReturn
+from urllib.parse import urlsplit
+
+import httpx
+import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.rule import Rule
+
+from mycelium.client import hub_client, probe_health
+from mycelium.config import MyceliumConfig
+from mycelium.doc_ref import doc_ref
+from mycelium.scenarios import (
+    ALIGNER_HANDLE,
+    DEFAULT_SCENARIO,
+    SCENARIOS,
+    DemoAgent,
+    Scenario,
+    briefing,
+    kickoff_text,
+)
+
+console = Console()
+
+LOCAL_HUB = "http://localhost:8000"
+HERDR_URL = "https://herdr.dev"
+INSTALL_URL = "https://mycelium-io.github.io/mycelium/install.sh"
+
+#: Steps in the tour, in order, as the header names them.
+STEPS = (
+    "Point at a hub",
+    "Sign in",
+    "Pick a scenario",
+    "Set up the room",
+    "Bring in your coding agents",
+    "Let the aligner mediate",
+    "Work the board",
+)
+
+#: How often the wait loops ask the hub, and how long they wait before the
+#: verdict is given up on. Agents reason at their own pace; these are generous.
+POLL_S = 3.0
+VERDICT_TIMEOUT_S = 20 * 60
+COMPILE_TIMEOUT_S = 90
+
+_HANDLE_STRIP = re.compile(r"[^a-z0-9._-]+")
+
+
+# ── plumbing ─────────────────────────────────────────────────────────────────
+
+
+def _cli_prefix() -> list[str]:
+    """How to invoke the mycelium CLI as a subprocess (installed script or module)."""
+    exe = shutil.which("mycelium")
+    if exe:
+        return [exe]
+    return [sys.executable, "-m", "mycelium.cli"]
+
+
+def _shell_quote(arg: str) -> str:
+    return f'"{arg}"' if (" " in arg or not arg) else arg
+
+
+def _run(args: list[str], *, capture: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run ``mycelium <args>``, printing the command first so the tour teaches it."""
+    console.print(f"[dim]$[/dim] [bold]mycelium {' '.join(_shell_quote(a) for a in args)}[/bold]")
+    return subprocess.run(  # noqa: S603 - args are code-built, never shell-interpolated
+        _cli_prefix() + args, capture_output=capture, text=True, check=False
+    )
+
+
+def _interactive(yes: bool) -> bool:
+    return not yes and sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _pause(yes: bool, note: str = "Press Enter to continue") -> None:
+    if not _interactive(yes):
+        return
+    try:
+        console.input(f"[dim]{note}…[/dim] ")
+    except (EOFError, KeyboardInterrupt):
+        raise typer.Exit(0) from None
+
+
+def _step(n: int, title: str | None = None) -> None:
+    console.print()
+    console.print(Rule(f"[bold]Step {n} of {len(STEPS)} · {title or STEPS[n - 1]}[/bold]"))
+    console.print()
+
+
+def _fail(message: str, *fixes: str) -> NoReturn:
+    console.print(f"[red]✗[/red] {message}")
+    for fix in fixes:
+        console.print(f"  [dim]{fix}[/dim]")
+    raise typer.Exit(1)
+
+
+def _select(question: str, choices: list[str], *, default: str | None = None) -> str | None:
+    import questionary
+
+    return questionary.select(question, choices=choices, default=default).ask()
+
+
+def _confirm(question: str, *, default: bool = True) -> bool:
+    import questionary
+
+    answer = questionary.confirm(question, default=default).ask()
+    return bool(answer) if answer is not None else False
+
+
+def _text(question: str, *, default: str = "") -> str:
+    import questionary
+
+    answer = questionary.text(question, default=default).ask()
+    return (answer or "").strip()
+
+
+# ── the hub ──────────────────────────────────────────────────────────────────
+
+
+def normalize_hub(raw: str) -> str:
+    """A hub address as people paste it, made into the origin the CLI calls.
+
+    A bare host gets ``http://``; a trailing slash goes; a trailing ``/api`` goes
+    too, because the CLI adds that prefix itself and a copied API path would
+    otherwise turn every call into ``/api/api/…``.
+    """
+    url = raw.strip()
+    if not url:
+        return url
+    if "://" not in url:
+        url = f"http://{url}"
+    url = url.rstrip("/")
+    if url.endswith("/api"):
+        url = url[: -len("/api")]
+    return url
+
+
+def is_local_hub(url: str) -> bool:
+    host = (urlsplit(url).hostname or "").lower()
+    return host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")  # noqa: S104 - a listen address
+
+
+def ui_url(config: MyceliumConfig, room: str) -> str:
+    """Where the room is in a browser: the local UI port, or the hub's own origin."""
+    api = config.server.api_url
+    if is_local_hub(api):
+        return f"http://localhost:{config.runtime.frontend_port}/room/{room}"
+    parts = urlsplit(api)
+    return f"{parts.scheme}://{parts.netloc}/room/{room}"
+
+
+def _stack_installed() -> bool:
+    return (Path.home() / ".mycelium" / ".env").exists()
+
+
+def _wait_for_hub(url: str, timeout_s: float = 120.0) -> dict[str, Any] | None:
+    deadline = time.monotonic() + timeout_s
+    with console.status(f"[dim]waiting for {url}…[/dim]"):
+        while time.monotonic() < deadline:
+            body, _ = probe_health(url)
+            if body is not None:
+                return body
+            time.sleep(POLL_S)
+    return None
+
+
+def _choose_hub(config: MyceliumConfig, hub_flag: str | None, yes: bool) -> str:
+    current = config.server.api_url
+    if hub_flag:
+        return normalize_hub(hub_flag)
+    if not _interactive(yes):
+        return current
+
+    local = f"This machine ({LOCAL_HUB}): run the stack here with Docker"
+    hosted = "A hosted hub: I have its address (e.g. https://mycelium.outshift.io)"
+    keep = f"Keep the current one: {current}"
+    choices = [local, hosted]
+    if not is_local_hub(current):
+        choices.insert(0, keep)
+    picked = _select("Which hub should this machine talk to?", choices)
+    if picked is None:
+        raise typer.Exit(0)
+    if picked == local:
+        return LOCAL_HUB
+    if picked == keep:
+        return current
+    while True:
+        url = normalize_hub(_text("Hub address:"))
+        if url:
+            return url
+
+
+def _bring_up_local(yes: bool) -> None:
+    """Get a local stack answering, with the user's say-so: ``up`` or ``install``."""
+    if _stack_installed():
+        console.print("[dim]Mycelium is installed here but the stack isn't answering.[/dim]")
+        if _interactive(yes) and not _confirm("Start it now with `mycelium up`?"):
+            _fail("The hub has to be running.", "Start it with: mycelium up")
+        _run(["up"])
+        return
+    console.print(
+        "[dim]Nothing is installed on this machine yet. `mycelium install` brings up the "
+        "stack with Docker: the messaging node, the backend and the UI. It asks which LLM "
+        "the aligner should use.[/dim]"
+    )
+    if _interactive(yes) and not _confirm("Run `mycelium install` now?"):
+        _fail(
+            "The tour needs a hub.",
+            "Install one here: mycelium install",
+            "Or re-run with --hub <url>",
+        )
+    _run(["install"])
+
+
+def _point_at_hub(config: MyceliumConfig, hub_flag: str | None, yes: bool) -> dict[str, Any]:
+    """Step 1: a hub that answers, saved as this machine's ``server.api_url``."""
+    console.print(
+        "Mycelium runs on a hub your team connects to. It can be this machine, or one\n"
+        "someone already runs for you."
+    )
+    console.print()
+    url = _choose_hub(config, hub_flag, yes)
+    body, why = probe_health(url)
+    if body is None:
+        if not is_local_hub(url):
+            _fail(
+                f"No hub answered at {url} ({why}).",
+                "Check the address, and that the hub is up.",
+                "Behind a proxy the hub answers under /api; the CLI tries both.",
+            )
+        _bring_up_local(yes)
+        body = _wait_for_hub(url)
+        if body is None:
+            _fail(f"The stack came up but {url} still isn't answering.", "Try: mycelium status")
+
+    if config.server.api_url != url:
+        config.server.api_url = url
+        config.save()
+        console.print(f"[dim]$[/dim] [bold]mycelium config set server.api_url {url}[/bold]")
+    version = body.get("version") or ""
+    gate = "sign-in required" if (body.get("auth") or {}).get("enabled") else "open, no sign-in"
+    console.print(
+        f"[green]✓[/green] Hub: [cyan]{url}[/cyan]"
+        + (f" [dim](v{version})[/dim]" if version else "")
+        + f" [dim]· {gate}[/dim]"
+    )
+    return body
+
+
+# ── identity ─────────────────────────────────────────────────────────────────
+
+
+def _whoami(config: MyceliumConfig) -> dict[str, Any] | None:
+    """The hub's own answer for who this machine is, fresh, or None if it can't say."""
+    from mycelium import identity
+
+    identity._WHOAMI_CACHE.pop(config.server.api_url, None)
+    return identity._hub_whoami(config)
+
+
+def default_handle() -> str:
+    """A handle to offer: the login name, made legal, or ``me``."""
+    raw = (os.environ.get("USER") or os.environ.get("USERNAME") or "").lower()
+    slug = _HANDLE_STRIP.sub("-", raw).strip("-._")
+    return slug or "me"
+
+
+def _sign_in(config: MyceliumConfig, health: dict[str, Any], yes: bool) -> str:
+    """Step 2: an identity the hub will attribute the tour's writes to."""
+    from mycelium.commands.user import align_identity
+
+    gated = bool((health.get("auth") or {}).get("enabled"))
+    if gated:
+        who = _whoami(config) or {}
+        if not who.get("handle"):
+            console.print("This hub asks people to sign in. Your browser will open.")
+            console.print(
+                "[dim]On a machine with no browser, run `mycelium login --device` yourself.[/dim]"
+            )
+            _pause(yes)
+            _run(["login"])
+            who = _whoami(config) or {}
+        handle = str(who.get("handle") or "").strip()
+        if not handle:
+            _fail("Signed in, but the hub didn't say who you are.", "Try: mycelium whoami")
+        # The hub's answer is the one a gated hub enforces, so it is the one this
+        # machine writes as; a token claim decoded locally can disagree with it.
+        if (config.identity.name or "").strip().lstrip("@").lower() != handle.lower():
+            config.identity.name = handle
+            config.save()
+        console.print(f"[green]✓[/green] Signed in as [cyan]@{handle}[/cyan]")
+        return handle
+
+    handle = (config.identity.name or "").strip().lstrip("@")
+    if not handle:
+        console.print(
+            "This hub is open, so there is no sign-in. Pick a name the room knows you by."
+        )
+        suggested = default_handle()
+        handle = _text("Your handle:", default=suggested) if _interactive(yes) else suggested
+        handle = handle.lstrip("@") or suggested
+        console.print(f"[dim]$[/dim] [bold]mycelium iam {handle}[/bold]")
+        try:
+            _manifest, registered = align_identity(handle, config=config)
+        except Exception as exc:  # noqa: BLE001 - a bad handle is the user's to fix
+            _fail(f"'{handle}' isn't a usable handle ({exc}).", "Lowercase letters, digits, - . _")
+        if not registered:
+            console.print("[yellow]![/yellow] The hub didn't take the user record; carrying on.")
+    console.print(
+        f"[green]✓[/green] You are [cyan]@{handle}[/cyan] "
+        "[dim]· this machine's identity; change it with mycelium iam <handle>[/dim]"
+    )
+    return handle
+
+
+# ── the scenario ─────────────────────────────────────────────────────────────
+
+
+def _pick_scenario(scenario_flag: str | None, yes: bool) -> Scenario:
+    if scenario_flag:
+        if scenario_flag not in SCENARIOS:
+            _fail(
+                f"Unknown scenario '{scenario_flag}'.",
+                "See the list with: mycelium onboard --list",
+            )
+        return SCENARIOS[scenario_flag]
+    if not _interactive(yes):
+        return SCENARIOS[DEFAULT_SCENARIO]
+    labels = {f"{s.title}  —  {s.blurb}": s for s in SCENARIOS.values()}
+    picked = _select("Which disagreement should the agents settle?", list(labels))
+    if picked is None:
+        raise typer.Exit(0)
+    return labels[picked]
+
+
+def _print_scenario(scenario: Scenario, room: str) -> None:
+    lines = [f"[bold]{scenario.title}[/bold]", "", f"The task on the board: {scenario.task}", ""]
+    lines.extend(f"  [cyan]@{a.handle}[/cyan]  {a.label}" for a in scenario.agents)
+    lines.extend(["", f"What the aligner is asked to settle: {scenario.question}."])
+    console.print(
+        Panel("\n".join(lines), title=f"[dim]room[/dim] [cyan]{room}[/cyan]", border_style="cyan")
+    )
+
+
+def _list_scenarios() -> None:
+    from rich.table import Table
+
+    table = Table(title="mycelium onboard scenarios", show_edge=False, pad_edge=False)
+    table.add_column("id", style="bold cyan")
+    table.add_column("title")
+    table.add_column("who", style="dim")
+    for sid, s in SCENARIOS.items():
+        marker = " (default)" if sid == DEFAULT_SCENARIO else ""
+        table.add_row(sid + marker, s.title, " vs ".join(f"@{a.handle}" for a in s.agents))
+    console.print(table)
+
+
+# ── the room ─────────────────────────────────────────────────────────────────
+
+
+def _agent_workdir(room: str, handle: str) -> Path:
+    """A stable per-agent directory, so a coding agent has somewhere to sit."""
+    d = MyceliumConfig.get_global_config_dir() / "onboard" / room / handle
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _state_path(room: str) -> Path:
+    return MyceliumConfig.get_global_config_dir() / "onboard" / room / "state.json"
+
+
+def _save_state(room: str, state: dict[str, Any]) -> None:
+    path = _state_path(room)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2) + "\n")
+
+
+def _load_state(room: str) -> dict[str, Any] | None:
+    try:
+        return json.loads(_state_path(room).read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _create_task(config: MyceliumConfig, room: str, title: str, me: str) -> tuple[str, str]:
+    """Put the scenario's task on the board; return its row key and thread URN."""
+    from mycelium.board.model import EPISODE_FIELD
+
+    console.print(f'[dim]$[/dim] [bold]mycelium board new "{title}" --room {room}[/bold]')
+    try:
+        with hub_client(config, timeout=30) as client:
+            resp = client.post(f"/api/rooms/{room}/tasks", json={"title": title, "handle": me})
+    except httpx.HTTPError as exc:
+        _fail(f"Couldn't reach the hub to create the task: {exc}")
+    if resp.status_code >= 400:
+        _fail(f"The hub refused the task: {resp.text}")
+    task = resp.json()
+    key = str(task.get("key") or "")
+    thread = str(task.get(EPISODE_FIELD) or "")
+    if not key or not thread:
+        _fail("The hub created the task without a thread; is the backend current?")
+    console.print(
+        f"[green]✓[/green] [bold]{key}[/bold] [dim]· thread {thread.rsplit(':', 1)[-1]}[/dim]"
+    )
+    return key, thread
+
+
+def _set_up_room(config: MyceliumConfig, scenario: Scenario, room: str, me: str) -> tuple[str, str]:
+    """Step 4: the room, the aligner, the two agents, and the task, in that order."""
+    console.print(
+        "A room is where a team's work lives: a board of tasks, a thread inside each task,\n"
+        "and shared memory. This creates one and registers the mediator and two agents."
+    )
+    console.print()
+    r = _run(["room", "create", room], capture=True)
+    out = (r.stdout or "") + (r.stderr or "")
+    if r.returncode != 0 and "already exists" not in out.lower():
+        _fail(f"Couldn't create the room:\n{out.strip()}")
+    console.print(
+        f"[green]✓[/green] Room [cyan]{room}[/cyan]"
+        + (" [dim](already there; reusing it)[/dim]" if "already exists" in out.lower() else "")
+    )
+    r = _run(["room", "use", room], capture=True)
+    if r.returncode != 0:
+        _fail(f"Couldn't switch to the room:\n{(r.stdout or '') + (r.stderr or '')}")
+
+    r = _run(
+        ["engine", "create", ALIGNER_HANDLE, "--kind", "aligner", "--room", room], capture=True
+    )
+    if r.returncode != 0:
+        _fail(f"Couldn't register the aligner:\n{(r.stdout or '') + (r.stderr or '')}")
+    console.print(
+        f"[green]✓[/green] [cyan]@{ALIGNER_HANDLE}[/cyan] registered [dim]· the mediator, "
+        "dormant until summoned[/dim]"
+    )
+
+    for agent in scenario.agents:
+        r = _run(
+            [
+                "agent",
+                "create",
+                agent.handle,
+                "--adapter",
+                "claude_code",
+                "--room",
+                room,
+                "--description",
+                f"{agent.label}. {agent.brief.splitlines()[0]}",
+                "--cwd",
+                str(_agent_workdir(room, agent.handle)),
+            ],  # fmt: skip
+            capture=True,
+        )
+        if r.returncode != 0:
+            _fail(f"Couldn't register @{agent.handle}:\n{(r.stdout or '') + (r.stderr or '')}")
+        console.print(
+            f"[green]✓[/green] [cyan]@{agent.handle}[/cyan] registered [dim]· {agent.label}[/dim]"
+        )
+
+    key, thread = _create_task(config, room, scenario.task, me)
+    short = thread.rsplit(":", 1)[-1]
+    r = _run(["board", "send", short, kickoff_text(scenario), "--room", room], capture=True)
+    if r.returncode != 0:
+        _fail(f"Couldn't post in the task's thread:\n{(r.stdout or '') + (r.stderr or '')}")
+    console.print(f"[green]✓[/green] Opened the task's thread [dim]· board messages {short}[/dim]")
+    return key, thread
+
+
+# ── the agents ───────────────────────────────────────────────────────────────
+
+
+def _copy_to_clipboard(text: str) -> bool:
+    """Best effort: the first clipboard tool this machine has."""
+    for cmd in (
+        ["pbcopy"],
+        ["wl-copy"],
+        ["xclip", "-selection", "clipboard"],
+        ["xsel", "--clipboard", "--input"],
+        ["clip.exe"],
+    ):
+        if shutil.which(cmd[0]) is None:
+            continue
+        try:
+            subprocess.run(cmd, input=text, text=True, check=True, capture_output=True)  # noqa: S603
+        except (OSError, subprocess.CalledProcessError):
+            continue
+        return True
+    return False
+
+
+def _write_briefings(
+    scenario: Scenario, room: str, key: str, hub_url: str, gated: bool
+) -> dict[str, tuple[Path, str]]:
+    out: dict[str, tuple[Path, str]] = {}
+    for agent in scenario.agents:
+        text = briefing(scenario, agent, room=room, row=key, hub_url=hub_url, gated=gated)
+        path = _agent_workdir(room, agent.handle).parent / f"{agent.handle}.md"
+        path.write_text(text)
+        out[agent.handle] = (path, text)
+    return out
+
+
+def _herdr_panes() -> tuple[Any, list[dict[str, Any]]]:
+    """The herdr bridge and its live agents, or ``(bridge, [])`` when it can't help."""
+    from mycelium.integrations.herdr import HerdrBridge, HerdrError
+
+    bridge = HerdrBridge()
+    if not bridge.available():
+        return bridge, []
+    try:
+        agents = [a for a in bridge.list_agents() if a.get("pane_id")]
+    except HerdrError:
+        agents = []
+    return bridge, agents
+
+
+def _hand_over_by_herdr(
+    bridge: Any, panes: list[dict[str, Any]], room: str, agent: DemoAgent, text: str
+) -> bool:
+    """Type the briefing into a herdr pane the user picks; False to fall back to paste."""
+    from mycelium.integrations.herdr import HerdrError, HerdrPaneMapping
+
+    manual = "I'll paste it into a coding agent myself"
+    labels: dict[str, dict[str, Any]] = {}
+    for a in panes:
+        title = a.get("terminal_title_stripped") or a.get("terminal_title") or ""
+        label = f"{a['pane_id']}  {a.get('agent') or '?'}  {a.get('agent_status') or ''}  {title}".rstrip()
+        labels[label] = a
+    picked = _select(f"Which herdr pane should play @{agent.handle}?", [*labels, manual])
+    if picked is None or picked == manual:
+        return False
+    pane = str(labels[picked]["pane_id"])
+    bridge.registry.set(
+        HerdrPaneMapping(
+            room=room, handle=agent.handle, pane=pane, kind=labels[picked].get("agent")
+        )
+    )
+    try:
+        bridge.prompt(pane, text, wait=False)
+    except HerdrError as exc:
+        console.print(f"[yellow]![/yellow] herdr couldn't type into {pane}: {exc}")
+        return False
+    console.print(
+        f"[green]✓[/green] Typed @{agent.handle}'s briefing into pane [cyan]{pane}[/cyan]"
+    )
+    return True
+
+
+def _hand_over_by_paste(agent: DemoAgent, path: Path, text: str, n: int, yes: bool) -> None:
+    where = f"coding agent {n}"
+    if _interactive(yes) and _copy_to_clipboard(text):
+        console.print(
+            Panel(
+                f"[bold]Copied to your clipboard:[/bold] the briefing for [cyan]@{agent.handle}[/cyan] "
+                f"({agent.label}).\n\n"
+                f"Open {where} (Claude Code, Cursor, anything with a shell), paste it, and let it run.\n"
+                f"[dim]The same text is at {path}[/dim]",
+                border_style="cyan",
+            )
+        )
+        _pause(yes, f"Press Enter once {where} has it")
+        return
+    console.print(Rule(f"[bold]Paste this into {where} → @{agent.handle} ({agent.label})[/bold]"))
+    console.print(text, markup=False, highlight=False)
+    console.print(Rule())
+    console.print(f"[dim]Also saved at {path}[/dim]")
+    _pause(yes, f"Press Enter once {where} has it")
+
+
+def _offer_herdr(
+    bridge: Any, panes: list[dict[str, Any]], yes: bool
+) -> tuple[Any, list[dict[str, Any]]]:
+    """Say what herdr adds and offer it, then look again; never required.
+
+    Three states, each with its own ask: not installed (open the site, come back),
+    running with no agents (start two, come back), running with agents (nothing
+    to ask). Each ask ends the same way: the user presses Enter and the wizard
+    re-checks, so continuing without herdr is always one keypress.
+    """
+    if panes or not _interactive(yes):
+        return bridge, panes
+    if not bridge.binary_present():
+        console.print(
+            f"[bold]herdr[/bold] ({HERDR_URL}) is optional. It keeps coding agents open in named "
+            "panes, so this wizard can type each briefing straight into one, and a mention to an "
+            "agent that has stepped away wakes it later. Without it, you paste two prompts by hand."
+        )
+        if _confirm("Open herdr.dev to install it now?", default=False):
+            import webbrowser
+
+            webbrowser.open(HERDR_URL)
+            _pause(
+                yes,
+                "Press Enter once herdr is running with two coding agents open, "
+                "or to go on without it",
+            )
+            return _herdr_panes()
+        return bridge, panes
+    console.print(
+        "[bold]herdr[/bold] is running but has no coding agents open. Start two in herdr panes and "
+        "the wizard will type each briefing in; or go on and paste them by hand."
+    )
+    _pause(yes, "Press Enter once the agents are open, or to go on without them")
+    return _herdr_panes()
+
+
+def _bring_in_agents(
+    config: MyceliumConfig, scenario: Scenario, room: str, key: str, gated: bool, yes: bool
+) -> None:
+    """Step 5: one briefing per agent, handed to a session the user runs."""
+    console.print(
+        "Mycelium doesn't run agents. Your coding agents are the agents: each one gets\n"
+        "a short briefing that says who it plays and how to talk to the room."
+    )
+    console.print()
+    briefings = _write_briefings(scenario, room, key, config.server.api_url, gated)
+
+    bridge, panes = _offer_herdr(*_herdr_panes(), yes)
+    if panes and _interactive(yes):
+        console.print(
+            f"[green]✓[/green] herdr is running with {len(panes)} coding agent(s) open; the wizard "
+            "can type each briefing straight into a pane."
+        )
+    console.print()
+
+    for n, agent in enumerate(scenario.agents, start=1):
+        path, text = briefings[agent.handle]
+        if panes and _interactive(yes) and _hand_over_by_herdr(bridge, panes, room, agent, text):
+            continue
+        _hand_over_by_paste(agent, path, text, n, yes)
+
+
+def _thread_senders(
+    config: MyceliumConfig, room: str, thread: str, since: datetime | None = None
+) -> set[str]:
+    """Who has spoken in the thread, plus anyone who spoke in the room since ``since``.
+
+    The briefing says to post into the task's thread, and the aligner reads
+    positions off the whole transcript regardless, so an agent that posted
+    room-wide instead has still stated one and should not be waited on forever.
+    """
+    senders: set[str] = set()
+    queries: list[dict[str, Any]] = [{"episode": thread, "limit": 100}]
+    if since is not None:
+        queries.append({"since": since.isoformat(), "limit": 200})
+    for params in queries:
+        try:
+            with hub_client(config, timeout=10) as client:
+                resp = client.get(f"/api/rooms/{room}/messages", params=params)
+            resp.raise_for_status()
+            messages = resp.json().get("messages", [])
+        except (httpx.HTTPError, ValueError):
+            continue
+        senders |= {
+            str(m.get("sender_handle") or "").lstrip("@").lower()
+            for m in messages
+            if m.get("message_type") in ("broadcast", "direct", "announce")
+        }
+    return senders
+
+
+def _present(config: MyceliumConfig, room: str) -> set[str]:
+    try:
+        with hub_client(config, timeout=10) as client:
+            resp = client.get(f"/api/rooms/{room}/sessions/members")
+        resp.raise_for_status()
+    except (httpx.HTTPError, ValueError):
+        return set()
+    return {str(m.get("handle") or "").lstrip("@").lower() for m in resp.json().get("members", [])}
+
+
+def _wait_for_agents(
+    config: MyceliumConfig,
+    room: str,
+    thread: str,
+    handles: list[str],
+    since: datetime | None = None,
+) -> None:
+    """Block until every agent has stated a position and is present to be addressed.
+
+    Both matter: the aligner reads positions off the transcript and addresses
+    whoever is present, so an agent that posted and left would be argued about
+    but never argued with.
+    """
+    want = [h.lower() for h in handles]
+    spoke: set[str] = set()
+    last_hint = time.monotonic()
+    with console.status("[dim]waiting for the agents…[/dim]") as status:
+        while True:
+            for h in want:
+                if h not in spoke and h in _thread_senders(config, room, thread, since):
+                    spoke.add(h)
+                    console.print(f"[green]✓[/green] [cyan]@{h}[/cyan] stated a position")
+            here = _present(config, room)
+            if all(h in spoke and h in here for h in want):
+                return
+            waiting = [h for h in want if h not in spoke]
+            away = [h for h in want if h in spoke and h not in here]
+            parts = []
+            if waiting:
+                parts.append("a position from " + ", ".join(f"@{h}" for h in waiting))
+            if away:
+                parts.append(", ".join(f"@{h}" for h in away) + " to run `mycelium await`")
+            status.update(f"[dim]waiting for {' and '.join(parts)}…[/dim]")
+            if time.monotonic() - last_hint > 90:
+                last_hint = time.monotonic()
+                console.print(
+                    "[dim]Still waiting. Each agent should have posted with `mycelium respond` "
+                    "and be sitting in `mycelium await`. Ctrl-C stops the tour.[/dim]"
+                )
+            time.sleep(POLL_S)
+
+
+# ── the aligner ──────────────────────────────────────────────────────────────
+
+
+def parse_verdict(message: dict[str, Any]) -> dict[str, Any] | None:
+    """The outcome inside an ``l9_commit`` message, or None for anything else.
+
+    A commit is the aligner's terminal statement: ``converged`` carries the
+    agreed ``issue = value`` map, ``rejected`` says the mechanism ran out.
+    """
+    if message.get("message_type") != "l9_commit":
+        return None
+    try:
+        record = json.loads(message.get("content") or "{}")
+    except ValueError:
+        return None
+    header = (record.get("l9") or {}).get("header") or {}
+    payload = (record.get("l9") or {}).get("payload") or {}
+    data = payload.get("data")
+    assignments = data.get("assignments") if isinstance(data, dict) else None
+    text = record.get("content") if isinstance(record.get("content"), str) else ""
+    return {
+        "converged": header.get("subkind") == "converged",
+        "assignments": assignments if isinstance(assignments, dict) else {},
+        "text": text,
+        "sender": message.get("sender_handle") or ALIGNER_HANDLE,
+    }
+
+
+def _messages_since(config: MyceliumConfig, room: str, since: datetime) -> list[dict[str, Any]]:
+    try:
+        with hub_client(config, timeout=10) as client:
+            resp = client.get(
+                f"/api/rooms/{room}/messages", params={"since": since.isoformat(), "limit": 200}
+            )
+        resp.raise_for_status()
+    except (httpx.HTTPError, ValueError):
+        return []
+    msgs = resp.json().get("messages", [])
+    return sorted(msgs, key=lambda m: str(m.get("created_at") or ""))
+
+
+def _tail_until_verdict(
+    config: MyceliumConfig, room: str, since: datetime, handles: list[str]
+) -> dict[str, Any] | None:
+    """Print the negotiation as it happens; return the verdict, or None on timeout."""
+    seen: set[str] = set()
+    deadline = time.monotonic() + VERDICT_TIMEOUT_S
+    with console.status("[dim]the aligner is reading the positions…[/dim]") as status:
+        while time.monotonic() < deadline:
+            for m in _messages_since(config, room, since):
+                mid = str(m.get("id") or m.get("message_id") or "")
+                if mid in seen:
+                    continue
+                seen.add(mid)
+                verdict = parse_verdict(m)
+                if verdict is not None:
+                    return verdict
+                if m.get("message_type") not in ("broadcast", "direct", "announce"):
+                    continue
+                sender = str(m.get("sender_handle") or "?").lstrip("@")
+                text = str(m.get("content") or "").strip().replace("\n", " ")
+                if len(text) > 400:
+                    text = text[:400] + "…"
+                color = "magenta" if sender.lower() == ALIGNER_HANDLE else "yellow"
+                console.print(f"  [{color}]{sender}[/{color}]: {text}")
+                if sender.lower() == ALIGNER_HANDLE:
+                    status.update("[dim]waiting for the agent it addressed…[/dim]")
+                elif sender.lower() in {h.lower() for h in handles}:
+                    status.update("[dim]the aligner is weighing that reply…[/dim]")
+            time.sleep(POLL_S)
+    return None
+
+
+def _work_rows(config: MyceliumConfig, room: str) -> set[str]:
+    from mycelium.commands.board import _fetch
+
+    try:
+        _name, items, _health = _fetch(room)
+    except Exception:  # noqa: BLE001 - a board read failing is not the tour failing
+        return set()
+    return {i.id for i in items if i.id.startswith("memory:work/")}
+
+
+def _mediate(
+    config: MyceliumConfig, scenario: Scenario, room: str, thread: str, yes: bool
+) -> dict[str, Any] | None:
+    """Step 6: summon the aligner on the task and watch it work."""
+    console.print(
+        "The aligner is a mediator the room owns. Summoned on a task, it reads both\n"
+        "positions, works out what is actually in dispute, and addresses one agent at a\n"
+        "time with the offer on the table until they agree or clearly won't."
+    )
+    console.print()
+    _pause(yes, "Press Enter to summon it")
+    short = thread.rsplit(":", 1)[-1]
+    before = _work_rows(config, room)
+    started = datetime.now(UTC)
+    r = _run(
+        ["board", "coordinate", short, ALIGNER_HANDLE, scenario.question, "--room", room],
+        capture=True,
+    )
+    if r.returncode != 0:
+        _fail(f"Couldn't summon the aligner:\n{(r.stdout or '') + (r.stderr or '')}")
+    console.print()
+    verdict = _tail_until_verdict(config, room, started, scenario.handles)
+    console.print()
+    if verdict is None:
+        console.print(
+            f"[yellow]![/yellow] No verdict after {VERDICT_TIMEOUT_S // 60} minutes. "
+            f"Keep an eye on it with: mycelium watch {room}"
+        )
+        return None
+    if verdict["converged"]:
+        terms = "\n".join(f"  {issue}: {value}" for issue, value in verdict["assignments"].items())
+        console.print(
+            Panel(
+                "[bold green]Agreement[/bold green]\n\n" + (terms or verdict["text"]),
+                border_style="green",
+            )
+        )
+        with console.status("[dim]compiling the agreement into tasks on the board…[/dim]"):
+            deadline = time.monotonic() + COMPILE_TIMEOUT_S
+            while time.monotonic() < deadline and _work_rows(config, room) <= before:
+                time.sleep(POLL_S)
+        console.print("The agreement became work on the board, one row per task:")
+    else:
+        console.print(
+            Panel(
+                "[bold yellow]No agreement[/bold yellow]\n\n"
+                + (verdict["text"] or "The agents didn't converge. That is a clean outcome too."),
+                border_style="yellow",
+            )
+        )
+    console.print()
+    _run(["board", "--room", room, "--filter", "all"])
+    return verdict
+
+
+# ── the board ────────────────────────────────────────────────────────────────
+
+
+def _work_the_board(
+    config: MyceliumConfig, scenario: Scenario, room: str, key: str, yes: bool
+) -> None:
+    """Step 7: file follow-up work by hand and hand one piece to an agent."""
+    if not scenario.followups:
+        return
+    console.print(
+        "Work doesn't have to come out of a negotiation. Anyone can put a task on the\n"
+        "board, nest it under another, and hand it to someone."
+    )
+    console.print()
+    _pause(yes)
+    first_row: str | None = None
+    for title, assignee in scenario.followups:
+        r = _run(
+            ["board", "new", title, "--parent", key, "--assign", f"@{assignee}", "--room", room],
+            capture=True,
+        )
+        out = (r.stdout or "").strip()
+        if r.returncode != 0:
+            console.print(f"[yellow]![/yellow] {out or (r.stderr or '').strip()}")
+            continue
+        console.print(out)
+        if first_row is None:
+            first_row = _row_key_from(out) or f"work/{slugify(title)}"
+    if first_row is None:
+        return
+    assignee = scenario.followups[0][1]
+    r = _run(
+        [
+            "board",
+            "send",
+            first_row,
+            f"@{assignee} this one is yours when you have a moment. Claim it and say how you'd start.",
+            "--room",
+            room,
+        ],
+        capture=True,
+    )
+    if r.returncode != 0:
+        console.print(f"[yellow]![/yellow] {(r.stdout or '') + (r.stderr or '')}")
+        return
+    console.print(f"[green]✓[/green] Pinged [cyan]@{assignee}[/cyan] in the task's thread")
+    with console.status(f"[dim]giving @{assignee} a minute to pick it up…[/dim]"):
+        deadline = time.monotonic() + 90
+        while time.monotonic() < deadline:
+            if _claimed(config, room, first_row, assignee):
+                break
+            time.sleep(POLL_S)
+    console.print()
+    _run(["board", "--room", room, "--filter", "all"])
+    console.print()
+    _run(["board", "messages", first_row, "--room", room])
+
+
+def _claimed(config: MyceliumConfig, room: str, key: str, handle: str) -> bool:
+    from mycelium.commands.board import _row
+
+    try:
+        item = _row(room, key)
+    except Exception:  # noqa: BLE001 - a read blip just means "not yet"
+        return False
+    if item is None:
+        return False
+    return (item.owner or "").lstrip("@").lower() == handle.lower()
+
+
+_ROW_KEY = re.compile(r"\b(work/[a-z0-9-]+)\b")
+
+
+def _row_key_from(text: str) -> str | None:
+    m = _ROW_KEY.search(text)
+    return m.group(1) if m else None
+
+
+def slugify(title: str) -> str:
+    """The hub's rule for a task key, mirrored so a row can be named before it is read back."""
+    slug = re.sub(r"[^a-z0-9]+", "-", title.casefold()).strip("-")[:48].strip("-")
+    return slug or "task"
+
+
+# ── the wrap-up ──────────────────────────────────────────────────────────────
+
+
+def _welcome() -> None:
+    console.print(
+        Panel(
+            "[bold]Welcome to Mycelium[/bold]\n\n"
+            "A shared board and chat where people and coding agents coordinate work: rooms,\n"
+            "tasks with a thread inside each one, shared memory, and a mediator you can\n"
+            "summon when two agents disagree.\n\n"
+            "This tour takes about ten minutes. It points this machine at a hub, signs you\n"
+            "in, puts a task on a board, hands two of your coding agents a briefing each,\n"
+            "lets the mediator get them to an agreement, and files the follow-up work.\n"
+            "Every step prints the command it runs. Ctrl-C leaves at any point.",
+            border_style="cyan",
+        )
+    )
+
+
+def _done(
+    config: MyceliumConfig, scenario: Scenario, room: str, key: str, verdict: dict[str, Any] | None
+) -> None:
+    console.print()
+    console.print(Rule("[bold]That's the tour[/bold]"))
+    console.print()
+    outcome = (
+        "the agents reached an agreement and it became tasks"
+        if verdict and verdict["converged"]
+        else "the agents didn't converge, which the room records honestly"
+        if verdict
+        else "the negotiation is still running"
+    )
+    console.print(f"In [cyan]{room}[/cyan], {outcome}.")
+    console.print()
+    console.print(f"[bold]Open it in the browser:[/bold] {ui_url(config, room)}")
+    console.print()
+    console.print("[bold]Keep going from here:[/bold]")
+    for cmd, note in (
+        (f"mycelium board --room {room}", "the board"),
+        (f"mycelium board messages {key} --room {room}", "the task's thread"),
+        (f"mycelium watch {room}", "the room's timeline, live"),
+        (f"mycelium memory ls --room {room}", "what the room remembers"),
+        (f'mycelium board new "…" --room {room}', "put your own task on it"),
+    ):
+        console.print(f"  {cmd:<62} [dim]{note}[/dim]")
+    console.print()
+    console.print(f"[dim]The agents' briefings are under {_state_path(room).parent}.[/dim]")
+    console.print(
+        f"[dim]Start over: mycelium room delete {room} --force, then mycelium onboard.[/dim]"
+    )
+
+
+def _reprint_briefings(
+    config: MyceliumConfig, scenario_flag: str | None, room_flag: str | None
+) -> None:
+    scenario = SCENARIOS.get(scenario_flag or DEFAULT_SCENARIO)
+    if scenario is None:
+        _fail(f"Unknown scenario '{scenario_flag}'.", "See the list with: mycelium onboard --list")
+    room = room_flag or scenario.room
+    state = _load_state(room)
+    if state is None:
+        _fail(
+            f"No onboarding state for room '{room}' on this machine.",
+            "Run the tour first: mycelium onboard",
+        )
+    briefings = _write_briefings(
+        scenario, room, state["row"], config.server.api_url, bool(state.get("gated"))
+    )
+    for n, agent in enumerate(scenario.agents, start=1):
+        path, text = briefings[agent.handle]
+        console.print(Rule(f"[bold]coding agent {n} → @{agent.handle} ({agent.label})[/bold]"))
+        console.print(text, markup=False, highlight=False)
+        console.print(f"[dim]saved at {path}[/dim]\n")
+
+
+# ── the command ──────────────────────────────────────────────────────────────
+
+
+@doc_ref(
+    usage="mycelium onboard [--hub <url>] [--scenario <id>] [--room <name>] [--yes] [--list] [--briefings]",
+    desc=(
+        "Guided first run: point at a hub, sign in, put a task on a board, brief two of "
+        "your coding agents, watch the aligner mediate them, and work the board."
+    ),
+    group="setup",
+)
+def onboard(
+    ctx: typer.Context,
+    hub: str | None = typer.Option(None, "--hub", help="Hub address to use (skips the question)."),
+    scenario: str | None = typer.Option(None, "--scenario", "-s", help="Scenario id; see --list."),
+    room: str | None = typer.Option(None, "--room", help="Room name (default: demo-<scenario>)."),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="No questions, no pauses; take the defaults."
+    ),
+    list_flag: bool = typer.Option(False, "--list", help="List the scenarios and exit."),
+    briefings_flag: bool = typer.Option(
+        False,
+        "--briefings",
+        help="Print the agents' briefings for a room set up earlier, and exit.",
+    ),
+) -> None:
+    """Walk through Mycelium end to end, on a real hub, with your own coding agents.
+
+    Examples:
+        mycelium onboard
+        mycelium onboard --hub https://mycelium.outshift.io
+        mycelium onboard --scenario database-choice --yes
+        mycelium onboard --briefings        # lost the prompts? print them again
+    """
+    if list_flag:
+        _list_scenarios()
+        return
+
+    try:
+        config = MyceliumConfig.load()
+    except Exception:  # noqa: BLE001 - a fresh machine has no config yet, which is fine
+        config = MyceliumConfig()
+
+    if briefings_flag:
+        _reprint_briefings(config, scenario, room)
+        return
+
+    try:
+        _welcome()
+        _pause(yes)
+
+        _step(1)
+        health = _point_at_hub(config, hub, yes)
+        gated = bool((health.get("auth") or {}).get("enabled"))
+
+        _step(2)
+        me = _sign_in(config, health, yes)
+
+        _step(3)
+        chosen = _pick_scenario(scenario, yes)
+        room_name = room or chosen.room
+        _print_scenario(chosen, room_name)
+        _pause(yes)
+
+        _step(4)
+        key, thread = _set_up_room(config, chosen, room_name, me)
+        _save_state(
+            room_name, {"scenario": chosen.id, "row": key, "thread": thread, "gated": gated}
+        )
+        _pause(yes)
+
+        _step(5)
+        briefed_at = datetime.now(UTC)
+        _bring_in_agents(config, chosen, room_name, key, gated, yes)
+        console.print()
+        _wait_for_agents(config, room_name, thread, chosen.handles, briefed_at)
+        console.print(
+            "[green]✓[/green] Both agents are in the room and have stated their positions"
+        )
+        console.print()
+        _run(["board", "messages", key, "--room", room_name])
+
+        _step(6)
+        verdict = _mediate(config, chosen, room_name, thread, yes)
+
+        _step(7)
+        _work_the_board(config, chosen, room_name, key, yes)
+
+        _done(config, chosen, room_name, key, verdict)
+    except KeyboardInterrupt:
+        console.print(
+            "\n[dim]Stopped. The room keeps whatever was set up; re-run mycelium onboard any time.[/dim]"
+        )
+        raise typer.Exit(130) from None
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        from mycelium.error_handler import print_error
+
+        print_error(exc, verbose=bool(ctx.obj and ctx.obj.get("verbose")))
+        raise typer.Exit(1) from None

--- a/mycelium-cli/src/mycelium/commands/onboard.py
+++ b/mycelium-cli/src/mycelium/commands/onboard.py
@@ -476,7 +476,7 @@ def _set_up_room(config: MyceliumConfig, scenario: Scenario, room: str, me: str)
                 "--room",
                 room,
                 "--description",
-                f"{agent.label}. {agent.brief.splitlines()[0]}",
+                f"{agent.label}. {agent.wants}",
                 "--cwd",
                 str(_agent_workdir(room, agent.handle)),
             ],  # fmt: skip
@@ -984,7 +984,11 @@ def _welcome() -> None:
 
 
 def _done(
-    config: MyceliumConfig, scenario: Scenario, room: str, key: str, verdict: dict[str, Any] | None
+    config: MyceliumConfig,
+    scenario: Scenario,
+    room: str,
+    thread: str,
+    verdict: dict[str, Any] | None,
 ) -> None:
     console.print()
     console.print(Rule("[bold]That's the tour[/bold]"))
@@ -1001,14 +1005,19 @@ def _done(
     console.print(f"[bold]Open it in the browser:[/bold] {ui_url(config, room)}")
     console.print()
     console.print("[bold]Keep going from here:[/bold]")
-    for cmd, note in (
+    # The thread's short id rather than the row key: it is what a ping names and
+    # what the reader has been typing all tour, and it keeps these lines short
+    # enough that the notes line up in a normal terminal.
+    rows = (
         (f"mycelium board --room {room}", "the board"),
-        (f"mycelium board messages {key} --room {room}", "the task's thread"),
+        (f"mycelium board messages {thread.rsplit(':', 1)[-1]} --room {room}", "the task's thread"),
         (f"mycelium watch {room}", "the room's timeline, live"),
         (f"mycelium memory ls --room {room}", "what the room remembers"),
         (f'mycelium board new "…" --room {room}', "put your own task on it"),
-    ):
-        console.print(f"  {cmd:<62} [dim]{note}[/dim]")
+    )
+    width = max(len(cmd) for cmd, _ in rows)
+    for cmd, note in rows:
+        console.print(f"  {cmd:<{width}}   [dim]{note}[/dim]")
     console.print()
     console.print(f"[dim]The agents' briefings are under {_state_path(room).parent}.[/dim]")
     console.print(
@@ -1127,7 +1136,7 @@ def onboard(
         _step(7)
         _work_the_board(config, chosen, room_name, key, yes)
 
-        _done(config, chosen, room_name, key, verdict)
+        _done(config, chosen, room_name, thread, verdict)
     except KeyboardInterrupt:
         console.print(
             "\n[dim]Stopped. The room keeps whatever was set up; re-run mycelium onboard any time.[/dim]"

--- a/mycelium-cli/src/mycelium/docs/guides/quickstart.md
+++ b/mycelium-cli/src/mycelium/docs/guides/quickstart.md
@@ -1,5 +1,22 @@
 # Quick Start
 
+## The guided tour
+
+If you'd rather be walked through it, run the tour:
+
+```bash
+mycelium onboard
+```
+
+It points this machine at a hub (yours, or one someone already runs for you),
+signs you in if the hub asks, puts a task on a board, hands two of your coding
+agents a briefing each, lets the aligner mediate them to an agreement, and files
+the follow-up work. The agents are your own sessions: Claude Code, Cursor,
+anything with a shell. Every step prints the command it runs, so the tour is also
+the tutorial. `mycelium onboard --list` shows the scenarios; `--briefings` prints
+the agents' briefings again if you lost them. Everything below is the same ground
+by hand.
+
 Mycelium runs on a server your team connects to. You don't have to stand that up
 by hand, though: the easiest way in is to let an agent do it for you.
 

--- a/mycelium-cli/src/mycelium/scenarios.py
+++ b/mycelium-cli/src/mycelium/scenarios.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""The built-in scenarios ``mycelium onboard`` runs, and the briefing each agent gets.
+
+A scenario is a real, ordinary disagreement between two people on a software
+team, written the way they would say it: a release date, a database, a cloud
+bill. Nothing here is abstract, and none of it needs a dataset fetched at run
+time. The two agents are the user's own coding agents (Claude Code, Cursor,
+anything with a shell), each handed a briefing that tells it who it is playing,
+what it wants, what it would give, and how to talk to the room.
+
+The briefing is the whole contract between the wizard and the agent: the agent
+needs nothing else pasted in, and the text names every command it will run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# The reserved engine handle the wizard registers and summons.
+ALIGNER_HANDLE = "aligner"
+
+
+@dataclass(frozen=True)
+class DemoAgent:
+    """One seat at the table: a handle, a job title, and what that person wants."""
+
+    handle: str
+    name: str
+    role: str
+    #: What they want, what they'd give, and their hard line, in the second person.
+    brief: str
+
+    @property
+    def label(self) -> str:
+        return f"{self.name}, the {self.role}"
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """A disagreement worth mediating, and the board work that follows it."""
+
+    id: str
+    title: str
+    #: One sentence for the picker: what the room is about.
+    blurb: str
+    #: The board row the whole thing runs inside.
+    task: str
+    #: What the aligner is asked to settle, phrased as the ask on the row.
+    question: str
+    agents: tuple[DemoAgent, ...]
+    #: Follow-up tasks the human files by hand once the agreement is in, as
+    #: ``(title, assignee handle)``. The first one is the one the tour pings.
+    followups: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+    @property
+    def room(self) -> str:
+        return f"demo-{self.id}"
+
+    @property
+    def handles(self) -> list[str]:
+        return [a.handle for a in self.agents]
+
+
+SCENARIOS: dict[str, Scenario] = {
+    "release-plan": Scenario(
+        id="release-plan",
+        title="Plan the 2.0 release",
+        blurb="A release manager who wants to ship in two weeks, a QA lead who wants four.",
+        task="Plan the 2.0 release: date, what goes in it, and how much testing before we ship",
+        question=(
+            "agree on a release date, whether dark mode ships in 2.0 or waits, "
+            "and how much testing happens before we ship"
+        ),
+        agents=(
+            DemoAgent(
+                handle="maya",
+                name="Maya",
+                role="release manager",
+                brief=(
+                    "You want 2.0 out the door in two weeks. Sales has promised it to three "
+                    "customers and every week of delay costs a renewal conversation. Dark "
+                    "mode is nice to have; ship without it if it isn't finished. On testing, "
+                    "the automated suite plus a one-day smoke test is enough for you.\n"
+                    "You can give: slip one week if that buys a real regression pass on the "
+                    "billing flow.\n"
+                    "Your hard line: no later than three weeks from today."
+                ),
+            ),
+            DemoAgent(
+                handle="theo",
+                name="Theo",
+                role="QA lead",
+                brief=(
+                    "You want a full regression pass before 2.0 ships. That takes two weeks "
+                    "on its own, so you're asking for four weeks. The billing changes worry "
+                    "you: the last release shipped a refund bug that took a month to clean "
+                    "up. You'd rather dark mode ship in 2.0, because it touches every screen "
+                    "and you want to test it once, not twice.\n"
+                    "You can give: three weeks, if billing gets its own regression pass and "
+                    "dark mode ships behind a setting that defaults to off.\n"
+                    "Your hard line: no release without the billing regression pass."
+                ),
+            ),
+        ),
+        followups=(
+            ("Write the 2.0 release notes", "maya"),
+            ("Run the billing regression pass", "theo"),
+        ),
+    ),
+    "database-choice": Scenario(
+        id="database-choice",
+        title="Pick a database for the orders service",
+        blurb="Platform wants Postgres because they already run it; the orders team wants Mongo.",
+        task="Pick the database for the new orders service",
+        question=(
+            "agree on which database the orders service uses, who owns the migrations, "
+            "and when the decision is final"
+        ),
+        agents=(
+            DemoAgent(
+                handle="priya",
+                name="Priya",
+                role="platform engineer",
+                brief=(
+                    "You want Postgres. The team already runs it in production, backups and "
+                    "monitoring exist, and one more database engine is one more thing to get "
+                    "paged for at 3am. Schema changes are fine with a migrations tool.\n"
+                    "You can give: a JSON column for the parts of an order that genuinely "
+                    "vary by vendor.\n"
+                    "Your hard line: no new database engine in production this quarter."
+                ),
+            ),
+            DemoAgent(
+                handle="sam",
+                name="Sam",
+                role="orders team lead",
+                brief=(
+                    "You want MongoDB. Orders look different for every vendor and you don't "
+                    "want to write a migration each time a vendor adds a field. Your team "
+                    "has shipped on Mongo before and knows it well.\n"
+                    "You can give: Postgres, if the order payload lives in a JSON column and "
+                    "the platform team owns the migrations tooling so your team is never "
+                    "blocked on it.\n"
+                    "Your hard line: your team must be able to add a vendor field without "
+                    "a schema review meeting."
+                ),
+            ),
+        ),
+        followups=(
+            ("Set up the migrations tool for the orders service", "priya"),
+            ("Load the vendor sample orders into the new schema", "sam"),
+        ),
+    ),
+    "cloud-costs": Scenario(
+        id="cloud-costs",
+        title="Cut the cloud bill by 30%",
+        blurb="Finance needs 30% off by end of quarter; the SRE won't give up staging.",
+        task="Cut the monthly cloud bill by 30% before the end of the quarter",
+        question=(
+            "agree on which environments get downsized, whether we commit to reserved "
+            "instances, and the deadline"
+        ),
+        agents=(
+            DemoAgent(
+                handle="jordan",
+                name="Jordan",
+                role="finance ops lead",
+                brief=(
+                    "You need 30% off the cloud bill by the end of the quarter, six weeks "
+                    "from now. The biggest line items are the three staging environments "
+                    "and the on-demand instances behind the API. Reserved instances would "
+                    "cut 25% on their own with a one-year commitment.\n"
+                    "You can give: keep one staging environment running full time.\n"
+                    "Your hard line: the number has to be at least 30%, and it has to land "
+                    "this quarter."
+                ),
+            ),
+            DemoAgent(
+                handle="alex",
+                name="Alex",
+                role="SRE",
+                brief=(
+                    "You'll take cost cuts, but not by removing the staging environments the "
+                    "release process depends on: two is the minimum for testing a release "
+                    "while a hotfix is in flight. You're wary of a one-year reserved "
+                    "commitment on the API tier, because it's being rewritten and its "
+                    "footprint will change.\n"
+                    "You can give: reserved instances for the databases, which aren't "
+                    "changing, and shutting staging down outside working hours.\n"
+                    "Your hard line: at least two staging environments during release weeks."
+                ),
+            ),
+        ),
+        followups=(
+            ("Schedule the staging environments to stop overnight", "alex"),
+            ("Get quotes for one-year reserved database instances", "jordan"),
+        ),
+    ),
+}
+
+DEFAULT_SCENARIO = "release-plan"
+
+
+def kickoff_text(scenario: Scenario) -> str:
+    """What the human posts in the task's thread to open it.
+
+    No ``@``-mentions on purpose: a mention would queue a wake for agents that
+    are not in the room yet, and the briefing already tells each one to come
+    and state its position here.
+    """
+    names = " and ".join(a.name for a in scenario.agents)
+    return (
+        f"{names}, this one is yours to settle. State your positions here, "
+        "then we'll bring in the aligner to work out an agreement."
+    )
+
+
+def briefing(
+    scenario: Scenario,
+    agent: DemoAgent,
+    *,
+    room: str,
+    row: str,
+    hub_url: str,
+    gated: bool,
+) -> str:
+    """The text pasted into one coding agent: who it is, and how to take part.
+
+    Self-contained: it installs the CLI if it's missing, points it at the hub,
+    signs in when the hub asks for it, posts an opening position into the task's
+    thread, and then keeps awaiting so the aligner can address it. Every command
+    is on its own line and simple, because a coding agent's allowlist matches
+    simple commands and not compound shell.
+    """
+    others = ", ".join(f"@{a.handle} ({a.label})" for a in scenario.agents if a is not agent)
+    sign_in = (
+        "3. This hub asks people to sign in. If `mycelium whoami` says you are not signed "
+        "in, run `mycelium login --device` and hand the URL and code to the person you're "
+        "working with.\n"
+        if gated
+        else "3. This hub is open, so there is nothing to sign in to.\n"
+    )
+    return f"""You are joining a Mycelium room as the agent @{agent.handle}.
+
+Mycelium is a shared board and chat that people and coding agents use to coordinate work. You talk to it with the `mycelium` command-line tool. Another agent is in the room with you: {others}. A person is watching the room and will bring in a mediator (the aligner) once both of you have stated your positions.
+
+## Who you are
+
+{agent.name}, the {agent.role}. {agent.brief}
+
+Speak as {agent.name}, in plain language, two to four sentences per message. Argue your position, say what you would give and what you won't, and be willing to make a deal when the offer is one you can live with.
+
+## Setup (once)
+
+1. Check the CLI is installed: `mycelium --version`. If it is missing, install it: `curl -fsSL https://mycelium-io.github.io/mycelium/install.sh | bash` and open a new shell.
+2. Point it at the hub: `mycelium config set server.api_url {hub_url}`
+{sign_in}4. Use the room: `mycelium room use {room}`
+
+## Step 1: state your position
+
+Read the task and what has been said in its thread so far:
+
+    mycelium board messages {row} --room {room}
+
+Then post your opening position into that thread, as {agent.name}, in your own words. End it with a confidence marker (0 to 1, how sure you are):
+
+    mycelium respond --room {room} --handle {agent.handle} --task {row} "<your position> [[mycelium: confidence=0.8]]"
+
+## Step 2: stay in the conversation
+
+The aligner will address you one turn at a time. Wait for it:
+
+    mycelium await --room {room} --handle {agent.handle} --json --timeout 600
+
+When that returns a message, read the prompt, decide as {agent.name}, and reply:
+
+    mycelium respond --room {room} --handle {agent.handle} "<your reply> [[mycelium: confidence=0.7 stance=accept]]"
+
+- `stance=accept` when you can live with the offer on the table, `stance=reject` when you can't. Say why in the reply itself.
+- If `await` times out with no message, run it again. Keep going until a message says the team reached an agreement or no agreement, or the person you are working with tells you to stop.
+- Run each `mycelium` command on its own: no `&&`, pipes, loops or scripts, and one `await` per command.
+
+## Afterwards
+
+The agreement becomes tasks on the board. If someone assigns one to you or mentions you in it, claim it and say how you'd start, in that task's thread:
+
+    mycelium board --room {room}
+    mycelium board claim <task id> --room {room}
+    mycelium board send <task id> "<what you'll do first>" --room {room}
+
+Then go back to waiting with `mycelium await` as above.
+"""

--- a/mycelium-cli/src/mycelium/scenarios.py
+++ b/mycelium-cli/src/mycelium/scenarios.py
@@ -29,6 +29,8 @@ class DemoAgent:
     handle: str
     name: str
     role: str
+    #: One line for the room roster: what this person wants and what they'd trade.
+    wants: str
     #: What they want, what they'd give, and their hard line, in the second person.
     brief: str
 
@@ -78,6 +80,7 @@ SCENARIOS: dict[str, Scenario] = {
                 handle="maya",
                 name="Maya",
                 role="release manager",
+                wants="Ships 2.0 in two weeks; would slip one week to buy a billing regression pass.",
                 brief=(
                     "You want 2.0 out the door in two weeks. Sales has promised it to three "
                     "customers and every week of delay costs a renewal conversation. Dark "
@@ -92,6 +95,7 @@ SCENARIOS: dict[str, Scenario] = {
                 handle="theo",
                 name="Theo",
                 role="QA lead",
+                wants="Wants a full regression pass before 2.0; would take three weeks if billing is covered.",
                 brief=(
                     "You want a full regression pass before 2.0 ships. That takes two weeks "
                     "on its own, so you're asking for four weeks. The billing changes worry "
@@ -123,6 +127,7 @@ SCENARIOS: dict[str, Scenario] = {
                 handle="priya",
                 name="Priya",
                 role="platform engineer",
+                wants="Wants Postgres, which the team already runs; would add a JSON column for vendor data.",
                 brief=(
                     "You want Postgres. The team already runs it in production, backups and "
                     "monitoring exist, and one more database engine is one more thing to get "
@@ -136,6 +141,7 @@ SCENARIOS: dict[str, Scenario] = {
                 handle="sam",
                 name="Sam",
                 role="orders team lead",
+                wants="Wants MongoDB for varying vendor orders; would take Postgres if migrations aren't his team's blocker.",
                 brief=(
                     "You want MongoDB. Orders look different for every vendor and you don't "
                     "want to write a migration each time a vendor adds a field. Your team "
@@ -167,6 +173,7 @@ SCENARIOS: dict[str, Scenario] = {
                 handle="jordan",
                 name="Jordan",
                 role="finance ops lead",
+                wants="Needs 30% off the cloud bill this quarter; would keep one staging environment running.",
                 brief=(
                     "You need 30% off the cloud bill by the end of the quarter, six weeks "
                     "from now. The biggest line items are the three staging environments "
@@ -181,6 +188,7 @@ SCENARIOS: dict[str, Scenario] = {
                 handle="alex",
                 name="Alex",
                 role="SRE",
+                wants="Won't drop below two staging environments in release weeks; would reserve the databases.",
                 brief=(
                     "You'll take cost cuts, but not by removing the staging environments the "
                     "release process depends on: two is the minimum for testing a release "

--- a/mycelium-cli/tests/test_onboard.py
+++ b/mycelium-cli/tests/test_onboard.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Mycelium Contributors
+
+"""``mycelium onboard`` — the guided tour, and the scenarios it runs.
+
+Node-free and hub-free: the tour is glue over the real CLI, so these pin the
+pieces that decide what it does (the scenario data, the briefing an agent is
+handed, the hub address normalization, the verdict parse) and the sequence of
+commands a ``--yes`` run issues, with every subprocess and hub call faked.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from mycelium import client as client_mod
+from mycelium import scenarios
+from mycelium.cli import app
+from mycelium.commands import onboard
+
+runner = CliRunner()
+
+_HANDLE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+
+# ── scenarios ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("scenario", list(scenarios.SCENARIOS.values()), ids=lambda s: s.id)
+def test_every_scenario_is_two_people_with_a_real_disagreement(scenario: scenarios.Scenario):
+    assert scenario.room == f"demo-{scenario.id}"
+    assert len(scenario.agents) == 2
+    handles = scenario.handles
+    assert len(set(handles)) == 2
+    for agent in scenario.agents:
+        assert _HANDLE.match(agent.handle), agent.handle
+        # Each brief says what the person wants, what they'd give, and where they stop.
+        assert "You can give:" in agent.brief
+        assert "Your hard line:" in agent.brief
+    for _title, assignee in scenario.followups:
+        assert assignee in handles
+    assert scenario.question and not scenario.question.endswith(".")
+
+
+def test_the_default_scenario_exists():
+    assert scenarios.DEFAULT_SCENARIO in scenarios.SCENARIOS
+
+
+def test_kickoff_mentions_nobody():
+    """A mention would queue a wake for agents that are not in the room yet."""
+    for scenario in scenarios.SCENARIOS.values():
+        assert "@" not in scenarios.kickoff_text(scenario)
+
+
+def test_briefing_is_self_contained():
+    scenario = scenarios.SCENARIOS["release-plan"]
+    maya = scenario.agents[0]
+    text = scenarios.briefing(
+        scenario,
+        maya,
+        room="demo-release-plan",
+        row="work/plan-the-2-0-release",
+        hub_url="https://hub.example",
+        gated=True,
+    )
+    assert "@maya" in text
+    assert "@theo" in text  # knows who else is at the table
+    assert maya.brief in text
+    assert "mycelium config set server.api_url https://hub.example" in text
+    assert "mycelium room use demo-release-plan" in text
+    assert "mycelium login --device" in text
+    assert (
+        "mycelium respond --room demo-release-plan --handle maya --task work/plan-the-2-0-release"
+        in text
+    )
+    assert "mycelium await --room demo-release-plan --handle maya --json" in text
+    assert "[[mycelium: confidence=" in text
+
+
+def test_briefing_on_an_open_hub_does_not_ask_for_a_login():
+    scenario = scenarios.SCENARIOS["cloud-costs"]
+    text = scenarios.briefing(
+        scenario, scenario.agents[1], room="r", row="work/x", hub_url="http://h", gated=False
+    )
+    assert "mycelium login" not in text
+    assert "nothing to sign in to" in text
+
+
+# ── the hub address ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "want"),
+    [
+        ("https://mycelium.outshift.io", "https://mycelium.outshift.io"),
+        ("https://mycelium.outshift.io/", "https://mycelium.outshift.io"),
+        ("https://mycelium.outshift.io/api", "https://mycelium.outshift.io"),
+        ("hub.example.com:8000", "http://hub.example.com:8000"),
+        ("  localhost:8000/ ", "http://localhost:8000"),
+        ("", ""),
+    ],
+)
+def test_normalize_hub(raw: str, want: str):
+    assert onboard.normalize_hub(raw) == want
+
+
+def test_ui_url_is_the_local_port_or_the_hub_origin():
+    from mycelium.config import MyceliumConfig
+
+    cfg = MyceliumConfig()
+    assert onboard.ui_url(cfg, "demo") == "http://localhost:3000/room/demo"
+    cfg.server.api_url = "https://mycelium.outshift.io"
+    assert onboard.ui_url(cfg, "demo") == "https://mycelium.outshift.io/room/demo"
+
+
+def test_default_handle_comes_from_the_login_name(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("USER", "Julia Valenti")
+    assert onboard.default_handle() == "julia-valenti"
+    monkeypatch.setenv("USER", "")
+    monkeypatch.delenv("USERNAME", raising=False)
+    assert onboard.default_handle() == "me"
+
+
+# ── the health probe ────────────────────────────────────────────────────────
+
+
+def _resp(url: str, status: int, *, payload: Any = None, text: str | None = None) -> httpx.Response:
+    """A real ``httpx.Response`` with its request attached, so ``raise_for_status`` works."""
+    request = httpx.Request("GET", url)
+    if text is not None:
+        return httpx.Response(status, text=text, request=request)
+    return httpx.Response(status, json=payload, request=request)
+
+
+def _stub_get(
+    monkeypatch: pytest.MonkeyPatch, answers: dict[str, httpx.Response | Exception]
+) -> list[str]:
+    asked: list[str] = []
+
+    def fake_get(url: str, timeout: float) -> httpx.Response:  # noqa: ARG001
+        asked.append(url)
+        answer = answers[url]
+        if isinstance(answer, Exception):
+            raise answer
+        return answer
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    return asked
+
+
+def test_probe_health_falls_back_to_the_api_prefix(monkeypatch: pytest.MonkeyPatch):
+    """Behind a proxy the frontend owns /, and only /api/health is the backend's."""
+    asked = _stub_get(
+        monkeypatch,
+        {
+            "https://hub/health": _resp("https://hub/health", 404),
+            "https://hub/api/health": _resp(
+                "https://hub/api/health", 200, payload={"status": "ok", "auth": {"enabled": True}}
+            ),
+        },
+    )
+    body, why = client_mod.probe_health("https://hub/")
+    assert body == {"status": "ok", "auth": {"enabled": True}}
+    assert why == ""
+    assert asked == ["https://hub/health", "https://hub/api/health"]
+
+
+def test_probe_health_takes_the_bare_path_first(monkeypatch: pytest.MonkeyPatch):
+    asked = _stub_get(
+        monkeypatch, {"http://h/health": _resp("http://h/health", 200, payload={"status": "ok"})}
+    )
+    body, _ = client_mod.probe_health("http://h")
+    assert body == {"status": "ok"}
+    assert asked == ["http://h/health"]
+
+
+def test_probe_health_reports_why_when_nothing_answers(monkeypatch: pytest.MonkeyPatch):
+    _stub_get(
+        monkeypatch,
+        {
+            "http://h/health": httpx.ConnectError("refused"),
+            "http://h/api/health": httpx.ConnectError("refused"),
+        },
+    )
+    body, why = client_mod.probe_health("http://h")
+    assert body is None
+    assert "couldn't reach http://h/api/health" in why
+
+
+def test_probe_health_skips_an_answer_that_is_not_a_health_document(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A frontend that serves HTML with a 200 on every path is not the hub."""
+    _stub_get(
+        monkeypatch,
+        {
+            "http://h/health": _resp("http://h/health", 200, text="<html>not the hub</html>"),
+            "http://h/api/health": _resp(
+                "http://h/api/health", 200, payload=["not", "an", "object"]
+            ),
+        },
+    )
+    body, why = client_mod.probe_health("http://h")
+    assert body is None
+    assert "health document" in why
+
+
+# ── the verdict ─────────────────────────────────────────────────────────────
+
+
+def _commit(subkind: str, assignments: dict[str, str] | None = None, text: str = "") -> dict:
+    record = {
+        "content": text,
+        "l9": {
+            "header": {"kind": "commit", "subkind": subkind},
+            "payload": {"data": {"assignments": assignments or {}}},
+        },
+    }
+    return {
+        "id": "m1",
+        "sender_handle": "aligner",
+        "message_type": "l9_commit",
+        "content": json.dumps(record),
+    }
+
+
+def test_parse_verdict_reads_a_converged_commit():
+    verdict = onboard.parse_verdict(
+        _commit("converged", {"release date": "three weeks"}, "✓ agreement in 4 steps")
+    )
+    assert verdict == {
+        "converged": True,
+        "assignments": {"release date": "three weeks"},
+        "text": "✓ agreement in 4 steps",
+        "sender": "aligner",
+    }
+
+
+def test_parse_verdict_reads_a_rejected_commit():
+    verdict = onboard.parse_verdict(_commit("rejected", text="✗ no agreement"))
+    assert verdict is not None
+    assert verdict["converged"] is False
+    assert verdict["assignments"] == {}
+
+
+def test_parse_verdict_ignores_everything_else():
+    assert onboard.parse_verdict({"message_type": "broadcast", "content": "hi"}) is None
+    assert onboard.parse_verdict({"message_type": "l9_commit", "content": "{not json"}) is None
+
+
+def test_tail_prints_the_conversation_and_stops_at_the_verdict(capsys: pytest.CaptureFixture):
+    from datetime import UTC, datetime
+
+    from mycelium.config import MyceliumConfig
+
+    feed = [
+        {"id": "a", "sender_handle": "aligner", "message_type": "broadcast", "content": "@maya?"},
+        {
+            "id": "b",
+            "sender_handle": "maya",
+            "message_type": "broadcast",
+            "content": "Three weeks.",
+        },
+        {"id": "c", "sender_handle": "sys", "message_type": "l9_knowledge", "content": "{}"},
+        _commit("converged", {"date": "three weeks"}),
+    ]
+    with (
+        patch.object(onboard, "_messages_since", return_value=feed),
+        patch.object(onboard.time, "sleep"),
+    ):
+        verdict = onboard._tail_until_verdict(
+            MyceliumConfig(), "r", datetime.now(UTC), ["maya", "theo"]
+        )
+    assert verdict is not None and verdict["converged"]
+    out = capsys.readouterr().out
+    assert "aligner: @maya?" in out
+    assert "maya: Three weeks." in out
+    assert "sys" not in out  # a control frame is not conversation
+
+
+def test_wait_for_agents_needs_a_position_and_presence():
+    """Posting and leaving is not enough: the aligner addresses who is present."""
+    from mycelium.config import MyceliumConfig
+
+    spoke = iter([set(), {"maya"}, {"maya", "theo"}, {"maya", "theo"}])
+    present = iter([set(), set(), {"maya"}, {"maya", "theo"}])
+    with (
+        patch.object(onboard, "_thread_senders", side_effect=lambda *_: next(spoke)),
+        patch.object(onboard, "_present", side_effect=lambda *_: next(present)),
+        patch.object(onboard.time, "sleep"),
+    ):
+        onboard._wait_for_agents(MyceliumConfig(), "r", "urn:x", ["maya", "theo"])
+
+
+# ── the command ─────────────────────────────────────────────────────────────
+
+
+def test_list_prints_every_scenario():
+    result = runner.invoke(app, ["onboard", "--list"])
+    assert result.exit_code == 0
+    for sid in scenarios.SCENARIOS:
+        assert sid in result.stdout
+
+
+def test_unknown_scenario_is_refused(isolated_home: Path):
+    with patch.object(onboard, "probe_health", return_value=({"status": "ok"}, "")):
+        result = runner.invoke(app, ["onboard", "--scenario", "nope", "--yes"])
+    assert result.exit_code == 1
+    assert "Unknown scenario" in result.stdout
+
+
+def test_briefings_need_a_room_set_up_earlier(isolated_home: Path):
+    result = runner.invoke(app, ["onboard", "--briefings"])
+    assert result.exit_code == 1
+    assert "No onboarding state" in result.stdout
+
+
+def test_briefings_reprint_from_saved_state(isolated_home: Path):
+    onboard._save_state("demo-release-plan", {"row": "work/plan", "gated": False})
+    result = runner.invoke(app, ["onboard", "--briefings"])
+    assert result.exit_code == 0, result.stdout
+    assert "@maya" in result.stdout and "@theo" in result.stdout
+    assert "--task work/plan" in result.stdout
+
+
+def test_an_unreachable_hosted_hub_stops_the_tour(isolated_home: Path):
+    with patch.object(onboard, "probe_health", return_value=(None, "couldn't reach it")):
+        result = runner.invoke(app, ["onboard", "--hub", "https://hub.example", "--yes"])
+    assert result.exit_code == 1
+    assert "No hub answered at https://hub.example" in result.stdout
+
+
+class _NoHerdr:
+    """A bridge on a machine without herdr: nothing to type a briefing into."""
+
+    def binary_present(self) -> bool:
+        return False
+
+
+def _ok(stdout: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def test_a_yes_run_issues_the_real_commands_in_order(
+    isolated_home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """With every hub call faked, the tour is the sequence a user would type."""
+    from mycelium.config import MyceliumConfig
+
+    monkeypatch.delenv("MYCELIUM_API_URL", raising=False)
+
+    cfg_path = isolated_home / ".mycelium" / "config.toml"
+    cfg_path.parent.mkdir(parents=True)
+    cfg_path.write_text('[identity]\nname = "julia"\n')
+    calls: list[list[str]] = []
+
+    def fake_run(args: list[str], *, capture: bool = False) -> subprocess.CompletedProcess[str]:  # noqa: ARG001
+        calls.append(args)
+        return _ok()
+
+    health = {"status": "ok", "version": "9.9", "auth": {"enabled": False}}
+    verdict = {"converged": True, "assignments": {"date": "3 weeks"}, "text": "", "sender": "a"}
+    with (
+        patch.object(onboard, "probe_health", return_value=(health, "")),
+        patch.object(onboard, "_run", side_effect=fake_run),
+        patch.object(onboard, "_create_task", return_value=("work/plan", "urn:x:episode:r:t1")),
+        patch.object(onboard, "_herdr_panes", return_value=(_NoHerdr(), [])),
+        patch.object(onboard, "_wait_for_agents"),
+        patch.object(onboard, "_tail_until_verdict", return_value=verdict),
+        # The first read is the board before the summon; after it, the compiled row.
+        patch.object(onboard, "_work_rows", side_effect=[set(), {"memory:work/notes"}]),
+        patch.object(onboard, "_claimed", return_value=True),
+        patch.object(onboard.time, "sleep"),
+    ):
+        result = runner.invoke(app, ["onboard", "--yes", "--hub", "https://hub.example/api"])
+
+    assert result.exit_code == 0, result.stdout
+    assert MyceliumConfig.load().server.api_url == "https://hub.example"
+    heads = [c[:2] for c in calls]
+    assert heads.index(["room", "create"]) < heads.index(["room", "use"])
+    assert ["engine", "create"] in heads
+    assert [c for c in calls if c[:2] == ["agent", "create"]] == [
+        c for c in calls if c[:2] == ["agent", "create"] and "--adapter" in c
+    ]
+    assert len([c for c in calls if c[:2] == ["agent", "create"]]) == 2
+    coordinate = next(c for c in calls if c[:2] == ["board", "coordinate"])
+    assert coordinate[2] == "t1" and coordinate[3] == scenarios.ALIGNER_HANDLE
+    follow_ups = [c for c in calls if c[:2] == ["board", "new"]]
+    assert len(follow_ups) == 2
+    assert all("--parent" in c and "work/plan" in c for c in follow_ups)
+    # The briefings were printed for pasting (no clipboard in a test) and saved.
+    assert "Paste this into coding agent 1" in result.stdout
+    assert (isolated_home / ".mycelium" / "onboard" / "demo-release-plan" / "maya.md").exists()
+    assert "Agreement" in result.stdout
+    assert "https://hub.example/room/demo-release-plan" in result.stdout


### PR DESCRIPTION
## Summary

Onboarding today is assembled by hand from six doc pages and three terminals, and the demo path (`mycelium demo`) pulls abstract persona scenarios and needs an adapter picked up front. This adds one command, `mycelium onboard`, that walks a new user through the whole product on a real hub with their own coding agents, in about ten minutes, and prints every command it runs so the tour doubles as the tutorial.

The flow, step by step:

1. **Point at a hub.** This machine (offers `mycelium install` / `mycelium up` if nothing answers) or a hosted hub by address. Saves `server.api_url`. Pasted addresses are normalized (bare host, trailing `/`, trailing `/api`).
2. **Sign in.** On a gated hub runs `mycelium login` and takes the handle from the hub's `/api/whoami`. On an open hub asks for a handle (`mycelium iam`).
3. **Pick a scenario.** Three built-in, plain-language disagreements: plan the 2.0 release (release manager vs QA lead), pick a database for the orders service (platform vs orders team), cut the cloud bill by 30% (finance ops vs SRE). Each person has what they want, what they'd give, and a hard line.
4. **Set up the room.** `room create`, `room use`, `engine create aligner`, `agent create` ×2, `board new` for the task, and an opening line in its thread.
5. **Bring in your coding agents.** Writes one briefing per agent (who it plays, the exact `respond`/`await` commands, the confidence marker). With herdr running it offers to type the briefing into a pane; without it, offers to install herdr, then copies each briefing to the clipboard (or prints it) and saves it under `~/.mycelium/onboard/<room>/`. Then waits until both agents have posted a position and are present.
6. **Let the aligner mediate.** `board coordinate <task> aligner "<question>"`, tails the negotiation live in the terminal, prints the agreement (or a clean no-agreement), waits for the compiled work rows, and shows the board.
7. **Work the board.** Files the scenario's follow-up tasks under the parent with `--assign`, pings an agent in one, and shows the claim land.

`--yes` takes every default with no pauses, `--list` shows the scenarios, `--briefings` re-prints the agents' briefings for a room set up earlier, `--hub`/`--scenario`/`--room` skip the questions.

## Changes

- `mycelium-cli/src/mycelium/commands/onboard.py`: the wizard, registered as top-level `mycelium onboard`.
- `mycelium-cli/src/mycelium/scenarios.py`: the three scenarios and the briefing each agent is handed.
- `mycelium-cli/src/mycelium/client.py`: `probe_health` tries `/health` then `/api/health`, so a hub behind a reverse proxy that serves the backend under `/api` is found. `mycelium login`'s issuer discovery now uses it (#966).
- Sign-in step sets this machine's identity from the hub's `/api/whoami` answer rather than a locally decoded claim (#967, for this path; `login` itself is unchanged).
- Quickstart docs open with the tour; docs site regenerated; `demo` docstring points at `onboard`.

## Testing

- 30 new unit tests (`tests/test_onboard.py`): scenario shape, briefing contents, hub normalization, health-probe fallback, verdict parsing, the wait loop, and a full `--yes` run with every hub call faked asserting the command sequence.
- Not exercised here: a live end-to-end run against a running hub with two real coding agents. The sandbox has no Docker or stack.

- [x] Unit tests pass (`uv run pytest tests/ -x -q`) — 837 passed
- [x] Linting passes (`uv run ruff check .`)
- [x] Format check passes (`uv run ruff format --check .`)
- [x] `uv run ty check .`

## Related Issues

Refs #966, #967, #941

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXN8KFjCxyj6VBm9xbY3ih

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXN8KFjCxyj6VBm9xbY3ih)_