### PR TITLE
Support safe room names with spaces

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -382,6 +382,12 @@
 <span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">watch</span>                    # stream live room activity
 <span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">delete</span> design-review     # delete a room and its data
 <span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">clone</span> design-review <span class="flag">--from</span> <span class="url">http://hub-ip:8000</span>  # pull a room from a remote backend</code></pre>
+      <h2 id="rooms-room-names">Room Names</h2>
+      <p>A room name is its stable filesystem and SLIM namespace identifier. Names are 1–100 printable characters long. Unicode, spaces and ordinary punctuation are supported.</p>
+      <p>Quote a spaced name when using a shell:</p>
+      <pre><code><span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">create</span> <span class="str">&quot;CE-Area Team&quot;</span>
+<span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">use</span> <span class="str">&quot;CE-Area Team&quot;</span></code></pre>
+      <p>Creation rejects blank names, <code>.</code> and <code>..</code>, path separators, control characters and the reserved <code>:session:</code> marker.</p>
       <h2 id="rooms-reading-history">Reading History</h2>
       <p><code>mycelium room messages</code> is a point-in-time read, newest first. History is paged by content rather than position: when older messages exist, the footer names the <code>--before</code> cursor that reads the next page back, so a walk through a busy room does not shift under messages arriving live. A stamp is ISO 8601 as printed, or an age like <code>2h</code>, <code>30m</code>, <code>1d</code>.</p>
       <pre><code><span class="bin">mycelium</span> <span class="cmd">room</span> <span class="cmd">messages</span> design-review <span class="flag">--limit</span> 50          # the latest page …

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -272,6 +272,22 @@ mycelium room delete design-review     # delete a room and its data
 mycelium room clone design-review --from http://hub-ip:8000  # pull a room from a remote backend
 ```
 
+## Room Names
+
+A room name is its stable filesystem and SLIM namespace identifier. Names are
+1–100 printable characters long. Unicode, spaces and ordinary punctuation are
+supported.
+
+Quote a spaced name when using a shell:
+
+```bash
+mycelium room create "CE-Area Team"
+mycelium room use "CE-Area Team"
+```
+
+Creation rejects blank names, `.` and `..`, path separators, control characters
+and the reserved `:session:` marker.
+
 ## Reading History
 
 `mycelium room messages` is a point-in-time read, newest first. History is

--- a/docs/search-index.js
+++ b/docs/search-index.js
@@ -84,6 +84,13 @@ window.MYCELIUM_SEARCH_INDEX = [
     "p": "Guide"
   },
   {
+    "u": "index.html#rooms-room-names",
+    "t": "Room Names",
+    "s": "Concepts › Rooms",
+    "x": "A room name is its stable filesystem and SLIM namespace identifier. Names are 1–100 printable characters long. Unicode, spaces and ordinary punctuation are supported. Quote a spaced name when using a shell: mycelium room create \"CE-Area Team\" mycelium room use \"CE-Area Team\" Creation rejects blank names, . and .., path separators, control characters and the reserved :session: marker.",
+    "p": "Guide"
+  },
+  {
     "u": "index.html#rooms-reading-history",
     "t": "Reading History",
     "s": "Concepts › Rooms",

--- a/fastapi-backend/app/schemas.py
+++ b/fastapi-backend/app/schemas.py
@@ -10,7 +10,7 @@ from enum import StrEnum
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Two shape rules, deliberately distinct. A *handle* is an identity and can be
 # minted by a real IdP, so it allows the `@` a corporate SSO `preferred_username`
@@ -25,12 +25,36 @@ SLUG_PATTERN = r"^[a-z0-9][a-z0-9._-]*$"
 
 
 class RoomCreate(BaseModel):
-    name: str = Field(..., min_length=1, max_length=100)
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description=(
+            "Room name: 1-100 printable characters; path separators, blank names, "
+            "'.', '..', and the reserved ':session:' marker are not allowed"
+        ),
+    )
     description: str | None = Field(None, max_length=500)
     title: str | None = Field(None, max_length=200)
     is_public: bool = True
     mas_id: str | None = None
     workspace_id: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        """Keep a room name safe as one filesystem and SLIM namespace segment."""
+        if not value.strip():
+            raise ValueError("Room name must not be blank")
+        if value in {".", ".."}:
+            raise ValueError("Room name must not be '.' or '..'")
+        if "/" in value or "\\" in value:
+            raise ValueError("Room name must not contain path separators")
+        if ":session:" in value:
+            raise ValueError("Room name must not contain the reserved ':session:' marker")
+        if not value.isprintable():
+            raise ValueError("Room name must contain only printable characters")
+        return value
 
 
 class RoomRead(BaseModel):

--- a/fastapi-backend/tests/test_a2a_agents_route.py
+++ b/fastapi-backend/tests/test_a2a_agents_route.py
@@ -190,8 +190,9 @@ async def test_non_http_card_scheme_rejected():
     ],
 )
 @pytest.mark.asyncio
-async def test_private_host_card_rejected_ssrf(url):
+async def test_private_host_card_rejected_ssrf(url, monkeypatch):
     """SSRF guard: a card host resolving to a non-public address is refused."""
+    monkeypatch.setattr("app.config.settings.A2A_ALLOW_PRIVATE_HOSTS", False)
     with pytest.raises(A2aCardError, match="SSRF|non-public|did not resolve"):
         await a2a_card.resolve_card(url)
 

--- a/fastapi-backend/tests/test_rooms_route.py
+++ b/fastapi-backend/tests/test_rooms_route.py
@@ -17,6 +17,57 @@ async def _create_room(client, name: str) -> None:
     assert resp.status_code == 201, resp.text
 
 
+@pytest.mark.asyncio
+async def test_room_name_with_spaces_round_trips(client) -> None:
+    name = "CE-Area Team"
+
+    created = await client.post("/api/rooms", json={"name": name})
+    fetched = await client.get("/api/rooms/CE-Area%20Team")
+
+    assert created.status_code == 201
+    assert created.json()["name"] == name
+    assert fetched.status_code == 200
+    assert fetched.json()["name"] == name
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name",
+    [
+        "café #1%",
+        "-leading-and-trailing-",
+        " padded ",
+        "room:name",
+    ],
+)
+async def test_create_room_accepts_safe_unicode_and_punctuation(client, name: str) -> None:
+    resp = await client.post("/api/rooms", json={"name": name})
+
+    assert resp.status_code == 201
+    assert resp.json()["name"] == name
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name",
+    [
+        "   ",
+        ".",
+        "..",
+        "room/name",
+        r"room\name",
+        "../escape",
+        "room:session:child",
+        "line\nbreak",
+        "null\u0000byte",
+    ],
+)
+async def test_create_room_rejects_unsafe_names(client, name: str) -> None:
+    resp = await client.post("/api/rooms", json={"name": name})
+
+    assert resp.status_code == 422
+
+
 def _touch_transcript(room: str) -> None:
     ensure_room_structure(get_room_dir(room))
     append_transcript(

--- a/mycelium-cli/src/mycelium/docs/concepts/rooms.md
+++ b/mycelium-cli/src/mycelium/docs/concepts/rooms.md
@@ -43,6 +43,22 @@ mycelium room delete design-review     # delete a room and its data
 mycelium room clone design-review --from http://hub-ip:8000  # pull a room from a remote backend
 ```
 
+## Room Names
+
+A room name is its stable filesystem and SLIM namespace identifier. Names are
+1–100 printable characters long. Unicode, spaces and ordinary punctuation are
+supported.
+
+Quote a spaced name when using a shell:
+
+```bash
+mycelium room create "CE-Area Team"
+mycelium room use "CE-Area Team"
+```
+
+Creation rejects blank names, `.` and `..`, path separators, control characters
+and the reserved `:session:` marker.
+
 ## Reading History
 
 `mycelium room messages` is a point-in-time read, newest first. History is

--- a/mycelium-frontend/src/app/api/stream/route.test.ts
+++ b/mycelium-frontend/src/app/api/stream/route.test.ts
@@ -126,6 +126,24 @@ describe("GET /api/stream", () => {
       ]);
     });
 
+    it("encodes a spaced room once in the upstream path", async () => {
+      const dialed: string[] = [];
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (url: string) => {
+          dialed.push(url);
+          return upstream().response;
+        }),
+      );
+
+      const res = await GET(new Request("http://ui/api/stream?room=CE-Area%20Team"));
+      await collect(res, 1);
+
+      expect(dialed).toEqual([
+        "http://backend:8000/api/rooms/CE-Area%20Team/messages/stream",
+      ]);
+    });
+
     it("deduplicates and caps the rooms a single request can open", async () => {
       const opened: string[] = [];
       vi.stubGlobal(

--- a/mycelium-frontend/src/app/room/[name]/graph/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/graph/page.tsx
@@ -9,11 +9,12 @@ import { ArrowLeft } from "lucide-react";
 import { AppShell } from "@/components/app-shell";
 import { MemoryGraphView } from "@/components/memory-graph-view";
 import { GlobalStatusItems } from "@/components/status-items";
+import { parseRoomNameParam } from "@/lib/memory-routes";
 
 /** Dedicated full-page memory graph route: `/room/{room}/graph`. */
 export default function MemoryGraphPage() {
   const params = useParams();
-  const roomName = params.name as string;
+  const roomName = parseRoomNameParam(params.name as string);
 
   return (
     <AppShell

--- a/mycelium-frontend/src/app/room/[name]/memory/[...key]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/memory/[...key]/page.tsx
@@ -8,11 +8,11 @@ import { useParams } from "next/navigation";
 import { AppShell } from "@/components/app-shell";
 import { MemoryPageView } from "@/components/memory-page-view";
 import { GlobalStatusItems } from "@/components/status-items";
-import { parseMemoryKeyParam } from "@/lib/memory-routes";
+import { parseMemoryKeyParam, parseRoomNameParam } from "@/lib/memory-routes";
 
 function MemoryPageBody() {
   const params = useParams();
-  const roomName = params.name as string;
+  const roomName = parseRoomNameParam(params.name as string);
   const keySegments = params.key;
   const memoryKey = parseMemoryKeyParam(
     Array.isArray(keySegments) ? keySegments : keySegments ? [keySegments] : [],
@@ -24,7 +24,7 @@ function MemoryPageBody() {
 /** Dedicated full-page memory route: `/room/{room}/memory/{key}`. */
 export default function MemoryPage() {
   const params = useParams();
-  const roomName = params.name as string;
+  const roomName = parseRoomNameParam(params.name as string);
 
   return (
     <AppShell

--- a/mycelium-frontend/src/app/room/[name]/page.tsx
+++ b/mycelium-frontend/src/app/room/[name]/page.tsx
@@ -9,7 +9,7 @@ import { useDefaultLayout } from "react-resizable-panels";
 import { type EpisodeSummary } from "@/lib/api";
 import { useRoom, useRoomRevalidate, useRoomThreads } from "@/lib/room-data";
 import { parseFocus, type FocusTarget } from "@/lib/search";
-import { memoryHref } from "@/lib/memory-routes";
+import { memoryHref, parseRoomNameParam } from "@/lib/memory-routes";
 import { AppShell } from "@/components/app-shell";
 import { EventStream, type View } from "@/components/event-stream";
 import { RoomChatBox } from "@/components/room-chat-box";
@@ -69,7 +69,7 @@ export default function RoomPage() {
 
 function RoomWorkspace() {
   const params = useParams();
-  const roomName = params.name as string;
+  const roomName = parseRoomNameParam(params.name as string);
   const [connected, setConnected] = useState(false);
   const [inspectorTab, setInspectorTab] = useState<Tab>("agents");
   const [inspectorOpen, setInspectorOpen] = useState(true);

--- a/mycelium-frontend/src/lib/api.room-name.test.ts
+++ b/mycelium-frontend/src/lib/api.room-name.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Mycelium Contributors
+
+import { afterEach, expect, it, vi } from "vitest";
+import { fetchRoom } from "@/lib/api";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+it("encodes a spaced room name as one API path segment", async () => {
+  const fetch = vi.fn(async () =>
+    Response.json({
+      name: "CE-Area Team",
+      created_at: "2026-09-11T00:00:00Z",
+      is_persistent: true,
+    }),
+  );
+  vi.stubGlobal("fetch", fetch);
+
+  await fetchRoom("CE-Area Team");
+
+  expect(fetch).toHaveBeenCalledWith("/api/rooms/CE-Area%20Team", {
+    cache: "no-store",
+  });
+});

--- a/mycelium-frontend/src/lib/api.ts
+++ b/mycelium-frontend/src/lib/api.ts
@@ -118,6 +118,11 @@ async function apiFetch<T = unknown>(path: string, opts: ApiFetchOptions<T> = {}
 
 const isArray = (d: unknown): d is unknown[] => Array.isArray(d);
 
+/** Canonical API path for a room whose name may contain spaces. */
+function roomApiPath(name: string): string {
+  return `/api/rooms/${encodeURIComponent(name)}`;
+}
+
 // ── Rooms ────────────────────────────────────────────────────────────────────
 
 export interface Room {
@@ -137,7 +142,7 @@ export interface Room {
 
 /** Rename a room. Throws `ApiError` on failure. */
 export async function setRoomTitle(roomName: string, title: string): Promise<Room> {
-  return apiFetch<Room>(`/api/rooms/${roomName}`, {
+  return apiFetch<Room>(roomApiPath(roomName), {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ title }),
@@ -149,7 +154,7 @@ export async function fetchRooms(): Promise<Room[]> {
 }
 
 export async function fetchRoom(name: string): Promise<Room> {
-  return apiFetch<Room>(`/api/rooms/${name}`, { cache: "no-store" });
+  return apiFetch<Room>(roomApiPath(name), { cache: "no-store" });
 }
 
 export async function createRoom(data: { name: string; is_persistent?: boolean }): Promise<Room> {
@@ -206,7 +211,7 @@ export async function createMemories(
   roomName: string,
   items: MemoryCreate[],
 ): Promise<void> {
-  await apiFetch<unknown>(`/api/rooms/${roomName}/memory`, {
+  await apiFetch<unknown>(`${roomApiPath(roomName)}/memory`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ items }),
@@ -240,7 +245,7 @@ export async function writeAssignment(
   action: "claim" | "release" | "resolve",
   body: { key: string; handle: string; ttl_minutes?: number; note?: string },
 ): Promise<AssignmentState> {
-  return apiFetch<AssignmentState>(`/api/rooms/${roomName}/assignments/${action}`, {
+  return apiFetch<AssignmentState>(`${roomApiPath(roomName)}/assignments/${action}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -265,7 +270,7 @@ export async function writeFields(
   roomName: string,
   body: { key: string; handle: string; fields: Record<string, unknown> },
 ): Promise<FieldState> {
-  return apiFetch<FieldState>(`/api/rooms/${roomName}/fields`, {
+  return apiFetch<FieldState>(`${roomApiPath(roomName)}/fields`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -280,7 +285,7 @@ export const MEMORIES_PAGE_LIMIT = 50;
 export async function fetchMemories(roomName: string, prefix?: string): Promise<Memory[]> {
   const params = new URLSearchParams({ limit: String(MEMORIES_PAGE_LIMIT) });
   if (prefix) params.set("prefix", prefix);
-  return apiFetch<Memory[]>(`/api/rooms/${roomName}/memory?${params}`, {
+  return apiFetch<Memory[]>(`${roomApiPath(roomName)}/memory?${params}`, {
     cache: "no-store",
     fallback: [],
     guard: isArray as (d: unknown) => d is Memory[],
@@ -290,7 +295,7 @@ export async function fetchMemories(roomName: string, prefix?: string): Promise<
 /** One memory by key. Returns null when it isn't there (or the read failed). */
 export async function fetchMemory(roomName: string, key: string): Promise<Memory | null> {
   const path = encodeMemoryKeyPath(key);
-  return apiFetch<Memory | null>(`/api/rooms/${roomName}/memory/${path}`, {
+  return apiFetch<Memory | null>(`${roomApiPath(roomName)}/memory/${path}`, {
     cache: "no-store",
     fallback: null,
   });
@@ -304,7 +309,7 @@ export interface MemorySearchResult {
 /** Semantic search. Throws on failure so the UI can distinguish "no results"
  *  from "the request failed". */
 export async function searchMemories(roomName: string, query: string): Promise<MemorySearchResult[]> {
-  const data = await apiFetch<{ results?: MemorySearchResult[] }>(`/api/rooms/${roomName}/memory/search`, {
+  const data = await apiFetch<{ results?: MemorySearchResult[] }>(`${roomApiPath(roomName)}/memory/search`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query, limit: 10 }),
@@ -352,7 +357,7 @@ const EMPTY_LINKS = { outbound: [], backlinks: [] };
 export async function fetchMemoryLinks(roomName: string, key: string): Promise<MemoryLinks> {
   const params = new URLSearchParams({ key });
   const data = await apiFetch<Omit<MemoryLinks, "key">>(
-    `/api/rooms/${roomName}/links?${params}`,
+    `${roomApiPath(roomName)}/links?${params}`,
     { cache: "no-store", fallback: EMPTY_LINKS },
   );
   return { key, outbound: data.outbound ?? [], backlinks: data.backlinks ?? [] };
@@ -371,7 +376,7 @@ const EMPTY_EXPAND: MemoryExpanded = { key: "", rendered: "", expansions: [], fo
 export async function fetchMemoryExpanded(roomName: string, key: string): Promise<MemoryExpanded> {
   const params = new URLSearchParams({ key });
   const data = await apiFetch<MemoryExpanded>(
-    `/api/rooms/${roomName}/links/expand?${params}`,
+    `${roomApiPath(roomName)}/links/expand?${params}`,
     { cache: "no-store", fallback: { ...EMPTY_EXPAND, key } },
   );
   return { ...EMPTY_EXPAND, ...data, key };
@@ -411,7 +416,7 @@ const EMPTY_GRAPH: MemoryGraph = { nodes: [], edges: [] };
 /** The room's whole link graph. Degrades to empty when the room has no link
  *  index yet, or the hub is unreachable. */
 export async function fetchMemoryGraph(roomName: string): Promise<MemoryGraph> {
-  const data = await apiFetch<Partial<MemoryGraph>>(`/api/rooms/${roomName}/links/graph`, {
+  const data = await apiFetch<Partial<MemoryGraph>>(`${roomApiPath(roomName)}/links/graph`, {
     cache: "no-store",
     fallback: EMPTY_GRAPH,
   });
@@ -439,7 +444,7 @@ export interface Skill {
  *  `skills/…` memories; in the GUI they surface as memories (with a tag), so this
  *  read is the only skill-specific frontend call. Degrades to empty on failure. */
 export async function fetchSkills(roomName: string): Promise<Skill[]> {
-  const data = await apiFetch<{ skills?: Skill[] }>(`/api/rooms/${roomName}/skills`, {
+  const data = await apiFetch<{ skills?: Skill[] }>(`${roomApiPath(roomName)}/skills`, {
     cache: "no-store",
     fallback: { skills: [] },
   });
@@ -450,7 +455,7 @@ export async function fetchSkills(roomName: string): Promise<Skill[]> {
  *  A read is answered from the hub's cache and never fetches, so polling this
  *  costs a cache lookup rather than a round trip to GitHub. */
 export async function fetchRoomStatus(roomName: string): Promise<RoomStatus> {
-  return apiFetch<RoomStatus>(`/api/rooms/${roomName}/status`, {
+  return apiFetch<RoomStatus>(`${roomApiPath(roomName)}/status`, {
     cache: "no-store",
     fallback: {
       room: roomName,
@@ -513,7 +518,7 @@ export async function fetchMessages(
   if (query.before) params.set("before", query.before);
   const qs = params.toString();
   return apiFetch<MessagesResponse>(
-    `/api/rooms/${roomName}/messages${qs ? `?${qs}` : ""}`,
+    `${roomApiPath(roomName)}/messages${qs ? `?${qs}` : ""}`,
     {
       cache: "no-store",
       fallback: { messages: [] },
@@ -533,7 +538,7 @@ export async function fetchL9History(
   const params = new URLSearchParams({ limit: String(limit) });
   if (before) params.set("before", before);
   return apiFetch<Record<string, unknown>[]>(
-    `/api/rooms/${roomName}/messages/l9?${params.toString()}`,
+    `${roomApiPath(roomName)}/messages/l9?${params.toString()}`,
     {
       cache: "no-store",
       fallback: [],
@@ -552,7 +557,7 @@ export async function sendRoomMessage(
     episode?: string | null;
   },
 ): Promise<RoomMessage> {
-  return apiFetch<RoomMessage>(`/api/rooms/${roomName}/messages`, {
+  return apiFetch<RoomMessage>(`${roomApiPath(roomName)}/messages`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ message_type: "broadcast", ...data }),
@@ -577,7 +582,7 @@ export interface AgentSummary {
 
 /** List addressable agents in a room. Used to drive `@`-mention autocomplete. */
 export async function fetchRoomAgents(roomName: string): Promise<AgentSummary[]> {
-  return apiFetch<AgentSummary[]>(`/api/rooms/${roomName}/agents`, {
+  return apiFetch<AgentSummary[]>(`${roomApiPath(roomName)}/agents`, {
     cache: "no-store",
     fallback: [],
     guard: isArray as (d: unknown) => d is AgentSummary[],
@@ -593,7 +598,7 @@ export async function createEngine(
   roomName: string,
   data: { handle: string; kind: EngineKind; description?: string; created_by?: string },
 ): Promise<AgentSummary> {
-  return apiFetch<AgentSummary>(`/api/rooms/${roomName}/engines`, {
+  return apiFetch<AgentSummary>(`${roomApiPath(roomName)}/engines`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
@@ -607,7 +612,7 @@ export async function registerA2aAgent(
   roomName: string,
   data: { handle: string; card: string; description?: string },
 ): Promise<AgentSummary> {
-  return apiFetch<AgentSummary>(`/api/rooms/${roomName}/a2a-agents`, {
+  return apiFetch<AgentSummary>(`${roomApiPath(roomName)}/a2a-agents`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(data),
@@ -674,7 +679,7 @@ export interface A2aBridgeState {
 /** Read a room's A2A bridge state. Returns null when the hub is unreachable
  *  or too old to serve the route. */
 export async function fetchA2aBridge(roomName: string): Promise<A2aBridgeState | null> {
-  return apiFetch<A2aBridgeState | null>(`/api/rooms/${roomName}/a2a/state`, {
+  return apiFetch<A2aBridgeState | null>(`${roomApiPath(roomName)}/a2a/state`, {
     cache: "no-store",
     fallback: null,
   });
@@ -703,7 +708,7 @@ export interface PresenceMember {
 
 /** Live presence set for a room: SLIM-connected + server-held lease members. */
 export async function fetchRoomMembers(roomName: string): Promise<PresenceMember[]> {
-  const data = await apiFetch<{ members?: PresenceMember[] }>(`/api/rooms/${roomName}/sessions/members`, {
+  const data = await apiFetch<{ members?: PresenceMember[] }>(`${roomApiPath(roomName)}/sessions/members`, {
     cache: "no-store",
     fallback: {},
   });
@@ -825,7 +830,7 @@ export interface EpisodeDetail extends EpisodeSummary {
 
 /** Episode summaries for a room, newest first. */
 export async function fetchEpisodes(roomName: string): Promise<EpisodeSummary[]> {
-  const data = await apiFetch<{ episodes?: EpisodeSummary[] }>(`/api/rooms/${roomName}/episodes`, {
+  const data = await apiFetch<{ episodes?: EpisodeSummary[] }>(`${roomApiPath(roomName)}/episodes`, {
     cache: "no-store",
     fallback: {},
   });
@@ -838,7 +843,7 @@ export async function fetchEpisode(
   shortId: string,
 ): Promise<EpisodeDetail | null> {
   return apiFetch<EpisodeDetail | null>(
-    `/api/rooms/${roomName}/episodes/${encodeURIComponent(shortId)}`,
+    `${roomApiPath(roomName)}/episodes/${encodeURIComponent(shortId)}`,
     { cache: "no-store", fallback: null },
   );
 }

--- a/mycelium-frontend/src/lib/memory-routes.test.ts
+++ b/mycelium-frontend/src/lib/memory-routes.test.ts
@@ -2,7 +2,13 @@
 // Copyright 2026 Mycelium Contributors
 
 import { describe, expect, it } from "vitest";
-import { encodeMemoryKeyPath, memoryGraphHref, memoryHref, parseMemoryKeyParam } from "@/lib/memory-routes";
+import {
+  encodeMemoryKeyPath,
+  memoryGraphHref,
+  memoryHref,
+  parseMemoryKeyParam,
+  parseRoomNameParam,
+} from "@/lib/memory-routes";
 
 describe("encodeMemoryKeyPath", () => {
   it("encodes each slash segment separately", () => {
@@ -23,6 +29,12 @@ describe("memoryHref", () => {
 
   it("encodes room names with spaces", () => {
     expect(memoryHref("atlas migration", "plan/title")).toBe("/room/atlas%20migration/memory/plan/title");
+  });
+});
+
+describe("parseRoomNameParam", () => {
+  it("decodes a room route segment exactly once", () => {
+    expect(parseRoomNameParam("CE-Area%20Team")).toBe("CE-Area Team");
   });
 });
 

--- a/mycelium-frontend/src/lib/memory-routes.ts
+++ b/mycelium-frontend/src/lib/memory-routes.ts
@@ -18,6 +18,11 @@ export function parseMemoryKeyParam(segments: string[]): string {
   return segments.map(decodeURIComponent).join("/");
 }
 
+/** Decode a `[name]` route segment to the canonical room name. */
+export function parseRoomNameParam(segment: string): string {
+  return decodeURIComponent(segment);
+}
+
 /** Canonical in-app URL for a room memory page. */
 export function memoryHref(room: string, key: string): string {
   return `/room/${encodeURIComponent(room)}/memory/${encodeMemoryKeyPath(key)}`;

--- a/mycelium-frontend/src/lib/stream-hub.test.tsx
+++ b/mycelium-frontend/src/lib/stream-hub.test.tsx
@@ -98,6 +98,21 @@ describe("stream hub", () => {
     expect(liveUrls()).toEqual(["/api/stream", "/api/stream?room=sprint"]);
   });
 
+  it("encodes a spaced room name once", () => {
+    const { getByTestId } = render(
+      <>
+        <RoomFeed room="CE-Area Team" />
+        <RoomBadge room="CE-Area Team" />
+      </>,
+    );
+    const connection = roomConnection();
+
+    expect(connection.url).toBe("/api/stream?room=CE-Area+Team");
+
+    act(() => connection.emitStatus("room", true, "CE-Area Team"));
+    expect(getByTestId("badge")).toHaveTextContent("live");
+  });
+
   it("routes each channel to the consumers that asked for it", () => {
     const room = vi.fn();
     const app = vi.fn();

--- a/openapi.json
+++ b/openapi.json
@@ -5814,7 +5814,8 @@
             "type": "string",
             "maxLength": 100,
             "minLength": 1,
-            "title": "Name"
+            "title": "Name",
+            "description": "Room name: 1-100 printable characters; path separators, blank names, '.', '..', and the reserved ':session:' marker are not allowed"
           },
           "description": {
             "anyOf": [


### PR DESCRIPTION
## Summary
- decode room route parameters once and consistently encode room API paths
- support spaces, Unicode, and printable punctuation while rejecting unsafe room names
- document the room-name contract and isolate the A2A SSRF test from local configuration

## Testing
- `cd fastapi-backend && uv run pytest tests/ -q` (1088 passed, 6 skipped)
- `cd mycelium-frontend && pnpm test` (846 passed)
- backend Ruff/ty checks and frontend lint
- regenerated OpenAPI and documentation artifacts